### PR TITLE
Move Constants from TuistCore to TuistShared

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/tuist/core.git",
         "state": {
           "branch": null,
-          "revision": "6b2741f3b732265d1d090c0fa02baffc99e0966b",
-          "version": "0.1.0"
+          "revision": "49c1b488b2eec6b1561e79ab96e61bf3acab5d91",
+          "version": "0.2.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -13,15 +13,19 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/tuist/xcodeproj.git", .upToNextMinor(from: "6.0.0")),
-        .package(url: "https://github.com/tuist/core.git", .upToNextMinor(from: "0.1.0")),
+        .package(url: "https://github.com/tuist/core.git", .upToNextMinor(from: "0.2.0")),
         .package(url: "https://github.com/apple/swift-package-manager", .upToNextMinor(from: "0.2.1")),
         .package(url: "https://github.com/Carthage/ReactiveTask.git", .upToNextMinor(from: "0.15.0")),
         .package(url: "https://github.com/jpsim/Yams.git", .upToNextMinor(from: "1.0.1")),
     ],
     targets: [
         .target(
+            name: "TuistShared",
+            dependencies: []
+        ),
+        .target(
             name: "TuistKit",
-            dependencies: ["xcodeproj", "Utility", "TuistCore", "Yams"]
+            dependencies: ["xcodeproj", "Utility", "TuistCore", "Yams", "TuistShared"]
         ),
         .testTarget(
             name: "TuistKitTests",
@@ -33,7 +37,7 @@ let package = Package(
         ),
         .target(
             name: "TuistEnvKit",
-            dependencies: ["Utility", "TuistCore"]
+            dependencies: ["Utility", "TuistCore", "TuistShared"]
         ),
         .testTarget(
             name: "TuistEnvKitTests",

--- a/Sources/TuistEnvKit/Commands/BundleCommand.swift
+++ b/Sources/TuistEnvKit/Commands/BundleCommand.swift
@@ -1,6 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
+import TuistShared
 import Utility
 
 enum BundleCommandError: FatalError, Equatable {

--- a/Sources/TuistEnvKit/Commands/CommandRunner.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRunner.swift
@@ -1,6 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
+import TuistShared
 
 protocol CommandRunning: AnyObject {
     func run() throws

--- a/Sources/TuistEnvKit/Commands/LocalCommand.swift
+++ b/Sources/TuistEnvKit/Commands/LocalCommand.swift
@@ -1,6 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
+import TuistShared
 import Utility
 
 class LocalCommand: Command {

--- a/Sources/TuistEnvKit/Installer/Installer.swift
+++ b/Sources/TuistEnvKit/Installer/Installer.swift
@@ -1,6 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
+import TuistShared
 
 protocol Installing: AnyObject {
     func install(version: String) throws

--- a/Sources/TuistEnvKit/Versions/VersionResolver.swift
+++ b/Sources/TuistEnvKit/Versions/VersionResolver.swift
@@ -1,6 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
+import TuistShared
 import Utility
 
 enum ResolvedVersion: Equatable {

--- a/Sources/TuistKit/Commands/CommandRegistry.swift
+++ b/Sources/TuistKit/Commands/CommandRegistry.swift
@@ -1,6 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
+import TuistShared
 import Utility
 
 public final class CommandRegistry {

--- a/Sources/TuistKit/Commands/VersionCommand.swift
+++ b/Sources/TuistKit/Commands/VersionCommand.swift
@@ -1,6 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
+import TuistShared
 import Utility
 
 class VersionCommand: NSObject, Command {

--- a/Sources/TuistKit/Generator/ConfigGenerator.swift
+++ b/Sources/TuistKit/Generator/ConfigGenerator.swift
@@ -1,6 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
+import TuistShared
 import xcodeproj
 
 protocol ConfigGenerating: AnyObject {

--- a/Sources/TuistShared/Constants.swift
+++ b/Sources/TuistShared/Constants.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public class Constants {
+    public static let versionFileName = ".tuist-version"
+    public static let binFolderName = ".tuist-bin"
+    public static let binName = "tuist"
+    public static let gitRepositoryURL = "https://github.com/tuist/tuist.git"
+    public static let version = "0.6.0"
+    public static let swiftVersion: String = "4.1.2"
+    public static let bundleName: String = "tuist.zip"
+}

--- a/Tests/TuistEnvKitTests/Commands/BundleCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/BundleCommandTests.swift
@@ -3,6 +3,7 @@ import Foundation
 @testable import TuistCore
 @testable import TuistCoreTesting
 @testable import TuistEnvKit
+import TuistShared
 @testable import Utility
 import XCTest
 

--- a/Tests/TuistEnvKitTests/Commands/LocalCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/LocalCommandTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import TuistCore
 @testable import TuistCoreTesting
 @testable import TuistEnvKit
+import TuistShared
 @testable import Utility
 import XCTest
 

--- a/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
+++ b/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import TuistCore
 @testable import TuistCoreTesting
 @testable import TuistEnvKit
+import TuistShared
 import Utility
 import XCTest
 

--- a/Tests/TuistEnvKitTests/Versions/VersionResolverTests.swift
+++ b/Tests/TuistEnvKitTests/Versions/VersionResolverTests.swift
@@ -2,6 +2,7 @@ import Basic
 import Foundation
 import TuistCore
 @testable import TuistEnvKit
+import TuistShared
 import XCTest
 
 final class VersionResolverErrorTests: XCTestCase {

--- a/Tests/TuistKitTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/ConfigGeneratorTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import TuistCore
 @testable import TuistCoreTesting
 @testable import TuistKit
+import TuistShared
 import xcodeproj
 import XCTest
 


### PR DESCRIPTION
### Short description 📝
Move `Constants.swift` into a new target, `TuistShared` which is dependency of `TuistEnvKit` and `TuistKit`