### PR TITLE
Fix the files and groups sorting order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ Carthage/Checkouts
 tuist.zip
 build/
 tuistenv
+TODO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next version
 
+### Fixed
+
+- Files and groups sort order https://github.com/tuist/tuist/pull/164 by @pepibumur.
+
 ## 0.8.0
 
 ### Added

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,15 +11,6 @@
         }
       },
       {
-        "package": "core",
-        "repositoryURL": "https://github.com/tuist/core.git",
-        "state": {
-          "branch": null,
-          "revision": "4500863dd846244323b29cb0950cb861e1fddcd0",
-          "version": null
-        }
-      },
-      {
         "package": "Nimble",
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {

--- a/Sources/TuistCore/Extensions/AbsolutePath+Extras.swift
+++ b/Sources/TuistCore/Extensions/AbsolutePath+Extras.swift
@@ -32,4 +32,12 @@ extension AbsolutePath {
     public func removingLastComponent() -> AbsolutePath {
         return AbsolutePath("/\(components.dropLast().joined(separator: "/"))")
     }
+
+    /// Returns a function to sorten files for Xcode projects.
+    /// - Returns: Sortening function.
+    public static func xcodeSortener() -> ((AbsolutePath, AbsolutePath) -> Bool) {
+        return { lhs, rhs in
+            lhs.components.count < rhs.components.count || lhs.asString < rhs.asString
+        }
+    }
 }

--- a/Sources/TuistKit/Generator/ProjectFileElements.swift
+++ b/Sources/TuistKit/Generator/ProjectFileElements.swift
@@ -37,7 +37,7 @@ class ProjectFileElements {
         files.formUnion(projectFiles(project: project))
 
         /// Files
-        generate(files: files.sorted(),
+        generate(files: files.sorted(by: AbsolutePath.xcodeSortener()),
                  groups: groups,
                  pbxproj: pbxproj,
                  sourceRootPath: sourceRootPath)
@@ -119,7 +119,7 @@ class ProjectFileElements {
     func generate(products: [String],
                   groups: ProjectGroups,
                   pbxproj: PBXProj) {
-        products.forEach { productName in
+        products.sorted().forEach { productName in
             if self.products[productName] != nil { return }
             let fileType = Xcode.filetype(extension: String(productName.split(separator: ".").last!))
             let fileReference = PBXFileReference(sourceTree: .buildProductsDir,
@@ -278,7 +278,7 @@ class ProjectFileElements {
                          toGroup: PBXGroup,
                          pbxproj: PBXProj) {
         // /path/to/*.lproj/*
-        absolutePath.glob("*").forEach { localizedFile in
+        absolutePath.glob("*").sorted().forEach { localizedFile in
             let localizedName = localizedFile.components.last!
 
             // Variant group

--- a/Tests/TuistCoreTests/Extensions/AbsolutePath+ExtrasTests.swift
+++ b/Tests/TuistCoreTests/Extensions/AbsolutePath+ExtrasTests.swift
@@ -1,0 +1,23 @@
+import Basic
+import Foundation
+import XCTest
+
+@testable import TuistCore
+
+final class AbsolutePathExtrasTests: XCTestCase {
+    func test_xcodeSortener() {
+        let subject = [
+            AbsolutePath("/sources/a.swift"),
+            AbsolutePath("/a.swift"),
+            AbsolutePath("/b.swift"),
+            AbsolutePath("/sources/b.swift"),
+        ].sorted(by: AbsolutePath.xcodeSortener())
+
+        XCTAssertEqual(subject, [
+            AbsolutePath("/a.swift"),
+            AbsolutePath("/b.swift"),
+            AbsolutePath("/sources/a.swift"),
+            AbsolutePath("/sources/b.swift"),
+        ])
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/140

### Short description 📝
Files and groups were sorted alphabetically. This PR changes the order to be sorted by type and then by name. After this change, files should be listed before groups.

### Solution 📦

I've created a sorting function that defines the sorting logic and changed the class that generates the files to use that function.

cc @asalom 