### PR TITLE
Use the patch version of SwiftShell

### DIFF
--- a/.github/invite-contributors.yml
+++ b/.github/invite-contributors.yml
@@ -1,0 +1,1 @@
+team: Contributors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next version
 
+### Fixed
+
+- Processes not stopping after receiving an interruption signal https://github.com/tuist/tuist/pull/180 by @pepibumur.
+
 ## 0.10.1
 
 ### Changed

--- a/Package.resolved
+++ b/Package.resolved
@@ -21,11 +21,11 @@
       },
       {
         "package": "SwiftShell",
-        "repositoryURL": "https://github.com/kareman/SwiftShell",
+        "repositoryURL": "https://github.com/tuist/SwiftShell/",
         "state": {
           "branch": null,
-          "revision": "beebe43c986d89ea5359ac3adcb42dac94e5e08a",
-          "version": "4.1.2"
+          "revision": "50d8186859aedd1ce3ab404d080ab6a781591e72",
+          "version": null
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/tuist/xcodeproj.git",
         "state": {
           "branch": null,
-          "revision": "b645d432f79303a805c65cf712b9d185dff6f25c",
-          "version": "6.0.0"
+          "revision": "1314329687682864119ecc03c73a413dfc24ade0",
+          "version": "6.0.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -21,7 +21,7 @@
       },
       {
         "package": "SwiftShell",
-        "repositoryURL": "https://github.com/tuist/SwiftShell/",
+        "repositoryURL": "https://github.com/tuist/SwiftShell.git",
         "state": {
           "branch": null,
           "revision": "50d8186859aedd1ce3ab404d080ab6a781591e72",

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .package(url: "https://github.com/tuist/xcodeproj.git", .upToNextMinor(from: "6.0.0")),
         .package(url: "https://github.com/apple/swift-package-manager", .upToNextMinor(from: "0.2.1")),
         .package(url: "https://github.com/jpsim/Yams.git", .upToNextMinor(from: "1.0.1")),
-        .package(url: "https://github.com/tuist/SwiftShell/", .revision("50d8186859aedd1ce3ab404d080ab6a781591e72")),
+        .package(url: "https://github.com/tuist/SwiftShell.git", .revision("50d8186859aedd1ce3ab404d080ab6a781591e72")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .package(url: "https://github.com/tuist/xcodeproj.git", .upToNextMinor(from: "6.0.0")),
         .package(url: "https://github.com/apple/swift-package-manager", .upToNextMinor(from: "0.2.1")),
         .package(url: "https://github.com/jpsim/Yams.git", .upToNextMinor(from: "1.0.1")),
-        .package(url: "https://github.com/kareman/SwiftShell", from: "4.1.2"),
+        .package(url: "https://github.com/tuist/SwiftShell/", .revision("50d8186859aedd1ce3ab404d080ab6a781591e72")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
### Short description 📝
With the recent [replacement of ReactiveTask](https://github.com/tuist/tuist/pull/179) with SwiftShell, we introduced a bug that caused the processes not getting stopped when Tuist exited after receiving an interruption signal.

This PR changes the SwiftShell dependency to point to our fork, which has a fix for that issue
