### PR TITLE
Pull Carthage dependencies automatically

### DIFF
--- a/Sources/TuistCore/Utils/FileHandler.swift
+++ b/Sources/TuistCore/Utils/FileHandler.swift
@@ -1,110 +1,53 @@
 import Basic
 import Foundation
 
-/// Protocol that represents an object that can handle files.
 public protocol FileHandling: AnyObject {
-    /// Returns the current path.
     var currentPath: AbsolutePath { get }
-
-    /// Returns whether a given path points to an existing file.
-    ///
-    /// - Parameter path: path to check.
-    /// - Returns: true if there's a file at the given path.
     func exists(_ path: AbsolutePath) -> Bool
-
-    /// Copies a file from one location to another.
-    ///
-    /// - Parameters:
-    ///   - from: the location the file is being copied from.
-    ///   - to: the location the file is being copied to.
     func copy(from: AbsolutePath, to: AbsolutePath) throws
-
-    /// Returns all the files using the glob pattern.
-    ///
-    /// - Parameters:
-    ///   - path: base path.
-    ///   - glob: glob pattern.
-    /// - Returns: list of paths that have been found matching the glob pattern.
     func glob(_ path: AbsolutePath, glob: String) -> [AbsolutePath]
-
-    /// Creates a folder at the given path.
-    ///
-    /// - Parameter path: path.
     func createFolder(_ path: AbsolutePath) throws
-
-    /// Deletes the file at the given path.
-    ///
-    /// - Parameter path: path where the file is.
-    /// - Throws: an error if the deletion fails.
     func delete(_ path: AbsolutePath) throws
-
-    /// Returns true if the file at the given path is a folder.
-    ///
-    /// - Parameter path: path to the file/folder.
-    /// - Returns: true if the path points to a folder.
     func isFolder(_ path: AbsolutePath) -> Bool
+    func touch(_ path: AbsolutePath) throws
 }
 
-/// Default file handler implementing FileHandling.
 public final class FileHandler: FileHandling {
     public init() {}
 
-    /// Returns the current path.
     public var currentPath: AbsolutePath {
         return AbsolutePath(FileManager.default.currentDirectoryPath)
     }
 
-    /// Returns whether a given path points to an existing file.
-    ///
-    /// - Parameter path: path to check.
-    /// - Returns: true if there's a file at the given path.
     public func exists(_ path: AbsolutePath) -> Bool {
         return FileManager.default.fileExists(atPath: path.asString)
     }
 
-    /// Copies a file from one location to another.
-    ///
-    /// - Parameters:
-    ///   - from: the location the file is being copied from.
-    ///   - to: the location the file is being copied to.
     public func copy(from: AbsolutePath, to: AbsolutePath) throws {
         try FileManager.default.copyItem(atPath: from.asString, toPath: to.asString)
     }
 
-    /// Returns all the files using the glob pattern.
-    ///
-    /// - Parameters:
-    ///   - path: base path.
-    ///   - glob: glob pattern.
-    /// - Returns: list of paths that have been found matching the glob pattern.
     public func glob(_ path: AbsolutePath, glob: String) -> [AbsolutePath] {
         return path.glob(glob)
     }
 
-    /// Creates a folder at the given path.
-    ///
-    /// - Parameter path: path.
     public func createFolder(_ path: AbsolutePath) throws {
         try FileManager.default.createDirectory(at: path.url,
                                                 withIntermediateDirectories: true,
                                                 attributes: nil)
     }
 
-    /// Deletes the file at the given path.
-    ///
-    /// - Parameter path: path where the file is.
-    /// - Throws: an error if the deletion fails.
     public func delete(_ path: AbsolutePath) throws {
         try FileManager.default.removeItem(atPath: path.asString)
     }
 
-    /// Returns true if the file at the given path is a folder.
-    ///
-    /// - Parameter path: path to the file/folder.
-    /// - Returns: true if the path points to a folder.
     public func isFolder(_ path: AbsolutePath) -> Bool {
         var isDirectory = ObjCBool(true)
         let exists = FileManager.default.fileExists(atPath: path.asString, isDirectory: &isDirectory)
         return exists && isDirectory.boolValue
+    }
+
+    public func touch(_ path: AbsolutePath) throws {
+        try Data().write(to: path.url)
     }
 }

