### PR TITLE
Add FRAMEWORK_SEARCH_PATHS settings when framework dependencies are defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Homebrew formula https://github.com/tuist/tuist/commit/0ab1c6e109134337d4a5e074d77bd305520a935d by @pepibumur.
 
+## Fixed
+
+- `FRAMEWORK_SEARCH_PATHS` build setting not being set for precompiled frameworks dependencies https://github.com/tuist/tuist/pull/87 by @pepibumur.
+
 ## 0.2.0
 
 ### Added

--- a/Sources/TuistCore/Extensions/AbsolutePath+Extras.swift
+++ b/Sources/TuistCore/Extensions/AbsolutePath+Extras.swift
@@ -18,4 +18,8 @@ extension AbsolutePath {
     public func glob(_ pattern: String) -> [AbsolutePath] {
         return Glob(pattern: appending(RelativePath(pattern)).asString).paths.map({ AbsolutePath($0) })
     }
+
+    public func removingLastComponent() -> AbsolutePath {
+        return AbsolutePath("/\(components.dropLast().joined(separator: "/"))")
+    }
 }

--- a/Tests/TuistKitTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/LinkGeneratorTests.swift
@@ -77,6 +77,32 @@ final class LinkGeneratorErrorTests: XCTestCase {
         }
     }
 
+    func test_setupFrameworkSearchPath() throws {
+        let dependencies = [
+            DependencyReference.absolute(AbsolutePath("/Dependencies/A.framework")),
+            DependencyReference.absolute(AbsolutePath("/Dependencies/B.framework")),
+            DependencyReference.absolute(AbsolutePath("/Dependencies/C/C.framework")),
+        ]
+        let sourceRootPath = AbsolutePath("/")
+
+        let objects = PBXObjects()
+        let pbxTarget = PBXNativeTarget(name: "Test")
+        let configurationList = XCConfigurationList(buildConfigurationsReferences: [])
+        pbxTarget.buildConfigurationListReference = objects.addObject(configurationList)
+        let debugConfig = XCBuildConfiguration(name: "Debug")
+        let releaseConfig = XCBuildConfiguration(name: "Release")
+        configurationList.buildConfigurationsReferences.append(objects.addObject(debugConfig))
+        configurationList.buildConfigurationsReferences.append(objects.addObject(releaseConfig))
+
+        try subject.setupFrameworkSearchPath(dependencies: dependencies,
+                                             pbxTarget: pbxTarget,
+                                             sourceRootPath: sourceRootPath)
+
+        let expected = "$(SRCROOT)/Dependencies $(SRCROOT)/Dependencies/C"
+        XCTAssertEqual(debugConfig.buildSettings["FRAMEWORK_SEARCH_PATHS"] as? String, expected)
+        XCTAssertEqual(releaseConfig.buildSettings["FRAMEWORK_SEARCH_PATHS"] as? String, expected)
+    }
+
     func test_setupHeadersSearchPath() throws {
         let headersFolders = [AbsolutePath("/headers")]
         let objects = PBXObjects()


### PR DESCRIPTION
### Short description 📝

Although we added the linking build phase, the framework search paths attributes were not set and that causes the compilation to fail when a target is linking precompiled frameworks.

### Solution 📦

Update the `LinkGenerator` to add that build setting.