### PR TITLE
WIP : Linking system libraries frameworks

### DIFF
--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -31,7 +31,7 @@ public enum TargetDependency: Codable {
 
 // MARK: - SDKStatus (Coding)
 
-extension SDKStatus: Codable { }
+extension SDKStatus: Codable {}
 
 // MARK: - TargetDependency (Coding)
 

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -181,6 +181,8 @@ extension TuistKit.Dependency {
             return .library(path: RelativePath(libraryPath),
                             publicHeaders: RelativePath(publicHeaders),
                             swiftModuleMap: swiftModuleMap.map { RelativePath($0) })
+        case let .sdk(name, status):
+            return .sdk(name: name, status: status)
         }
     }
 }

--- a/Sources/TuistKit/Graph/Graph.swift
+++ b/Sources/TuistKit/Graph/Graph.swift
@@ -277,6 +277,10 @@ extension TargetNode {
     fileprivate var frameworkDependencies: [FrameworkNode] {
         return dependencies.lazy.compactMap { $0 as? FrameworkNode }
     }
+
+    fileprivate var sdkDependencies: [SDKNode] {
+        return dependencies.lazy.compactMap { $0 as? SDKNode }
+    }
 }
 
 extension Graph {

--- a/Sources/TuistKit/Graph/GraphNode.swift
+++ b/Sources/TuistKit/Graph/GraphNode.swift
@@ -1,6 +1,6 @@
 import Basic
 import Foundation
-import ProjectDescription
+import enum ProjectDescription.SDKStatus
 import TuistCore
 
 class GraphNode: Equatable, Hashable {

--- a/Sources/TuistKit/Graph/GraphNode.swift
+++ b/Sources/TuistKit/Graph/GraphNode.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import ProjectDescription
+import TuistCore
 
 class GraphNode: Equatable, Hashable {
     // MARK: - Attributes
@@ -135,7 +135,6 @@ enum PrecompiledNodeError: FatalError, Equatable {
 }
 
 class SDKNode: GraphNode {
-
     enum Error: Swift.Error {
         case invalidExtension(String?)
     }
@@ -145,7 +144,7 @@ class SDKNode: GraphNode {
 
         init(from string: String) throws {
             guard let type = Type(rawValue: string)
-                else { throw Error.invalidExtension(string) }
+            else { throw Error.invalidExtension(string) }
 
             self = type
         }
@@ -159,11 +158,11 @@ class SDKNode: GraphNode {
         let sdk = AbsolutePath("/\(name)")
 
         guard let string = sdk.extension
-            else { throw Error.invalidExtension(sdk.extension)}
+        else { throw Error.invalidExtension(sdk.extension) }
 
         self.name = name
         self.status = status
-        self.type = try Type(from: string)
+        type = try Type(from: string)
 
         let path: AbsolutePath
 

--- a/Sources/TuistKit/Models/Dependency.swift
+++ b/Sources/TuistKit/Models/Dependency.swift
@@ -1,9 +1,11 @@
 import Basic
 import Foundation
+import ProjectDescription
 
 enum Dependency: Equatable {
     case target(name: String)
     case project(target: String, path: RelativePath)
     case framework(path: RelativePath)
     case library(path: RelativePath, publicHeaders: RelativePath, swiftModuleMap: RelativePath?)
+    case sdk(name: String, status: SDKStatus)
 }

--- a/fixtures/ios_app_with_sdk/.gitignore
+++ b/fixtures/ios_app_with_sdk/.gitignore
@@ -1,0 +1,63 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two 
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace

--- a/fixtures/ios_app_with_sdk/Info.plist
+++ b/fixtures/ios_app_with_sdk/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_sdk/Playgrounds/App.playground/Contents.swift
+++ b/fixtures/ios_app_with_sdk/Playgrounds/App.playground/Contents.swift
@@ -1,0 +1,3 @@
+//: Playground - noun: a place where people can play
+
+import Foundation

--- a/fixtures/ios_app_with_sdk/Playgrounds/App.playground/contents.xcplayground
+++ b/fixtures/ios_app_with_sdk/Playgrounds/App.playground/contents.xcplayground
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='ios'>
+<timeline fileName='timeline.xctimeline'/>
+</playground>

--- a/fixtures/ios_app_with_sdk/Project.swift
+++ b/fixtures/ios_app_with_sdk/Project.swift
@@ -1,0 +1,29 @@
+import ProjectDescription
+
+let project = Project(name: "App",
+                      targets: [
+                          Target(name: "App",
+                                 platform: .iOS,
+                                 product: .app,
+                                 bundleId: "io.tuist.App",
+                                 infoPlist: "Info.plist",
+                                 sources: "Sources/**",
+                                 dependencies: [
+                                     /* Target dependencies can be defined here */
+                                     /* .framework(path: "framework") */
+                                    .sdk(name: "StoreKit.framework", status: .required)
+                                 ],
+                                 settings: Settings(base: ["CODE_SIGN_IDENTITY": "",
+                                                           "CODE_SIGNING_REQUIRED": "NO"])),
+                          Target(name: "AppTests",
+                                 platform: .iOS,
+                                 product: .unitTests,
+                                 bundleId: "io.tuist.AppTests",
+                                 infoPlist: "Tests.plist",
+                                 sources: "Tests/**",
+                                 dependencies: [
+                                     .target(name: "App"),
+                                 ],
+                                 settings: Settings(base: ["CODE_SIGN_IDENTITY": "",
+                                                           "CODE_SIGNING_REQUIRED": "NO"])),
+])

--- a/fixtures/ios_app_with_sdk/Project.swift
+++ b/fixtures/ios_app_with_sdk/Project.swift
@@ -11,7 +11,7 @@ let project = Project(name: "App",
                                  dependencies: [
                                      /* Target dependencies can be defined here */
                                      /* .framework(path: "framework") */
-                                    .sdk(name: "StoreKit.framework", status: .required)
+                                     .sdk(name: "StoreKit.framework", status: .required),
                                  ],
                                  settings: Settings(base: ["CODE_SIGN_IDENTITY": "",
                                                            "CODE_SIGNING_REQUIRED": "NO"])),

--- a/fixtures/ios_app_with_sdk/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_sdk/Sources/AppDelegate.swift
@@ -1,0 +1,15 @@
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        let viewController = UIViewController()
+        viewController.view.backgroundColor = .white
+        window?.rootViewController = viewController
+        window?.makeKeyAndVisible()
+        return true
+    }
+}

--- a/fixtures/ios_app_with_sdk/Tests.plist
+++ b/fixtures/ios_app_with_sdk/Tests.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_sdk/Tests/AppTests.swift
+++ b/fixtures/ios_app_with_sdk/Tests/AppTests.swift
@@ -1,0 +1,6 @@
+import Foundation
+import XCTest
+
+@testable import App
+
+final class AppTests: XCTestCase {}


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/174

### Short description 📝

Not sure if this is the best way to do this but either way it will help me get familiar with the code base.

Although system frameworks can often be linked automatically there are times you need to link them yourself or modify the status of linked SDKs.

### Solution 📦

Still WIP

Add the ability to link system frameworks or libraries via the `Project.swift`.

### Implementation 👩‍💻👨‍💻

- [x] Added a new `case .sdk(name:status)` to `TargetDependencies`
- [x] Add to `ProjectDescription`
- [x] Add new `SDKNode: GraphNode`
- [ ] Add to linked libraries build phase

### Questions ❓
So I thought the API in the `Project.swift` would be nice if the status was an `enum`

```swift
public enum SDKStatus: String {
    case required, optional
}
```

However, this needs to be exposed in `ProjectDescription` as well as `TuistKit`. At the moment I have declared the `enum` in `ProjectDescription` and have limited the `import` scope to only the `SDKStatus` `enum` and added `Codeable` only within `TuistKit`. But has anyone got any thoughts on how this could be improved?
