### PR TITLE
Remove YAML and JSON project specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Removed
 
 - Up attribute from the `Project` model https://github.com/tuist/tuist/pull/228 by @pepibumur.
+- Support for YAML and JSON formats as Project specifications https://github.com/tuist/tuist/pull/230 by @ollieatkinson
 
 ### Fixed
 

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "ProjectDescription",
                  type: .dynamic,
                  targets: ["ProjectDescription"]),
-        
+
         /// TuistGenerator
         ///
         /// A high level Xcode generator library
@@ -28,12 +28,11 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/tuist/xcodeproj.git", .upToNextMinor(from: "6.3.0")),
         .package(url: "https://github.com/apple/swift-package-manager", .revision("a107d28d1b40491cf505799a046fee53e7c422e1")),
-        .package(url: "https://github.com/jpsim/Yams.git", .upToNextMinor(from: "1.0.1")),
     ],
     targets: [
         .target(
             name: "TuistKit",
-            dependencies: ["xcodeproj", "Utility", "TuistCore", "TuistGenerator", "Yams"]
+            dependencies: ["xcodeproj", "Utility", "TuistCore", "TuistGenerator"]
         ),
         .testTarget(
             name: "TuistKitTests",

--- a/Sources/TuistCore/Utils/Functions.swift
+++ b/Sources/TuistCore/Utils/Functions.swift
@@ -34,3 +34,14 @@ public func and<T>(_ lhs: @escaping (T) -> Bool, _ rhs: @escaping (T) -> Bool) -
 public func or<T>(_ lhs: @escaping (T) -> Bool, _ rhs: @escaping (T) -> Bool) -> (T) -> Bool {
     return { lhs($0) || rhs($0) }
 }
+
+
+infix operator |>
+
+public func |> <Root, Value, T>(keyPath: KeyPath<Root, Value>, block: @escaping (Value) -> T) -> (Root) -> T {
+    return pipeForward(keyPath: keyPath, block: block)
+}
+
+public func pipeForward<Root, Value, T>(keyPath: KeyPath<Root, Value>, block: @escaping (Value) -> T) -> (Root) -> T {
+    return { block($0[keyPath: keyPath]) }
+}

--- a/Sources/TuistCore/Utils/Functions.swift
+++ b/Sources/TuistCore/Utils/Functions.swift
@@ -35,13 +35,6 @@ public func or<T>(_ lhs: @escaping (T) -> Bool, _ rhs: @escaping (T) -> Bool) ->
     return { lhs($0) || rhs($0) }
 }
 
-
-infix operator |>
-
-public func |> <Root, Value, T>(keyPath: KeyPath<Root, Value>, block: @escaping (Value) -> T) -> (Root) -> T {
-    return pipeForward(keyPath: keyPath, block: block)
-}
-
-public func pipeForward<Root, Value, T>(keyPath: KeyPath<Root, Value>, block: @escaping (Value) -> T) -> (Root) -> T {
-    return { block($0[keyPath: keyPath]) }
+public func pipe<Root, Value, T>(_ lhs: @escaping (Root) -> Value, _ rhs: @escaping (Value) -> T) -> (Root) -> T {
+    return { rhs(lhs($0)) }
 }

--- a/Sources/TuistKit/Generator/WorkspaceGenerator.swift
+++ b/Sources/TuistKit/Generator/WorkspaceGenerator.swift
@@ -16,32 +16,37 @@ final class WorkspaceGenerator: WorkspaceGenerating {
     let printer: Printing
     let resourceLocator: ResourceLocating
     let projectDirectoryHelper: ProjectDirectoryHelping
+    let fileHandler: FileHandling
 
     // MARK: - Init
 
     convenience init(system: Systeming = System(),
                      printer: Printing = Printer(),
                      resourceLocator: ResourceLocating = ResourceLocator(),
-                     projectDirectoryHelper: ProjectDirectoryHelping = ProjectDirectoryHelper()) {
+                     projectDirectoryHelper: ProjectDirectoryHelping = ProjectDirectoryHelper(),
+                     fileHandler: FileHandling = FileHandler()) {
         self.init(system: system,
                   printer: printer,
                   resourceLocator: resourceLocator,
                   projectDirectoryHelper: projectDirectoryHelper,
                   projectGenerator: ProjectGenerator(printer: printer,
                                                      system: system,
-                                                     resourceLocator: resourceLocator))
+                                                     resourceLocator: resourceLocator),
+                  fileHandler: fileHandler)
     }
 
     init(system: Systeming,
          printer: Printing,
          resourceLocator: ResourceLocating,
          projectDirectoryHelper: ProjectDirectoryHelping,
-         projectGenerator: ProjectGenerating) {
+         projectGenerator: ProjectGenerating,
+         fileHandler: FileHandling) {
         self.system = system
         self.printer = printer
         self.resourceLocator = resourceLocator
         self.projectDirectoryHelper = projectDirectoryHelper
         self.projectGenerator = projectGenerator
+        self.fileHandler = fileHandler
     }
 
     // MARK: - WorkspaceGenerating
@@ -59,7 +64,23 @@ final class WorkspaceGenerator: WorkspaceGenerating {
         let workspacePath = workspaceRootPath.appending(component: workspaceName)
         let workspaceData = XCWorkspaceData(children: [])
         let workspace = XCWorkspace(data: workspaceData)
+        
+        /*-----------------------------------------------------------------------------------------
+         // MARK: - Manifest Group
+         -----------------------------------------------------------------------------------------*/
 
+        let manifestFiles: [XCWorkspaceDataElement] = [ Manifest.workspace, Manifest.setup ]
+            .lazy
+            .map(\.fileName |> path.appending(component:))
+            .filter(fileHandler.exists)
+            .map(\.workspaceFileElement)
+
+        workspace.data.children.append(contentsOf: manifestFiles)
+        
+        /*-----------------------------------------------------------------------------------------
+         // MARK: - Projects
+         -----------------------------------------------------------------------------------------*/
+        
         try graph.projects.forEach { project in
             let sourceRootPath = try projectDirectoryHelper.setupProjectDirectory(project: project,
                                                                                   directory: directory)
@@ -67,14 +88,35 @@ final class WorkspaceGenerator: WorkspaceGenerating {
                                                                  options: options,
                                                                  graph: graph,
                                                                  sourceRootPath: sourceRootPath)
-
+            
             let relativePath = generatedProject.path.relative(to: path)
-            let location = XCWorkspaceDataElementLocationType.group(relativePath.asString)
-            let fileRef = XCWorkspaceDataFileRef(location: location)
-            workspace.data.children.append(XCWorkspaceDataElement.file(fileRef))
+            workspace.data.children.append(relativePath.workspaceFileElement)
         }
+        
         try workspace.write(path: workspacePath.path, override: true)
 
         return workspacePath
     }
+    
 }
