### PR TITLE
Show a linting warning if a Carthage dependency doesnt exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next version
 
+### Changed
+
+- Don't fail if a Carthage framework doesn't exist. Print a warning instead https://github.com/tuist/tuist/pull/96 by @pepibuymur
+
 ## 0.3.0
 
 ### Added

--- a/Sources/TuistCore/Utils/FileHandler.swift
+++ b/Sources/TuistCore/Utils/FileHandler.swift
@@ -1,107 +1,50 @@
 import Basic
 import Foundation
 
-/// Protocol that represents an object that can handle files.
 public protocol FileHandling: AnyObject {
-    /// Returns the current path.
     var currentPath: AbsolutePath { get }
-
-    /// Returns whether a given path points to an existing file.
-    ///
-    /// - Parameter path: path to check.
-    /// - Returns: true if there's a file at the given path.
     func exists(_ path: AbsolutePath) -> Bool
-
-    /// Copies a file from one location to another.
-    ///
-    /// - Parameters:
-    ///   - from: the location the file is being copied from.
-    ///   - to: the location the file is being copied to.
     func copy(from: AbsolutePath, to: AbsolutePath) throws
-
-    /// Returns all the files using the glob pattern.
-    ///
-    /// - Parameters:
-    ///   - path: base path.
-    ///   - glob: glob pattern.
-    /// - Returns: list of paths that have been found matching the glob pattern.
     func glob(_ path: AbsolutePath, glob: String) -> [AbsolutePath]
-
-    /// Creates a folder at the given path.
-    ///
-    /// - Parameter path: path.
     func createFolder(_ path: AbsolutePath) throws
-
-    /// Deletes the file at the given path.
-    ///
-    /// - Parameter path: path where the file is.
-    /// - Throws: an error if the deletion fails.
     func delete(_ path: AbsolutePath) throws
-
-    /// Returns true if the file at the given path is a folder.
-    ///
-    /// - Parameter path: path to the file/folder.
-    /// - Returns: true if the path points to a folder.
     func isFolder(_ path: AbsolutePath) -> Bool
+    func touch(_ path: AbsolutePath) throws
 }
 
