### PR TITLE
Use https links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Homebrew formula https://github.com/tuist/tuist/commit/0ab1c6e109134337d4a5e074d77bd305520a935d by @pepibumur.
 
+## Changed
+
+- Replaced ssh links with the https version of them https://github.com/tuist/tuist/pull/91 by @pepibumur.
+
 ## Fixed
 
 - `FRAMEWORK_SEARCH_PATHS` build setting not being set for precompiled frameworks dependencies https://github.com/tuist/tuist/pull/87 by @pepibumur.

--- a/Package.swift
+++ b/Package.swift
@@ -12,9 +12,9 @@ let package = Package(
                  targets: ["ProjectDescription"]),
     ],
     dependencies: [
-        .package(url: "git@github.com:tuist/xcodeproj.git", .revision("549d67686d90ef8e45fccdca147682f185af2ad0")),
-        .package(url: "git@github.com:carthage/ReactiveTask.git", .revision("57d221b82270b05380d66117e07ac4069b78a4e9")),
-        .package(url: "git@github.com:apple/swift-package-manager.git", .revision("3e71e57db41ebb32ccec1841a7e26c428a9c08c5")),
+        .package(url: "https://github.com/tuist/xcodeproj.git", .revision("549d67686d90ef8e45fccdca147682f185af2ad0")),
+        .package(url: "https://github.com/carthage/ReactiveTask.git", .revision("57d221b82270b05380d66117e07ac4069b78a4e9")),
+        .package(url: "https://github.com/apple/swift-package-manager.git", .revision("3e71e57db41ebb32ccec1841a7e26c428a9c08c5")),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@
 
 **Using Homebrew:**
 
-```
-brew tap tuist/tuist git@github.com:tuist/tuist.git
+```bash
+brew tap tuist/tuist https://github.com/tuist/tuist
 brew install tuist
 ```
 

--- a/Sources/TuistCore/Constants.swift
+++ b/Sources/TuistCore/Constants.swift
@@ -4,7 +4,7 @@ public class Constants {
     public static let versionFileName = ".tuist-version"
     public static let binFolderName = ".tuist-bin"
     public static let binName = "tuist"
-    public static let gitRepositorySSH = "git@github.com:tuist/tuist.git"
+    public static let gitRepositorySSH = "https://github.com/tuist/tuist.git"
     public static let version = "0.2.0"
     public static let swiftVersion: String = "4.1.2"
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/88

### Short description 📝

As @dcordero pointed out, GitHub encourages using https links instead of ssh's.

### Solution 📦

Replace ssh links with the https version of them.