### PR TITLE
Support resources as array and xcassets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next version
 
+### Changed
+
+- Use array `[String]` for Source and Resource paths https://github.com/tuist/tuist/pull/201 by @dangthaison91
+
 ### Added
 
 - Integration tests for `generate` command https://github.com/tuist/tuist/pull/208 by @marciniwanicki & @kwridan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Changed
 
-- Use `FilesList` for Source and Resource paths https://github.com/tuist/tuist/pull/201 by @dangthaison91
+- Support array for `sources` and `resources` paths https://github.com/tuist/tuist/pull/201 by @dangthaison91
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Changed
 
-- Use array `[String]` for Source and Resource paths https://github.com/tuist/tuist/pull/201 by @dangthaison91
+- Use `FilesList` for Source and Resource paths https://github.com/tuist/tuist/pull/201 by @dangthaison91
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ let project = Project(name: "App",
                                product: .app,
                                bundleId: "io.tuist.App",
                                infoPlist: "Info.plist",
-                               sources: "Sources/**",
+                               sources: ["Sources/**", "OtherSources/**"],
                                dependencies: [
                                     /* Target dependencies can be defined here */
                                     /* .framework(path: "framework") */
@@ -41,7 +41,7 @@ let project = Project(name: "App",
                                product: .unitTests,
                                bundleId: "io.tuist.AppTests",
                                infoPlist: "Tests.plist",
-                               sources: "Tests/**",
+                               sources: ["Tests/**"],
                                dependencies: [
                                     .target(name: "App")
                                ])

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ let project = Project(name: "App",
                                product: .app,
                                bundleId: "io.tuist.App",
                                infoPlist: "Info.plist",
-                               sources: FileList(globs: ["Sources/**", "OtherSources/**"]),
+                               sources: ["Sources/**", "OtherSources/**"],
                                dependencies: [
                                     /* Target dependencies can be defined here */
                                     /* .framework(path: "framework") */
@@ -41,7 +41,7 @@ let project = Project(name: "App",
                                product: .unitTests,
                                bundleId: "io.tuist.AppTests",
                                infoPlist: "Tests.plist",
-                               sources: FileList(globs: ["Tests/**"]),
+                               sources: "Tests/**",
                                dependencies: [
                                     .target(name: "App")
                                ])

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ let project = Project(name: "App",
                                product: .app,
                                bundleId: "io.tuist.App",
                                infoPlist: "Info.plist",
-                               sources: ["Sources/**", "OtherSources/**"],
+                               sources: FileList(globs: ["Sources/**", "OtherSources/**"]),
                                dependencies: [
                                     /* Target dependencies can be defined here */
                                     /* .framework(path: "framework") */
@@ -41,7 +41,7 @@ let project = Project(name: "App",
                                product: .unitTests,
                                bundleId: "io.tuist.AppTests",
                                infoPlist: "Tests.plist",
-                               sources: ["Tests/**"],
+                               sources: FileList(globs: ["Tests/**"]),
                                dependencies: [
                                     .target(name: "App")
                                ])

--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -17,14 +17,14 @@ public final class FileList: Codable {
 /// Support file as single string
 extension FileList: ExpressibleByStringLiteral {
     public convenience init(stringLiteral value: String) {
-        self.init(files: [value])
+        self.init(globs: [value])
     }
 }
 
 extension FileList: ExpressibleByArrayLiteral {
     
     public convenience init(arrayLiteral elements: String...) {
-        self.init(files: elements)
+        self.init(globs: elements)
     }
 }
 

--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -31,7 +31,7 @@ public class Target: Codable {
     let sources: String
 
     /// Relative path to the resources directory.
-    let resources: String?
+    let resources: [String]
 
     /// Headers.
     let headers: Headers?
@@ -85,7 +85,7 @@ public class Target: Codable {
                 bundleId: String,
                 infoPlist: String,
                 sources: String,
-                resources: String? = nil,
+                resources: [String] = [],
                 headers: Headers? = nil,
                 entitlements: String? = nil,
                 actions: [TargetAction] = [],

--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -28,7 +28,7 @@ public class Target: Codable {
     let dependencies: [TargetDependency]
 
     /// Relative path to the sources directory.
-    let sources: String
+    let sources: [String]
 
     /// Relative path to the resources directory.
     let resources: [String]
@@ -70,8 +70,8 @@ public class Target: Codable {
     ///   - product: product type.
     ///   - bundleId: bundle identifier.
     ///   - infoPlist: relative path to the Info.plist file.
-    ///   - sources: relative path to the sources directory.
-    ///   - resources: relative path to the resources directory.
+    ///   - sources: relative paths to the sources directory.
+    ///   - resources: relative paths to the resources directory.
     ///   - headers: headers.
     ///   - entitlements: relative path to the entitlements file.
     ///   - actions: target actions.
@@ -84,7 +84,7 @@ public class Target: Codable {
                 product: Product,
                 bundleId: String,
                 infoPlist: String,
-                sources: String,
+                sources: [String],
                 resources: [String] = [],
                 headers: Headers? = nil,
                 entitlements: String? = nil,

--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -1,5 +1,33 @@
 import Foundation
 
+// MARK: - FileList
+
+public final class FileList: Codable {
+    public enum CodingKeys: String, CodingKey {
+        case globs
+    }
+    
+    let globs: [String]
+    
+    public init(globs: [String]) {
+        self.globs = globs
+    }
+}
+
+/// Support file as single string
+extension FileList: ExpressibleByStringLiteral {
+    public convenience init(stringLiteral value: String) {
+        self.init(files: [value])
+    }
+}
+
+extension FileList: ExpressibleByArrayLiteral {
+    
+    public convenience init(arrayLiteral elements: String...) {
+        self.init(files: elements)
+    }
+}
+
 // MARK: - Target
 
 public class Target: Codable {
@@ -28,10 +56,10 @@ public class Target: Codable {
     let dependencies: [TargetDependency]
 
     /// Relative path to the sources directory.
-    let sources: [String]
-
+    let sources: FileList?
+    
     /// Relative path to the resources directory.
-    let resources: [String]
+    let resources: FileList?
 
     /// Headers.
     let headers: Headers?
@@ -84,8 +112,8 @@ public class Target: Codable {
                 product: Product,
                 bundleId: String,
                 infoPlist: String,
-                sources: [String],
-                resources: [String] = [],
+                sources: FileList? = nil,
+                resources: FileList? = nil,
                 headers: Headers? = nil,
                 entitlements: String? = nil,
                 actions: [TargetAction] = [],

--- a/Sources/TuistKit/Models/FileList.swift
+++ b/Sources/TuistKit/Models/FileList.swift
@@ -1,0 +1,24 @@
+import Basic
+import Foundation
+import TuistCore
+
+class FileList: JSONMappable, Equatable {
+    
+    // MARK: - Attributes
+    
+    let globs: [String]
+    
+    // MARK: - Init
+    
+    required init(json: JSON) throws {
+        if let globs: [String] = try? json.get("globs") {
+            self.globs = globs
+        } else {
+            globs = []
+        }
+    }
+    
+    static func == (lhs: FileList, rhs: FileList) -> Bool {
+        return lhs.globs == rhs.globs
+    }
+}

--- a/Sources/TuistKit/Models/Target.swift
+++ b/Sources/TuistKit/Models/Target.swift
@@ -6,7 +6,7 @@ class Target: GraphInitiatable, Equatable {
     // MARK: - Static
 
     static let validSourceExtensions: [String] = ["m", "swift", "mm", "cpp", "c"]
-    static let validFolderExtensions: [String] = ["framework", "bundle", "app", "appiconset"]
+    static let validFolderExtensions: [String] = ["framework", "bundle", "app", "xcassets", "appiconset"]
 
     // MARK: - Attributes
 
@@ -91,8 +91,10 @@ class Target: GraphInitiatable, Equatable {
         self.sources = try Target.sources(projectPath: projectPath, sources: sources, fileHandler: fileHandler)
 
         // Resources
-        if let resources: String = try? dictionary.get("resources") {
-            self.resources = try Target.resources(projectPath: projectPath, resources: resources, fileHandler: fileHandler)
+        if let resources: [String] = try? dictionary.get("resources") {
+            self.resources = try resources.flatMap({
+                try Target.resources(projectPath: projectPath, resources: $0, fileHandler: fileHandler)
+            })
         } else {
             resources = []
         }

--- a/Sources/TuistKit/Models/Target.swift
+++ b/Sources/TuistKit/Models/Target.swift
@@ -87,8 +87,13 @@ class Target: GraphInitiatable, Equatable {
         })
 
         // Sources
-        let sources: String = try dictionary.get("sources")
-        self.sources = try Target.sources(projectPath: projectPath, sources: sources, fileHandler: fileHandler)
+        if let sources: [String] = try? dictionary.get("sources") {
+            self.sources = try sources.flatMap({
+                try Target.sources(projectPath: projectPath, sources: sources, fileHandler: fileHandler)
+            })
+        } else {
+            sources = []
+        }
 
         // Resources
         if let resources: [String] = try? dictionary.get("resources") {

--- a/Sources/TuistKit/Models/Target.swift
+++ b/Sources/TuistKit/Models/Target.swift
@@ -87,17 +87,17 @@ class Target: GraphInitiatable, Equatable {
         })
 
         // Sources
-        if let sources: [String] = try? dictionary.get("sources") {
-            self.sources = try sources.flatMap({
-                try Target.sources(projectPath: projectPath, sources: sources, fileHandler: fileHandler)
+        if let sources: FileList = try? dictionary.get("sources") {
+            self.sources = try sources.globs.flatMap({
+                try Target.sources(projectPath: projectPath, sources: $0, fileHandler: fileHandler)
             })
         } else {
             sources = []
         }
 
         // Resources
-        if let resources: [String] = try? dictionary.get("resources") {
-            self.resources = try resources.flatMap({
+        if let resources: FileList = try? dictionary.get("resources") {
+            self.resources = try resources.globs.flatMap({
                 try Target.resources(projectPath: projectPath, resources: $0, fileHandler: fileHandler)
             })
         } else {

--- a/Tests/ProjectDescriptionTests/TargetTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetTests.swift
@@ -32,7 +32,7 @@ final class TargetTests: XCTestCase {
                              coreDataModels: [CoreDataModel("pat", currentVersion: "version")],
                              environment: ["a": "b"])
 
-        let expected = "{\"bundle_id\": \"bundle_id\", \"core_data_models\": [{\"current_version\": \"version\", \"path\": \"pat\"}], \"dependencies\": [{\"path\": \"path\", \"type\": \"framework\"}, {\"path\": \"path\", \"public_headers\": \"public\", \"swift_module_map\": \"module\", \"type\": \"library\"}, {\"path\": \"path\", \"target\": \"target\", \"type\": \"project\"}, {\"name\": \"name\", \"type\": \"target\"}], \"entitlements\": \"entitlement\", \"headers\": {\"private\": \"private/*\", \"project\": \"project/*\", \"public\": \"public/*\"}, \"info_plist\": \"info.plist\", \"name\": \"name\", \"platform\": \"ios\", \"product\": \"app\", \"resources\": {\"files\": [\"resources/*\"]}, \"settings\": {\"base\": {\"a\": \"b\"}, \"debug\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}, \"release\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}}, \"sources\": {\"files\": [\"sources/*\"]}, \"actions\": [ { \"path\": \"path\", \"arguments\": [\"arg\"], \"name\": \"name\", \"order\": \"post\"}], \"environment\": {\"a\": \"b\"}}"
+        let expected = "{\"bundle_id\": \"bundle_id\", \"core_data_models\": [{\"current_version\": \"version\", \"path\": \"pat\"}], \"dependencies\": [{\"path\": \"path\", \"type\": \"framework\"}, {\"path\": \"path\", \"public_headers\": \"public\", \"swift_module_map\": \"module\", \"type\": \"library\"}, {\"path\": \"path\", \"target\": \"target\", \"type\": \"project\"}, {\"name\": \"name\", \"type\": \"target\"}], \"entitlements\": \"entitlement\", \"headers\": {\"private\": \"private/*\", \"project\": \"project/*\", \"public\": \"public/*\"}, \"info_plist\": \"info.plist\", \"name\": \"name\", \"platform\": \"ios\", \"product\": \"app\", \"resources\": {\"globs\": [\"resources/*\"]}, \"settings\": {\"base\": {\"a\": \"b\"}, \"debug\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}, \"release\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}}, \"sources\": {\"globs\": [\"sources/*\"]}, \"actions\": [ { \"path\": \"path\", \"arguments\": [\"arg\"], \"name\": \"name\", \"order\": \"post\"}], \"environment\": {\"a\": \"b\"}}"
         assertCodableEqualToJson(subject, expected)
     }
     
@@ -42,8 +42,8 @@ final class TargetTests: XCTestCase {
                              product: .app,
                              bundleId: "bundle_id",
                              infoPlist: "info.plist",
-                             sources: FileList(files: ["sources/*"]),
-                             resources: FileList(files: ["resources/*"]),
+                             sources: FileList(globs: ["sources/*"]),
+                             resources: FileList(globs: ["resources/*"]),
                              headers: Headers(public: "public/*",
                                               private: "private/*",
                                               project: "project/*"),
@@ -65,7 +65,7 @@ final class TargetTests: XCTestCase {
                              coreDataModels: [CoreDataModel("pat", currentVersion: "version")],
                              environment: ["a": "b"])
         
-        let expected = "{\"bundle_id\": \"bundle_id\", \"core_data_models\": [{\"current_version\": \"version\", \"path\": \"pat\"}], \"dependencies\": [{\"path\": \"path\", \"type\": \"framework\"}, {\"path\": \"path\", \"public_headers\": \"public\", \"swift_module_map\": \"module\", \"type\": \"library\"}, {\"path\": \"path\", \"target\": \"target\", \"type\": \"project\"}, {\"name\": \"name\", \"type\": \"target\"}], \"entitlements\": \"entitlement\", \"headers\": {\"private\": \"private/*\", \"project\": \"project/*\", \"public\": \"public/*\"}, \"info_plist\": \"info.plist\", \"name\": \"name\", \"platform\": \"ios\", \"product\": \"app\", \"resources\": {\"files\": [\"resources/*\"]}, \"settings\": {\"base\": {\"a\": \"b\"}, \"debug\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}, \"release\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}}, \"sources\": {\"files\": [\"sources/*\"]}, \"actions\": [ { \"path\": \"path\", \"arguments\": [\"arg\"], \"name\": \"name\", \"order\": \"post\"}], \"environment\": {\"a\": \"b\"}}"
+        let expected = "{\"bundle_id\": \"bundle_id\", \"core_data_models\": [{\"current_version\": \"version\", \"path\": \"pat\"}], \"dependencies\": [{\"path\": \"path\", \"type\": \"framework\"}, {\"path\": \"path\", \"public_headers\": \"public\", \"swift_module_map\": \"module\", \"type\": \"library\"}, {\"path\": \"path\", \"target\": \"target\", \"type\": \"project\"}, {\"name\": \"name\", \"type\": \"target\"}], \"entitlements\": \"entitlement\", \"headers\": {\"private\": \"private/*\", \"project\": \"project/*\", \"public\": \"public/*\"}, \"info_plist\": \"info.plist\", \"name\": \"name\", \"platform\": \"ios\", \"product\": \"app\", \"resources\": {\"globs\": [\"resources/*\"]}, \"settings\": {\"base\": {\"a\": \"b\"}, \"debug\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}, \"release\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}}, \"sources\": {\"globs\": [\"sources/*\"]}, \"actions\": [ { \"path\": \"path\", \"arguments\": [\"arg\"], \"name\": \"name\", \"order\": \"post\"}], \"environment\": {\"a\": \"b\"}}"
         assertCodableEqualToJson(subject, expected)
     }
 }

--- a/Tests/ProjectDescriptionTests/TargetTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetTests.swift
@@ -10,7 +10,7 @@ final class TargetTests: XCTestCase {
                              bundleId: "bundle_id",
                              infoPlist: "info.plist",
                              sources: "sources/*",
-                             resources: "resources/*",
+                             resources: ["resources/*"],
                              headers: Headers(public: "public/*",
                                               private: "private/*",
                                               project: "project/*"),
@@ -32,7 +32,7 @@ final class TargetTests: XCTestCase {
                              coreDataModels: [CoreDataModel("pat", currentVersion: "version")],
                              environment: ["a": "b"])
 
-        let expected = "{\"bundle_id\": \"bundle_id\", \"core_data_models\": [{\"current_version\": \"version\", \"path\": \"pat\"}], \"dependencies\": [{\"path\": \"path\", \"type\": \"framework\"}, {\"path\": \"path\", \"public_headers\": \"public\", \"swift_module_map\": \"module\", \"type\": \"library\"}, {\"path\": \"path\", \"target\": \"target\", \"type\": \"project\"}, {\"name\": \"name\", \"type\": \"target\"}], \"entitlements\": \"entitlement\", \"headers\": {\"private\": \"private/*\", \"project\": \"project/*\", \"public\": \"public/*\"}, \"info_plist\": \"info.plist\", \"name\": \"name\", \"platform\": \"ios\", \"product\": \"app\", \"resources\": \"resources/*\", \"settings\": {\"base\": {\"a\": \"b\"}, \"debug\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}, \"release\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}}, \"sources\": \"sources/*\", \"actions\": [ { \"path\": \"path\", \"arguments\": [\"arg\"], \"name\": \"name\", \"order\": \"post\"}], \"environment\": {\"a\": \"b\"}}"
+        let expected = "{\"bundle_id\": \"bundle_id\", \"core_data_models\": [{\"current_version\": \"version\", \"path\": \"pat\"}], \"dependencies\": [{\"path\": \"path\", \"type\": \"framework\"}, {\"path\": \"path\", \"public_headers\": \"public\", \"swift_module_map\": \"module\", \"type\": \"library\"}, {\"path\": \"path\", \"target\": \"target\", \"type\": \"project\"}, {\"name\": \"name\", \"type\": \"target\"}], \"entitlements\": \"entitlement\", \"headers\": {\"private\": \"private/*\", \"project\": \"project/*\", \"public\": \"public/*\"}, \"info_plist\": \"info.plist\", \"name\": \"name\", \"platform\": \"ios\", \"product\": \"app\", \"resources\": [\"resources/*\"], \"settings\": {\"base\": {\"a\": \"b\"}, \"debug\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}, \"release\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}}, \"sources\": \"sources/*\", \"actions\": [ { \"path\": \"path\", \"arguments\": [\"arg\"], \"name\": \"name\", \"order\": \"post\"}], \"environment\": {\"a\": \"b\"}}"
         assertCodableEqualToJson(subject, expected)
     }
 }

--- a/Tests/ProjectDescriptionTests/TargetTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetTests.swift
@@ -9,8 +9,8 @@ final class TargetTests: XCTestCase {
                              product: .app,
                              bundleId: "bundle_id",
                              infoPlist: "info.plist",
-                             sources: ["sources/*"],
-                             resources: ["resources/*"],
+                             sources: "sources/*",
+                             resources: "resources/*",
                              headers: Headers(public: "public/*",
                                               private: "private/*",
                                               project: "project/*"),
@@ -32,7 +32,40 @@ final class TargetTests: XCTestCase {
                              coreDataModels: [CoreDataModel("pat", currentVersion: "version")],
                              environment: ["a": "b"])
 
-        let expected = "{\"bundle_id\": \"bundle_id\", \"core_data_models\": [{\"current_version\": \"version\", \"path\": \"pat\"}], \"dependencies\": [{\"path\": \"path\", \"type\": \"framework\"}, {\"path\": \"path\", \"public_headers\": \"public\", \"swift_module_map\": \"module\", \"type\": \"library\"}, {\"path\": \"path\", \"target\": \"target\", \"type\": \"project\"}, {\"name\": \"name\", \"type\": \"target\"}], \"entitlements\": \"entitlement\", \"headers\": {\"private\": \"private/*\", \"project\": \"project/*\", \"public\": \"public/*\"}, \"info_plist\": \"info.plist\", \"name\": \"name\", \"platform\": \"ios\", \"product\": \"app\", \"resources\": [\"resources/*\"], \"settings\": {\"base\": {\"a\": \"b\"}, \"debug\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}, \"release\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}}, \"sources\": [\"sources/*\"], \"actions\": [ { \"path\": \"path\", \"arguments\": [\"arg\"], \"name\": \"name\", \"order\": \"post\"}], \"environment\": {\"a\": \"b\"}}"
+        let expected = "{\"bundle_id\": \"bundle_id\", \"core_data_models\": [{\"current_version\": \"version\", \"path\": \"pat\"}], \"dependencies\": [{\"path\": \"path\", \"type\": \"framework\"}, {\"path\": \"path\", \"public_headers\": \"public\", \"swift_module_map\": \"module\", \"type\": \"library\"}, {\"path\": \"path\", \"target\": \"target\", \"type\": \"project\"}, {\"name\": \"name\", \"type\": \"target\"}], \"entitlements\": \"entitlement\", \"headers\": {\"private\": \"private/*\", \"project\": \"project/*\", \"public\": \"public/*\"}, \"info_plist\": \"info.plist\", \"name\": \"name\", \"platform\": \"ios\", \"product\": \"app\", \"resources\": {\"files\": [\"resources/*\"]}, \"settings\": {\"base\": {\"a\": \"b\"}, \"debug\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}, \"release\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}}, \"sources\": {\"files\": [\"sources/*\"]}, \"actions\": [ { \"path\": \"path\", \"arguments\": [\"arg\"], \"name\": \"name\", \"order\": \"post\"}], \"environment\": {\"a\": \"b\"}}"
+        assertCodableEqualToJson(subject, expected)
+    }
+    
+    func test_toJSON_withFileList() {
+        let subject = Target(name: "name",
+                             platform: .iOS,
+                             product: .app,
+                             bundleId: "bundle_id",
+                             infoPlist: "info.plist",
+                             sources: FileList(files: ["sources/*"]),
+                             resources: FileList(files: ["resources/*"]),
+                             headers: Headers(public: "public/*",
+                                              private: "private/*",
+                                              project: "project/*"),
+                             entitlements: "entitlement",
+                             actions: [
+                                TargetAction.post(path: "path", arguments: ["arg"], name: "name"),
+                                ],
+                             dependencies: [
+                                .framework(path: "path"),
+                                .library(path: "path", publicHeaders: "public", swiftModuleMap: "module"),
+                                .project(target: "target", path: "path"),
+                                .target(name: "name"),
+                                ],
+                             settings: Settings(base: ["a": "b"],
+                                                debug: Configuration(settings: ["a": "b"],
+                                                                     xcconfig: "config"),
+                                                release: Configuration(settings: ["a": "b"],
+                                                                       xcconfig: "config")),
+                             coreDataModels: [CoreDataModel("pat", currentVersion: "version")],
+                             environment: ["a": "b"])
+        
+        let expected = "{\"bundle_id\": \"bundle_id\", \"core_data_models\": [{\"current_version\": \"version\", \"path\": \"pat\"}], \"dependencies\": [{\"path\": \"path\", \"type\": \"framework\"}, {\"path\": \"path\", \"public_headers\": \"public\", \"swift_module_map\": \"module\", \"type\": \"library\"}, {\"path\": \"path\", \"target\": \"target\", \"type\": \"project\"}, {\"name\": \"name\", \"type\": \"target\"}], \"entitlements\": \"entitlement\", \"headers\": {\"private\": \"private/*\", \"project\": \"project/*\", \"public\": \"public/*\"}, \"info_plist\": \"info.plist\", \"name\": \"name\", \"platform\": \"ios\", \"product\": \"app\", \"resources\": {\"files\": [\"resources/*\"]}, \"settings\": {\"base\": {\"a\": \"b\"}, \"debug\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}, \"release\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}}, \"sources\": {\"files\": [\"sources/*\"]}, \"actions\": [ { \"path\": \"path\", \"arguments\": [\"arg\"], \"name\": \"name\", \"order\": \"post\"}], \"environment\": {\"a\": \"b\"}}"
         assertCodableEqualToJson(subject, expected)
     }
 }

--- a/Tests/ProjectDescriptionTests/TargetTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetTests.swift
@@ -9,7 +9,7 @@ final class TargetTests: XCTestCase {
                              product: .app,
                              bundleId: "bundle_id",
                              infoPlist: "info.plist",
-                             sources: "sources/*",
+                             sources: ["sources/*"],
                              resources: ["resources/*"],
                              headers: Headers(public: "public/*",
                                               private: "private/*",
@@ -32,7 +32,7 @@ final class TargetTests: XCTestCase {
                              coreDataModels: [CoreDataModel("pat", currentVersion: "version")],
                              environment: ["a": "b"])
 
-        let expected = "{\"bundle_id\": \"bundle_id\", \"core_data_models\": [{\"current_version\": \"version\", \"path\": \"pat\"}], \"dependencies\": [{\"path\": \"path\", \"type\": \"framework\"}, {\"path\": \"path\", \"public_headers\": \"public\", \"swift_module_map\": \"module\", \"type\": \"library\"}, {\"path\": \"path\", \"target\": \"target\", \"type\": \"project\"}, {\"name\": \"name\", \"type\": \"target\"}], \"entitlements\": \"entitlement\", \"headers\": {\"private\": \"private/*\", \"project\": \"project/*\", \"public\": \"public/*\"}, \"info_plist\": \"info.plist\", \"name\": \"name\", \"platform\": \"ios\", \"product\": \"app\", \"resources\": [\"resources/*\"], \"settings\": {\"base\": {\"a\": \"b\"}, \"debug\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}, \"release\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}}, \"sources\": \"sources/*\", \"actions\": [ { \"path\": \"path\", \"arguments\": [\"arg\"], \"name\": \"name\", \"order\": \"post\"}], \"environment\": {\"a\": \"b\"}}"
+        let expected = "{\"bundle_id\": \"bundle_id\", \"core_data_models\": [{\"current_version\": \"version\", \"path\": \"pat\"}], \"dependencies\": [{\"path\": \"path\", \"type\": \"framework\"}, {\"path\": \"path\", \"public_headers\": \"public\", \"swift_module_map\": \"module\", \"type\": \"library\"}, {\"path\": \"path\", \"target\": \"target\", \"type\": \"project\"}, {\"name\": \"name\", \"type\": \"target\"}], \"entitlements\": \"entitlement\", \"headers\": {\"private\": \"private/*\", \"project\": \"project/*\", \"public\": \"public/*\"}, \"info_plist\": \"info.plist\", \"name\": \"name\", \"platform\": \"ios\", \"product\": \"app\", \"resources\": [\"resources/*\"], \"settings\": {\"base\": {\"a\": \"b\"}, \"debug\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}, \"release\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}}, \"sources\": [\"sources/*\"], \"actions\": [ { \"path\": \"path\", \"arguments\": [\"arg\"], \"name\": \"name\", \"order\": \"post\"}], \"environment\": {\"a\": \"b\"}}"
         assertCodableEqualToJson(subject, expected)
     }
 }

--- a/Tests/TuistKitTests/Models/FileListTest.swift
+++ b/Tests/TuistKitTests/Models/FileListTest.swift
@@ -16,7 +16,7 @@ final class FileListTests: XCTestCase {
     }
     
     func test_init() throws {
-        let dictionary = JSON.dictionary(["files": ["sources/*"].toJSON()])
+        let dictionary = JSON.dictionary(["globs": ["sources/*"].toJSON()])
         let got = try FileList(json: dictionary)
             
         XCTAssertEqual(got.globs, ["sources/*"])

--- a/Tests/TuistKitTests/Models/FileListTest.swift
+++ b/Tests/TuistKitTests/Models/FileListTest.swift
@@ -1,0 +1,24 @@
+
+import Basic
+import Foundation
+import TuistCore
+import XCTest
+
+@testable import TuistCoreTesting
+@testable import TuistKit
+
+final class FileListTests: XCTestCase {
+    var fileHandler: MockFileHandler!
+    
+    override func setUp() {
+        fileHandler = try! MockFileHandler()
+        super.setUp()
+    }
+    
+    func test_init() throws {
+        let dictionary = JSON.dictionary(["files": ["sources/*"].toJSON()])
+        let got = try FileList(json: dictionary)
+            
+        XCTAssertEqual(got.globs, ["sources/*"])
+    }
+}


### PR DESCRIPTION
Resolves #138 

### Short description 📝
- Support multi-path sources and resources
- Index xcassets to target

This configuration work perfectly for me:
```swift
sources: FileList(globs: ["Sources/**", "Configuration/**"]),
resources: FileList(globs: ["Tuist-Demo/Storyboard/**/*.{storyboard}", "Tuist-Demo/Resources/**/*.{xcassets,png,strings}"])
```