-/// Default file handler implementing FileHandling.
 public final class FileHandler: FileHandling {
     public init() {}
 
-    /// Returns the current path.
     public var currentPath: AbsolutePath {
         return AbsolutePath(FileManager.default.currentDirectoryPath)
     }
 
-    /// Returns whether a given path points to an existing file.
-    ///
-    /// - Parameter path: path to check.
-    /// - Returns: true if there's a file at the given path.
     public func exists(_ path: AbsolutePath) -> Bool {
         return FileManager.default.fileExists(atPath: path.asString)
     }
 
-    /// Copies a file from one location to another.
-    ///
-    /// - Parameters:
-    ///   - from: the location the file is being copied from.
-    ///   - to: the location the file is being copied to.
     public func copy(from: AbsolutePath, to: AbsolutePath) throws {
         try FileManager.default.copyItem(atPath: from.asString, toPath: to.asString)
     }
 
-    /// Returns all the files using the glob pattern.
-    ///
-    /// - Parameters:
-    ///   - path: base path.
-    ///   - glob: glob pattern.
-    /// - Returns: list of paths that have been found matching the glob pattern.
     public func glob(_ path: AbsolutePath, glob: String) -> [AbsolutePath] {
         return path.glob(glob)
     }
 
-    /// Creates a folder at the given path.
-    ///
-    /// - Parameter path: path.
     public func createFolder(_ path: AbsolutePath) throws {
         try FileManager.default.createDirectory(at: path.url,
                                                 withIntermediateDirectories: true,
                                                 attributes: nil)
     }
 
-    /// Deletes the file at the given path.
-    ///
-    /// - Parameter path: path where the file is.
-    /// - Throws: an error if the deletion fails.
     public func delete(_ path: AbsolutePath) throws {
         try FileManager.default.removeItem(atPath: path.asString)
     }
 
-    /// Returns true if the file at the given path is a folder.
-    ///
-    /// - Parameter path: path to the file/folder.
-    /// - Returns: true if the path points to a folder.
+    public func touch(_ path: AbsolutePath) throws {
+        try Data().write(to: path.url)
+    }
+
     public func isFolder(_ path: AbsolutePath) -> Bool {
         var isDirectory = ObjCBool(true)
         let exists = FileManager.default.fileExists(atPath: path.asString, isDirectory: &isDirectory)

--- a/Sources/TuistCoreTesting/Utils/MockFileHandler.swift
+++ b/Sources/TuistCoreTesting/Utils/MockFileHandler.swift
@@ -35,6 +35,10 @@ public final class MockFileHandler: FileHandling {
         try fileHandler.delete(path)
     }
 
+    public func touch(_ path: AbsolutePath) throws {
+        try fileHandler.touch(path)
+    }
+
     public func isFolder(_ path: AbsolutePath) -> Bool {
         return fileHandler.isFolder(path)
     }

--- a/Sources/TuistKit/Linter/GraphLinter.swift
+++ b/Sources/TuistKit/Linter/GraphLinter.swift
@@ -42,9 +42,22 @@ class GraphLinter: GraphLinting {
     }
 
     fileprivate func lintCarthageDependencies(graph: Graphing) -> [LintingIssue] {
-        return graph.carthageFrameworks
+        let frameworks = graph.frameworks
+        let carthageFrameworks = frameworks.filter({ $0.isCarthage })
+        let nonCarthageFrameworks = frameworks.filter({ !$0.isCarthage })
+
+        let carthageIssues = carthageFrameworks
             .filter({ !fileHandler.exists($0.path) })
-            .map({ LintingIssue(reason: "Carthage framework at path \($0.path.asString) doesn't exist. Run 'carthage update'.", severity: .warning) })
+            .map({ LintingIssue(reason: "Framework not found at path \($0.path.asString). The path might be wrong or Carthage dependencies not fetched.", severity: .warning) })
+        let nonCarthageIssues = nonCarthageFrameworks
+            .filter({ !fileHandler.exists($0.path) })
+            .map({ LintingIssue(reason: "Framework not found at path \($0.path.asString).", severity: .error) })
+
+        var issues: [LintingIssue] = []
+        issues.append(contentsOf: carthageIssues)
+        issues.append(contentsOf: nonCarthageIssues)
+
+        return []
     }
 
     fileprivate func lintGraphNode(node: GraphNode, evaluatedNodes: inout [GraphNode]) -> [LintingIssue] {

--- a/Sources/TuistKit/Linter/GraphLinter.swift
+++ b/Sources/TuistKit/Linter/GraphLinter.swift
@@ -38,6 +38,8 @@ class GraphLinter: GraphLinting {
             issues.append(contentsOf: lintGraphNode(node: $0, evaluatedNodes: &evaluatedNodes))
         }
 
+        issues.append(contentsOf: lintCarthageDependencies(graph: graph))
+
         return issues
     }
 
@@ -48,16 +50,16 @@ class GraphLinter: GraphLinting {
 
         let carthageIssues = carthageFrameworks
             .filter({ !fileHandler.exists($0.path) })
-            .map({ LintingIssue(reason: "Framework not found at path \($0.path.asString). The path might be wrong or Carthage dependencies not fetched.", severity: .warning) })
+            .map({ LintingIssue(reason: "Framework not found at path \($0.path.asString). The path might be wrong or Carthage dependencies not fetched", severity: .warning) })
         let nonCarthageIssues = nonCarthageFrameworks
             .filter({ !fileHandler.exists($0.path) })
-            .map({ LintingIssue(reason: "Framework not found at path \($0.path.asString).", severity: .error) })
+            .map({ LintingIssue(reason: "Framework not found at path \($0.path.asString)", severity: .error) })
 
         var issues: [LintingIssue] = []
         issues.append(contentsOf: carthageIssues)
         issues.append(contentsOf: nonCarthageIssues)
 
-        return []
+        return issues
     }
 
     fileprivate func lintGraphNode(node: GraphNode, evaluatedNodes: inout [GraphNode]) -> [LintingIssue] {

--- a/Sources/TuistKit/Linter/LintingIssue.swift
+++ b/Sources/TuistKit/Linter/LintingIssue.swift
@@ -37,8 +37,8 @@ struct LintingIssue: CustomStringConvertible, Equatable {
 
     // MARK: - Attributes
 
-    fileprivate let reason: String
-    fileprivate let severity: Severity
+    let reason: String
+    let severity: Severity
 
     // MARK: - Init
 

--- a/Sources/TuistKit/Loader/Graph.swift
+++ b/Sources/TuistKit/Loader/Graph.swift
@@ -42,6 +42,8 @@ protocol Graphing: AnyObject {
     var cache: GraphLoaderCaching { get }
     var entryNodes: [GraphNode] { get }
     var projects: [Project] { get }
+    var carthageFrameworks: [FrameworkNode] { get }
+
     func linkableDependencies(path: AbsolutePath, name: String) throws -> [DependencyReference]
     func librariesPublicHeadersFolders(path: AbsolutePath, name: String) -> [AbsolutePath]
     func embeddableFrameworks(path: AbsolutePath, name: String, system: Systeming) throws -> [DependencyReference]
@@ -75,6 +77,12 @@ class Graph: Graphing {
     }
 
     // MARK: - Internal
+
+    var carthageFrameworks: [FrameworkNode] {
+        return cache.precompiledNodes.values
+            .compactMap({ $0 as? FrameworkNode })
+            .filter({ $0.path.asString.contains("Carthage/Build") })
+    }
 
     func dependencies(path: AbsolutePath) -> Set<GraphNode> {
         var dependencies: Set<GraphNode> = Set()

--- a/Sources/TuistKit/Loader/Graph.swift
+++ b/Sources/TuistKit/Loader/Graph.swift
@@ -42,7 +42,7 @@ protocol Graphing: AnyObject {
     var cache: GraphLoaderCaching { get }
     var entryNodes: [GraphNode] { get }
     var projects: [Project] { get }
-    var carthageFrameworks: [FrameworkNode] { get }
+    var frameworks: [FrameworkNode] { get }
 
     func linkableDependencies(path: AbsolutePath, name: String) throws -> [DependencyReference]
     func librariesPublicHeadersFolders(path: AbsolutePath, name: String) -> [AbsolutePath]
@@ -78,10 +78,8 @@ class Graph: Graphing {
 
     // MARK: - Internal
 
-    var carthageFrameworks: [FrameworkNode] {
-        return cache.precompiledNodes.values
-            .compactMap({ $0 as? FrameworkNode })
-            .filter({ $0.path.asString.contains("Carthage/Build") })
+    var frameworks: [FrameworkNode] {
+        return cache.precompiledNodes.values.compactMap({ $0 as? FrameworkNode })
     }
 
     func dependencies(path: AbsolutePath) -> Set<GraphNode> {

--- a/Sources/TuistKit/Loader/Graph.swift
+++ b/Sources/TuistKit/Loader/Graph.swift
@@ -39,7 +39,6 @@ enum DependencyReference: Equatable {
 protocol Graphing: AnyObject {
     var name: String { get }
     var entryPath: AbsolutePath { get }
-    var cache: GraphLoaderCaching { get }
     var entryNodes: [GraphNode] { get }
     var projects: [Project] { get }
     var frameworks: [FrameworkNode] { get }
@@ -56,9 +55,9 @@ class Graph: Graphing {
 
     // MARK: - Attributes
 
+    private let cache: GraphLoaderCaching
     let name: String
     let entryPath: AbsolutePath
-    let cache: GraphLoaderCaching
     let entryNodes: [GraphNode]
     var projects: [Project] {
         return Array(cache.projects.values)

--- a/Sources/TuistKit/Loader/GraphNode.swift
+++ b/Sources/TuistKit/Loader/GraphNode.swift
@@ -93,7 +93,6 @@ class TargetNode: GraphNode {
             let frameworkPath: RelativePath = try RelativePath(dictionary.get("path"))
             return try FrameworkNode.parse(projectPath: path,
                                            path: frameworkPath,
-                                           fileHandler: fileHandler,
                                            cache: cache)
         } else if type == "library" {
             let libraryPath: RelativePath = try RelativePath(dictionary.get("path"))
@@ -172,12 +171,8 @@ class PrecompiledNode: GraphNode {
 class FrameworkNode: PrecompiledNode {
     static func parse(projectPath: AbsolutePath,
                       path: RelativePath,
-                      fileHandler: FileHandling,
                       cache: GraphLoaderCaching) throws -> FrameworkNode {
         let absolutePath = projectPath.appending(path)
-        if !fileHandler.exists(absolutePath) {
-            throw GraphLoadingError.missingFile(absolutePath)
-        }
         if let frameworkNode = cache.precompiledNode(absolutePath) as? FrameworkNode { return frameworkNode }
         let framewokNode = FrameworkNode(path: absolutePath)
         cache.add(precompiledNode: framewokNode)

--- a/Sources/TuistKit/Loader/GraphNode.swift
+++ b/Sources/TuistKit/Loader/GraphNode.swift
@@ -179,6 +179,10 @@ class FrameworkNode: PrecompiledNode {
         return framewokNode
     }
 
+    var isCarthage: Bool {
+        return path.asString.contains("Carthage/Build")
+    }
+
     override var binaryPath: AbsolutePath {
         let frameworkName = path.components.last!.replacingOccurrences(of: ".framework", with: "")
         return path.appending(component: frameworkName)

--- a/Tests/TuistKitTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistKitTests/Linter/GraphLinterTests.swift
@@ -1,13 +1,60 @@
 import Basic
 import Foundation
+@testable import TuistCoreTesting
 @testable import TuistKit
 import XCTest
 
 final class GraphLinterTests: XCTestCase {
     var subject: GraphLinter!
+    var fileHandler: MockFileHandler!
 
     override func setUp() {
         super.setUp()
-        subject = GraphLinter()
+        fileHandler = try! MockFileHandler()
+        subject = GraphLinter(fileHandler: fileHandler)
+    }
+
+    func test_lint_when_carthage_frameworks_are_missing() throws {
+        let cache = GraphLoaderCache()
+        let graph = Graph.test(cache: cache)
+
+        let frameworkAPath = fileHandler.currentPath.appending(RelativePath("Carthage/Build/iOS/A.framework"))
+        let frameworkBPath = fileHandler.currentPath.appending(RelativePath("Carthage/Build/iOS/B.framework"))
+
+        try fileHandler.createFolder(frameworkAPath)
+
+        let frameworkA = FrameworkNode(path: frameworkAPath)
+        let frameworkB = FrameworkNode(path: frameworkBPath)
+
+        cache.add(precompiledNode: frameworkA)
+        cache.add(precompiledNode: frameworkB)
+
+        let result = subject.lint(graph: graph)
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.severity, .warning)
+        XCTAssertEqual(result.first?.reason, "Framework not found at path \(frameworkBPath.asString). The path might be wrong or Carthage dependencies not fetched")
+    }
+
+    func test_lint_when_frameworks_are_missing() throws {
+        let cache = GraphLoaderCache()
+        let graph = Graph.test(cache: cache)
+
+        let frameworkAPath = fileHandler.currentPath.appending(component: "A.framework")
+        let frameworkBPath = fileHandler.currentPath.appending(component: "B.framework")
+
+        try fileHandler.createFolder(frameworkAPath)
+
+        let frameworkA = FrameworkNode(path: frameworkAPath)
+        let frameworkB = FrameworkNode(path: frameworkBPath)
+
+        cache.add(precompiledNode: frameworkA)
+        cache.add(precompiledNode: frameworkB)
+
+        let result = subject.lint(graph: graph)
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.severity, .error)
+        XCTAssertEqual(result.first?.reason, "Framework not found at path \(frameworkBPath.asString)")
     }
 }

--- a/Tests/TuistKitTests/Loader/GraphNodeTests.swift
+++ b/Tests/TuistKitTests/Loader/GraphNodeTests.swift
@@ -36,6 +36,12 @@ final class FrameworkNodeTests: XCTestCase {
         XCTAssertEqual(subject.binaryPath.asString, "/test.framework/test")
     }
 
+    func test_isCarthage() {
+        XCTAssertFalse(subject.isCarthage)
+        subject = FrameworkNode(path: AbsolutePath("/path/Carthage/Build/iOS/A.framework"))
+        XCTAssertTrue(subject.isCarthage)
+    }
+
     func test_architectures() throws {
         system.stub(args: ["lipo -info /test.framework/test"], stderror: nil, stdout: "Non-fat file: path is architecture: x86_64", exitstatus: 0)
         try XCTAssertEqual(subject.architectures(system: system).first, .x8664)

--- a/Tests/TuistKitTests/Loader/GraphTests.swift
+++ b/Tests/TuistKitTests/Loader/GraphTests.swift
@@ -26,6 +26,14 @@ final class GraphTests: XCTestCase {
         system = MockSystem()
     }
 
+    func test_frameworks() throws {
+        let framework = FrameworkNode(path: AbsolutePath("/path/to/framework.framework"))
+        let cache = GraphLoaderCache()
+        cache.add(precompiledNode: framework)
+        let graph = Graph.test(cache: cache)
+        XCTAssertTrue(graph.frameworks.contains(framework))
+    }
+
     func test_targetDependencies() throws {
         let target = Target.test(name: "Main")
         let dependency = Target.test(name: "Dependency", product: .staticLibrary)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/93

### Short description 📝

When a Carthage framework doesn't exist, print a warning instead of failing the command.

### Implementation
- [x] Implement it
- [x] Add some tests