### PR TITLE
Bump xcodeproj version to 6.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Rename manifest group to `Manifest` https://github.com/tuist/tuist/pull/227 by @pepibumur.
 - Rename manifest target to `Project-Manifest` https://github.com/tuist/tuist/pull/227 by @pepibumur.
 - Replace swiftlint with swiftformat https://github.com/tuist/tuist/pull/239 by @pepibumur.
+- Bump xcodeproj version to 6.6.0 https://github.com/tuist/tuist/pull/248 by @pepibumur.
 
 ### Added
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,17 +60,8 @@
         "repositoryURL": "https://github.com/tuist/xcodeproj.git",
         "state": {
           "branch": null,
-          "revision": "23da51abd3de3bedaad59a0afbb150b48504b5b0",
-          "version": "6.3.0"
-        }
-      },
-      {
-        "package": "Yams",
-        "repositoryURL": "https://github.com/jpsim/Yams.git",
-        "state": {
-          "branch": null,
-          "revision": "26ab35f50ea891e8edefcc9d975db2f6b67e1d68",
-          "version": "1.0.1"
+          "revision": "3fe1bd763072c81050b867d34db56d11cb9085bb",
+          "version": "6.6.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
                  targets: ["TuistGenerator"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tuist/xcodeproj.git", .upToNextMinor(from: "6.3.0")),
+        .package(url: "https://github.com/tuist/xcodeproj.git", .upToNextMinor(from: "6.6.0")),
         .package(url: "https://github.com/apple/swift-package-manager", .revision("a107d28d1b40491cf505799a046fee53e7c422e1")),
     ],
     targets: [


### PR DESCRIPTION
### Short description 📝
Just bump the version of xcodeproj to [6.6.0](https://github.com/tuist/xcodeproj/releases/tag/6.6.0). The latest version has notable performance improvements that Tuist will benefit from.