### PR TITLE
Model / linter tidy ups 

### DIFF
--- a/Sources/TuistKit/Graph/GraphLoader.swift
+++ b/Sources/TuistKit/Graph/GraphLoader.swift
@@ -61,7 +61,7 @@ class GraphLoader: GraphLoading {
     fileprivate func loadWorkspace(path: AbsolutePath) throws -> Graph {
         let cache = GraphLoaderCache()
         let circularDetector = GraphCircularDetector()
-        let workspace = try Workspace.at(path)
+        let workspace = try modelLoader.loadWorkspace(at: path)
         let projects = try workspace.projects.map { (projectPath) -> (AbsolutePath, Project) in
             try (projectPath, Project.at(projectPath, cache: cache, circularDetector: circularDetector, modelLoader: modelLoader))
         }

--- a/Sources/TuistKit/Linter/ProjectLinter.swift
+++ b/Sources/TuistKit/Linter/ProjectLinter.swift
@@ -11,16 +11,13 @@ class ProjectLinter: ProjectLinting {
 
     let targetLinter: TargetLinting
     let settingsLinter: SettingsLinting
-    let upLinter: UpLinting
 
     // MARK: - Init
 
     init(targetLinter: TargetLinting = TargetLinter(),
-         settingsLinter: SettingsLinting = SettingsLinter(),
-         upLinter: UpLinting = UpLinter()) {
+         settingsLinter: SettingsLinting = SettingsLinter()) {
         self.targetLinter = targetLinter
         self.settingsLinter = settingsLinter
-        self.upLinter = upLinter
     }
 
     // MARK: - ProjectLinting

--- a/Sources/TuistKit/Models/Project.swift
+++ b/Sources/TuistKit/Models/Project.swift
@@ -37,14 +37,15 @@ class Project: Equatable, CustomStringConvertible {
 
     // MARK: - Init
 
-    /// Parses the project manifest at the given path and returns a Project instance with the representation.
+    /// Returns a project model from the cache if present, otherwise loads a new instance.
     ///
     /// - Parameters:
-    ///   - path: Path to the folder that contains the project manifest.
+    ///   - path: Path of the project
     ///   - cache: Cache instance to cache projects and dependencies.
     ///   - circularDetector: Utility to find circular dependencies between targets.
-    /// - Returns: Initialized project.
-    /// - Throws: An error if the project has an invalid format.
+    ///   - modelLoader: Entity responsible for providing new instances of project models
+    /// - Returns: Project instance.
+    /// - Throws: An error if the project can't be loaded, or if circular dependencies are detected.
     static func at(_ path: AbsolutePath,
                    cache: GraphLoaderCaching,
                    circularDetector: GraphCircularDetecting,

--- a/Sources/TuistKit/Models/Scheme.swift
+++ b/Sources/TuistKit/Models/Scheme.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 
-class Scheme: JSONMappable, Equatable {
+class Scheme: Equatable {
     // MARK: - Attributes
 
     let name: String
@@ -24,14 +24,6 @@ class Scheme: JSONMappable, Equatable {
         self.runAction = runAction
     }
 
-    required init(json: JSON) throws {
-        name = try json.get("name")
-        shared = try json.get("shared")
-        buildAction = try? json.get("build_action")
-        testAction = try? json.get("test_action")
-        runAction = try? json.get("run_action")
-    }
-
     // MARK: - Equatable
 
     static func == (lhs: Scheme, rhs: Scheme) -> Bool {
@@ -43,7 +35,7 @@ class Scheme: JSONMappable, Equatable {
     }
 }
 
-class Arguments: JSONMappable, Equatable {
+class Arguments: Equatable {
     // MARK: - Attributes
 
     let environment: [String: String]
@@ -57,11 +49,6 @@ class Arguments: JSONMappable, Equatable {
         self.launch = launch
     }
 
-    required init(json: JSON) throws {
-        environment = try json.get("environment")
-        launch = try json.get("launch")
-    }
-
     // MARK: - Equatable
 
     static func == (lhs: Arguments, rhs: Arguments) -> Bool {
@@ -70,7 +57,7 @@ class Arguments: JSONMappable, Equatable {
     }
 }
 
-class BuildAction: JSONMappable, Equatable {
+class BuildAction: Equatable {
     // MARK: - Attributes
 
     let targets: [String]
@@ -81,10 +68,6 @@ class BuildAction: JSONMappable, Equatable {
         self.targets = targets
     }
 
-    required init(json: JSON) throws {
-        targets = try json.get("targets")
-    }
-
     // MARK: - Equatable
 
     static func == (lhs: BuildAction, rhs: BuildAction) -> Bool {
@@ -92,7 +75,7 @@ class BuildAction: JSONMappable, Equatable {
     }
 }
 
-class TestAction: JSONMappable, Equatable {
+class TestAction: Equatable {
     // MARK: - Attributes
 
     let targets: [String]
@@ -112,14 +95,6 @@ class TestAction: JSONMappable, Equatable {
         self.coverage = coverage
     }
 
-    required init(json: JSON) throws {
-        targets = try json.get("targets")
-        arguments = try? json.get("arguments")
-        let configString: String = try json.get("config")
-        config = BuildConfiguration(rawValue: configString)!
-        coverage = try json.get("coverage")
-    }
-
     // MARK: - Equatable
 
     static func == (lhs: TestAction, rhs: TestAction) -> Bool {
@@ -130,7 +105,7 @@ class TestAction: JSONMappable, Equatable {
     }
 }
 
-class RunAction: JSONMappable, Equatable {
+class RunAction: Equatable {
     // MARK: - Attributes
 
     let config: BuildConfiguration
@@ -145,13 +120,6 @@ class RunAction: JSONMappable, Equatable {
         self.config = config
         self.executable = executable
         self.arguments = arguments
-    }
-
-    required init(json: JSON) throws {
-        let configString: String = try json.get("config")
-        config = BuildConfiguration(rawValue: configString)!
-        executable = try? json.get("executable")
-        arguments = try? json.get("arguments")
     }
 
     // MARK: - Equatable

--- a/Sources/TuistKit/Models/Workspace.swift
+++ b/Sources/TuistKit/Models/Workspace.swift
@@ -15,18 +15,6 @@ class Workspace: Equatable {
         self.projects = projects
     }
 
-    static func at(_ path: AbsolutePath,
-                   fileHandler _: FileHandling = FileHandler(),
-                   manifestLoader: GraphManifestLoading = GraphManifestLoader()) throws -> Workspace {
-        let json = try manifestLoader.load(.workspace, path: path)
-
-        let projectsStrings: [String] = try json.get("projects")
-        let name: String = try json.get("name")
-        let projectsRelativePaths: [RelativePath] = projectsStrings.map({ RelativePath($0) })
-        let projects = projectsRelativePaths.map({ path.appending($0) })
-        return Workspace(name: name, projects: projects)
-    }
-
     // MARK: - Equatable
 
     static func == (lhs: Workspace, rhs: Workspace) -> Bool {

--- a/Tests/TuistKitTests/Generator/TestData/ProjectDescription+TestData.swift
+++ b/Tests/TuistKitTests/Generator/TestData/ProjectDescription+TestData.swift
@@ -64,3 +64,53 @@ extension TargetAction {
                             arguments: arguments)
     }
 }
+
+extension Scheme {
+    static func test(name: String = "Scheme",
+                     shared: Bool = false,
+                     buildAction: BuildAction? = nil,
+                     testAction: TestAction? = nil,
+                     runAction: RunAction? = nil) -> Scheme {
+        return Scheme(name: name,
+                      shared: shared,
+                      buildAction: buildAction,
+                      testAction: testAction,
+                      runAction: runAction)
+    }
+}
+
+extension BuildAction {
+    static func test(targets: [String] = []) -> BuildAction {
+        return BuildAction(targets: targets)
+    }
+}
+
+extension TestAction {
+    static func test(targets: [String] = [],
+                     arguments: Arguments? = nil,
+                     config: BuildConfiguration = .debug,
+                     coverage: Bool = true) -> TestAction {
+        return TestAction(targets: targets,
+                          arguments: arguments,
+                          config: config,
+                          coverage: coverage)
+    }
+}
+
+extension RunAction {
+    static func test(config: BuildConfiguration = .debug,
+                     executable: String? = nil,
+                     arguments: Arguments? = nil) -> RunAction {
+        return RunAction(config: config,
+                         executable: executable,
+                         arguments: arguments)
+    }
+}
+
+extension Arguments {
+    static func test(environment: [String: String] = [:],
+                     launch: [String: Bool] = [:]) -> Arguments {
+        return Arguments(environment: environment,
+                         launch: launch)
+    }
+}


### PR DESCRIPTION
### Short description 📝

A few tidy ups post some of the work done on [decoupling models from manifests JSON](https://github.com/tuist/tuist/pull/237) and [extracting Up from the project graph](https://github.com/tuist/tuist/pull/207)

### Implementation 👩‍💻👨‍💻

- Removed `JSON` initializers for `Workspace` and `Scheme` (was missed in the last update)
- Removed `UpLinter` from `ProjectLinter` (as it's no longer used within it)