### PR TITLE
Danger warn that reminds contributors to update the docuementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - **Breaking** Up can now be specified via `Setup.swift` https://github.com/tuist/tuist/issues/203 by @marciniwanicki & @kwridan
 - Schemes generation https://github.com/tuist/tuist/pull/188 by @pepibumur.
 - Environment variables per target https://github.com/tuist/tuist/pull/189 by @pepibumur.
+- Danger warn that reminds contributors to update the docuementation https://github.com/tuist/tuist/pull/214 by @pepibumur
 
 ### Fixed
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,11 +1,21 @@
+all_files = git.modified_files + git.added_files
+
 # Changelog
 if !git.modified_files.include?("CHANGELOG.md")
   message = <<~MESSAGE
     Please include a CHANGELOG entry.
     You can find it at [CHANGELOG.md](https://github.com/tuist/tuist/blob/master/CHANGELOG.md).
   MESSAGE
-  fail(message, sticky: false)
+  fail(message)
 end
 
 # Swiftlint
 swiftlint.lint_files(additional_swiftlint_args: "--strict")
+
+# Update documentation
+if all_files.any? { |f| f =~ /Sources\// }
+  message = <<~MESSAGE
+  Have you introduced any user-facing changes? If so, please take some time to [update the documentation](https://github.com/tuist/documentation). Keeping the documentation up to date makes it easier for users to learn how to use Tuist. 
+  MESSAGE
+  warn(message)
+end


### PR DESCRIPTION
### Short description 📝
This PR adds a new Danger check that reminds the contributors to update the documentation before merging a PR if they have introduced any user-facing changes into the project.