### PR TITLE
 Manifest loader now returns concrete manifest objects

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
     targets: [
         .target(
             name: "TuistKit",
-            dependencies: ["xcodeproj", "Utility", "TuistCore", "TuistGenerator"]
+            dependencies: ["xcodeproj", "Utility", "TuistCore", "TuistGenerator", "ProjectDescription"]
         ),
         .testTarget(
             name: "TuistKitTests",

--- a/Sources/ProjectDescription/CoreDataModel.swift
+++ b/Sources/ProjectDescription/CoreDataModel.swift
@@ -3,10 +3,10 @@ import Foundation
 /// Core Data model.
 public class CoreDataModel: Codable {
     /// Relative path to the model.
-    let path: String
+    public let path: String
 
     /// Current version (with or without extension)
-    let currentVersion: String
+    public let currentVersion: String
 
     public enum CodingKeys: String, CodingKey {
         case path

--- a/Sources/ProjectDescription/Headers.swift
+++ b/Sources/ProjectDescription/Headers.swift
@@ -3,13 +3,13 @@ import Foundation
 /// Headers
 public class Headers: Codable {
     /// Relative path to public headers.
-    let `public`: String?
+    public let `public`: String?
 
     /// Relative path to private headers.
-    let `private`: String?
+    public let `private`: String?
 
     /// Relative path to project headers.
-    let project: String?
+    public let project: String?
 
     public init(public: String? = nil,
                 private: String? = nil,

--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -4,46 +4,46 @@ import Foundation
 
 public class Target: Codable {
     /// Target name.
-    let name: String
+    public let name: String
 
     /// Product platform.
-    let platform: Platform
+    public let platform: Platform
 
     /// Product type.
-    let product: Product
+    public let product: Product
 
     /// Bundle identifier.
-    let bundleId: String
+    public let bundleId: String
 
     /// Relative path to the Info.plist file.
-    let infoPlist: String
+    public let infoPlist: String
 
     /// Relative path to the entitlements file.
-    let entitlements: String?
+    public let entitlements: String?
 
     /// Target settings.
-    let settings: Settings?
+    public let settings: Settings?
 
     /// Target dependencies.
-    let dependencies: [TargetDependency]
+    public let dependencies: [TargetDependency]
 
     /// Relative path to the sources directory.
-    let sources: String
+    public let sources: String
 
     /// Relative path to the resources directory.
-    let resources: String?
+    public let resources: String?
 
     /// Headers.
-    let headers: Headers?
+    public let headers: Headers?
 
     /// Target actions.
-    let actions: [TargetAction]
+    public let actions: [TargetAction]
 
     /// CoreData models.
-    let coreDataModels: [CoreDataModel]
+    public let coreDataModels: [CoreDataModel]
 
     /// Environment variables to be exposed to the target.
-    let environment: [String: String]
+    public let environment: [String: String]
 
     public enum CodingKeys: String, CodingKey {
         case name

--- a/Sources/ProjectDescription/TargetAction.swift
+++ b/Sources/ProjectDescription/TargetAction.swift
@@ -5,25 +5,25 @@ public struct TargetAction: Codable {
     ///
     /// - pre: Before the sources and resources build phase.
     /// - post: After the sources and resources build phase.
-    enum Order: String, Codable {
+    public enum Order: String, Codable {
         case pre
         case post
     }
 
     /// Name of the build phase when the project gets generated.
-    private let name: String
+    public let name: String
 
     /// Name of the tool to execute. Tuist will look up the tool on the environment's PATH.
-    private let tool: String?
+    public let tool: String?
 
     /// Path to the script to execute.
-    private let path: String?
+    public let path: String?
 
     /// Target action order.
-    private let order: Order
+    public let order: Order
 
     /// Arguments that to be passed.
-    private let arguments: [String]
+    public let arguments: [String]
 
     public enum CodingKeys: String, CodingKey {
         case name

--- a/Sources/TuistKit/Commands/DumpCommand.swift
+++ b/Sources/TuistKit/Commands/DumpCommand.swift
@@ -49,7 +49,8 @@ class DumpCommand: NSObject, Command {
         } else {
             path = AbsolutePath.current
         }
-        let json: JSON = try manifestLoader.load(.project, path: path)
+        let project = try manifestLoader.loadProject(at: path)
+        let json: JSON = try project.toJSON()
         printer.print(json.toString(prettyPrint: true))
     }
 }

--- a/Sources/TuistKit/Extensions/Encodable+JSON.swift
+++ b/Sources/TuistKit/Extensions/Encodable+JSON.swift
@@ -1,0 +1,14 @@
+//
+// Created by kwridan on 2/23/19. 
+//
+
+import Foundation
+import Basic
+
+extension Encodable {
+    func toJSON() throws -> JSON {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(self)
+        return try JSON(data: data)
+    }
+}

--- a/Sources/TuistKit/Extensions/Encodable+JSON.swift
+++ b/Sources/TuistKit/Extensions/Encodable+JSON.swift
@@ -1,7 +1,3 @@
-//
-// Created by kwridan on 2/23/19. 
-//
-
 import Foundation
 import Basic
 

--- a/Sources/TuistKit/Extensions/Encodable+JSON.swift
+++ b/Sources/TuistKit/Extensions/Encodable+JSON.swift
@@ -1,5 +1,5 @@
-import Foundation
 import Basic
+import Foundation
 
 extension Encodable {
     func toJSON() throws -> JSON {

--- a/Sources/TuistKit/Graph/GraphManifestLoader.swift
+++ b/Sources/TuistKit/Graph/GraphManifestLoader.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import ProjectDescription
+import TuistCore
 
 enum GraphManifestLoaderError: FatalError, Equatable {
     case projectDescriptionNotFound(AbsolutePath)
@@ -89,10 +89,10 @@ class GraphManifestLoader: GraphManifestLoading {
 
     /// Depreactor to notify about deprecations.
     let deprecator: Deprecating
-    
+
     /// A decoder instance for decoding the raw manifest data to their concrete types
     private let decoder: JSONDecoder
-    
+
     // MARK: - Init
 
     /// Initializes the manifest loader with its attributes.
@@ -110,7 +110,7 @@ class GraphManifestLoader: GraphManifestLoading {
         self.system = system
         self.resourceLocator = resourceLocator
         self.deprecator = deprecator
-        self.decoder = JSONDecoder()
+        decoder = JSONDecoder()
     }
 
     func manifestPath(at path: AbsolutePath, manifest: Manifest) throws -> AbsolutePath {
@@ -132,11 +132,11 @@ class GraphManifestLoader: GraphManifestLoading {
     func loadProject(at path: AbsolutePath) throws -> ProjectDescription.Project {
         return try loadManifest(.project, at: path)
     }
-    
+
     func loadWorkspace(at path: AbsolutePath) throws -> ProjectDescription.Workspace {
         return try loadManifest(.workspace, at: path)
     }
-    
+
     func loadSetup(at path: AbsolutePath) throws -> [Upping] {
         let setupPath = path.appending(component: Manifest.setup.fileName)
         guard fileHandler.exists(setupPath) else {
@@ -162,7 +162,7 @@ class GraphManifestLoader: GraphManifestLoading {
         let data = try loadManifestData(at: manifestPath)
         return try decoder.decode(T.self, from: data)
     }
-    
+
     private func loadManifestData(at path: AbsolutePath) throws -> Data {
         let projectDescriptionPath = try resourceLocator.projectDescription()
         var arguments: [String] = [
@@ -182,7 +182,7 @@ class GraphManifestLoader: GraphManifestLoading {
             let data = jsonString.data(using: .utf8) else {
             throw GraphManifestLoaderError.unexpectedOutput(path)
         }
-        
+
         return data
     }
 }

--- a/Sources/TuistKit/Graph/GraphManifestLoader.swift
+++ b/Sources/TuistKit/Graph/GraphManifestLoader.swift
@@ -89,7 +89,10 @@ class GraphManifestLoader: GraphManifestLoading {
 
     /// Depreactor to notify about deprecations.
     let deprecator: Deprecating
-
+    
+    /// A decoder instance for decoding the raw manifest data to their concrete types
+    private let decoder: JSONDecoder
+    
     // MARK: - Init
 
     /// Initializes the manifest loader with its attributes.
@@ -107,6 +110,7 @@ class GraphManifestLoader: GraphManifestLoading {
         self.system = system
         self.resourceLocator = resourceLocator
         self.deprecator = deprecator
+        self.decoder = JSONDecoder()
     }
 
     func manifestPath(at path: AbsolutePath, manifest: Manifest) throws -> AbsolutePath {
@@ -156,7 +160,7 @@ class GraphManifestLoader: GraphManifestLoading {
             throw GraphManifestLoaderError.manifestNotFound(manifest, path)
         }
         let data = try loadManifestData(at: manifestPath)
-        return try JSONDecoder().decode(T.self, from: data)
+        return try decoder.decode(T.self, from: data)
     }
     
     private func loadManifestData(at path: AbsolutePath) throws -> Data {

--- a/Tests/TuistKitTests/Generator/GeneratorModelLoaderTest.swift
+++ b/Tests/TuistKitTests/Generator/GeneratorModelLoaderTest.swift
@@ -103,7 +103,7 @@ class GeneratorModelLoaderTest: XCTestCase {
         let manifests = [
             path: WorkspaceManifest.test(name: "SomeWorkspace", projects: ["A", "B"]),
         ]
-        
+
         let manifestLoader = createManifestLoader(with: manifests)
         let subject = GeneratorModelLoader(fileHandler: fileHandler,
                                            manifestLoader: manifestLoader)
@@ -124,7 +124,7 @@ class GeneratorModelLoaderTest: XCTestCase {
 
         // When
         let model = TuistKit.Settings.from(manifest: manifest, path: path)
-        
+
         // Then
         assert(settings: model, matches: manifest, at: path)
     }
@@ -147,7 +147,7 @@ class GeneratorModelLoaderTest: XCTestCase {
 
         // When
         let model = TuistKit.Headers.from(manifest: manifest, path: path, fileHandler: fileHandler)
-        
+
         // Then
         XCTAssertEqual(model.public, [
             publicPath.appending(component: "a.h"),
@@ -169,7 +169,7 @@ class GeneratorModelLoaderTest: XCTestCase {
 
         // When
         let model = try TuistKit.CoreDataModel.from(manifest: manifest, path: path, fileHandler: fileHandler)
-        
+
         // Then
         XCTAssertTrue(coreDataModel(model, matches: manifest, at: path))
     }
@@ -183,7 +183,7 @@ class GeneratorModelLoaderTest: XCTestCase {
                                                             arguments: ["arg1", "arg2"])
         // When
         let model = TuistKit.TargetAction.from(manifest: manifest, path: path)
-        
+
         // Then
         XCTAssertEqual(model.name, "MyScript")
         XCTAssertEqual(model.tool, "my_tool")
@@ -191,14 +191,14 @@ class GeneratorModelLoaderTest: XCTestCase {
         XCTAssertEqual(model.order, .pre)
         XCTAssertEqual(model.arguments, ["arg1", "arg2"])
     }
-    
+
     func test_scheme_withoutActions() throws {
         // Given
         let manifest = SchemeManifest.test(name: "Scheme",
                                            shared: false)
         // When
         let model = TuistKit.Scheme.from(manifest: manifest)
-        
+
         // Then
         assert(scheme: model, matches: manifest)
     }
@@ -223,29 +223,29 @@ class GeneratorModelLoaderTest: XCTestCase {
                                            runAction: runActions)
         // When
         let model = TuistKit.Scheme.from(manifest: manifest)
-        
+
         // Then
         assert(scheme: model, matches: manifest)
     }
-    
+
     func test_platform_watchOSNotSupported() {
         XCTAssertThrowsError(
             try TuistKit.Platform.from(manifest: .watchOS)
         ) { error in
-            XCTAssertEqual(error as? GeneratorModelLoaderError, GeneratorModelLoaderError.featureNotYetSupported("watchOS platform") )
+            XCTAssertEqual(error as? GeneratorModelLoaderError, GeneratorModelLoaderError.featureNotYetSupported("watchOS platform"))
         }
     }
-    
+
     func test_generatorModelLoaderError_type() {
         XCTAssertEqual(GeneratorModelLoaderError.featureNotYetSupported("").type, .abort)
     }
-    
+
     func test_generatorModelLoaderError_description() {
         XCTAssertEqual(GeneratorModelLoaderError.featureNotYetSupported("abc").description, "abc is not yet supported")
     }
-    
+
     // MARK: - Helpers
-    
+
     func createManifestLoader(with projects: [AbsolutePath: ProjectDescription.Project]) -> GraphManifestLoading {
         let manifestLoader = MockGraphManifestLoader()
         manifestLoader.loadProjectStub = { path in
@@ -256,7 +256,7 @@ class GeneratorModelLoaderTest: XCTestCase {
         }
         return manifestLoader
     }
-    
+
     func createManifestLoader(with workspaces: [AbsolutePath: ProjectDescription.Workspace]) -> GraphManifestLoading {
         let manifestLoader = MockGraphManifestLoader()
         manifestLoader.loadWorkspaceStub = { path in
@@ -407,7 +407,7 @@ private func == (_ lhs: TuistKit.Platform,
     let map: [TuistKit.Platform: ProjectDescription.Platform] = [
         .iOS: .iOS,
         .macOS: .macOS,
-        .tvOS: .tvOS
+        .tvOS: .tvOS,
     ]
     return map[lhs] != nil
 }

--- a/Tests/TuistKitTests/Generator/GeneratorModelLoaderTest.swift
+++ b/Tests/TuistKitTests/Generator/GeneratorModelLoaderTest.swift
@@ -100,10 +100,10 @@ class GeneratorModelLoaderTest: XCTestCase {
     func test_loadWorkspace_withProjects() throws {
         // Given
         let path = AbsolutePath("/root/")
-        let manifests: [AbsolutePath: Encodable] = [
+        let manifests = [
             path: WorkspaceManifest.test(name: "SomeWorkspace", projects: ["A", "B"]),
         ]
-
+        
         let manifestLoader = createManifestLoader(with: manifests)
         let subject = GeneratorModelLoader(fileHandler: fileHandler,
                                            manifestLoader: manifestLoader)
@@ -123,8 +123,8 @@ class GeneratorModelLoaderTest: XCTestCase {
         let manifest = SettingsManifest(base: ["base": "base"], debug: debug, release: release)
 
         // When
-        let model = try TuistKit.Settings.from(json: manifest.toJSON(), path: path, fileHandler: fileHandler)
-
+        let model = TuistKit.Settings.from(manifest: manifest, path: path)
+        
         // Then
         assert(settings: model, matches: manifest, at: path)
     }
@@ -146,8 +146,8 @@ class GeneratorModelLoaderTest: XCTestCase {
         let manifest = HeadersManifest(public: "public/*.h", private: "private/*.h", project: "project/*.h")
 
         // When
-        let model = try TuistKit.Headers.from(json: manifest.toJSON(), path: path, fileHandler: fileHandler)
-
+        let model = TuistKit.Headers.from(manifest: manifest, path: path, fileHandler: fileHandler)
+        
         // Then
         XCTAssertEqual(model.public, [
             publicPath.appending(component: "a.h"),
@@ -168,8 +168,8 @@ class GeneratorModelLoaderTest: XCTestCase {
                                                         currentVersion: "1")
 
         // When
-        let model = try TuistKit.CoreDataModel.from(json: manifest.toJSON(), path: path, fileHandler: fileHandler)
-
+        let model = try TuistKit.CoreDataModel.from(manifest: manifest, path: path, fileHandler: fileHandler)
+        
         // Then
         XCTAssertTrue(coreDataModel(model, matches: manifest, at: path))
     }
@@ -182,8 +182,8 @@ class GeneratorModelLoaderTest: XCTestCase {
                                                             order: .pre,
                                                             arguments: ["arg1", "arg2"])
         // When
-        let model = try TuistKit.TargetAction.from(json: manifest.toJSON(), path: path, fileHandler: fileHandler)
-
+        let model = TuistKit.TargetAction.from(manifest: manifest, path: path)
+        
         // Then
         XCTAssertEqual(model.name, "MyScript")
         XCTAssertEqual(model.tool, "my_tool")
@@ -191,69 +191,14 @@ class GeneratorModelLoaderTest: XCTestCase {
         XCTAssertEqual(model.order, .pre)
         XCTAssertEqual(model.arguments, ["arg1", "arg2"])
     }
-
-    func test_target_invalidProduct() throws {
-        // Given
-        let malformedManifest = [
-            "name": "malformed",
-            "product": "<invalid>",
-            "platform": "ios",
-        ]
-        // When / Then
-        XCTAssertThrowsError(
-            try TuistKit.Target.from(json: malformedManifest.toJSON(), path: path, fileHandler: fileHandler)
-        ) { error in
-            XCTAssertEqual(error as? GeneratorModelLoaderError,
-                           GeneratorModelLoaderError.malformedManifest("unrecognized product '<invalid>'"))
-        }
-    }
-
-    func test_target_invalidPlatform() throws {
-        // Given
-        let malformedManifest = [
-            "name": "malformed",
-            "product": "framework",
-            "platform": "<invalid>",
-        ]
-
-        // When / Then
-        XCTAssertThrowsError(
-            try TuistKit.Target.from(json: malformedManifest.toJSON(), path: path, fileHandler: fileHandler)
-        ) { error in
-            XCTAssertEqual(error as? GeneratorModelLoaderError,
-                           GeneratorModelLoaderError.malformedManifest("unrecognized platform '<invalid>'"))
-        }
-    }
-
-    func test_target_invalidDependency() throws {
-        // Given
-        let malformedManifest = ["type": "<invalid>"]
-
-        // When / Then
-        XCTAssertThrowsError(
-            try TuistKit.Dependency.from(json: malformedManifest.toJSON(), path: path, fileHandler: fileHandler)
-        ) { error in
-            XCTAssertEqual(error as? GeneratorModelLoaderError,
-                           GeneratorModelLoaderError.malformedManifest("unrecognized dependency type '<invalid>'"))
-        }
-    }
-
-    func test_modelLoaderError_description() {
-        XCTAssertEqual(GeneratorModelLoaderError.malformedManifest("invalid product").description,
-                       "The Project manifest appears to be malformed: invalid product")
-    }
-
-    func test_modelLoaderError_errorType() {
-        XCTAssertEqual(GeneratorModelLoaderError.malformedManifest("invalid product").type, .abort)
-    }
-
+    
     func test_scheme_withoutActions() throws {
         // Given
         let manifest = SchemeManifest.test(name: "Scheme",
                                            shared: false)
         // When
-        let model = try TuistKit.Scheme.from(json: try manifest.toJSON())
-
+        let model = TuistKit.Scheme.from(manifest: manifest)
+        
         // Then
         assert(scheme: model, matches: manifest)
     }
@@ -277,21 +222,48 @@ class GeneratorModelLoaderTest: XCTestCase {
                                            testAction: testAction,
                                            runAction: runActions)
         // When
-        let model = try TuistKit.Scheme.from(json: try manifest.toJSON())
-
+        let model = TuistKit.Scheme.from(manifest: manifest)
+        
         // Then
         assert(scheme: model, matches: manifest)
     }
-
+    
+    func test_platform_watchOSNotSupported() {
+        XCTAssertThrowsError(
+            try TuistKit.Platform.from(manifest: .watchOS)
+        ) { error in
+            XCTAssertEqual(error as? GeneratorModelLoaderError, GeneratorModelLoaderError.featureNotYetSupported("watchOS platform") )
+        }
+    }
+    
+    func test_generatorModelLoaderError_type() {
+        XCTAssertEqual(GeneratorModelLoaderError.featureNotYetSupported("").type, .abort)
+    }
+    
+    func test_generatorModelLoaderError_description() {
+        XCTAssertEqual(GeneratorModelLoaderError.featureNotYetSupported("abc").description, "abc is not yet supported")
+    }
+    
     // MARK: - Helpers
-
-    func createManifestLoader(with manifests: [AbsolutePath: Encodable]) -> GraphManifestLoading {
+    
+    func createManifestLoader(with projects: [AbsolutePath: ProjectDescription.Project]) -> GraphManifestLoading {
         let manifestLoader = MockGraphManifestLoader()
-        manifestLoader.loadStub = { _, path in
-            guard let manifest = manifests[path] else {
+        manifestLoader.loadProjectStub = { path in
+            guard let manifest = projects[path] else {
                 throw GraphLoadingError.manifestNotFound(path)
             }
-            return try manifest.toJSON()
+            return manifest
+        }
+        return manifestLoader
+    }
+    
+    func createManifestLoader(with workspaces: [AbsolutePath: ProjectDescription.Workspace]) -> GraphManifestLoading {
+        let manifestLoader = MockGraphManifestLoader()
+        manifestLoader.loadWorkspaceStub = { path in
+            guard let manifest = workspaces[path] else {
+                throw GraphLoadingError.manifestNotFound(path)
+            }
+            return manifest
         }
         return manifestLoader
     }
@@ -435,6 +407,7 @@ private func == (_ lhs: TuistKit.Platform,
     let map: [TuistKit.Platform: ProjectDescription.Platform] = [
         .iOS: .iOS,
         .macOS: .macOS,
+        .tvOS: .tvOS
     ]
     return map[lhs] != nil
 }
@@ -459,14 +432,6 @@ private func == (_ lhs: TuistKit.BuildConfiguration,
         .release: .release,
     ]
     return map[lhs] != nil
-}
-
-private extension Encodable {
-    func toJSON() throws -> JSON {
-        let encoder = JSONEncoder()
-        let data = try encoder.encode(self)
-        return try JSON(data: data)
-    }
 }
 
 extension AbsolutePath: ExpressibleByStringLiteral {

--- a/Tests/TuistKitTests/Graph/GraphManifestLoaderTests.swift
+++ b/Tests/TuistKitTests/Graph/GraphManifestLoaderTests.swift
@@ -40,34 +40,124 @@ final class GraphManifestLoaderTests: XCTestCase {
                                       deprecator: deprecator)
     }
 
-    func test_load_when_swift() throws {
+    func test_loadProject() throws {
+        // Given
         let content = """
         import ProjectDescription
         let project = Project(name: "tuist")
         """
-
+        
         let manifestPath = fileHandler.currentPath.appending(component: Manifest.project.fileName)
         try content.write(to: manifestPath.url,
                           atomically: true,
                           encoding: .utf8)
-
+        
+        // When
         let got = try subject.loadProject(at: fileHandler.currentPath)
+        
+        // Then
+        
         XCTAssertEqual(got.name, "tuist")
     }
-
-    func test_manifestPath_when_swift() throws {
-        try fileHandler.touch(fileHandler.currentPath.appending(component: Manifest.project.fileName))
-        let got = try subject.manifestPath(at: fileHandler.currentPath, manifest: .project)
-
-        XCTAssertEqual(got, fileHandler.currentPath.appending(component: Manifest.project.fileName))
+    
+    func test_loadWorkspace() throws {
+        // Given
+        let content = """
+        import ProjectDescription
+        let workspace = Workspace(name: "tuist", projects: [])
+        """
+        
+        let manifestPath = fileHandler.currentPath.appending(component: Manifest.workspace.fileName)
+        try content.write(to: manifestPath.url,
+                          atomically: true,
+                          encoding: .utf8)
+        
+        // When
+        let got = try subject.loadWorkspace(at: fileHandler.currentPath)
+        
+        // Then
+        XCTAssertEqual(got.name, "tuist")
+    }
+    
+    func test_loadSetup() throws {
+        // Given
+        let content = """
+        import ProjectDescription
+        let setup = Setup([
+                        .custom(name: "hello", meet: ["a", "b"], isMet: ["c"])
+                    ])
+        """
+        
+        let manifestPath = fileHandler.currentPath.appending(component: Manifest.setup.fileName)
+        try content.write(to: manifestPath.url,
+                          atomically: true,
+                          encoding: .utf8)
+        
+        // When
+        let got = try subject.loadSetup(at: fileHandler.currentPath)
+        
+        // Then
+        let customUp = got.first as? UpCustom
+        XCTAssertEqual(got.count, 1)
+        XCTAssertEqual(customUp?.name, "hello")
+        XCTAssertEqual(customUp?.meet, ["a", "b"])
+        XCTAssertEqual(customUp?.isMet, ["c"])
+    }
+    
+    func test_load_invalidFormat() throws {
+        // Given
+        let content = """
+        import ABC
+        let project
+        """
+        
+        let manifestPath = fileHandler.currentPath.appending(component: Manifest.project.fileName)
+        try content.write(to: manifestPath.url,
+                          atomically: true,
+                          encoding: .utf8)
+        
+        // When / Then
+        XCTAssertThrowsError(
+            try subject.loadProject(at: fileHandler.currentPath)
+        )
+    }
+    
+    func test_load_missingManifest() throws {
+        XCTAssertThrowsError(
+            try subject.loadProject(at: fileHandler.currentPath)
+        ) { error in
+            XCTAssertEqual(error as? GraphManifestLoaderError, GraphManifestLoaderError.manifestNotFound(.project, fileHandler.currentPath))
+        }
     }
 
-    func test_manifestsAt_when_swift() throws {
+    func test_manifestPath() throws {
+        // Given
+        let manifestsPaths = Manifest.allCases.map {
+            fileHandler.currentPath.appending(component: $0.fileName)
+        }
+        try manifestsPaths.forEach { try fileHandler.touch($0) }
+        
+        // When
+        let got = try Manifest.allCases.map {
+            try subject.manifestPath(at: fileHandler.currentPath, manifest: $0)
+        }
+
+        // Then
+        XCTAssertEqual(got, manifestsPaths)
+    }
+
+    func test_manifestsAt() throws {
+        // Given
         try fileHandler.touch(fileHandler.currentPath.appending(component: "Project.swift"))
         try fileHandler.touch(fileHandler.currentPath.appending(component: "Workspace.swift"))
+        try fileHandler.touch(fileHandler.currentPath.appending(component: "Setup.swift"))
+        
+        // When
         let got = subject.manifests(at: fileHandler.currentPath)
 
+        // Then
         XCTAssertTrue(got.contains(.project))
         XCTAssertTrue(got.contains(.workspace))
+        XCTAssertTrue(got.contains(.setup))
     }
 }

--- a/Tests/TuistKitTests/Graph/GraphManifestLoaderTests.swift
+++ b/Tests/TuistKitTests/Graph/GraphManifestLoaderTests.swift
@@ -46,39 +46,39 @@ final class GraphManifestLoaderTests: XCTestCase {
         import ProjectDescription
         let project = Project(name: "tuist")
         """
-        
+
         let manifestPath = fileHandler.currentPath.appending(component: Manifest.project.fileName)
         try content.write(to: manifestPath.url,
                           atomically: true,
                           encoding: .utf8)
-        
+
         // When
         let got = try subject.loadProject(at: fileHandler.currentPath)
-        
+
         // Then
-        
+
         XCTAssertEqual(got.name, "tuist")
     }
-    
+
     func test_loadWorkspace() throws {
         // Given
         let content = """
         import ProjectDescription
         let workspace = Workspace(name: "tuist", projects: [])
         """
-        
+
         let manifestPath = fileHandler.currentPath.appending(component: Manifest.workspace.fileName)
         try content.write(to: manifestPath.url,
                           atomically: true,
                           encoding: .utf8)
-        
+
         // When
         let got = try subject.loadWorkspace(at: fileHandler.currentPath)
-        
+
         // Then
         XCTAssertEqual(got.name, "tuist")
     }
-    
+
     func test_loadSetup() throws {
         // Given
         let content = """
@@ -87,15 +87,15 @@ final class GraphManifestLoaderTests: XCTestCase {
                         .custom(name: "hello", meet: ["a", "b"], isMet: ["c"])
                     ])
         """
-        
+
         let manifestPath = fileHandler.currentPath.appending(component: Manifest.setup.fileName)
         try content.write(to: manifestPath.url,
                           atomically: true,
                           encoding: .utf8)
-        
+
         // When
         let got = try subject.loadSetup(at: fileHandler.currentPath)
-        
+
         // Then
         let customUp = got.first as? UpCustom
         XCTAssertEqual(got.count, 1)
@@ -103,25 +103,25 @@ final class GraphManifestLoaderTests: XCTestCase {
         XCTAssertEqual(customUp?.meet, ["a", "b"])
         XCTAssertEqual(customUp?.isMet, ["c"])
     }
-    
+
     func test_load_invalidFormat() throws {
         // Given
         let content = """
         import ABC
         let project
         """
-        
+
         let manifestPath = fileHandler.currentPath.appending(component: Manifest.project.fileName)
         try content.write(to: manifestPath.url,
                           atomically: true,
                           encoding: .utf8)
-        
+
         // When / Then
         XCTAssertThrowsError(
             try subject.loadProject(at: fileHandler.currentPath)
         )
     }
-    
+
     func test_load_missingManifest() throws {
         XCTAssertThrowsError(
             try subject.loadProject(at: fileHandler.currentPath)
@@ -136,7 +136,7 @@ final class GraphManifestLoaderTests: XCTestCase {
             fileHandler.currentPath.appending(component: $0.fileName)
         }
         try manifestsPaths.forEach { try fileHandler.touch($0) }
-        
+
         // When
         let got = try Manifest.allCases.map {
             try subject.manifestPath(at: fileHandler.currentPath, manifest: $0)
@@ -151,7 +151,7 @@ final class GraphManifestLoaderTests: XCTestCase {
         try fileHandler.touch(fileHandler.currentPath.appending(component: "Project.swift"))
         try fileHandler.touch(fileHandler.currentPath.appending(component: "Workspace.swift"))
         try fileHandler.touch(fileHandler.currentPath.appending(component: "Setup.swift"))
-        
+
         // When
         let got = subject.manifests(at: fileHandler.currentPath)
 

--- a/Tests/TuistKitTests/Graph/GraphManifestLoaderTests.swift
+++ b/Tests/TuistKitTests/Graph/GraphManifestLoaderTests.swift
@@ -10,14 +10,12 @@ final class GraphManifestLoaderErrorTests: XCTestCase {
         XCTAssertEqual(GraphManifestLoaderError.unexpectedOutput(AbsolutePath("/test/")).description, "Unexpected output trying to parse the manifest at path /test")
         XCTAssertEqual(GraphManifestLoaderError.manifestNotFound(.project, AbsolutePath("/test/")).description, "Project.swift not found at path /test")
         XCTAssertEqual(GraphManifestLoaderError.manifestNotFound(nil, AbsolutePath("/test/")).description, "Manifest not found at path /test")
-        XCTAssertEqual(GraphManifestLoaderError.setupNotFound(AbsolutePath("/test/")).description, "Setup.swift not found at path /test")
     }
 
     func test_type() {
         XCTAssertEqual(GraphManifestLoaderError.projectDescriptionNotFound(AbsolutePath("/test")).type, .bug)
         XCTAssertEqual(GraphManifestLoaderError.unexpectedOutput(AbsolutePath("/test/")).type, .bug)
         XCTAssertEqual(GraphManifestLoaderError.manifestNotFound(.project, AbsolutePath("/test/")).type, .abort)
-        XCTAssertEqual(GraphManifestLoaderError.setupNotFound(AbsolutePath("/test/")).type, .abort)
     }
 }
 
@@ -53,8 +51,8 @@ final class GraphManifestLoaderTests: XCTestCase {
                           atomically: true,
                           encoding: .utf8)
 
-        let got = try subject.load(.project, path: fileHandler.currentPath)
-        XCTAssertEqual(try got.get("name") as String, "tuist")
+        let got = try subject.loadProject(at: fileHandler.currentPath)
+        XCTAssertEqual(got.name, "tuist")
     }
 
     func test_manifestPath_when_swift() throws {

--- a/Tests/TuistKitTests/Graph/Mocks/MockManifestLoader.swift
+++ b/Tests/TuistKitTests/Graph/Mocks/MockManifestLoader.swift
@@ -1,10 +1,14 @@
 import Basic
 import Foundation
 @testable import TuistKit
+import ProjectDescription
 
 final class MockGraphManifestLoader: GraphManifestLoading {
-    var loadCount: UInt = 0
-    var loadStub: ((Manifest, AbsolutePath) throws -> JSON)?
+    var loadProjectCount: UInt = 0
+    var loadProjectStub: ((AbsolutePath) throws -> ProjectDescription.Project)?
+    
+    var loadWorkspaceCount: UInt = 0
+    var loadWorkspaceStub: ((AbsolutePath) throws -> ProjectDescription.Workspace)?
 
     var manifestsAtCount: UInt = 0
     var manifestsAtStub: ((AbsolutePath) -> Set<Manifest>)?
@@ -15,9 +19,12 @@ final class MockGraphManifestLoader: GraphManifestLoading {
     var loadSetupCount: UInt = 0
     var loadSetupStub: ((AbsolutePath) throws -> [Upping])?
 
-    func load(_ manifest: Manifest, path: AbsolutePath) throws -> JSON {
-        loadCount += 1
-        return try loadStub?(manifest, path) ?? JSON([:])
+    func loadProject(at path: AbsolutePath) throws -> ProjectDescription.Project {
+        return try loadProjectStub?(path) ?? ProjectDescription.Project.test()
+    }
+    
+    func loadWorkspace(at path: AbsolutePath) throws -> ProjectDescription.Workspace {
+        return try loadWorkspaceStub?(path) ?? ProjectDescription.Workspace.test()
     }
 
     func manifests(at path: AbsolutePath) -> Set<Manifest> {

--- a/Tests/TuistKitTests/Graph/Mocks/MockManifestLoader.swift
+++ b/Tests/TuistKitTests/Graph/Mocks/MockManifestLoader.swift
@@ -1,12 +1,12 @@
 import Basic
 import Foundation
-@testable import TuistKit
 import ProjectDescription
+@testable import TuistKit
 
 final class MockGraphManifestLoader: GraphManifestLoading {
     var loadProjectCount: UInt = 0
     var loadProjectStub: ((AbsolutePath) throws -> ProjectDescription.Project)?
-    
+
     var loadWorkspaceCount: UInt = 0
     var loadWorkspaceStub: ((AbsolutePath) throws -> ProjectDescription.Workspace)?
 
@@ -22,7 +22,7 @@ final class MockGraphManifestLoader: GraphManifestLoading {
     func loadProject(at path: AbsolutePath) throws -> ProjectDescription.Project {
         return try loadProjectStub?(path) ?? ProjectDescription.Project.test()
     }
-    
+
     func loadWorkspace(at path: AbsolutePath) throws -> ProjectDescription.Workspace {
         return try loadWorkspaceStub?(path) ?? ProjectDescription.Workspace.test()
     }

--- a/Tests/TuistKitTests/Setup/SetupLoaderTests.swift
+++ b/Tests/TuistKitTests/Setup/SetupLoaderTests.swift
@@ -71,11 +71,11 @@ final class SetupLoaderTests: XCTestCase {
     func test_meet_when_loadSetup_throws() {
         // given
         let projectPath = AbsolutePath("/test/test1")
-        graphManifestLoader.loadSetupStub = { path in throw GraphManifestLoaderError.setupNotFound(path) }
+        graphManifestLoader.loadSetupStub = { path in throw GraphManifestLoaderError.manifestNotFound(.setup, projectPath) }
 
         // when / then
         XCTAssertThrowsError(try subject.meet(at: projectPath)) { error in
-            XCTAssertEqual(error as? GraphManifestLoaderError, GraphManifestLoaderError.setupNotFound(projectPath))
+            XCTAssertEqual(error as? GraphManifestLoaderError, GraphManifestLoaderError.manifestNotFound(.setup, projectPath))
         }
     }
 

--- a/Tests/TuistKitTests/Setup/SetupLoaderTests.swift
+++ b/Tests/TuistKitTests/Setup/SetupLoaderTests.swift
@@ -71,7 +71,7 @@ final class SetupLoaderTests: XCTestCase {
     func test_meet_when_loadSetup_throws() {
         // given
         let projectPath = AbsolutePath("/test/test1")
-        graphManifestLoader.loadSetupStub = { path in throw GraphManifestLoaderError.manifestNotFound(.setup, projectPath) }
+        graphManifestLoader.loadSetupStub = { _ in throw GraphManifestLoaderError.manifestNotFound(.setup, projectPath) }
 
         // when / then
         XCTAssertThrowsError(try subject.meet(at: projectPath)) { error in


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/236

### Short description 📝

There's currently a manual step of parsing `ProjectDescription` manifests from `JSON`. 

### Solution 📦

This can be simplified slightly by leveraging the `Codable` nature of the `ProjectDescription` classes, as such the raw manifest data can be directly converted back to a strongly type `ProjectDescription` class. This can then be mapped to the `TuistKit` Modes

### Implementation 👩‍💻👨‍💻

- The manifest loader now returns `ProjectDescription` classes
- The model loader now transforms `ProjectDescription` classes >  generator `Models`

Test Plan:

- Verify unit tests pass `swift test`
- Verify acceptance tests pass `bundle exec rake features`