### PR TITLE
LocalCommand prints the local versions if no arguments are given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Added
 
+- Local command prints all the local versions if no argument is given https://github.com/tuist/tuist/pull/79 by @pepibumur.
 - Platform, product, path and name arguments to the init command https://github.com/tuist/tuist/pull/64 by @pepibumur.
 - Lint that `Info.plist` and `.entitlements` files are not copied into the target products https://github.com/tuist/tuist/pull/65 by @pepibumur
 - Lint that there's only one resources build phase https://github.com/tuist/tuist/pull/65 by @pepibumur.

--- a/Sources/TuistEnvKit/Commands/BundleCommand.swift
+++ b/Sources/TuistEnvKit/Commands/BundleCommand.swift
@@ -3,9 +3,6 @@ import Foundation
 import TuistCore
 import Utility
 
-/// Error thrown by the BundleCommand
-///
-/// - missingVersionFile: Thrown when the developer runs the command in a directory where there isn't a .tuist-version file.
 enum BundleCommandError: FatalError, Equatable {
     case missingVersionFile(AbsolutePath)
 
@@ -31,29 +28,22 @@ enum BundleCommandError: FatalError, Equatable {
     }
 }
 
-/// Command that bundles the tuist binary in a .tuist-bin in the current directory.
 final class BundleCommand: Command {
-    /// Command name.
-    static var command: String = "bundle"
 
-    /// Command overview.
+    // MARK: - Command
+
+    static var command: String = "bundle"
     static var overview: String = "Bundles the version specified in the .tuist-version file into the .tuist-bin directory."
 
-    /// Versions controller.
+    // MARK: - Attributes
+
     private let versionsController: VersionsControlling
-
-    /// File handler.
     private let fileHandler: FileHandling
-
-    /// Installer.
     private let installer: Installing
-
-    /// Printer.
     private let printer: Printing
 
-    /// Initializes the command with its attributes.
-    ///
-    /// - Parameter parser: argument parser.
+    // MARK: - Init
+
     convenience init(parser: ArgumentParser) {
         self.init(parser: parser,
                   versionsController: VersionsController(),
@@ -62,14 +52,6 @@ final class BundleCommand: Command {
                   installer: Installer())
     }
 
-    /// Initializes the command with its attributes.
-    ///
-    /// - Parameters:
-    ///   - parser: argument parser.
-    ///   - versionsController: versions controller.
-    ///   - fileHandler: file handler.
-    ///   - printer: printer.
-    ///   - installer: installer.
     init(parser: ArgumentParser,
          versionsController: VersionsControlling,
          fileHandler: FileHandling,
@@ -82,10 +64,8 @@ final class BundleCommand: Command {
         self.installer = installer
     }
 
-    /// Runs the command used the argument parser result.
-    ///
-    /// - Parameter arguments: parsed arguments.
-    /// - Throws: an error if the bundling process fails.
+    // MARK: - Internal
+
     func run(with _: ArgumentParser.Result) throws {
         let versionFilePath = fileHandler.currentPath.appending(component: Constants.versionFileName)
         let binFolderPath = fileHandler.currentPath.appending(component: Constants.binFolderName)
@@ -95,7 +75,7 @@ final class BundleCommand: Command {
         }
 
         let version = try String(contentsOf: versionFilePath.url)
-        printer.print(section: "Bundling the version \(version) in the directory \(binFolderPath.asString).")
+        printer.print(section: "Bundling the version \(version) in the directory \(binFolderPath.asString)")
 
         let versionPath = versionsController.path(version: version)
 
@@ -111,6 +91,6 @@ final class BundleCommand: Command {
         }
         try fileHandler.copy(from: versionPath, to: binFolderPath)
 
-        printer.print(success: "tuist bundled successfully at \(binFolderPath.asString).")
+        printer.print(success: "tuist bundled successfully at \(binFolderPath.asString)")
     }
 }

--- a/Sources/TuistEnvKit/Commands/CommandRunnerMessageMapper.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRunnerMessageMapper.swift
@@ -1,21 +1,11 @@
 import Foundation
 
-/// The instance that conforms this protocol is responsible
-/// for generating the messages that are printed by the command runner.
 protocol CommandRunnerMessageMapping: AnyObject {
-    /// It returns the message that should be printed for a given resolved version.
-    ///
-    /// - Parameter version: resolved version.
-    /// - Returns: message that should be printed.
     func resolvedVersion(_ version: ResolvedVersion) -> String?
 }
 
 /// Command runner message mapper.
 class CommandRunnerMessageMapper: CommandRunnerMessageMapping {
-    /// It returns the message that should be printed for a given resolved version.
-    ///
-    /// - Parameter version: resolved version.
-    /// - Returns: message that should be printed.
     func resolvedVersion(_ version: ResolvedVersion) -> String? {
         switch version {
         case let .bin(path):

--- a/Sources/TuistEnvKit/Commands/LocalCommand.swift
+++ b/Sources/TuistEnvKit/Commands/LocalCommand.swift
@@ -6,49 +6,67 @@ import Utility
 class LocalCommand: Command {
 
     // MARK: - Command
-    
+
     static var command: String = "local"
-    static var overview: String = "Creates a .tuist-version file to pin the tuist version that should be used in the current directory. If the version is not specified, it prints the current version."
-    
+    static var overview: String = "Creates a .tuist-version file to pin the tuist version that should be used in the current directory. If the version is not specified, it prints the local versions."
+
     // MARK: - Attributes
-    
+
     let versionArgument: PositionalArgument<String>
     let fileHandler: FileHandling
     let printer: Printing
-
+    let versionController: VersionsControlling
 
     // MARK: - Init
-    
+
     required convenience init(parser: ArgumentParser) {
         self.init(parser: parser,
                   fileHandler: FileHandler(),
-                  printer: Printer())
+                  printer: Printer(),
+                  versionController: VersionsController())
     }
 
     init(parser: ArgumentParser,
          fileHandler: FileHandling,
-         printer: Printing) {
+         printer: Printing,
+         versionController: VersionsControlling) {
         let subParser = parser.add(subparser: LocalCommand.command,
                                    overview: LocalCommand.overview)
         versionArgument = subParser.add(positional: "version",
                                         kind: String.self,
-                                        optional: false,
+                                        optional: true,
                                         usage: "The version that you would like to pin your current directory to.")
         self.fileHandler = fileHandler
         self.printer = printer
+        self.versionController = versionController
     }
 
-
     // MARK: - Internal
-    
+
     func run(with result: ArgumentParser.Result) throws {
-        let version = result.get(versionArgument)!
+        if let version = result.get(versionArgument) {
+            try createVersionFile(version: version)
+        } else {
+            try printLocalVersions()
+        }
+    }
+
+    // MARK: - Fileprivate
+
+    private func printLocalVersions() throws {
+        printer.print(section: "The following versions are available in the local environment:")
+        let versions = versionController.semverVersions()
+        let output = versions.sorted().reversed().map({ "- \($0)" }).joined(separator: "\n")
+        printer.print(output)
+    }
+
+    private func createVersionFile(version: String) throws {
         let currentPath = fileHandler.currentPath
-        printer.print(section: "Generating \(Constants.versionFileName) file with version \(version).")
+        printer.print(section: "Generating \(Constants.versionFileName) file with version \(version)")
         let tuistVersionPath = currentPath.appending(component: Constants.versionFileName)
         try "\(version)".write(to: URL(fileURLWithPath: tuistVersionPath.asString),
                                atomically: true,
                                encoding: .utf8)
-        printer.print(success: "File generated at path \(tuistVersionPath.asString).")
+        printer.print(success: "File generated at path \(tuistVersionPath.asString)")
     }
 }

--- a/Sources/TuistEnvKit/Commands/UpdateCommand.swift
+++ b/Sources/TuistEnvKit/Commands/UpdateCommand.swift
@@ -1,12 +1,11 @@
 import Foundation
 import TuistCore
 import Utility
-import TuistCore
 
 final class UpdateCommand: Command {
 
     // MARK: - Command
-    
+
     static var command: String = "update"
     static var overview: String = "Installs the latest version if it's not already installed."
 
@@ -17,7 +16,7 @@ final class UpdateCommand: Command {
     private let printer: Printing
 
     // MARK: - Init
-    
+
     convenience init(parser: ArgumentParser) {
         self.init(parser: parser,
                   versionsController: VersionsController(),
@@ -35,7 +34,7 @@ final class UpdateCommand: Command {
         self.updater = updater
     }
 
-    func run(with: ArgumentParser.Result) throws {
+    func run(with _: ArgumentParser.Result) throws {
         printer.print(section: "Checking for updates...")
         try updater.update()
     }

--- a/Sources/TuistEnvKit/Updater/Updater.swift
+++ b/Sources/TuistEnvKit/Updater/Updater.swift
@@ -8,7 +8,7 @@ protocol Updating: AnyObject {
 final class Updater: Updating {
 
     // MARK: - Attributes
-    
+
     let githubClient: GitHubClienting
     let githubRequestFactory: GitHubRequestsFactory = GitHubRequestsFactory()
     let versionsController: VersionsControlling
@@ -16,7 +16,7 @@ final class Updater: Updating {
     let printer: Printing
 
     // MARK: - Init
-    
+
     init(githubClient: GitHubClienting = GitHubClient(),
          versionsController: VersionsControlling = VersionsController(),
          installer: Installing = Installer(),
@@ -28,7 +28,7 @@ final class Updater: Updating {
     }
 
     // MARK: - Internal
-    
+
     func update() throws {
         let json = try githubClient.execute(request: githubRequestFactory.releases())
         let jsonDecoder = JSONDecoder()
@@ -40,7 +40,7 @@ final class Updater: Updating {
             print("No remote versions found")
             return
         }
-        
+
         if let highestLocalVersion = versionsController.semverVersions().sorted().last {
             if highestRemoteVersion <= highestLocalVersion {
                 printer.print("There are no updates available")

--- a/Sources/TuistEnvKit/Versions/VersionResolver.swift
+++ b/Sources/TuistEnvKit/Versions/VersionResolver.swift
@@ -3,11 +3,6 @@ import Foundation
 import TuistCore
 import Utility
 
-/// Resolved version.
-///
-/// - local: An existing local version.
-/// - pinned: A pinned version.
-/// - unspecified: When no version has been specified.
 enum ResolvedVersion: Equatable {
     case bin(AbsolutePath)
     case versionFile(AbsolutePath, String)
@@ -31,10 +26,6 @@ protocol VersionResolving: AnyObject {
     func resolve(path: AbsolutePath) throws -> ResolvedVersion
 }
 
-/// Version resolver errors.
-///
-/// - readError: thrown when a version file cannot be read.
-/// - invalidFormat: thrown when the version file contains an invalid format.
 enum VersionResolverError: FatalError, Equatable {
     case readError(path: AbsolutePath)
     case invalidFormat(String, path: AbsolutePath)
@@ -67,41 +58,27 @@ enum VersionResolverError: FatalError, Equatable {
     }
 }
 
-/// Resolves the version that should be used at the given path.
-/// The tool looks up recursively the directory and its ancestors until it finds a .tuist-version
-/// If a version is not defined it returns nil.
 class VersionResolver: VersionResolving {
 
     // MARK: - Attributes
 
-    /// Settings controller.
     private let settingsController: SettingsControlling
-
-    /// File manager.
     private let fileManager: FileManager = .default
 
-    /// Default verion resolver constructor.
-    ///
-    /// - Parameter settingsController: settings controller.
+    // MARK: - Init
+
     init(settingsController: SettingsControlling = SettingsController()) {
         self.settingsController = settingsController
     }
 
-    /// Resolves the version for the given path.
-    ///
-    /// - Parameter path: path for which the version will be resolved.
-    /// - Returns: the resolved version that should be used at the given path.
+    // MARK: - VersionResolving
+
     func resolve(path: AbsolutePath) throws -> ResolvedVersion {
         return try resolveTraversing(from: path)
     }
 
-    /// Resolves the version by traversing through the parents looking up for a .tuist-version
-    /// file or a .tuist-bin directory.
-    ///
-    /// - Parameter path: path to traverse from.
-    /// - Returns: resolved version.
-    /// - Throws: an error if the resolution fails. It can happen if the .tuist-version has an invalid format
-    ///   or cannot be read or the bundled binary is in a invalid state.
+    // MARK: - Fileprivate
+
     fileprivate func resolveTraversing(from path: AbsolutePath) throws -> ResolvedVersion {
         let versionPath = path.appending(component: Constants.versionFileName)
         let binPath = path.appending(component: Constants.binFolderName)
@@ -116,11 +93,6 @@ class VersionResolver: VersionResolving {
         return .undefined
     }
 
-    /// Resolves a .tuist-version file.
-    ///
-    /// - Parameter path: path to the .tuist-version file.
-    /// - Returns: resolved version.
-    /// - Throws: an error if the file cannot be opened or it has an invalid format.
     fileprivate func resolveVersionFile(path: AbsolutePath) throws -> ResolvedVersion {
         var value: String!
         do {

--- a/Sources/TuistEnvKit/Versions/VersionsController.swift
+++ b/Sources/TuistEnvKit/Versions/VersionsController.swift
@@ -4,46 +4,18 @@ import TuistCore
 import Utility
 
 protocol VersionsControlling: AnyObject {
-    /// Installation
     typealias Installation = (AbsolutePath) throws -> Void
 
-    /// This methods should be used for installing new versions of tuist.
-    /// It calls the given installation closure with a directory where the
-    /// app should be installed.
-    ///
-    /// - Parameters:
-    ///   - version: version of the app that will be installed.
-    ///   - installation: installation closure.
     func install(version: String, installation: Installation) throws
-
-    /// Returns the path for given version.
-    /// Note: The path is returned regardless of the version existing or not.
-    ///
-    /// - Parameter version: version whose path will be returned.
-    /// - Returns: absolute path to the version.
     func path(version: String) -> AbsolutePath
-
-    /// Returns a list with all the installed versions.
-    ///
-    /// - Returns: installed versions.
     func versions() -> [InstalledVersion]
-
-    /// Returns the list of the semver versions.
-    ///
-    /// - Returns: semver versions.
     func semverVersions() -> [Version]
 }
 
-/// It represents an installed version that can be identified
-/// by either the semver version, or the git reference.
-///
-/// - semver: semver-versioned version.
-/// - reference: git-referenced version.
 enum InstalledVersion: CustomStringConvertible, Equatable {
     case semver(Version)
     case reference(String)
 
-    /// Version string value.
     var description: String {
         switch self {
         case let .reference(value): return value
@@ -51,12 +23,6 @@ enum InstalledVersion: CustomStringConvertible, Equatable {
         }
     }
 
-    /// Compares two instances of InstalledVersion.
-    ///
-    /// - Parameters:
-    ///   - lhs: first instance to be compared.
-    ///   - rhs: second instance to be compared.
-    /// - Returns: true if the two instances are equal.
     static func == (lhs: InstalledVersion, rhs: InstalledVersion) -> Bool {
         switch (lhs, rhs) {
         case let (.semver(lhsVersion), .semver(rhsVersion)):
@@ -70,30 +36,22 @@ enum InstalledVersion: CustomStringConvertible, Equatable {
 }
 
 class VersionsController: VersionsControlling {
-    /// Environment controller.
-    let environmentController: EnvironmentControlling
 
-    /// File handler.
+    // MARK: - Attributes
+
+    let environmentController: EnvironmentControlling
     let fileHandler: FileHandling
 
-    /// Initializes the controller with its attributes.
-    ///
-    /// - Parameters:
-    ///   - environmentController: environment controller.
-    ///   - fileHandler: file handler.
+    // MARK: - Init
+
     init(environmentController: EnvironmentControlling = EnvironmentController(),
          fileHandler: FileHandling = FileHandler()) {
         self.environmentController = environmentController
         self.fileHandler = fileHandler
     }
 
-    /// This methods should be used for installing new versions of tuist.
-    /// It calls the given installation closure with a directory where the
-    /// app should be installed.
-    ///
-    /// - Parameters:
-    ///   - version: version of the app that will be installed.
-    ///   - installation: installation closure.
+    // MARK: - VersionsControlling
+
     func install(version: String, installation: Installation) throws {
         let tmpDir = try TemporaryDirectory(removeTreeOnDeinit: true)
 
@@ -109,18 +67,10 @@ class VersionsController: VersionsControlling {
         }
     }
 
-    /// Returns the path for given version.
-    /// Note: The path is returned regardless of the version existing or not.
-    ///
-    /// - Parameter version: version whose path will be returned.
-    /// - Returns: absolute path to the version.
     func path(version: String) -> AbsolutePath {
         return environmentController.versionsDirectory.appending(component: version)
     }
 
-    /// Returns a list with all the installed versions.
-    ///
-    /// - Returns: installed versions.
     func versions() -> [InstalledVersion] {
         return environmentController.versionsDirectory.glob("*").map { path in
             let versionStringValue = path.components.last!
@@ -132,9 +82,6 @@ class VersionsController: VersionsControlling {
         }
     }
 
-    /// Returns the list of the semver versions.
-    ///
-    /// - Returns: semver versions.
     func semverVersions() -> [Version] {
         return versions().compactMap { version in
             if case let InstalledVersion.semver(semver) = version {

--- a/Tests/TuistEnvKitTests/Commands/BundleCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/BundleCommandTests.swift
@@ -111,12 +111,12 @@ final class BundleCommandTests: XCTestCase {
         try subject.run(with: result)
 
         XCTAssertEqual(printer.printSectionArgs.count, 1)
-        XCTAssertEqual(printer.printSectionArgs.first, "Bundling the version 3.2.1 in the directory \(binPath.asString).")
+        XCTAssertEqual(printer.printSectionArgs.first, "Bundling the version 3.2.1 in the directory \(binPath.asString)")
 
         XCTAssertEqual(printer.printArgs.count, 1)
         XCTAssertEqual(printer.printArgs.first, "Version 3.2.1 not available locally. Installing...")
 
         XCTAssertEqual(printer.printSuccessArgs.count, 1)
-        XCTAssertEqual(printer.printSuccessArgs.first, "tuist bundled successfully at \(binPath.asString).")
+        XCTAssertEqual(printer.printSuccessArgs.first, "tuist bundled successfully at \(binPath.asString)")
     }
 }

--- a/Tests/TuistEnvKitTests/Commands/LocalCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/LocalCommandTests.swift
@@ -11,15 +11,18 @@ final class LocalCommandTests: XCTestCase {
     var subject: LocalCommand!
     var fileHandler: MockFileHandler!
     var printer: MockPrinter!
+    var versionController: MockVersionsController!
 
     override func setUp() {
         super.setUp()
         argumentParser = ArgumentParser(usage: "test", overview: "overview")
         printer = MockPrinter()
         fileHandler = try! MockFileHandler()
+        versionController = try! MockVersionsController()
         subject = LocalCommand(parser: argumentParser,
                                fileHandler: fileHandler,
-                               printer: printer)
+                               printer: printer,
+                               versionController: versionController)
     }
 
     func test_command() {
@@ -27,7 +30,7 @@ final class LocalCommandTests: XCTestCase {
     }
 
     func test_overview() {
-        XCTAssertEqual(LocalCommand.overview, "Creates a .tuist-version file to pin the tuist version that should be used in the current directory.")
+        XCTAssertEqual(LocalCommand.overview, "Creates a .tuist-version file to pin the tuist version that should be used in the current directory. If the version is not specified, it prints the local versions.")
     }
 
     func test_init_registers_the_command() {
@@ -36,7 +39,7 @@ final class LocalCommandTests: XCTestCase {
         XCTAssertEqual(argumentParser.subparsers.first?.value.overview, LocalCommand.overview)
     }
 
-    func test_run() throws {
+    func test_run_when_version_argument_is_passed() throws {
         let result = try argumentParser.parse(["local", "3.2.1"])
         try subject.run(with: result)
 
@@ -45,16 +48,28 @@ final class LocalCommandTests: XCTestCase {
         XCTAssertEqual(try String(contentsOf: versionPath.url), "3.2.1")
     }
 
-    func test_run_prints() throws {
+    func test_run_prints_when_version_argument_is_passed() throws {
         let result = try argumentParser.parse(["local", "3.2.1"])
         try subject.run(with: result)
 
         let versionPath = fileHandler.currentPath.appending(component: Constants.versionFileName)
 
         XCTAssertEqual(printer.printSectionArgs.count, 1)
-        XCTAssertEqual(printer.printSectionArgs.first, "Generating \(Constants.versionFileName) file with version 3.2.1.")
+        XCTAssertEqual(printer.printSectionArgs.first, "Generating \(Constants.versionFileName) file with version 3.2.1")
 
         XCTAssertEqual(printer.printSuccessArgs.count, 1)
-        XCTAssertEqual(printer.printSuccessArgs.last, "File generated at path \(versionPath.asString).")
+        XCTAssertEqual(printer.printSuccessArgs.last, "File generated at path \(versionPath.asString)")
+    }
+
+    func test_run_prints_when_no_argument_is_passed() throws {
+        let result = try argumentParser.parse(["local"])
+        versionController.semverVersionsStub = [Version("1.2.3"), Version("3.2.1")]
+        try subject.run(with: result)
+
+        XCTAssertEqual(printer.printSectionArgs.count, 1)
+        XCTAssertEqual(printer.printSectionArgs.first, "The following versions are available in the local environment:")
+
+        XCTAssertEqual(printer.printArgs.count, 1)
+        XCTAssertEqual(printer.printArgs.last, "- 3.2.1\n- 1.2.3")
     }
 }

--- a/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
+++ b/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
@@ -14,7 +14,7 @@ final class InstallerTests: XCTestCase {
     var subject: Installer!
     var tmpDir: TemporaryDirectory!
     var system: MockSystem!
-    
+
     override func setUp() {
         super.setUp()
         system = MockSystem()
@@ -29,5 +29,4 @@ final class InstallerTests: XCTestCase {
                             buildCopier: buildCopier,
                             versionsController: versionsController)
     }
-
 }


### PR DESCRIPTION
### Short description 📝
By default, `tuist local 3.2.1` will create a `.tuist-version` file in the directory where the command is executed from, that pins that directory to the 3.2.1 version.

This PR adds support for the following command `tuist local` that will print the list of local versions that are available:

![tuist](https://user-images.githubusercontent.com/663605/43228334-4ac8c26c-902f-11e8-96e8-a966a82e8e80.gif)
