### PR TITLE
Fix build settings not being generated properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Fix duplicated embedded frameworks https://github.com/tuist/tuist/pull/280 by @pepibumur
 - Fix manifest target linker errors https://github.com/tuist/tuist/pull/287 by @kwridan
+- Build settings not being generated properly https://github.com/tuist/tuist/pull/282 by @pepibumur
+- Duplicated embedded frameworks https://github.com/tuist/tuist/pull/280 by @pepibumur
 
 ## 0.12.0
 

--- a/Sources/TuistKit/Generator/ConfigGenerator.swift
+++ b/Sources/TuistKit/Generator/ConfigGenerator.swift
@@ -122,11 +122,11 @@ final class ConfigGenerator: ConfigGenerating {
                                                sourceRootPath: AbsolutePath) throws {
         let product = settingsProviderProduct(target)
         let platform = settingsProviderPlatform(target)
-
-        let defaultConfigSettings = BuildSettingsProvider.targetDefault(platform: platform, product: product)
+        let variant: BuildSettingsProvider.Variant = (buildConfiguration == .debug) ? .debug : .release
 
         var settings: [String: Any] = [:]
-        extend(buildSettings: &settings, with: defaultConfigSettings)
+        extend(buildSettings: &settings, with: BuildSettingsProvider.targetDefault(variant: .all, platform: platform, product: product, swift: true))
+        extend(buildSettings: &settings, with: BuildSettingsProvider.targetDefault(variant: variant, platform: platform, product: product, swift: true))
         extend(buildSettings: &settings, with: target.settings?.base ?? [:])
         extend(buildSettings: &settings, with: configuration?.settings ?? [:])
 

--- a/Sources/TuistKit/Generator/ConfigGenerator.swift
+++ b/Sources/TuistKit/Generator/ConfigGenerator.swift
@@ -192,7 +192,7 @@ final class ConfigGenerator: ConfigGenerating {
 
     fileprivate func extend(buildSettings: inout [String: Any], with other: [String: Any]) {
         other.forEach { key, value in
-            if buildSettings[key] == nil {
+            if buildSettings[key] == nil || (value as? String)?.contains("$(inherited)") == false {
                 buildSettings[key] = value
             } else {
                 let previousValue: Any = buildSettings[key]!

--- a/Tests/TuistKitTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/ConfigGeneratorTests.swift
@@ -101,14 +101,7 @@ final class ConfigGeneratorTests: XCTestCase {
                                               options: options)
     }
 
-    private func generateManifestsConfig() throws {
-        let options = GenerationOptions()
-        _ = try subject.generateManifestsConfig(pbxproj: pbxproj,
-                                                options: options,
-                                                resourceLocator: resourceLocator)
-    }
-
-    private func generateTargetConfig(config _: BuildConfiguration) throws {
+    private func generateTargetConfig() throws {
         let dir = try TemporaryDirectory(removeTreeOnDeinit: true)
         let xcconfigsDir = dir.path.appending(component: "xcconfigs")
         try fileHandler.createFolder(xcconfigsDir)

--- a/Tests/TuistKitTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/ConfigGeneratorTests.swift
@@ -46,24 +46,37 @@ final class ConfigGeneratorTests: XCTestCase {
     }
 
     func test_generateTargetConfig() throws {
-        try generateTargetConfig(config: .release)
+        // Given / When
+        try generateTargetConfig()
+
+        // Then
         let configurationList = pbxTarget.buildConfigurationList
         let debugConfig = configurationList?.configuration(name: "Debug")
         let releaseConfig = configurationList?.configuration(name: "Release")
 
-        func assert(config: XCBuildConfiguration?) {
-            XCTAssertEqual(config?.buildSettings["Base"] as? String, "Base")
-            XCTAssertEqual(config?.buildSettings["INFOPLIST_FILE"] as? String, "$(SRCROOT)/Info.plist")
-            XCTAssertEqual(config?.buildSettings["PRODUCT_BUNDLE_IDENTIFIER"] as? String, "com.test.bundle_id")
-            XCTAssertEqual(config?.buildSettings["CODE_SIGN_ENTITLEMENTS"] as? String, "$(SRCROOT)/Test.entitlements")
-            XCTAssertEqual(config?.buildSettings["SWIFT_VERSION"] as? String, Constants.swiftVersion)
+        let commonSettings = [
+            "Base": "Base",
+            "INFOPLIST_FILE": "$(SRCROOT)/Info.plist",
+            "PRODUCT_BUNDLE_IDENTIFIER": "com.test.bundle_id",
+            "CODE_SIGN_ENTITLEMENTS": "$(SRCROOT)/Test.entitlements",
+            "SWIFT_VERSION": Constants.swiftVersion,
+        ]
 
-            let xcconfig: PBXFileReference? = config?.baseConfiguration
-            XCTAssertEqual(xcconfig?.path, "\(config!.name.lowercased()).xcconfig")
-        }
+        let debugSettings = [
+            "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+        ]
 
-        assert(config: debugConfig)
-        assert(config: releaseConfig)
+        let releaseSettings = [
+            "SWIFT_OPTIMIZATION_LEVEL": "-Owholemodule",
+        ]
+
+        assert(config: debugConfig, contains: commonSettings)
+        assert(config: debugConfig, contains: debugSettings)
+        assert(config: debugConfig, hasXcconfig: "debug.xcconfig")
+
+        assert(config: releaseConfig, contains: commonSettings)
+        assert(config: releaseConfig, contains: releaseSettings)
+        assert(config: releaseConfig, hasXcconfig: "release.xcconfig")
     }
 
     private func generateProjectConfig(config _: BuildConfiguration) throws {
@@ -86,6 +99,13 @@ final class ConfigGeneratorTests: XCTestCase {
                                               pbxproj: pbxproj,
                                               fileElements: fileElements,
                                               options: options)
+    }
+
+    private func generateManifestsConfig() throws {
+        let options = GenerationOptions()
+        _ = try subject.generateManifestsConfig(pbxproj: pbxproj,
+                                                options: options,
+                                                resourceLocator: resourceLocator)
     }
 
     private func generateTargetConfig(config _: BuildConfiguration) throws {
@@ -119,5 +139,33 @@ final class ConfigGeneratorTests: XCTestCase {
                                              fileElements: fileElements,
                                              options: options,
                                              sourceRootPath: AbsolutePath("/"))
+    }
+
+    // MARK: - Helpers
+
+    func assert(config: XCBuildConfiguration?,
+                contains settings: [String: String],
+                file: StaticString = #file,
+                line: UInt = #line) {
+        let matches = settings.filter {
+            config?.buildSettings[$0.key] as? String == $0.value
+        }
+
+        XCTAssertEqual(matches.count,
+                       settings.count,
+                       "Settings \(String(describing: config?.buildSettings)) do not contain expected settings \(settings)",
+                       file: file,
+                       line: line)
+    }
+
+    func assert(config: XCBuildConfiguration?,
+                hasXcconfig xconfigPath: String,
+                file: StaticString = #file,
+                line: UInt = #line) {
+        let xcconfig: PBXFileReference? = config?.baseConfiguration
+        XCTAssertEqual(xcconfig?.path,
+                       xconfigPath,
+                       file: file,
+                       line: line)
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/279

### Short description 📝
There was a bug in the configuration generation and as a consequence, some build settings were missing.

### Solution 📦
Fix the bug and use the right settings that are provided by the xcodeproj `BuildSettingsProvider` class.
