### PR TITLE
Generate a scheme with all the project targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Integration tests for `generate` command https://github.com/tuist/tuist/pull/208 by @marciniwanicki & @kwridan
 - Frequently asked questions to the documentation https://github.com/tuist/tuist/pull/223/ by @pepibumur.
+- Generate a scheme with all the project targets https://github.com/tuist/tuist/pull/226 by @pepibumur
 
 ### Removed
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -8,7 +8,7 @@ unless git.modified_files.include?("CHANGELOG.md")
     Please include a CHANGELOG entry.
     You can find it at [CHANGELOG.md](https://github.com/tuist/tuist/blob/master/CHANGELOG.md).
   MESSAGE
-  raise(message)
+  warn(message)
 end
 
 # Swiftlint

--- a/Sources/TuistKit/Generator/ProjectGenerator.swift
+++ b/Sources/TuistKit/Generator/ProjectGenerator.swift
@@ -149,7 +149,8 @@ final class ProjectGenerator: ProjectGenerating {
         try schemesGenerator.generateTargetSchemes(project: project,
                                                    generatedProject: generatedProject)
         try schemesGenerator.generateProjectScheme(project: project,
-                                                   generatedProject: generatedProject)
+                                                   generatedProject: generatedProject,
+                                                   graph: graph)
 
         return generatedProject
     }

--- a/Sources/TuistKit/Generator/ProjectGenerator.swift
+++ b/Sources/TuistKit/Generator/ProjectGenerator.swift
@@ -148,6 +148,8 @@ final class ProjectGenerator: ProjectGenerating {
                                                 targets: nativeTargets)
         try schemesGenerator.generateTargetSchemes(project: project,
                                                    generatedProject: generatedProject)
+        try schemesGenerator.generateProjectScheme(project: project,
+                                                   generatedProject: generatedProject)
 
         return generatedProject
     }

