### PR TITLE
Fix duplicated embedded frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ## Next version
 
 ### Changed
+
 ### Added
+
 ### Removed
+
 ### Fixed
+
+- Fix duplicated embedded frameworks https://github.com/tuist/tuist/pull/280 by @pepibumur
 
 ## 0.12.0
 

--- a/Sources/TuistKit/Generator/LinkGenerator.swift
+++ b/Sources/TuistKit/Generator/LinkGenerator.swift
@@ -120,7 +120,7 @@ final class LinkGenerator: LinkGenerating {
         }
     }
 
-    func generateEmbedPhase(dependencies: [DependencyReference],
+    func generateEmbedPhase(dependencies: Set<DependencyReference>,
                             pbxTarget: PBXTarget,
                             pbxproj: PBXProj,
                             fileElements: ProjectFileElements,

--- a/Sources/TuistKit/Graph/Graph.swift
+++ b/Sources/TuistKit/Graph/Graph.swift
@@ -20,9 +20,18 @@ enum GraphError: FatalError {
     }
 }
 
-enum DependencyReference: Equatable {
+enum DependencyReference: Equatable, Hashable {
     case absolute(AbsolutePath)
     case product(String)
+
+    public func hash(into hasher: inout Hasher) {
+        switch self {
+        case let .absolute(path):
+            hasher.combine(path)
+        case let .product(product):
+            hasher.combine(product)
+        }
+    }
 
     static func == (lhs: DependencyReference, rhs: DependencyReference) -> Bool {
         switch (lhs, rhs) {
@@ -45,7 +54,7 @@ protocol Graphing: AnyObject {
 
     func linkableDependencies(path: AbsolutePath, name: String) throws -> [DependencyReference]
     func librariesPublicHeadersFolders(path: AbsolutePath, name: String) -> [AbsolutePath]
-    func embeddableFrameworks(path: AbsolutePath, name: String, system: Systeming) throws -> [DependencyReference]
+    func embeddableFrameworks(path: AbsolutePath, name: String, system: Systeming) throws -> Set<DependencyReference>
     func targetDependencies(path: AbsolutePath, name: String) -> [TargetNode]
     func staticDependencies(path: AbsolutePath, name: String) -> [DependencyReference]
 
@@ -163,7 +172,7 @@ class Graph: Graphing {
 
     func embeddableFrameworks(path: AbsolutePath,
                               name: String,
-                              system: Systeming) throws -> [DependencyReference] {
+                              system: Systeming) throws -> Set<DependencyReference> {
         guard let targetNode = findTargetNode(path: path, name: name) else {
             return []
         }
@@ -172,14 +181,6 @@ class Graph: Graphing {
             .app,
             .unitTests,
             .uiTests,
-//            .tvExtension,
-//            .appExtension,
-//            .watchExtension,
-//            .watch2Extension,
-//            .messagesExtension,
-//            .watchApp,
-//            .watch2App,
-//            .messagesApplication,
         ]
 
         if validProducts.contains(targetNode.target.product) == false {
@@ -212,7 +213,7 @@ class Graph: Graphing {
 
         references.append(contentsOf: transitiveFrameworks)
 
-        return references
+        return Set(references)
     }
 
     // MARK: - Fileprivate

--- a/Tests/TuistKitTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/LinkGeneratorTests.swift
@@ -36,7 +36,7 @@ final class LinkGeneratorErrorTests: XCTestCase {
         fileElements.products["waka.framework"] = wakaFile
         let sourceRootPath = AbsolutePath("/")
 
-        try subject.generateEmbedPhase(dependencies: dependencies,
+        try subject.generateEmbedPhase(dependencies: Set(dependencies),
                                        pbxTarget: pbxTarget,
                                        pbxproj: pbxproj,
                                        fileElements: fileElements,
@@ -62,7 +62,7 @@ final class LinkGeneratorErrorTests: XCTestCase {
         let fileElements = ProjectFileElements()
         let sourceRootPath = AbsolutePath("/")
 
-        XCTAssertThrowsError(try subject.generateEmbedPhase(dependencies: dependencies,
+        XCTAssertThrowsError(try subject.generateEmbedPhase(dependencies: Set(dependencies),
                                                             pbxTarget: pbxTarget,
                                                             pbxproj: pbxproj,
                                                             fileElements: fileElements,


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/277

### Short description 📝
If several targets that are part of the dependency graph refer the same pre-compiled dynamic framework, we end up with duplicates in the frameworks embed build phase as reported [here](https://github.com/tuist/tuist/issues/277).

### Solution 📦
- Make `DependencyReference` conform `Hashable`.
- Change the method that returns the frameworks to embed to return a `Set` instead. 