### PR TITLE
Fail init command right away if the directory is not empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Environment variables per target https://github.com/tuist/tuist/pull/189 by @pepibumur.
 - Danger warn that reminds contributors to update the docuementation https://github.com/tuist/tuist/pull/214 by @pepibumur
 - Rubocop https://github.com/tuist/tuist/pull/216 by @pepibumur.
+- Fail init command if the directory is not empty https://github.com/tuist/tuist/pull/218 by @pepibumur.
 
 ### Fixed
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/209

### Short description 📝
When `tuist init` is executed in a directory that contains files that conflict with the ones that the command generates, the command fails without a clear message.

### Solution 📦
To prevent that this PR adds a check that is executed before the initialisation starts. If it detects that directory where the project is being initialised contains other files, it fails immediately.

### Implementation 👩‍💻👨‍💻
- [x] Add the logic to `InitCommand`.
- [x] Add unit tests.