### PR TITLE
Update Package.resolved so that it links to https urls

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -39,7 +39,7 @@
       },
       {
         "package": "ReactiveTask",
-        "repositoryURL": "git@github.com:carthage/ReactiveTask.git",
+        "repositoryURL": "https://github.com/carthage/ReactiveTask.git",
         "state": {
           "branch": null,
           "revision": "57d221b82270b05380d66117e07ac4069b78a4e9",
@@ -57,7 +57,7 @@
       },
       {
         "package": "SwiftPM",
-        "repositoryURL": "https://github.com/apple/swift-package-manager",
+        "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
           "branch": null,
           "revision": "3e71e57db41ebb32ccec1841a7e26c428a9c08c5",
@@ -66,7 +66,7 @@
       },
       {
         "package": "xcodeproj",
-        "repositoryURL": "git@github.com:tuist/xcodeproj.git",
+        "repositoryURL": "https://github.com/tuist/xcodeproj.git",
         "state": {
           "branch": null,
           "revision": "549d67686d90ef8e45fccdca147682f185af2ad0",


### PR DESCRIPTION
### Short description 📝

Minor change. This PR only updates Package.resolved after the changes introduced in #91, so that resolved dependencies are actually fetched from https urls.