### PR TITLE
Create a Setup.swift file when running the init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 - Add Homebrew tap up https://github.com/tuist/tuist/pull/281 by @pepibumur
+- Create a Setup.swift file when running the init command https://github.com/tuist/tuist/pull/283 by @pepibumur
 
 ### Removed
 

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -244,6 +244,7 @@ class InitCommand: NSObject, Command {
         import ProjectDescription
 
         let setup = Setup([
+            // .homebrew(packages: ["swiftlint", "carthage"]),
             // .carthage()
         ])
         """

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -108,6 +108,7 @@ class InitCommand: NSObject, Command {
         try generatePlists(platform: platform, product: product, path: path)
         try generatePlaygrounds(name: name, path: path, platform: platform)
         try generateGitIgnore(path: path)
+        try generateSetup(path: path)
         printer.print(success: "Project generated at path \(path.asString).")
     }
 
@@ -232,6 +233,22 @@ class InitCommand: NSObject, Command {
         *.xcworkspace
         """
         try content.write(to: path.url, atomically: true, encoding: .utf8)
+    }
+
+    /// Generates a Setup.swift file in the given directory.
+    ///
+    /// - Parameter path: Path where the Setup.swift file will be created.
+    /// - Throws: An error if the file cannot be created.
+    fileprivate func generateSetup(path: AbsolutePath) throws {
+        let content = """
+        import ProjectDescription
+
+        let setup = Setup([
+            // .carthage()
+        ])
+        """
+        let setupPath = path.appending(component: "Setup.swift")
+        try content.write(to: setupPath.url, atomically: true, encoding: .utf8)
     }
 
     // swiftlint:disable:next function_body_length

--- a/Tests/TuistKitTests/Commands/InitCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/InitCommandTests.swift
@@ -106,6 +106,7 @@ final class InitCommandTests: XCTestCase {
         let name = fileHandler.currentPath.components.last!
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: ".gitignore")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Project.swift")))
+        XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Setup.swift")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Info.plist")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Tests.plist")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(RelativePath("Sources/AppDelegate.swift"))))
@@ -127,6 +128,7 @@ final class InitCommandTests: XCTestCase {
         let name = fileHandler.currentPath.components.last!
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: ".gitignore")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Project.swift")))
+        XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Setup.swift")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Info.plist")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Tests.plist")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(RelativePath("Sources/AppDelegate.swift"))))
@@ -148,6 +150,7 @@ final class InitCommandTests: XCTestCase {
         let name = fileHandler.currentPath.components.last!
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: ".gitignore")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Project.swift")))
+        XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Setup.swift")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Info.plist")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Tests.plist")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(RelativePath("Sources/AppDelegate.swift"))))
@@ -169,6 +172,7 @@ final class InitCommandTests: XCTestCase {
         let name = fileHandler.currentPath.components.last!
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: ".gitignore")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Project.swift")))
+        XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Setup.swift")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Info.plist")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Tests.plist")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(RelativePath("Sources/\(name).swift"))))
@@ -191,6 +195,7 @@ final class InitCommandTests: XCTestCase {
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: ".gitignore")))
 
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Project.swift")))
+        XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Setup.swift")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Info.plist")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Tests.plist")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(RelativePath("Sources/\(name).swift"))))
@@ -212,6 +217,7 @@ final class InitCommandTests: XCTestCase {
         let name = fileHandler.currentPath.components.last!
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: ".gitignore")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Project.swift")))
+        XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Setup.swift")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Info.plist")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Tests.plist")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(RelativePath("Sources/\(name).swift"))))


### PR DESCRIPTION
### Short description 📝
Create a `Setup.swift` file when running the `tuist init` command. The `Setup.swift` doesn't contain any up command is intended to work as a reference for developers to know that it exists and how they can use it.

### Solution 📦
- Add a new private method to the init command that generates the file.
- Add tests.