--- a/Sources/TuistKit/Generator/SchemesGenerator.swift
+++ b/Sources/TuistKit/Generator/SchemesGenerator.swift
@@ -104,7 +104,7 @@ final class SchemesGenerator: SchemesGenerating {
             }
             
             return XCScheme.BuildAction.Entry(buildableReference: buildableReference,
-                                              buildFor: [.analyzing])
+                                              buildFor: buildFor)
         }
         
         return XCScheme.BuildAction(buildActionEntries: entries,

--- a/Sources/TuistKit/Generator/SchemesGenerator.swift
+++ b/Sources/TuistKit/Generator/SchemesGenerator.swift
@@ -100,7 +100,7 @@ final class SchemesGenerator: SchemesGenerating {
         let targets = project.sortedTargetsForProjectScheme(graph: graph)
         let entries: [XCScheme.BuildAction.Entry] = targets.map { (target) -> XCScheme.BuildAction.Entry in
             let pbxTarget = generatedProject.targets[target.name]!
-            let buildableReference = self.targetBuildableReference(target: target,
+            let buildableReference = targetBuildableReference(target: target,
                                                                    pbxTarget: pbxTarget,
                                                                    projectPath: generatedProject.path)
             var buildFor: [XCScheme.BuildAction.Entry.BuildFor] = []
@@ -217,7 +217,7 @@ final class SchemesGenerator: SchemesGenerating {
             .analyzing, .archiving, .profiling, .running, .testing
         ]
 
-        let buildableReference = self.targetBuildableReference(target: target,
+        let buildableReference = targetBuildableReference(target: target,
                                                          pbxTarget: pbxTarget,
                                                          projectPath: projectPath)
         var entries: [XCScheme.BuildAction.Entry] = []
@@ -240,7 +240,7 @@ final class SchemesGenerator: SchemesGenerating {
                       projectPath: AbsolutePath) -> XCScheme.LaunchAction? {
         var buildableProductRunnable: XCScheme.BuildableProductRunnable?
         var macroExpansion: XCScheme.BuildableReference?
-        let buildableReference = self.targetBuildableReference(target: target, pbxTarget: pbxTarget, projectPath: projectPath)
+        let buildableReference = targetBuildableReference(target: target, pbxTarget: pbxTarget, projectPath: projectPath)
         if target.product.runnable {
             buildableProductRunnable = XCScheme.BuildableProductRunnable(buildableReference: buildableReference, runnableDebuggingMode: "0")
         } else {
@@ -267,7 +267,7 @@ final class SchemesGenerator: SchemesGenerating {
                        projectPath: AbsolutePath) -> XCScheme.ProfileAction? {
         var buildableProductRunnable: XCScheme.BuildableProductRunnable?
         var macroExpansion: XCScheme.BuildableReference?
-        let buildableReference = self.targetBuildableReference(target: target, pbxTarget: pbxTarget, projectPath: projectPath)
+        let buildableReference = targetBuildableReference(target: target, pbxTarget: pbxTarget, projectPath: projectPath)
 
         if target.product.runnable {
             buildableProductRunnable = XCScheme.BuildableProductRunnable(buildableReference: buildableReference, runnableDebuggingMode: "0")

--- a/Sources/TuistKit/Generator/TargetGenerator.swift
+++ b/Sources/TuistKit/Generator/TargetGenerator.swift
@@ -164,9 +164,9 @@ final class TargetGenerator: TargetGenerating {
                                     graph: Graphing) throws {
         try targets.forEach { targetSpec in
             let dependencies = graph.targetDependencies(path: path, name: targetSpec.name)
-            try dependencies.forEach { dependencyName in
+            try dependencies.forEach { dependency in
                 let target = nativeTargets[targetSpec.name]!
-                let dependency = nativeTargets[dependencyName]!
+                let dependency = nativeTargets[dependency.target.name]!
                 _ = try target.addDependency(target: dependency)
             }
         }

--- a/Sources/TuistKit/Graph/Graph.swift
+++ b/Sources/TuistKit/Graph/Graph.swift
@@ -46,7 +46,7 @@ protocol Graphing: AnyObject {
     func linkableDependencies(path: AbsolutePath, name: String) throws -> [DependencyReference]
     func librariesPublicHeadersFolders(path: AbsolutePath, name: String) -> [AbsolutePath]
     func embeddableFrameworks(path: AbsolutePath, name: String, system: Systeming) throws -> [DependencyReference]
-    func targetDependencies(path: AbsolutePath, name: String) -> [String]
+    func targetDependencies(path: AbsolutePath, name: String) -> [TargetNode]
     func staticLibraryDependencies(path: AbsolutePath, name: String) -> [DependencyReference]
 
     // MARK: - Depth First Search
@@ -91,14 +91,13 @@ class Graph: Graphing {
         return cache.precompiledNodes.values.compactMap { $0 as? FrameworkNode }
     }
 
-    func targetDependencies(path: AbsolutePath, name: String) -> [String] {
+    func targetDependencies(path: AbsolutePath, name: String) -> [TargetNode] {
         guard let targetNode = findTargetNode(path: path, name: name) else {
             return []
         }
 
         return targetNode.targetDependencies
             .filter { $0.path == path }
-            .map(\.target.name)
     }
 
     func staticLibraryDependencies(path: AbsolutePath, name: String) -> [DependencyReference] {

--- a/Sources/TuistKit/Models/Project.swift
+++ b/Sources/TuistKit/Models/Project.swift
@@ -2,7 +2,7 @@ import Basic
 import Foundation
 import TuistCore
 
-class Project: Equatable {
+class Project: Equatable, CustomStringConvertible {
     // MARK: - Attributes
 
     /// Path to the folder that contains the project manifest.
@@ -72,6 +72,47 @@ class Project: Equatable {
         targets = try targetsJSONs.map({ try Target(dictionary: $0, projectPath: path, fileHandler: fileHandler) })
         let settingsJSON: JSON? = try? json.get("settings")
         settings = try settingsJSON.map({ try Settings(dictionary: $0, projectPath: path, fileHandler: fileHandler) })
+    }
+    
+    /// It returns the project targets sorted based on the target type and the dependencies between them.
+    /// The most dependent and non-tests targets are sorted first in the list.
+    ///
+    /// - Parameter graph: Dependencies graph.
+    /// - Returns: Sorted targets.
+    func sortedTargetsForProjectScheme(graph: Graphing) -> [Target] {
+        return targets.sorted { (first, second) -> Bool in
+            // First criteria: Test bundles at the end
+            if first.product.testsBundle && !second.product.testsBundle {
+                return false
+            }
+            if !first.product.testsBundle && second.product.testsBundle {
+                return true
+            }
+            
+            // Second criteria: Most dependent targets first.
+            let secondDependencies = graph.targetDependencies(path: self.path, name: second.name)
+                .filter({ $0.path == self.path })
+                .map({ $0.target.name })
+            let firstDependencies = graph.targetDependencies(path: self.path, name: first.name)
+                .filter({ $0.path == self.path })
+                .map({ $0.target.name })
+            
+            if secondDependencies.contains(first.name) {
+                return true
+            } else if firstDependencies.contains(second.name) {
+                return false
+                
+                // Third criteria: Name
+            } else {
+                return first.name < second.name
+            }
+        }
+    }
+    
+    // MARK: - CustomStringConvertible
+    
+    var description: String {
+        return self.name
     }
 
     // MARK: - Equatable

--- a/Sources/TuistKit/Models/Target.swift
+++ b/Sources/TuistKit/Models/Target.swift
@@ -194,12 +194,12 @@ extension Sequence where Element == Target {
     
     /// Filters and returns only the targets that are test bundles.
     var testBundles: [Target] {
-        return self.filter({ $0.product.testsBundle })
+        return filter({ $0.product.testsBundle })
     }
     
     /// Filters and returns only the targets that are apps.
     var apps: [Target] {
-        return self.filter({ $0.product == .app})
+        return filter({ $0.product == .app})
     }
     
 }

--- a/Sources/TuistKit/Models/Target.swift
+++ b/Sources/TuistKit/Models/Target.swift
@@ -185,3 +185,17 @@ class Target: GraphInitiatable, Equatable {
             lhs.environment == rhs.environment
     }
 }
+
+extension Sequence where Element == Target {
+    
+    /// Filters and returns only the targets that are test bundles.
+    var testBundles: [Target] {
+        return self.filter({ $0.product.testsBundle })
+    }
+    
+    /// Filters and returns only the targets that are apps.
+    var apps: [Target] {
+        return self.filter({ $0.product == .app})
+    }
+    
+}

--- a/Sources/TuistKit/Models/Target.swift
+++ b/Sources/TuistKit/Models/Target.swift
@@ -130,10 +130,14 @@ class Target: GraphInitiatable, Equatable {
         }
     }
 
+    /// Return true if the target can be linked.
+    ///
+    /// - Returns: True if the target can be linked from another target.
     func isLinkable() -> Bool {
         return product == .dynamicLibrary || product == .staticLibrary || product == .framework
     }
 
+    /// Returns the product name including the extension.
     var productName: String {
         switch product {
         case .staticLibrary, .dynamicLibrary:

--- a/Tests/TuistKitTests/Generator/Mocks/MockSchemesGenerator.swift
+++ b/Tests/TuistKitTests/Generator/Mocks/MockSchemesGenerator.swift
@@ -3,8 +3,13 @@ import Foundation
 
 final class MockSchemesGenerator: SchemesGenerating {
     var generateTargetSchemesArgs: [(project: Project, generatedProject: GeneratedProject)] = []
+    var generateProjectSchemeArgs: [(project: Project, generatedProject: GeneratedProject)] = []
 
     func generateTargetSchemes(project: Project, generatedProject: GeneratedProject) throws {
         generateTargetSchemesArgs.append((project: project, generatedProject: generatedProject))
+    }
+    
+    func generateProjectScheme(project: Project, generatedProject: GeneratedProject) throws {
+        generateProjectSchemeArgs.append((project: project, generatedProject: generatedProject))
     }
 }

--- a/Tests/TuistKitTests/Generator/Mocks/MockSchemesGenerator.swift
+++ b/Tests/TuistKitTests/Generator/Mocks/MockSchemesGenerator.swift
@@ -3,13 +3,13 @@ import Foundation
 
 final class MockSchemesGenerator: SchemesGenerating {
     var generateTargetSchemesArgs: [(project: Project, generatedProject: GeneratedProject)] = []
-    var generateProjectSchemeArgs: [(project: Project, generatedProject: GeneratedProject)] = []
+    var generateProjectSchemeArgs: [(project: Project, generatedProject: GeneratedProject, graph: Graphing)] = []
 
     func generateTargetSchemes(project: Project, generatedProject: GeneratedProject) throws {
         generateTargetSchemesArgs.append((project: project, generatedProject: generatedProject))
     }
     
-    func generateProjectScheme(project: Project, generatedProject: GeneratedProject) throws {
-        generateProjectSchemeArgs.append((project: project, generatedProject: generatedProject))
+    func generateProjectScheme(project: Project, generatedProject: GeneratedProject, graph: Graphing) throws {
+        generateProjectSchemeArgs.append((project: project, generatedProject: generatedProject, graph: graph))
     }
 }

--- a/Tests/TuistKitTests/Generator/SchemesGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/SchemesGeneratorTests.swift
@@ -28,8 +28,13 @@ final class SchemeGeneratorTests: XCTestCase {
         
         let generatedProject = GeneratedProject(path: projectPath,
                                                 targets: targets)
+
+        let graphCache = GraphLoaderCache()
+        let graph = Graph.test(cache: graphCache)
+        
         let got = subject.projectBuildAction(project: project,
-                                            generatedProject: generatedProject)
+                                            generatedProject: generatedProject,
+                                            graph: graph)
         
         XCTAssertTrue(got.parallelizeBuild)
         XCTAssertTrue(got.buildImplicitDependencies)

--- a/Tests/TuistKitTests/Generator/SchemesGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/SchemesGeneratorTests.swift
@@ -20,7 +20,7 @@ final class SchemeGeneratorTests: XCTestCase {
         let pbxTarget = PBXNativeTarget(name: "App")
         let projectPath = AbsolutePath("/project.xcodeproj")
 
-        let got = subject.testAction(target: target,
+        let got = subject.targetTestAction(target: target,
                                      pbxTarget: pbxTarget,
                                      projectPath: projectPath)
 
@@ -35,7 +35,7 @@ final class SchemeGeneratorTests: XCTestCase {
         let pbxTarget = PBXNativeTarget(name: "App")
         let projectPath = AbsolutePath("/project.xcodeproj")
 
-        let got = subject.testAction(target: target,
+        let got = subject.targetTestAction(target: target,
                                      pbxTarget: pbxTarget,
                                      projectPath: projectPath)
 
@@ -57,7 +57,7 @@ final class SchemeGeneratorTests: XCTestCase {
         let pbxTarget = PBXNativeTarget(name: "App")
         let projectPath = AbsolutePath("/project.xcodeproj")
 
-        let got = subject.buildAction(target: target,
+        let got = subject.targetBuildAction(target: target,
                                       pbxTarget: pbxTarget,
                                       projectPath: projectPath)
 
@@ -79,7 +79,7 @@ final class SchemeGeneratorTests: XCTestCase {
         let target = Target.test(name: "App", product: .app, environment: ["a": "b"])
         let pbxTarget = PBXNativeTarget(name: "App")
         let projectPath = AbsolutePath("/project.xcodeproj")
-        let got = subject.launchAction(target: target,
+        let got = subject.targetLaunchAction(target: target,
                                        pbxTarget: pbxTarget,
                                        projectPath: projectPath)
 
@@ -100,7 +100,7 @@ final class SchemeGeneratorTests: XCTestCase {
                                  product: .dynamicLibrary)
         let pbxTarget = PBXNativeTarget(name: "App")
         let projectPath = AbsolutePath("/project.xcodeproj")
-        let got = subject.launchAction(target: target,
+        let got = subject.targetLaunchAction(target: target,
                                        pbxTarget: pbxTarget,
                                        projectPath: projectPath)
 
@@ -119,7 +119,7 @@ final class SchemeGeneratorTests: XCTestCase {
                                  product: .app)
         let pbxTarget = PBXNativeTarget(name: "App")
         let projectPath = AbsolutePath("/project.xcodeproj")
-        let got = subject.profileAction(target: target,
+        let got = subject.targetProfileAction(target: target,
                                         pbxTarget: pbxTarget,
                                         projectPath: projectPath)
 
@@ -151,7 +151,7 @@ final class SchemeGeneratorTests: XCTestCase {
                                  product: .dynamicLibrary)
         let pbxTarget = PBXNativeTarget(name: "App")
         let projectPath = AbsolutePath("/project.xcodeproj")
-        let got = subject.profileAction(target: target,
+        let got = subject.targetProfileAction(target: target,
                                         pbxTarget: pbxTarget,
                                         projectPath: projectPath)
 
@@ -178,12 +178,12 @@ final class SchemeGeneratorTests: XCTestCase {
     }
 
     func test_analyzeAction() {
-        let got = subject.analyzeAction()
+        let got = subject.targetAnalyzeAction()
         XCTAssertEqual(got.buildConfiguration, "Debug")
     }
 
     func test_archiveAction() {
-        let got = subject.archiveAction()
+        let got = subject.targetArchiveAction()
         XCTAssertEqual(got.buildConfiguration, "Release")
         XCTAssertEqual(got.revealArchiveInOrganizer, true)
     }

--- a/Tests/TuistKitTests/Graph/GraphTests.swift
+++ b/Tests/TuistKitTests/Graph/GraphTests.swift
@@ -49,7 +49,7 @@ final class GraphTests: XCTestCase {
         let graph = Graph.test(cache: cache)
         let dependencies = graph.targetDependencies(path: project.path,
                                                     name: target.name)
-        XCTAssertEqual(dependencies.first, "Dependency")
+        XCTAssertEqual(dependencies.first?.target.name, "Dependency")
     }
 
     func test_linkableDependencies_whenPrecompiled() throws {

--- a/Tests/TuistKitTests/Models/ProjectTests.swift
+++ b/Tests/TuistKitTests/Models/ProjectTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Basic
+@testable import TuistKit
+import XCTest
+
+final class ProjectTests: XCTestCase {
+    func test_sortedTargetsForProjectScheme() {
+        let framework = Target.test(name: "Framework", product: .framework)
+        let app = Target.test(name: "App", product: .app)
+        let appTests = Target.test(name: "AppTets", product: .unitTests)
+        let frameworkTests = Target.test(name: "FrameworkTests", product: .unitTests)
+        let project = Project.test(targets: [
+            framework, app, appTests, frameworkTests
+            ])
+        
+        let cache = GraphLoaderCache()
+        let graph = Graph.test(cache: cache)
+        let frameworkNode = TargetNode(project: project,
+                                       target: framework,
+                                       dependencies: [])
+        let frameworkTestsNode = TargetNode(project: project,
+                                            target: frameworkTests,
+                                            dependencies: [frameworkNode])
+        let appNode = TargetNode(project: project,
+                                 target: app,
+                                 dependencies: [frameworkNode])
+        let appTestsNode = TargetNode(project: project,
+                                      target: appTests,
+                                      dependencies: [appNode])
+        
+        cache.add(targetNode: frameworkNode)
+        cache.add(targetNode: frameworkTestsNode)
+        cache.add(targetNode: appNode)
+        cache.add(targetNode: appTestsNode)
+
+        let got = project.sortedTargetsForProjectScheme(graph: graph)
+        XCTAssertEqual(got.count, 4)
+        XCTAssertEqual(got[0], framework)
+        XCTAssertEqual(got[1], app)
+        XCTAssertEqual(got[2], appTests)
+        XCTAssertEqual(got[3], frameworkTests)
+    }
+}

--- a/Tests/TuistKitTests/Models/TargetTests.swift
+++ b/Tests/TuistKitTests/Models/TargetTests.swift
@@ -21,4 +21,20 @@ final class TargetTests: XCTestCase {
         let target = Target.test(name: "Test", product: .app)
         XCTAssertEqual(target.productName, "Test.app")
     }
+    
+    func test_sequence_testBundles() {
+        let app = Target.test(product: .app)
+        let tests = Target.test(product: .unitTests)
+        let targets = [app, tests]
+        
+        XCTAssertEqual(targets.testBundles, [tests])
+    }
+    
+    func test_sequence_apps() {
+        let app = Target.test(product: .app)
+        let tests = Target.test(product: .unitTests)
+        let targets = [app, tests]
+        
+        XCTAssertEqual(targets.apps, [app])
+    }
 }

--- a/fixtures/app_with_framework_and_tests/.gitignore
+++ b/fixtures/app_with_framework_and_tests/.gitignore
@@ -1,0 +1,63 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two 
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace

--- a/fixtures/app_with_framework_and_tests/App/AppDelegate.swift
+++ b/fixtures/app_with_framework_and_tests/App/AppDelegate.swift
@@ -1,0 +1,20 @@
+import UIKit
+import Framework
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+    var framework: FrameworkClass = FrameworkClass()
+
+    func application(_ application: UIApplication,
+                       didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        let viewController = UIViewController()
+        viewController.view.backgroundColor = .white
+        window?.rootViewController = viewController
+        window?.makeKeyAndVisible()
+        return true
+    }
+
+}

--- a/fixtures/app_with_framework_and_tests/AppTests/AppTests.swift
+++ b/fixtures/app_with_framework_and_tests/AppTests/AppTests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+@testable import App
+
+final class AppTests: XCTestCase {
+
+}

--- a/fixtures/app_with_framework_and_tests/Framework/Framework.swift
+++ b/fixtures/app_with_framework_and_tests/Framework/Framework.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public class FrameworkClass {
+  public init() {}
+}

--- a/fixtures/app_with_framework_and_tests/FrameworkTests/FrameworkTests.swift
+++ b/fixtures/app_with_framework_and_tests/FrameworkTests/FrameworkTests.swift
@@ -1,0 +1,7 @@
+import Foundation
+import XCTest
+@testable import Framework
+
+final class FrameworkTests: XCTestCase {
+  var subject: FrameworkClass = FrameworkClass()
+}

--- a/fixtures/app_with_framework_and_tests/Info.plist
+++ b/fixtures/app_with_framework_and_tests/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/fixtures/app_with_framework_and_tests/Project.swift
+++ b/fixtures/app_with_framework_and_tests/Project.swift
@@ -1,0 +1,40 @@
+import ProjectDescription
+
+let project = Project(name: "App",
+                      targets: [
+                        Target(name: "App",
+                               platform: .iOS,
+                               product: .app,
+                               bundleId: "io.tuist.app",
+                               infoPlist: "Info.plist",
+                               sources: "App/**",
+                               dependencies: [
+                                 .target(name: "Framework")
+                                ]),
+                        Target(name: "AppTests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               bundleId: "io.tuist.appTests",
+                               infoPlist: "Info.plist",
+                               sources: "AppTests/**",
+                               dependencies: [
+                                  .target(name: "App")
+                               ]),
+                        Target(name: "Framework",
+                               platform: .iOS,
+                               product: .framework,
+                               bundleId: "io.tuist.framework",
+                               infoPlist: "Info.plist",
+                               sources: "Framework/**",
+                               dependencies: [
+                               ]),
+                        Target(name: "FrameworkTests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               bundleId: "io.tuist.frameworkTests",
+                               infoPlist: "Info.plist",
+                               sources: "FrameworkTests/**",
+                               dependencies: [
+                                 .target(name: "Framework")
+                               ])
+                      ])


### PR DESCRIPTION
### Short description 📝
With this PR an extra scheme is generated for each project. The scheme called `xxx-Project` *(`xxx` is the name of the project)* contains all the targets within the project. Moreover, it defines test actions for all the targets that represent test bundles.

This change will make possible supporting the following commands:

```bash
tuist build all
tuist test all
```

### Implementation 👩‍💻👨‍💻
- [x] Add a new method to the `SchemesGenerator` to generate the project scheme.
- [x] Unit-test the generation of the scheme.
- [x] Add some acceptance tests that verify that the generated scheme can be tested and built.