### PR TITLE
Remove ReactiveTask

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,13 +13,12 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/tuist/xcodeproj.git", .revision("549d67686d90ef8e45fccdca147682f185af2ad0")),
-        .package(url: "https://github.com/carthage/ReactiveTask.git", .revision("57d221b82270b05380d66117e07ac4069b78a4e9")),
         .package(url: "https://github.com/apple/swift-package-manager.git", .revision("3e71e57db41ebb32ccec1841a7e26c428a9c08c5")),
     ],
     targets: [
         .target(
             name: "TuistCore",
-            dependencies: ["Utility", "ReactiveTask"]),
+            dependencies: ["Utility"]),
         .target(
             name: "TuistCoreTesting",
             dependencies: ["TuistCore"]),

--- a/Sources/TuistCore/Utils/System.swift
+++ b/Sources/TuistCore/Utils/System.swift
@@ -1,6 +1,5 @@
+import Basic
 import Foundation
-import ReactiveSwift
-import ReactiveTask
 
 public protocol Systeming {
     func capture(_ args: [String], verbose: Bool) throws -> SystemResult
@@ -24,6 +23,15 @@ public struct SystemError: FatalError {
     public init(stderror: String? = nil, exitcode: Int32) {
         self.stderror = stderror
         self.exitcode = exitcode
+    }
+}
+
+extension ProcessResult.ExitStatus {
+    var exitcode: Int32 {
+        switch self {
+        case let .signalled(exitcode): return exitcode
+        case let .terminated(exitcode): return exitcode
+        }
     }
 }
 
@@ -67,7 +75,8 @@ public final class System: Systeming {
     public func capture(_ args: [String], verbose _: Bool = false) throws -> SystemResult {
         precondition(args.count >= 1, "Invalid number of argumentss")
         let arguments = ["/bin/bash", "-c", "\(args.map({ $0.shellEscaped() }).joined(separator: " "))"]
-        return try task(arguments).first()!.dematerialize()
+        let result = try Process.popen(arguments: arguments)
+        return try SystemResult(stdout: result.utf8Output(), stderror: result.utf8stderrOutput(), exitcode: result.exitStatus.exitcode)
     }
 
     public func popen(_ args: String..., verbose: Bool = false) throws {
@@ -77,41 +86,8 @@ public final class System: Systeming {
     public func popen(_ args: [String], verbose _: Bool = false) throws {
         precondition(args.count >= 1, "Invalid number of arguments")
         let arguments = ["/bin/bash", "-c", "\(args.map({ $0.shellEscaped() }).joined(separator: " "))"]
-        _ = task(arguments, print: true).wait()
-    }
-
-    // MARK: - Fileprivate
-
-    fileprivate func task(_ args: [String], print: Bool = false) -> SignalProducer<SystemResult, SystemError> {
-        let task = Task(args.first!, arguments: Array(args.dropFirst()), workingDirectoryPath: nil, environment: nil)
-        return task.launch()
-            .on(value: {
-                if !print { return }
-                switch $0 {
-                case let .standardError(error):
-                    FileHandle.standardError.write(error)
-                case let .standardOutput(output):
-                    FileHandle.standardOutput.write(output)
-                default:
-                    break
-                }
-            })
-            .ignoreTaskData()
-            .mapError { (error: TaskError) -> SystemError in
-                switch error {
-                case let TaskError.posixError(code):
-                    return SystemError(stderror: nil, exitcode: code)
-                case let TaskError.shellTaskFailed(_, code, standardError):
-                    return SystemError(stderror: standardError, exitcode: code)
-                }
-            }
-            .map { data in
-                let stdout = String(data: data, encoding: .utf8)!
-                return SystemResult(stdout: stdout, stderror: "", exitcode: 0)
-            }
-    }
-
-    fileprivate func print(command: [String]) {
-        printer.print(command.joined(separator: " "))
+        let process = Process(arguments: arguments, redirectOutput: false)
+        try process.launch()
+        try process.waitUntilExit()
     }
 }


### PR DESCRIPTION
### Short description 📝
The `Process` util class from SPM is enough for what we need now. It makes no sense introducing a dependency like `ReactiveTask` that comes with a large dependency, `ReactiveSwift`.

### Solution 📦
Delete and update `System` to use `Process` from SPM.