+
+/*-----------------------------------------------------------------------------------------
+ // MARK: - Helper for generating XCWorkspaceDataElement from AbsolutePath and RelativePath
+ -----------------------------------------------------------------------------------------*/
+
+private protocol WorkspaceFileElement {
+    var asString: String { get }
+}
+
+extension WorkspaceFileElement {
+    
+    var workspaceFileElement: XCWorkspaceDataElement {
+        let location = XCWorkspaceDataElementLocationType.group(asString)
+        let fileRef = XCWorkspaceDataFileRef(location: location)
+        return .file(fileRef)
+    }
+    
+}
+
+extension AbsolutePath: WorkspaceFileElement { }
+extension RelativePath: WorkspaceFileElement { }

--- a/Sources/TuistKit/Graph/GraphManifestLoader.swift
+++ b/Sources/TuistKit/Graph/GraphManifestLoader.swift
@@ -6,7 +6,6 @@ import Yams
 enum GraphManifestLoaderError: FatalError, Equatable {
     case projectDescriptionNotFound(AbsolutePath)
     case unexpectedOutput(AbsolutePath)
-    case invalidYaml(AbsolutePath)
     case manifestNotFound(Manifest, AbsolutePath)
     case setupNotFound(AbsolutePath)
 
@@ -16,10 +15,8 @@ enum GraphManifestLoaderError: FatalError, Equatable {
             return "Couldn't find ProjectDescription.framework at path \(path.asString)"
         case let .unexpectedOutput(path):
             return "Unexpected output trying to parse the manifest at path \(path.asString)"
-        case let .invalidYaml(path):
-            return "Invalid yaml at path \(path.asString). The root element should be a dictionary"
         case let .manifestNotFound(manifest, path):
-            return "\(manifest.fileName.capitalized) not found at \(path.asString)"
+            return "\(manifest.fileName) not found at \(path.asString)"
         case let .setupNotFound(path):
             return "Setup.swift not found at \(path.asString)"
         }
@@ -31,8 +28,6 @@ enum GraphManifestLoaderError: FatalError, Equatable {
             return .bug
         case .projectDescriptionNotFound:
             return .bug
-        case .invalidYaml:
-            return .abort
         case .manifestNotFound:
             return .abort
         case .setupNotFound:
@@ -48,8 +43,6 @@ enum GraphManifestLoaderError: FatalError, Equatable {
             return lhsPath == rhsPath
         case let (.unexpectedOutput(lhsPath), .unexpectedOutput(rhsPath)):
             return lhsPath == rhsPath
-        case let (.invalidYaml(lhsPath), .invalidYaml(rhsPath)):
-            return lhsPath == rhsPath
         case let (.manifestNotFound(lhsManifest, lhsPath), .manifestNotFound(rhsManifest, rhsPath)):
             return lhsManifest == rhsManifest && lhsPath == rhsPath
         case let (.setupNotFound(lhsPath), .setupNotFound(rhsPath)):
@@ -60,20 +53,22 @@ enum GraphManifestLoaderError: FatalError, Equatable {
     }
 }
 
-enum Manifest {
+enum Manifest: CaseIterable {
     case project
     case workspace
+    case setup
 
     var fileName: String {
         switch self {
         case .project:
-            return "Project"
+            return "Project.swift"
         case .workspace:
-            return "Workspace"
+            return "Workspace.swift"
+        case .setup:
+            return "Setup.swift"
         }
     }
 
-    static var supportedExtensions: Set<String> = ["json", "swift", "yaml", "yml"]
 }
 
 protocol GraphManifestLoading {
@@ -119,46 +114,25 @@ class GraphManifestLoader: GraphManifestLoading {
 
     func load(_ manifest: Manifest, path: AbsolutePath) throws -> JSON {
         let manifestPath = try self.manifestPath(at: path, manifest: manifest)
-        if manifestPath.extension == "swift" {
-            return try loadSwiftManifest(path: manifestPath)
-        } else if manifestPath.extension == "json" {
-            deprecator.notify(deprecation: "JSON manifests", suggestion: "Swift manifests")
-            return try loadJSONManifest(path: manifestPath)
-        } else if manifestPath.extension == "yaml" || manifestPath.extension == "yml" {
-            deprecator.notify(deprecation: "YAML manifests", suggestion: "Swift manifests")
-            return try loadYamlManifest(path: manifestPath)
-        } else {
-            throw GraphManifestLoaderError.manifestNotFound(manifest, path)
-        }
+        return try loadManifest(path: manifestPath)
     }
 
     func manifestPath(at path: AbsolutePath, manifest: Manifest) throws -> AbsolutePath {
-        let swiftPath = path.appending(component: "\(manifest.fileName).swift")
-        let jsonPath = path.appending(component: "\(manifest.fileName).json")
-        let yamlPath = path.appending(component: "\(manifest.fileName).yaml")
-        let ymlPath = path.appending(component: "\(manifest.fileName).yml")
+        
+        let filePath = path.appending(component: manifest.fileName)
 
-        if fileHandler.exists(swiftPath) {
-            return swiftPath
-        } else if fileHandler.exists(jsonPath) {
-            return jsonPath
-        } else if fileHandler.exists(yamlPath) {
-            return yamlPath
-        } else if fileHandler.exists(ymlPath) {
-            return ymlPath
+        if fileHandler.exists(filePath) {
+            return filePath
         } else {
             throw GraphManifestLoaderError.manifestNotFound(manifest, path)
         }
+        
     }
 
     func manifests(at path: AbsolutePath) -> Set<Manifest> {
-        let manifests: [Manifest] = [.project, .workspace].filter { manifest in
-            let paths = Manifest.supportedExtensions.map {
-                path.appending(component: "\(manifest.fileName).\($0)")
-            }
-            return paths.contains(where: { fileHandler.exists($0) })
-        }
-        return Set(manifests)
+        return .init(Manifest.allCases.filter{
+            return fileHandler.exists(path.appending(component: $0.fileName))
+        })
     }
 
     func loadSetup(at path: AbsolutePath) throws -> [Upping] {
@@ -167,7 +141,7 @@ class GraphManifestLoader: GraphManifestLoading {
             throw GraphManifestLoaderError.setupNotFound(path)
         }
 
-        let setup = try loadSwiftManifest(path: setupPath)
+        let setup = try loadManifest(path: setupPath)
         let actionsJson: [JSON] = try setup.get("actions")
         return try actionsJson.compactMap {
             try Up.with(dictionary: $0,
@@ -177,22 +151,7 @@ class GraphManifestLoader: GraphManifestLoading {
 
     // MARK: - Fileprivate
 
-    fileprivate func loadYamlManifest(path: AbsolutePath) throws -> JSON {
-        let content = try String(contentsOf: path.url)
-        guard let object = try Yams.load(yaml: content) as? [String: Any] else {
-            throw GraphManifestLoaderError.invalidYaml(path)
-        }
-        let data = try JSONSerialization.data(withJSONObject: object, options: [])
-        let json = String(data: data, encoding: .utf8) ?? "{}"
-        return try JSON(string: json)
-    }
-
-    fileprivate func loadJSONManifest(path: AbsolutePath) throws -> JSON {
-        let content = try String(contentsOf: path.url)
-        return try JSON(string: content)
-    }
-
-    fileprivate func loadSwiftManifest(path: AbsolutePath) throws -> JSON {
+    fileprivate func loadManifest(path: AbsolutePath) throws -> JSON {
         let projectDescriptionPath = try resourceLocator.projectDescription()
         var arguments: [String] = [
             "/usr/bin/xcrun",

--- a/Sources/TuistKit/Graph/GraphManifestLoader.swift
+++ b/Sources/TuistKit/Graph/GraphManifestLoader.swift
@@ -1,7 +1,6 @@
 import Basic
 import Foundation
 import TuistCore
-import Yams
 
 enum GraphManifestLoaderError: FatalError, Equatable {
     case projectDescriptionNotFound(AbsolutePath)

--- a/Tests/TuistKitTests/Commands/DumpCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/DumpCommandTests.swift
@@ -68,49 +68,4 @@ final class DumpCommandTests: XCTestCase {
         XCTAssertEqual(printer.printArgs.first, expected)
     }
 
-    func test_prints_the_manifest_when_json_manifest() throws {
-        let tmpDir = try TemporaryDirectory(removeTreeOnDeinit: true)
-        let config = """
-        {
-            "name": "tuist",
-            "targets": []
-        }
-        """
-        try config.write(toFile: tmpDir.path.appending(component: "Project.json").asString,
-                         atomically: true,
-                         encoding: .utf8)
-        let result = try parser.parse([DumpCommand.command, "-p", tmpDir.path.asString])
-        try subject.run(with: result)
-        let expected = """
-        {
-          "name": "tuist",
-          "targets": [
-
-          ]
-        }\n
-        """
-        XCTAssertEqual(printer.printArgs.first, expected)
-    }
-
-    func test_prints_the_manifest_when_yaml_manifest() throws {
-        let tmpDir = try TemporaryDirectory(removeTreeOnDeinit: true)
-        let config = """
-        name: tuist
-        targets: []
-        """
-        try config.write(toFile: tmpDir.path.appending(component: "Project.yaml").asString,
-                         atomically: true,
-                         encoding: .utf8)
-        let result = try parser.parse([DumpCommand.command, "-p", tmpDir.path.asString])
-        try subject.run(with: result)
-        let expected = """
-        {
-          "name": "tuist",
-          "targets": [
-
-          ]
-        }\n
-        """
-        XCTAssertEqual(printer.printArgs.first, expected)
-    }
 }

--- a/Tests/TuistKitTests/Generator/WorkspaceGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/WorkspaceGeneratorTests.swift
@@ -1,14 +1,122 @@
 import Basic
 import Foundation
 @testable import TuistKit
+@testable import TuistCoreTesting
 import XCTest
+import ProjectDescription
 
 final class WorkspaceGeneratorTests: XCTestCase {
-    var projectGenerator: MockProjectGenerator!
+    
     var subject: WorkspaceGenerator!
-
+    
+    var path: AbsolutePath!
+    var target: TuistKit.Target!
+    var project: TuistKit.Project!
+    var graph: Graph!
+    var fileHandler: MockFileHandler!
+    
     override func setUp() {
         super.setUp()
-        projectGenerator = MockProjectGenerator()
+        
+        do {
+
+            fileHandler = try MockFileHandler()
+            path = fileHandler.currentPath
+            
+            target = Target.test(name: "App")
+            project = Project.test(path: path)
+
+            let projectDirectoryHelper = ProjectDirectoryHelper(environmentController: try MockEnvironmentController(), fileHandler: fileHandler)
+            
+            subject = WorkspaceGenerator(
+                system: MockSystem(),
+                printer: MockPrinter(),
+                resourceLocator: MockResourceLocator(),
+                projectDirectoryHelper: projectDirectoryHelper,
+                fileHandler: fileHandler
+            )
+            
+            let targetNode = TargetNode(project: project, target: target, dependencies: [ ])
+            let cache = GraphLoaderCache()
+            cache.add(targetNode: targetNode)
+            
+            graph = Graph.test(entryPath: path, cache: cache)
+            
+        } catch {
+            XCTFail()
+        }
+        
     }
+    
+
+    func test_generate_includesManifests_bothFilesExist() throws {
+        
+        // Given both files are available
+        // When generating the workspace
+        // I expect both files to be added to the workspace
+        
+        try fileHandler.touch(path.appending(component: "Workspace.swift"))
+        try fileHandler.touch(path.appending(component: "Setup.swift"))
+
+        try subject.generate(path: path, graph: graph, options: GenerationOptions())
+        
+        let workspace = try readWorkspace(at: path)
+        
+        XCTAssertTrue(workspace.contains("Setup.swift"))
+        XCTAssertTrue(workspace.contains("Workspace.swift"))
+        
+    }
+    
+    func test_generate_includesManifests_oneFilesExists() throws {
+        
+        // Given only Setup.swift is available
+        // When generating the workspace
+        // I expect Setup.swift to be added to the workspace and Workspace.swift to not be added
+        
+        try fileHandler.touch(path.appending(component: "Setup.swift"))
+        
+        try subject.generate(path: path, graph: graph, options: GenerationOptions())
+        
+        let workspace = try readWorkspace(at: path)
+        
+        XCTAssertTrue(workspace.contains("Setup.swift"))
+        XCTAssertFalse(workspace.contains("Workspace.swift"))
+        
+    }
+    
+    func test_generate_includesManifests_noFilesExists() throws {
+        
+        // Given no manifest files exist
+        // When generating the workspace
+        // I do not expect Setup.swift or Workspace.swift to be added
+        
+        try subject.generate(path: path, graph: graph, options: GenerationOptions())
+        
+        let workspace = try readWorkspace(at: path)
+        
+        XCTAssertFalse(workspace.contains("Setup.swift"))
+        XCTAssertFalse(workspace.contains("Workspace.swift"))
+        
+    }
+    
+    func test_generate_relativeToGroup() throws {
+        
+        try fileHandler.touch(path.appending(component: "Workspace.swift"))
+        
+        // Given the workspace manifest file exists
+        // When generating the workspace
+        // I expect the file to be relative to the workspace
+        
+        try subject.generate(path: path, graph: graph, options: GenerationOptions())
+        
+        let workspace = try readWorkspace(at: path)
+        
+        XCTAssertTrue(workspace.contains("location = \"group:Workspace.swift\">"))
+        
+    }
+    
+    func readWorkspace(at path: AbsolutePath) throws -> String {
+        return try fileHandler.readTextFile(path.appending(component: "test.xcworkspace").appending(component: "contents.xcworkspacedata"))
+    }
+    
 }

--- a/Tests/TuistKitTests/Generator/WorkspaceGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/WorkspaceGeneratorTests.swift
@@ -43,7 +43,7 @@ final class WorkspaceGeneratorTests: XCTestCase {
             graph = Graph.test(entryPath: path, cache: cache)
             
         } catch {
-            XCTFail()
+            XCTFail(error.localizedDescription)
         }
         
     }

--- a/Tests/TuistKitTests/Graph/GraphManifestLoaderTests.swift
+++ b/Tests/TuistKitTests/Graph/GraphManifestLoaderTests.swift
@@ -8,15 +8,13 @@ final class GraphManifestLoaderErrorTests: XCTestCase {
     func test_description() {
         XCTAssertEqual(GraphManifestLoaderError.projectDescriptionNotFound(AbsolutePath("/test")).description, "Couldn't find ProjectDescription.framework at path /test")
         XCTAssertEqual(GraphManifestLoaderError.unexpectedOutput(AbsolutePath("/test/")).description, "Unexpected output trying to parse the manifest at path /test")
-        XCTAssertEqual(GraphManifestLoaderError.invalidYaml(AbsolutePath("/test/")).description, "Invalid yaml at path /test. The root element should be a dictionary")
-        XCTAssertEqual(GraphManifestLoaderError.manifestNotFound(.project, AbsolutePath("/test/")).description, "Project not found at /test")
+        XCTAssertEqual(GraphManifestLoaderError.manifestNotFound(.project, AbsolutePath("/test/")).description, "Project.swift not found at /test")
         XCTAssertEqual(GraphManifestLoaderError.setupNotFound(AbsolutePath("/test/")).description, "Setup.swift not found at /test")
     }
 
     func test_type() {
         XCTAssertEqual(GraphManifestLoaderError.projectDescriptionNotFound(AbsolutePath("/test")).type, .bug)
         XCTAssertEqual(GraphManifestLoaderError.unexpectedOutput(AbsolutePath("/test/")).type, .bug)
-        XCTAssertEqual(GraphManifestLoaderError.invalidYaml(AbsolutePath("/test/")).type, .abort)
         XCTAssertEqual(GraphManifestLoaderError.manifestNotFound(.project, AbsolutePath("/test/")).type, .abort)
         XCTAssertEqual(GraphManifestLoaderError.setupNotFound(AbsolutePath("/test/")).type, .abort)
     }
@@ -24,13 +22,9 @@ final class GraphManifestLoaderErrorTests: XCTestCase {
 
 final class ManifestTests: XCTestCase {
     func test_fileName() {
-        XCTAssertEqual(Manifest.project.fileName, "Project")
-        XCTAssertEqual(Manifest.workspace.fileName, "Workspace")
-    }
-
-    func test_supportedExtensions() {
-        let expected = Set(arrayLiteral: "json", "swift", "yaml", "yml")
-        XCTAssertEqual(Manifest.supportedExtensions, expected)
+        XCTAssertEqual(Manifest.project.fileName, "Project.swift")
+        XCTAssertEqual(Manifest.workspace.fileName, "Workspace.swift")
+        XCTAssertEqual(Manifest.setup.fileName, "Setup.swift")
     }
 }
 
@@ -53,103 +47,20 @@ final class GraphManifestLoaderTests: XCTestCase {
         let project = Project(name: "tuist")
         """
 
-        let manifestPath = fileHandler.currentPath.appending(component: "\(Manifest.project.fileName).swift")
+        let manifestPath = fileHandler.currentPath.appending(component: Manifest.project.fileName)
         try content.write(to: manifestPath.url,
                           atomically: true,
                           encoding: .utf8)
 
         let got = try subject.load(.project, path: fileHandler.currentPath)
-        XCTAssertEqual(try got.get("name") as String, "tuist")
-    }
-
-    func test_load_when_json() throws {
-        let content = """
-        {
-            "name": "tuist"
-        }
-        """
-
-        let manifestPath = fileHandler.currentPath.appending(component: "\(Manifest.project.fileName).json")
-        try content.write(to: manifestPath.url,
-                          atomically: true,
-                          encoding: .utf8)
-
-        let got = try subject.load(.project, path: fileHandler.currentPath)
-
-        XCTAssertEqual(try got.get("name") as String, "tuist")
-        XCTAssertEqual(deprecator.notifyArgs.count, 1)
-        XCTAssertEqual(deprecator.notifyArgs.first?.deprecation, "JSON manifests")
-        XCTAssertEqual(deprecator.notifyArgs.first?.suggestion, "Swift manifests")
-    }
-
-    func test_load_when_yaml() throws {
-        let content = """
-        name: tuist
-        """
-
-        let manifestPath = fileHandler.currentPath.appending(component: "\(Manifest.project.fileName).yaml")
-        try content.write(to: manifestPath.url,
-                          atomically: true,
-                          encoding: .utf8)
-
-        let got = try subject.load(.project, path: fileHandler.currentPath)
-
-        XCTAssertEqual(try got.get("name") as String, "tuist")
-        XCTAssertEqual(deprecator.notifyArgs.count, 1)
-        XCTAssertEqual(deprecator.notifyArgs.first?.deprecation, "YAML manifests")
-        XCTAssertEqual(deprecator.notifyArgs.first?.suggestion, "Swift manifests")
-    }
-
-    func test_load_when_yml() throws {
-        let content = """
-        name: tuist
-        """
-
-        let manifestPath = fileHandler.currentPath.appending(component: "\(Manifest.project.fileName).yml")
-        try content.write(to: manifestPath.url,
-                          atomically: true,
-                          encoding: .utf8)
-
-        let got = try subject.load(.project, path: fileHandler.currentPath)
-
         XCTAssertEqual(try got.get("name") as String, "tuist")
     }
 
     func test_manifestPath_when_swift() throws {
-        try fileHandler.touch(fileHandler.currentPath.appending(component: "\(Manifest.project.fileName).swift"))
+        try fileHandler.touch(fileHandler.currentPath.appending(component: Manifest.project.fileName))
         let got = try subject.manifestPath(at: fileHandler.currentPath, manifest: .project)
 
-        XCTAssertEqual(got, fileHandler.currentPath.appending(component: "\(Manifest.project.fileName).swift"))
-    }
-
-    func test_manifestPath_when_json() throws {
-        try fileHandler.touch(fileHandler.currentPath.appending(component: "\(Manifest.project.fileName).json"))
-        let got = try subject.manifestPath(at: fileHandler.currentPath, manifest: .project)
-
-        XCTAssertEqual(got, fileHandler.currentPath.appending(component: "\(Manifest.project.fileName).json"))
-    }
-
-    func test_manifestPath_when_yaml() throws {
-        try fileHandler.touch(fileHandler.currentPath.appending(component: "\(Manifest.project.fileName).yaml"))
-        let got = try subject.manifestPath(at: fileHandler.currentPath, manifest: .project)
-
-        XCTAssertEqual(got, fileHandler.currentPath.appending(component: "\(Manifest.project.fileName).yaml"))
-    }
-
-    func test_manifestPath_when_yml() throws {
-        try fileHandler.touch(fileHandler.currentPath.appending(component: "\(Manifest.project.fileName).yml"))
-        let got = try subject.manifestPath(at: fileHandler.currentPath, manifest: .project)
-
-        XCTAssertEqual(got, fileHandler.currentPath.appending(component: "\(Manifest.project.fileName).yml"))
-    }
-
-    func test_manifestsAt_when_json() throws {
-        try fileHandler.touch(fileHandler.currentPath.appending(component: "Project.json"))
-        try fileHandler.touch(fileHandler.currentPath.appending(component: "Workspace.json"))
-        let got = subject.manifests(at: fileHandler.currentPath)
-
-        XCTAssertTrue(got.contains(.project))
-        XCTAssertTrue(got.contains(.workspace))
+        XCTAssertEqual(got, fileHandler.currentPath.appending(component: Manifest.project.fileName))
     }
 
     func test_manifestsAt_when_swift() throws {
@@ -161,21 +72,4 @@ final class GraphManifestLoaderTests: XCTestCase {
         XCTAssertTrue(got.contains(.workspace))
     }
 
-    func test_manifestsAt_when_yaml() throws {
-        try fileHandler.touch(fileHandler.currentPath.appending(component: "Project.yaml"))
-        try fileHandler.touch(fileHandler.currentPath.appending(component: "Workspace.yaml"))
-        let got = subject.manifests(at: fileHandler.currentPath)
-
-        XCTAssertTrue(got.contains(.project))
-        XCTAssertTrue(got.contains(.workspace))
-    }
-
-    func test_manifestsAt_when_yml() throws {
-        try fileHandler.touch(fileHandler.currentPath.appending(component: "Project.yml"))
-        try fileHandler.touch(fileHandler.currentPath.appending(component: "Workspace.yml"))
-        let got = subject.manifests(at: fileHandler.currentPath)
-
-        XCTAssertTrue(got.contains(.project))
-        XCTAssertTrue(got.contains(.workspace))
-    }
 }


### PR DESCRIPTION
### Short description 📝

Remove the deprecated YAML and JSON project specifications.
Also add Setup.swift and Workspace.swift to the Generated Workspace to allow for easier editing.

### Solution 📦

- Remove YAMS
- Remove YAML and JSON Graph Manifest Loading mechanism
- Inline ".swift" as the supported extension

---

Any feedback on the approach is appreciated.