### PR TITLE
Rename manifest group and target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next version
 
+### Changed
+
+- Rename manifest group to `Manifest` https://github.com/tuist/tuist/pull/227 by @pepibumur.
+- Rename manifest target to `Project-Manifest` https://github.com/tuist/tuist/pull/227 by @pepibumur.
+
 ### Added
 
 - Integration tests for `generate` command https://github.com/tuist/tuist/pull/208 by @marciniwanicki & @kwridan

--- a/Sources/TuistKit/Generator/ProjectGroups.swift
+++ b/Sources/TuistKit/Generator/ProjectGroups.swift
@@ -56,7 +56,7 @@ class ProjectGroups {
         mainGroup.children.append(projectGroup)
 
         /// ProjectDescription
-        let projectManifestGroup = PBXGroup(children: [], sourceTree: .group, name: "ProjectManifest")
+        let projectManifestGroup = PBXGroup(children: [], sourceTree: .group, name: "Manifest")
         pbxproj.add(object: projectManifestGroup)
         mainGroup.children.append(projectManifestGroup)
 

--- a/Sources/TuistKit/Generator/ProjectGroups.swift
+++ b/Sources/TuistKit/Generator/ProjectGroups.swift
@@ -7,7 +7,7 @@ class ProjectGroups {
 
     let main: PBXGroup
     let products: PBXGroup
-    let projectDescription: PBXGroup
+    let projectManifest: PBXGroup
     let project: PBXGroup
     let frameworks: PBXGroup
     let playgrounds: PBXGroup?
@@ -17,14 +17,14 @@ class ProjectGroups {
 
     init(main: PBXGroup,
          products: PBXGroup,
-         projectDescription: PBXGroup,
+         projectManifest: PBXGroup,
          frameworks: PBXGroup,
          project: PBXGroup,
          playgrounds: PBXGroup?,
          pbxproj: PBXProj) {
         self.main = main
         self.products = products
-        self.projectDescription = projectDescription
+        self.projectManifest = projectManifest
         self.frameworks = frameworks
         self.project = project
         self.playgrounds = playgrounds
@@ -56,9 +56,9 @@ class ProjectGroups {
         mainGroup.children.append(projectGroup)
 
         /// ProjectDescription
-        let projectDescriptionGroup = PBXGroup(children: [], sourceTree: .group, name: "ProjectDescription")
-        pbxproj.add(object: projectDescriptionGroup)
-        mainGroup.children.append(projectDescriptionGroup)
+        let projectManifestGroup = PBXGroup(children: [], sourceTree: .group, name: "ProjectManifest")
+        pbxproj.add(object: projectManifestGroup)
+        mainGroup.children.append(projectManifestGroup)
 
         /// Frameworks
         let frameworksGroup = PBXGroup(children: [], sourceTree: .group, name: "Frameworks")
@@ -80,7 +80,7 @@ class ProjectGroups {
 
         return ProjectGroups(main: mainGroup,
                              products: productsGroup,
-                             projectDescription: projectDescriptionGroup,
+                             projectManifest: projectManifestGroup,
                              frameworks: frameworksGroup,
                              project: projectGroup,
                              playgrounds: playgroundsGroup,

--- a/Sources/TuistKit/Generator/TargetGenerator.swift
+++ b/Sources/TuistKit/Generator/TargetGenerator.swift
@@ -63,7 +63,7 @@ final class TargetGenerator: TargetGenerating {
                                  options: GenerationOptions,
                                  resourceLocator: ResourceLocating = ResourceLocator()) throws {
         /// Names
-        let name = "\(project.name)Description"
+        let name = "\(project.name)-Manifest"
         let frameworkName = "\(name).framework"
 
         /// Products reference.
@@ -75,7 +75,7 @@ final class TargetGenerator: TargetGenerating {
         var files: [PBXFileElement] = []
         let projectManifestPath = try manifestLoader.manifestPath(at: project.path, manifest: .project)
         let fileReference = try fileGenerator.generateFile(path: projectManifestPath,
-                                                           in: groups.projectDescription,
+                                                           in: groups.projectManifest,
                                                            sourceRootPath: sourceRootPath)
         files.append(fileReference)
 

--- a/Tests/TuistKitTests/Generator/ProjectGroupsTests.swift
+++ b/Tests/TuistKitTests/Generator/ProjectGroupsTests.swift
@@ -43,7 +43,7 @@ final class ProjectGroupsTests: XCTestCase {
         XCTAssertEqual(subject.project.sourceTree, .group)
 
         XCTAssertTrue(main.children.contains(subject.projectManifest))
-        XCTAssertEqual(subject.projectManifest.name, "ProjectManifest")
+        XCTAssertEqual(subject.projectManifest.name, "Manifest")
         XCTAssertNil(subject.projectManifest.path)
         XCTAssertEqual(subject.projectManifest.sourceTree, .group)
 

--- a/Tests/TuistKitTests/Generator/ProjectGroupsTests.swift
+++ b/Tests/TuistKitTests/Generator/ProjectGroupsTests.swift
@@ -42,10 +42,10 @@ final class ProjectGroupsTests: XCTestCase {
         XCTAssertNil(subject.project.path)
         XCTAssertEqual(subject.project.sourceTree, .group)
 
-        XCTAssertTrue(main.children.contains(subject.projectDescription))
-        XCTAssertEqual(subject.projectDescription.name, "ProjectDescription")
-        XCTAssertNil(subject.projectDescription.path)
-        XCTAssertEqual(subject.projectDescription.sourceTree, .group)
+        XCTAssertTrue(main.children.contains(subject.projectManifest))
+        XCTAssertEqual(subject.projectManifest.name, "ProjectManifest")
+        XCTAssertNil(subject.projectManifest.path)
+        XCTAssertEqual(subject.projectManifest.sourceTree, .group)
 
         XCTAssertTrue(main.children.contains(subject.frameworks))
         XCTAssertEqual(subject.frameworks.name, "Frameworks")

--- a/features/generate.feature
+++ b/features/generate.feature
@@ -7,7 +7,7 @@ Feature: Generate a new project using Tuist
     Then tuist generates the project
     Then I should be able to build the scheme App
     Then I should be able to test the scheme AppTests
-
+    Then I should be able to build the scheme App-Manifest
 
   Scenario: The project is an iOS application with frameworks and tests (ios_app_with_frameworks)
     Given that tuist is available
@@ -20,7 +20,7 @@ Feature: Generate a new project using Tuist
     Then I should be able to test the scheme Framework1Tests
     Then I should be able to build the scheme Framework2
     Then I should be able to test the scheme Framework2Tests
-
+    Then I should be able to build the scheme MyApp-Manifest
 
   Scenario: The project is a directory without valid manifest file (invalid_workspace_manifest_name)
     Given that tuist is available

--- a/features/generate.feature
+++ b/features/generate.feature
@@ -20,7 +20,9 @@ Feature: Generate a new project using Tuist
     Then I should be able to test the scheme Framework1Tests
     Then I should be able to build the scheme Framework2
     Then I should be able to test the scheme Framework2Tests
-    Then I should be able to build the scheme MyApp-Manifest
+    Then I should be able to build the scheme MainApp-Manifest
+    Then I should be able to build the scheme Framework1-Manifest
+    Then I should be able to build the scheme Framework2-Manifest
 
   Scenario: The project is a directory without valid manifest file (invalid_workspace_manifest_name)
     Given that tuist is available


### PR DESCRIPTION
### Short description 📝
Inspired by the SwiftPM, we named both the target and the group that contains the project Manifest `XXXDescription` where `XXX` is the name of the project.

This is inconsistent with how we are naming that file, manifest, across the whole project.

### Solution 📦
- Rename the target to `XXX-Manifest`. Including the project name helps distinguish the project the associated scheme refers to.
- Rename group to `Manifest` *(there's only a manifest per project)*

I've taken the opportunity to add an acceptance test that makes sure the target can be compiled.
