### PR TITLE
Use binary name instead of absolute path in the embed frameworks build phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next version
 
+### Fixed
+
+- Use environment tuist instead of the absolute path in the embed frameworks build phase https://github.com/tuist/tuist/pull/185 by @pepibumur.
+
 ## 0.10.2
 
 ### Fixed

--- a/Sources/TuistKit/Generator/LinkGenerator.swift
+++ b/Sources/TuistKit/Generator/LinkGenerator.swift
@@ -49,7 +49,6 @@ protocol LinkGenerating: AnyObject {
                        path: AbsolutePath,
                        sourceRootPath: AbsolutePath,
                        graph: Graphing,
-                       resourceLocator: ResourceLocating,
                        system: Systeming) throws
 }
 
@@ -64,7 +63,6 @@ final class LinkGenerator: LinkGenerating {
                        path: AbsolutePath,
                        sourceRootPath: AbsolutePath,
                        graph: Graphing,
-                       resourceLocator: ResourceLocating = ResourceLocator(),
                        system: Systeming = System()) throws {
         let embeddableFrameworks = try graph.embeddableFrameworks(path: path, name: target.name, system: system)
         let headersSearchPaths = graph.librariesPublicHeadersFolders(path: path, name: target.name)
@@ -74,7 +72,6 @@ final class LinkGenerator: LinkGenerating {
                                pbxTarget: pbxTarget,
                                pbxproj: pbxproj,
                                fileElements: fileElements,
-                               resourceLocator: resourceLocator,
                                sourceRootPath: sourceRootPath)
 
         try setupFrameworkSearchPath(dependencies: linkableModules,
@@ -95,7 +92,6 @@ final class LinkGenerator: LinkGenerating {
                             pbxTarget: PBXTarget,
                             pbxproj: PBXProj,
                             fileElements: ProjectFileElements,
-                            resourceLocator _: ResourceLocating,
                             sourceRootPath: AbsolutePath) throws {
         let precompiledEmbedPhase = PBXShellScriptBuildPhase(name: "Embed Precompiled Frameworks")
         let embedPhase = PBXCopyFilesBuildPhase(dstSubfolderSpec: .frameworks,

--- a/Sources/TuistKit/Generator/LinkGenerator.swift
+++ b/Sources/TuistKit/Generator/LinkGenerator.swift
@@ -95,7 +95,7 @@ final class LinkGenerator: LinkGenerating {
                             pbxTarget: PBXTarget,
                             pbxproj: PBXProj,
                             fileElements: ProjectFileElements,
-                            resourceLocator: ResourceLocating,
+                            resourceLocator _: ResourceLocating,
                             sourceRootPath: AbsolutePath) throws {
         let precompiledEmbedPhase = PBXShellScriptBuildPhase(name: "Embed Precompiled Frameworks")
         let embedPhase = PBXCopyFilesBuildPhase(dstSubfolderSpec: .frameworks,
@@ -107,12 +107,11 @@ final class LinkGenerator: LinkGenerating {
         pbxTarget.buildPhases.append(embedPhase)
 
         var script: [String] = []
-        let cliPath = try resourceLocator.cliPath()
 
         try dependencies.forEach { dependency in
             if case let DependencyReference.absolute(path) = dependency {
                 let relativePath = "$(SRCROOT)/\(path.relative(to: sourceRootPath).asString)"
-                script.append("\(cliPath.asString) embed \(path.relative(to: sourceRootPath).asString)")
+                script.append("tuist embed \(path.relative(to: sourceRootPath).asString)")
                 precompiledEmbedPhase.inputPaths.append(relativePath)
                 precompiledEmbedPhase.outputPaths.append("$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/\(path.components.last!)")
 

--- a/Sources/TuistKit/Generator/TargetGenerator.swift
+++ b/Sources/TuistKit/Generator/TargetGenerator.swift
@@ -154,7 +154,6 @@ final class TargetGenerator: TargetGenerating {
                                         path: path,
                                         sourceRootPath: sourceRootPath,
                                         graph: graph,
-                                        resourceLocator: resourceLocator,
                                         system: system)
         return pbxTarget
     }

--- a/Tests/TuistKitTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/LinkGeneratorTests.swift
@@ -47,7 +47,7 @@ final class LinkGeneratorErrorTests: XCTestCase {
 
         let scriptBuildPhase: PBXShellScriptBuildPhase? = pbxTarget.buildPhases.first as? PBXShellScriptBuildPhase
         XCTAssertEqual(scriptBuildPhase?.name, "Embed Precompiled Frameworks")
-        XCTAssertEqual(scriptBuildPhase?.shellScript, "/ embed test.framework")
+        XCTAssertEqual(scriptBuildPhase?.shellScript, "tuist embed test.framework")
         XCTAssertEqual(scriptBuildPhase?.inputPaths, ["$(SRCROOT)/test.framework"])
         XCTAssertEqual(scriptBuildPhase?.outputPaths, ["$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/test.framework"])
 

--- a/Tests/TuistKitTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/LinkGeneratorTests.swift
@@ -34,15 +34,12 @@ final class LinkGeneratorErrorTests: XCTestCase {
         let wakaFile = PBXFileReference()
         pbxproj.add(object: wakaFile)
         fileElements.products["waka.framework"] = wakaFile
-        let resourceLocator = MockResourceLocator()
-        resourceLocator.embedPathStub = { AbsolutePath("/embed") }
         let sourceRootPath = AbsolutePath("/")
 
         try subject.generateEmbedPhase(dependencies: dependencies,
                                        pbxTarget: pbxTarget,
                                        pbxproj: pbxproj,
                                        fileElements: fileElements,
-                                       resourceLocator: resourceLocator,
                                        sourceRootPath: sourceRootPath)
 
         let scriptBuildPhase: PBXShellScriptBuildPhase? = pbxTarget.buildPhases.first as? PBXShellScriptBuildPhase
@@ -63,15 +60,12 @@ final class LinkGeneratorErrorTests: XCTestCase {
         let pbxproj = PBXProj()
         let pbxTarget = PBXNativeTarget(name: "Test")
         let fileElements = ProjectFileElements()
-        let resourceLocator = MockResourceLocator()
-        resourceLocator.embedPathStub = { AbsolutePath("/embed") }
         let sourceRootPath = AbsolutePath("/")
 
         XCTAssertThrowsError(try subject.generateEmbedPhase(dependencies: dependencies,
                                                             pbxTarget: pbxTarget,
                                                             pbxproj: pbxproj,
                                                             fileElements: fileElements,
-                                                            resourceLocator: resourceLocator,
                                                             sourceRootPath: sourceRootPath)) {
             XCTAssertEqual($0 as? LinkGeneratorError, LinkGeneratorError.missingProduct(name: "waka.framework"))
         }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/161

### Short description 📝
As @enhorn pointed out, using the absolute path to Tuist in the generated Xcode project makes the build fail if someone runs the build with someone else's absolute path.

### Solution 📦
Change it to use the environment `tuist` instance.