### PR TITLE
WIP: Configurations

### DIFF
--- a/Sources/ProjectDescription/Settings.swift
+++ b/Sources/ProjectDescription/Settings.swift
@@ -3,36 +3,53 @@ import Foundation
 // MARK: - Configuration
 
 public class Configuration: Codable {
+    public let name: String
+    public let type: BuildConfiguration
     public let settings: [String: String]
     public let xcconfig: String?
 
     public enum CodingKeys: String, CodingKey {
+        case name
+        case type
         case settings
         case xcconfig
     }
 
-    public init(settings: [String: String] = [:], xcconfig: String? = nil) {
+    public init(name: String, type: BuildConfiguration, settings: [String: String] = [:], xcconfig: String? = nil) {
+        self.name = name
+        self.type = type
         self.settings = settings
         self.xcconfig = xcconfig
     }
 
-    public static func settings(_ settings: [String: String], xcconfig: String? = nil) -> Configuration {
-        return Configuration(settings: settings, xcconfig: xcconfig)
+    public static func debug(_ settings: [String: String] = [:], xcconfig: String? = nil) -> Configuration {
+        return Configuration(name: "Debug", type: .debug, settings: settings, xcconfig: xcconfig)
     }
+    
+    public static func release(_ settings: [String: String] = [:], xcconfig: String? = nil) -> Configuration {
+        return Configuration(name: "Release", type: .release, settings: settings, xcconfig: xcconfig)
+    }
+    
+    public static func configuration(name: String, type: BuildConfiguration = .debug, settings: [String: String] = [:], xcconfig: String? = nil) -> Configuration {
+        return Configuration(name: name, type: type, settings: settings, xcconfig: xcconfig)
+    }
+    
 }
 
 // MARK: - Settings
 
 public class Settings: Codable {
     public let base: [String: String]
-    public let debug: Configuration?
-    public let release: Configuration?
+    public let configurations: [Configuration]
 
-    public init(base: [String: String] = [:],
-                debug: Configuration? = nil,
-                release: Configuration? = nil) {
+    public init(base: [String: String] = [:], debug: Configuration = .debug(), release: Configuration = .release()) {
         self.base = base
-        self.debug = debug
-        self.release = release
+        self.configurations = [ debug, release ]
     }
+    
+    public init(base: [String: String] = [:], configurations: [Configuration]) {
+        self.base = base
+        self.configurations = configurations
+    }
+    
 }

--- a/Sources/ProjectDescription/Settings.swift
+++ b/Sources/ProjectDescription/Settings.swift
@@ -27,11 +27,11 @@ public class Configuration: Codable {
         self.buildConfiguration = buildConfiguration
     }
 
-    public static func debug(name: String, settings: BuildSettings = [:], xcconfig: String? = nil) -> Configuration {
+    public static func debug(name: String = "Debug", settings: BuildSettings = [:], xcconfig: String? = nil) -> Configuration {
         return Configuration(name: name, settings: settings, xcconfig: xcconfig, buildConfiguration: .debug)
     }
     
-    public static func release(name: String, settings: BuildSettings = [:], xcconfig: String? = nil) -> Configuration {
+    public static func release(name: String = "Release", settings: BuildSettings = [:], xcconfig: String? = nil) -> Configuration {
         return Configuration(name: name, settings: settings, xcconfig: xcconfig, buildConfiguration: .release)
     }
     
@@ -47,18 +47,6 @@ public class Settings: Codable {
     public init(base: BuildSettings = [:], configurations: [Configuration] = []) {
         self.base = base
         self.configurations = configurations
-    }
-    
-}
-
-public class TargetSettings: Codable {
-    
-    public let base: BuildSettings
-    public let buildSettings: [Configuration.Name: BuildSettings]
-    
-    public init(base: BuildSettings = [:], buildSettings: [Configuration.Name: BuildSettings] = [:]) {
-        self.base = base
-        self.buildSettings = buildSettings
     }
     
 }

--- a/Sources/ProjectDescription/Settings.swift
+++ b/Sources/ProjectDescription/Settings.swift
@@ -44,7 +44,7 @@ public class Settings: Codable {
     public let base: BuildSettings
     public let configurations: [Configuration]
 
-    public init(base: BuildSettings = [:], configurations: [Configuration]) {
+    public init(base: BuildSettings = [:], configurations: [Configuration] = []) {
         self.base = base
         self.configurations = configurations
     }

--- a/Sources/ProjectDescription/Settings.swift
+++ b/Sources/ProjectDescription/Settings.swift
@@ -2,36 +2,37 @@ import Foundation
 
 // MARK: - Configuration
 
+public typealias BuildSettings = [String: String]
+
 public class Configuration: Codable {
-    public let name: String
-    public let type: BuildConfiguration
-    public let settings: [String: String]
+    
+    public typealias Name = String
+    
+    public let name: Name
+    public let settings: BuildSettings
     public let xcconfig: String?
+    public let buildConfiguration: BuildConfiguration
 
     public enum CodingKeys: String, CodingKey {
         case name
-        case type
         case settings
         case xcconfig
+        case buildConfiguration
     }
 
-    public init(name: String, type: BuildConfiguration, settings: [String: String] = [:], xcconfig: String? = nil) {
+    public init(name: String, settings: BuildSettings = [:], xcconfig: String? = nil, buildConfiguration: BuildConfiguration) {
         self.name = name
-        self.type = type
         self.settings = settings
         self.xcconfig = xcconfig
+        self.buildConfiguration = buildConfiguration
     }
 
-    public static func debug(_ settings: [String: String] = [:], xcconfig: String? = nil) -> Configuration {
-        return Configuration(name: "Debug", type: .debug, settings: settings, xcconfig: xcconfig)
+    public static func debug(name: String, settings: BuildSettings = [:], xcconfig: String? = nil) -> Configuration {
+        return Configuration(name: name, settings: settings, xcconfig: xcconfig, buildConfiguration: .debug)
     }
     
-    public static func release(_ settings: [String: String] = [:], xcconfig: String? = nil) -> Configuration {
-        return Configuration(name: "Release", type: .release, settings: settings, xcconfig: xcconfig)
-    }
-    
-    public static func configuration(name: String, type: BuildConfiguration = .debug, settings: [String: String] = [:], xcconfig: String? = nil) -> Configuration {
-        return Configuration(name: name, type: type, settings: settings, xcconfig: xcconfig)
+    public static func release(name: String, settings: BuildSettings = [:], xcconfig: String? = nil) -> Configuration {
+        return Configuration(name: name, settings: settings, xcconfig: xcconfig, buildConfiguration: .release)
     }
     
 }
@@ -39,17 +40,25 @@ public class Configuration: Codable {
 // MARK: - Settings
 
 public class Settings: Codable {
-    public let base: [String: String]
+    
+    public let base: BuildSettings
     public let configurations: [Configuration]
 
-    public init(base: [String: String] = [:], debug: Configuration = .debug(), release: Configuration = .release()) {
-        self.base = base
-        self.configurations = [ debug, release ]
-    }
-    
-    public init(base: [String: String] = [:], configurations: [Configuration]) {
+    public init(base: BuildSettings = [:], configurations: [Configuration]) {
         self.base = base
         self.configurations = configurations
+    }
+    
+}
+
+public class TargetSettings: Codable {
+    
+    public let base: BuildSettings
+    public let buildSettings: [Configuration.Name: BuildSettings]
+    
+    public init(base: BuildSettings = [:], buildSettings: [Configuration.Name: BuildSettings] = [:]) {
+        self.base = base
+        self.buildSettings = buildSettings
     }
     
 }

--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -22,7 +22,7 @@ public class Target: Codable {
     let entitlements: String?
 
     /// Target settings.
-    let settings: TargetSettings?
+    let settings: Settings?
 
     /// Target dependencies.
     let dependencies: [TargetDependency]
@@ -90,7 +90,7 @@ public class Target: Codable {
                 entitlements: String? = nil,
                 actions: [TargetAction] = [],
                 dependencies: [TargetDependency] = [],
-                settings: TargetSettings? = nil,
+                settings: Settings? = nil,
                 coreDataModels: [CoreDataModel] = [],
                 environment: [String: String] = [:]) {
         self.name = name

--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -22,7 +22,7 @@ public class Target: Codable {
     let entitlements: String?
 
     /// Target settings.
-    let settings: Settings?
+    let settings: TargetSettings?
 
     /// Target dependencies.
     let dependencies: [TargetDependency]
@@ -90,7 +90,7 @@ public class Target: Codable {
                 entitlements: String? = nil,
                 actions: [TargetAction] = [],
                 dependencies: [TargetDependency] = [],
-                settings: Settings? = nil,
+                settings: TargetSettings? = nil,
                 coreDataModels: [CoreDataModel] = [],
                 environment: [String: String] = [:]) {
         self.name = name

--- a/Sources/TuistKit/Generator/ConfigGenerator.swift
+++ b/Sources/TuistKit/Generator/ConfigGenerator.swift
@@ -219,6 +219,7 @@ final class ConfigGenerator: ConfigGenerating {
         var settings: [String: Any] = [:]
         
         extend(buildSettings: &settings, with: defaultConfigSettings)
+        extend(buildSettings: &settings, with: target.settings?.base ?? [:])
 
         /// If any configurations in the project match the root project configuration name, then merge the settings
         /// else, If any of the default build configuration types (Debug, Release) match then assign using that.
@@ -231,10 +232,7 @@ final class ConfigGenerator: ConfigGenerating {
         let variantBuildConfiguration = XCBuildConfiguration(name: configuration.name, baseConfiguration: nil, buildSettings: [:])
 
         if let variantConfig = targetConfiguration {
-            if let xcconfig = variantConfig.xcconfig {
-                let fileReference = fileElements.file(path: xcconfig)
-                variantBuildConfiguration.baseConfiguration = fileReference
-            }
+            variantBuildConfiguration.baseConfiguration = variantConfig.xcconfig.flatMap(fileElements.file)
         }
         
         /// Target attributes

--- a/Sources/TuistKit/Generator/ProjectFileElements.swift
+++ b/Sources/TuistKit/Generator/ProjectFileElements.swift
@@ -105,14 +105,6 @@ class ProjectFileElements {
         if let entitlements = target.entitlements {
             files.insert(entitlements)
         }
-        
-        if let settings = target.settings {
-            
-            for case .some(let xcconfigFile) in settings.configurations.map(\.xcconfig) {
-                files.insert(xcconfigFile)
-            }
-            
-        }
 
         return files
     }

--- a/Sources/TuistKit/Generator/ProjectFileElements.swift
+++ b/Sources/TuistKit/Generator/ProjectFileElements.swift
@@ -77,18 +77,6 @@ class ProjectFileElements {
             }
             
         }
-        
-        for target in project.targets {
-            
-            guard let settings = target.settings else {
-                continue
-            }
-            
-            for case .some(let xcconfigFile) in settings.configurations.map(\.xcconfig) {
-                files.insert(xcconfigFile)
-            }
-            
-        }
 
         return files
     }
@@ -116,6 +104,12 @@ class ProjectFileElements {
         files.insert(target.infoPlist)
         if let entitlements = target.entitlements {
             files.insert(entitlements)
+        }
+        
+        if let settings = target.settings {
+            for case .some(let xcconfigFile) in settings.configurations.map(\.xcconfig) {
+                files.insert(xcconfigFile)
+            }
         }
 
         return files

--- a/Sources/TuistKit/Generator/ProjectFileElements.swift
+++ b/Sources/TuistKit/Generator/ProjectFileElements.swift
@@ -77,6 +77,18 @@ class ProjectFileElements {
             }
             
         }
+        
+        for target in project.targets {
+            
+            guard let settings = target.settings else {
+                continue
+            }
+            
+            for case .some(let xcconfigFile) in settings.configurations.map(\.xcconfig) {
+                files.insert(xcconfigFile)
+            }
+            
+        }
 
         return files
     }

--- a/Sources/TuistKit/Generator/ProjectFileElements.swift
+++ b/Sources/TuistKit/Generator/ProjectFileElements.swift
@@ -69,14 +69,15 @@ class ProjectFileElements {
 
     func projectFiles(project: Project) -> Set<AbsolutePath> {
         var files = Set<AbsolutePath>()
+        
+        if let settings = project.settings {
+            
+            for case .some(let xcconfigFile) in settings.configurations.map(\.xcconfig) {
+                files.insert(xcconfigFile)
+            }
+            
+        }
 
-        /// Config files
-        if let debugConfigFile = project.settings?.debug?.xcconfig {
-            files.insert(debugConfigFile)
-        }
-        if let releaseConfigFile = project.settings?.release?.xcconfig {
-            files.insert(releaseConfigFile)
-        }
         return files
     }
 
@@ -104,14 +105,15 @@ class ProjectFileElements {
         if let entitlements = target.entitlements {
             files.insert(entitlements)
         }
+        
+        if let settings = target.settings {
+            
+            for case .some(let xcconfigFile) in settings.configurations.map(\.xcconfig) {
+                files.insert(xcconfigFile)
+            }
+            
+        }
 
-        // Config files
-        if let debugConfigFile = target.settings?.debug?.xcconfig {
-            files.insert(debugConfigFile)
-        }
-        if let releaseConfigFile = target.settings?.release?.xcconfig {
-            files.insert(releaseConfigFile)
-        }
         return files
     }
 

--- a/Sources/TuistKit/Generator/ProjectGenerator.swift
+++ b/Sources/TuistKit/Generator/ProjectGenerator.swift
@@ -92,6 +92,7 @@ final class ProjectGenerator: ProjectGenerating {
                                                                           pbxproj: pbxproj,
                                                                           fileElements: fileElements,
                                                                           configurations: configurations,
+                                                                          isRoot: graph.rootProject == project,
                                                                           options: options)
 
         /// Generate project object.

--- a/Sources/TuistKit/Generator/ProjectGenerator.swift
+++ b/Sources/TuistKit/Generator/ProjectGenerator.swift
@@ -7,6 +7,7 @@ protocol ProjectGenerating: AnyObject {
     func generate(project: Project,
                   options: GenerationOptions,
                   graph: Graphing,
+                  configurations: ConfigurationList,
                   sourceRootPath: AbsolutePath?) throws -> GeneratedProject
 }
 
@@ -61,6 +62,7 @@ final class ProjectGenerator: ProjectGenerating {
     func generate(project: Project,
                   options: GenerationOptions,
                   graph: Graphing,
+                  configurations: ConfigurationList,
                   sourceRootPath: AbsolutePath? = nil) throws -> GeneratedProject {
         printer.print("Generating project \(project.name)")
 
@@ -89,6 +91,7 @@ final class ProjectGenerator: ProjectGenerating {
         let configurationList = try configGenerator.generateProjectConfig(project: project,
                                                                           pbxproj: pbxproj,
                                                                           fileElements: fileElements,
+                                                                          configurations: configurations,
                                                                           options: options)
 
         /// Generate project object.
@@ -114,7 +117,8 @@ final class ProjectGenerator: ProjectGenerating {
                                                     groups: groups,
                                                     sourceRootPath: sourceRootPath,
                                                     options: options,
-                                                    resourceLocator: resourceLocator)
+                                                    resourceLocator: resourceLocator,
+                                                    configurations: configurations)
 
         /// Native targets
         var nativeTargets: [String: PBXNativeTarget] = [:]
@@ -129,7 +133,8 @@ final class ProjectGenerator: ProjectGenerating {
                                                                   options: options,
                                                                   graph: graph,
                                                                   resourceLocator: resourceLocator,
-                                                                  system: system)
+                                                                  system: system,
+                                                                  configurations: configurations)
             nativeTargets[target.name] = nativeTarget
         }
 

--- a/Sources/TuistKit/Generator/TargetGenerator.swift
+++ b/Sources/TuistKit/Generator/TargetGenerator.swift
@@ -10,7 +10,8 @@ protocol TargetGenerating: AnyObject {
                                  groups: ProjectGroups,
                                  sourceRootPath: AbsolutePath,
                                  options: GenerationOptions,
-                                 resourceLocator: ResourceLocating) throws
+                                 resourceLocator: ResourceLocating,
+                                 configurations: ConfigurationList) throws
 
     func generateTarget(target: Target,
                         pbxproj: PBXProj,
@@ -22,7 +23,8 @@ protocol TargetGenerating: AnyObject {
                         options: GenerationOptions,
                         graph: Graphing,
                         resourceLocator: ResourceLocating,
-                        system: Systeming) throws -> PBXNativeTarget
+                        system: Systeming,
+                        configurations: ConfigurationList) throws -> PBXNativeTarget
 
     func generateTargetDependencies(path: AbsolutePath,
                                     targets: [Target],
@@ -61,7 +63,8 @@ final class TargetGenerator: TargetGenerating {
                                  groups: ProjectGroups,
                                  sourceRootPath: AbsolutePath,
                                  options: GenerationOptions,
-                                 resourceLocator: ResourceLocating = ResourceLocator()) throws {
+                                 resourceLocator: ResourceLocating = ResourceLocator(),
+                                 configurations: ConfigurationList) throws {
         /// Names
         let name = "\(project.name)-Manifest"
         let frameworkName = "\(name).framework"
@@ -82,7 +85,8 @@ final class TargetGenerator: TargetGenerating {
         // Configuration
         let configurationList = try configGenerator.generateManifestsConfig(pbxproj: pbxproj,
                                                                             options: options,
-                                                                            resourceLocator: resourceLocator)
+                                                                            resourceLocator: resourceLocator,
+                                                                            configurations: configurations)
 
         // Build phases
         let sourcesPhase = PBXSourcesBuildPhase()
@@ -113,7 +117,8 @@ final class TargetGenerator: TargetGenerating {
                         options: GenerationOptions,
                         graph: Graphing,
                         resourceLocator: ResourceLocating = ResourceLocator(),
-                        system: Systeming = System()) throws -> PBXNativeTarget {
+                        system: Systeming = System(),
+                        configurations: ConfigurationList) throws -> PBXNativeTarget {
         /// Products reference.
         let productFileReference = fileElements.products[target.productName]!
 
@@ -137,6 +142,7 @@ final class TargetGenerator: TargetGenerating {
                                                  pbxTarget: pbxTarget,
                                                  pbxproj: pbxproj,
                                                  fileElements: fileElements,
+                                                 configurations: configurations,
                                                  options: options,
                                                  sourceRootPath: sourceRootPath)
 

--- a/Sources/TuistKit/Generator/WorkspaceGenerator.swift
+++ b/Sources/TuistKit/Generator/WorkspaceGenerator.swift
@@ -71,10 +71,7 @@ final class WorkspaceGenerator: WorkspaceGenerating {
         if let projectConfigurations = graph.rootProject.settings?.configurations {
             configurationList = ConfigurationList(projectConfigurations)
         } else {
-            configurationList = ConfigurationList([
-                Configuration(name: "Debug", type: .debug),
-                Configuration(name: "Release", type: .release),
-            ])
+            configurationList = ConfigurationList(BuildConfiguration.allCases.map{ Configuration(name: $0.xcodeValue, buildConfiguration: $0) })
         }
         
         // MARK: - Manifests

--- a/Sources/TuistKit/Generator/WorkspaceGenerator.swift
+++ b/Sources/TuistKit/Generator/WorkspaceGenerator.swift
@@ -65,7 +65,19 @@ final class WorkspaceGenerator: WorkspaceGenerating {
         let workspaceData = XCWorkspaceData(children: [])
         let workspace = XCWorkspace(data: workspaceData)
         
-         // MARK: - Manifests
+
+        let configurationList: ConfigurationList
+        
+        if let projectConfigurations = graph.rootProject.settings?.configurations {
+            configurationList = ConfigurationList(projectConfigurations)
+        } else {
+            configurationList = ConfigurationList([
+                Configuration(name: "Debug", type: .debug),
+                Configuration(name: "Release", type: .release),
+            ])
+        }
+        
+        // MARK: - Manifests
 
         let manifestFiles: [XCWorkspaceDataElement] = [ Manifest.workspace, Manifest.setup ]
             .lazy
@@ -84,6 +96,7 @@ final class WorkspaceGenerator: WorkspaceGenerating {
             let generatedProject = try projectGenerator.generate(project: project,
                                                                  options: options,
                                                                  graph: graph,
+                                                                 configurations: configurationList,
                                                                  sourceRootPath: sourceRootPath)
             
             let relativePath = generatedProject.path.relative(to: path)

--- a/Sources/TuistKit/Graph/Graph.swift
+++ b/Sources/TuistKit/Graph/Graph.swift
@@ -72,7 +72,6 @@ class Graph: Graphing {
     let entryNodes: [GraphNode]
     
     var rootProject: Project {
-        precondition(cache.projects.count > 0)
         return cache.projects[entryPath]!
     }
     

--- a/Sources/TuistKit/Graph/Graph.swift
+++ b/Sources/TuistKit/Graph/Graph.swift
@@ -40,6 +40,7 @@ protocol Graphing: AnyObject {
     var name: String { get }
     var entryPath: AbsolutePath { get }
     var entryNodes: [GraphNode] { get }
+    var rootProject: Project { get }
     var projects: [Project] { get }
     var frameworks: [FrameworkNode] { get }
 
@@ -69,6 +70,12 @@ class Graph: Graphing {
     let name: String
     let entryPath: AbsolutePath
     let entryNodes: [GraphNode]
+    
+    var rootProject: Project {
+        precondition(cache.projects.count > 0)
+        return cache.projects[entryPath]!
+    }
+    
     var projects: [Project] {
         return Array(cache.projects.values)
     }

--- a/Sources/TuistKit/Linter/ProjectLinter.swift
+++ b/Sources/TuistKit/Linter/ProjectLinter.swift
@@ -27,10 +27,23 @@ class ProjectLinter: ProjectLinting {
 
     func lint(_ project: Project) -> [LintingIssue] {
         var issues: [LintingIssue] = []
+        
         issues.append(contentsOf: lintTargets(project: project))
+        
         if let settings = project.settings {
             issues.append(contentsOf: settingsLinter.lint(settings: settings))
         }
+        
+        for target in project.targets {
+            
+            guard let settings = target.settings else {
+                continue
+            }
+            
+            issues.append(contentsOf: settingsLinter.lint(settings: settings))
+            
+        }
+        
         return issues
     }
 

--- a/Sources/TuistKit/Linter/ProjectLinter.swift
+++ b/Sources/TuistKit/Linter/ProjectLinter.swift
@@ -34,16 +34,6 @@ class ProjectLinter: ProjectLinting {
             issues.append(contentsOf: settingsLinter.lint(settings: settings))
         }
         
-        for target in project.targets {
-            
-            guard let settings = target.settings else {
-                continue
-            }
-            
-            issues.append(contentsOf: settingsLinter.lint(settings: settings))
-            
-        }
-        
         return issues
     }
 

--- a/Sources/TuistKit/Linter/SettingsLinter.swift
+++ b/Sources/TuistKit/Linter/SettingsLinter.swift
@@ -36,11 +36,8 @@ final class SettingsLinter: SettingsLinting {
             }
         }
 
-        if let debugConfigFilePath = settings.debug?.xcconfig {
-            lintPath(debugConfigFilePath)
-        }
-        if let releaseConfigFilePath = settings.release?.xcconfig {
-            lintPath(releaseConfigFilePath)
+        for case .some(let xcconfigFile) in settings.configurations.map(\.xcconfig) {
+            lintPath(xcconfigFile)
         }
 
         return issues

--- a/Sources/TuistKit/Linter/TargetLinter.swift
+++ b/Sources/TuistKit/Linter/TargetLinter.swift
@@ -30,7 +30,11 @@ class TargetLinter: TargetLinting {
         issues.append(contentsOf: lintHasSourceFiles(target: target))
         issues.append(contentsOf: lintCopiedFiles(target: target))
         issues.append(contentsOf: lintLibraryHasNoResources(target: target))
-
+        
+        if let settings = target.settings {
+            issues.append(contentsOf: settingsLinter.lint(settings: settings))
+        }
+        
         target.actions.forEach { action in
             issues.append(contentsOf: targetActionLinter.lint(action))
         }

--- a/Sources/TuistKit/Linter/TargetLinter.swift
+++ b/Sources/TuistKit/Linter/TargetLinter.swift
@@ -31,9 +31,6 @@ class TargetLinter: TargetLinting {
         issues.append(contentsOf: lintCopiedFiles(target: target))
         issues.append(contentsOf: lintLibraryHasNoResources(target: target))
 
-        if let settings = target.settings {
-            issues.append(contentsOf: settingsLinter.lint(settings: settings))
-        }
         target.actions.forEach { action in
             issues.append(contentsOf: targetActionLinter.lint(action))
         }

--- a/Sources/TuistKit/Models/BuildConfiguration.swift
+++ b/Sources/TuistKit/Models/BuildConfiguration.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum BuildConfiguration: String {
+enum BuildConfiguration: String, CaseIterable {
     case debug
     case release
 }

--- a/Sources/TuistKit/Models/BuildConfiguration.swift
+++ b/Sources/TuistKit/Models/BuildConfiguration.swift
@@ -13,3 +13,19 @@ extension BuildConfiguration: XcodeRepresentable {
         }
     }
 }
+
+struct ConfigurationList: Sequence {
+    
+    typealias Element = Configuration
+    typealias Iterator = IndexingIterator<[Configuration]>
+    
+    let configurations: [Configuration]
+    init(_ configurations: [Configuration]) {
+        self.configurations = configurations
+    }
+    
+    func makeIterator() -> ConfigurationList.Iterator {
+        return configurations.makeIterator()
+    }
+    
+}

--- a/Sources/TuistKit/Models/Settings.swift
+++ b/Sources/TuistKit/Models/Settings.swift
@@ -2,26 +2,30 @@ import Basic
 import Foundation
 import TuistCore
 
+typealias BuildSettings = [String: String]
+
 class Configuration: Equatable {
+    
+    typealias Name = String
     // MARK: - Attributes
 
     let name: String
-    let type: BuildConfiguration
-    let settings: [String: String]
+    let buildConfiguration: BuildConfiguration
+    let settings: BuildSettings
     let xcconfig: AbsolutePath?
 
     // MARK: - Init
 
-    init(name: String, type: BuildConfiguration, settings: [String: String] = [:], xcconfig: AbsolutePath? = nil) {
+    init(name: String, buildConfiguration: BuildConfiguration, settings: BuildSettings = [:], xcconfig: AbsolutePath? = nil) {
         self.name = name
-        self.type = type
+        self.buildConfiguration = buildConfiguration
         self.settings = settings
         self.xcconfig = xcconfig
     }
 
     init(json: JSON, projectPath: AbsolutePath, fileHandler _: FileHandling) throws {
         name = try json.get("name")
-        type = BuildConfiguration(rawValue: try json.get("type"))! //FIXME Don't force unwrap
+        buildConfiguration = BuildConfiguration(rawValue: try json.get("buildConfiguration")) ?? .debug
         settings = try json.get("settings")
         let xcconfigString: String? = json.get("xcconfig")
         xcconfig = xcconfigString.flatMap({ projectPath.appending(RelativePath($0)) })
@@ -37,13 +41,12 @@ class Configuration: Equatable {
 class Settings: Equatable {
     // MARK: - Attributes
 
-    let base: [String: String]
+    let base: BuildSettings
     let configurations: [Configuration]
 
     // MARK: - Init
 
-    init(base: [String: String] = [:],
-         configurations: [Configuration]) {
+    init(base: BuildSettings = [:], configurations: [Configuration]) {
         self.base = base
         self.configurations = configurations
     }
@@ -64,47 +67,49 @@ class Settings: Equatable {
     // MARK: - Equatable
 
     static func == (lhs: Settings, rhs: Settings) -> Bool {
-        return lhs.base == rhs.base &&
-            lhs.configurations == rhs.configurations
+        return lhs.base == rhs.base && lhs.configurations == rhs.configurations
     }
 }
-//
-//class TargetSettings: GraphInitiatable, Equatable {
-//    // MARK: - Attributes
-//
-//    let base: [String: String]
-//    let debug: Configuration
-//    let release: Configuration
-//
-//    // MARK: - Init
-//
-//    init(base: [String: String] = [:], debug: Configuration = Configuration(name: "Debug", type: .debug), release: Configuration = Configuration(name: "Release", type: .release)) {
-//        self.base = base
-//        self.debug = debug
-//        self.release = release
-//    }
-//
-//    /// Default constructor of entities that are part of the manifest.
-//    ///
-//    /// - Parameters:
-//    ///   - dictionary: Dictionary with the object representation.
-//    ///   - projectPath: Absolute path to the folder that contains the manifest.
-//    ///     This is useful to obtain absolute paths from the relative paths provided in the manifest by the user.
-//    ///   - fileHandler: File handler for any file operations like checking whether a file exists or not.
-//    /// - Throws: A decoding error if an expected property is missing or has an invalid value.
-//    required init(dictionary: JSON, projectPath: AbsolutePath, fileHandler: FileHandling) throws {
-//        base = try dictionary.get("base")
-//        let debugJSON: JSON? = try? dictionary.get("debug")
-//        debug = try debugJSON.flatMap{ _ in try Configuration(name: "Debug", type: .debug, settings: [String:String](), xcconfig: nil) }!
-//        let releaseJSON: JSON? = try? dictionary.get("release")
-//        release = try releaseJSON.flatMap{ _ in try Configuration(name: "Release", type: .release, settings: [String:String](), xcconfig: nil) }!
-////        configurations = try dictionary.getArray("configurations").compactMap{ try Configuration(json: $0, projectPath: projectPath, fileHandler: fileHandler) }
-//    }
-//
-//    // MARK: - Equatable
-//
-//    static func == (lhs: TargetSettings, rhs: TargetSettings) -> Bool {
-//        return lhs.base == rhs.base &&
-//            lhs.debug == rhs.debug
-//    }
-//}
+
+class TargetSettings: GraphInitiatable, Equatable {
+    
+    public let base: BuildSettings
+    public let buildSettings: [Configuration.Name: BuildSettings]
+    
+    public init(base: BuildSettings, buildSettings: [Configuration.Name: BuildSettings]) {
+        self.base = base
+        self.buildSettings = buildSettings
+    }
+    
+    /// Default constructor of entities that are part of the manifest.
+    ///
+    /// - Parameters:
+    ///   - dictionary: Dictionary with the object representation.
+    ///   - projectPath: Absolute path to the folder that contains the manifest.
+    ///     This is useful to obtain absolute paths from the relative paths provided in the manifest by the user.
+    ///   - fileHandler: File handler for any file operations like checking whether a file exists or not.
+    /// - Throws: A decoding error if an expected property is missing or has an invalid value.
+    required init(dictionary: JSON, projectPath: AbsolutePath, fileHandler: FileHandling) throws {
+        base = try dictionary.get("base")
+        buildSettings = try dictionary.get("buildsSettings").mapValues{ try $0.getDictionary() }
+    }
+    
+    // MARK: - Equatable
+    
+    static func == (lhs: TargetSettings, rhs: TargetSettings) -> Bool {
+        return lhs.buildSettings == rhs.buildSettings
+    }
+    
+}
+
+extension JSON {
+    
+    /// Returns a JSON mappable dictionary for self.
+    func getDictionary<T: JSONMappable>() throws -> [String: T] {
+        guard case .dictionary(let value) = self else {
+            throw MapError.typeMismatch(key: "<self>", expected: Dictionary<String, T>.self, json: self)
+        }
+        return try Dictionary(items: value.map({ ($0.0, try T.init(json: $0.1)) }))
+    }
+    
+}

--- a/Sources/TuistKit/Models/Settings.swift
+++ b/Sources/TuistKit/Models/Settings.swift
@@ -5,17 +5,23 @@ import TuistCore
 class Configuration: Equatable {
     // MARK: - Attributes
 
+    let name: String
+    let type: BuildConfiguration
     let settings: [String: String]
     let xcconfig: AbsolutePath?
 
     // MARK: - Init
 
-    init(settings: [String: String] = [:], xcconfig: AbsolutePath? = nil) {
+    init(name: String, type: BuildConfiguration, settings: [String: String] = [:], xcconfig: AbsolutePath? = nil) {
+        self.name = name
+        self.type = type
         self.settings = settings
         self.xcconfig = xcconfig
     }
 
     init(json: JSON, projectPath: AbsolutePath, fileHandler _: FileHandling) throws {
+        name = try json.get("name")
+        type = BuildConfiguration(rawValue: try json.get("type"))! //FIXME Don't force unwrap
         settings = try json.get("settings")
         let xcconfigString: String? = json.get("xcconfig")
         xcconfig = xcconfigString.flatMap({ projectPath.appending(RelativePath($0)) })
@@ -32,24 +38,73 @@ class Settings: Equatable {
     // MARK: - Attributes
 
     let base: [String: String]
-    let debug: Configuration?
-    let release: Configuration?
+    let configurations: [Configuration]
 
     // MARK: - Init
 
     init(base: [String: String] = [:],
-         debug: Configuration?,
-         release: Configuration?) {
+         configurations: [Configuration]) {
         self.base = base
-        self.debug = debug
-        self.release = release
+        self.configurations = configurations
+    }
+
+    /// Default constructor of entities that are part of the manifest.
+    ///
+    /// - Parameters:
+    ///   - dictionary: Dictionary with the object representation.
+    ///   - projectPath: Absolute path to the folder that contains the manifest.
+    ///     This is useful to obtain absolute paths from the relative paths provided in the manifest by the user.
+    ///   - fileHandler: File handler for any file operations like checking whether a file exists or not.
+    /// - Throws: A decoding error if an expected property is missing or has an invalid value.
+    required init(dictionary: JSON, projectPath: AbsolutePath, fileHandler: FileHandling) throws {
+        base = try dictionary.get("base")
+        configurations = try dictionary.getArray("configurations").compactMap({ try Configuration(json: $0, projectPath: projectPath, fileHandler: fileHandler) })
     }
 
     // MARK: - Equatable
 
     static func == (lhs: Settings, rhs: Settings) -> Bool {
-        return lhs.debug == rhs.debug &&
-            lhs.release == rhs.release &&
-            lhs.base == rhs.base
+        return lhs.base == rhs.base &&
+            lhs.configurations == rhs.configurations
     }
 }
+//
+//class TargetSettings: GraphInitiatable, Equatable {
+//    // MARK: - Attributes
+//
+//    let base: [String: String]
+//    let debug: Configuration
+//    let release: Configuration
+//
+//    // MARK: - Init
+//
+//    init(base: [String: String] = [:], debug: Configuration = Configuration(name: "Debug", type: .debug), release: Configuration = Configuration(name: "Release", type: .release)) {
+//        self.base = base
+//        self.debug = debug
+//        self.release = release
+//    }
+//
+//    /// Default constructor of entities that are part of the manifest.
+//    ///
+//    /// - Parameters:
+//    ///   - dictionary: Dictionary with the object representation.
+//    ///   - projectPath: Absolute path to the folder that contains the manifest.
+//    ///     This is useful to obtain absolute paths from the relative paths provided in the manifest by the user.
+//    ///   - fileHandler: File handler for any file operations like checking whether a file exists or not.
+//    /// - Throws: A decoding error if an expected property is missing or has an invalid value.
+//    required init(dictionary: JSON, projectPath: AbsolutePath, fileHandler: FileHandling) throws {
+//        base = try dictionary.get("base")
+//        let debugJSON: JSON? = try? dictionary.get("debug")
+//        debug = try debugJSON.flatMap{ _ in try Configuration(name: "Debug", type: .debug, settings: [String:String](), xcconfig: nil) }!
+//        let releaseJSON: JSON? = try? dictionary.get("release")
+//        release = try releaseJSON.flatMap{ _ in try Configuration(name: "Release", type: .release, settings: [String:String](), xcconfig: nil) }!
+////        configurations = try dictionary.getArray("configurations").compactMap{ try Configuration(json: $0, projectPath: projectPath, fileHandler: fileHandler) }
+//    }
+//
+//    // MARK: - Equatable
+//
+//    static func == (lhs: TargetSettings, rhs: TargetSettings) -> Bool {
+//        return lhs.base == rhs.base &&
+//            lhs.debug == rhs.debug
+//    }
+//}

--- a/Sources/TuistKit/Models/Settings.swift
+++ b/Sources/TuistKit/Models/Settings.swift
@@ -23,18 +23,13 @@ class Configuration: Equatable {
         self.xcconfig = xcconfig
     }
 
-    init(json: JSON, projectPath: AbsolutePath, fileHandler _: FileHandling) throws {
-        name = try json.get("name")
-        buildConfiguration = BuildConfiguration(rawValue: try json.get("buildConfiguration")) ?? .debug
-        settings = try json.get("settings")
-        let xcconfigString: String? = json.get("xcconfig")
-        xcconfig = xcconfigString.flatMap({ projectPath.appending(RelativePath($0)) })
-    }
-
     // MARK: - Equatable
 
     static func == (lhs: Configuration, rhs: Configuration) -> Bool {
-        return lhs.settings == rhs.settings && lhs.xcconfig == rhs.xcconfig
+        return lhs.name == rhs.name &&
+            lhs.buildConfiguration == rhs.buildConfiguration &&
+            lhs.settings == rhs.settings &&
+            lhs.xcconfig == rhs.xcconfig
     }
 }
 
@@ -50,66 +45,10 @@ class Settings: Equatable {
         self.base = base
         self.configurations = configurations
     }
-
-    /// Default constructor of entities that are part of the manifest.
-    ///
-    /// - Parameters:
-    ///   - dictionary: Dictionary with the object representation.
-    ///   - projectPath: Absolute path to the folder that contains the manifest.
-    ///     This is useful to obtain absolute paths from the relative paths provided in the manifest by the user.
-    ///   - fileHandler: File handler for any file operations like checking whether a file exists or not.
-    /// - Throws: A decoding error if an expected property is missing or has an invalid value.
-    required init(dictionary: JSON, projectPath: AbsolutePath, fileHandler: FileHandling) throws {
-        base = try dictionary.get("base")
-        configurations = try dictionary.getArray("configurations").compactMap({ try Configuration(json: $0, projectPath: projectPath, fileHandler: fileHandler) })
-    }
-
+    
     // MARK: - Equatable
 
     static func == (lhs: Settings, rhs: Settings) -> Bool {
         return lhs.base == rhs.base && lhs.configurations == rhs.configurations
     }
-}
-
-class TargetSettings: GraphInitiatable, Equatable {
-    
-    public let base: BuildSettings
-    public let buildSettings: [Configuration.Name: BuildSettings]
-    
-    public init(base: BuildSettings, buildSettings: [Configuration.Name: BuildSettings]) {
-        self.base = base
-        self.buildSettings = buildSettings
-    }
-    
-    /// Default constructor of entities that are part of the manifest.
-    ///
-    /// - Parameters:
-    ///   - dictionary: Dictionary with the object representation.
-    ///   - projectPath: Absolute path to the folder that contains the manifest.
-    ///     This is useful to obtain absolute paths from the relative paths provided in the manifest by the user.
-    ///   - fileHandler: File handler for any file operations like checking whether a file exists or not.
-    /// - Throws: A decoding error if an expected property is missing or has an invalid value.
-    required init(dictionary: JSON, projectPath: AbsolutePath, fileHandler: FileHandling) throws {
-        base = try dictionary.get("base")
-        buildSettings = try dictionary.get("buildSettings").mapValues{ try $0.getDictionary() }
-    }
-    
-    // MARK: - Equatable
-    
-    static func == (lhs: TargetSettings, rhs: TargetSettings) -> Bool {
-        return lhs.buildSettings == rhs.buildSettings
-    }
-    
-}
-
-extension JSON {
-    
-    /// Returns a JSON mappable dictionary for self.
-    func getDictionary<T: JSONMappable>() throws -> [String: T] {
-        guard case .dictionary(let value) = self else {
-            throw MapError.typeMismatch(key: "<self>", expected: Dictionary<String, T>.self, json: self)
-        }
-        return try Dictionary(items: value.map({ ($0.0, try T.init(json: $0.1)) }))
-    }
-    
 }

--- a/Sources/TuistKit/Models/Settings.swift
+++ b/Sources/TuistKit/Models/Settings.swift
@@ -91,7 +91,7 @@ class TargetSettings: GraphInitiatable, Equatable {
     /// - Throws: A decoding error if an expected property is missing or has an invalid value.
     required init(dictionary: JSON, projectPath: AbsolutePath, fileHandler: FileHandling) throws {
         base = try dictionary.get("base")
-        buildSettings = try dictionary.get("buildsSettings").mapValues{ try $0.getDictionary() }
+        buildSettings = try dictionary.get("buildSettings").mapValues{ try $0.getDictionary() }
     }
     
     // MARK: - Equatable

--- a/Sources/TuistKit/Models/Target.swift
+++ b/Sources/TuistKit/Models/Target.swift
@@ -16,7 +16,7 @@ class Target: Equatable {
     let bundleId: String
     let infoPlist: AbsolutePath
     let entitlements: AbsolutePath?
-    let settings: TargetSettings?
+    let settings: Settings?
     let dependencies: [Dependency]
     let sources: [AbsolutePath]
     let resources: [AbsolutePath]
@@ -33,7 +33,7 @@ class Target: Equatable {
          bundleId: String,
          infoPlist: AbsolutePath,
          entitlements: AbsolutePath? = nil,
-         settings: TargetSettings? = nil,
+         settings: Settings? = nil,
          sources: [AbsolutePath] = [],
          resources: [AbsolutePath] = [],
          headers: Headers? = nil,

--- a/Sources/TuistKit/Models/Target.swift
+++ b/Sources/TuistKit/Models/Target.swift
@@ -16,7 +16,7 @@ class Target: Equatable {
     let bundleId: String
     let infoPlist: AbsolutePath
     let entitlements: AbsolutePath?
-    let settings: Settings?
+    let settings: TargetSettings?
     let dependencies: [Dependency]
     let sources: [AbsolutePath]
     let resources: [AbsolutePath]
@@ -33,7 +33,7 @@ class Target: Equatable {
          bundleId: String,
          infoPlist: AbsolutePath,
          entitlements: AbsolutePath? = nil,
-         settings: Settings? = nil,
+         settings: TargetSettings? = nil,
          sources: [AbsolutePath] = [],
          resources: [AbsolutePath] = [],
          headers: Headers? = nil,
@@ -56,7 +56,10 @@ class Target: Equatable {
         self.environment = environment
         self.dependencies = dependencies
     }
-    
+
+    /// Return true if the target can be linked.
+    ///
+    /// - Returns: True if the target can be linked from another target.
     func isLinkable() -> Bool {
         return [ .dynamicLibrary, .staticLibrary, .framework, .staticFramework ].contains(product)
     }

--- a/Tests/ProjectDescriptionTests/SettingsTests.swift
+++ b/Tests/ProjectDescriptionTests/SettingsTests.swift
@@ -18,7 +18,7 @@ final class SettingsTests: XCTestCase {
                 "debug": "debug"
             },
             "name": "Debug",
-            "type": "debug",
+            "buildConfiguration": "debug",
             "xcconfig": "/path/debug.xcconfig"
         },
         {
@@ -26,7 +26,7 @@ final class SettingsTests: XCTestCase {
                 "release": "release"
             },
             "name": "Release",
-            "type": "release",
+            "buildConfiguration": "release",
             "xcconfig": "/path/release.xcconfig"
         }
     ]
@@ -35,8 +35,10 @@ final class SettingsTests: XCTestCase {
         
         let subject = Settings(
             base: ["base": "base"],
-            debug: .debug(["debug": "debug"], xcconfig: "/path/debug.xcconfig"),
-            release: .release(["release": "release"], xcconfig: "/path/release.xcconfig")
+            configurations: [
+                .debug(name: "Debug", settings: ["debug": "debug"], xcconfig: "/path/debug.xcconfig"),
+                .release(name: "Release", settings: ["release": "release"], xcconfig: "/path/release.xcconfig")
+            ]
         )
 
         assertCodableEqualToJson(subject, expected)
@@ -56,7 +58,7 @@ final class SettingsTests: XCTestCase {
                 "debug": "debug"
             },
             "name": "Debug",
-            "type": "debug",
+            "buildConfiguration": "debug",
             "xcconfig": "/path/debug.xcconfig"
         },
         {
@@ -64,7 +66,7 @@ final class SettingsTests: XCTestCase {
                 "release": "release"
             },
             "name": "Release",
-            "type": "release",
+            "buildConfiguration": "release",
             "xcconfig": "/path/release.xcconfig"
         }
     ]
@@ -74,42 +76,12 @@ final class SettingsTests: XCTestCase {
         let subject = Settings(
             base: [ "base": "base" ],
             configurations: [
-                .debug([ "debug": "debug" ], xcconfig: "/path/debug.xcconfig"),
-                .release([ "release": "release" ], xcconfig: "/path/release.xcconfig")
+                .debug(name: "Debug", settings: [ "debug": "debug" ], xcconfig: "/path/debug.xcconfig"),
+                .release(name: "Release", settings: [ "release": "release" ], xcconfig: "/path/release.xcconfig")
             ]
         )
 
         assertCodableEqualToJson(subject, expected)
     }
-    
-    func test_toJSON_array_literal() {
-        
-        let expected =
-        """
-{
-    "base": { },
-    "configurations": [
-        {
-            "settings": { },
-            "name": "Debug",
-            "type": "debug",
-            "xcconfig": "/path/debug.xcconfig"
-        },
-        {
-            "settings": { },
-            "name": "Release",
-            "type": "release",
-            "xcconfig": "/path/release.xcconfig"
-        }
-    ]
-}
-"""
-        
-        let subject: Settings = [
-            .debug(xcconfig: "/path/debug.xcconfig"),
-            .release(xcconfig: "/path/release.xcconfig")
-        ]
-        
-        assertCodableEqualToJson(subject, expected)
-    }
+
 }

--- a/Tests/ProjectDescriptionTests/SettingsTests.swift
+++ b/Tests/ProjectDescriptionTests/SettingsTests.swift
@@ -3,16 +3,113 @@ import Foundation
 import XCTest
 
 final class SettingsTests: XCTestCase {
+    
     func test_toJSON() {
-        let subject = Settings(base: ["base": "base"],
-                               debug: Configuration(settings: ["debug": "debug"],
-                                                    xcconfig: "/path/debug.xcconfig"),
-                               release: Configuration(settings: ["release": "release"],
-                                                      xcconfig: "/path/release"))
-
-        let expected = """
-        {"base": {"base": "base"}, "debug": {"settings": {"debug": "debug"}, "xcconfig": "/path/debug.xcconfig"}, "release": {"settings": {"release": "release"}, "xcconfig": "/path/release"}}
+        
+        let expected =
         """
+{
+    "base": {
+        "base": "base"
+    },
+    "configurations": [
+        {
+            "settings": {
+                "debug": "debug"
+            },
+            "name": "Debug",
+            "type": "debug",
+            "xcconfig": "/path/debug.xcconfig"
+        },
+        {
+            "settings": {
+                "release": "release"
+            },
+            "name": "Release",
+            "type": "release",
+            "xcconfig": "/path/release.xcconfig"
+        }
+    ]
+}
+"""
+        
+        let subject = Settings(
+            base: ["base": "base"],
+            debug: .debug(["debug": "debug"], xcconfig: "/path/debug.xcconfig"),
+            release: .release(["release": "release"], xcconfig: "/path/release.xcconfig")
+        )
+
+        assertCodableEqualToJson(subject, expected)
+    }
+    
+    func test_toJSON_array() {
+        
+        let expected =
+        """
+{
+    "base": {
+        "base": "base"
+    },
+    "configurations": [
+        {
+            "settings": {
+                "debug": "debug"
+            },
+            "name": "Debug",
+            "type": "debug",
+            "xcconfig": "/path/debug.xcconfig"
+        },
+        {
+            "settings": {
+                "release": "release"
+            },
+            "name": "Release",
+            "type": "release",
+            "xcconfig": "/path/release.xcconfig"
+        }
+    ]
+}
+"""
+        
+        let subject = Settings(
+            base: [ "base": "base" ],
+            configurations: [
+                .debug([ "debug": "debug" ], xcconfig: "/path/debug.xcconfig"),
+                .release([ "release": "release" ], xcconfig: "/path/release.xcconfig")
+            ]
+        )
+
+        assertCodableEqualToJson(subject, expected)
+    }
+    
+    func test_toJSON_array_literal() {
+        
+        let expected =
+        """
+{
+    "base": { },
+    "configurations": [
+        {
+            "settings": { },
+            "name": "Debug",
+            "type": "debug",
+            "xcconfig": "/path/debug.xcconfig"
+        },
+        {
+            "settings": { },
+            "name": "Release",
+            "type": "release",
+            "xcconfig": "/path/release.xcconfig"
+        }
+    ]
+}
+"""
+        
+        let subject: Settings = [
+            .debug(xcconfig: "/path/debug.xcconfig"),
+            .release(xcconfig: "/path/release.xcconfig")
+        ]
+        
         assertCodableEqualToJson(subject, expected)
     }
 }

--- a/Tests/ProjectDescriptionTests/TargetTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetTests.swift
@@ -4,33 +4,109 @@ import XCTest
 
 final class TargetTests: XCTestCase {
     func test_toJSON() {
-        let subject = Target(name: "name",
-                             platform: .iOS,
-                             product: .app,
-                             bundleId: "bundle_id",
-                             infoPlist: "info.plist",
-                             sources: "sources/*",
-                             resources: "resources/*",
-                             headers: Headers(public: "public/*",
-                                              private: "private/*",
-                                              project: "project/*"),
-                             entitlements: "entitlement",
-                             actions: [
-                                 TargetAction.post(path: "path", arguments: ["arg"], name: "name"),
-                             ],
-                             dependencies: [
-                                 .framework(path: "path"),
-                                 .library(path: "path", publicHeaders: "public", swiftModuleMap: "module"),
-                                 .project(target: "target", path: "path"),
-                                 .target(name: "name"),
-                             ],
-                             settings: Settings(base: ["a": "b"],
-                                                debug: .debug(["a": "b"], xcconfig: "config"),
-                                                release: .release(["a": "b"], xcconfig: "config")),
-                             coreDataModels: [CoreDataModel("pat", currentVersion: "version")],
-                             environment: ["a": "b"])
+        
+        let subject = Target(
+            name: "name",
+            platform: .iOS,
+            product: .app,
+            bundleId: "bundle_id",
+            infoPlist: "info.plist",
+            sources: "sources/*",
+            resources: "resources/*",
+            headers: Headers(
+                public: "public/*",
+                private: "private/*",
+                project: "project/*"),
+            entitlements: "entitlement",
+            actions: [
+                TargetAction.post(path: "path", arguments: ["arg"], name: "name"),
+            ],
+            dependencies: [
+                .framework(path: "path"),
+                .library(path: "path", publicHeaders: "public", swiftModuleMap: "module"),
+                .project(target: "target", path: "path"),
+                .target(name: "name"),
+            ],
+            settings: TargetSettings(base: ["a": "b"], buildSettings: [
+                "Debug": ["a": "b"],
+                "Release": ["a": "b"]
+            ]),
+            coreDataModels: [CoreDataModel("pat", currentVersion: "version")],
+            environment: ["a": "b"]
+        )
+        
+        let expected =
+"""
+{
+    "headers": {
+        "public": "public/*",
+        "private": "private/*",
+        "project": "project/*"
+    },
+    "bundle_id": "bundle_id",
+    "core_data_models": [
+        {
+            "path": "pat",
+            "current_version": "version"
+        }
+    ],
+    "actions": [
+        {
+            "arguments": [
+                "arg"
+            ],
+            "path": "path",
+            "order": "post",
+            "name": "name"
+        }
+    ],
+    "product": "app",
+    "sources": "sources/*",
+    "settings": {
+        "base": {
+            "a": "b"
+        },
+        "buildSettings": {
+            "Release": {
+                "a": "b"
+            },
+            "Debug": {
+                "a": "b"
+            }
+        }
+    },
+    "resources": "resources/*",
+    "platform": "ios",
+    "entitlements": "entitlement",
+    "info_plist": "info.plist",
+    "dependencies": [
+        {
+            "type": "framework",
+            "path": "path"
+        },
+        {
+            "path": "path",
+            "public_headers": "public",
+            "swift_module_map": "module",
+            "type": "library"
+        },
+        {
+            "type": "project",
+            "target": "target",
+            "path": "path"
+        },
+        {
+            "type": "target",
+            "name": "name"
+        }
+    ],
+    "environment": {
+        "a": "b"
+    },
+    "name": "name"
+}
+"""
 
-        let expected = "{\"bundle_id\": \"bundle_id\", \"core_data_models\": [{\"current_version\": \"version\", \"path\": \"pat\"}], \"dependencies\": [{\"path\": \"path\", \"type\": \"framework\"}, {\"path\": \"path\", \"public_headers\": \"public\", \"swift_module_map\": \"module\", \"type\": \"library\"}, {\"path\": \"path\", \"target\": \"target\", \"type\": \"project\"}, {\"name\": \"name\", \"type\": \"target\"}], \"entitlements\": \"entitlement\", \"headers\": {\"private\": \"private/*\", \"project\": \"project/*\", \"public\": \"public/*\"}, \"info_plist\": \"info.plist\", \"name\": \"name\", \"platform\": \"ios\", \"product\": \"app\", \"resources\": \"resources/*\", \"settings\": {\"base\": {\"a\": \"b\"}, \"debug\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}, \"release\": {\"settings\": {\"a\": \"b\"}, \"xcconfig\": \"config\"}}, \"sources\": \"sources/*\", \"actions\": [ { \"path\": \"path\", \"arguments\": [\"arg\"], \"name\": \"name\", \"order\": \"post\"}], \"environment\": {\"a\": \"b\"}}"
         assertCodableEqualToJson(subject, expected)
     }
 }

--- a/Tests/ProjectDescriptionTests/TargetTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetTests.swift
@@ -25,10 +25,8 @@ final class TargetTests: XCTestCase {
                                  .target(name: "name"),
                              ],
                              settings: Settings(base: ["a": "b"],
-                                                debug: Configuration(settings: ["a": "b"],
-                                                                     xcconfig: "config"),
-                                                release: Configuration(settings: ["a": "b"],
-                                                                       xcconfig: "config")),
+                                                debug: .debug(["a": "b"], xcconfig: "config"),
+                                                release: .release(["a": "b"], xcconfig: "config")),
                              coreDataModels: [CoreDataModel("pat", currentVersion: "version")],
                              environment: ["a": "b"])
 

--- a/Tests/ProjectDescriptionTests/TargetTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetTests.swift
@@ -16,7 +16,8 @@ final class TargetTests: XCTestCase {
             headers: Headers(
                 public: "public/*",
                 private: "private/*",
-                project: "project/*"),
+                project: "project/*"
+            ),
             entitlements: "entitlement",
             actions: [
                 TargetAction.post(path: "path", arguments: ["arg"], name: "name"),

--- a/Tests/ProjectDescriptionTests/TargetTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetTests.swift
@@ -28,10 +28,13 @@ final class TargetTests: XCTestCase {
                 .project(target: "target", path: "path"),
                 .target(name: "name"),
             ],
-            settings: TargetSettings(base: ["a": "b"], buildSettings: [
-                "Debug": ["a": "b"],
-                "Release": ["a": "b"]
-            ]),
+            settings: Settings(
+                base: ["base": "base"],
+                configurations: [
+                    .debug(name: "Debug", settings: ["debug": "debug"], xcconfig: "/path/debug.xcconfig"),
+                    .release(name: "Release", settings: ["release": "release"], xcconfig: "/path/release.xcconfig")
+                ]
+            ),
             coreDataModels: [CoreDataModel("pat", currentVersion: "version")],
             environment: ["a": "b"]
         )
@@ -65,16 +68,26 @@ final class TargetTests: XCTestCase {
     "sources": "sources/*",
     "settings": {
         "base": {
-            "a": "b"
+            "base": "base"
         },
-        "buildSettings": {
-            "Release": {
-                "a": "b"
+        "configurations": [
+            {
+                "settings": {
+                    "debug": "debug"
+                },
+                "name": "Debug",
+                "buildConfiguration": "debug",
+                "xcconfig": "/path/debug.xcconfig"
             },
-            "Debug": {
-                "a": "b"
+            {
+                "settings": {
+                    "release": "release"
+                },
+                "name": "Release",
+                "buildConfiguration": "release",
+                "xcconfig": "/path/release.xcconfig"
             }
-        }
+        ]
     },
     "resources": "resources/*",
     "platform": "ios",

--- a/Tests/ProjectDescriptionTests/assertCodableEqualToJson.swift
+++ b/Tests/ProjectDescriptionTests/assertCodableEqualToJson.swift
@@ -1,7 +1,7 @@
 import Foundation
 import XCTest
 
-func assertCodableEqualToJson<C: Codable>(_ subject: C, _ json: String) {
+func assertCodableEqualToJson<C: Codable>(_ subject: C, _ json: String, file: StaticString = #file, line: UInt = #line) {
     let decoder = JSONDecoder()
     let decoded = try! decoder.decode(C.self, from: json.data(using: .utf8)!)
     let encoder = JSONEncoder()
@@ -9,5 +9,5 @@ func assertCodableEqualToJson<C: Codable>(_ subject: C, _ json: String) {
     let jsonData = try! encoder.encode(decoded)
     let subjectData = try! encoder.encode(subject)
 
-    XCTAssert(jsonData == subjectData, "JSON does not match the encoded \(String(describing: subject))")
+    XCTAssert(jsonData == subjectData, "JSON does not match the encoded \(String(describing: subject))", file: file, line: line)
 }

--- a/Tests/TuistKitTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/ConfigGeneratorTests.swift
@@ -84,8 +84,8 @@ final class ConfigGeneratorTests: XCTestCase {
             XCTAssertEqual(config?.buildSettings["CODE_SIGN_ENTITLEMENTS"] as? String, "$(SRCROOT)/Test.entitlements")
             XCTAssertEqual(config?.buildSettings["SWIFT_VERSION"] as? String, Constants.swiftVersion)
 
-//            let xcconfig: PBXFileReference? = config?.baseConfiguration
-//            XCTAssertEqual(xcconfig?.path, "\(config!.name.lowercased()).xcconfig")
+            let xcconfig: PBXFileReference? = config?.baseConfiguration
+            XCTAssertEqual(xcconfig?.path, "\(config!.name.lowercased()).xcconfig")
         }
 
         assert(config: debugConfig)
@@ -150,14 +150,9 @@ final class ConfigGeneratorTests: XCTestCase {
                           xcconfig: xcconfigsDir.appending(component: "release.xcconfig"))
         ]
         
-        let target = Target.test(name: "Test", settings: TargetSettings.test(buildSettings: [
-            "Debug": [
-                "Base": "Base"
-            ],
-            "Release": [
-                "Base": "Base"
-            ]
-        ]))
+        let target = Target.test(name: "Test", settings: Settings.test(base: [
+            "Base": "Base"
+        ], configurations: configurations))
         
         let project = Project(path: dir.path,
                               name: "Test",

--- a/Tests/TuistKitTests/Generator/GeneratorModelLoaderTest.swift
+++ b/Tests/TuistKitTests/Generator/GeneratorModelLoaderTest.swift
@@ -113,9 +113,9 @@ class GeneratorModelLoaderTest: XCTestCase {
     
     func test_settings() throws {
         // Given
-        let debug = ConfigurationManifest(settings: ["Debug": "Debug"], xcconfig: "debug.xcconfig")
-        let release = ConfigurationManifest(settings: ["Release": "Release"], xcconfig: "release.xcconfig")
-        let manifest = SettingsManifest(base: ["base": "base"], debug: debug, release: release)
+        let debug = ConfigurationManifest(name: "Debug", settings: ["Debug": "Debug"], xcconfig: "debug.xcconfig", buildConfiguration: .debug)
+        let release = ConfigurationManifest(name: "Release", settings: ["Release": "Release"], xcconfig: "release.xcconfig", buildConfiguration: .release)
+        let manifest = SettingsManifest(base: ["base": "base"], configurations: [ debug, release ])
         
         // When
         let model = try TuistKit.Settings.from(json: manifest.toJSON(), path: path, fileHandler: fileHandler)
@@ -280,13 +280,10 @@ class GeneratorModelLoaderTest: XCTestCase {
                 line: UInt = #line) {
         XCTAssertEqual(settings.base, manifest.base, file: file, line: line)
         
-        optionalAssert(settings.debug, manifest.debug, file: file, line: line) {
-            assert(configuration: $0, matches: $1, at: path, file: file, line: line)
+        for (configuration, manifestConfiguration) in zip(settings.configurations, manifest.configurations) {
+            assert(configuration: configuration, matches: manifestConfiguration, at: path, file: file, line: line)
         }
-        
-        optionalAssert(settings.release, manifest.release, file: file, line: line) {
-            assert(configuration: $0, matches: $1, at: path, file: file, line: line)
-        }
+
     }
     
     func assert(configuration: TuistKit.Configuration,
@@ -294,6 +291,8 @@ class GeneratorModelLoaderTest: XCTestCase {
                 at path: AbsolutePath,
                 file: StaticString = #file,
                 line: UInt = #line) {
+        XCTAssertEqual(configuration.name, manifest.name)
+        XCTAssertEqual(configuration.buildConfiguration.rawValue, manifest.buildConfiguration.rawValue)
         XCTAssertEqual(configuration.settings, manifest.settings, file: file, line: line)
         XCTAssertEqual(configuration.xcconfig, manifest.xcconfig.map { path.appending(RelativePath($0)) }, file: file, line: line)
     }

--- a/Tests/TuistKitTests/Generator/Mocks/MockProjectGenerator.swift
+++ b/Tests/TuistKitTests/Generator/Mocks/MockProjectGenerator.swift
@@ -4,12 +4,14 @@ import TuistCore
 @testable import TuistKit
 
 final class MockProjectGenerator: ProjectGenerating {
-    var generateStub: ((Project, GenerationOptions, Graphing, AbsolutePath?) throws -> GeneratedProject)?
+
+    var generateStub: ((Project, GenerationOptions, Graphing, ConfigurationList, AbsolutePath?) throws -> GeneratedProject)?
 
     func generate(project: Project,
                   options: GenerationOptions,
                   graph: Graphing,
+                  configurations: ConfigurationList,
                   sourceRootPath: AbsolutePath?) throws -> GeneratedProject {
-        return try generateStub?(project, options, graph, sourceRootPath) ?? GeneratedProject.test()
+        return try generateStub?(project, options, graph, configurations, sourceRootPath) ?? GeneratedProject.test()
     }
 }

--- a/Tests/TuistKitTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistKitTests/Generator/ProjectFileElementsTests.swift
@@ -16,13 +16,16 @@ final class ProjectFileElementsTests: XCTestCase {
         playgrounds = MockPlaygrounds()
         subject = ProjectFileElements(playgrounds: playgrounds)
     }
-
+    
     func test_projectFiles() {
-        let settings = Settings(base: [:],
-                                debug: Configuration(settings: [:],
-                                                     xcconfig: AbsolutePath("/project/debug.xcconfig")),
-                                release: Configuration(settings: [:],
-                                                       xcconfig: AbsolutePath("/project/release.xcconfig")))
+        
+        let settings = Settings(
+            base: [:],
+            configurations: [
+                Configuration(name: "Debug", buildConfiguration: .debug, settings: [:], xcconfig: AbsolutePath("/project/debug.xcconfig")),
+                Configuration(name: "Release", buildConfiguration: .release, settings: [:], xcconfig: AbsolutePath("/project/release.xcconfig"))
+            ]
+        )
 
         let project = Project.test(path: AbsolutePath("/project/"), settings: settings)
         let files = subject.projectFiles(project: project)
@@ -37,11 +40,17 @@ final class ProjectFileElementsTests: XCTestCase {
     }
 
     func test_targetFiles() {
-        let settings = Settings(base: [:],
-                                debug: Configuration(settings: [:],
-                                                     xcconfig: AbsolutePath("/project/debug.xcconfig")),
-                                release: Configuration(settings: [:],
-                                                       xcconfig: AbsolutePath("/project/release.xcconfig")))
+
+        let settings = TargetSettings.test(buildSettings: [
+            "Debug": [
+                "A": "Configuration"
+            ],
+            "Release": [
+                "B": "Configuration"
+            ]
+        ])
+        
+        
         let target = Target.test(name: "name",
                                  platform: .iOS,
                                  product: .app,
@@ -61,8 +70,8 @@ final class ProjectFileElementsTests: XCTestCase {
 
         let files = subject.targetFiles(target: target)
 
-        XCTAssertTrue(files.contains(AbsolutePath("/project/debug.xcconfig")))
-        XCTAssertTrue(files.contains(AbsolutePath("/project/release.xcconfig")))
+//        XCTAssertTrue(files.contains(AbsolutePath("/project/debug.xcconfig")))
+//        XCTAssertTrue(files.contains(AbsolutePath("/project/release.xcconfig")))
         XCTAssertTrue(files.contains(AbsolutePath("/project/file.swift")))
         XCTAssertTrue(files.contains(AbsolutePath("/project/image.png")))
         XCTAssertTrue(files.contains(AbsolutePath("/project/public.h")))

--- a/Tests/TuistKitTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistKitTests/Generator/ProjectFileElementsTests.swift
@@ -41,15 +41,11 @@ final class ProjectFileElementsTests: XCTestCase {
 
     func test_targetFiles() {
 
-        let settings = TargetSettings.test(buildSettings: [
-            "Debug": [
-                "A": "Configuration"
-            ],
-            "Release": [
-                "B": "Configuration"
-            ]
-        ])
-        
+        let settings = Settings.test(
+            base: [:],
+            debug: .init(name: "Debug", buildConfiguration: .debug, settings: [ "Configuration": "A" ], xcconfig: "/project/debug.xcconfig"),
+            release: .init(name: "Release", buildConfiguration: .release, settings: [ "Configuration": "B" ], xcconfig: "/project/release.xcconfig")
+        )
         
         let target = Target.test(name: "name",
                                  platform: .iOS,
@@ -70,8 +66,8 @@ final class ProjectFileElementsTests: XCTestCase {
 
         let files = subject.targetFiles(target: target)
 
-//        XCTAssertTrue(files.contains(AbsolutePath("/project/debug.xcconfig")))
-//        XCTAssertTrue(files.contains(AbsolutePath("/project/release.xcconfig")))
+        XCTAssertTrue(files.contains(AbsolutePath("/project/debug.xcconfig")))
+        XCTAssertTrue(files.contains(AbsolutePath("/project/release.xcconfig")))
         XCTAssertTrue(files.contains(AbsolutePath("/project/file.swift")))
         XCTAssertTrue(files.contains(AbsolutePath("/project/image.png")))
         XCTAssertTrue(files.contains(AbsolutePath("/project/public.h")))

--- a/Tests/TuistKitTests/Generator/WorkspaceGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/WorkspaceGeneratorTests.swift
@@ -28,17 +28,22 @@ final class WorkspaceGeneratorTests: XCTestCase {
 
             let projectDirectoryHelper = ProjectDirectoryHelper(environmentController: try MockEnvironmentController(), fileHandler: fileHandler)
             
+            
+            
             subject = WorkspaceGenerator(
                 system: MockSystem(),
                 printer: MockPrinter(),
                 resourceLocator: MockResourceLocator(),
                 projectDirectoryHelper: projectDirectoryHelper,
+                projectGenerator: MockProjectGenerator(),
                 fileHandler: fileHandler
             )
             
             let targetNode = TargetNode(project: project, target: target, dependencies: [ ])
             let cache = GraphLoaderCache()
+            
             cache.add(targetNode: targetNode)
+            cache.add(project: project)
             
             graph = Graph.test(entryPath: path, cache: cache)
             

--- a/Tests/TuistKitTests/Linter/SettingsLinterTests.swift
+++ b/Tests/TuistKitTests/Linter/SettingsLinterTests.swift
@@ -18,8 +18,10 @@ final class SettingsLinterTests: XCTestCase {
         let debugPath = fileHandler.currentPath.appending(component: "Debug.xcconfig")
         let releasePath = fileHandler.currentPath.appending(component: "Release.xcconfig")
 
-        let settings = Settings(debug: Configuration(xcconfig: debugPath),
-                                release: Configuration(xcconfig: releasePath))
+        let settings = Settings(configurations: [
+            Configuration(name: "Debug", buildConfiguration: .debug, xcconfig: debugPath),
+            Configuration(name: "Release", buildConfiguration: .release, xcconfig: releasePath)
+        ])
 
         let got = subject.lint(settings: settings)
 

--- a/Tests/TuistKitTests/Models/TestData/Settings+TestData.swift
+++ b/Tests/TuistKitTests/Models/TestData/Settings+TestData.swift
@@ -5,17 +5,21 @@ import Foundation
 extension Configuration {
     static func test(settings: [String: String] = [:],
                      xcconfig: AbsolutePath? = AbsolutePath("/Config.xcconfig")) -> Configuration {
-        return Configuration(settings: settings,
-                             xcconfig: xcconfig)
+        return Configuration(name: "Test", buildConfiguration: .debug, settings: settings, xcconfig: xcconfig)
     }
 }
 
 extension Settings {
     static func test(base: [String: String] = [:],
-                     debug: Configuration? = Configuration(xcconfig: AbsolutePath("/Debug.xcconfig")),
-                     release: Configuration? = Configuration(xcconfig: AbsolutePath("/Debug.xcconfig"))) -> Settings {
-        return Settings(base: base,
-                        debug: debug,
-                        release: release)
+                     debug: Configuration = Configuration(name: "Debug", buildConfiguration: .debug, xcconfig: AbsolutePath("/Debug.xcconfig")),
+                     release: Configuration = Configuration(name: "Release", buildConfiguration: .release, xcconfig: AbsolutePath("/Release.xcconfig"))
+    ) -> Settings {
+        return Settings(base: base, configurations: [debug, release])
+    }
+}
+
+extension TargetSettings {
+    static func test(base: BuildSettings = [:], buildSettings: [Configuration.Name: BuildSettings] = [:]) -> TargetSettings {
+        return TargetSettings(base: base, buildSettings: buildSettings)
     }
 }

--- a/Tests/TuistKitTests/Models/TestData/Settings+TestData.swift
+++ b/Tests/TuistKitTests/Models/TestData/Settings+TestData.swift
@@ -16,10 +16,9 @@ extension Settings {
     ) -> Settings {
         return Settings(base: base, configurations: [debug, release])
     }
-}
-
-extension TargetSettings {
-    static func test(base: BuildSettings = [:], buildSettings: [Configuration.Name: BuildSettings] = [:]) -> TargetSettings {
-        return TargetSettings(base: base, buildSettings: buildSettings)
+    
+    static func test(base: [String: String] = [:], configurations: [Configuration] = [ ]) -> Settings {
+        return Settings(base: base, configurations: configurations)
     }
+    
 }

--- a/Tests/TuistKitTests/Models/TestData/Target+TestData.swift
+++ b/Tests/TuistKitTests/Models/TestData/Target+TestData.swift
@@ -9,7 +9,7 @@ extension Target {
                      bundleId: String = "com.test.bundle_id",
                      infoPlist: AbsolutePath = AbsolutePath("/Info.plist"),
                      entitlements: AbsolutePath? = AbsolutePath("/Test.entitlements"),
-                     settings: Settings? = Settings.test(),
+                     settings: TargetSettings? = TargetSettings.test(),
                      sources: [AbsolutePath] = [AbsolutePath("/sources/*")],
                      resources: [AbsolutePath] = [AbsolutePath("/resources/*")],
                      coreDataModels: [CoreDataModel] = [],

--- a/Tests/TuistKitTests/Models/TestData/Target+TestData.swift
+++ b/Tests/TuistKitTests/Models/TestData/Target+TestData.swift
@@ -9,7 +9,7 @@ extension Target {
                      bundleId: String = "com.test.bundle_id",
                      infoPlist: AbsolutePath = AbsolutePath("/Info.plist"),
                      entitlements: AbsolutePath? = AbsolutePath("/Test.entitlements"),
-                     settings: TargetSettings? = TargetSettings.test(),
+                     settings: Settings? = Settings.test(),
                      sources: [AbsolutePath] = [AbsolutePath("/sources/*")],
                      resources: [AbsolutePath] = [AbsolutePath("/resources/*")],
                      coreDataModels: [CoreDataModel] = [],

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -35,6 +35,39 @@ Simple app with tests.
 
 Contains a single file `Workspac.swift`, incorrectly named workspace manifest file.
 
+## ios_app_with_multiple_configurations
+
+This workspace contains 3 projects and a set of shared xcconfig files within `configs`. Each of the projects declares multiple configurations / build settings at different levels.
+
+```
+Workspace:
+  - App:
+    - MainApp (iOS app)
+    - MainAppTests (iOS unit tests)
+  - configs:
+    - beta.xcconfig
+    - debug.xcconfig
+    - release.xcconfig
+    - shared.xcconfig
+  - Framework1:
+    - Framework1 (dynamic iOS framework)
+    - Framework1Tests (iOS unit tests)
+  - Framework2:
+    - Framework2 (dynamic iOS framework)
+    - Framework2Tests (iOS unit tests)
+```
+
+Dependencies:
+  - App -> Framework1
+  - App -> Framework2
+  - Framework1 -> Framework2
+
+Config files:
+  - beta.xcconfig -> shared.xcconfig
+  - debug.xcconfig -> shared.xcconfig
+  - release.xcconfig -> shared.xcconfig
+
+
 ## ios_app_with_static_libraries
 
 This application provides a top level application with two static library dependencies. The first static library dependency has another static library dependency so that we are able to test how tuist handles the transitiveness of the static libraries in the linked frameworks of the main app.
@@ -57,7 +90,7 @@ Dependencies:
   - App -> A
   - A -> B
 
-## ios_app_with_static_libraries
+## ios_app_with_static_frameworks
 
 Same as `ios_app_with_static_libraries` except using static frameworks instead of libraries.
 

--- a/fixtures/ios_app_with_multiple_configurations/App/Config/App-Info.plist
+++ b/fixtures/ios_app_with_multiple_configurations/App/Config/App-Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright Tuist©. All rights reserved.</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_multiple_configurations/App/Config/AppTests-Info.plist
+++ b/fixtures/ios_app_with_multiple_configurations/App/Config/AppTests-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_multiple_configurations/App/Project.swift
+++ b/fixtures/ios_app_with_multiple_configurations/App/Project.swift
@@ -1,0 +1,48 @@
+import ProjectDescription
+
+
+let projectSettings = Settings(base: [
+                            "CONFIG_SOURCE": "MainApp.Project.Base",
+                            "MAINAPP_BASE": "YES",
+                        ],
+                        configurations: [
+                            .debug(settings: [ "OVERRIDEABLE_CONFIG": "Debug.Base" ], xcconfig: "../configs/debug.xcconfig"),
+                            .release(settings: [ "OVERRIDEABLE_CONFIG": "Release.Base" ], xcconfig: "../configs/release.xcconfig"),
+                            .release(name: "Beta", settings: [ "OVERRIDEABLE_CONFIG": "Beta.Base" ], xcconfig: "../configs/beta.xcconfig"),
+                        ])
+
+let targetSettings = Settings(base: [
+                                    "CONFIG_SOURCE": "MainApp.AppTarget.Base",
+                                    "APPTARGET_BASE": "YES",
+                                ],
+                              configurations: [
+                                .debug(settings: [ "OVERRIDEABLE_CONFIG": "AppTarget.Debug.Base" ]),
+                                .release(settings: [ "OVERRIDEABLE_CONFIG": "AppTarget.Release.Base" ]),
+                                .release(name: "Beta", settings: [ "OVERRIDEABLE_CONFIG": "AppTarget.Beta.Base" ]),
+                                .debug(name: "Testing", settings: [ "OVERRIDEABLE_CONFIG": "AppTarget.Testing.Base" ]),
+                            ])
+
+let project = Project(name: "MainApp",
+                      settings: projectSettings,
+                      targets: [
+                        Target(name: "App",
+                               platform: .iOS,
+                               product: .app,
+                               bundleId: "io.tuist.App",
+                               infoPlist: "Config/App-Info.plist",
+                               sources: "Sources/**",
+                               dependencies: [
+                                    .project(target: "Framework1", path: "../Framework1"),
+                                    .project(target: "Framework2", path: "../Framework2")
+                                ],
+                               settings: targetSettings),
+                        Target(name: "AppTests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               bundleId: "io.tuist.AppTests",
+                               infoPlist: "Config/AppTests-Info.plist",
+                               sources: "Tests/**",
+                               dependencies: [
+                                .target(name: "App")
+                            ])
+                        ])

--- a/fixtures/ios_app_with_multiple_configurations/App/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_multiple_configurations/App/Sources/AppDelegate.swift
@@ -1,0 +1,24 @@
+import UIKit
+import Framework1
+import Framework2
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+    func applicationDidFinishLaunching(_ application: UIApplication){
+
+        let framework1 = Framework1File()
+        let framework2 = Framework2File()
+
+        print(hello())
+        print("AppDelegate -> \(framework1.hello())")
+        print("AppDelegate -> \(framework1.helloFromFramework2())")
+        print("AppDelegate -> \(framework2.hello())")
+    }
+
+    func hello() -> String {
+        return "AppDelegate.hello()"
+    }
+}

--- a/fixtures/ios_app_with_multiple_configurations/App/Tests/AppDelegateTests.swift
+++ b/fixtures/ios_app_with_multiple_configurations/App/Tests/AppDelegateTests.swift
@@ -1,0 +1,14 @@
+//@testable import App
+import XCTest
+
+
+// Generated project does not set "Host Application" and "Allow testing Host Application APIs",
+// what leads to "ld: symbol(s) not found for architecture x86_64" linker error.
+class AppDelegateTests: XCTestCase {
+
+//    func testHello() {
+//        let sut = AppDelegate()
+//
+//        XCTAssertEqual("AppDelegate.hello()", sut.hello())
+//    }
+}

--- a/fixtures/ios_app_with_multiple_configurations/Framework1/Config/Framework1-Info.plist
+++ b/fixtures/ios_app_with_multiple_configurations/Framework1/Config/Framework1-Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright Tuist©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_multiple_configurations/Framework1/Config/Framework1Tests-Info.plist
+++ b/fixtures/ios_app_with_multiple_configurations/Framework1/Config/Framework1Tests-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_multiple_configurations/Framework1/Project.swift
+++ b/fixtures/ios_app_with_multiple_configurations/Framework1/Project.swift
@@ -1,0 +1,36 @@
+import ProjectDescription
+
+let projectSettings = Settings(base: [ 
+                                   "CONFIG_SOURCE": "Framework1.Project.Base",
+                                   "FRAMEWORK1_BASE": "YES",
+                                ],
+                                 configurations: [
+                                   .debug(settings: [ "OVERRIDEABLE_CONFIG": "Framework1.Debug.Base" ], xcconfig: "../configs/debug.xcconfig"),
+                                   .release(settings: [ "OVERRIDEABLE_CONFIG": "Framework1.Release.Base" ], xcconfig: "../configs/release.xcconfig"),
+                                   .release(name: "Beta", settings: [ "OVERRIDEABLE_CONFIG": "Framework1.Beta.Base" ], xcconfig: "../configs/beta.xcconfig"),
+                                   .debug(name: "Testing", settings: [ "OVERRIDEABLE_CONFIG": "Framework1.Testing.Base" ]),
+                                ])
+
+let project = Project(name: "Framework1",
+                      settings: projectSettings,
+                      targets: [
+                        Target(name: "Framework1",
+                               platform: .iOS,
+                               product: .framework,
+                               bundleId: "io.tuist.Framework1",
+                               infoPlist: "Config/Framework1-Info.plist",
+                               sources: "Sources/**",
+                               dependencies: [
+                                .project(target: "Framework2", path: "../Framework2")
+                               ]),
+                        Target(name: "Framework1Tests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               bundleId: "io.tuist.Framework1Tests",
+                               infoPlist: "Config/Framework1Tests-Info.plist",
+                               sources: "Tests/**",
+                               dependencies: [
+                                .target(name: "Framework1")
+                               ]),
+                      ])
+

--- a/fixtures/ios_app_with_multiple_configurations/Framework1/Sources/Framework1File.swift
+++ b/fixtures/ios_app_with_multiple_configurations/Framework1/Sources/Framework1File.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Framework2
+
+public class Framework1File {
+
+    private let framework2File = Framework2File()
+
+    public init() {}
+
+    public func hello() -> String {
+        return "Framework1File.hello()"
+    }
+
+    public func helloFromFramework2() -> String {
+        return "Framework1File -> \(framework2File.hello())"
+    }
+}

--- a/fixtures/ios_app_with_multiple_configurations/Framework1/Tests/Framework1FileTests.swift
+++ b/fixtures/ios_app_with_multiple_configurations/Framework1/Tests/Framework1FileTests.swift
@@ -1,0 +1,17 @@
+@testable import Framework1
+import XCTest
+
+class Framework1Tests: XCTestCase {
+
+   func testHello() {
+       let sut = Framework1File()
+
+       XCTAssertEqual("Framework1File.hello()", sut.hello())
+   }
+
+   func testHelloFromFramework2() {
+       let sut = Framework1File()
+
+       XCTAssertEqual("Framework1File -> Framework2File.hello()", sut.helloFromFramework2())
+   }
+}

--- a/fixtures/ios_app_with_multiple_configurations/Framework2/Config/Framework2-Info.plist
+++ b/fixtures/ios_app_with_multiple_configurations/Framework2/Config/Framework2-Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright Tuist©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_multiple_configurations/Framework2/Config/Framework2Tests-Info.plist
+++ b/fixtures/ios_app_with_multiple_configurations/Framework2/Config/Framework2Tests-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_multiple_configurations/Framework2/Project.swift
+++ b/fixtures/ios_app_with_multiple_configurations/Framework2/Project.swift
@@ -1,0 +1,33 @@
+import ProjectDescription
+
+let targetSettings = Settings(base: [ 
+                                   "CONFIG_SOURCE": "Framework2.Project.Base",
+                                   "FRAMEWORK2_BASE": "YES",
+                                ],
+                                 configurations: [
+                                   .debug(settings: [ "OVERRIDEABLE_CONFIG": "Framework2.Debug.Base" ], xcconfig: "../configs/debug.xcconfig"),
+                                   .release(settings: [ "OVERRIDEABLE_CONFIG": "Framework2.Release.Base" ], xcconfig: "../configs/release.xcconfig"),
+                                   .release(name: "Beta", settings: [ "OVERRIDEABLE_CONFIG": "Framework2.Beta.Base" ], xcconfig: "../configs/beta.xcconfig"),
+                                   .debug(name: "Testing", settings: [ "OVERRIDEABLE_CONFIG": "Framework2.Testing.Base" ]),
+                                ])
+
+let project = Project(name: "Framework2",
+                      targets: [
+                        Target(name: "Framework2",
+                               platform: .iOS,
+                               product: .framework,
+                               bundleId: "io.tuist.Framework2",
+                               infoPlist: "Config/Framework2-Info.plist",
+                               sources: "Sources/**",
+                               dependencies: [],
+                               settings: targetSettings),
+                        Target(name: "Framework2Tests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               bundleId: "io.tuist.Framework2Tests",
+                               infoPlist: "Config/Framework2Tests-Info.plist",
+                               sources: "Tests/**",
+                               dependencies: [
+                                .target(name: "Framework2")
+                            ]),
+                        ])

--- a/fixtures/ios_app_with_multiple_configurations/Framework2/Sources/Framework2File.swift
+++ b/fixtures/ios_app_with_multiple_configurations/Framework2/Sources/Framework2File.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public class Framework2File {
+
+    public init() {}
+
+    public func hello() -> String {
+        return "Framework2File.hello()"
+    }
+}

--- a/fixtures/ios_app_with_multiple_configurations/Framework2/Tests/Framework2FileTests.swift
+++ b/fixtures/ios_app_with_multiple_configurations/Framework2/Tests/Framework2FileTests.swift
@@ -1,0 +1,11 @@
+@testable import Framework2
+import XCTest
+
+class Framework2Tests: XCTestCase {
+
+    func testHello() {
+        let sut = Framework2File()
+
+        XCTAssertEqual("Framework2File.hello()", sut.hello())
+    }
+}

--- a/fixtures/ios_app_with_multiple_configurations/Workspace.swift
+++ b/fixtures/ios_app_with_multiple_configurations/Workspace.swift
@@ -1,0 +1,4 @@
+import ProjectDescription
+
+let workspace = Workspace(name: "Workspace",
+                          projects: ["App", "Framework1", "Framework2"])

--- a/fixtures/ios_app_with_multiple_configurations/configs/beta.xcconfig
+++ b/fixtures/ios_app_with_multiple_configurations/configs/beta.xcconfig
@@ -1,0 +1,5 @@
+#include "shared.xcconfig"
+
+CONFIG_SOURCE="beta.xcconfig"
+BETA_XCCONFIG=YES
+OVERRIDEABLE_CONFIG="beta"

--- a/fixtures/ios_app_with_multiple_configurations/configs/debug.xcconfig
+++ b/fixtures/ios_app_with_multiple_configurations/configs/debug.xcconfig
@@ -1,0 +1,5 @@
+#include "shared.xcconfig"
+
+CONFIG_SOURCE="debug.xcconfig"
+DEBUG_XCCONFIG=YES
+OVERRIDEABLE_CONFIG="debug"

--- a/fixtures/ios_app_with_multiple_configurations/configs/release.xcconfig
+++ b/fixtures/ios_app_with_multiple_configurations/configs/release.xcconfig
@@ -1,0 +1,5 @@
+#include "shared.xcconfig"
+
+CONFIG_SOURCE="release.xcconfig"
+RELEASE_XCCONFIG=YES
+OVERRIDEABLE_CONFIG="release"

--- a/fixtures/ios_app_with_multiple_configurations/configs/shared.xcconfig
+++ b/fixtures/ios_app_with_multiple_configurations/configs/shared.xcconfig
@@ -1,0 +1,4 @@
+
+CONFIG_SOURCE="shared.xcconfig"
+SHARED_XCCONFIG=YES
+OVERRIDEABLE_CONFIG="shared"

--- a/fixtures/ios_app_with_setup/Project.swift
+++ b/fixtures/ios_app_with_setup/Project.swift
@@ -12,7 +12,7 @@ let project = Project(name: "App",
                                      /* Target dependencies can be defined here */
                                      /* .framework(path: "framework") */
                                  ],
-                                 settings: Settings(base: ["CODE_SIGN_IDENTITY": "",
+                                 settings: TargetSettings(base: ["CODE_SIGN_IDENTITY": "",
                                                            "CODE_SIGNING_REQUIRED": "NO"])),
                           Target(name: "AppTests",
                                  platform: .iOS,
@@ -23,6 +23,6 @@ let project = Project(name: "App",
                                  dependencies: [
                                      .target(name: "App"),
                                  ],
-                                 settings: Settings(base: ["CODE_SIGN_IDENTITY": "",
+                                 settings: TargetSettings(base: ["CODE_SIGN_IDENTITY": "",
                                                            "CODE_SIGNING_REQUIRED": "NO"])),
 ])

--- a/fixtures/ios_app_with_setup/Project.swift
+++ b/fixtures/ios_app_with_setup/Project.swift
@@ -12,7 +12,7 @@ let project = Project(name: "App",
                                      /* Target dependencies can be defined here */
                                      /* .framework(path: "framework") */
                                  ],
-                                 settings: TargetSettings(base: ["CODE_SIGN_IDENTITY": "",
+                                 settings: Settings(base: ["CODE_SIGN_IDENTITY": "",
                                                            "CODE_SIGNING_REQUIRED": "NO"])),
                           Target(name: "AppTests",
                                  platform: .iOS,
@@ -23,6 +23,6 @@ let project = Project(name: "App",
                                  dependencies: [
                                      .target(name: "App"),
                                  ],
-                                 settings: TargetSettings(base: ["CODE_SIGN_IDENTITY": "",
+                                 settings: Settings(base: ["CODE_SIGN_IDENTITY": "",
                                                            "CODE_SIGNING_REQUIRED": "NO"])),
 ])

--- a/fixtures/ios_app_with_tests/Project.swift
+++ b/fixtures/ios_app_with_tests/Project.swift
@@ -12,7 +12,7 @@ let project = Project(name: "App",
                                      /* Target dependencies can be defined here */
                                      /* .framework(path: "framework") */
                                  ],
-                                 settings: Settings(base: ["CODE_SIGN_IDENTITY": "",
+                                 settings: TargetSettings(base: ["CODE_SIGN_IDENTITY": "",
                                                            "CODE_SIGNING_REQUIRED": "NO"])),
                           Target(name: "AppTests",
                                  platform: .iOS,
@@ -23,6 +23,6 @@ let project = Project(name: "App",
                                  dependencies: [
                                      .target(name: "App"),
                                  ],
-                                 settings: Settings(base: ["CODE_SIGN_IDENTITY": "",
+                                 settings: TargetSettings(base: ["CODE_SIGN_IDENTITY": "",
                                                            "CODE_SIGNING_REQUIRED": "NO"])),
 ])

--- a/fixtures/ios_app_with_tests/Project.swift
+++ b/fixtures/ios_app_with_tests/Project.swift
@@ -12,7 +12,7 @@ let project = Project(name: "App",
                                      /* Target dependencies can be defined here */
                                      /* .framework(path: "framework") */
                                  ],
-                                 settings: TargetSettings(base: ["CODE_SIGN_IDENTITY": "",
+                                 settings: Settings(base: ["CODE_SIGN_IDENTITY": "",
                                                            "CODE_SIGNING_REQUIRED": "NO"])),
                           Target(name: "AppTests",
                                  platform: .iOS,
@@ -23,6 +23,6 @@ let project = Project(name: "App",
                                  dependencies: [
                                      .target(name: "App"),
                                  ],
-                                 settings: TargetSettings(base: ["CODE_SIGN_IDENTITY": "",
+                                 settings: Settings(base: ["CODE_SIGN_IDENTITY": "",
                                                            "CODE_SIGNING_REQUIRED": "NO"])),
 ])


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/160

### Short description 📝

Supporting more than one configuration is pretty common amongst projects, so this is something we should naturally support. The discussion around the approach can be found on #160.

I really wanted to capture a declarative way to describe configuration so that you really do not care about the underlying implementation. You say what you want and that's what you get.

There were some challenges to deal with:

1. Every project in the workspace has to have the same build configurations.
2. Dependencies probably won't define the same configurations as the root project, they may only care about `Debug` and `Release`.
3. Dependencies may care about the configurations defined by the root project but want to provide overrides specific to them.
4. Targets may specify configuration overrides in the form of more build settings, or more xcconfig files.

I managed to solve 1, 2, 3 and part of 4. 

In this pull request I do not implement the requirement for adding additional xcconfig overrides at the target level. If this is something you think is worth implementation [please open an issue](https://github.com/sky-uk/my-sky-app-evolution/issues/new) and quote this pull request.

### Solution 📦

The root project is important. The root project defines the base set of configurations which will be propagated throughout the rest of the loaded projects.

Each project has the ability to specify an xcconfig file as an override for each configuration.

If your module does not specify the configurations that the root project does by name then it will fall-back and find the configuration which matches the build configuration type (e.g. Debug or Release) and failing that it will not specify anything.

An example root project might look something like the following:

```swift
import ProjectDescription

let project = Project(
    name: "MyApp",
    settings: Settings(configurations: [
      .debug(name: "Integration", xcconfig: "Configs/App/Integration.xcconfig"),
      .debug(name: "Private Production", xcconfig: "Configs/App/PrivateProduction.xcconfig"),
      .debug(name: "E02", xcconfig: "Configs/App/E02.xcconfig"),
      .debug(name: "F02", xcconfig: "Configs/App/F02.xcconfig"),
      .release(name: "Automation", xcconfig: "Configs/App/Automation.xcconfig"),
      .release(name: "Production", xcconfig: "Configs/App/Production.xcconfig"),
    ]),
    targets: [
        Target(
            name: "App",
            platform: .iOS,
            product: .app,
            bundleId: "com.oliver.app",
            infoPlist: "Supporting/Info.plist",
            sources: "Sources/**",
            dependencies: [
                .project(target: "LayoutView", path: "Modules/LayoutView"),
                .project(target: "SortedCollection", path: "Modules/SortedCollection"),
            ]
        ),
        Target(
            name: "AppTests",
            platform: .iOS,
            product: .unitTests,
            bundleId: "com.oliver.app-tests",
            infoPlist: "Supporting/Tests.plist",
            sources: "Tests/**",
            dependencies: [
                .target(name: "App"),
            ]
        )
    ]
)
```

An example module project might look something like the following:

```swift
import ProjectDescription

let project = Project(
    name: "SortedCollection",
    settings: Settings(
        base: [ "ProjectBase": "YES" ],
        configurations: [
            .debug(name: "Debug", settings: [ "Project": "Debug" ], xcconfig: "Configs/Debug.xcconfig"),
            .release(name: "Release", settings: [ "Project": "Release" ], xcconfig: "Configs/Release.xcconfig"),
        ]
    ),
    targets: [
        Target(
            name: "SortedCollection",
            platform: Platform.iOS,
            product: Product.framework,
            bundleId: "com.bskyb.SortedCollection",
            infoPlist: "Info.plist",
            sources: "Sources/**",
            settings: TargetSettings(
                base: [ "ModuleBase": "YES" ],
                buildSettings: [
                    "Debug" : [ "Target": "Debug" ],
                    "Release" : [ "Target": "Release" ],
                ]
            )
        ),
        Target(
            name: "SortedCollectionTests",
            platform: Platform.iOS,
            product: Product.unitTests,
            bundleId: "com.bskyb.SortedCollectionTests",
            infoPlist: "Tests.plist",
            sources: "Tests/**",
            dependencies: [
                TargetDependency.target(name: "SortedCollection"),
            ],
            settings: TargetSettings(
                base: [ "TestBase": "YES" ],
                buildSettings: [
                    "Debug" : [ "Target": "Debug" ],
                    "Release" : [ "Target": "Release" ],
                ]
            )
        ),
    ]
)
```

In the above instance, if `tuist generate` is run on the root project then `SortedCollection` will inherit the build configurations `Integration`, `Private Production` ... and for each of those configurations it will apply the appropriate settings from it's own configuration. e.g. `Integration` will be assigned the `Debug` configuration.

This is currently a work in progress, so any feedback on the implementation and design is *greatly* appreciated.

We need to determine if the pattern described above is worth going for, or if there are any alternatives worth searching.