--- a/Sources/TuistCore/Utils/System.swift
+++ b/Sources/TuistCore/Utils/System.swift
@@ -64,8 +64,11 @@ public final class System: Systeming {
     }
 
     @discardableResult
-    public func capture(_ args: [String], verbose _: Bool = false) throws -> SystemResult {
-        precondition(args.count >= 1, "Invalid number of argumentss")
+    public func capture(_ args: [String], verbose: Bool = false) throws -> SystemResult {
+        precondition(args.count >= 1, "Invalid number of arguments")
+        if verbose {
+            printer.print("Running command: \(args.joined(separator: " "))")
+        }
         let arguments = ["/bin/bash", "-c", "\(args.map({ $0.shellEscaped() }).joined(separator: " "))"]
         return try task(arguments).first()!.dematerialize()
     }
@@ -74,8 +77,11 @@ public final class System: Systeming {
         try popen(args, verbose: verbose)
     }
 
-    public func popen(_ args: [String], verbose _: Bool = false) throws {
+    public func popen(_ args: [String], verbose: Bool = false) throws {
         precondition(args.count >= 1, "Invalid number of arguments")
+        if verbose {
+            printer.print("Running command: \(args.joined(separator: " "))")
+        }
         let arguments = ["/bin/bash", "-c", "\(args.map({ $0.shellEscaped() }).joined(separator: " "))"]
         _ = task(arguments, print: true).wait()
     }

--- a/Sources/TuistCore/Utils/System.swift
+++ b/Sources/TuistCore/Utils/System.swift
@@ -9,7 +9,7 @@ public protocol Systeming {
     func popen(_ args: [String], verbose: Bool) throws
 }
 
-public struct SystemError: FatalError {
+public struct SystemError: FatalError, Equatable {
     let stderror: String?
     let exitcode: Int32
 
@@ -24,6 +24,11 @@ public struct SystemError: FatalError {
     public init(stderror: String? = nil, exitcode: Int32) {
         self.stderror = stderror
         self.exitcode = exitcode
+    }
+
+    public static func == (lhs: SystemError, rhs: SystemError) -> Bool {
+        return lhs.stderror == rhs.stderror &&
+            lhs.exitcode == rhs.exitcode
     }
 }
 

--- a/Sources/TuistCoreTesting/Utils/MockFileHandler.swift
+++ b/Sources/TuistCoreTesting/Utils/MockFileHandler.swift
@@ -38,4 +38,8 @@ public final class MockFileHandler: FileHandling {
     public func isFolder(_ path: AbsolutePath) -> Bool {
         return fileHandler.isFolder(path)
     }
+
+    public func touch(_ path: AbsolutePath) throws {
+        try fileHandler.touch(path)
+    }
 }

--- a/Sources/TuistKit/Carthage/CarthageController.swift
+++ b/Sources/TuistKit/Carthage/CarthageController.swift
@@ -12,6 +12,14 @@ final class CarthageController: CarthageControlling {
 
     private static let pathRegex: NSRegularExpression = try! NSRegularExpression(pattern: "(.+)/Carthage/Build/.+/.+\\.framework", options: [])
 
+    static func isCarthageFramework(_ path: AbsolutePath) -> Bool {
+        let range = NSRange(location: 0, length: path.asString.count)
+        if CarthageController.pathRegex.matches(in: path.asString, options: [], range: range).isEmpty {
+            return false
+        }
+        return true
+    }
+
     // MARK: - Attributes
 
     private let system: Systeming

--- a/Sources/TuistKit/Carthage/CarthageController.swift
+++ b/Sources/TuistKit/Carthage/CarthageController.swift
@@ -1,0 +1,103 @@
+import Basic
+import Foundation
+import TuistCore
+
+protocol CarthageControlling: AnyObject {
+    func updateIfNecessary(graph: Graphing) throws
+}
+
+final class CarthageController: CarthageControlling {
+
+    // MARK: - Static
+
+    private static let pathRegex: NSRegularExpression = try! NSRegularExpression(pattern: "(.+)/Carthage/Build/.+/.+\\.framework", options: [])
+
+    // MARK: - Attributes
+
+    private let system: Systeming
+    private let fileHandler: FileHandling
+    private let printer: Printing
+
+    // MARK: - Init
+
+    init(system: Systeming = System(),
+         fileHandler: FileHandling = FileHandler(),
+         printer: Printing = Printer()) {
+        self.system = system
+        self.fileHandler = fileHandler
+        self.printer = printer
+    }
+
+    // MARK: - Internal
+
+    func carthagePath() throws -> AbsolutePath? {
+        do {
+            guard let path = try system.capture("which", "carthage", verbose: false).stdout.chuzzle() else {
+                return nil
+            }
+            return AbsolutePath(path)
+        } catch {
+            return nil
+        }
+    }
+
+    func updateIfNecessary(graph: Graphing) throws {
+        let carthageDependencies = self.carthageDependencies(graph: graph)
+        if carthageDependencies.isEmpty { return }
+
+        let nonExistingCarthageDependencies = carthageDependencies.filter { !fileHandler.exists($0) }
+        if nonExistingCarthageDependencies.isEmpty { return }
+
+        let foldersWithCartfile = self.foldersWithCartfile(dependenciesPaths: nonExistingCarthageDependencies)
+
+        var message = "The following Carthage dependencies need to be pulled:\n"
+        message.append(nonExistingCarthageDependencies.map({ " - \($0.asString)" }).joined(separator: "\n"))
+        printer.print(message)
+
+        try foldersWithCartfile.forEach { path in
+            printer.print("Updating Carthage dependencies at \(path.asString)")
+
+            guard let carthagePath = try self.carthagePath() else {
+                throw CarthageError.notFound
+            }
+
+            try system.capture(carthagePath.asString,
+                               "--project-directory",
+                               path.asString, verbose: true).throwIfError()
+        }
+    }
+
+    // MARK: - Private
+
+    func foldersWithCartfile(dependenciesPaths: [AbsolutePath]) -> [AbsolutePath] {
+        return dependenciesPaths.compactMap { (path) -> AbsolutePath? in
+            let pathString = path.asString
+            let pathRange = NSRange(location: 0, length: pathString.count)
+
+            guard let match = CarthageController.pathRegex.firstMatch(in: pathString, options: [], range: pathRange) else {
+                return nil
+            }
+
+            let folderPath = AbsolutePath((pathString as NSString).substring(with: match.range(at: 1)))
+            let cartfilePath = folderPath.appending(component: "Cartfile")
+
+            if fileHandler.exists(cartfilePath) {
+                return folderPath
+            }
+
+            return nil
+        }
+    }
+
+    func carthageDependencies(graph: Graphing) -> [AbsolutePath] {
+        let precompiledPaths = graph.precompiledNodes.map { $0.path }
+        return precompiledPaths.compactMap { (path) -> AbsolutePath? in
+            let pathString = path.asString
+            let pathRange = NSRange(location: 0, length: pathString.count)
+            if CarthageController.pathRegex.matches(in: pathString, options: [], range: pathRange).isEmpty {
+                return nil
+            }
+            return path
+        }
+    }
+}

--- a/Sources/TuistKit/Carthage/CarthageError.swift
+++ b/Sources/TuistKit/Carthage/CarthageError.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TuistCore
 
-enum CarthageError: FatalError {
+enum CarthageError: FatalError, Equatable {
     case notFound
 
     var type: ErrorType {

--- a/Sources/TuistKit/Carthage/CarthageError.swift
+++ b/Sources/TuistKit/Carthage/CarthageError.swift
@@ -1,0 +1,20 @@
+import Foundation
+import TuistCore
+
+enum CarthageError: FatalError {
+    case notFound
+
+    var type: ErrorType {
+        switch self {
+        case .notFound:
+            return .abort
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .notFound:
+            return "Carthage not found"
+        }
+    }
+}

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -63,6 +63,8 @@ class GenerateCommand: NSObject, Command {
     }
 
     func run(with arguments: ArgumentParser.Result) throws {
+        printer.print(section: "Generating project")
+
         let path = self.path(arguments: arguments)
         let config = try parseConfig(arguments: arguments)
         let graph = try graphLoader.load(path: path)
@@ -80,7 +82,7 @@ class GenerateCommand: NSObject, Command {
                                         printer: printer,
                                         resourceLocator: resourceLocator)
 
-        printer.print(success: "Project generated.")
+        printer.print(success: "Project generated")
     }
 
     // MARK: - Fileprivate

--- a/Sources/TuistKit/Generator/GenerationOptions.swift
+++ b/Sources/TuistKit/Generator/GenerationOptions.swift
@@ -1,16 +1,13 @@
 import Basic
 import Foundation
 
-/// Generation options.
 class GenerationOptions {
-    /// Build configuration to be generated (Debug or Release)
     let buildConfiguration: BuildConfiguration
+    let skipCarthage: Bool
 
-    /// Initializes the options with its attributes.
-    ///
-    /// - Parameters:
-    ///   - buildConfiguration: build configuration.
-    init(buildConfiguration: BuildConfiguration = .debug) {
+    init(buildConfiguration: BuildConfiguration = .debug,
+         skipCarthage: Bool = false) {
         self.buildConfiguration = buildConfiguration
+        self.skipCarthage = skipCarthage
     }
 }

--- a/Sources/TuistKit/Generator/GenerationOptions.swift
+++ b/Sources/TuistKit/Generator/GenerationOptions.swift
@@ -3,11 +3,8 @@ import Foundation
 
 class GenerationOptions {
     let buildConfiguration: BuildConfiguration
-    let skipCarthage: Bool
 
-    init(buildConfiguration: BuildConfiguration = .debug,
-         skipCarthage: Bool = false) {
+    init(buildConfiguration: BuildConfiguration = .debug) {
         self.buildConfiguration = buildConfiguration
-        self.skipCarthage = skipCarthage
     }
 }

--- a/Sources/TuistKit/Loader/Graph.swift
+++ b/Sources/TuistKit/Loader/Graph.swift
@@ -42,6 +42,7 @@ protocol Graphing: AnyObject {
     var cache: GraphLoaderCaching { get }
     var entryNodes: [GraphNode] { get }
     var projects: [Project] { get }
+    var precompiledNodes: [PrecompiledNode] { get }
     func linkableDependencies(path: AbsolutePath, name: String) throws -> [DependencyReference]
     func librariesPublicHeadersFolders(path: AbsolutePath, name: String) -> [AbsolutePath]
     func embeddableFrameworks(path: AbsolutePath, name: String, system: Systeming) throws -> [DependencyReference]
@@ -60,6 +61,10 @@ class Graph: Graphing {
     let entryNodes: [GraphNode]
     var projects: [Project] {
         return Array(cache.projects.values)
+    }
+
+    var precompiledNodes: [PrecompiledNode] {
+        return Array(cache.precompiledNodes.values)
     }
 
     // MARK: - Init

--- a/Sources/TuistKit/Loader/GraphNode.swift
+++ b/Sources/TuistKit/Loader/GraphNode.swift
@@ -174,7 +174,9 @@ class FrameworkNode: PrecompiledNode {
                       fileHandler: FileHandling,
                       cache: GraphLoaderCaching) throws -> FrameworkNode {
         let absolutePath = projectPath.appending(path)
-        if !fileHandler.exists(absolutePath) {
+        if !fileHandler.exists(absolutePath) &&
+            // If a Carthage framework doesn't exist, tuist will pull it
+            !CarthageController.isCarthageFramework(absolutePath) {
             throw GraphLoadingError.missingFile(absolutePath)
         }
         if let frameworkNode = cache.precompiledNode(absolutePath) as? FrameworkNode { return frameworkNode }

--- a/Tests/TuistKitTests/Carthage/CarthageControllerTests.swift
+++ b/Tests/TuistKitTests/Carthage/CarthageControllerTests.swift
@@ -1,0 +1,79 @@
+import Basic
+import Foundation
+import TuistCore
+@testable import TuistCoreTesting
+@testable import TuistKit
+import XCTest
+
+final class CarthageControllerTests: XCTestCase {
+    var system: MockSystem!
+    var fileHandler: MockFileHandler!
+    var printer: MockPrinter!
+    var subject: CarthageController!
+    var graph: MockGraph!
+    var frameworkNode: FrameworkNode!
+    var cartfilePath: AbsolutePath!
+    var frameworkPath: AbsolutePath!
+
+    override func setUp() {
+        super.setUp()
+        system = MockSystem()
+        fileHandler = try! MockFileHandler()
+        printer = MockPrinter()
+
+        cartfilePath = fileHandler.currentPath.appending(components: "Cartfile")
+        frameworkPath = fileHandler.currentPath.appending(components: "Carthage", "Build", "iOS", "Test.framework")
+
+        try! fileHandler.touch(cartfilePath)
+        frameworkNode = FrameworkNode(path: frameworkPath)
+
+        graph = MockGraph(entryPath: fileHandler.currentPath,
+                          precompiledNodes: [frameworkNode])
+        subject = CarthageController(system: system,
+                                     fileHandler: fileHandler,
+                                     printer: printer)
+    }
+
+    func test_updateIfNecessary() throws {
+        system.stub(args: ["which", "carthage"],
+                    stderror: nil,
+                    stdout: "/bin/carthage",
+                    exitstatus: 0)
+        system.stub(args: ["/bin/carthage", "--project-directory", fileHandler.currentPath.asString],
+                    stderror: nil,
+                    stdout: "output",
+                    exitstatus: 0)
+
+        try subject.updateIfNecessary(graph: graph)
+
+        XCTAssertEqual(printer.printArgs.first, "The following Carthage dependencies need to be pulled:\n - \(frameworkPath.asString)")
+        XCTAssertEqual(printer.printArgs.last, "Updating Carthage dependencies at \(fileHandler.currentPath.asString)")
+    }
+
+    func test_updateIfNecessary_throws_when_carthage_cannot_be_found() throws {
+        system.stub(args: ["which", "carthage"],
+                    stderror: "carthage not found",
+                    stdout: nil,
+                    exitstatus: 1)
+
+        XCTAssertThrowsError(try subject.updateIfNecessary(graph: graph)) {
+            XCTAssertEqual($0 as? CarthageError, .notFound)
+        }
+    }
+
+    func test_updateIfNecessary_throws_when_carthage_update_fails() throws {
+        system.stub(args: ["which", "carthage"],
+                    stderror: nil,
+                    stdout: "/bin/carthage",
+                    exitstatus: 0)
+        system.stub(args: ["/bin/carthage", "--project-directory", fileHandler.currentPath.asString],
+                    stderror: "it failed",
+                    stdout: nil,
+                    exitstatus: 1)
+
+        XCTAssertThrowsError(try subject.updateIfNecessary(graph: graph)) {
+            XCTAssertEqual($0 as? SystemError, SystemError(stderror: "it failed",
+                                                           exitcode: 1))
+        }
+    }
+}

--- a/Tests/TuistKitTests/Carthage/Mocks/MockCarthageController.swift
+++ b/Tests/TuistKitTests/Carthage/Mocks/MockCarthageController.swift
@@ -1,0 +1,12 @@
+import Foundation
+@testable import TuistKit
+
+final class MockCarthageController: CarthageControlling {
+    var updateIfNecessaryCount: UInt = 0
+    var updateIfNecessaryStub: ((Graphing) throws -> Void)?
+
+    func updateIfNecessary(graph: Graphing) throws {
+        updateIfNecessaryCount += 1
+        try updateIfNecessaryStub?(graph)
+    }
+}

--- a/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
@@ -13,6 +13,7 @@ final class GenerateCommandTests: XCTestCase {
     var workspaceGenerator: MockWorkspaceGenerator!
     var parser: ArgumentParser!
     var printer: MockPrinter!
+    var carthageController: MockCarthageController!
 
     override func setUp() {
         super.setUp()
@@ -21,9 +22,11 @@ final class GenerateCommandTests: XCTestCase {
         graphLoader = MockGraphLoader()
         workspaceGenerator = MockWorkspaceGenerator()
         parser = ArgumentParser.test()
+        carthageController = MockCarthageController()
         subject = GenerateCommand(graphLoader: graphLoader,
                                   workspaceGenerator: workspaceGenerator,
                                   parser: parser,
+                                  carthageController: carthageController,
                                   printer: printer)
     }
 
@@ -58,5 +61,17 @@ final class GenerateCommandTests: XCTestCase {
         let result = try parser.parse([GenerateCommand.command, "-c", "Debug"])
         try subject.run(with: result)
         XCTAssertEqual(printer.printSuccessArgs.first, "Project generated.")
+    }
+
+    func test_run_updates_carthage_dependencies() throws {
+        let result = try parser.parse([GenerateCommand.command])
+        try subject.run(with: result)
+        XCTAssertEqual(carthageController.updateIfNecessaryCount, 1)
+    }
+
+    func test_run_doesnt_update_carthage_dependencies_when_skipCarthage_is_passed() throws {
+        let result = try parser.parse([GenerateCommand.command, "--skip-carthage"])
+        try subject.run(with: result)
+        XCTAssertEqual(carthageController.updateIfNecessaryCount, 0)
     }
 }

--- a/Tests/TuistKitTests/Loader/Mocks/MockGraph.swift
+++ b/Tests/TuistKitTests/Loader/Mocks/MockGraph.swift
@@ -1,0 +1,57 @@
+import Basic
+import Foundation
+import TuistCore
+@testable import TuistKit
+
+final class MockGraph: Graphing {
+    let name: String
+    let entryPath: AbsolutePath
+    let entryNodes: [GraphNode]
+    let cache: GraphLoaderCaching
+    let projects: [Project]
+    let precompiledNodes: [PrecompiledNode]
+    var linkableDependenciesCallStub: ((AbsolutePath, String) throws -> [DependencyReference])?
+    var librariesPublicHeadersFoldersStub: ((AbsolutePath, String) -> [AbsolutePath])?
+    var embeddableFrameworksStub: ((AbsolutePath, String, Systeming) throws -> [DependencyReference])?
+    var dependenciesWithNameStub: ((AbsolutePath, String) -> Set<GraphNode>)?
+    var dependenciesStub: ((AbsolutePath) -> Set<GraphNode>)?
+    var targetDependenciesStub: ((AbsolutePath, String) -> [String])?
+
+    init(name: String = "Test",
+         entryPath: AbsolutePath,
+         cache: GraphLoaderCaching = GraphLoaderCache(),
+         projects: [Project] = [],
+         entryNodes: [GraphNode] = [],
+         precompiledNodes: [PrecompiledNode] = []) {
+        self.name = name
+        self.entryPath = entryPath
+        self.projects = projects
+        self.entryNodes = entryNodes
+        self.precompiledNodes = precompiledNodes
+        self.cache = cache
+    }
+
+    func linkableDependencies(path: AbsolutePath, name: String) throws -> [DependencyReference] {
+        return try linkableDependenciesCallStub?(path, name) ?? []
+    }
+
+    func librariesPublicHeadersFolders(path: AbsolutePath, name: String) -> [AbsolutePath] {
+        return librariesPublicHeadersFoldersStub?(path, name) ?? []
+    }
+
+    func embeddableFrameworks(path: AbsolutePath, name: String, system: Systeming) throws -> [DependencyReference] {
+        return try embeddableFrameworksStub?(path, name, system) ?? []
+    }
+
+    func dependencies(path: AbsolutePath, name: String) -> Set<GraphNode> {
+        return dependenciesWithNameStub?(path, name) ?? Set()
+    }
+
+    func dependencies(path: AbsolutePath) -> Set<GraphNode> {
+        return dependenciesStub?(path) ?? Set()
+    }
+
+    func targetDependencies(path: AbsolutePath, name: String) -> [String] {
+        return targetDependenciesStub?(path, name) ?? []
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/https://github.com/tuist/tuist/issues/89
Resolves https://github.com/tuist/tuist/issues/85

### Short description 📝

Tuist pulls Carthage dependencies automatically. It matches the paths of the precompiled frameworks and if they are in a Carthage path, `.../Carthage/Build/.../....` it pulls them if they don't exist.

This behavior can be disabled by passing the argument `--skip-carthage`

```bash
tuist generate --skip-carthage
```

### Implementation 👩‍💻👨‍💻

- [x] Add Carthage controller.
- [x] Update `GenerateCommand` to use it.
- [x] Add tests to `CarthageController` and `GenerateCommand`.