### PR TITLE
Introducing `TuistGenerator`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,20 @@ let package = Package(
         .library(name: "ProjectDescription",
                  type: .dynamic,
                  targets: ["ProjectDescription"]),
+        
+        /// TuistGenerator
+        ///
+        /// A high level Xcode generator library
+        /// responsible for generating Xcode projects & workspaces.
+        ///
+        /// This library can be used in external tools that wish to
+        /// leverage Tuist's Xcode generation features.
+        ///
+        /// Note: This library should be treated as **unstable** as
+        ///       it is still under development and may include breaking
+        ///       changes in future releases.
+        .library(name: "TuistGenerator",
+                 targets: ["TuistGenerator"]),
     ],
     dependencies: [
         .package(url: "https://github.com/tuist/xcodeproj.git", .upToNextMinor(from: "6.3.0")),
@@ -19,7 +33,7 @@ let package = Package(
     targets: [
         .target(
             name: "TuistKit",
-            dependencies: ["xcodeproj", "Utility", "TuistCore", "Yams"]
+            dependencies: ["xcodeproj", "Utility", "TuistCore", "TuistGenerator", "Yams"]
         ),
         .testTarget(
             name: "TuistKitTests",
@@ -60,6 +74,14 @@ let package = Package(
         .testTarget(
             name: "TuistCoreTests",
             dependencies: ["TuistCore", "TuistCoreTesting"]
+        ),
+        .target(
+            name: "TuistGenerator",
+            dependencies: ["xcodeproj", "Utility", "TuistCore"]
+        ),
+        .testTarget(
+            name: "TuistGeneratorTests",
+            dependencies: ["TuistGenerator", "TuistCoreTesting"]
         ),
     ]
 )

--- a/Sources/TuistGenerator/Generator.swift
+++ b/Sources/TuistGenerator/Generator.swift
@@ -1,0 +1,64 @@
+import Basic
+import TuistCore
+
+/// A component responsible for generating Xcode projects & workspaces
+public protocol Generating {
+
+    /// Generate an Xcode project at a given path.
+    ///
+    /// - Parameters:
+    ///   - path: The absolute path to the directory where an Xcode project should be generated.
+    ///           (e.g. /path/to/directory)
+    /// - Returns: An absolute path to the generated Xcode workspace
+    ///            (e.g. /path/to/directory/project.xcodeproj)
+    /// - Throws: Errors encountered during the generation process
+    ///           many of which adopt `FatalError`
+    /// - seealso: TuistCore.FatalError
+    @discardableResult
+    func generateProject(at path: AbsolutePath) throws -> AbsolutePath
+
+    /// Generate an Xcode workspace at a given path.
+    ///
+    /// - Parameters:
+    ///   - path: The absolute path to the directory where an Xcode project should be generated.
+    ///           (e.g. /path/to/directory)
+    /// - Returns: An absolute path to the generated Xcode workspace
+    ///            (e.g. /path/to/directory/project.xcodeproj)
+    /// - Throws: Errors encountered during the generation process
+    ///           many of which adopt `FatalError`
+    /// - seealso: TuistCore.FatalError
+    @discardableResult
+    func generateWorkspace(at path: AbsolutePath) throws -> AbsolutePath
+}
+
+public enum GeneratorError: FatalError {
+    
+    case notImplemented
+    
+    public var type: ErrorType {
+        switch self {
+        case .notImplemented:
+            return .abort
+        }
+    }
+    
+    public var description: String {
+        switch self {
+        case .notImplemented:
+            return "This feature is not yet implemented"
+        }
+    }
+}
+
+/// A default implementation of `Generating`
+///
+/// - seealso: Generating
+public class Generator: Generating {
+    public func generateProject(at path: AbsolutePath) throws -> AbsolutePath {
+        throw GeneratorError.notImplemented
+    }
+
+    public func generateWorkspace(at path: AbsolutePath) throws -> AbsolutePath {
+        throw GeneratorError.notImplemented
+    }
+}

--- a/Tests/TuistGeneratorTests/GeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/GeneratorTests.swift
@@ -1,0 +1,36 @@
+import Basic
+@testable import TuistGenerator
+import XCTest
+
+final class GeneratorTests: XCTestCase {
+    
+    func test_generator_generateProject() throws {
+        // Given
+        let subject = Generator()
+        let workspacePath = AbsolutePath("/tmp/some/directory")
+        
+        // When / Then
+        XCTAssertThrowsError(try subject.generateProject(at: workspacePath)) {
+            XCTAssertEqual($0 as? GeneratorError, .notImplemented)
+        }
+    }
+    
+    func test_generator_generateWorkspace() throws {
+        // Given
+        let subject = Generator()
+        let workspacePath = AbsolutePath("/tmp/some/directory")
+
+        // When / Then
+        XCTAssertThrowsError(try subject.generateWorkspace(at: workspacePath)) {
+            XCTAssertEqual($0 as? GeneratorError, .notImplemented)
+        }
+    }
+    
+    func test_generatorError_type() {
+        XCTAssertEqual(GeneratorError.notImplemented.type, .abort)
+    }
+    
+    func test_generatorError_description() {
+        XCTAssertEqual(GeneratorError.notImplemented.description, "This feature is not yet implemented")
+    }
+}


### PR DESCRIPTION
Part of: https://github.com/tuist/tuist/issues/205

### Short description 📝

To allow external tools to leverage Tuist's Xcode generation capabilities, a new library is needed to host all the Xcode generation related logic.

### Solution 📦

`TuistGenerator` (library) is being introduced to host many of the Xcode generation related classes that currently reside in `TuistKit`.

To break up the changes into smaller chunks, this first change simply introduces the library with a stubbed default interface.

### Notes 📝

`TuistGenerator` should be treated as unstable at this time as it's still being developed.

### Test Plan ⚒

- Ensure Tuist continues to build `swift build`
- Ensure unit tests pass `swift test`