### PR TITLE
Add Danger check to make sure tuistenv is generated when files are changed

### DIFF
--- a/Sources/TuistEnvKit/Environment/EnvironmentController.swift
+++ b/Sources/TuistEnvKit/Environment/EnvironmentController.swift
@@ -22,6 +22,7 @@ class EnvironmentController: EnvironmentControlling {
     private let directory: AbsolutePath
 
     /// Filemanager.
+    
     private let fileManager: FileManager = .default
 
     init(directory: AbsolutePath = EnvironmentController.defaultDirectory) {

--- a/peril/pull_request.js
+++ b/peril/pull_request.js
@@ -1,0 +1,14 @@
+import { schedule, danger, warn, fail } from 'danger'
+import { includes } from 'lodash'
+
+// Ensure that the tuistenv binary is generated when tuistenv files are modified
+const hasTuistEnvBin = includes(danger.git.modified_files, 'bin/tuistenv')
+const tuistEnvFiles = danger.git.modified_files.filter(path => {
+  return path.includes('Sources/TuistEnvKit')
+})
+
+if (tuistEnvFiles.length > 0 && !hasTuistEnvBin) {
+  fail(
+    "bin/tuistenv needs to be regenerated. Run 'make build-env' and commit the changes."
+  )
+}

--- a/peril/pull_request.js
+++ b/peril/pull_request.js
@@ -2,15 +2,15 @@ import { schedule, danger, warn, fail } from 'danger'
 import { includes } from 'lodash'
 
 // Ensure that the tuistenv binary is generated when tuistenv files are modified
-const hasTuistEnvBin = includes(danger.git.modified_files, 'bin/tuistenv')
-const tuistEnvFiles = danger.git.modified_files.filter(path => {
-  return path.includes('Sources/TuistEnvKit')
-})
+// const hasTuistEnvBin = includes(danger.git.modified_files, 'bin/tuistenv')
+// const tuistEnvFiles = danger.git.modified_files.filter(path => {
+//   return path.includes('Sources/TuistEnvKit')
+// })
 
-if (tuistEnvFiles.length > 0 && !hasTuistEnvBin) {
-  fail(
-    "bin/tuistenv needs to be regenerated. Run 'make build-env' and commit the changes."
-  )
-}
+// if (tuistEnvFiles.length > 0 && !hasTuistEnvBin) {
+//   fail(
+//     "bin/tuistenv needs to be regenerated. Run 'make build-env' and commit the changes."
+//   )
+// }
 
 fail('fail')

--- a/peril/pull_request.js
+++ b/peril/pull_request.js
@@ -12,3 +12,5 @@ if (tuistEnvFiles.length > 0 && !hasTuistEnvBin) {
     "bin/tuistenv needs to be regenerated. Run 'make build-env' and commit the changes."
   )
 }
+
+fail('fail')


### PR DESCRIPTION
### Short description 📝
Add a Danger check that fails the PR if the `bin/tuistenv` hasn't been re-generated after modifying files under the path `Sources/TuistEnvKit`. 