### PR TITLE
Lint that the bundle identifier has the right format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Danger warn that reminds contributors to update the docuementation https://github.com/tuist/tuist/pull/214 by @pepibumur
 - Rubocop https://github.com/tuist/tuist/pull/216 by @pepibumur.
 - Fail init command if the directory is not empty https://github.com/tuist/tuist/pull/218 by @pepibumur.
+- Verify that the bundle identifier has only valid characters https://github.com/tuist/tuist/pull/219 by @pepibumur.
 
 ### Fixed
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    danger (5.10.3)
+    danger (5.14.0)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)

--- a/Sources/TuistKit/Linter/TargetLinter.swift
+++ b/Sources/TuistKit/Linter/TargetLinter.swift
@@ -41,21 +41,21 @@ class TargetLinter: TargetLinting {
     }
 
     // MARK: - Fileprivate
-    
+
     /// Verifies that the bundle identifier doesn't include characters that are not supported.
     ///
     /// - Parameter target: Target whose bundle identified will be linted.
     /// - Returns: An array with a linting issue if the bundle identifier contains invalid characters.
     fileprivate func lintBundleIdentifier(target: Target) -> [LintingIssue] {
         let bundleIdentifier = target.bundleId
-        
-         var allowed = CharacterSet.alphanumerics
-        allowed.formUnion(CharacterSet.init(charactersIn: "-."))
-        
+
+        var allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+        allowed.formUnion(CharacterSet(charactersIn: "-."))
+
         if !bundleIdentifier.unicodeScalars.allSatisfy({ allowed.contains($0) }) {
             let reason = "Invalid bundle identifier '\(bundleIdentifier)'. This string must be a uniform type identifier (UTI) that contains only alphanumeric (A-Z,a-z,0-9), hyphen (-), and period (.) characters."
-            
-            return [LintingIssue.init(reason: reason, severity: .error)]
+
+            return [LintingIssue(reason: reason, severity: .error)]
         }
         return []
     }

--- a/Sources/TuistKit/Linter/TargetLinter.swift
+++ b/Sources/TuistKit/Linter/TargetLinter.swift
@@ -26,6 +26,7 @@ class TargetLinter: TargetLinting {
 
     func lint(target: Target) -> [LintingIssue] {
         var issues: [LintingIssue] = []
+        issues.append(contentsOf: lintBundleIdentifier(target: target))
         issues.append(contentsOf: lintHasSourceFiles(target: target))
         issues.append(contentsOf: lintCopiedFiles(target: target))
         issues.append(contentsOf: lintLibraryHasNoResources(target: target))
@@ -40,6 +41,24 @@ class TargetLinter: TargetLinting {
     }
 
     // MARK: - Fileprivate
+    
+    /// Verifies that the bundle identifier doesn't include characters that are not supported.
+    ///
+    /// - Parameter target: Target whose bundle identified will be linted.
+    /// - Returns: An array with a linting issue if the bundle identifier contains invalid characters.
+    fileprivate func lintBundleIdentifier(target: Target) -> [LintingIssue] {
+        let bundleIdentifier = target.bundleId
+        
+         var allowed = CharacterSet.alphanumerics
+        allowed.formUnion(CharacterSet.init(charactersIn: "-."))
+        
+        if !bundleIdentifier.unicodeScalars.allSatisfy({ allowed.contains($0) }) {
+            let reason = "Invalid bundle identifier '\(bundleIdentifier)'. This string must be a uniform type identifier (UTI) that contains only alphanumeric (A-Z,a-z,0-9), hyphen (-), and period (.) characters."
+            
+            return [LintingIssue.init(reason: reason, severity: .error)]
+        }
+        return []
+    }
 
     fileprivate func lintHasSourceFiles(target: Target) -> [LintingIssue] {
         let files = target.sources

--- a/Tests/TuistKitTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistKitTests/Linter/TargetLinterTests.swift
@@ -13,6 +13,17 @@ final class TargetLinterTests: XCTestCase {
         fileHandler = try! MockFileHandler()
         subject = TargetLinter(fileHandler: fileHandler)
     }
+    
+    func test_lint_when_target_has_invalid_bundle_identifier() {
+        let reason: (String) -> String = { bundleId in
+            return "Invalid bundle identifier '\(bundleId)'. This string must be a uniform type identifier (UTI) that contains only alphanumeric (A-Z,a-z,0-9), hyphen (-), and period (.) characters."
+        }
+        
+        let bundleId = "_.company.app"
+        let target = Target.test(bundleId: bundleId)
+        let got = subject.lint(target: target)
+        XCTAssertTrue(got.contains(LintingIssue(reason: reason(bundleId), severity: .error)))
+    }
 
     func test_lint_when_target_no_source_files() {
         let target = Target.test(sources: [])

--- a/Tests/TuistKitTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistKitTests/Linter/TargetLinterTests.swift
@@ -13,16 +13,20 @@ final class TargetLinterTests: XCTestCase {
         fileHandler = try! MockFileHandler()
         subject = TargetLinter(fileHandler: fileHandler)
     }
-    
+
     func test_lint_when_target_has_invalid_bundle_identifier() {
-        let reason: (String) -> String = { bundleId in
-            return "Invalid bundle identifier '\(bundleId)'. This string must be a uniform type identifier (UTI) that contains only alphanumeric (A-Z,a-z,0-9), hyphen (-), and period (.) characters."
+        let XCTAssertInvalidBundleId: (String) -> Void = { bundleId in
+            let bundleId = "_.company.app"
+            let target = Target.test(bundleId: bundleId)
+            let got = self.subject.lint(target: target)
+            let reason = "Invalid bundle identifier '\(bundleId)'. This string must be a uniform type identifier (UTI) that contains only alphanumeric (A-Z,a-z,0-9), hyphen (-), and period (.) characters."
+            XCTAssertTrue(got.contains(LintingIssue(reason: reason, severity: .error)))
         }
-        
-        let bundleId = "_.company.app"
-        let target = Target.test(bundleId: bundleId)
-        let got = subject.lint(target: target)
-        XCTAssertTrue(got.contains(LintingIssue(reason: reason(bundleId), severity: .error)))
+
+        XCTAssertInvalidBundleId("_.company.app")
+        XCTAssertInvalidBundleId("com.company.◌́")
+        XCTAssertInvalidBundleId("Ⅻ.company.app")
+        XCTAssertInvalidBundleId("ؼ.company.app")
     }
 
     func test_lint_when_target_no_source_files() {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/193

### Short description 📝
As @ollieatkinson pointed out [here](https://github.com/tuist/tuist/issues/193), Xcode allows only a set of characters in the bundle identifier. If the bundle identifier in the `Project.swift`, includes an unsupported character, Tuist doesn't detect it and Xcode ends up raising an error.

### Solution 📦
Since we know the characters that are supported, this PR adds a new linting check that verifies that all the characters in the bundle identifier are supported. If any of them is not supported, Tuist fails with an error.