### PR TITLE
Remove App Delegate Warning

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -2,6 +2,7 @@
 
 --symlinks ignore
 --exclude Tests/XCTestManifests.swift
+--exclude fixtures/
 
 # format options
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fix duplicated embedded frameworks https://github.com/tuist/tuist/pull/280 by @pepibumur
 - Fix manifest target linker errors https://github.com/tuist/tuist/pull/287 by @kwridan
 - Build settings not being generated properly https://github.com/tuist/tuist/pull/282 by @pepibumur
-- Duplicated embedded frameworks https://github.com/tuist/tuist/pull/280 by @pepibumur
+- Fix `instance method nearly matches optional requirements` warning in generated `AppDelegate.swift` in iOS projects https://github.com/tuist/tuist/pull/291 by @BalestraPatrick
 
 ## 0.12.0
 

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -292,8 +292,7 @@ class InitCommand: NSObject, Command {
             
                 var window: UIWindow?
             
-                func application(_ application: UIApplication,
-                                   didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+                func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
                     window = UIWindow(frame: UIScreen.main.bounds)
                     let viewController = UIViewController()
                     viewController.view.backgroundColor = .white

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -292,7 +292,10 @@ class InitCommand: NSObject, Command {
             
                 var window: UIWindow?
             
-                func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+                func application(
+                    _ application: UIApplication,
+                    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
+                ) -> Bool {
                     window = UIWindow(frame: UIScreen.main.bounds)
                     let viewController = UIViewController()
                     viewController.view.backgroundColor = .white

--- a/Sources/TuistKit/Generator/ConfigGenerator.swift
+++ b/Sources/TuistKit/Generator/ConfigGenerator.swift
@@ -125,8 +125,14 @@ final class ConfigGenerator: ConfigGenerating {
         let variant: BuildSettingsProvider.Variant = (buildConfiguration == .debug) ? .debug : .release
 
         var settings: [String: Any] = [:]
-        extend(buildSettings: &settings, with: BuildSettingsProvider.targetDefault(variant: .all, platform: platform, product: product, swift: true))
-        extend(buildSettings: &settings, with: BuildSettingsProvider.targetDefault(variant: variant, platform: platform, product: product, swift: true))
+        extend(buildSettings: &settings, with: BuildSettingsProvider.targetDefault(variant: .all,
+                                                                                   platform: platform,
+                                                                                   product: product,
+                                                                                   swift: true))
+        extend(buildSettings: &settings, with: BuildSettingsProvider.targetDefault(variant: variant,
+                                                                                   platform: platform,
+                                                                                   product: product,
+                                                                                   swift: true))
         extend(buildSettings: &settings, with: target.settings?.base ?? [:])
         extend(buildSettings: &settings, with: configuration?.settings ?? [:])
 

--- a/fixtures/app_with_framework_and_tests/App/AppDelegate.swift
+++ b/fixtures/app_with_framework_and_tests/App/AppDelegate.swift
@@ -6,8 +6,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     var framework: FrameworkClass = FrameworkClass()
 
-    func application(_: UIApplication,
-                     didFinishLaunchingWithOptions _: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
         let viewController = UIViewController()
         viewController.view.backgroundColor = .white

--- a/fixtures/ios_app_with_setup/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_setup/Sources/AppDelegate.swift
@@ -4,7 +4,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-    func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
         let viewController = UIViewController()
         viewController.view.backgroundColor = .white

--- a/fixtures/ios_app_with_static_frameworks/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_static_frameworks/Sources/AppDelegate.swift
@@ -5,7 +5,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-    func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
         let viewController = UIViewController()
         viewController.view.backgroundColor = .white

--- a/fixtures/ios_app_with_static_libraries/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_static_libraries/Sources/AppDelegate.swift
@@ -5,7 +5,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-    func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
         let viewController = UIViewController()
         viewController.view.backgroundColor = .white

--- a/fixtures/ios_app_with_tests/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_tests/Sources/AppDelegate.swift
@@ -4,7 +4,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-    func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
         let viewController = UIViewController()
         viewController.view.backgroundColor = .white


### PR DESCRIPTION
### Short description 📝

I tried creating a new project with `tuist init --platform ios --product application` and after building the generated project, the following warning was shown in Xcode.
<img width="860" alt="Screenshot 2019-03-16 at 2 04 57 PM" src="https://user-images.githubusercontent.com/3658887/54476164-4fef7500-47fa-11e9-80ac-cd364c3eeb83.png">

### Solution 📦

Fixed the template used to generate the iOS `AppDelegate.swift` and also changed all existing instances of this method in the fixtures just to make sure the tests pass.

Ran `swift test` and `rake features` locally and they are both 100% green.