### PR TITLE
Fix #296 - Do not include manifest inside of project scheme

### DIFF
--- a/Sources/TuistKit/Generator/ManifestTargetGenerator.swift
+++ b/Sources/TuistKit/Generator/ManifestTargetGenerator.swift
@@ -28,7 +28,8 @@ class ManifestTargetGenerator: ManifestTargetGenerating {
                       bundleId: "io.tuist.manifests.${PRODUCT_NAME:rfc1034identifier}",
                       settings: settings,
                       sources: [manifest],
-                      filesGroup: .group(name: "Manifest"))
+                      filesGroup: .group(name: "Manifest"),
+                      includeInProjectScheme: false)
     }
 
     func manifestTargetBuildSettings() throws -> [String: String] {

--- a/Sources/TuistKit/Generator/SchemesGenerator.swift
+++ b/Sources/TuistKit/Generator/SchemesGenerator.swift
@@ -97,7 +97,10 @@ final class SchemesGenerator: SchemesGenerating {
                             generatedProject: GeneratedProject,
                             graph: Graphing) -> XCScheme.BuildAction {
         let targets = project.sortedTargetsForProjectScheme(graph: graph)
-        let entries: [XCScheme.BuildAction.Entry] = targets.map { (target) -> XCScheme.BuildAction.Entry in
+        let entries: [XCScheme.BuildAction.Entry] = targets
+            .filter(\.includeInProjectScheme)
+            .map { (target) -> XCScheme.BuildAction.Entry in
+
             let pbxTarget = generatedProject.targets[target.name]!
             let buildableReference = targetBuildableReference(target: target,
                                                               pbxTarget: pbxTarget,

--- a/Sources/TuistKit/Models/Target.swift
+++ b/Sources/TuistKit/Models/Target.swift
@@ -28,6 +28,7 @@ class Target: Equatable {
     let actions: [TargetAction]
     let environment: [String: String]
     let filesGroup: ProjectGroup
+    let includeInProjectScheme: Bool
 
     // MARK: - Init
 
@@ -45,7 +46,8 @@ class Target: Equatable {
          actions: [TargetAction] = [],
          environment: [String: String] = [:],
          filesGroup: ProjectGroup,
-         dependencies: [Dependency] = []) {
+         dependencies: [Dependency] = [],
+         includeInProjectScheme: Bool = true) {
         self.name = name
         self.product = product
         self.platform = platform
@@ -61,6 +63,7 @@ class Target: Equatable {
         self.environment = environment
         self.filesGroup = filesGroup
         self.dependencies = dependencies
+        self.includeInProjectScheme = includeInProjectScheme
     }
 
     func isLinkable() -> Bool {

--- a/Tests/TuistKitTests/Generator/SchemesGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/SchemesGeneratorTests.swift
@@ -245,6 +245,30 @@ final class SchemeGeneratorTests: XCTestCase {
         XCTAssertEqual(got.buildConfiguration, "Release")
         XCTAssertEqual(got.revealArchiveInOrganizer, true)
     }
+    
+    func test_projectBuildAction_includeInProjectScheme_false() {
+        let app = Target.test(name: "App", product: .app)
+        let excluded = Target.test(name: "Excluded", product: .framework, includeInProjectScheme: false)
+       
+        let targets = [app, excluded]
+        
+        let project = Project.test(targets: targets)
+        let graphCache = GraphLoaderCache()
+        let graph = Graph.test(cache: graphCache)
+        
+        let got = subject.projectBuildAction(project: project,
+                                             generatedProject: generatedProject(targets: targets),
+                                             graph: graph)
+        
+        XCTAssertTrue(got.parallelizeBuild)
+        XCTAssertEqual(got.buildActionEntries.count, 1)
+        
+        let appEntry = got.buildActionEntries[0]
+
+        XCTAssertEqual(appEntry.buildableReference.buildableName, app.productName)
+        XCTAssertEqual(appEntry.buildableReference.blueprintName, app.name)
+        
+    }
 
     // MARK: - Private
 

--- a/Tests/TuistKitTests/Models/TestData/Target+TestData.swift
+++ b/Tests/TuistKitTests/Models/TestData/Target+TestData.swift
@@ -17,7 +17,8 @@ extension Target {
                      actions: [TargetAction] = [],
                      environment: [String: String] = [:],
                      filesGroup: ProjectGroup = .group(name: "Project"),
-                     dependencies: [Dependency] = []) -> Target {
+                     dependencies: [Dependency] = [],
+                     includeInProjectScheme: Bool = true) -> Target {
         return Target(name: name,
                       platform: platform,
                       product: product,
@@ -32,6 +33,7 @@ extension Target {
                       actions: actions,
                       environment: environment,
                       filesGroup: filesGroup,
-                      dependencies: dependencies)
+                      dependencies: dependencies,
+                      includeInProjectScheme: includeInProjectScheme)
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/296

### Solution 📦

Add `includeInProjectScheme` to TuistKit.Target so that we are able to explicitly include/exclude generated targets from the project scheme.
