### PR TITLE
Add acceptance tests for generate command - transitive static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Changed default value of SWIFT_VERSION to 4.2 @ollieatkinson
+- Added fixture tests for ios app with static libraries @ollieatkinson
 
 ## 0.11.0
 

--- a/features/generate.feature
+++ b/features/generate.feature
@@ -29,3 +29,15 @@ Feature: Generate a new project using Tuist
     And I have a working directory
     Then I copy the fixture invalid_workspace_manifest_name into the working directory
     Then tuist generates reports error "❌ Error: Couldn't find manifest at path: '${ARG_PATH}'"
+
+  Scenario: The project is an iOS application with frameworks and tests (ios_app_with_static_libraries)
+    Given that tuist is available
+    And I have a working directory
+    Then I copy the fixture ios_app_with_static_libraries into the working directory
+    Then tuist generates the project
+    Then I should be able to build the scheme App
+    Then I should be able to test the scheme AppTests
+    Then I should be able to build the scheme A
+    Then I should be able to test the scheme ATests
+    Then I should be able to build the scheme B
+    Then I should be able to test the scheme BTests

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,11 +1,11 @@
 # Fixtures
 
-This folder contains sample projects we use in the integration and acceptance tests. 
+This folder contains sample projects we use in the integration and acceptance tests.
 Please keep this keep in alphabetical order.
 
 ## app_with_frameworks
 
-Slightly more complicated project consists of an iOS app and few frameworks. 
+Slightly more complicated project consists of an iOS app and few frameworks.
 
 #### Structure
 
@@ -34,3 +34,25 @@ Simple app with tests.
 ## invalid_workspace_manifest_name
 
 Contains a single file `Workspac.swift`, incorrectly named workspace manifest file.
+
+## ios_app_with_static_libraries
+
+This application provides a top level application with two static library dependencies. The first static library dependency has another static library dependency so that we are able to test how tuist handles the transitiveness of the static libraries in the linked frameworks of the main app.
+
+
+```
+Workspace:
+  - App:
+    - MainApp (iOS app)
+    - MainAppTests (iOS unit tests)
+  - A:
+    - A (static library iOS)
+    - ATests (iOS unit tests)
+  - B:
+    - B (static library iOS)
+    - BTests (iOS unit tests)
+```
+
+Dependencies:
+  - App -> A
+  - A -> B

--- a/fixtures/ios_app_with_static_libraries/.gitignore
+++ b/fixtures/ios_app_with_static_libraries/.gitignore
@@ -1,0 +1,63 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two 
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace

--- a/fixtures/ios_app_with_static_libraries/Info.plist
+++ b/fixtures/ios_app_with_static_libraries/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_static_libraries/Modules/A/.gitignore
+++ b/fixtures/ios_app_with_static_libraries/Modules/A/.gitignore
@@ -1,0 +1,63 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two 
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace

--- a/fixtures/ios_app_with_static_libraries/Modules/A/Info.plist
+++ b/fixtures/ios_app_with_static_libraries/Modules/A/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_static_libraries/Modules/A/Playgrounds/A.playground/Contents.swift
+++ b/fixtures/ios_app_with_static_libraries/Modules/A/Playgrounds/A.playground/Contents.swift
@@ -1,0 +1,3 @@
+//: Playground - noun: a place where people can play
+
+import Foundation

--- a/fixtures/ios_app_with_static_libraries/Modules/A/Playgrounds/A.playground/contents.xcplayground
+++ b/fixtures/ios_app_with_static_libraries/Modules/A/Playgrounds/A.playground/contents.xcplayground
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='ios'>
+<timeline fileName='timeline.xctimeline'/>
+</playground>

--- a/fixtures/ios_app_with_static_libraries/Modules/A/Project.swift
+++ b/fixtures/ios_app_with_static_libraries/Modules/A/Project.swift
@@ -1,0 +1,23 @@
+import ProjectDescription
+
+let project = Project(name: "A",
+                      targets: [
+                        Target(name: "A",
+                               platform: .iOS,
+                               product: .staticLibrary,
+                               bundleId: "io.tuist.A",
+                               infoPlist: "Info.plist",
+                               sources: "Sources/**",
+                               dependencies: [
+                                   .project(target: "B", path: "../B")
+                                ]),
+                        Target(name: "ATests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               bundleId: "io.tuist.ATests",
+                               infoPlist: "Tests.plist",
+                               sources: "Tests/**",
+                               dependencies: [
+                                    .target(name: "A")
+                               ])
+                      ])

--- a/fixtures/ios_app_with_static_libraries/Modules/A/Sources/A.swift
+++ b/fixtures/ios_app_with_static_libraries/Modules/A/Sources/A.swift
@@ -1,0 +1,12 @@
+import B
+
+public class A {
+
+    public static let value: String = "aValue"
+
+    static public func printFromA() {
+        print("print from A")
+        B.printFromB()
+    }
+
+}

--- a/fixtures/ios_app_with_static_libraries/Modules/A/Tests.plist
+++ b/fixtures/ios_app_with_static_libraries/Modules/A/Tests.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_static_libraries/Modules/A/Tests/ATests.swift
+++ b/fixtures/ios_app_with_static_libraries/Modules/A/Tests/ATests.swift
@@ -1,0 +1,12 @@
+import Foundation
+import XCTest
+
+@testable import A
+
+final class ATests: XCTestCase {
+
+  func test_value() {
+      XCTAssertEqual(A.value, "aValue")
+  }
+
+}

--- a/fixtures/ios_app_with_static_libraries/Modules/B/.gitignore
+++ b/fixtures/ios_app_with_static_libraries/Modules/B/.gitignore
@@ -1,0 +1,63 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two 
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace

