### PR TITLE
Remove up attribute from the Project model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Integration tests for `generate` command https://github.com/tuist/tuist/pull/208 by @marciniwanicki & @kwridan
 - Frequently asked questions to the documentation https://github.com/tuist/tuist/pull/223/ by @pepibumur.
 
+### Removed
+
+- Up attribute from the `Project` model https://github.com/tuist/tuist/pull/228 by @pepibumur.
+
 ## 0.11.0
 
 ### Added

--- a/Sources/ProjectDescription/Project.swift
+++ b/Sources/ProjectDescription/Project.swift
@@ -4,23 +4,19 @@ import Foundation
 
 public class Project: Codable {
     public let name: String
-    public let up: [Up]
     public let targets: [Target]
     public let settings: Settings?
 
     public enum CodingKeys: String, CodingKey {
         case name
-        case up
         case targets
         case settings
     }
 
     public init(name: String,
-                up: [Up] = [],
                 settings: Settings? = nil,
                 targets: [Target] = []) {
         self.name = name
-        self.up = up
         self.targets = targets
         self.settings = settings
         dumpIfNeeded(self)

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -134,10 +134,6 @@ class InitCommand: NSObject, Command {
         import ProjectDescription
         
         let project = Project(name: "\(name)",
-                              up: [
-                                /* Configures the environment for the project */
-                                /* .homebrew(packages: ["swiftlint"]) */
-                              ],
                               targets: [
                                 Target(name: "\(name)",
                                        platform: .\(platform.caseValue),

--- a/Sources/TuistKit/Models/Project.swift
+++ b/Sources/TuistKit/Models/Project.swift
@@ -11,9 +11,6 @@ class Project: Equatable {
     /// Project name.
     let name: String
 
-    /// Up instances to configure the environment for the project.
-    let up: [Upping]
-
     /// Project targets.
     let targets: [Target]
 
@@ -27,16 +24,13 @@ class Project: Equatable {
     /// - Parameters:
     ///   - path: Path to the folder that contains the project manifest.
     ///   - name: Project name.
-    ///   - up: Up instances to configure the environment for the project.
     ///   - targets: Project settings.
     init(path: AbsolutePath,
          name: String,
-         up: [Upping] = [],
          settings: Settings? = nil,
          targets: [Target]) {
         self.path = path
         self.name = name
-        self.up = up
         self.targets = targets
         self.settings = settings
     }
@@ -76,8 +70,6 @@ class Project: Equatable {
         name = try json.get("name")
         let targetsJSONs: [JSON] = try json.get("targets")
         targets = try targetsJSONs.map({ try Target(dictionary: $0, projectPath: path, fileHandler: fileHandler) })
-        let upJSONs: [JSON] = try json.get("up")
-        up = try upJSONs.compactMap({ try Up.with(dictionary: $0, projectPath: path, fileHandler: fileHandler) })
         let settingsJSON: JSON? = try? json.get("settings")
         settings = try settingsJSON.map({ try Settings(dictionary: $0, projectPath: path, fileHandler: fileHandler) })
     }

--- a/Tests/TuistKitTests/Commands/DumpCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/DumpCommandTests.swift
@@ -64,7 +64,7 @@ final class DumpCommandTests: XCTestCase {
                          encoding: .utf8)
         let result = try parser.parse([DumpCommand.command, "-p", tmpDir.path.asString])
         try subject.run(with: result)
-        let expected = "{\n  \"name\": \"tuist\",\n  \"targets\": [\n\n  ],\n  \"up\": [\n\n  ]\n}\n"
+        let expected = "{\n  \"name\": \"tuist\",\n  \"targets\": [\n\n  ]\n}\n"
         XCTAssertEqual(printer.printArgs.first, expected)
     }
 

--- a/Tests/TuistKitTests/Models/TestData/Project+TestData.swift
+++ b/Tests/TuistKitTests/Models/TestData/Project+TestData.swift
@@ -5,12 +5,10 @@ import Foundation
 extension Project {
     static func test(path: AbsolutePath = AbsolutePath("/test/"),
                      name: String = "Project",
-                     up: [Upping] = [],
                      settings: Settings? = Settings.test(),
                      targets: [Target] = [Target.test()]) -> Project {
         return Project(path: path,
                        name: name,
-                       up: up,
                        settings: settings,
                        targets: targets)
     }

--- a/fixtures/ios_app_with_tests/Project.swift
+++ b/fixtures/ios_app_with_tests/Project.swift
@@ -1,10 +1,6 @@
 import ProjectDescription
 
 let project = Project(name: "App",
-                      up: [
-                          /* Configures the environment for the project */
-                          /* .homebrew(packages: ["swiftlint"]) */
-                      ],
                       targets: [
                           Target(name: "App",
                                  platform: .iOS,


### PR DESCRIPTION
### Short description 📝
With [this PR merged](https://github.com/tuist/tuist/pull/207), we can get rid of all the references to up from the `Project` model.

This PR removes the references and adjusts some classes and tests accordingly. 