### PR TITLE
Lint that require files exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next version
 
+### Added
+
+- Throw an error if a library target contains resources https://github.com/tuist/tuist/pull/98 by @pepibumur.
+
 ### Changed
 
 - Don't fail if a Carthage framework doesn't exist. Print a warning instead https://github.com/tuist/tuist/pull/96 by @pepibuymur
+- Missing file errors are printed together https://github.com/tuist/tuist/pull/98 by @pepibumur.
 
 ## 0.3.0
 

--- a/Sources/TuistCore/Utils/Printer.swift
+++ b/Sources/TuistCore/Utils/Printer.swift
@@ -3,6 +3,7 @@ import Foundation
 
 public protocol Printing: AnyObject {
     func print(_ text: String)
+    func print(_ text: String, color: TerminalController.Color)
     func print(section: String)
     func print(warning: String)
     func print(error: Error)
@@ -24,6 +25,12 @@ public class Printer: Printing {
         writer.write("\n")
     }
 
+    public func print(_ text: String, color: TerminalController.Color) {
+        let writer = InteractiveWriter.stdout
+        writer.write(text, inColor: color, bold: false)
+        writer.write("\n")
+    }
+
     public func print(error: Error) {
         let writer = InteractiveWriter.stderr
         writer.write("❌ Error: ", inColor: .red, bold: true)
@@ -41,14 +48,14 @@ public class Printer: Printing {
     public func print(warning: String) {
         let writer = InteractiveWriter.stdout
         writer.write("⚠️  Warning: ", inColor: .yellow, bold: true)
-        writer.write(warning)
+        writer.write(warning, inColor: .yellow, bold: false)
         writer.write("\n")
     }
 
     public func print(errorMessage: String) {
         let writer = InteractiveWriter.stderr
         writer.write("❌ Error: ", inColor: .red, bold: true)
-        writer.write(errorMessage)
+        writer.write(errorMessage, inColor: .red, bold: false)
         writer.write("\n")
     }
 

--- a/Sources/TuistCoreTesting/Utils/MockPrinter.swift
+++ b/Sources/TuistCoreTesting/Utils/MockPrinter.swift
@@ -1,8 +1,10 @@
+import Basic
 import Foundation
 import TuistCore
 
 public final class MockPrinter: Printing {
     public var printArgs: [String] = []
+    public var printWithColorArgs: [(String, TerminalController.Color)] = []
     public var printErrorArgs: [Error] = []
     public var printSectionArgs: [String] = []
     public var printErrorMessageArgs: [String] = []
@@ -11,6 +13,10 @@ public final class MockPrinter: Printing {
 
     public func print(_ text: String) {
         printArgs.append(text)
+    }
+
+    public func print(_ text: String, color: TerminalController.Color) {
+        printWithColorArgs.append((text, color))
     }
 
     public func print(section: String) {

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -114,7 +114,7 @@ class InitCommand: NSObject, Command {
                                        platform: .\(platform.rawValue),
                                        product: .unitTests,
                                        bundleId: "io.tuist.\(name)Tests",
-                                       infoPlist: "Info.plist",
+                                       infoPlist: "Tests.plist",
                                        sources: "Tests/**",
                                        dependencies: [
                                             .target(name: "\(name)")

--- a/Sources/TuistKit/Linter/LintingIssue.swift
+++ b/Sources/TuistKit/Linter/LintingIssue.swift
@@ -2,30 +2,8 @@ import Foundation
 import TuistCore
 
 struct LintingError: FatalError, Equatable {
-
-    // MARK: - Attributes
-
-    private let issues: [LintingIssue]
-
-    // MARK: - Init
-
-    init(issues: [LintingIssue]) {
-        self.issues = issues
-    }
-
-    // MARK: - FatalError
-
-    var description: String {
-        return issues.map({ "- \($0.description)" }).joined(separator: "\n")
-    }
-
-    var type: ErrorType {
-        return .abort
-    }
-
-    static func == (lhs: LintingError, rhs: LintingError) -> Bool {
-        return lhs.issues == rhs.issues
-    }
+    var description: String = "Fatal linting issues found"
+    var type: ErrorType = .abort
 }
 
 /// Linting issue.
@@ -71,21 +49,17 @@ extension Array where Element == LintingIssue {
         let warningIssues = filter({ $0.severity == .warning })
 
         if warningIssues.count != 0 {
-            let message = "The following issues have been found:\n"
-            let warningsMessage = message.appending(warningIssues
-                .map({ "- \($0.description)" })
-                .joined(separator: "\n"))
-            printer.print(warning: warningsMessage)
+            printer.print("The following issues have been found:", color: .yellow)
+            let message = warningIssues.map({ "  - \($0.description)" }).joined(separator: "\n")
+            printer.print(message)
         }
 
         if errorIssues.count != 0 {
-            let message = "The following critical issues have been found:\n"
-            let errorMessage = message.appending(errorIssues
-                .map({ "- \($0.description)" })
-                .joined(separator: "\n"))
-            printer.print(errorMessage: errorMessage)
+            printer.print("The following critical issues have been found:", color: .red)
+            let message = errorIssues.map({ "  - \($0.description)" }).joined(separator: "\n")
+            printer.print(message)
 
-            throw LintingError(issues: errorIssues)
+            throw LintingError()
         }
     }
 }

--- a/Sources/TuistKit/Linter/ProjectLinter.swift
+++ b/Sources/TuistKit/Linter/ProjectLinter.swift
@@ -11,11 +11,14 @@ class ProjectLinter: ProjectLinting {
     // MARK: - Attributes
 
     let targetLinter: TargetLinting
+    let settingsLinter: SettingsLinting
 
     // MARK: - Init
 
-    init(targetLinter: TargetLinting = TargetLinter()) {
+    init(targetLinter: TargetLinting = TargetLinter(),
+         settingsLinter: SettingsLinting = SettingsLinter()) {
         self.targetLinter = targetLinter
+        self.settingsLinter = settingsLinter
     }
 
     // MARK: - ProjectLinting
@@ -23,6 +26,9 @@ class ProjectLinter: ProjectLinting {
     func lint(_ project: Project) -> [LintingIssue] {
         var issues: [LintingIssue] = []
         issues.append(contentsOf: lintTargets(project: project))
+        if let settings = project.settings {
+            issues.append(contentsOf: settingsLinter.lint(settings: settings))
+        }
         return issues
     }
 

--- a/Sources/TuistKit/Linter/SettingsLinter.swift
+++ b/Sources/TuistKit/Linter/SettingsLinter.swift
@@ -1,0 +1,49 @@
+import Basic
+import Foundation
+import TuistCore
+
+protocol SettingsLinting: AnyObject {
+    func lint(settings: Settings) -> [LintingIssue]
+}
+
+final class SettingsLinter: SettingsLinting {
+
+    // MARK: - Attributes
+
+    let fileHandler: FileHandling
+
+    // MARK: - Init
+
+    init(fileHandler: FileHandling = FileHandler()) {
+        self.fileHandler = fileHandler
+    }
+
+    // MARK: - SettingsLinting
+
+    func lint(settings: Settings) -> [LintingIssue] {
+        var issues: [LintingIssue] = []
+        issues.append(contentsOf: lintConfigFilesExist(settings: settings))
+        return issues
+    }
+
+    // MARK: - Fileprivate
+
+    fileprivate func lintConfigFilesExist(settings: Settings) -> [LintingIssue] {
+        var issues: [LintingIssue] = []
+
+        let lintPath: (AbsolutePath) -> Void = { path in
+            if !self.fileHandler.exists(path) {
+                issues.append(LintingIssue(reason: "Configuration file not found at path \(path.asString)", severity: .error))
+            }
+        }
+
+        if let debugConfigFilePath = settings.debug?.xcconfig {
+            lintPath(debugConfigFilePath)
+        }
+        if let releaseConfigFilePath = settings.release?.xcconfig {
+            lintPath(releaseConfigFilePath)
+        }
+
+        return issues
+    }
+}

--- a/Sources/TuistKit/Linter/TargetLinter.swift
+++ b/Sources/TuistKit/Linter/TargetLinter.swift
@@ -26,6 +26,8 @@ class TargetLinter: TargetLinting {
         var issues: [LintingIssue] = []
         issues.append(contentsOf: lintHasSourceFiles(target: target))
         issues.append(contentsOf: lintCopiedFiles(target: target))
+        issues.append(contentsOf: lintLibraryHasNoResources(target: target))
+
         if let settings = target.settings {
             issues.append(contentsOf: settingsLinter.lint(settings: settings))
         }
@@ -55,7 +57,6 @@ class TargetLinter: TargetLinting {
 
         issues.append(contentsOf: lintInfoplistExists(target: target))
         issues.append(contentsOf: lintEntitlementsExist(target: target))
-
         return issues
     }
 
@@ -73,5 +74,15 @@ class TargetLinter: TargetLinting {
             issues.append(LintingIssue(reason: "Entitlements file not found at path \(path.asString)", severity: .error))
         }
         return issues
+    }
+
+    fileprivate func lintLibraryHasNoResources(target: Target) -> [LintingIssue] {
+        if target.product != .dynamicLibrary && target.product != .staticLibrary {
+            return []
+        }
+        if target.resources.count != 0 {
+            return [LintingIssue(reason: "Target \(target.name) cannot contain resources. Libraries don't support resources", severity: .error)]
+        }
+        return []
     }
 }

--- a/Sources/TuistKit/Models/Settings.swift
+++ b/Sources/TuistKit/Models/Settings.swift
@@ -16,13 +16,10 @@ class Configuration: Equatable {
         self.xcconfig = xcconfig
     }
 
-    init(json: JSON, projectPath: AbsolutePath, fileHandler: FileHandling) throws {
+    init(json: JSON, projectPath: AbsolutePath, fileHandler _: FileHandling) throws {
         settings = try json.get("settings")
         let xcconfigString: String? = json.get("xcconfig")
         xcconfig = xcconfigString.flatMap({ projectPath.appending(RelativePath($0)) })
-        if let xcconfig = xcconfig, !fileHandler.exists(xcconfig) {
-            throw GraphLoadingError.missingFile(xcconfig)
-        }
     }
 
     // MARK: - Equatable

--- a/Sources/TuistKit/Models/Target.swift
+++ b/Sources/TuistKit/Models/Target.swift
@@ -62,16 +62,10 @@ class Target: GraphJSONInitiatable, Equatable {
         // Info.plist
         let infoPlistPath: String = try json.get("info_plist")
         infoPlist = projectPath.appending(RelativePath(infoPlistPath))
-        if !fileHandler.exists(infoPlist) {
-            throw GraphLoadingError.missingFile(infoPlist)
-        }
 
         // Entitlements
         let entitlementsPath: String? = try? json.get("entitlements")
         entitlements = entitlementsPath.map({ projectPath.appending(RelativePath($0)) })
-        if let entitlements = entitlements, !fileHandler.exists(entitlements) {
-            throw GraphLoadingError.missingFile(entitlements)
-        }
 
         // Settings
         let settingsDictionary: [String: JSONSerializable]? = try? json.get("settings")

--- a/Tests/TuistKitTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistKitTests/Linter/GraphLinterTests.swift
@@ -31,9 +31,7 @@ final class GraphLinterTests: XCTestCase {
 
         let result = subject.lint(graph: graph)
 
-        XCTAssertEqual(result.count, 1)
-        XCTAssertEqual(result.first?.severity, .warning)
-        XCTAssertEqual(result.first?.reason, "Framework not found at path \(frameworkBPath.asString). The path might be wrong or Carthage dependencies not fetched")
+        XCTAssertTrue(result.contains(LintingIssue(reason: "Framework not found at path \(frameworkBPath.asString). The path might be wrong or Carthage dependencies not fetched", severity: .warning)))
     }
 
     func test_lint_when_frameworks_are_missing() throws {
@@ -53,8 +51,6 @@ final class GraphLinterTests: XCTestCase {
 
         let result = subject.lint(graph: graph)
 
-        XCTAssertEqual(result.count, 1)
-        XCTAssertEqual(result.first?.severity, .error)
-        XCTAssertEqual(result.first?.reason, "Framework not found at path \(frameworkBPath.asString)")
+        XCTAssertTrue(result.contains(LintingIssue(reason: "Framework not found at path \(frameworkBPath.asString)", severity: .error)))
     }
 }

--- a/Tests/TuistKitTests/Linter/LintingIssueTests.swift
+++ b/Tests/TuistKitTests/Linter/LintingIssueTests.swift
@@ -1,28 +1,8 @@
+import Basic
 import Foundation
 @testable import TuistCoreTesting
 @testable import TuistKit
 import XCTest
-
-final class LintingErrorTests: XCTestCase {
-    var subject: LintingError!
-
-    override func setUp() {
-        super.setUp()
-        subject = LintingError(issues: [LintingIssue(reason: "test", severity: .error)])
-    }
-
-    func test_type() {
-        XCTAssertEqual(subject.type, .abort)
-    }
-
-    func test_equal() {
-        XCTAssertEqual(subject, subject)
-    }
-
-    func test_description() {
-        XCTAssertEqual(subject.description, "- test")
-    }
-}
 
 final class LintingIssueTests: XCTestCase {
     func test_description() {
@@ -45,7 +25,12 @@ final class LintingIssueTests: XCTestCase {
 
         XCTAssertThrowsError(try [first, second].printAndThrowIfNeeded(printer: printer))
 
-        XCTAssertEqual(printer.printWarningArgs, ["The following issues have been found:\n- warning"])
-        XCTAssertEqual(printer.printErrorMessageArgs, ["The following critical issues have been found:\n- error"])
+        XCTAssertEqual(printer.printWithColorArgs.first?.0, "The following issues have been found:")
+        XCTAssertEqual(printer.printWithColorArgs.first?.1, .yellow)
+        XCTAssertEqual(printer.printArgs.first, "  - warning")
+
+        XCTAssertEqual(printer.printWithColorArgs.last?.0, "The following critical issues have been found:")
+        XCTAssertEqual(printer.printWithColorArgs.last?.1, .red)
+        XCTAssertEqual(printer.printArgs.last, "  - error")
     }
 }

--- a/Tests/TuistKitTests/Linter/SettingsLinterTests.swift
+++ b/Tests/TuistKitTests/Linter/SettingsLinterTests.swift
@@ -1,0 +1,29 @@
+import Basic
+import Foundation
+@testable import TuistCoreTesting
+@testable import TuistKit
+import XCTest
+
+final class SettingsLinterTests: XCTestCase {
+    var fileHandler: MockFileHandler!
+    var subject: SettingsLinter!
+
+    override func setUp() {
+        super.setUp()
+        fileHandler = try! MockFileHandler()
+        subject = SettingsLinter(fileHandler: fileHandler)
+    }
+
+    func test_lint_when_config_files_are_missing() {
+        let debugPath = fileHandler.currentPath.appending(component: "Debug.xcconfig")
+        let releasePath = fileHandler.currentPath.appending(component: "Release.xcconfig")
+
+        let settings = Settings(debug: Configuration(xcconfig: debugPath),
+                                release: Configuration(xcconfig: releasePath))
+
+        let got = subject.lint(settings: settings)
+
+        XCTAssertTrue(got.contains(LintingIssue(reason: "Configuration file not found at path \(debugPath.asString)", severity: .error)))
+        XCTAssertTrue(got.contains(LintingIssue(reason: "Configuration file not found at path \(releasePath.asString)", severity: .error)))
+    }
+}

--- a/Tests/TuistKitTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistKitTests/Linter/TargetLinterTests.swift
@@ -55,4 +55,17 @@ final class TargetLinterTests: XCTestCase {
 
         XCTAssertTrue(got.contains(LintingIssue(reason: "Entitlements file not found at path \(path.asString)", severity: .error)))
     }
+
+    func test_lint_when_library_has_resources() {
+        let path = fileHandler.currentPath.appending(component: "Image.png")
+
+        let staticLibrary = Target.test(product: .staticLibrary, resources: [path])
+        let dynamicLibrary = Target.test(product: .dynamicLibrary, resources: [path])
+
+        let staticResult = subject.lint(target: staticLibrary)
+        XCTAssertTrue(staticResult.contains(LintingIssue(reason: "Target \(staticLibrary.name) cannot contain resources. Libraries don't support resources", severity: .error)))
+
+        let dynamicResult = subject.lint(target: staticLibrary)
+        XCTAssertTrue(dynamicResult.contains(LintingIssue(reason: "Target \(dynamicLibrary.name) cannot contain resources. Libraries don't support resources", severity: .error)))
+    }
 }


### PR DESCRIPTION
### Short description 📝
Before this check, we used to throw if we detect that a required file was missing while parsing the project. If there were more than one issue, this was inconvenient because you had to execute tuist multiple times to get each of the errors.

### Solution 📦
Move the logic into the linters so that we can collect all the issues and output them in one shot.
