### PR TITLE
Replace SwiftShell and use SPM.Process

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,35 @@
         "repositoryURL": "https://github.com/tadija/AEXML.git",
         "state": {
           "branch": null,
-          "revision": "6eea665515d079c338690147082a8084a36484b0",
-          "version": "4.3.0"
+          "revision": "54bb8ea6fb693dd3f92a89e5fcc19e199fdeedd0",
+          "version": "4.3.3"
+        }
+      },
+      {
+        "package": "PathKit",
+        "repositoryURL": "https://github.com/kylef/PathKit",
+        "state": {
+          "branch": null,
+          "revision": "e2f5be30e4c8f531c9c1e8765aa7b71c0a45d7a0",
+          "version": "0.9.2"
+        }
+      },
+      {
+        "package": "Spectre",
+        "repositoryURL": "https://github.com/kylef/Spectre.git",
+        "state": {
+          "branch": null,
+          "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
+          "version": "0.9.0"
+        }
+      },
+      {
+        "package": "llbuild",
+        "repositoryURL": "https://github.com/apple/swift-llbuild.git",
+        "state": {
+          "branch": "master",
+          "revision": "c7aa6e5ea11b39362159b4edc98bfd5dd6d57cf3",
+          "version": null
         }
       },
       {
@@ -15,17 +42,17 @@
         "repositoryURL": "https://github.com/apple/swift-package-manager",
         "state": {
           "branch": null,
-          "revision": "6983434787dec4e543e9d398a0a9acf63ccd4da1",
-          "version": "0.2.1"
+          "revision": "a107d28d1b40491cf505799a046fee53e7c422e1",
+          "version": null
         }
       },
       {
         "package": "SwiftShell",
-        "repositoryURL": "https://github.com/tuist/SwiftShell.git",
+        "repositoryURL": "https://github.com/kareman/SwiftShell",
         "state": {
           "branch": null,
-          "revision": "193356dabffac07ec9081913475b60cbf8972365",
-          "version": null
+          "revision": "beebe43c986d89ea5359ac3adcb42dac94e5e08a",
+          "version": "4.1.2"
         }
       },
       {
@@ -33,8 +60,8 @@
         "repositoryURL": "https://github.com/tuist/xcodeproj.git",
         "state": {
           "branch": null,
-          "revision": "1314329687682864119ecc03c73a413dfc24ade0",
-          "version": "6.0.1"
+          "revision": "23da51abd3de3bedaad59a0afbb150b48504b5b0",
+          "version": "6.3.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/tuist/xcodeproj.git", .upToNextMinor(from: "6.3.0")),
         .package(url: "https://github.com/apple/swift-package-manager", .revision("a107d28d1b40491cf505799a046fee53e7c422e1")),
-        .package(url: "https://github.com/jpsim/Yams.git", .upToNextMinor(from: "1.0.1"))
+        .package(url: "https://github.com/jpsim/Yams.git", .upToNextMinor(from: "1.0.1")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -12,10 +12,9 @@ let package = Package(
                  targets: ["ProjectDescription"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tuist/xcodeproj.git", .upToNextMinor(from: "6.0.0")),
-        .package(url: "https://github.com/apple/swift-package-manager", .upToNextMinor(from: "0.2.1")),
-        .package(url: "https://github.com/jpsim/Yams.git", .upToNextMinor(from: "1.0.1")),
-        .package(url: "https://github.com/tuist/SwiftShell.git", .revision("193356dabffac07ec9081913475b60cbf8972365")),
+        .package(url: "https://github.com/tuist/xcodeproj.git", .upToNextMinor(from: "6.3.0")),
+        .package(url: "https://github.com/apple/swift-package-manager", .revision("a107d28d1b40491cf505799a046fee53e7c422e1")),
+        .package(url: "https://github.com/jpsim/Yams.git", .upToNextMinor(from: "1.0.1"))
     ],
     targets: [
         .target(
@@ -52,7 +51,7 @@ let package = Package(
         ),
         .target(
             name: "TuistCore",
-            dependencies: ["Utility", "SwiftShell"]
+            dependencies: ["Utility"]
         ),
         .target(
             name: "TuistCoreTesting",

--- a/Sources/TuistCore/Utils/Opener.swift
+++ b/Sources/TuistCore/Utils/Opener.swift
@@ -50,10 +50,6 @@ public class Opener: Opening {
         if !fileHandler.exists(path) {
             throw OpeningError.notFound(path)
         }
-        try system.popen("/usr/bin/open",
-                         arguments: path.asString,
-                         verbose: false,
-                         workingDirectoryPath: nil,
-                         environment: nil)
+        try system.popen("/usr/bin/open", path.asString)
     }
 }

--- a/Sources/TuistCore/Utils/Printer.swift
+++ b/Sources/TuistCore/Utils/Printer.swift
@@ -72,23 +72,31 @@ public class Printer: Printing {
     }
 }
 
-final class InteractiveWriter {
-    // MARK: - Attributes
-
+/// This class is used to write on the underlying stream.
+///
+/// If underlying stream is a not tty, the string will be written in without any
+/// formatting.
+private final class InteractiveWriter {
+    
+    /// The standard error writer.
     static let stderr = InteractiveWriter(stream: stderrStream)
+    
+    /// The standard output writer.
     static let stdout = InteractiveWriter(stream: stdoutStream)
+    
+    /// The terminal controller, if present.
     let term: TerminalController?
+    
+    /// The output byte stream reference.
     let stream: OutputByteStream
-
-    // MARK: - Init
-
+    
+    /// Create an instance with the given stream.
     init(stream: OutputByteStream) {
-        term = (stream as? LocalFileOutputByteStream).flatMap(TerminalController.init(stream:))
+        self.term = TerminalController(stream: stream)
         self.stream = stream
     }
-
-    // MARK: - Internal
-
+    
+    /// Write the string to the contained terminal or stream.
     func write(_ string: String, inColor color: TerminalController.Color = .noColor, bold: Bool = false) {
         if let term = term {
             term.write(string, inColor: color, bold: bold)

--- a/Sources/TuistCoreTesting/Utils/MockSystem.swift
+++ b/Sources/TuistCoreTesting/Utils/MockSystem.swift
@@ -2,49 +2,93 @@ import struct Basic.AbsolutePath
 import Foundation
 import TuistCore
 
+enum MockSystemError: Error, CustomStringConvertible {
+    case notStubbedCommand(String)
+    case stubbedCommandErrored(String)
+    
+    var description: String {
+        switch self {
+        case .notStubbedCommand(let command):
+            return "Command '\(command)' not stubbed"
+        case .stubbedCommandErrored(let command):
+            return "Command '\(command)' errored"
+        }
+    }
+}
+
 public final class MockSystem: Systeming {
+    
     private var stubs: [String: (stderror: String?, stdout: String?, exitstatus: Int?)] = [:]
     private var calls: [String] = []
     var swiftVersionStub: (() throws -> String?)?
     var whichStub: ((String) throws -> String?)?
 
     public init() {}
-
-    public func stub(args: [String], stderror: String? = nil, stdout: String? = nil, exitstatus: Int? = nil) {
-        stubs[args.joined(separator: " ")] = (stderror: stderror, stdout: stdout, exitstatus: exitstatus)
+    
+    public func errorCommand(_ arguments: [String], error: String? = nil) {
+        stubs[arguments.joined(separator: " ")] = (stderror: error, stdout: nil, exitstatus: 1)
     }
-
-    public func capture(_ launchPath: String, arguments: String..., verbose: Bool, workingDirectoryPath: AbsolutePath?, environment: [String: String]?) throws -> SystemResult {
-        return try capture(launchPath, arguments: arguments, verbose: verbose, workingDirectoryPath: workingDirectoryPath, environment: environment)
+    
+    public func succeedCommand(_ arguments: [String], output: String? = nil) {
+        stubs[arguments.joined(separator: " ")] = (stderror: nil, stdout: output, exitstatus: 0)
     }
-
-    public func capture(_ launchPath: String, arguments: [String], verbose _: Bool, workingDirectoryPath: AbsolutePath?, environment _: [String: String]?) throws -> SystemResult {
-        var arguments = arguments
-        arguments.insert(launchPath, at: 0)
+    
+    public func run(_ arguments: [String]) throws {
         let command = arguments.joined(separator: " ")
-        calls.append(command)
-        if let stub = stubs[command] {
-            return SystemResult(stdout: stub.stdout ?? "", stderror: stub.stderror ?? "", exitcode: stub.exitstatus ?? -1)
-        } else {
-            return SystemResult(stdout: "", stderror: "", exitcode: -1)
+        guard let stub = self.stubs[command] else {
+            throw MockSystemError.notStubbedCommand(command)
+        }
+        if stub.exitstatus != 0 {
+            throw MockSystemError.stubbedCommandErrored(command)
         }
     }
-
-    public func popen(_ launchPath: String, arguments: String..., verbose: Bool, workingDirectoryPath: AbsolutePath?, environment: [String: String]?) throws {
-        try popen(launchPath, arguments: arguments, verbose: verbose, workingDirectoryPath: workingDirectoryPath, environment: environment)
+    
+    public func run(_ arguments: String...) throws {
+        try self.run(arguments)
     }
-
-    public func popen(_ launchPath: String, arguments: [String], verbose _: Bool, workingDirectoryPath: AbsolutePath?, environment _: [String: String]?) throws {
-        var arguments = arguments
-        arguments.insert(launchPath, at: 0)
+    
+    public func capture(_ arguments: [String]) throws -> String {
+        return try self.capture(arguments, verbose: false, environment: [:])
+    }
+    
+    public func capture(_ arguments: String...) throws -> String {
+        return try self.capture(arguments, verbose: false, environment: [:])
+    }
+    
+    public func capture(_ arguments: String..., verbose: Bool, environment: [String : String]) throws -> String {
+        return try self.capture(arguments, verbose: verbose, environment: environment)
+    }
+    
+    public func capture(_ arguments: [String], verbose: Bool, environment: [String : String]) throws -> String {
         let command = arguments.joined(separator: " ")
-        calls.append(command)
-        if let stub = stubs[command] {
-            if stub.exitstatus != 0 {
-                throw SystemError(stderror: stub.stderror ?? "", exitcode: stub.exitstatus ?? -1)
-            }
-        } else {
-            throw SystemError(stderror: "Command not supported: \(command)", exitcode: -1)
+        guard let stub = self.stubs[command] else {
+            throw MockSystemError.notStubbedCommand(command)
+        }
+        if stub.exitstatus != 0 {
+            throw MockSystemError.stubbedCommandErrored(command)
+        }
+        return stub.stdout ?? ""
+    }
+    
+    public func popen(_ arguments: String...) throws {
+        try self.popen(arguments)
+    }
+    
+    public func popen(_ arguments: [String]) throws {
+        try self.popen(arguments, verbose: false, environment: [:])
+    }
+    
+    public func popen(_ arguments: String..., verbose: Bool, environment: [String : String]) throws {
+        try self.popen(arguments, verbose: verbose, environment: environment)
+    }
+    
+    public func popen(_ arguments: [String], verbose: Bool, environment: [String : String]) throws {
+        let command = arguments.joined(separator: " ")
+        guard let stub = self.stubs[command] else {
+            throw MockSystemError.notStubbedCommand(command)
+        }
+        if stub.exitstatus != 0 {
+            throw MockSystemError.stubbedCommandErrored(command)
         }
     }
 

--- a/Sources/TuistEnvKit/Commands/CommandRunner.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRunner.swift
@@ -115,11 +115,10 @@ class CommandRunner: CommandRunning {
     }
 
     func runAtPath(_ path: AbsolutePath) throws {
-        try system.popen(path.appending(component: Constants.binName).asString,
-                         arguments: Array(arguments().dropFirst()),
-                         verbose: false,
-                         workingDirectoryPath: nil,
-                         environment: System.userEnvironment)
+        var args = [path.appending(component: Constants.binName).asString]
+        args.append(contentsOf: Array(arguments().dropFirst()))
+        
+        try system.popen(args)
     }
 
     // MARK: - Static

--- a/Sources/TuistEnvKit/Commands/CommandRunner.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRunner.swift
@@ -117,7 +117,7 @@ class CommandRunner: CommandRunning {
     func runAtPath(_ path: AbsolutePath) throws {
         var args = [path.appending(component: Constants.binName).asString]
         args.append(contentsOf: Array(arguments().dropFirst()))
-        
+
         try system.popen(args)
     }
 

--- a/Sources/TuistEnvKit/GitHub/GitHubClient.swift
+++ b/Sources/TuistEnvKit/GitHub/GitHubClient.swift
@@ -90,7 +90,7 @@ class GitHubClient: GitHubClienting {
         do {
             guard let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
                 let content = json["content"] as? String,
-                let base64Data = Data(base64Encoded: content.chomp()),
+                let base64Data = Data(base64Encoded: content.spm_chomp()),
                 let decodedContent = String(data: base64Data, encoding: .utf8) else {
                 throw GitHubClientError.invalidResponse
             }

--- a/Sources/TuistEnvKit/Installer/BuildCopier.swift
+++ b/Sources/TuistEnvKit/Installer/BuildCopier.swift
@@ -36,9 +36,9 @@ class BuildCopier: BuildCopying {
             let filePath = from.appending(component: file)
             let toPath = to.appending(component: file)
             if !fileHandler.exists(filePath) { return }
-            try system.capture("/bin/cp", arguments: "-rf", filePath.asString, toPath.asString, verbose: false, workingDirectoryPath: nil, environment: nil).throwIfError()
+            try system.run("/bin/cp", "-rf", filePath.asString, toPath.asString)
             if file == "tuist" {
-                try system.capture("/bin/chmod", arguments: "+x", toPath.asString, verbose: false, workingDirectoryPath: nil, environment: nil).throwIfError()
+                try system.run("/bin/chmod", "+x", toPath.asString)
             }
         }
     }

--- a/Sources/TuistKit/Commands/CreateIssueCommand.swift
+++ b/Sources/TuistKit/Commands/CreateIssueCommand.swift
@@ -29,10 +29,6 @@ class CreateIssueCommand: NSObject, Command {
     // MARK: - Command
 
     func run(with _: ArgumentParser.Result) throws {
-        try system.popen("/usr/bin/open",
-                         arguments: CreateIssueCommand.createIssueUrl,
-                         verbose: false,
-                         workingDirectoryPath: nil,
-                         environment: nil)
+        try system.run("/usr/bin/open", CreateIssueCommand.createIssueUrl)
     }
 }

--- a/Sources/TuistKit/Embed/Embeddable.swift
+++ b/Sources/TuistKit/Embed/Embeddable.swift
@@ -91,12 +91,7 @@ final class Embeddable {
 
     func architectures(system: Systeming = System()) throws -> [String] {
         guard let binPath = try binaryPath() else { return [] }
-        let lipoResult = try system.capture("/usr/bin/lipo",
-                                            arguments: "-info",
-                                            binPath.asString,
-                                            verbose: false,
-                                            workingDirectoryPath: nil,
-                                            environment: nil).stdout.chuzzle() ?? ""
+        let lipoResult = try system.capture("/usr/bin/lipo", "-info").spm_chuzzle() ?? ""
         var characterSet = CharacterSet.alphanumerics
         characterSet.insert(charactersIn: " _-")
         let scanner = Scanner(string: lipoResult)
@@ -175,11 +170,7 @@ final class Embeddable {
     fileprivate func stripArchitecture(packagePath: AbsolutePath,
                                        architecture: String,
                                        system: Systeming = System()) throws {
-        try system.popen("/usr/bin/lipo",
-                         arguments: "-remove", architecture, "-output", packagePath.asString, packagePath.asString,
-                         verbose: false,
-                         workingDirectoryPath: nil,
-                         environment: nil)
+        try system.run("/usr/bin/lipo", "-remove", architecture, "-output", packagePath.asString, packagePath.asString)
     }
 
     fileprivate func stripHeaders(frameworkPath: AbsolutePath) throws {
@@ -226,11 +217,7 @@ final class Embeddable {
 
     fileprivate func uuidsFromDwarfdump(path: AbsolutePath,
                                         system: Systeming = System()) throws -> Set<UUID> {
-        let result = try system.capture("/usr/bin/dwarfdump",
-                                        arguments: "--uuid", path.asString,
-                                        verbose: false,
-                                        workingDirectoryPath: nil,
-                                        environment: nil).stdout.chuzzle() ?? ""
+        let result = try system.capture("/usr/bin/dwarfdump", "--uuid", path.asString).spm_chuzzle() ?? ""
         var uuidCharacterSet = CharacterSet()
         uuidCharacterSet.formUnion(.letters)
         uuidCharacterSet.formUnion(.decimalDigits)

--- a/Sources/TuistKit/Embed/Embeddable.swift
+++ b/Sources/TuistKit/Embed/Embeddable.swift
@@ -91,7 +91,7 @@ final class Embeddable {
 
     func architectures(system: Systeming = System()) throws -> [String] {
         guard let binPath = try binaryPath() else { return [] }
-        let lipoResult = try system.capture("/usr/bin/lipo", "-info").spm_chuzzle() ?? ""
+        let lipoResult = try system.capture("/usr/bin/lipo", "-info", binPath.asString).spm_chuzzle() ?? ""
         var characterSet = CharacterSet.alphanumerics
         characterSet.insert(charactersIn: " _-")
         let scanner = Scanner(string: lipoResult)

--- a/Sources/TuistKit/Extensions/AbsolutePath+Extras.swift
+++ b/Sources/TuistKit/Extensions/AbsolutePath+Extras.swift
@@ -1,9 +1,9 @@
-import Foundation
 import Basic
+import Foundation
 import PathKit
 
 extension AbsolutePath {
     var path: Path {
-        return Path(self.asString)
+        return Path(asString)
     }
 }

--- a/Sources/TuistKit/Extensions/AbsolutePath+Extras.swift
+++ b/Sources/TuistKit/Extensions/AbsolutePath+Extras.swift
@@ -1,0 +1,9 @@
+import Foundation
+import Basic
+import PathKit
+
+extension AbsolutePath {
+    var path: Path {
+        return Path(self.asString)
+    }
+}

--- a/Sources/TuistKit/Generator/FileGenerator.swift
+++ b/Sources/TuistKit/Generator/FileGenerator.swift
@@ -12,6 +12,6 @@ final class FileGenerator: FileGenerating {
     func generateFile(path: AbsolutePath,
                       in group: PBXGroup,
                       sourceRootPath: AbsolutePath) throws -> PBXFileReference {
-        return try group.addFile(at: path, sourceTree: .group, sourceRoot: sourceRootPath)
+        return try group.addFile(at: path.path, sourceTree: .group, sourceRoot: sourceRootPath.path)
     }
 }

--- a/Sources/TuistKit/Generator/ProjectGenerator.swift
+++ b/Sources/TuistKit/Generator/ProjectGenerator.swift
@@ -115,7 +115,7 @@ final class ProjectGenerator: ProjectGenerating {
 
         /// Write.
         let xcodeproj = XcodeProj(workspace: workspace, pbxproj: pbxproj)
-        try xcodeproj.write(path: xcodeprojPath)
+        try xcodeproj.write(path: xcodeprojPath.path)
         return xcodeprojPath
     }
 }

--- a/Sources/TuistKit/Generator/WorkspaceGenerator.swift
+++ b/Sources/TuistKit/Generator/WorkspaceGenerator.swift
@@ -63,7 +63,7 @@ final class WorkspaceGenerator: WorkspaceGenerating {
             let fileRef = XCWorkspaceDataFileRef(location: location)
             workspace.data.children.append(XCWorkspaceDataElement.file(fileRef))
         }
-        try workspace.write(path: workspacePath, override: true)
+        try workspace.write(path: workspacePath.path, override: true)
 
         return workspacePath
     }

--- a/Sources/TuistKit/Graph/GraphManifestLoader.swift
+++ b/Sources/TuistKit/Graph/GraphManifestLoader.swift
@@ -168,7 +168,7 @@ class GraphManifestLoader: GraphManifestLoading {
         ]
         arguments.append(path.asString)
         arguments.append("--dump")
-                
+
         guard let jsonString = try system.capture(arguments).spm_chuzzle() else {
             throw GraphManifestLoaderError.unexpectedOutput(path)
         }

--- a/Sources/TuistKit/Graph/GraphManifestLoader.swift
+++ b/Sources/TuistKit/Graph/GraphManifestLoader.swift
@@ -157,6 +157,7 @@ class GraphManifestLoader: GraphManifestLoading {
     fileprivate func loadSwiftManifest(path: AbsolutePath) throws -> JSON {
         let projectDescriptionPath = try resourceLocator.projectDescription()
         var arguments: [String] = [
+            "/usr/bin/xcrun",
             "swiftc",
             "--driver-mode=swift",
             "-suppress-warnings",
@@ -167,14 +168,8 @@ class GraphManifestLoader: GraphManifestLoading {
         ]
         arguments.append(path.asString)
         arguments.append("--dump")
-        let result = try system.capture("/usr/bin/xcrun",
-                                        arguments: arguments,
-                                        verbose: false,
-                                        workingDirectoryPath: nil,
-                                        environment: System.userEnvironment)
-        try result.throwIfError()
-        let jsonString: String! = result.stdout.chuzzle()
-        if jsonString == nil {
+                
+        guard let jsonString = try system.capture(arguments).spm_chuzzle() else {
             throw GraphManifestLoaderError.unexpectedOutput(path)
         }
         return try JSON(string: jsonString)

--- a/Sources/TuistKit/Graph/GraphNode.swift
+++ b/Sources/TuistKit/Graph/GraphNode.swift
@@ -151,11 +151,7 @@ class PrecompiledNode: GraphNode {
     }
 
     func architectures(system: Systeming = System()) throws -> [Architecture] {
-        let result = try system.capture("/usr/bin/lipo",
-                                        arguments: "-info", binaryPath.asString,
-                                        verbose: false,
-                                        workingDirectoryPath: nil,
-                                        environment: nil).stdout.chuzzle() ?? ""
+        let result = try system.capture("/usr/bin/lipo", "-info", binaryPath.asString).spm_chuzzle() ?? ""
         let regex = try NSRegularExpression(pattern: ".+:\\s.+\\sis\\sarchitecture:\\s(.+)", options: [])
         guard let match = regex.firstMatch(in: result, options: [], range: NSRange(location: 0, length: result.count)) else {
             throw PrecompiledNodeError.architecturesNotFound(binaryPath)
@@ -165,11 +161,7 @@ class PrecompiledNode: GraphNode {
     }
 
     func linking(system: Systeming = System()) throws -> Linking {
-        let result = try system.capture("/usr/bin/file",
-                                        arguments: binaryPath.asString,
-                                        verbose: false,
-                                        workingDirectoryPath: nil,
-                                        environment: nil).throwIfError().stdout.chuzzle() ?? ""
+        let result = try system.capture("/usr/bin/file", binaryPath.asString).spm_chuzzle() ?? ""
         return result.contains("dynamically linked") ? .dynamic : .static
     }
 }

--- a/Sources/TuistKit/Models/TargetAction.swift
+++ b/Sources/TuistKit/Models/TargetAction.swift
@@ -81,7 +81,7 @@ public struct TargetAction: GraphInitiatable {
         if let path = path {
             return "\(path.relative(to: sourceRootPath).asString) \(arguments.joined(separator: " "))"
         } else {
-            return try "\(system.which(tool!).chomp().chuzzle()!) \(arguments.joined(separator: " "))"
+            return try "\(system.which(tool!).spm_chomp().spm_chuzzle()!) \(arguments.joined(separator: " "))"
         }
     }
 }

--- a/Sources/TuistKit/Models/UpCustom.swift
+++ b/Sources/TuistKit/Models/UpCustom.swift
@@ -46,10 +46,10 @@ class UpCustom: Up, GraphInitiatable {
     /// - Throws: An error if any error is thrown while running it.
     override func meet(system: Systeming, printer _: Printing, projectPath: AbsolutePath) throws {
         let launchPath = try self.launchPath(command: meet, projectPath: projectPath, system: system)
-        
+
         var arguments = [launchPath.asString]
         arguments.append(contentsOf: Array(meet.dropFirst()))
-        
+
         try system.popen(arguments)
     }
 
@@ -69,7 +69,7 @@ class UpCustom: Up, GraphInitiatable {
         }
         var arguments = [launchPath.asString]
         arguments.append(contentsOf: Array(isMet.dropFirst()))
-        
+
         do {
             try system.run(arguments)
             return true

--- a/Sources/TuistKit/Models/UpCustom.swift
+++ b/Sources/TuistKit/Models/UpCustom.swift
@@ -46,7 +46,11 @@ class UpCustom: Up, GraphInitiatable {
     /// - Throws: An error if any error is thrown while running it.
     override func meet(system: Systeming, printer _: Printing, projectPath: AbsolutePath) throws {
         let launchPath = try self.launchPath(command: meet, projectPath: projectPath, system: system)
-        try system.popen(launchPath.asString, arguments: Array(meet.dropFirst()), verbose: false, workingDirectoryPath: nil, environment: System.userEnvironment)
+        
+        var arguments = [launchPath.asString]
+        arguments.append(contentsOf: Array(meet.dropFirst()))
+        
+        try system.popen(arguments)
     }
 
     /// Returns true when the command doesn't need to be run.
@@ -63,8 +67,15 @@ class UpCustom: Up, GraphInitiatable {
         } catch {
             return false
         }
-        let result = try system.capture(launchPath.asString, arguments: Array(isMet.dropFirst()), verbose: false, workingDirectoryPath: nil, environment: System.userEnvironment)
-        return result.succeeded
+        var arguments = [launchPath.asString]
+        arguments.append(contentsOf: Array(isMet.dropFirst()))
+        
+        do {
+            try system.run(arguments)
+            return true
+        } catch {
+            return false
+        }
     }
 
     /// Given the command components, it returns the launch path.

--- a/Sources/TuistKit/Models/UpHomebrew.swift
+++ b/Sources/TuistKit/Models/UpHomebrew.swift
@@ -51,14 +51,14 @@ class UpHomebrew: Up, GraphInitiatable {
             printer.print("Installing Homebrew")
             try system.popen("/usr/bin/ruby", "-e", "\"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)\"",
                              verbose: true,
-                             environment: System.userEnvironment)
+                             environment: system.env)
         }
         let nonInstalledPackages = packages.filter({ !toolInstalled($0, system: system) })
         try nonInstalledPackages.forEach { package in
             printer.print("Installing Homebrew package: \(package)")
             try system.popen("/usr/local/bin/brew", "install", package,
                              verbose: true,
-                             environment: System.userEnvironment)
+                             environment: system.env)
         }
     }
 }

--- a/Sources/TuistKit/Models/UpHomebrew.swift
+++ b/Sources/TuistKit/Models/UpHomebrew.swift
@@ -49,18 +49,15 @@ class UpHomebrew: Up, GraphInitiatable {
     override func meet(system: Systeming, printer: Printing, projectPath _: AbsolutePath) throws {
         if !toolInstalled("brew", system: system) {
             printer.print("Installing Homebrew")
-            try system.popen("/usr/bin/ruby", arguments: ["-e", "\"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)\""],
+            try system.popen("/usr/bin/ruby", "-e", "\"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)\"",
                              verbose: true,
-                             workingDirectoryPath: nil,
                              environment: System.userEnvironment)
         }
         let nonInstalledPackages = packages.filter({ !toolInstalled($0, system: system) })
         try nonInstalledPackages.forEach { package in
             printer.print("Installing Homebrew package: \(package)")
-            try system.popen("/usr/local/bin/brew",
-                             arguments: ["install", package],
-                             verbose: false,
-                             workingDirectoryPath: nil,
+            try system.popen("/usr/local/bin/brew", "install", package,
+                             verbose: true,
                              environment: System.userEnvironment)
         }
     }

--- a/Sources/TuistKit/Utils/Carthage.swift
+++ b/Sources/TuistKit/Utils/Carthage.swift
@@ -53,7 +53,7 @@ final class Carthage: Carthaging {
     func update(path: AbsolutePath, platforms: [Platform], dependencies: [String]) throws {
         let carthagePath = try system.which("carthage")
 
-        var command: [String] = []
+        var command: [String] = [carthagePath]
         command.append("update")
 
         if !platforms.isEmpty {
@@ -62,11 +62,8 @@ final class Carthage: Carthaging {
         }
 
         command.append(contentsOf: dependencies)
-        try system.popen(carthagePath,
-                         arguments: command,
-                         verbose: false,
-                         workingDirectoryPath: path,
-                         environment: System.userEnvironment)
+        
+        try system.run(command)
     }
 
     /// Returns the list of outdated dependencies in the given directory.

--- a/Sources/TuistKit/Utils/Carthage.swift
+++ b/Sources/TuistKit/Utils/Carthage.swift
@@ -55,6 +55,8 @@ final class Carthage: Carthaging {
 
         var command: [String] = [carthagePath]
         command.append("update")
+        command.append("--project-directory")
+        command.append(path.asString)
 
         if !platforms.isEmpty {
             command.append("--platform")
@@ -62,7 +64,7 @@ final class Carthage: Carthaging {
         }
 
         command.append(contentsOf: dependencies)
-        
+
         try system.run(command)
     }
 

--- a/Tests/TuistCoreTests/Utils/OpenerTests.swift
+++ b/Tests/TuistCoreTests/Utils/OpenerTests.swift
@@ -41,11 +41,7 @@ final class OpenerTests: XCTestCase {
     func test_open() throws {
         let path = fileHandler.currentPath.appending(component: "tool")
         try fileHandler.touch(path)
-
-        system.stub(args: ["/usr/bin/open", path.asString],
-                    stderror: nil,
-                    stdout: nil,
-                    exitstatus: 0)
+        system.succeedCommand("/usr/bin/open", path.asString)
         try subject.open(path: path)
     }
 }

--- a/Tests/TuistEnvKitTests/Commands/CommandRunnerTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/CommandRunnerTests.swift
@@ -53,10 +53,7 @@ final class CommandRunnerTests: XCTestCase {
         arguments = ["tuist", "--help"]
 
         versionResolver.resolveStub = { _ in ResolvedVersion.bin(self.fileHandler.currentPath) }
-        system.stub(args: [binaryPath.asString, "--help"],
-                    stderror: nil,
-                    stdout: "output",
-                    exitstatus: 0)
+        system.succeedCommand(binaryPath.asString, "--help", output: "output")
         try subject.run()
     }
 
@@ -65,10 +62,7 @@ final class CommandRunnerTests: XCTestCase {
         arguments = ["tuist", "--help"]
 
         versionResolver.resolveStub = { _ in ResolvedVersion.bin(self.fileHandler.currentPath) }
-        system.stub(args: [binaryPath.asString, "--help"],
-                    stderror: "error",
-                    stdout: nil,
-                    exitstatus: -1)
+        system.errorCommand(binaryPath.asString, "--help", error: "error")
 
         XCTAssertThrowsError(try subject.run())
     }
@@ -86,11 +80,7 @@ final class CommandRunnerTests: XCTestCase {
 
         var installArgs: [(version: String, force: Bool)] = []
         installer.installStub = { version, force in installArgs.append((version: version, force: force)) }
-
-        system.stub(args: [binaryPath.asString, "--help"],
-                    stderror: nil,
-                    stdout: "",
-                    exitstatus: 0)
+        system.succeedCommand(binaryPath.asString, "--help", output: "")
 
         try subject.run()
 
@@ -126,10 +116,7 @@ final class CommandRunnerTests: XCTestCase {
         versionResolver.resolveStub = { _ in ResolvedVersion.versionFile(self.fileHandler.currentPath, "3.2.1")
         }
 
-        system.stub(args: [binaryPath.asString, "--help"],
-                    stderror: "error",
-                    stdout: nil,
-                    exitstatus: 1)
+        system.errorCommand(binaryPath.asString, "--help", error: "error")
 
         XCTAssertThrowsError(try subject.run())
     }
@@ -145,10 +132,7 @@ final class CommandRunnerTests: XCTestCase {
             $0 == "3.2.1" ? self.fileHandler.currentPath : AbsolutePath("/invalid")
         }
 
-        system.stub(args: [binaryPath.asString, "--help"],
-                    stderror: nil,
-                    stdout: "",
-                    exitstatus: 0)
+        system.succeedCommand(binaryPath.asString, "--help", output: "")
 
         try subject.run()
     }
@@ -168,10 +152,7 @@ final class CommandRunnerTests: XCTestCase {
             $0 == "3.2.1" ? self.fileHandler.currentPath : AbsolutePath("/invalid")
         }
 
-        system.stub(args: [binaryPath.asString, "--help"],
-                    stderror: nil,
-                    stdout: "",
-                    exitstatus: 0)
+        system.succeedCommand(binaryPath.asString, "--help", output: "")
 
         try subject.run()
     }
@@ -205,10 +186,7 @@ final class CommandRunnerTests: XCTestCase {
             $0 == "3.2.1" ? self.fileHandler.currentPath : AbsolutePath("/invalid")
         }
 
-        system.stub(args: [binaryPath.asString, "--help"],
-                    stderror: "error",
-                    stdout: nil,
-                    exitstatus: 1)
+        system.errorCommand(binaryPath.asString, "--help", error: "error")
 
         XCTAssertThrowsError(try subject.run())
     }

--- a/Tests/TuistKitTests/Commands/CreateIssueCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/CreateIssueCommandTests.swift
@@ -23,7 +23,7 @@ final class CreateIssueCommandTests: XCTestCase {
     }
 
     func test_run() throws {
-        system.stub(args: ["/usr/bin/open", CreateIssueCommand.createIssueUrl], stderror: nil, stdout: nil, exitstatus: 0)
+        system.succeedCommand("/usr/bin/open", CreateIssueCommand.createIssueUrl)
         try subject.run(with: ArgumentParser.Result.test())
     }
 }

--- a/Tests/TuistKitTests/Graph/GraphNodeTests.swift
+++ b/Tests/TuistKitTests/Graph/GraphNodeTests.swift
@@ -43,12 +43,14 @@ final class FrameworkNodeTests: XCTestCase {
     }
 
     func test_architectures() throws {
-        system.stub(args: ["/usr/bin/lipo -info /test.framework/test"], stderror: nil, stdout: "Non-fat file: path is architecture: x86_64", exitstatus: 0)
+        system.succeedCommand("/usr/bin/lipo -info /test.framework/test",
+                              output: "Non-fat file: path is architecture: x86_64")
         try XCTAssertEqual(subject.architectures(system: system).first, .x8664)
     }
 
     func test_linking() {
-        system.stub(args: ["/usr/bin/file", "/test.framework/test"], stderror: nil, stdout: "whatever dynamically linked", exitstatus: 0)
+        system.succeedCommand("/usr/bin/file", "/test.framework/test",
+                              output: "whatever dynamically linked")
         try XCTAssertEqual(subject.linking(system: system), .dynamic)
     }
 }
@@ -70,12 +72,12 @@ final class LibraryNodeTests: XCTestCase {
     }
 
     func test_architectures() throws {
-        system.stub(args: ["/usr/bin/lipo", "-info", "/test.a"], stderror: nil, stdout: "Non-fat file: path is architecture: x86_64", exitstatus: 0)
+        system.succeedCommand("/usr/bin/lipo", "-info", "/test.a", output: "Non-fat file: path is architecture: x86_64")
         try XCTAssertEqual(subject.architectures(system: system).first, .x8664)
     }
 
     func test_linking() {
-        system.stub(args: ["/usr/bin/file", "/test.a"], stderror: nil, stdout: "whatever dynamically linked", exitstatus: 0)
+        system.succeedCommand("/usr/bin/file", "/test.a", output: "whatever dynamically linked")
         try XCTAssertEqual(subject.linking(system: system), .dynamic)
     }
 }

--- a/Tests/TuistKitTests/Graph/GraphTests.swift
+++ b/Tests/TuistKitTests/Graph/GraphTests.swift
@@ -133,7 +133,7 @@ final class GraphTests: XCTestCase {
         let cache = GraphLoaderCache()
         cache.add(targetNode: targetNode)
         let graph = Graph.test(cache: cache)
-        system.stub(args: [], stderror: nil, stdout: "dynamically linked", exitstatus: 0)
+        system.succeedCommand([], output: "dynamically linked")
 
         let got = try graph.embeddableFrameworks(path: project.path,
                                                  name: target.name,
@@ -156,7 +156,7 @@ final class GraphTests: XCTestCase {
         cache.add(targetNode: targetNode)
         let graph = Graph.test(cache: cache)
 
-        system.stub(args: [], stderror: nil, stdout: "dynamically linked", exitstatus: 0)
+        system.succeedCommand([], output: "dynamically linked")
         let got = try graph.embeddableFrameworks(path: project.path,
                                                  name: target.name,
                                                  system: system)
@@ -175,10 +175,8 @@ final class GraphTests: XCTestCase {
         cache.add(targetNode: targetNode)
         let graph = Graph.test(cache: cache)
 
-        system.stub(args: ["/usr/bin/file", "/test/test.framework/test"],
-                    stderror: nil,
-                    stdout: "dynamically linked",
-                    exitstatus: 0)
+        system.succeedCommand("/usr/bin/file", "/test/test.framework/test",
+                              output: "dynamically linked")
 
         let got = try graph.embeddableFrameworks(path: project.path,
                                                  name: target.name,

--- a/Tests/TuistKitTests/Models/UpHomebrewTests.swift
+++ b/Tests/TuistKitTests/Models/UpHomebrewTests.swift
@@ -55,16 +55,10 @@ final class UpHomebrewTests: XCTestCase {
         let subject = UpHomebrew(packages: ["swiftlint"])
 
         system.whichStub = { _ in nil }
-        system.stub(args: ["/usr/bin/ruby",
-                           "-e",
-                           "\"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)\""],
-                    stderror: nil,
-                    stdout: nil,
-                    exitstatus: 0)
-        system.stub(args: ["/usr/local/bin/brew", "install", "swiftlint"],
-                    stderror: nil,
-                    stdout: nil,
-                    exitstatus: 0)
+        system.succeedCommand("/usr/bin/ruby",
+                              "-e",
+                              "\"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)\"")
+        system.succeedCommand("/usr/local/bin/brew", "install", "swiftlint")
 
         try subject.meet(system: system, printer: printer, projectPath: fileHandler.currentPath)
 

--- a/Tests/TuistKitTests/Utils/CarthageTests.swift
+++ b/Tests/TuistKitTests/Utils/CarthageTests.swift
@@ -26,11 +26,8 @@ final class CarthageTests: XCTestCase {
                 throw NSError.test()
             }
         }
-
-        system.stub(args: ["/path/to/carthage", "update", "--platform", "iOS,macOS", "Alamofire"],
-                    stderror: nil,
-                    stdout: "",
-                    exitstatus: 0)
+        system.succeedCommand("/path/to/carthage", "update", "--project-directory", fileHandler.currentPath.asString, "--platform", "iOS,macOS", "Alamofire",
+                              output: "")
 
         try subject.update(path: fileHandler.currentPath,
                            platforms: [.iOS, .macOS],


### PR DESCRIPTION
### Short description 📝
[SwiftShell](https://github.com/tuist/tuist/pull/179) doesn't handle interruption signals properly. This PR replaces it with the Swift Package Manager `Process` class which is extensively used in the SPM and maintained by Apple.