### PR TITLE
Don't add the Playgrounds group if there are no playgrounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next version
 
+### Fixed
+
+- Don't generate the Playgrounds group if there are no playgrounds https://github.com/tuist/tuist/pull/177 by @pepibumur.
+
 ## 0.9.0
 
 ### Added

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "core",
+        "repositoryURL": "https://github.com/tuist/core.git",
+        "state": {
+          "branch": null,
+          "revision": "4500863dd846244323b29cb0950cb861e1fddcd0",
+          "version": null
+        }
+      },
+      {
         "package": "Nimble",
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {

--- a/Sources/TuistKit/Generator/ProjectFileElements.swift
+++ b/Sources/TuistKit/Generator/ProjectFileElements.swift
@@ -16,11 +16,14 @@ class ProjectFileElements {
 
     var elements: [AbsolutePath: PBXFileElement] = [:]
     var products: [String: PBXFileReference] = [:]
+    let playgrounds: Playgrounding
 
     // MARK: - Init
 
-    init(_ elements: [AbsolutePath: PBXFileElement] = [:]) {
+    init(_ elements: [AbsolutePath: PBXFileElement] = [:],
+         playgrounds: Playgrounding = Playgrounds()) {
         self.elements = elements
+        self.playgrounds = playgrounds
     }
 
     func generateProjectFiles(project: Project,
@@ -136,7 +139,9 @@ class ProjectFileElements {
                              groups: ProjectGroups,
                              pbxproj: PBXProj,
                              sourceRootPath _: AbsolutePath) {
-        let paths = path.glob("Playgrounds/*.playground").sorted()
+        let paths = playgrounds.playgrounds(path: path)
+        if paths.isEmpty { return }
+
         let group = groups.playgrounds
         paths.forEach { playgroundPath in
             let name = playgroundPath.components.last!
@@ -145,7 +150,7 @@ class ProjectFileElements {
                                              path: name,
                                              xcLanguageSpecificationIdentifier: "xcode.lang.swift")
             pbxproj.add(object: reference)
-            group.children.append(reference)
+            group!.children.append(reference)
         }
     }
 

--- a/Sources/TuistKit/Generator/ProjectFileElements.swift
+++ b/Sources/TuistKit/Generator/ProjectFileElements.swift
@@ -139,7 +139,7 @@ class ProjectFileElements {
                              groups: ProjectGroups,
                              pbxproj: PBXProj,
                              sourceRootPath _: AbsolutePath) {
-        let paths = playgrounds.playgrounds(path: path)
+        let paths = playgrounds.paths(path: path)
         if paths.isEmpty { return }
 
         let group = groups.playgrounds

--- a/Sources/TuistKit/Generator/ProjectGroups.swift
+++ b/Sources/TuistKit/Generator/ProjectGroups.swift
@@ -67,7 +67,7 @@ class ProjectGroups {
 
         /// Playgrounds
         var playgroundsGroup: PBXGroup!
-        if !playgrounds.playgrounds(path: project.path).isEmpty {
+        if !playgrounds.paths(path: project.path).isEmpty {
             playgroundsGroup = PBXGroup(children: [], sourceTree: .group, path: "Playgrounds")
             pbxproj.add(object: playgroundsGroup)
             mainGroup.children.append(playgroundsGroup)

--- a/Sources/TuistKit/Generator/ProjectGroups.swift
+++ b/Sources/TuistKit/Generator/ProjectGroups.swift
@@ -10,7 +10,7 @@ class ProjectGroups {
     let projectDescription: PBXGroup
     let project: PBXGroup
     let frameworks: PBXGroup
-    let playgrounds: PBXGroup
+    let playgrounds: PBXGroup?
     let pbxproj: PBXProj
 
     // MARK: - Init
@@ -20,7 +20,7 @@ class ProjectGroups {
          projectDescription: PBXGroup,
          frameworks: PBXGroup,
          project: PBXGroup,
-         playgrounds: PBXGroup,
+         playgrounds: PBXGroup?,
          pbxproj: PBXProj) {
         self.main = main
         self.products = products
@@ -41,7 +41,8 @@ class ProjectGroups {
 
     static func generate(project: Project,
                          pbxproj: PBXProj,
-                         sourceRootPath: AbsolutePath) -> ProjectGroups {
+                         sourceRootPath: AbsolutePath,
+                         playgrounds: Playgrounding = Playgrounds()) -> ProjectGroups {
         /// Main
         let projectRelativePath = project.path.relative(to: sourceRootPath).asString
         let mainGroup = PBXGroup(children: [],
@@ -65,9 +66,12 @@ class ProjectGroups {
         mainGroup.children.append(frameworksGroup)
 
         /// Playgrounds
-        let playgroundsGroup = PBXGroup(children: [], sourceTree: .group, path: "Playgrounds")
-        pbxproj.add(object: playgroundsGroup)
-        mainGroup.children.append(playgroundsGroup)
+        var playgroundsGroup: PBXGroup!
+        if !playgrounds.playgrounds(path: project.path).isEmpty {
+            playgroundsGroup = PBXGroup(children: [], sourceTree: .group, path: "Playgrounds")
+            pbxproj.add(object: playgroundsGroup)
+            mainGroup.children.append(playgroundsGroup)
+        }
 
         /// Products
         let productsGroup = PBXGroup(children: [], sourceTree: .group, name: "Products")

--- a/Sources/TuistKit/Utils/Playgrounds.swift
+++ b/Sources/TuistKit/Utils/Playgrounds.swift
@@ -7,7 +7,7 @@ protocol Playgrounding {
     ///
     /// - Parameter path: Directory where the project is defined.
     /// - Returns: List of paths.
-    func playgrounds(path: AbsolutePath) -> [AbsolutePath]
+    func paths(path: AbsolutePath) -> [AbsolutePath]
 }
 
 final class Playgrounds: Playgrounding {
@@ -16,7 +16,7 @@ final class Playgrounds: Playgrounding {
     ///
     /// - Parameter path: Directory where the project is defined.
     /// - Returns: List of paths.
-    func playgrounds(path: AbsolutePath) -> [AbsolutePath] {
+    func paths(path: AbsolutePath) -> [AbsolutePath] {
         return path.glob("Playgrounds/*.playground").sorted()
     }
 }

--- a/Sources/TuistKit/Utils/Playgrounds.swift
+++ b/Sources/TuistKit/Utils/Playgrounds.swift
@@ -1,0 +1,22 @@
+import Basic
+import Foundation
+
+/// Protocol that defines an interface to interact with the project.
+protocol Playgrounding {
+    /// Returns the list project Playgrounds in the given project directory.
+    ///
+    /// - Parameter path: Directory where the project is defined.
+    /// - Returns: List of paths.
+    func playgrounds(path: AbsolutePath) -> [AbsolutePath]
+}
+
+final class Playgrounds: Playgrounding {
+    /// Returns the list project Playgrounds in the given project directory.
+    /// It enforces an implicit convention for the Playgrounds to be in the Playgrounds directory.
+    ///
+    /// - Parameter path: Directory where the project is defined.
+    /// - Returns: List of paths.
+    func playgrounds(path: AbsolutePath) -> [AbsolutePath] {
+        return path.glob("Playgrounds/*.playground").sorted()
+    }
+}

--- a/Tests/TuistKitTests/Generator/Mocks/MockPlaygrounds.swift
+++ b/Tests/TuistKitTests/Generator/Mocks/MockPlaygrounds.swift
@@ -1,0 +1,12 @@
+import Basic
+import Foundation
+import TuistCore
+@testable import TuistKit
+
+final class MockPlaygrounds: Playgrounding {
+    var pathsStub: ((AbsolutePath) -> [AbsolutePath])?
+
+    func paths(path: AbsolutePath) -> [AbsolutePath] {
+        return pathsStub?(path) ?? []
+    }
+}

--- a/Tests/TuistKitTests/Generator/ProjectGroupsTests.swift
+++ b/Tests/TuistKitTests/Generator/ProjectGroupsTests.swift
@@ -75,7 +75,7 @@ final class ProjectGroupsTests: XCTestCase {
 
     func test_targetFrameworks() throws {
         subject = ProjectGroups.generate(project: project, pbxproj: pbxproj, sourceRootPath: sourceRootPath, playgrounds: playgrounds)
-        s
+        
         let got = try subject.targetFrameworks(target: "Test")
         XCTAssertEqual(got.name, "Test")
         XCTAssertEqual(got.sourceTree, .group)

--- a/Tests/TuistKitTests/Generator/ProjectGroupsTests.swift
+++ b/Tests/TuistKitTests/Generator/ProjectGroupsTests.swift
@@ -6,20 +6,33 @@ import XCTest
 
 final class ProjectGroupsTests: XCTestCase {
     var subject: ProjectGroups!
+    var playgrounds: MockPlaygrounds!
+    var sourceRootPath: AbsolutePath!
+    var project: Project!
+    var pbxproj: PBXProj!
 
     override func setUp() {
         super.setUp()
         let path = AbsolutePath("/test/")
-        let sourceRootPath = AbsolutePath("/test/")
-        let project = Project(path: path,
-                              name: "Project",
-                              settings: nil,
-                              targets: [])
-        let pbxproj = PBXProj()
-        subject = ProjectGroups.generate(project: project, pbxproj: pbxproj, sourceRootPath: sourceRootPath)
+        playgrounds = MockPlaygrounds()
+        sourceRootPath = AbsolutePath("/test/")
+        project = Project(path: path,
+                          name: "Project",
+                          settings: nil,
+                          targets: [])
+        pbxproj = PBXProj()
     }
 
     func test_generate() {
+        playgrounds.pathsStub = { projectPath in
+            if projectPath == self.sourceRootPath {
+                return [self.sourceRootPath.appending(RelativePath("Playgrounds/Test.playground"))]
+            } else {
+                return []
+            }
+        }
+        subject = ProjectGroups.generate(project: project, pbxproj: pbxproj, sourceRootPath: sourceRootPath, playgrounds: playgrounds)
+
         let main = subject.main
         XCTAssertNil(main.path)
         XCTAssertEqual(main.sourceTree, .group)
@@ -44,13 +57,25 @@ final class ProjectGroupsTests: XCTestCase {
         XCTAssertNil(subject.products.path)
         XCTAssertEqual(subject.products.sourceTree, .group)
 
-        XCTAssertTrue(main.children.contains(subject.playgrounds))
-        XCTAssertEqual(subject.playgrounds.path, "Playgrounds")
-        XCTAssertNil(subject.playgrounds.name)
-        XCTAssertEqual(subject.playgrounds.sourceTree, .group)
+        XCTAssertNotNil(subject.playgrounds)
+        XCTAssertTrue(main.children.contains(subject.playgrounds!))
+        XCTAssertEqual(subject.playgrounds?.path, "Playgrounds")
+        XCTAssertNil(subject.playgrounds?.name)
+        XCTAssertEqual(subject.playgrounds?.sourceTree, .group)
+    }
+
+    func test_generate_when_there_are_no_playgrounds() {
+        playgrounds.pathsStub = { _ in
+            []
+        }
+        subject = ProjectGroups.generate(project: project, pbxproj: pbxproj, sourceRootPath: sourceRootPath, playgrounds: playgrounds)
+
+        XCTAssertNil(subject.playgrounds)
     }
 
     func test_targetFrameworks() throws {
+        subject = ProjectGroups.generate(project: project, pbxproj: pbxproj, sourceRootPath: sourceRootPath, playgrounds: playgrounds)
+        s
         let got = try subject.targetFrameworks(target: "Test")
         XCTAssertEqual(got.name, "Test")
         XCTAssertEqual(got.sourceTree, .group)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/176

### Short description 📝
If there are no Playgrounds in the `Playgrounds` directory under the project path, don't generate any group on the generated Xcode project.

### Solution 📦
- Add a class, `Playgrounds` that abstracts the Playground convention.
- Use it from `ProjectGroups` and `ProjectFileElements` to skip the group generation. 