### PR TITLE
Support cpp source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Added
 
-- Support `cpp` source files https://github.com/tuist/tuist/pull/178 by @pepibumur.
+- Support `.cpp` and `.c` source files https://github.com/tuist/tuist/pull/178 by @pepibumur.
 
 ## 0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Don't generate the Playgrounds group if there are no playgrounds https://github.com/tuist/tuist/pull/177 by @pepibumur.
 
+### Added
+
+- Support `cpp` source files https://github.com/tuist/tuist/pull/178 by @pepibumur.
+
 ## 0.9.0
 
 ### Added

--- a/Sources/TuistKit/Models/Target.swift
+++ b/Sources/TuistKit/Models/Target.swift
@@ -5,7 +5,7 @@ import TuistCore
 class Target: GraphJSONInitiatable, Equatable {
     // MARK: - Static
 
-    static let validSourceExtensions: [String] = ["m", "swift", "mm", "cpp"]
+    static let validSourceExtensions: [String] = ["m", "swift", "mm", "cpp", "c"]
     static let validFolderExtensions: [String] = ["framework", "bundle", "app", "appiconset"]
 
     // MARK: - Attributes

--- a/Sources/TuistKit/Models/Target.swift
+++ b/Sources/TuistKit/Models/Target.swift
@@ -5,7 +5,7 @@ import TuistCore
 class Target: GraphJSONInitiatable, Equatable {
     // MARK: - Static
 
-    static let validSourceExtensions: [String] = ["m", "swift", "mm"]
+    static let validSourceExtensions: [String] = ["m", "swift", "mm", "cpp"]
     static let validFolderExtensions: [String] = ["framework", "bundle", "app", "appiconset"]
 
     // MARK: - Attributes

--- a/Tests/TuistKitTests/Models/TargetTests.swift
+++ b/Tests/TuistKitTests/Models/TargetTests.swift
@@ -4,6 +4,6 @@ import XCTest
 
 final class TargetTests: XCTestCase {
     func test_validSourceExtensions() {
-        XCTAssertEqual(Target.validSourceExtensions, ["m", "swift", "mm", "cpp"])
+        XCTAssertEqual(Target.validSourceExtensions, ["m", "swift", "mm", "cpp", "c"])
     }
 }

--- a/Tests/TuistKitTests/Models/TargetTests.swift
+++ b/Tests/TuistKitTests/Models/TargetTests.swift
@@ -1,0 +1,9 @@
+import Foundation
+@testable import TuistKit
+import XCTest
+
+final class TargetTests: XCTestCase {
+    func test_validSourceExtensions() {
+        XCTAssertEqual(Target.validSourceExtensions, ["m", "swift", "mm", "cpp"])
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/173

### Short description 📝
Update the logic in the `Target` model that unfolds the glob pattern to include `.cpp` source files.

cc  @kwridan