### PR TITLE
Add coding keys manually

### DIFF
--- a/Sources/ProjectDescription/CoreDataModel.swift
+++ b/Sources/ProjectDescription/CoreDataModel.swift
@@ -8,6 +8,11 @@ public class CoreDataModel: Codable {
     /// Current version (with or without extension)
     let currentVersion: String
 
+    public enum CodingKeys: String, CodingKey {
+        case path
+        case currentVersion = "current_version"
+    }
+
     /// Initializes the build file with its attributes.
     ///
     /// - Parameters:

--- a/Sources/ProjectDescription/Dump.swift
+++ b/Sources/ProjectDescription/Dump.swift
@@ -4,7 +4,6 @@ func dumpIfNeeded<E: Encodable>(_ entity: E) {
     if CommandLine.argc > 0 {
         if CommandLine.arguments.contains("--dump") {
             let encoder = JSONEncoder()
-            encoder.keyEncodingStrategy = .convertToSnakeCase
             let data = try! encoder.encode(entity)
             let string = String(data: data, encoding: .utf8)!
             print(string)

--- a/Sources/ProjectDescription/Project.swift
+++ b/Sources/ProjectDescription/Project.swift
@@ -7,6 +7,12 @@ public class Project: Codable {
     public let targets: [Target]
     public let settings: Settings?
 
+    public enum CodingKeys: String, CodingKey {
+        case name
+        case targets
+        case settings
+    }
+
     public init(name: String,
                 settings: Settings? = nil,
                 targets: [Target] = []) {

--- a/Sources/ProjectDescription/Scheme.swift
+++ b/Sources/ProjectDescription/Scheme.swift
@@ -8,6 +8,15 @@ public class Scheme: Codable {
     public let buildAction: BuildAction?
     public let testAction: TestAction?
     public let runAction: RunAction?
+
+    public enum CodingKeys: String, CodingKey {
+        case name
+        case shared
+        case buildAction = "build_action"
+        case testAction = "test_action"
+        case runAction = "run_action"
+    }
+
     public init(name: String,
                 shared: Bool = true,
                 buildAction: BuildAction? = nil,
@@ -26,6 +35,12 @@ public class Scheme: Codable {
 public class Arguments: Codable {
     public let environment: [String: String]
     public let launch: [String: Bool]
+
+    public enum CodingKeys: String, CodingKey {
+        case environment
+        case launch
+    }
+
     public init(environment: [String: String],
                 launch: [String: Bool]) {
         self.environment = environment
@@ -37,6 +52,11 @@ public class Arguments: Codable {
 
 public class BuildAction: Codable {
     public let targets: [String]
+
+    public enum CodingKeys: String, CodingKey {
+        case targets
+    }
+
     public init(targets: [String]) {
         self.targets = targets
     }
@@ -49,6 +69,14 @@ public class TestAction: Codable {
     public let arguments: Arguments?
     public let config: BuildConfiguration
     public let coverage: Bool
+
+    public enum CodingKeys: String, CodingKey {
+        case targets
+        case arguments
+        case config
+        case coverage
+    }
+
     public init(targets: [String],
                 arguments: Arguments? = nil,
                 config: BuildConfiguration = .debug,
@@ -66,6 +94,13 @@ public class RunAction: Codable {
     public let config: BuildConfiguration
     public let executable: String?
     public let arguments: Arguments?
+
+    public enum CodingKeys: String, CodingKey {
+        case config
+        case executable
+        case arguments
+    }
+
     public init(config: BuildConfiguration = .debug,
                 executable: String? = nil,
                 arguments: Arguments? = nil) {

--- a/Sources/ProjectDescription/Settings.swift
+++ b/Sources/ProjectDescription/Settings.swift
@@ -5,6 +5,12 @@ import Foundation
 public class Configuration: Codable {
     public let settings: [String: String]
     public let xcconfig: String?
+
+    public enum CodingKeys: String, CodingKey {
+        case settings
+        case xcconfig
+    }
+
     public init(settings: [String: String] = [:], xcconfig: String? = nil) {
         self.settings = settings
         self.xcconfig = xcconfig

--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -39,6 +39,21 @@ public class Target: Codable {
     /// CoreData models.
     let coreDataModels: [CoreDataModel]
 
+    public enum CodingKeys: String, CodingKey {
+        case name
+        case platform
+        case product
+        case bundleId = "bundle_id"
+        case infoPlist = "info_plist"
+        case entitlements
+        case settings
+        case dependencies
+        case sources
+        case resources
+        case headers
+        case coreDataModels = "core_data_models"
+    }
+
     /// Initializes the target.
     ///
     /// - Parameters:

--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -34,8 +34,8 @@ extension TargetDependency {
         case name
         case target
         case path
-        case publicHeaders
-        case swiftModuleMap
+        case publicHeaders = "public_headers"
+        case swiftModuleMap = "swift_module_map"
     }
 
     public init(from decoder: Decoder) throws {

--- a/Sources/ProjectDescription/Workspace.swift
+++ b/Sources/ProjectDescription/Workspace.swift
@@ -3,13 +3,21 @@ import Foundation
 // MARK: - Workspace
 
 public class Workspace: Codable {
+
+    // MARK: - Codable
+
     enum CodingKeys: String, CodingKey {
         case name
         case projects
     }
 
+    // Workspace name
     public let name: String
+
+    // Relative paths to the projects.
+    // Note: The paths are relative from the folder that contains the workspace.
     public let projects: [String]
+
     public init(name: String,
                 projects: [String]) {
         self.name = name

--- a/Tests/ProjectDescriptionTests/assertCodableEqualToJson.swift
+++ b/Tests/ProjectDescriptionTests/assertCodableEqualToJson.swift
@@ -3,7 +3,6 @@ import XCTest
 
 func assertCodableEqualToJson<C: Codable>(_ subject: C, _ json: String) {
     let decoder = JSONDecoder()
-    decoder.keyDecodingStrategy = .convertFromSnakeCase
     let decoded = try! decoder.decode(C.self, from: json.data(using: .utf8)!)
     let encoder = JSONEncoder()
     encoder.keyEncodingStrategy = .convertToSnakeCase


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/100

### Short description 📝
Since we used the encoding strategy that converts camel cased keys into snake-cased, it was also converting the keys of the build settings.

### Solution 📦
Remove the strategy, which applies to all the encoded models, and define the key's value manually.

I've taken the opportunity to document the models in the `ProjectDescription` framework.