### PR TITLE
Fixing duplicate manifest group

### DIFF
--- a/Sources/TuistKit/Generator/ProjectGroups.swift
+++ b/Sources/TuistKit/Generator/ProjectGroups.swift
@@ -26,7 +26,6 @@ class ProjectGroups {
 
     let main: PBXGroup
     let products: PBXGroup
-    let projectManifest: PBXGroup
     let frameworks: PBXGroup
     let playgrounds: PBXGroup?
 
@@ -38,14 +37,12 @@ class ProjectGroups {
     private init(main: PBXGroup,
                  projectGroups: [(name: String, group: PBXGroup)],
                  products: PBXGroup,
-                 projectManifest: PBXGroup,
                  frameworks: PBXGroup,
                  playgrounds: PBXGroup?,
                  pbxproj: PBXProj) {
         self.main = main
         self.projectGroups = Dictionary(uniqueKeysWithValues: projectGroups)
         self.products = products
-        self.projectManifest = projectManifest
         self.frameworks = frameworks
         self.playgrounds = playgrounds
         self.pbxproj = pbxproj
@@ -88,11 +85,6 @@ class ProjectGroups {
             projectGroups.append(($0, projectGroup))
         }
 
-        /// ProjectDescription
-        let projectManifestGroup = PBXGroup(children: [], sourceTree: .group, name: "Manifest")
-        pbxproj.add(object: projectManifestGroup)
-        mainGroup.children.append(projectManifestGroup)
-
         /// Frameworks
         let frameworksGroup = PBXGroup(children: [], sourceTree: .group, name: "Frameworks")
         pbxproj.add(object: frameworksGroup)
@@ -114,7 +106,6 @@ class ProjectGroups {
         return ProjectGroups(main: mainGroup,
                              projectGroups: projectGroups,
                              products: productsGroup,
-                             projectManifest: projectManifestGroup,
                              frameworks: frameworksGroup,
                              playgrounds: playgroundsGroup,
                              pbxproj: pbxproj)

--- a/Sources/TuistKit/Generator/TargetGenerator.swift
+++ b/Sources/TuistKit/Generator/TargetGenerator.swift
@@ -28,20 +28,17 @@ final class TargetGenerator: TargetGenerating {
     let buildPhaseGenerator: BuildPhaseGenerating
     let linkGenerator: LinkGenerating
     let fileGenerator: FileGenerating
-    let manifestLoader: GraphManifestLoading
 
     // MARK: - Init
 
     init(configGenerator: ConfigGenerating = ConfigGenerator(),
          fileGenerator: FileGenerating = FileGenerator(),
          buildPhaseGenerator: BuildPhaseGenerating = BuildPhaseGenerator(),
-         linkGenerator: LinkGenerating = LinkGenerator(),
-         manifestLoader: GraphManifestLoading = GraphManifestLoader()) {
+         linkGenerator: LinkGenerating = LinkGenerator()) {
         self.configGenerator = configGenerator
         self.fileGenerator = fileGenerator
         self.buildPhaseGenerator = buildPhaseGenerator
         self.linkGenerator = linkGenerator
-        self.manifestLoader = manifestLoader
     }
 
     // MARK: - TargetGenerating

--- a/Tests/TuistKitTests/Generator/ProjectGroupsTests.swift
+++ b/Tests/TuistKitTests/Generator/ProjectGroupsTests.swift
@@ -46,7 +46,7 @@ final class ProjectGroupsTests: XCTestCase {
         let main = subject.main
         XCTAssertNil(main.path)
         XCTAssertEqual(main.sourceTree, .group)
-        XCTAssertEqual(main.children.count, 6)
+        XCTAssertEqual(main.children.count, 5)
 
         XCTAssertNotNil(main.group(named: "Project"))
         XCTAssertNil(main.group(named: "Project")?.path)
@@ -55,11 +55,6 @@ final class ProjectGroupsTests: XCTestCase {
         XCTAssertNotNil(main.group(named: "Target"))
         XCTAssertNil(main.group(named: "Target")?.path)
         XCTAssertEqual(main.group(named: "Target")?.sourceTree, .group)
-
-        XCTAssertTrue(main.children.contains(subject.projectManifest))
-        XCTAssertEqual(subject.projectManifest.name, "Manifest")
-        XCTAssertNil(subject.projectManifest.path)
-        XCTAssertEqual(subject.projectManifest.sourceTree, .group)
 
         XCTAssertTrue(main.children.contains(subject.frameworks))
         XCTAssertEqual(subject.frameworks.name, "Frameworks")
@@ -109,7 +104,6 @@ final class ProjectGroupsTests: XCTestCase {
             "B",
             "C",
             "A",
-            "Manifest",
             "Frameworks",
             "Playgrounds",
             "Products",


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/294

### Short description 📝

Duplicate manifest groups were being generated - this was caused by #271, where one crucial step was missed (removing the pre-defined "Manifest group")

### Solution 📦

Remove the pre-defined manifest group

### Test Plan ⚒

- Generate any of the fixtures
- Inspect the generated project
- Verify there are no duplicate manifest groups