### PR TITLE
Commands now use `Generator` component

### DIFF
--- a/Sources/TuistGenerator/Generator.swift
+++ b/Sources/TuistGenerator/Generator.swift
@@ -2,7 +2,7 @@ import Basic
 import TuistCore
 
 /// A component responsible for generating Xcode projects & workspaces
-public protocol Generating {
+protocol Generating {
 
     /// Generate an Xcode project at a given path.
     ///
@@ -31,7 +31,7 @@ public protocol Generating {
     func generateWorkspace(at path: AbsolutePath) throws -> AbsolutePath
 }
 
-public enum GeneratorError: FatalError {
+enum GeneratorError: FatalError {
     
     case notImplemented
     
@@ -53,12 +53,12 @@ public enum GeneratorError: FatalError {
 /// A default implementation of `Generating`
 ///
 /// - seealso: Generating
-public class Generator: Generating {
-    public func generateProject(at path: AbsolutePath) throws -> AbsolutePath {
+class Generator: Generating {
+    func generateProject(at path: AbsolutePath) throws -> AbsolutePath {
         throw GeneratorError.notImplemented
     }
 
-    public func generateWorkspace(at path: AbsolutePath) throws -> AbsolutePath {
+    func generateWorkspace(at path: AbsolutePath) throws -> AbsolutePath {
         throw GeneratorError.notImplemented
     }
 }

--- a/Sources/TuistKit/Generator/Generator.swift
+++ b/Sources/TuistKit/Generator/Generator.swift
@@ -1,0 +1,74 @@
+import Basic
+import Foundation
+import TuistCore
+
+struct GeneratorConfig {
+    
+    static let `default` =  GeneratorConfig()
+    
+    var options: GenerationOptions
+    var directory: GenerationDirectory
+    
+    init(options: GenerationOptions = GenerationOptions(),
+         directory: GenerationDirectory = .manifest) {
+        self.options = options
+        self.directory = directory
+    }
+}
+
+protocol Generating {
+    func generateProject(at path: AbsolutePath, config: GeneratorConfig) throws -> AbsolutePath
+    func generateWorkspace(at path: AbsolutePath, config: GeneratorConfig) throws -> AbsolutePath
+}
+
+extension Generating {
+    
+    func generate(at path: AbsolutePath,
+                  config: GeneratorConfig,
+                  manifestLoader: GraphManifestLoading) throws -> AbsolutePath {
+        let manifests = manifestLoader.manifests(at: path)
+        if manifests.contains(.workspace) {
+            return try generateWorkspace(at: path, config: config)
+        } else if manifests.contains(.project) {
+            return try generateProject(at: path, config: config)
+        } else {
+            throw GraphManifestLoaderError.manifestNotFound(path)
+        }
+    }
+}
+class Generator: Generating {
+    
+    private let graphLoader: GraphLoading
+    private let workspaceGenerator: WorkspaceGenerating
+    
+    init(system: Systeming = System(),
+         printer: Printing = Printer(),
+         resourceLocator: ResourceLocating = ResourceLocator(),
+         fileHandler: FileHandling = FileHandler(),
+         modelLoader: GeneratorModelLoading) {
+        self.graphLoader = GraphLoader(printer: printer, modelLoader: modelLoader)
+        self.workspaceGenerator = WorkspaceGenerator(system: system,
+                                                     printer: printer,
+                                                     resourceLocator: resourceLocator,
+                                                     projectDirectoryHelper: ProjectDirectoryHelper(),
+                                                     fileHandler: fileHandler)
+    }
+    
+    func generateProject(at path: AbsolutePath, config: GeneratorConfig) throws -> AbsolutePath {
+        let graph = try graphLoader.loadProject(path: path)
+        
+        return try workspaceGenerator.generate(path: path,
+                                               graph: graph,
+                                               options: config.options,
+                                               directory: config.directory)
+    }
+    
+    func generateWorkspace(at path: AbsolutePath, config: GeneratorConfig) throws -> AbsolutePath {
+        let graph = try graphLoader.loadWorkspace(path: path)
+        
+        return try workspaceGenerator.generate(path: path,
+                                               graph: graph,
+                                               options: config.options,
+                                               directory: config.directory)
+    }
+}

--- a/Sources/TuistKit/Graph/GraphLoader.swift
+++ b/Sources/TuistKit/Graph/GraphLoader.swift
@@ -3,62 +3,46 @@ import Foundation
 import TuistCore
 
 protocol GraphLoading: AnyObject {
-    func load(path: AbsolutePath) throws -> Graph
+    func loadProject(path: AbsolutePath) throws -> Graph
+    func loadWorkspace(path: AbsolutePath) throws -> Graph
 }
 
 class GraphLoader: GraphLoading {
     // MARK: - Attributes
-
+    
     let linter: GraphLinting
     let printer: Printing
     let fileHandler: FileHandling
-    let manifestLoader: GraphManifestLoading
     let modelLoader: GeneratorModelLoading
-
+    
     // MARK: - Init
-
+    
     init(linter: GraphLinting = GraphLinter(),
          printer: Printing = Printer(),
          fileHandler: FileHandling = FileHandler(),
-         manifestLoader: GraphManifestLoading = GraphManifestLoader(),
          modelLoader: GeneratorModelLoading) {
         self.linter = linter
         self.printer = printer
         self.fileHandler = fileHandler
-        self.manifestLoader = manifestLoader
         self.modelLoader = modelLoader
     }
-
-    func load(path: AbsolutePath) throws -> Graph {
-        var graph: Graph!
-        let manifests = manifestLoader.manifests(at: path)
-        if manifests.contains(.workspace) {
-            graph = try loadWorkspace(path: path)
-        } else if manifests.contains(.project) {
-            graph = try loadProject(path: path)
-        } else {
-            throw GraphLoadingError.manifestNotFound(path)
-        }
-        try linter.lint(graph: graph).printAndThrowIfNeeded(printer: printer)
-        return graph
-    }
-
-    // MARK: - Fileprivate
-
-    fileprivate func loadProject(path: AbsolutePath) throws -> Graph {
+    
+    func loadProject(path: AbsolutePath) throws -> Graph {
         let cache = GraphLoaderCache()
         let circularDetector = GraphCircularDetector()
         let project = try Project.at(path, cache: cache, circularDetector: circularDetector, modelLoader: modelLoader)
         let entryNodes: [GraphNode] = try project.targets.map({ $0.name }).map { targetName in
             try TargetNode.read(name: targetName, path: path, cache: cache, circularDetector: circularDetector, modelLoader: modelLoader)
         }
-        return Graph(name: project.name,
-                     entryPath: path,
-                     cache: cache,
-                     entryNodes: entryNodes)
+        let graph = Graph(name: project.name,
+                          entryPath: path,
+                          cache: cache,
+                          entryNodes: entryNodes)
+        try lint(graph: graph)
+        return graph
     }
-
-    fileprivate func loadWorkspace(path: AbsolutePath) throws -> Graph {
+    
+    func loadWorkspace(path: AbsolutePath) throws -> Graph {
         let cache = GraphLoaderCache()
         let circularDetector = GraphCircularDetector()
         let workspace = try modelLoader.loadWorkspace(at: path)
@@ -70,9 +54,16 @@ class GraphLoader: GraphLoading {
                 try TargetNode.read(name: targetName, path: project.0, cache: cache, circularDetector: circularDetector, modelLoader: modelLoader)
             }
         }
-        return Graph(name: workspace.name,
-                     entryPath: path,
-                     cache: cache,
-                     entryNodes: entryNodes)
+        let graph = Graph(name: workspace.name,
+                          entryPath: path,
+                          cache: cache,
+                          entryNodes: entryNodes)
+        
+        try lint(graph: graph)
+        return graph
+    }
+    
+    private func lint(graph: Graph) throws {
+        try linter.lint(graph: graph).printAndThrowIfNeeded(printer: printer)
     }
 }

--- a/Sources/TuistKit/Graph/GraphManifestLoader.swift
+++ b/Sources/TuistKit/Graph/GraphManifestLoader.swift
@@ -5,9 +5,13 @@ import TuistCore
 enum GraphManifestLoaderError: FatalError, Equatable {
     case projectDescriptionNotFound(AbsolutePath)
     case unexpectedOutput(AbsolutePath)
-    case manifestNotFound(Manifest, AbsolutePath)
+    case manifestNotFound(Manifest?, AbsolutePath)
     case setupNotFound(AbsolutePath)
 
+    static func manifestNotFound(_ path: AbsolutePath) -> GraphManifestLoaderError {
+        return .manifestNotFound(nil, path)
+    }
+    
     var description: String {
         switch self {
         case let .projectDescriptionNotFound(path):
@@ -15,9 +19,9 @@ enum GraphManifestLoaderError: FatalError, Equatable {
         case let .unexpectedOutput(path):
             return "Unexpected output trying to parse the manifest at path \(path.asString)"
         case let .manifestNotFound(manifest, path):
-            return "\(manifest.fileName) not found at \(path.asString)"
+            return "\(manifest?.fileName ?? "Manifest") not found at path \(path.asString)"
         case let .setupNotFound(path):
-            return "Setup.swift not found at \(path.asString)"
+            return "Setup.swift not found at path \(path.asString)"
         }
     }
 

--- a/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
@@ -9,52 +9,153 @@ import XCTest
 
 final class GenerateCommandTests: XCTestCase {
     var subject: GenerateCommand!
-    var errorHandler: MockErrorHandler!
-    var graphLoader: MockGraphLoader!
-    var workspaceGenerator: MockWorkspaceGenerator!
+    var generator: MockGenerator!
     var parser: ArgumentParser!
     var printer: MockPrinter!
-    var resourceLocator: ResourceLocator!
-
+    var fileHandler: MockFileHandler!
+    var manifestLoader: MockGraphManifestLoader!
+    
     override func setUp() {
         super.setUp()
-        printer = MockPrinter()
-        errorHandler = MockErrorHandler()
-        graphLoader = MockGraphLoader()
-        workspaceGenerator = MockWorkspaceGenerator()
-        parser = ArgumentParser.test()
-        resourceLocator = ResourceLocator()
-
-        subject = GenerateCommand(graphLoader: graphLoader,
-                                  workspaceGenerator: workspaceGenerator,
-                                  parser: parser,
-                                  printer: printer,
-                                  system: System(),
-                                  resourceLocator: resourceLocator)
+        do {
+            printer = MockPrinter()
+            generator = MockGenerator()
+            parser = ArgumentParser.test()
+            fileHandler = try MockFileHandler()
+            manifestLoader = MockGraphManifestLoader()
+            
+            subject = GenerateCommand(parser: parser,
+                                      printer: printer,
+                                      fileHandler: fileHandler,
+                                      generator: generator,
+                                      manifestLoader: manifestLoader)
+        } catch {
+            XCTFail("failed to setup test: \(error.localizedDescription)")
+        }
     }
-
+    
     func test_command() {
         XCTAssertEqual(GenerateCommand.command, "generate")
     }
-
+    
     func test_overview() {
         XCTAssertEqual(GenerateCommand.overview, "Generates an Xcode workspace to start working on the project.")
     }
-
-    func test_run_fatalErrors_when_theworkspaceGenerationFails() throws {
+    
+    func test_run_withProjectManifestPrints() throws {
+        // Given
         let result = try parser.parse([GenerateCommand.command])
-        let error = NSError.test()
-        workspaceGenerator.generateStub = { _, _, _, _ in
-            throw error
+        manifestLoader.manifestsAtStub = { _ in
+            return Set([.project])
         }
+        
+        // When
+        try subject.run(with: result)
+        
+        // Then
+        XCTAssertEqual(printer.printSuccessArgs.first, "Project generated.")
+    }
+    
+    func test_run_withWorkspacetManifestPrints() throws {
+        // Given
+        let result = try parser.parse([GenerateCommand.command])
+        manifestLoader.manifestsAtStub = { _ in
+            return Set([.workspace])
+        }
+        
+        // When
+        try subject.run(with: result)
+        
+        // Then
+        XCTAssertEqual(printer.printSuccessArgs.first, "Project generated.")
+    }
+    
+    func test_run_withRelativePathParamter() throws {
+        // Given
+        let path = fileHandler.currentPath
+        let result = try parser.parse([GenerateCommand.command, "--path", "subpath"])
+        var generationPath: AbsolutePath?
+        manifestLoader.manifestsAtStub = { _ in
+            return Set([.project])
+        }
+        generator.generateProjectStub = { path, _ in
+            generationPath = path
+            return path.appending(component: "project.xcworkspace")
+        }
+        
+        // When
+        try subject.run(with: result)
+        
+        // Then
+        XCTAssertEqual(generationPath, AbsolutePath("subpath", relativeTo: path))
+    }
+    
+    func test_run_withAbsoultePathParamter() throws {
+        // Given
+        let result = try parser.parse([GenerateCommand.command, "--path", "/some/path"])
+        var generationPath: AbsolutePath?
+        manifestLoader.manifestsAtStub = { _ in
+            return Set([.project])
+        }
+        generator.generateProjectStub = { path, _ in
+            generationPath = path
+            return path.appending(component: "project.xcworkspace")
+        }
+        
+        // When
+        try subject.run(with: result)
+        
+        // Then
+        XCTAssertEqual(generationPath, AbsolutePath("/some/path"))
+    }
+    
+    func test_run_withoutPathParamter() throws {
+        // Given
+        let result = try parser.parse([GenerateCommand.command])
+        var generationPath: AbsolutePath?
+        manifestLoader.manifestsAtStub = { _ in
+            return Set([.project])
+        }
+        generator.generateProjectStub = { path, _ in
+            generationPath = path
+            return path.appending(component: "project.xcworkspace")
+        }
+        
+        // When
+        try subject.run(with: result)
+        
+        // Then
+        XCTAssertEqual(generationPath, fileHandler.currentPath)
+    }
+    
+    func test_run_withMissingManifest_throws() throws {
+        // Given
+        let path = fileHandler.currentPath
+        let result = try parser.parse([GenerateCommand.command])
+        manifestLoader.manifestsAtStub = { _ in
+            return Set()
+        }
+        
+        // When / Then
         XCTAssertThrowsError(try subject.run(with: result)) {
-            XCTAssertEqual($0 as NSError?, error)
+            XCTAssertEqual($0 as? GraphManifestLoaderError, GraphManifestLoaderError.manifestNotFound(path))
         }
     }
-
-    func test_run_prints() throws {
+    
+    func test_run_fatalErrors_when_theworkspaceGenerationFails() throws {
+        // Given
         let result = try parser.parse([GenerateCommand.command])
-        try subject.run(with: result)
-        XCTAssertEqual(printer.printSuccessArgs.first, "Project generated.")
+        let error = NSError.test()
+        manifestLoader.manifestsAtStub = { _ in
+            return Set([.project])
+        }
+        generator.generateProjectStub = { _, _ in
+            throw error
+        }
+        
+        // When / Then
+        XCTAssertThrowsError(try subject.run(with: result)) {
+            XCTAssertEqual($0 as NSError, error)
+        }
     }
 }

--- a/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
@@ -70,7 +70,7 @@ final class GenerateCommandTests: XCTestCase {
         XCTAssertEqual(printer.printSuccessArgs.first, "Project generated.")
     }
     
-    func test_run_withRelativePathParamter() throws {
+    func test_run_withRelativePathParameter() throws {
         // Given
         let path = fileHandler.currentPath
         let result = try parser.parse([GenerateCommand.command, "--path", "subpath"])
@@ -90,7 +90,7 @@ final class GenerateCommandTests: XCTestCase {
         XCTAssertEqual(generationPath, AbsolutePath("subpath", relativeTo: path))
     }
     
-    func test_run_withAbsoultePathParamter() throws {
+    func test_run_withAbsoultePathParameter() throws {
         // Given
         let result = try parser.parse([GenerateCommand.command, "--path", "/some/path"])
         var generationPath: AbsolutePath?
@@ -109,7 +109,7 @@ final class GenerateCommandTests: XCTestCase {
         XCTAssertEqual(generationPath, AbsolutePath("/some/path"))
     }
     
-    func test_run_withoutPathParamter() throws {
+    func test_run_withoutPathParameter() throws {
         // Given
         let result = try parser.parse([GenerateCommand.command])
         var generationPath: AbsolutePath?

--- a/Tests/TuistKitTests/Generator/Mocks/MockGenerator.swift
+++ b/Tests/TuistKitTests/Generator/Mocks/MockGenerator.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Basic
+@testable import TuistKit
+
+class MockGenerator: Generating {
+    var generateProjectStub: ((AbsolutePath, GeneratorConfig) throws -> AbsolutePath)?
+    func generateProject(at path: AbsolutePath, config: GeneratorConfig) throws -> AbsolutePath {
+        return try generateProjectStub?(path, config) ?? AbsolutePath("/test")
+    }
+    
+    var generateWorkspaceStub: ((AbsolutePath, GeneratorConfig) throws -> AbsolutePath)?
+    func generateWorkspace(at path: AbsolutePath, config: GeneratorConfig) throws -> AbsolutePath {
+        return try generateWorkspaceStub?(path, config) ?? AbsolutePath("/test")
+    }
+}

--- a/Tests/TuistKitTests/Graph/GraphManifestLoaderTests.swift
+++ b/Tests/TuistKitTests/Graph/GraphManifestLoaderTests.swift
@@ -8,8 +8,9 @@ final class GraphManifestLoaderErrorTests: XCTestCase {
     func test_description() {
         XCTAssertEqual(GraphManifestLoaderError.projectDescriptionNotFound(AbsolutePath("/test")).description, "Couldn't find ProjectDescription.framework at path /test")
         XCTAssertEqual(GraphManifestLoaderError.unexpectedOutput(AbsolutePath("/test/")).description, "Unexpected output trying to parse the manifest at path /test")
-        XCTAssertEqual(GraphManifestLoaderError.manifestNotFound(.project, AbsolutePath("/test/")).description, "Project.swift not found at /test")
-        XCTAssertEqual(GraphManifestLoaderError.setupNotFound(AbsolutePath("/test/")).description, "Setup.swift not found at /test")
+        XCTAssertEqual(GraphManifestLoaderError.manifestNotFound(.project, AbsolutePath("/test/")).description, "Project.swift not found at path /test")
+        XCTAssertEqual(GraphManifestLoaderError.manifestNotFound(nil, AbsolutePath("/test/")).description, "Manifest not found at path /test")
+        XCTAssertEqual(GraphManifestLoaderError.setupNotFound(AbsolutePath("/test/")).description, "Setup.swift not found at path /test")
     }
 
     func test_type() {

--- a/Tests/TuistKitTests/Graph/Mocks/MockGraphLoader.swift
+++ b/Tests/TuistKitTests/Graph/Mocks/MockGraphLoader.swift
@@ -3,9 +3,13 @@ import Foundation
 @testable import TuistKit
 
 final class MockGraphLoader: GraphLoading {
-    var loadStub: ((AbsolutePath) throws -> Graph)?
-
-    func load(path: AbsolutePath) throws -> Graph {
-        return try loadStub?(path) ?? Graph.test()
+    var loadProjectStub: ((AbsolutePath) throws -> Graph)?
+    func loadProject(path: AbsolutePath) throws -> Graph {
+        return try loadProjectStub?(path) ?? Graph.test()
+    }
+    
+    var loadWorkspaceStub: ((AbsolutePath) throws -> Graph)?
+    func loadWorkspace(path: AbsolutePath) throws -> Graph {
+        return try loadWorkspaceStub?(path) ?? Graph.test()
     }
 }

--- a/features/generate.feature
+++ b/features/generate.feature
@@ -28,7 +28,7 @@ Feature: Generate a new project using Tuist
     Given that tuist is available
     And I have a working directory
     Then I copy the fixture invalid_workspace_manifest_name into the working directory
-    Then tuist generates reports error "❌ Error: Couldn't find manifest at path: '${ARG_PATH}'"
+    Then tuist generates reports error "❌ Error: Manifest not found at path ${ARG_PATH}"
 
   Scenario: The project is an iOS application with frameworks and tests (ios_app_with_static_libraries)
     Given that tuist is available


### PR DESCRIPTION
Part of: #205

### Short description 📝

To ease the migration of classes to the generator library (see [POC branch](https://github.com/bloomberg/tuist/tree/feature/205-tuist-generator-library)), commands are being decoupled from the workspace generator / graph loader components. 

### Implementation 👩‍💻👨‍💻

- Adding a `Generator` component (temporarily to `TuistKit`)
   - This component will later move to `TuistGenerator`
- `GraphLoader` no longer depends on the `GraphManifestLoader`
- Focus command no longer has a `--config` option as it's no longer used
- Adding more tests for the generate command

### Test Plan ⚒

- Ensure unit tests pass `swift test`
- Ensure acceptance tests pass `bundle exec rake features`
- Navigate to any of the fixtures and test out `tuist focus`
