### PR TITLE
Manifest targets are now static frameworks (to avoid link errors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Fix duplicated embedded frameworks https://github.com/tuist/tuist/pull/280 by @pepibumur
+- Fix manifest target linker errors https://github.com/tuist/tuist/pull/287 by @kwridan
 
 ## 0.12.0
 

--- a/Sources/TuistKit/Generator/ManifestTargetGenerator.swift
+++ b/Sources/TuistKit/Generator/ManifestTargetGenerator.swift
@@ -24,7 +24,7 @@ class ManifestTargetGenerator: ManifestTargetGenerating {
         let manifest = try manifestLoader.manifestPath(at: path, manifest: .project)
         return Target(name: "\(project)-Manifest",
                       platform: .macOS,
-                      product: .framework,
+                      product: .staticFramework,
                       bundleId: "io.tuist.manifests.${PRODUCT_NAME:rfc1034identifier}",
                       settings: settings,
                       sources: [manifest],
@@ -36,13 +36,8 @@ class ManifestTargetGenerator: ManifestTargetGenerating {
         var buildSettings = [String: String]()
         buildSettings["FRAMEWORK_SEARCH_PATHS"] = frameworkParentDirectory.asString
         buildSettings["LIBRARY_SEARCH_PATHS"] = frameworkParentDirectory.asString
-        buildSettings["SWIFT_FORCE_DYNAMIC_LINK_STDLIB"] = "YES"
-        buildSettings["SWIFT_FORCE_STATIC_LINK_STDLIB"] = "NO"
         buildSettings["SWIFT_INCLUDE_PATHS"] = frameworkParentDirectory.asString
         buildSettings["SWIFT_VERSION"] = Constants.swiftVersion
-        buildSettings["LD"] = "/usr/bin/true"
-        buildSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = "SWIFT_PACKAGE"
-        buildSettings["OTHER_SWIFT_FLAGS"] = "-swift-version 4 -I \(frameworkParentDirectory.asString)"
         return buildSettings
     }
 }

--- a/Tests/TuistKitTests/Generator/ManifestTargetGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/ManifestTargetGeneratorTests.swift
@@ -24,6 +24,7 @@ final class ManifestTargetGeneratorTests: XCTestCase {
 
         // Then
         XCTAssertEqual(target.name, "MyProject-Manifest")
+        XCTAssertEqual(target.product, .staticFramework)
         XCTAssertEqual(target.sources.map { $0.asString }, ["/test/Project.swift"])
         XCTAssertNil(target.infoPlist)
         assertValidManifestBuildSettings(for: target,
@@ -41,12 +42,7 @@ final class ManifestTargetGeneratorTests: XCTestCase {
 
         XCTAssertEqual(settings.base["FRAMEWORK_SEARCH_PATHS"], expectedSearchPath)
         XCTAssertEqual(settings.base["LIBRARY_SEARCH_PATHS"], expectedSearchPath)
-        XCTAssertEqual(settings.base["SWIFT_FORCE_DYNAMIC_LINK_STDLIB"], "YES")
-        XCTAssertEqual(settings.base["SWIFT_FORCE_STATIC_LINK_STDLIB"], "NO")
         XCTAssertEqual(settings.base["SWIFT_INCLUDE_PATHS"], expectedSearchPath)
         XCTAssertEqual(settings.base["SWIFT_VERSION"], Constants.swiftVersion)
-        XCTAssertEqual(settings.base["LD"], "/usr/bin/true")
-        XCTAssertEqual(settings.base["SWIFT_ACTIVE_COMPILATION_CONDITIONS"], "SWIFT_PACKAGE")
-        XCTAssertEqual(settings.base["OTHER_SWIFT_FLAGS"], "-swift-version 4 -I \(expectedSearchPath)")
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/286

### Short description 📝

The generated manifest target (e.g. "MyProject-Manifest") is used to allow code completion on the project manifest files (`Project.swift`) as well as validate the code written within it syntacticly valid.

Building this target will succeed however a few linker errors do appear as a consequence: 

e.g.

```
error: unable to open dependencies file ( .../Build/Intermediates.noindex/MainApp.build/Debug/MainApp-Manifest.build/Objects-normal/x86_64/MainApp_Manifest_dependency_info.dat)Command Ld emitted errors but did not return a nonzero exit code to indicate failure
```

### Solution 📦

The link step can be skipped all together by declaring the manifest target will be staticly linked. 

### Implementation 👩‍💻👨‍💻

- Modify the manifest target product type to be a `.staticFramework`

### Test Plan 🛠

- Run `tuist generate` on any fixture within `fixtures`
- Open the generated workspace (you can use `tuist focus` as a shortcut to those steps)
- Build the `<Project>-Manifest` scheme in Xcode
- Verify no link errors appear