### PR TITLE
Create empty BuildCommand

### DIFF
--- a/Sources/TuistCore/Commands/Command.swift
+++ b/Sources/TuistCore/Commands/Command.swift
@@ -35,3 +35,21 @@ public protocol HiddenCommand {
     /// Default constructor
     init()
 }
+
+/// It represents a command that accepts the raw argument without parsing them beforehand.
+public protocol RawCommand {
+    /// Name of the command that the user should use to execute the command.
+    static var command: String { get }
+
+    /// A short sentece that describes what the command is for.
+    static var overview: String { get }
+
+    /// Initializes the command
+    init()
+
+    /// Runs the command using the arguments that the user passed to the CLI.
+    ///
+    /// - Parameter arguments: Arguments that the user passed to the CLI: cli command arg1 arg2 arg3
+    /// - Throws: Errors that are thrown by the underlying command action.
+    func run(arguments: [String]) throws
+}

--- a/Sources/TuistCoreTesting/Commands/MockRawCommand.swift
+++ b/Sources/TuistCoreTesting/Commands/MockRawCommand.swift
@@ -1,0 +1,18 @@
+import Foundation
+import TuistCore
+import Utility
+
+public final class MockRawCommand: RawCommand {
+    public static var command: String = "raw"
+    public static var overview: String = "raw command"
+
+    public var runStub: (([String]) throws -> Void)? = { _ in }
+    public var runCallCount: UInt = 0
+
+    public init() {}
+
+    public func run(arguments: [String]) throws {
+        runCallCount += 1
+        try runStub?(arguments)
+    }
+}

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -1,0 +1,39 @@
+import Basic
+import Foundation
+import TuistCore
+import Utility
+
+enum BuildCommandError: FatalError {
+    // Error description
+    var description: String {
+        return ""
+    }
+
+    // Error type
+    var type: ErrorType { return .abort }
+}
+
+/// Command that builds a target from the project in the current directory.
+class BuildCommand: NSObject, RawCommand {
+    /// Command name.
+    static var command: String = "build"
+
+    /// Command description.
+    static var overview: String = "Builds a project target."
+
+    /// Printer instance to output the information to the user.
+    let printer: Printing
+
+    init(printer: Printing) {
+        self.printer = printer
+    }
+
+    /// Main constructor.
+    required convenience override init() {
+        self.init(printer: Printer())
+    }
+
+    func run(arguments: [String]) throws {
+        print(arguments)
+    }
+}

--- a/Tests/TuistKitTests/Commands/BuildCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/BuildCommandTests.swift
@@ -1,0 +1,14 @@
+import Foundation
+import XCTest
+
+@testable import TuistKit
+
+final class BuildCommandTests: XCTestCase {
+    func test_command() {
+        XCTAssertEqual(BuildCommand.command, "build")
+    }
+
+    func test_overview() {
+        XCTAssertEqual(BuildCommand.overview, "Builds a project target.")
+    }
+}


### PR DESCRIPTION
### Short description 📝
Add an empty `BuildCommand` that handle the compilation of projects. It'll run `xcodebuild` passing the arguments that have ben passed to tuist.

### Solution 📦
- Add a new type of command `RawCommand`, which accepts raw arguments instead of pre-parsed arguments.
- Change the `CommandRegistry` to support that type of command.
- Create an empty `BuildCommand` of type `RawCommand`. 
