### PR TITLE
Add Kassem and Marcin as core contributors

### DIFF
--- a/docs/contribution/core-team.md
+++ b/docs/contribution/core-team.md
@@ -17,6 +17,8 @@ Note that the Tuist Core Team – and all Tuist contributors – are open source
 
 - [@pepibumur](https://github.com/pepibumur)
 - [@ollieatkinson](https://github.com/ollieatkinson)
+- [@kwridan](https://github.com/kwridan)
+- [@marciniwanicki](https://github.com/marciniwanicki)
 
 ## Adding new Core Team Members
 


### PR DESCRIPTION
From their first contribution, @kwridan and @marciniwanicki  have been contributing to make Tuist everyday and make Xcode projects more approachable at any scale. Their commitment, enthusiasm and great collaboration skills motivated me to invite them to be [core-team](https://github.com/tuist/tuist/blob/master/docs/contribution/core-team.md) together with @ollieatkinson.

I'm happy to have them onboard. They've been invited to the team on GitHub and I'm updating the documentation document to include them in the list of core contributors.

![giphy](https://user-images.githubusercontent.com/663605/53054732-572d9800-3473-11e9-8ac3-66cfeb906089.gif)
