### PR TITLE
Add force flag to the update and install command

### DIFF
--- a/Sources/TuistCore/Utils/EnvironmentController.swift
+++ b/Sources/TuistCore/Utils/EnvironmentController.swift
@@ -1,6 +1,5 @@
 import Basic
 import Foundation
-import TuistCore
 
 /// Protocol that defines the interface of a local environment controller.
 /// It manages the local directory where tuistenv stores the tuist versions and user settings.

--- a/Sources/TuistEnvKit/Commands/BundleCommand.swift
+++ b/Sources/TuistEnvKit/Commands/BundleCommand.swift
@@ -81,7 +81,7 @@ final class BundleCommand: Command {
         // Installing
         if !fileHandler.exists(versionPath) {
             printer.print("Version \(version) not available locally. Installing...")
-            try installer.install(version: version)
+            try installer.install(version: version, force: false)
         }
 
         // Copying

--- a/Sources/TuistEnvKit/Commands/CommandRunner.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRunner.swift
@@ -93,7 +93,7 @@ class CommandRunner: CommandRunning {
         if let highgestVersion = versionsController.semverVersions().last?.description {
             version = highgestVersion
         } else {
-            try updater.update()
+            try updater.update(force: false)
             guard let highgestVersion = versionsController.semverVersions().last?.description else {
                 throw CommandRunnerError.versionNotFound
             }

--- a/Sources/TuistEnvKit/Commands/CommandRunner.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRunner.swift
@@ -107,7 +107,7 @@ class CommandRunner: CommandRunning {
     func runVersion(_ version: String) throws {
         if !versionsController.versions().contains(where: { $0.description == version }) {
             printer.print("Version \(version) not found locally. Installing...")
-            try installer.install(version: version)
+            try installer.install(version: version, force: false)
         }
 
         let path = versionsController.path(version: version)

--- a/Sources/TuistEnvKit/Commands/InstallCommand.swift
+++ b/Sources/TuistEnvKit/Commands/InstallCommand.swift
@@ -2,18 +2,32 @@ import Foundation
 import TuistCore
 import Utility
 
+/// Command that installs new versions of Tuist in the system.
 final class InstallCommand: Command {
     // MARK: - Command
 
+    /// Command name.
     static var command: String = "install"
+
+    /// Command description.
     static var overview: String = "Installs a version of tuist"
 
     // MARK: - Attributes
 
+    /// Controller to manage system versions.
     private let versionsController: VersionsControlling
+
+    /// Printer instance to output messages to the user.
     private let printer: Printing
+
+    /// Installer instance to run the installation.
     private let installer: Installing
+
+    /// Version argument to specify the version that will be installed.
     let versionArgument: PositionalArgument<String>
+
+    /// Force argument (-f). When passed, it re-installs the version compiling it from the source.
+    let forceArgument: OptionArgument<Bool>
 
     // MARK: - Init
 
@@ -37,15 +51,24 @@ final class InstallCommand: Command {
                                         kind: String.self,
                                         optional: false,
                                         usage: "The version of tuist to be installed")
+        forceArgument = subParser.add(option: "--force",
+                                      shortName: "-f",
+                                      kind: Bool.self,
+                                      usage: "Re-installs the version compiling it from the source", completion: nil)
     }
 
+    /// Runs the install command.
+    ///
+    /// - Parameter result: Result obtained from parsing the CLI arguments.
+    /// - Throws: An error if the installation process fails.
     func run(with result: ArgumentParser.Result) throws {
+        let force = result.get(forceArgument) ?? false
         let version = result.get(versionArgument)!
         let versions = versionsController.versions().map({ $0.description })
         if versions.contains(version) {
             printer.print(warning: "Version \(version) already installed, skipping")
             return
         }
-        try installer.install(version: version)
+        try installer.install(version: version, force: force)
     }
 }

--- a/Sources/TuistEnvKit/Commands/UpdateCommand.swift
+++ b/Sources/TuistEnvKit/Commands/UpdateCommand.swift
@@ -10,31 +10,33 @@ final class UpdateCommand: Command {
 
     // MARK: - Attributes
 
-    private let versionsController: VersionsControlling
     private let updater: Updating
     private let printer: Printing
+    let forceArgument: OptionArgument<Bool>
 
     // MARK: - Init
 
     convenience init(parser: ArgumentParser) {
         self.init(parser: parser,
-                  versionsController: VersionsController(),
                   updater: Updater(),
                   printer: Printer())
     }
 
     init(parser: ArgumentParser,
-         versionsController: VersionsControlling,
          updater: Updating,
-         printer: Printer) {
-        parser.add(subparser: UpdateCommand.command, overview: UpdateCommand.overview)
-        self.versionsController = versionsController
+         printer: Printing) {
+        let subparser = parser.add(subparser: UpdateCommand.command, overview: UpdateCommand.overview)
         self.printer = printer
         self.updater = updater
+        forceArgument = subparser.add(option: "--force",
+                                      shortName: "-f",
+                                      kind: Bool.self,
+                                      usage: "Re-installs the latest version compiling it from the source", completion: nil)
     }
 
-    func run(with _: ArgumentParser.Result) throws {
+    func run(with result: ArgumentParser.Result) throws {
+        let force = result.get(forceArgument) ?? false
         printer.print(section: "Checking for updates...")
-        try updater.update()
+        try updater.update(force: force)
     }
 }

--- a/Sources/TuistEnvKit/Commands/UpdateCommand.swift
+++ b/Sources/TuistEnvKit/Commands/UpdateCommand.swift
@@ -2,26 +2,44 @@ import Foundation
 import TuistCore
 import Utility
 
+/// Command that updates the version of Tuist in the environment.
 final class UpdateCommand: Command {
     // MARK: - Command
 
+    /// Name of the command.
     static var command: String = "update"
+
+    /// Description of the command.
     static var overview: String = "Installs the latest version if it's not already installed"
 
     // MARK: - Attributes
 
+    /// Updater instance that runs the update.
     private let updater: Updating
+
+    /// Printer instance to output updates during the process.
     private let printer: Printing
+
+    /// Force argument (-f). When passed, it re-installs the latest version compiling it from the source.
     let forceArgument: OptionArgument<Bool>
 
     // MARK: - Init
 
+    /// Initializes the update command.
+    ///
+    /// - Parameter parser: Argument parser where the command should be registered.
     convenience init(parser: ArgumentParser) {
         self.init(parser: parser,
                   updater: Updater(),
                   printer: Printer())
     }
 
+    /// Initializes the update command.
+    ///
+    /// - Parameters:
+    ///   - parser: Argument parser where the command should be registered.
+    ///   - updater: Updater instance that runs the update.
+    ///   - printer: Printer instance to output updates during the process.
     init(parser: ArgumentParser,
          updater: Updating,
          printer: Printing) {
@@ -34,6 +52,10 @@ final class UpdateCommand: Command {
                                       usage: "Re-installs the latest version compiling it from the source", completion: nil)
     }
 
+    /// Runs the update command.
+    ///
+    /// - Parameter result: Result obtained from parsing the CLI arguments.
+    /// - Throws: An error if the update process fails.
     func run(with result: ArgumentParser.Result) throws {
         let force = result.get(forceArgument) ?? false
         printer.print(section: "Checking for updates...")

--- a/Sources/TuistEnvKit/Commands/UpdateCommand.swift
+++ b/Sources/TuistEnvKit/Commands/UpdateCommand.swift
@@ -43,10 +43,10 @@ final class UpdateCommand: Command {
     init(parser: ArgumentParser,
          updater: Updating,
          printer: Printing) {
-        let subparser = parser.add(subparser: UpdateCommand.command, overview: UpdateCommand.overview)
+        let subParser = parser.add(subparser: UpdateCommand.command, overview: UpdateCommand.overview)
         self.printer = printer
         self.updater = updater
-        forceArgument = subparser.add(option: "--force",
+        forceArgument = subParser.add(option: "--force",
                                       shortName: "-f",
                                       kind: Bool.self,
                                       usage: "Re-installs the latest version compiling it from the source", completion: nil)

--- a/Sources/TuistEnvKit/Installer/Installer.swift
+++ b/Sources/TuistEnvKit/Installer/Installer.swift
@@ -3,7 +3,7 @@ import Foundation
 import TuistCore
 
 protocol Installing: AnyObject {
-    func install(version: String) throws
+    func install(version: String, force: Bool) throws
 }
 
 enum InstallerError: FatalError, Equatable {
@@ -66,7 +66,7 @@ final class Installer: Installing {
 
     // MARK: - Installing
 
-    func install(version: String) throws {
+    func install(version: String, force _: Bool) throws {
         let temporaryDirectory = try TemporaryDirectory(removeTreeOnDeinit: true)
         try install(version: version, temporaryDirectory: temporaryDirectory)
     }

--- a/Sources/TuistEnvKit/Installer/Installer.swift
+++ b/Sources/TuistEnvKit/Installer/Installer.swift
@@ -2,10 +2,21 @@ import Basic
 import Foundation
 import TuistCore
 
+/// Protocol that defines the interface of an instance that can install versions of Tuist.
 protocol Installing: AnyObject {
+    /// It installs a version of Tuist in the local environment.
+    ///
+    /// - Parameters:
+    ///   - version: Version to be installed.
+    ///   - force: When true, it ignores the Swift version and compiles it from the source.
+    /// - Throws: An error if the installation fails.
     func install(version: String, force: Bool) throws
 }
 
+/// Error thrown by the installer.
+///
+/// - versionNotFound: When the specified version cannot be found.
+/// - incompatibleSwiftVersion: When the environment Swift version is incompatible with the Swift version Tuist has been compiled with.
 enum InstallerError: FatalError, Equatable {
     case versionNotFound(String)
     case incompatibleSwiftVersion(local: String, expected: String)
@@ -38,6 +49,7 @@ enum InstallerError: FatalError, Equatable {
     }
 }
 
+/// Class that manages the installation of Tuist versions.
 final class Installer: Installing {
     // MARK: - Attributes
 
@@ -66,12 +78,20 @@ final class Installer: Installing {
 
     // MARK: - Installing
 
-    func install(version: String, force _: Bool) throws {
+    func install(version: String, force: Bool) throws {
         let temporaryDirectory = try TemporaryDirectory(removeTreeOnDeinit: true)
-        try install(version: version, temporaryDirectory: temporaryDirectory)
+        try install(version: version, temporaryDirectory: temporaryDirectory, force: force)
     }
 
-    func install(version: String, temporaryDirectory: TemporaryDirectory) throws {
+    func install(version: String, temporaryDirectory: TemporaryDirectory, force: Bool = false) throws {
+        // We ignore the Swift version and install from the soruce code
+        if force {
+            printer.print("Forcing the installation of \(version) from the source code")
+            try installFromSource(version: version,
+                                  temporaryDirectory: temporaryDirectory)
+            return
+        }
+
         try verifySwiftVersion(version: version)
 
         var bundleURL: URL?
@@ -184,10 +204,11 @@ final class Installer: Installing {
                                verbose: false,
                                environment: System.userEnvironment).throwIfError()
 
-            // Copying files
-            if !fileHandler.exists(installationDirectory) {
-                try system.capture("/bin/mkdir", arguments: installationDirectory.asString, verbose: false, environment: nil).throwIfError()
+            if fileHandler.exists(installationDirectory) {
+                try fileHandler.delete(installationDirectory)
             }
+            try fileHandler.createFolder(installationDirectory)
+
             try buildCopier.copy(from: buildDirectory,
                                  to: installationDirectory)
 

--- a/Sources/TuistEnvKit/Updater/Updater.swift
+++ b/Sources/TuistEnvKit/Updater/Updater.swift
@@ -27,7 +27,7 @@ final class Updater: Updating {
 
     // MARK: - Internal
 
-    func update(force _: Bool) throws {
+    func update(force: Bool) throws {
         let releases = try githubClient.releases()
 
         guard let highestRemoteVersion = releases.map({ $0.version }).sorted().last else {
@@ -35,16 +35,19 @@ final class Updater: Updating {
             return
         }
 
-        if let highestLocalVersion = versionsController.semverVersions().sorted().last {
+        if force {
+            printer.print("Forcing the update of version \(highestRemoteVersion)")
+            try installer.install(version: highestRemoteVersion.description, force: true)
+        } else if let highestLocalVersion = versionsController.semverVersions().sorted().last {
             if highestRemoteVersion <= highestLocalVersion {
                 printer.print("There are no updates available")
             } else {
                 printer.print("Installing new version available \(highestRemoteVersion)")
-                try installer.install(version: highestRemoteVersion.description)
+                try installer.install(version: highestRemoteVersion.description, force: false)
             }
         } else {
             printer.print("No local versions available. Installing the latest version \(highestRemoteVersion)")
-            try installer.install(version: highestRemoteVersion.description)
+            try installer.install(version: highestRemoteVersion.description, force: false)
         }
     }
 }

--- a/Sources/TuistEnvKit/Updater/Updater.swift
+++ b/Sources/TuistEnvKit/Updater/Updater.swift
@@ -31,7 +31,7 @@ final class Updater: Updating {
         let releases = try githubClient.releases()
 
         guard let highestRemoteVersion = releases.map({ $0.version }).sorted().last else {
-            print("No remote versions found")
+            printer.print("No remote versions found")
             return
         }
 

--- a/Sources/TuistEnvKit/Updater/Updater.swift
+++ b/Sources/TuistEnvKit/Updater/Updater.swift
@@ -2,7 +2,7 @@ import Foundation
 import TuistCore
 
 protocol Updating: AnyObject {
-    func update() throws
+    func update(force: Bool) throws
 }
 
 final class Updater: Updating {
@@ -27,7 +27,7 @@ final class Updater: Updating {
 
     // MARK: - Internal
 
-    func update() throws {
+    func update(force _: Bool) throws {
         let releases = try githubClient.releases()
 
         guard let highestRemoteVersion = releases.map({ $0.version }).sorted().last else {

--- a/Tests/TuistEnvKitTests/Commands/BundleCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/BundleCommandTests.swift
@@ -68,8 +68,8 @@ final class BundleCommandTests: XCTestCase {
         let tuistVersionPath = fileHandler.currentPath.appending(component: Constants.versionFileName)
         try "3.2.1".write(to: tuistVersionPath.url, atomically: true, encoding: .utf8)
 
-        installer.installStub = { versionToInstall in
-            let versionPath = self.versionsController.path(version: versionToInstall)
+        installer.installStub = { version, _ in
+            let versionPath = self.versionsController.path(version: version)
             try self.fileHandler.createFolder(versionPath)
             try Data().write(to: versionPath.appending(component: "test").url)
         }
@@ -102,8 +102,8 @@ final class BundleCommandTests: XCTestCase {
 
         try "3.2.1".write(to: tuistVersionPath.url, atomically: true, encoding: .utf8)
 
-        installer.installStub = { versionToInstall in
-            let versionPath = self.versionsController.path(version: versionToInstall)
+        installer.installStub = { version, _ in
+            let versionPath = self.versionsController.path(version: version)
             try self.fileHandler.createFolder(versionPath)
             try Data().write(to: versionPath.appending(component: "test").url)
         }

--- a/Tests/TuistEnvKitTests/Commands/CommandRunnerTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/CommandRunnerTests.swift
@@ -159,7 +159,7 @@ final class CommandRunnerTests: XCTestCase {
         versionResolver.resolveStub = { _ in ResolvedVersion.undefined }
 
         versionsController.semverVersionsStub = []
-        updater.updateStub = {
+        updater.updateStub = { _ in
             self.versionsController.semverVersionsStub = [Version(string: "3.2.1")!]
         }
 
@@ -182,7 +182,7 @@ final class CommandRunnerTests: XCTestCase {
 
         versionsController.semverVersionsStub = []
         let error = NSError.test()
-        updater.updateStub = {
+        updater.updateStub = { _ in
             throw error
         }
 

--- a/Tests/TuistEnvKitTests/Commands/InstallCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/InstallCommandTests.swift
@@ -54,11 +54,28 @@ final class InstallCommandTests: XCTestCase {
 
         versionsController.versionsStub = []
 
-        var installedVersion: String?
-        installer.installStub = { installedVersion = $0 }
+        var installArgs: [(version: String, force: Bool)] = []
+        installer.installStub = { version, force in installArgs.append((version: version, force: force)) }
 
         try subject.run(with: result)
 
-        XCTAssertEqual(installedVersion, "3.2.1")
+        XCTAssertEqual(installArgs.count, 1)
+        XCTAssertEqual(installArgs.first?.version, "3.2.1")
+        XCTAssertEqual(installArgs.first?.force, false)
+    }
+
+    func test_run_when_force() throws {
+        let result = try parser.parse(["install", "3.2.1", "-f"])
+
+        versionsController.versionsStub = []
+
+        var installArgs: [(version: String, force: Bool)] = []
+        installer.installStub = { version, force in installArgs.append((version: version, force: force)) }
+
+        try subject.run(with: result)
+
+        XCTAssertEqual(installArgs.count, 1)
+        XCTAssertEqual(installArgs.first?.version, "3.2.1")
+        XCTAssertEqual(installArgs.first?.force, true)
     }
 }

--- a/Tests/TuistEnvKitTests/Commands/UpdateCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/UpdateCommandTests.swift
@@ -1,14 +1,51 @@
 import Foundation
-@testable import TuistEnvKit
-import Utility
 import XCTest
 
+@testable import TuistCoreTesting
+@testable import TuistEnvKit
+@testable import Utility
+
 final class UpdateCommandTests: XCTestCase {
+    var parser: ArgumentParser!
+    var subject: UpdateCommand!
+    var updater: MockUpdater!
+    var printer: MockPrinter!
+
+    override func setUp() {
+        super.setUp()
+        parser = ArgumentParser(usage: "test", overview: "overview")
+        updater = MockUpdater()
+        printer = MockPrinter()
+        subject = UpdateCommand(parser: parser,
+                                updater: updater,
+                                printer: printer)
+    }
+
     func test_command() {
         XCTAssertEqual(UpdateCommand.command, "update")
     }
 
     func test_overview() {
         XCTAssertEqual(UpdateCommand.overview, "Installs the latest version if it's not already installed")
+    }
+
+    func test_init_registers_the_command() {
+        XCTAssertEqual(parser.subparsers.count, 1)
+        XCTAssertEqual(parser.subparsers.first?.key, UpdateCommand.command)
+        XCTAssertEqual(parser.subparsers.first?.value.overview, UpdateCommand.overview)
+    }
+
+    func test_run() throws {
+        let result = try parser.parse(["update", "-f"])
+
+        var updateCalls: [Bool] = []
+        updater.updateStub = { force in
+            updateCalls.append(force)
+        }
+
+        try subject.run(with: result)
+
+        XCTAssertEqual(printer.printSectionArgs, ["Checking for updates..."])
+        XCTAssertEqual(updateCalls, [true])
     }
 }

--- a/Tests/TuistEnvKitTests/Installer/Mocks/MockInstaller.swift
+++ b/Tests/TuistEnvKitTests/Installer/Mocks/MockInstaller.swift
@@ -3,10 +3,10 @@ import Foundation
 
 final class MockInstaller: Installing {
     var installCallCount: UInt = 0
-    var installStub: ((String) throws -> Void)?
+    var installStub: ((String, Bool) throws -> Void)?
 
-    func install(version: String) throws {
+    func install(version: String, force: Bool) throws {
         installCallCount += 1
-        try installStub?(version)
+        try installStub?(version, force)
     }
 }

--- a/Tests/TuistEnvKitTests/Updater/Mocks/MockUpdater.swift
+++ b/Tests/TuistEnvKitTests/Updater/Mocks/MockUpdater.swift
@@ -3,10 +3,10 @@ import Foundation
 
 final class MockUpdater: Updating {
     var updateCallCount: UInt = 0
-    var updateStub: (() throws -> Void)?
+    var updateStub: ((Bool) throws -> Void)?
 
-    func update() throws {
+    func update(force: Bool) throws {
         updateCallCount += 1
-        try updateStub?()
+        try updateStub?(force)
     }
 }

--- a/Tests/TuistEnvKitTests/Updater/UpdaterTests.swift
+++ b/Tests/TuistEnvKitTests/Updater/UpdaterTests.swift
@@ -1,10 +1,80 @@
 import Foundation
-@testable import TuistEnvKit
 import XCTest
+
+@testable import TuistCoreTesting
+@testable import TuistEnvKit
 
 final class UpdaterTests: XCTestCase {
     var githubClient: MockGitHubClient!
     var versionsController: MockVersionsController!
     var installer: MockInstaller!
+    var printer: MockPrinter!
     var subject: Updater!
+
+    override func setUp() {
+        githubClient = MockGitHubClient()
+        versionsController = try! MockVersionsController()
+        installer = MockInstaller()
+        printer = MockPrinter()
+        subject = Updater(githubClient: githubClient,
+                          versionsController: versionsController,
+                          installer: installer,
+                          printer: printer)
+    }
+
+    func test_update_when_no_remote_releases() throws {
+        githubClient.releasesStub = { [] }
+        try subject.update(force: false)
+        XCTAssertEqual(printer.printArgs, ["No remote versions found"])
+    }
+
+    func test_update_when_force() throws {
+        githubClient.releasesStub = { [Release.test(version: "3.2.1")] }
+        var installArgs: [(version: String, force: Bool)] = []
+        installer.installStub = { version, force in installArgs.append((version: version, force: force)) }
+
+        try subject.update(force: true)
+
+        XCTAssertEqual(printer.printArgs, ["Forcing the update of version 3.2.1"])
+        XCTAssertEqual(installArgs.count, 1)
+        XCTAssertEqual(installArgs.first?.version, "3.2.1")
+        XCTAssertEqual(installArgs.first?.force, true)
+    }
+
+    func test_update_when_there_are_no_updates() throws {
+        versionsController.semverVersionsStub = ["3.2.1"]
+        githubClient.releasesStub = { [Release.test(version: "3.2.1")] }
+
+        try subject.update(force: false)
+
+        XCTAssertEqual(printer.printArgs, ["There are no updates available"])
+    }
+
+    func test_update_when_there_are_updates() throws {
+        versionsController.semverVersionsStub = ["3.1.1"]
+        githubClient.releasesStub = { [Release.test(version: "3.2.1")] }
+        var installArgs: [(version: String, force: Bool)] = []
+        installer.installStub = { version, force in installArgs.append((version: version, force: force)) }
+
+        try subject.update(force: false)
+
+        XCTAssertEqual(printer.printArgs, ["Installing new version available 3.2.1"])
+        XCTAssertEqual(installArgs.count, 1)
+        XCTAssertEqual(installArgs.first?.version, "3.2.1")
+        XCTAssertEqual(installArgs.first?.force, false)
+    }
+
+    func test_update_when_no_local_versions_available() throws {
+        versionsController.semverVersionsStub = []
+        githubClient.releasesStub = { [Release.test(version: "3.2.1")] }
+        var installArgs: [(version: String, force: Bool)] = []
+        installer.installStub = { version, force in installArgs.append((version: version, force: force)) }
+
+        try subject.update(force: false)
+
+        XCTAssertEqual(printer.printArgs, ["No local versions available. Installing the latest version 3.2.1"])
+        XCTAssertEqual(installArgs.count, 1)
+        XCTAssertEqual(installArgs.first?.version, "3.2.1")
+        XCTAssertEqual(installArgs.first?.force, false)
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/156

### Short description 📝
Add support for the `-f / --force` flag in the install and update commands. When passed, it re-installs Tuist from the source even if there's an existing local version.

### Implementation 👩‍💻👨‍💻

- [x] Add force flag to `Installer`.
- [x] Add force flag to `Updater`.
- [x] Accept force argument from the `UpdateCommand`.
- [x] Accept force argument from the `InstallCommand`.

![tuist](https://user-images.githubusercontent.com/663605/48136905-d86b7100-e26e-11e8-8bb2-8ad29f23650f.gif)

cc @ladislas