--- a/fixtures/ios_app_with_static_libraries/Modules/B/Info.plist
+++ b/fixtures/ios_app_with_static_libraries/Modules/B/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_static_libraries/Modules/B/Playgrounds/B.playground/Contents.swift
+++ b/fixtures/ios_app_with_static_libraries/Modules/B/Playgrounds/B.playground/Contents.swift
@@ -1,0 +1,3 @@
+//: Playground - noun: a place where people can play
+
+import Foundation

--- a/fixtures/ios_app_with_static_libraries/Modules/B/Playgrounds/B.playground/contents.xcplayground
+++ b/fixtures/ios_app_with_static_libraries/Modules/B/Playgrounds/B.playground/contents.xcplayground
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='ios'>
+<timeline fileName='timeline.xctimeline'/>
+</playground>

--- a/fixtures/ios_app_with_static_libraries/Modules/B/Project.swift
+++ b/fixtures/ios_app_with_static_libraries/Modules/B/Project.swift
@@ -1,0 +1,24 @@
+import ProjectDescription
+
+let project = Project(name: "B",
+                      targets: [
+                        Target(name: "B",
+                               platform: .iOS,
+                               product: .staticLibrary,
+                               bundleId: "io.tuist.B",
+                               infoPlist: "Info.plist",
+                               sources: "Sources/**",
+                               dependencies: [
+                                    /* Target dependencies can be defined here */
+                                    /* .framework(path: "framework") */
+                                ]),
+                        Target(name: "BTests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               bundleId: "io.tuist.BTests",
+                               infoPlist: "Tests.plist",
+                               sources: "Tests/**",
+                               dependencies: [
+                                    .target(name: "B")
+                               ])
+                      ])

--- a/fixtures/ios_app_with_static_libraries/Modules/B/Sources/B.swift
+++ b/fixtures/ios_app_with_static_libraries/Modules/B/Sources/B.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public class B {
+
+    public static let value: String = "bValue"
+
+    public static func printFromB() {
+        print("print from B")
+    }
+
+}

--- a/fixtures/ios_app_with_static_libraries/Modules/B/Tests.plist
+++ b/fixtures/ios_app_with_static_libraries/Modules/B/Tests.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_static_libraries/Modules/B/Tests/BTests.swift
+++ b/fixtures/ios_app_with_static_libraries/Modules/B/Tests/BTests.swift
@@ -1,0 +1,12 @@
+import Foundation
+import XCTest
+
+@testable import B
+
+final class BTests: XCTestCase {
+
+  func test_value() {
+      XCTAssertEqual(B.value, "bValue")
+  }
+
+}

--- a/fixtures/ios_app_with_static_libraries/Playgrounds/application_with_transistive_static_dependency.playground/Contents.swift
+++ b/fixtures/ios_app_with_static_libraries/Playgrounds/application_with_transistive_static_dependency.playground/Contents.swift
@@ -1,0 +1,3 @@
+//: Playground - noun: a place where people can play
+
+import Foundation

--- a/fixtures/ios_app_with_static_libraries/Playgrounds/application_with_transistive_static_dependency.playground/contents.xcplayground
+++ b/fixtures/ios_app_with_static_libraries/Playgrounds/application_with_transistive_static_dependency.playground/contents.xcplayground
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='ios'>
+<timeline fileName='timeline.xctimeline'/>
+</playground>

--- a/fixtures/ios_app_with_static_libraries/Project.swift
+++ b/fixtures/ios_app_with_static_libraries/Project.swift
@@ -1,0 +1,23 @@
+import ProjectDescription
+
+let project = Project(name: "iOSAppWithTransistiveStaticLibraries",
+                      targets: [
+                        Target(name: "App",
+                               platform: .iOS,
+                               product: .app,
+                               bundleId: "io.tuist.App",
+                               infoPlist: "Info.plist",
+                               sources: "Sources/**",
+                               dependencies: [
+                                    .project(target: "A", path: "Modules/A")
+                                ]),
+                        Target(name: "AppTests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               bundleId: "io.tuist.AppTests",
+                               infoPlist: "Tests.plist",
+                               sources: "Tests/**",
+                               dependencies: [
+                                    .target(name: "App")
+                               ])
+                      ])

--- a/fixtures/ios_app_with_static_libraries/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_static_libraries/Sources/AppDelegate.swift
@@ -1,0 +1,27 @@
+import UIKit
+import A
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        let viewController = UIViewController()
+        viewController.view.backgroundColor = .white
+        window?.rootViewController = viewController
+        window?.makeKeyAndVisible()
+
+        A.printFromA()
+
+        return true
+    }
+
+}
+
+public class AClassInThisBundle {
+
+  public static let value: String = "aValue"
+
+}

--- a/fixtures/ios_app_with_static_libraries/Tests.plist
+++ b/fixtures/ios_app_with_static_libraries/Tests.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_static_libraries/Tests/AppTests.swift
+++ b/fixtures/ios_app_with_static_libraries/Tests/AppTests.swift
@@ -1,0 +1,12 @@
+import Foundation
+import XCTest
+
+@testable import App
+
+final class AppTests: XCTestCase {
+
+    // func test_application() {
+    //     XCTAssertEqual(App.AClassInThisBundle.value, "aValue")
+    // }
+
+}


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/198

### Short description 📝

Added 1 simple acceptance tests for generate command.

The test verifies tuist is able to generate a workspace with transitive static dependencies, and that the main app and individual libraries test pass.

There is a problem with the main app tests described here: https://github.com/tuist/tuist/issues/204. I left these commented out for the time being.

To run the acceptance tests:

```bash
bundle exec rake features
```