### PR TITLE
[WIP] Update tuistenv when updating Tuist

### DIFF
--- a/Sources/TuistCore/Constants.swift
+++ b/Sources/TuistCore/Constants.swift
@@ -8,4 +8,5 @@ public class Constants {
     public static let version = "0.12.0"
     public static let swiftVersion: String = "4.2"
     public static let bundleName: String = "tuist.zip"
+    public static let envBundleName: String = "tuistenv.zip"
 }

--- a/Sources/TuistCore/Utils/System.swift
+++ b/Sources/TuistCore/Utils/System.swift
@@ -53,6 +53,21 @@ public protocol Systeming {
     /// - Throws: An error if the command fails.
     func capture(_ arguments: [String], verbose: Bool, environment: [String: String]) throws -> String
 
+    /// Runs a task asynchronously. If the process that triggers the task terminates, the task continues to execute.
+    ///
+    /// - Parameters:
+    ///   - arguments: Command arguments
+    /// - Throws: An error if the command fails.
+    func async(_ arguments: [String]) throws
+
+    /// Runs a task asynchronously. If the process that triggers the task terminates, the task continues to execute.
+    ///
+    /// - Parameters:
+    ///   - arguments: Command arguments
+    ///   - environment: Environment that should be used when running the task.
+    /// - Throws: An error if the command fails.
+    func async(_ arguments: [String], environment: [String: String]) throws
+
     /// Runs a command in the shell printing its output.
     ///
     /// - Parameters:
@@ -295,6 +310,30 @@ public final class System: Systeming {
                               startNewProcessGroup: false)
         try process.launch()
         try process.waitUntilExit()
+    }
+
+    /// Runs a task asynchronously. If the process that triggers the task terminates, the task continues to execute.
+    ///
+    /// - Parameters:
+    ///   - arguments: Command arguments
+    /// - Throws: An error if the command fails.
+    public func async(_ arguments: [String]) throws {
+        try async(arguments, environment: env)
+    }
+
+    /// Runs a task asynchronously. If the process that triggers the task terminates, the task continues to execute.
+    ///
+    /// - Parameters:
+    ///   - arguments: Command arguments
+    ///   - environment: Environment that should be used when running the task.
+    /// - Throws: An error if the command fails.
+    public func async(_ arguments: [String], environment: [String: String]) throws {
+        let process = Process(arguments: arguments,
+                              environment: environment,
+                              outputRedirection: .none,
+                              verbose: false,
+                              startNewProcessGroup: true)
+        try process.launch()
     }
 
     /// Returns the Swift version.

--- a/Sources/TuistCoreTesting/Utils/MockSystem.swift
+++ b/Sources/TuistCoreTesting/Utils/MockSystem.swift
@@ -28,6 +28,20 @@ public final class MockSystem: Systeming {
         stubs[arguments.joined(separator: " ")] = (stderror: nil, stdout: output, exitstatus: 0)
     }
 
+    public func async(_ arguments: [String]) throws {
+        try self.async(arguments, environment: [:])
+    }
+
+    public func async(_ arguments: [String], environment _: [String: String]) throws {
+        let command = arguments.joined(separator: " ")
+        guard let stub = self.stubs[command] else {
+            throw SystemError.terminated(code: 1, error: "command '\(command)' not stubbed")
+        }
+        if stub.exitstatus != 0 {
+            throw SystemError.terminated(code: 1, error: stub.stderror ?? "")
+        }
+    }
+
     public func run(_ arguments: [String]) throws {
         let command = arguments.joined(separator: " ")
         guard let stub = self.stubs[command] else {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/260

### Short description 📝
Update `tuistenv` when updating Tuist. Since the update requires replacing the binary from which we run the update, I've added a new shell tasks that runs asynchronously in the system. Even if the update process gets killed as a result of the update, the update command shouldn't be terminated.

### Solution 📦
- [x] Add `System.async`
- [x] Change `Installer` to install `tuistenv` as well.
- [ ] Tests