### PR TITLE
Manage Transitive Dependencies for Static Libraries

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,15 +11,6 @@
         }
       },
       {
-        "package": "ColorizeSwift",
-        "repositoryURL": "https://github.com/mtynior/ColorizeSwift.git",
-        "state": {
-          "branch": null,
-          "revision": "16cb4545a54311ca29d314fa3b907296285cfde9",
-          "version": "1.2.0"
-        }
-      },
-      {
         "package": "PathKit",
         "repositoryURL": "https://github.com/kylef/PathKit",
         "state": {

--- a/Sources/TuistCore/Extensions/Sequence+KeyPath.swift
+++ b/Sources/TuistCore/Extensions/Sequence+KeyPath.swift
@@ -1,0 +1,23 @@
+extension Sequence {
+    
+    public func filter(where keyPath: KeyPath<Element, Bool>) -> [Element] {
+        return filter(get(keyPath))
+    }
+    
+    public func filter(_ keyPath: KeyPath<Element, Bool>) -> [Element] {
+        return filter(get(keyPath))
+    }
+    
+    public func map<Property>(_ keyPath: KeyPath<Element, Property>) -> [Property] {
+        return map(get(keyPath))
+    }
+    
+    public func compactMap<Property>(_ keyPath: KeyPath<Element, Property?>) -> [Property] {
+        return compactMap(get(keyPath))
+    }
+    
+    public func first(_ keyPath: KeyPath<Element, Bool>) -> Element? {
+        return first(where: get(keyPath))
+    }
+    
+}

--- a/Sources/TuistCore/Utils/Functions.swift
+++ b/Sources/TuistCore/Utils/Functions.swift
@@ -1,0 +1,36 @@
+/// Produces a getter function for a given key path. Useful for composing property access with functions.
+///
+///     get(\String.count)
+///     // (String) -> Int
+///
+/// - Parameter keyPath: A key path.
+/// - Returns: A getter function.
+public func get<Root, Value>(_ keyPath: KeyPath<Root, Value>) -> (Root) -> Value {
+    return { root in root[keyPath: keyPath] }
+}
+
+/// Produces a logical AND function for two given closures. Useful for composing predicates with functions.
+///
+///    func isFramework(node: GraphNode) -> Bool
+///    func isDynamicLibrary(node: GraphNode) -> Bool
+///
+///     and(isFramework, isDynamicLibrary)
+///     // (GraphNode) -> True
+///
+/// - Returns: A predicate function.
+public func and<T>(_ lhs: @escaping (T) -> Bool, _ rhs: @escaping (T) -> Bool) -> (T) -> Bool {
+    return { lhs($0) && rhs($0) }
+}
+
+/// Produces a logical OR function for two given closures. Useful for composing predicates with functions.
+///
+///    func isFramework(node: GraphNode) -> Bool
+///    func isDynamicLibrary(node: GraphNode) -> Bool
+///
+///     or(isFramework, isDynamicLibrary)
+///     // (GraphNode) -> True
+///
+/// - Returns: A predicate function.
+public func or<T>(_ lhs: @escaping (T) -> Bool, _ rhs: @escaping (T) -> Bool) -> (T) -> Bool {
+    return { lhs($0) || rhs($0) }
+}

--- a/Sources/TuistCore/Utils/Stack.swift
+++ b/Sources/TuistCore/Utils/Stack.swift
@@ -1,0 +1,24 @@
+/// Implements a Stack - helper class for push/pop that uses an array internally.
+public struct Stack<T> {
+    
+    fileprivate var array = [T]()
+    
+    public init() { }
+    
+    public var isEmpty: Bool {
+        return array.isEmpty
+    }
+    
+    public var count: Int {
+        return array.count
+    }
+    
+    public mutating func push(_ element: T) {
+        array.append(element)
+    }
+    
+    public mutating func pop() -> T? {
+        return array.popLast()
+    }
+    
+}

--- a/Sources/TuistKit/Generator/ProjectFileElements.swift
+++ b/Sources/TuistKit/Generator/ProjectFileElements.swift
@@ -56,8 +56,10 @@ class ProjectFileElements {
                             pbxproj: pbxproj,
                             sourceRootPath: sourceRootPath)
 
+        let dependencies = graph.findAll(path: project.path)
+        
         /// Dependencies
-        generate(dependencies: graph.dependencies(path: project.path),
+        generate(dependencies: dependencies,
                  path: project.path,
                  groups: groups,
                  pbxproj: pbxproj,

--- a/Sources/TuistKit/Graph/Graph.swift
+++ b/Sources/TuistKit/Graph/Graph.swift
@@ -4,14 +4,14 @@ import TuistCore
 
 enum GraphError: FatalError {
     case unsupportedFileExtension(String)
-
+    
     var description: String {
         switch self {
         case let .unsupportedFileExtension(productType):
             return "Could't obtain product file extension for product type: \(productType)"
         }
     }
-
+    
     var type: ErrorType {
         switch self {
         case .unsupportedFileExtension:
@@ -23,7 +23,7 @@ enum GraphError: FatalError {
 enum DependencyReference: Equatable {
     case absolute(AbsolutePath)
     case product(String)
-
+    
     static func == (lhs: DependencyReference, rhs: DependencyReference) -> Bool {
         switch (lhs, rhs) {
         case let (.absolute(lhsPath), .absolute(rhsPath)):
@@ -37,23 +37,37 @@ enum DependencyReference: Equatable {
 }
 
 protocol Graphing: AnyObject {
+    
     var name: String { get }
     var entryPath: AbsolutePath { get }
     var entryNodes: [GraphNode] { get }
     var projects: [Project] { get }
     var frameworks: [FrameworkNode] { get }
-
+    
     func linkableDependencies(path: AbsolutePath, name: String) throws -> [DependencyReference]
     func librariesPublicHeadersFolders(path: AbsolutePath, name: String) -> [AbsolutePath]
     func embeddableFrameworks(path: AbsolutePath, name: String, system: Systeming) throws -> [DependencyReference]
-    func dependencies(path: AbsolutePath, name: String) -> Set<GraphNode>
-    func dependencies(path: AbsolutePath) -> Set<GraphNode>
     func targetDependencies(path: AbsolutePath, name: String) -> [String]
+    func staticLibraryDependencies(path: AbsolutePath, name: String) -> [DependencyReference]
+    
+    // MARK:- Depth First Search
+    
+    /// Depth-first search (DFS) is an algorithm for traversing graph data structures. It starts at a source node
+    /// and explores as far as possible along each branch before backtracking.
+    ///
+    /// This implementation looks for TargetNode's and traverses their dependencies so that we are able to build
+    /// up a graph of dependencies to later be used to define the "Link Binary with Library" in an xcodeproj.
+    
+    func findAll<T: GraphNode>(path: AbsolutePath) -> Set<T>
+    func findAll<T: GraphNode>(path: AbsolutePath, test: (T) -> Bool) -> Set<T>
+    func findAll<T: GraphNode>(path: AbsolutePath, name: String, test: (T) -> Bool) -> Set<T>
+    
 }
 
 class Graph: Graphing {
+    
     // MARK: - Attributes
-
+    
     private let cache: GraphLoaderCaching
     let name: String
     let entryPath: AbsolutePath
@@ -61,9 +75,9 @@ class Graph: Graphing {
     var projects: [Project] {
         return Array(cache.projects.values)
     }
-
+    
     // MARK: - Init
-
+    
     init(name: String,
          entryPath: AbsolutePath,
          cache: GraphLoaderCaching,
@@ -73,83 +87,96 @@ class Graph: Graphing {
         self.cache = cache
         self.entryNodes = entryNodes
     }
-
+    
     // MARK: - Internal
-
+    
     var frameworks: [FrameworkNode] {
-        return cache.precompiledNodes.values.compactMap({ $0 as? FrameworkNode })
+        return cache.precompiledNodes.values.compactMap{ $0 as? FrameworkNode }
     }
-
-    func dependencies(path: AbsolutePath) -> Set<GraphNode> {
-        var dependencies: Set<GraphNode> = Set()
-        cache.targetNodes[path]?.forEach {
-            dependencies.formUnion(self.dependencies(path: path, name: $0.key))
-        }
-        return dependencies
-    }
-
-    func dependencies(path: AbsolutePath, name: String) -> Set<GraphNode> {
-        var dependencies: Set<GraphNode> = Set()
-        var add: ((GraphNode) -> Void)!
-        add = { node in
-            guard let targetNode = node as? TargetNode else { return }
-            targetNode.dependencies.forEach({ dependencies.insert($0) })
-            targetNode.dependencies.compactMap({ $0 as? TargetNode }).forEach(add)
-        }
-        if let targetNode = self.targetNode(path: path, name: name) {
-            add(targetNode)
-        }
-        return dependencies
-    }
-
+    
     func targetDependencies(path: AbsolutePath, name: String) -> [String] {
-        guard let targetNode = self.targetNode(path: path, name: name) else { return [] }
-        return targetNode.dependencies
-            .compactMap({ $0 as? TargetNode })
-            .filter({ $0.path == path })
-            .map({ $0.target.name })
+        
+        guard let targetNode = findTargetNode(path: path, name: name) else {
+            return [ ]
+        }
+        
+        return targetNode.targetDependencies
+            .filter{ $0.path == path }
+            .map(\.target.name)
     }
-
+    
+    func staticLibraryDependencies(path: AbsolutePath, name: String) -> [DependencyReference] {
+        
+        guard let targetNode = findTargetNode(path: path, name: name) else {
+            return [ ]
+        }
+        
+        return targetNode.targetDependencies
+            .filter(isStaticLibrary)
+            .map(\.target.productName)
+            .map(DependencyReference.product)
+    }
+    
     func linkableDependencies(path: AbsolutePath, name: String) throws -> [DependencyReference] {
-        guard let targetNode = self.targetNode(path: path, name: name) else { return [] }
-
-        var references: [DependencyReference] = []
-
+        
+        guard let targetNode = findTargetNode(path: path, name: name) else {
+            return [ ]
+        }
+        
+        var references: [DependencyReference] = [ ]
+        
         /// Precompiled libraries and frameworks
-        references.append(contentsOf: targetNode
-            .dependencies
-            .compactMap({ $0 as? PrecompiledNode })
-            .map({ DependencyReference.absolute($0.path) }))
-
-        /// Other targets frameworks and libraries
-        try references.append(contentsOf: targetNode
-            .dependencies
-            .compactMap({ $0 as? TargetNode })
-            .filter({ $0.target.isLinkable() })
-            .map({ targetNode in
-                let xcodeProduct = targetNode.target.product.xcodeValue
-                guard let `extension` = xcodeProduct.fileExtension else {
-                    throw GraphError.unsupportedFileExtension(xcodeProduct.rawValue)
-                }
-                return DependencyReference.product("\(targetNode.target.name).\(`extension`)")
-        }))
-
+        
+        let precompiledLibrariesAndFrameworks = targetNode.precompiledDependencies
+            .map(\.path)
+            .map(DependencyReference.absolute)
+        
+        references.append(contentsOf: precompiledLibrariesAndFrameworks)
+        
+        switch targetNode.target.product {
+        case .staticLibrary, .dynamicLibrary, .framework:
+            // Ignore the products, they do not want to directly link the static libraries, the top level bundles will be responsible.
+            break
+        case .app, .unitTests, .uiTests:
+            
+            let staticLibraries = findAll(targetNode: targetNode, test: isStaticLibrary)
+                .lazy
+                .map(\.target.productName)
+                .map(DependencyReference.product)
+            
+            references.append(contentsOf: staticLibraries)
+        }
+        
+        // Link dynamic libraries and frameworks
+        
+        let dynamicLibrariesAndFrameworks = targetNode.targetDependencies
+            .filter(or(isFramework, isDynamicLibrary))
+            .map(\.target.productName)
+            .map(DependencyReference.product)
+        
+        references.append(contentsOf: dynamicLibrariesAndFrameworks)
+        
         return references
     }
-
+    
     func librariesPublicHeadersFolders(path: AbsolutePath, name: String) -> [AbsolutePath] {
-        guard let targetNode = self.targetNode(path: path, name: name) else { return [] }
-        return targetNode
-            .dependencies
-            .compactMap({ $0 as? LibraryNode })
-            .map({ $0.publicHeaders })
+        
+        guard let targetNode = findTargetNode(path: path, name: name) else {
+            return [ ]
+        }
+        
+        return targetNode.libraryDependencies
+            .map(\.publicHeaders)
     }
-
+    
     func embeddableFrameworks(path: AbsolutePath,
                               name: String,
                               system: Systeming) throws -> [DependencyReference] {
-        guard let targetNode = self.targetNode(path: path, name: name) else { return [] }
-
+        
+        guard let targetNode = findTargetNode(path: path, name: name) else {
+            return [ ]
+        }
+        
         let validProducts: [Product] = [
             .app,
             .unitTests,
@@ -163,41 +190,173 @@ class Graph: Graphing {
 //            .watch2App,
 //            .messagesApplication,
         ]
-
-        if !validProducts.contains(targetNode.target.product) { return [] }
-
-        var references: [DependencyReference] = []
-        let dependencies = self.dependencies(path: path, name: name)
-
+        
+        if validProducts.contains(targetNode.target.product) == false {
+            return [ ]
+        }
+        
+        var references: [DependencyReference] = [ ]
+        
         /// Precompiled frameworks
-        references.append(contentsOf: try dependencies
-            .compactMap({ $0 as? FrameworkNode })
-            .filter({ try $0.linking(system: system) == .dynamic })
-            .map({ DependencyReference.absolute($0.path) }))
-
+        let precompiledFrameworks = findAll(targetNode: targetNode, test: frameworkUsesDynamicLinking(system: system))
+            .lazy
+            .map(\.path)
+            .map(DependencyReference.absolute)
+        
+        references.append(contentsOf: precompiledFrameworks)
+        
         /// Other targets' frameworks.
-        try references.append(contentsOf: dependencies
-            .compactMap({ $0 as? TargetNode })
-            .filter({ $0.target.product == .framework })
-            .map({ targetNode in
-                let xcodeProduct = targetNode.target.product.xcodeValue
-                guard let `extension` = xcodeProduct.fileExtension else {
-                    throw GraphError.unsupportedFileExtension(xcodeProduct.rawValue)
-                }
-                return DependencyReference.product("\(targetNode.target.name).\(`extension`)")
-        }))
+        let otherTargetFrameworks = findAll(targetNode: targetNode, test: isFramework)
+            .lazy
+            .map(\.target.productName)
+            .map(DependencyReference.product)
+        
+        references.append(contentsOf: otherTargetFrameworks)
+        
         return references
     }
-
+    
     // MARK: - Fileprivate
-
-    fileprivate func targetNode(path: AbsolutePath, name: String) -> TargetNode? {
-        if let targetNode = self.entryNodes.compactMap({ $0 as? TargetNode }).first(where: {
-            $0.path == path && $0.target.name == name
-        }) {
+    
+    fileprivate func findTargetNode(path: AbsolutePath, name: String) -> TargetNode? {
+        
+        func isPathAndNameEqual(node: TargetNode) -> Bool {
+            return node.path == path && node.target.name == name
+        }
+        
+        let targetNodes = entryNodes.compactMap{ $0 as? TargetNode }
+        
+        if let targetNode = targetNodes.first(where: isPathAndNameEqual) {
             return targetNode
         }
-        guard let targetNodes = cache.targetNodes[path] else { return nil }
-        return targetNodes[name]
+        
+        guard let cachedTargetNodesForPath = cache.targetNodes[path] else {
+            return nil
+        }
+        
+        return cachedTargetNodesForPath[name]
+    }
+}
+
+// MARK:- Predicates
+
+extension Graph {
+    
+    internal func isStaticLibrary(targetNode: TargetNode) -> Bool {
+        return targetNode.target.product == .staticLibrary
+    }
+    
+    internal func isDynamicLibrary(targetNode: TargetNode) -> Bool {
+        return targetNode.target.product == .dynamicLibrary
+    }
+    
+    internal func isFramework(targetNode: TargetNode) -> Bool {
+        return targetNode.target.product == .framework
+    }
+    
+    internal func frameworkUsesDynamicLinking(system: Systeming) -> (_ frameworkNode: FrameworkNode) -> Bool {
+        return { frameworkNode in
+            let isDynamicLink = try? frameworkNode.linking(system: system) == .dynamic
+            return isDynamicLink ?? false
+        }
+    }
+    
+}
+
+// MARK:- TargetNode helper computed properties, provide lazy arrays by default.
+
+extension TargetNode {
+    
+    fileprivate var targetDependencies: [TargetNode] {
+        return dependencies.lazy.compactMap{ $0 as? TargetNode }
+    }
+    
+    fileprivate var precompiledDependencies: [PrecompiledNode] {
+        return dependencies.lazy.compactMap{ $0 as? PrecompiledNode }
+    }
+    
+    fileprivate var libraryDependencies: [LibraryNode] {
+        return dependencies.lazy.compactMap{ $0 as? LibraryNode }
+    }
+    
+    fileprivate var frameworkDependencies: [FrameworkNode] {
+        return dependencies.lazy.compactMap{ $0 as? FrameworkNode }
+    }
+    
+}
+
+extension Graph {
+    
+    internal func findAll<T: GraphNode>(path: AbsolutePath) -> Set<T> {
+        let alwaysTrue: (T) -> Bool = { _ in true }
+        return findAll(path: path, test: alwaysTrue)
+    }
+    
+    // Traverse the graph for all cached target nodes using DFS and return all results passing the test.
+    internal func findAll<T: GraphNode>(path: AbsolutePath, test: (T) -> Bool) -> Set<T> {
+        
+        guard let targetNodes = cache.targetNodes[path] else {
+            return [ ]
+        }
+        
+        var references = Set<T>()
+        
+        for (_, node) in targetNodes {
+            references.formUnion(findAll(targetNode: node, test: test))
+        }
+        
+        return references
+        
+    }
+    
+    // Traverse the graph finding target node with name using DFS and return all results passing the test.
+    internal func findAll<T: GraphNode>(path: AbsolutePath, name: String, test: (T) -> Bool) -> Set<T> {
+        
+        guard let targetNode = findTargetNode(path: path, name: name) else {
+            return []
+        }
+        
+        return findAll(targetNode: targetNode, test: test)
+    }
+    
+    // Traverse the graph from the target node using DFS and return all results passing the test.
+    internal func findAll<T: GraphNode>(targetNode: TargetNode, test: (T) -> Bool) -> Set<T> {
+        
+        var stack = Stack<GraphNode>()
+        
+        for node in targetNode.dependencies where node is T {
+            stack.push(node as! T)
+        }
+        
+        var visited: Set<GraphNode> = .init()
+        var references = Set<T>()
+        
+        while !stack.isEmpty {
+            
+            guard let node = stack.pop() else {
+                continue
+            }
+            
+            if visited.contains(node) {
+                continue
+            }
+            
+            visited.insert(node)
+            
+            if node is T, test(node as! T) {
+                references.insert(node as! T)
+            }
+            
+            if let targetNode = node as? TargetNode {
+                
+                for child in targetNode.dependencies where !visited.contains(child) {
+                    stack.push(child)
+                }
+                
+            }
+            
+        }
+        
+        return references
     }
 }

--- a/Sources/TuistKit/Linter/TargetLinter.swift
+++ b/Sources/TuistKit/Linter/TargetLinter.swift
@@ -82,12 +82,16 @@ class TargetLinter: TargetLinting {
     }
 
     fileprivate func lintLibraryHasNoResources(target: Target) -> [LintingIssue] {
-        if target.product != .dynamicLibrary && target.product != .staticLibrary {
-            return []
+        
+        if target.product == .dynamicLibrary || target.product == .staticLibrary {
+            return [ ]
         }
+        
         if target.resources.count != 0 {
             return [LintingIssue(reason: "Target \(target.name) cannot contain resources. Libraries don't support resources", severity: .error)]
         }
-        return []
+        
+        return [ ]
+        
     }
 }

--- a/Tests/TuistCoreTests/Utils/StackTests.swift
+++ b/Tests/TuistCoreTests/Utils/StackTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import TuistCore
+
+final class StackTests: XCTestCase {
+    
+    func testEmpty() {
+        var stack = Stack<Int>()
+        XCTAssertTrue(stack.isEmpty)
+        XCTAssertEqual(stack.count, 0)
+        XCTAssertNil(stack.pop())
+    }
+    
+    func testOneElement() {
+        var stack = Stack<Int>()
+        
+        stack.push(123)
+        XCTAssertFalse(stack.isEmpty)
+        XCTAssertEqual(stack.count, 1)
+        
+        let result = stack.pop()
+        XCTAssertEqual(result, 123)
+        XCTAssertTrue(stack.isEmpty)
+        XCTAssertEqual(stack.count, 0)
+        XCTAssertNil(stack.pop())
+    }
+    
+    func testTwoElements() {
+        var stack = Stack<Int>()
+        
+        stack.push(123)
+        stack.push(456)
+        XCTAssertFalse(stack.isEmpty)
+        XCTAssertEqual(stack.count, 2)
+        
+        let result1 = stack.pop()
+        XCTAssertEqual(result1, 456)
+        XCTAssertFalse(stack.isEmpty)
+        XCTAssertEqual(stack.count, 1)
+        
+        let result2 = stack.pop()
+        XCTAssertEqual(result2, 123)
+        XCTAssertTrue(stack.isEmpty)
+        XCTAssertEqual(stack.count, 0)
+        XCTAssertNil(stack.pop())
+    }
+    
+    func testMakeEmpty() {
+        var stack = Stack<Int>()
+        
+        stack.push(123)
+        stack.push(456)
+        XCTAssertNotNil(stack.pop())
+        XCTAssertNotNil(stack.pop())
+        XCTAssertNil(stack.pop())
+        
+        stack.push(789)
+        XCTAssertEqual(stack.count, 1)
+        
+        let result = stack.pop()
+        XCTAssertEqual(result, 789)
+        XCTAssertTrue(stack.isEmpty)
+        XCTAssertEqual(stack.count, 0)
+        XCTAssertNil(stack.pop())
+    }
+    
+}


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/60

### Short description 📝 & Solution 📦

Static Libraries were not yet fully supported, the dependency graph would include the static libraries in each dependency producing duplicate symbols.

- Include all transitive dependencies in top level bundles when using static libraries
- Create "Fake Swift Dependencies" to allow Xcode to build the static libraries in the correct order 
- WIP

### Implementation 👩‍💻👨‍💻

- Implemented DFS in `Graph.linkableDependencies` to search for all static libraries, this will include them if the top level bundle is an app, ui or unit test target.
- Continue to link dynamic libraries and frameworks the same way, this needs further testing
- Ignore linking any static libraries to static libraries (need to check if we would ever actually want this, see L142)
- Implement `Graph.staticLibraryDependencies` to resolve a one-level-deep dependency for the use of generating the fake dependencies build phase 
- Implement `LinkGenerator.generateFakeSwiftDependenciesForStaticLibraries` to create a copy files phase which act's as a build file dependency resolution.

This is a WIP so any guidance would be appreciated.