### PR TITLE
Support variables in the bundle id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Changed default value of SWIFT_VERSION to 4.2 @ollieatkinson
 - Added fixture tests for ios app with static libraries @ollieatkinson
+- Bundle id linting failing when the bundle id contains variables https://github.com/tuist/tuist/pull/252 by @pepibumur
 
 ## 0.11.0
 

--- a/Sources/TuistKit/Linter/TargetLinter.swift
+++ b/Sources/TuistKit/Linter/TargetLinter.swift
@@ -49,17 +49,9 @@ class TargetLinter: TargetLinting {
     fileprivate func lintBundleIdentifier(target: Target) -> [LintingIssue] {
         var bundleIdentifier = target.bundleId
 
-        let varRegex = try! NSRegularExpression(pattern: "\\$\\{.+\\}", options: [])
-        var match = varRegex.firstMatch(in: bundleIdentifier,
-                                        options: [],
-                                        range: NSRange(location: 0, length: bundleIdentifier.count))
-        while match != nil {
-            bundleIdentifier = (bundleIdentifier as NSString).replacingCharacters(in: match!.range(at: 0),
-                                                                                  with: "") as String
-            match = varRegex.firstMatch(in: bundleIdentifier,
-                                        options: [],
-                                        range: NSRange(location: 0, length: bundleIdentifier.count))
-        }
+        // Remove any interpolated variables
+        bundleIdentifier = bundleIdentifier.replacingOccurrences(of: "\\$\\{.+\\}", with: "", options: .regularExpression)
+        bundleIdentifier = bundleIdentifier.replacingOccurrences(of: "\\$\\(.+\\)", with: "", options: .regularExpression)
 
         var allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
         allowed.formUnion(CharacterSet(charactersIn: "-."))

--- a/Sources/TuistKit/Linter/TargetLinter.swift
+++ b/Sources/TuistKit/Linter/TargetLinter.swift
@@ -47,7 +47,19 @@ class TargetLinter: TargetLinting {
     /// - Parameter target: Target whose bundle identified will be linted.
     /// - Returns: An array with a linting issue if the bundle identifier contains invalid characters.
     fileprivate func lintBundleIdentifier(target: Target) -> [LintingIssue] {
-        let bundleIdentifier = target.bundleId
+        var bundleIdentifier = target.bundleId
+
+        let varRegex = try! NSRegularExpression(pattern: "\\$\\{.+\\}", options: [])
+        var match = varRegex.firstMatch(in: bundleIdentifier,
+                                        options: [],
+                                        range: NSRange(location: 0, length: bundleIdentifier.count))
+        while match != nil {
+            bundleIdentifier = (bundleIdentifier as NSString).replacingCharacters(in: match!.range(at: 0),
+                                                                                  with: "") as String
+            match = varRegex.firstMatch(in: bundleIdentifier,
+                                        options: [],
+                                        range: NSRange(location: 0, length: bundleIdentifier.count))
+        }
 
         var allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
         allowed.formUnion(CharacterSet(charactersIn: "-."))

--- a/Tests/TuistKitTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistKitTests/Linter/TargetLinterTests.swift
@@ -27,10 +27,10 @@ final class TargetLinterTests: XCTestCase {
             XCTAssertNil(got.first(where: { $0.description.contains("Invalid bundle identifier") }))
         }
 
-        XCTAssertInvalidBundleId("_.company.app")
-        XCTAssertInvalidBundleId("com.company.◌́")
-        XCTAssertInvalidBundleId("Ⅻ.company.app")
-        XCTAssertInvalidBundleId("ؼ.company.app")
+//        XCTAssertInvalidBundleId("_.company.app")
+//        XCTAssertInvalidBundleId("com.company.◌́")
+//        XCTAssertInvalidBundleId("Ⅻ.company.app")
+//        XCTAssertInvalidBundleId("ؼ.company.app")
         XCTAssertValidBundleId("com.company.MyModule${BUNDLE_SUFFIX}")
     }
 

--- a/Tests/TuistKitTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistKitTests/Linter/TargetLinterTests.swift
@@ -27,10 +27,10 @@ final class TargetLinterTests: XCTestCase {
             XCTAssertNil(got.first(where: { $0.description.contains("Invalid bundle identifier") }))
         }
 
-//        XCTAssertInvalidBundleId("_.company.app")
-//        XCTAssertInvalidBundleId("com.company.◌́")
-//        XCTAssertInvalidBundleId("Ⅻ.company.app")
-//        XCTAssertInvalidBundleId("ؼ.company.app")
+        XCTAssertInvalidBundleId("_.company.app")
+        XCTAssertInvalidBundleId("com.company.◌́")
+        XCTAssertInvalidBundleId("Ⅻ.company.app")
+        XCTAssertInvalidBundleId("ؼ.company.app")
         XCTAssertValidBundleId("com.company.MyModule${BUNDLE_SUFFIX}")
     }
 

--- a/Tests/TuistKitTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistKitTests/Linter/TargetLinterTests.swift
@@ -16,17 +16,22 @@ final class TargetLinterTests: XCTestCase {
 
     func test_lint_when_target_has_invalid_bundle_identifier() {
         let XCTAssertInvalidBundleId: (String) -> Void = { bundleId in
-            let bundleId = "_.company.app"
             let target = Target.test(bundleId: bundleId)
             let got = self.subject.lint(target: target)
             let reason = "Invalid bundle identifier '\(bundleId)'. This string must be a uniform type identifier (UTI) that contains only alphanumeric (A-Z,a-z,0-9), hyphen (-), and period (.) characters."
             XCTAssertTrue(got.contains(LintingIssue(reason: reason, severity: .error)))
+        }
+        let XCTAssertValidBundleId: (String) -> Void = { bundleId in
+            let target = Target.test(bundleId: bundleId)
+            let got = self.subject.lint(target: target)
+            XCTAssertNil(got.first(where: { $0.description.contains("Invalid bundle identifier") }))
         }
 
         XCTAssertInvalidBundleId("_.company.app")
         XCTAssertInvalidBundleId("com.company.◌́")
         XCTAssertInvalidBundleId("Ⅻ.company.app")
         XCTAssertInvalidBundleId("ؼ.company.app")
+        XCTAssertValidBundleId("com.company.MyModule${BUNDLE_SUFFIX}")
     }
 
     func test_lint_when_target_no_source_files() {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/250

### Short description 📝
As @enhorn reported, using variables in bundle ids results in Tuist returning an error.

### Solution 📦
Replace all the variables in the bundle id and run the validation of the character on the remaining string.