### PR TITLE
Change the swift version to 4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Up attribute from the `Project` model https://github.com/tuist/tuist/pull/228 by @pepibumur.
 
+### Fixed
+
+- Changed default value of SWIFT_VERSION to 4.2 @ollieatkinson
+
 ## 0.11.0
 
 ### Added

--- a/Sources/TuistCore/Constants.swift
+++ b/Sources/TuistCore/Constants.swift
@@ -6,6 +6,6 @@ public class Constants {
     public static let binName = "tuist"
     public static let gitRepositoryURL = "https://github.com/tuist/tuist.git"
     public static let version = "0.11.0"
-    public static let swiftVersion: String = "4.2.1"
+    public static let swiftVersion: String = "4.2"
     public static let bundleName: String = "tuist.zip"
 }

--- a/fixtures/ios_app_with_setup/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_setup/Sources/AppDelegate.swift
@@ -4,7 +4,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-    func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
         let viewController = UIViewController()
         viewController.view.backgroundColor = .white

--- a/fixtures/ios_app_with_tests/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_tests/Sources/AppDelegate.swift
@@ -4,7 +4,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-    func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
         let viewController = UIViewController()
         viewController.view.backgroundColor = .white


### PR DESCRIPTION

### Short description 📝

* 4.2.1 is an invalid specification for SWIFT_VERSION.

### Solution 📦

* Change default to to 4.2