### PR TITLE
Allow linking of static frameworks/libraries into dynamic frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Add Homebrew tap up https://github.com/tuist/tuist/pull/281 by @pepibumur
 - Create a Setup.swift file when running the init command https://github.com/tuist/tuist/pull/283 by @pepibumur
 - Update `tuistenv` when running `tuist update` https://github.com/tuist/tuist/pull/288 by @pepibumur.
+- Allow linking of static products into dynamic frameworks https://github.com/tuist/tuist/pull/299 by @ollieatkinson
 
 ### Removed
 

--- a/Sources/TuistCore/Utils/Stack.swift
+++ b/Sources/TuistCore/Utils/Stack.swift
@@ -1,6 +1,6 @@
 /// Implements a Stack - helper class for push/pop that uses an array internally.
 public struct Stack<T> {
-    fileprivate var array = [T]()
+    private var array = [T]()
 
     public init() {}
 

--- a/Sources/TuistEnvKit/Commands/CommandRegistry.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRegistry.swift
@@ -22,7 +22,7 @@ public final class CommandRegistry {
                       UpdateCommand.self,
                       InstallCommand.self,
                       UninstallCommand.self,
-                  ])
+        ])
     }
 
     init(processArguments: @escaping () -> [String],

--- a/Sources/TuistEnvKit/Commands/CommandRegistry.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRegistry.swift
@@ -22,7 +22,7 @@ public final class CommandRegistry {
                       UpdateCommand.self,
                       InstallCommand.self,
                       UninstallCommand.self,
-        ])
+                  ])
     }
 
     init(processArguments: @escaping () -> [String],
@@ -58,7 +58,7 @@ public final class CommandRegistry {
 
     // MARK: - Fileprivate
 
-    fileprivate func parse() throws -> ArgumentParser.Result? {
+    private func parse() throws -> ArgumentParser.Result? {
         let arguments = Array(processArguments().dropFirst())
         guard let firstArgument = arguments.first else { return nil }
         if commands.map({ type(of: $0).command }).contains(firstArgument) {
@@ -67,11 +67,11 @@ public final class CommandRegistry {
         return nil
     }
 
-    fileprivate func register(command: Command.Type) {
+    private func register(command: Command.Type) {
         commands.append(command.init(parser: parser))
     }
 
-    fileprivate func process(arguments: ArgumentParser.Result) throws {
+    private func process(arguments: ArgumentParser.Result) throws {
         let subparser = arguments.subparser(parser)!
         let command = commands.first(where: { type(of: $0).command == subparser })!
         try command.run(with: arguments)

--- a/Sources/TuistKit/Commands/CommandRegistry.swift
+++ b/Sources/TuistKit/Commands/CommandRegistry.swift
@@ -101,18 +101,18 @@ public final class CommandRegistry {
         return arguments[1]
     }
 
-    fileprivate func parse() throws -> ArgumentParser.Result {
+    private func parse() throws -> ArgumentParser.Result {
         let arguments = Array(processArguments().dropFirst())
         return try parser.parse(arguments)
     }
 
-    fileprivate func hiddenCommand() -> HiddenCommand? {
+    private func hiddenCommand() -> HiddenCommand? {
         let arguments = Array(processArguments().dropFirst())
         guard let commandName = arguments.first else { return nil }
         return hiddenCommands[commandName]
     }
 
-    fileprivate func process(arguments: ArgumentParser.Result) throws {
+    private func process(arguments: ArgumentParser.Result) throws {
         guard let subparser = arguments.subparser(parser) else {
             parser.printUsage(on: stdoutStream)
             return

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -70,7 +70,7 @@ class InitCommand: NSObject, Command {
                                         completion: ShellCompletion.values([
                                             (value: "application", description: "Application"),
                                             (value: "framework", description: "Framework"),
-        ]))
+                                        ]))
         platformArgument = subParser.add(option: "--platform",
                                          shortName: nil,
                                          kind: String.self,
@@ -79,7 +79,7 @@ class InitCommand: NSObject, Command {
                                              (value: "ios", description: "iOS platform"),
                                              (value: "tvos", description: "tvOS platform"),
                                              (value: "macos", description: "macOS platform"),
-        ]))
+                                         ]))
         pathArgument = subParser.add(option: "--path",
                                      shortName: "-p",
                                      kind: String.self,

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -70,7 +70,7 @@ class InitCommand: NSObject, Command {
                                         completion: ShellCompletion.values([
                                             (value: "application", description: "Application"),
                                             (value: "framework", description: "Framework"),
-                                        ]))
+        ]))
         platformArgument = subParser.add(option: "--platform",
                                          shortName: nil,
                                          kind: String.self,
@@ -79,7 +79,7 @@ class InitCommand: NSObject, Command {
                                              (value: "ios", description: "iOS platform"),
                                              (value: "tvos", description: "tvOS platform"),
                                              (value: "macos", description: "macOS platform"),
-                                         ]))
+        ]))
         pathArgument = subParser.add(option: "--path",
                                      shortName: "-p",
                                      kind: String.self,

--- a/Sources/TuistKit/Embed/Embeddable.swift
+++ b/Sources/TuistKit/Embed/Embeddable.swift
@@ -146,18 +146,18 @@ final class Embeddable {
         }
     }
 
-    fileprivate func stripFramework(keepingArchitectures: [String]) throws {
+    private func stripFramework(keepingArchitectures: [String]) throws {
         try stripArchitectures(keepingArchitectures: keepingArchitectures)
         try stripHeaders(frameworkPath: path)
         try stripPrivateHeaders(frameworkPath: path)
         try stripModulesDirectory(frameworkPath: path)
     }
 
-    fileprivate func stripDSYM(keepingArchitectures: [String]) throws {
+    private func stripDSYM(keepingArchitectures: [String]) throws {
         try stripArchitectures(keepingArchitectures: keepingArchitectures)
     }
 
-    fileprivate func stripArchitectures(keepingArchitectures: [String]) throws {
+    private func stripArchitectures(keepingArchitectures: [String]) throws {
         let architecturesInPackage = try architectures()
         let architecturesToStrip = architecturesInPackage.filter { !keepingArchitectures.contains($0) }
         try architecturesToStrip.forEach {
@@ -167,25 +167,25 @@ final class Embeddable {
         }
     }
 
-    fileprivate func stripArchitecture(packagePath: AbsolutePath,
-                                       architecture: String,
-                                       system: Systeming = System()) throws {
+    private func stripArchitecture(packagePath: AbsolutePath,
+                                   architecture: String,
+                                   system: Systeming = System()) throws {
         try system.run("/usr/bin/lipo", "-remove", architecture, "-output", packagePath.asString, packagePath.asString)
     }
 
-    fileprivate func stripHeaders(frameworkPath: AbsolutePath) throws {
+    private func stripHeaders(frameworkPath: AbsolutePath) throws {
         try stripDirectory(name: "Headers", from: frameworkPath)
     }
 
-    fileprivate func stripPrivateHeaders(frameworkPath: AbsolutePath) throws {
+    private func stripPrivateHeaders(frameworkPath: AbsolutePath) throws {
         try stripDirectory(name: "PrivateHeaders", from: frameworkPath)
     }
 
-    fileprivate func stripModulesDirectory(frameworkPath: AbsolutePath) throws {
+    private func stripModulesDirectory(frameworkPath: AbsolutePath) throws {
         try stripDirectory(name: "Modules", from: frameworkPath)
     }
 
-    fileprivate func stripDirectory(name: String, from frameworkPath: AbsolutePath) throws {
+    private func stripDirectory(name: String, from frameworkPath: AbsolutePath) throws {
         let fileHandler = FileHandler()
         let path = frameworkPath.appending(RelativePath(name))
         if fileHandler.exists(path) {
@@ -206,17 +206,17 @@ final class Embeddable {
         }
     }
 
-    fileprivate func uuidsForFramework() throws -> Set<UUID> {
+    private func uuidsForFramework() throws -> Set<UUID> {
         guard let binaryPath = try binaryPath() else { return Set() }
         return try uuidsFromDwarfdump(path: binaryPath)
     }
 
-    fileprivate func uuidsForDSYM() throws -> Set<UUID> {
+    private func uuidsForDSYM() throws -> Set<UUID> {
         return try uuidsFromDwarfdump(path: path)
     }
 
-    fileprivate func uuidsFromDwarfdump(path: AbsolutePath,
-                                        system: Systeming = System()) throws -> Set<UUID> {
+    private func uuidsFromDwarfdump(path: AbsolutePath,
+                                    system: Systeming = System()) throws -> Set<UUID> {
         let result = try system.capture("/usr/bin/dwarfdump", "--uuid", path.asString).spm_chuzzle() ?? ""
         var uuidCharacterSet = CharacterSet()
         uuidCharacterSet.formUnion(.letters)

--- a/Sources/TuistKit/Graph/Graph.swift
+++ b/Sources/TuistKit/Graph/Graph.swift
@@ -141,7 +141,7 @@ class Graph: Graphing {
             break
         case .app, .unitTests, .uiTests, .framework:
 
-            let staticLibraries = findAll(targetNode: targetNode, test: isStaticLibrary, doNotTraverseWhen: isFramework)
+            let staticLibraries = findAll(targetNode: targetNode, test: isStaticLibrary, skip: isFramework)
                 .lazy
                 .map(\.target.productName)
                 .map(DependencyReference.product)
@@ -311,7 +311,7 @@ extension Graph {
     }
 
     // Traverse the graph from the target node using DFS and return all results passing the test.
-    internal func findAll<T: GraphNode>(targetNode: TargetNode, test: (T) -> Bool, doNotTraverseWhen: (T) -> Bool = { _ in false }) -> Set<T> {
+    internal func findAll<T: GraphNode>(targetNode: TargetNode, test: (T) -> Bool, skip: (T) -> Bool = { _ in false }) -> Set<T> {
         var stack = Stack<GraphNode>()
 
         for node in targetNode.dependencies where node is T {
@@ -339,7 +339,7 @@ extension Graph {
                 references.insert(node as! T)
             }
 
-            if node is T, doNotTraverseWhen(node as! T) {
+            if node is T, skip(node as! T) {
                 continue
             } else if let targetNode = node as? TargetNode {
                 for child in targetNode.dependencies where !visited.contains(child) {

--- a/Sources/TuistKit/Graph/Graph.swift
+++ b/Sources/TuistKit/Graph/Graph.swift
@@ -335,10 +335,8 @@ extension Graph {
 
             // swiftlint:disable:next force_cast
             if node is T, test(node as! T) {
-
                 // swiftlint:disable:next force_cast
                 references.insert(node as! T)
-                
             }
 
             if node is T, doNotTraverseWhen(node as! T) {

--- a/Sources/TuistKit/Graph/GraphNode.swift
+++ b/Sources/TuistKit/Graph/GraphNode.swift
@@ -41,12 +41,12 @@ class TargetNode: GraphNode {
         self.dependencies = dependencies
         super.init(path: project.path)
     }
-    
+
     override func hash(into hasher: inout Hasher) {
         hasher.combine(path)
         hasher.combine(target.name)
     }
-    
+
     static func == (lhs: TargetNode, rhs: TargetNode) -> Bool {
         return lhs.path == rhs.path && lhs.target == rhs.target
     }
@@ -203,13 +203,13 @@ class LibraryNode: PrecompiledNode {
         self.swiftModuleMap = swiftModuleMap
         super.init(path: path)
     }
-    
+
     override func hash(into hasher: inout Hasher) {
         hasher.combine(path)
         hasher.combine(swiftModuleMap)
         hasher.combine(publicHeaders)
     }
-    
+
     static func == (lhs: LibraryNode, rhs: LibraryNode) -> Bool {
         return lhs.path == rhs.path && lhs.swiftModuleMap == rhs.swiftModuleMap && lhs.publicHeaders == rhs.publicHeaders
     }

--- a/Sources/TuistKit/Graph/GraphNode.swift
+++ b/Sources/TuistKit/Graph/GraphNode.swift
@@ -41,10 +41,14 @@ class TargetNode: GraphNode {
         self.dependencies = dependencies
         super.init(path: project.path)
     }
-
+    
     override func hash(into hasher: inout Hasher) {
         hasher.combine(path)
         hasher.combine(target.name)
+    }
+    
+    static func == (lhs: TargetNode, rhs: TargetNode) -> Bool {
+        return lhs.path == rhs.path && lhs.target == rhs.target
     }
 
     static func read(name: String,
@@ -198,6 +202,16 @@ class LibraryNode: PrecompiledNode {
         self.publicHeaders = publicHeaders
         self.swiftModuleMap = swiftModuleMap
         super.init(path: path)
+    }
+    
+    override func hash(into hasher: inout Hasher) {
+        hasher.combine(path)
+        hasher.combine(swiftModuleMap)
+        hasher.combine(publicHeaders)
+    }
+    
+    static func == (lhs: LibraryNode, rhs: LibraryNode) -> Bool {
+        return lhs.path == rhs.path && lhs.swiftModuleMap == rhs.swiftModuleMap && lhs.publicHeaders == rhs.publicHeaders
     }
 
     static func parse(publicHeaders: RelativePath,

--- a/Sources/TuistKit/Linter/GraphLinter.swift
+++ b/Sources/TuistKit/Linter/GraphLinter.swift
@@ -18,22 +18,20 @@ class GraphLinter: GraphLinting {
         self.projectLinter = projectLinter
         self.fileHandler = fileHandler
     }
-    
+
     struct StaticDepedencyWarning: Hashable {
-        
         let targetNode: TargetNode
         let linkingStaticTargetNode: TargetNode
-        
+
         var hashValue: Int {
             return linkingStaticTargetNode.hashValue
         }
-        
+
         static func == (lhs: StaticDepedencyWarning, rhs: StaticDepedencyWarning) -> Bool {
             return lhs.linkingStaticTargetNode == rhs.linkingStaticTargetNode
         }
-        
     }
-    
+
     var linkedStaticProducts = Set<StaticDepedencyWarning>()
 
     // MARK: - GraphLinting
@@ -87,18 +85,16 @@ class GraphLinter: GraphLinting {
 
         targetNode.dependencies.forEach { toNode in
             if let toTargetNode = toNode as? TargetNode {
-                
                 if toTargetNode.target.product.isStatic {
                     let (inserted, oldMember) = linkedStaticProducts.insert(StaticDepedencyWarning(targetNode: targetNode, linkingStaticTargetNode: toTargetNode))
-                    
+
                     if inserted == false {
                         let reason = "Target \(toTargetNode.target.name) has been linked against \(oldMember.targetNode.target.name) and \(targetNode.target.name), it is a static product so may introduce unwanted side effects."
                         let issue = LintingIssue(reason: reason, severity: .warning)
                         issues.append(issue)
                     }
-                    
                 }
-                
+
                 issues.append(contentsOf: lintDependency(from: targetNode, to: toTargetNode))
             }
             issues.append(contentsOf: lintGraphNode(node: toNode, evaluatedNodes: &evaluatedNodes))

--- a/Sources/TuistKit/Linter/GraphLinter.swift
+++ b/Sources/TuistKit/Linter/GraphLinter.swift
@@ -133,6 +133,8 @@ class GraphLinter: GraphLinting {
         ],
         LintableTarget(platform: .iOS, product: .framework): [
             LintableTarget(platform: .iOS, product: .framework),
+            LintableTarget(platform: .iOS, product: .staticLibrary),
+            LintableTarget(platform: .iOS, product: .staticFramework),
         ],
         LintableTarget(platform: .iOS, product: .unitTests): [
             LintableTarget(platform: .iOS, product: .app),
@@ -190,6 +192,8 @@ class GraphLinter: GraphLinting {
         ],
         LintableTarget(platform: .macOS, product: .framework): [
             LintableTarget(platform: .macOS, product: .framework),
+            LintableTarget(platform: .macOS, product: .staticLibrary),
+            LintableTarget(platform: .macOS, product: .staticFramework),
         ],
         LintableTarget(platform: .macOS, product: .unitTests): [
             LintableTarget(platform: .macOS, product: .app),
@@ -231,6 +235,8 @@ class GraphLinter: GraphLinting {
         ],
         LintableTarget(platform: .tvOS, product: .framework): [
             LintableTarget(platform: .tvOS, product: .framework),
+            LintableTarget(platform: .tvOS, product: .staticLibrary),
+            LintableTarget(platform: .tvOS, product: .staticFramework),
         ],
         LintableTarget(platform: .tvOS, product: .unitTests): [
             LintableTarget(platform: .tvOS, product: .app),

--- a/Sources/TuistKit/Linter/GraphLinter.swift
+++ b/Sources/TuistKit/Linter/GraphLinter.swift
@@ -18,6 +18,23 @@ class GraphLinter: GraphLinting {
         self.projectLinter = projectLinter
         self.fileHandler = fileHandler
     }
+    
+    struct StaticDepedencyWarning: Hashable {
+        
+        let targetNode: TargetNode
+        let linkingStaticTargetNode: TargetNode
+        
+        var hashValue: Int {
+            return linkingStaticTargetNode.hashValue
+        }
+        
+        static func == (lhs: StaticDepedencyWarning, rhs: StaticDepedencyWarning) -> Bool {
+            return lhs.linkingStaticTargetNode == rhs.linkingStaticTargetNode
+        }
+        
+    }
+    
+    var linkedStaticProducts = Set<StaticDepedencyWarning>()
 
     // MARK: - GraphLinting
 
@@ -70,6 +87,18 @@ class GraphLinter: GraphLinting {
 
         targetNode.dependencies.forEach { toNode in
             if let toTargetNode = toNode as? TargetNode {
+                
+                if toTargetNode.target.product.isStatic {
+                    let (inserted, oldMember) = linkedStaticProducts.insert(StaticDepedencyWarning(targetNode: targetNode, linkingStaticTargetNode: toTargetNode))
+                    
+                    if inserted == false {
+                        let reason = "Target \(toTargetNode.target.name) has been linked against \(oldMember.targetNode.target.name) and \(targetNode.target.name), it is a static product so may introduce unwanted side effects."
+                        let issue = LintingIssue(reason: reason, severity: .warning)
+                        issues.append(issue)
+                    }
+                    
+                }
+                
                 issues.append(contentsOf: lintDependency(from: targetNode, to: toTargetNode))
             }
             issues.append(contentsOf: lintGraphNode(node: toNode, evaluatedNodes: &evaluatedNodes))

--- a/Sources/TuistKit/Models/Up/Up.swift
+++ b/Sources/TuistKit/Models/Up/Up.swift
@@ -3,7 +3,7 @@ import Foundation
 import TuistCore
 
 /// Protocol that defines the interface of an up command.
-protocol Upping: class {
+protocol Upping: AnyObject {
     /// Name of the command.
     var name: String { get }
 

--- a/Tests/TuistKitTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/BuildPhaseGeneratorTests.swift
@@ -41,7 +41,7 @@ final class BuildPhaseGeneratorTests: XCTestCase {
                                  actions: [
                                      TargetAction(name: "post", order: .post, path: tmpDir.path.appending(component: "script.sh"), arguments: ["arg"]),
                                      TargetAction(name: "pre", order: .pre, path: tmpDir.path.appending(component: "script.sh"), arguments: ["arg"]),
-        ])
+                                 ])
 
         try subject.generateBuildPhases(target: target,
                                         pbxTarget: pbxTarget,

--- a/Tests/TuistKitTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/BuildPhaseGeneratorTests.swift
@@ -41,7 +41,7 @@ final class BuildPhaseGeneratorTests: XCTestCase {
                                  actions: [
                                      TargetAction(name: "post", order: .post, path: tmpDir.path.appending(component: "script.sh"), arguments: ["arg"]),
                                      TargetAction(name: "pre", order: .pre, path: tmpDir.path.appending(component: "script.sh"), arguments: ["arg"]),
-                                 ])
+        ])
 
         try subject.generateBuildPhases(target: target,
                                         pbxTarget: pbxTarget,

--- a/Tests/TuistKitTests/Generator/GeneratorModelLoaderTest.swift
+++ b/Tests/TuistKitTests/Generator/GeneratorModelLoaderTest.swift
@@ -67,7 +67,7 @@ class GeneratorModelLoaderTest: XCTestCase {
                                        targets: [
                                            targetA,
                                            targetB,
-            ]),
+                                       ]),
         ]
 
         let manifestLoader = createManifestLoader(with: manifests)

--- a/Tests/TuistKitTests/Generator/GeneratorModelLoaderTest.swift
+++ b/Tests/TuistKitTests/Generator/GeneratorModelLoaderTest.swift
@@ -67,7 +67,7 @@ class GeneratorModelLoaderTest: XCTestCase {
                                        targets: [
                                            targetA,
                                            targetB,
-                                       ]),
+            ]),
         ]
 
         let manifestLoader = createManifestLoader(with: manifests)

--- a/Tests/TuistKitTests/Generator/ProjectGroupsTests.swift
+++ b/Tests/TuistKitTests/Generator/ProjectGroupsTests.swift
@@ -26,7 +26,7 @@ final class ProjectGroupsTests: XCTestCase {
                           targets: [
                               .test(filesGroup: .group(name: "Target")),
                               .test(),
-        ])
+                          ])
         pbxproj = PBXProj()
     }
 

--- a/Tests/TuistKitTests/Generator/ProjectGroupsTests.swift
+++ b/Tests/TuistKitTests/Generator/ProjectGroupsTests.swift
@@ -26,7 +26,7 @@ final class ProjectGroupsTests: XCTestCase {
                           targets: [
                               .test(filesGroup: .group(name: "Target")),
                               .test(),
-                          ])
+        ])
         pbxproj = PBXProj()
     }
 

--- a/Tests/TuistKitTests/Graph/GraphTests.swift
+++ b/Tests/TuistKitTests/Graph/GraphTests.swift
@@ -92,20 +92,20 @@ final class GraphTests: XCTestCase {
         let project = Project.test(targets: [target])
 
         let staticDependencyNode = TargetNode(project: project,
-                                               target: staticDependency,
-                                               dependencies: [])
+                                              target: staticDependency,
+                                              dependencies: [])
         let dependencyNode = TargetNode(project: project,
                                         target: dependency,
                                         dependencies: [staticDependencyNode])
         let targetNode = TargetNode(project: project,
                                     target: target,
                                     dependencies: [dependencyNode])
-        
+
         let cache = GraphLoaderCache()
         cache.add(targetNode: targetNode)
         cache.add(targetNode: dependencyNode)
         cache.add(targetNode: staticDependencyNode)
-        
+
         let graph = Graph.test(cache: cache)
         let got = try graph.linkableDependencies(path: project.path,
                                                  name: target.name)

--- a/Tests/TuistKitTests/Graph/GraphTests.swift
+++ b/Tests/TuistKitTests/Graph/GraphTests.swift
@@ -91,13 +91,13 @@ final class GraphTests: XCTestCase {
         let staticDependency1 = Target.test(name: "StaticDependency1", product: .staticLibrary)
         let staticDependency2 = Target.test(name: "StaticDependency2", product: .staticLibrary)
         let project = Project.test(targets: [target])
-        
+
         let staticDependencyNode1 = TargetNode(project: project,
-                                              target: staticDependency1,
-                                              dependencies: [])
+                                               target: staticDependency1,
+                                               dependencies: [])
         let staticDependencyNode2 = TargetNode(project: project,
-                                        target: staticDependency2,
-                                        dependencies: [staticDependencyNode1])
+                                               target: staticDependency2,
+                                               dependencies: [staticDependencyNode1])
         let dependencyNode = TargetNode(project: project,
                                         target: dependency,
                                         dependencies: [staticDependencyNode2])
@@ -114,10 +114,10 @@ final class GraphTests: XCTestCase {
                                                  name: target.name)
         XCTAssertEqual(got.count, 1)
         XCTAssertEqual(got.first, .product("Dependency.framework"))
-        
+
         let frameworkGot = try graph.linkableDependencies(path: project.path,
                                                           name: dependency.name)
-        
+
         XCTAssertEqual(frameworkGot.count, 2)
         XCTAssertTrue(frameworkGot.contains(.product("libStaticDependency1.a")))
         XCTAssertTrue(frameworkGot.contains(.product("libStaticDependency2.a")))

--- a/Tests/TuistKitTests/Graph/GraphTests.swift
+++ b/Tests/TuistKitTests/Graph/GraphTests.swift
@@ -88,27 +88,24 @@ final class GraphTests: XCTestCase {
     func test_linkableDependencies_whenAFrameworkTarget() throws {
         let target = Target.test(name: "Main")
         let dependency = Target.test(name: "Dependency", product: .framework)
-        let staticDependency1 = Target.test(name: "StaticDependency1", product: .staticLibrary)
-        let staticDependency2 = Target.test(name: "StaticDependency2", product: .staticLibrary)
+        let staticDependency = Target.test(name: "StaticDependency", product: .staticLibrary)
         let project = Project.test(targets: [target])
 
-        let staticDependencyNode1 = TargetNode(project: project,
-                                               target: staticDependency1,
+        let staticDependencyNode = TargetNode(project: project,
+                                               target: staticDependency,
                                                dependencies: [])
-        let staticDependencyNode2 = TargetNode(project: project,
-                                               target: staticDependency2,
-                                               dependencies: [staticDependencyNode1])
         let dependencyNode = TargetNode(project: project,
                                         target: dependency,
-                                        dependencies: [staticDependencyNode2])
+                                        dependencies: [staticDependencyNode])
         let targetNode = TargetNode(project: project,
                                     target: target,
                                     dependencies: [dependencyNode])
+        
         let cache = GraphLoaderCache()
         cache.add(targetNode: targetNode)
         cache.add(targetNode: dependencyNode)
-        cache.add(targetNode: staticDependencyNode1)
-        cache.add(targetNode: staticDependencyNode2)
+        cache.add(targetNode: staticDependencyNode)
+        
         let graph = Graph.test(cache: cache)
         let got = try graph.linkableDependencies(path: project.path,
                                                  name: target.name)
@@ -118,9 +115,8 @@ final class GraphTests: XCTestCase {
         let frameworkGot = try graph.linkableDependencies(path: project.path,
                                                           name: dependency.name)
 
-        XCTAssertEqual(frameworkGot.count, 2)
-        XCTAssertTrue(frameworkGot.contains(.product("libStaticDependency1.a")))
-        XCTAssertTrue(frameworkGot.contains(.product("libStaticDependency2.a")))
+        XCTAssertEqual(frameworkGot.count, 1)
+        XCTAssertTrue(frameworkGot.contains(.product("libStaticDependency.a")))
     }
 
     func test_librariesPublicHeaders() throws {

--- a/Tests/TuistKitTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistKitTests/Linter/GraphLinterTests.swift
@@ -53,31 +53,31 @@ final class GraphLinterTests: XCTestCase {
 
         XCTAssertTrue(result.contains(LintingIssue(reason: "Framework not found at path \(frameworkBPath.asString)", severity: .error)))
     }
-    
+
     func test_lint_when_static_product_linked_twice() throws {
         let cache = GraphLoaderCache()
-        
-        let appTarget = Target.test(name: "AppTarget", dependencies: [ .target(name: "staticFramework"), .target(name: "frameworkA") ])
-        let frameworkTarget = Target.test(name: "frameworkA", dependencies: [ .target(name: "staticFramework") ])
+
+        let appTarget = Target.test(name: "AppTarget", dependencies: [.target(name: "staticFramework"), .target(name: "frameworkA")])
+        let frameworkTarget = Target.test(name: "frameworkA", dependencies: [.target(name: "staticFramework")])
         let staticFrameworkTarget = Target.test(name: "staticFramework", product: .staticFramework)
-        
-        let app = Project.test(path: "/tmp/app", name: "App", targets: [ appTarget ])
-        let projectFramework = Project.test(path: "/tmp/framework", name: "projectFramework", targets: [ frameworkTarget ])
-        let projectStaticFramework = Project.test(path: "/tmp/staticframework", name: "projectStaticFramework", targets: [ staticFrameworkTarget ])
-        
-        let staticFramework = TargetNode(project: projectStaticFramework, target: staticFrameworkTarget, dependencies: [ ])
-        let framework = TargetNode(project: projectFramework, target: frameworkTarget, dependencies: [ staticFramework ])
-        let appTargetNode = TargetNode(project: app, target: appTarget, dependencies: [ staticFramework, framework ])
-        
+
+        let app = Project.test(path: "/tmp/app", name: "App", targets: [appTarget])
+        let projectFramework = Project.test(path: "/tmp/framework", name: "projectFramework", targets: [frameworkTarget])
+        let projectStaticFramework = Project.test(path: "/tmp/staticframework", name: "projectStaticFramework", targets: [staticFrameworkTarget])
+
+        let staticFramework = TargetNode(project: projectStaticFramework, target: staticFrameworkTarget, dependencies: [])
+        let framework = TargetNode(project: projectFramework, target: frameworkTarget, dependencies: [staticFramework])
+        let appTargetNode = TargetNode(project: app, target: appTarget, dependencies: [staticFramework, framework])
+
         cache.add(project: app)
         cache.add(targetNode: appTargetNode)
         cache.add(targetNode: framework)
         cache.add(targetNode: staticFramework)
-        
-        let graph = Graph.test(cache: cache, entryNodes: [ appTargetNode, framework, staticFramework ])
-        
+
+        let graph = Graph.test(cache: cache, entryNodes: [appTargetNode, framework, staticFramework])
+
         let result = subject.lint(graph: graph)
-        
+
         XCTAssertTrue(result.contains(LintingIssue(reason: "Target staticFramework has been linked against AppTarget and frameworkA, it is a static product so may introduce unwanted side effects.", severity: .warning)))
     }
 }

--- a/Tests/TuistKitTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistKitTests/Linter/GraphLinterTests.swift
@@ -53,4 +53,31 @@ final class GraphLinterTests: XCTestCase {
 
         XCTAssertTrue(result.contains(LintingIssue(reason: "Framework not found at path \(frameworkBPath.asString)", severity: .error)))
     }
+    
+    func test_lint_when_static_product_linked_twice() throws {
+        let cache = GraphLoaderCache()
+        
+        let appTarget = Target.test(name: "AppTarget", dependencies: [ .target(name: "staticFramework"), .target(name: "frameworkA") ])
+        let frameworkTarget = Target.test(name: "frameworkA", dependencies: [ .target(name: "staticFramework") ])
+        let staticFrameworkTarget = Target.test(name: "staticFramework", product: .staticFramework)
+        
+        let app = Project.test(path: "/tmp/app", name: "App", targets: [ appTarget ])
+        let projectFramework = Project.test(path: "/tmp/framework", name: "projectFramework", targets: [ frameworkTarget ])
+        let projectStaticFramework = Project.test(path: "/tmp/staticframework", name: "projectStaticFramework", targets: [ staticFrameworkTarget ])
+        
+        let staticFramework = TargetNode(project: projectStaticFramework, target: staticFrameworkTarget, dependencies: [ ])
+        let framework = TargetNode(project: projectFramework, target: frameworkTarget, dependencies: [ staticFramework ])
+        let appTargetNode = TargetNode(project: app, target: appTarget, dependencies: [ staticFramework, framework ])
+        
+        cache.add(project: app)
+        cache.add(targetNode: appTargetNode)
+        cache.add(targetNode: framework)
+        cache.add(targetNode: staticFramework)
+        
+        let graph = Graph.test(cache: cache, entryNodes: [ appTargetNode, framework, staticFramework ])
+        
+        let result = subject.lint(graph: graph)
+        
+        XCTAssertTrue(result.contains(LintingIssue(reason: "Target staticFramework has been linked against AppTarget and frameworkA, it is a static product so may introduce unwanted side effects.", severity: .warning)))
+    }
 }

--- a/features/generate.feature
+++ b/features/generate.feature
@@ -72,3 +72,23 @@ Scenario: The project is an iOS application that has resources (ios_app_with_fra
     Then I should be able to build the scheme App
     Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'tuist.png'
     Then the product 'App.app' with destination 'Debug-iphoneos' does not contain resource 'do_not_include.dat'
+
+Scenario: The project is an iOS application with frameworks and tests (ios_app_with_framework_linking_static_framework)
+    Given that tuist is available
+    And I have a working directory
+    Then I copy the fixture ios_app_with_framework_linking_static_framework into the working directory
+    Then tuist generates the project
+    Then I should be able to build the scheme App
+    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'Frameworks/Framework1.framework/Framework1'
+    Then the product 'App.app' with destination 'Debug-iphoneos' does not contain resource 'Frameworks/Framework2.framework/Framework2'
+    Then the product 'App.app' with destination 'Debug-iphoneos' does not contain resource 'Frameworks/Framework3.framework/Framework3'
+    Then the product 'App.app' with destination 'Debug-iphoneos' does not contain resource 'Frameworks/Framework4.framework/Framework4'
+    Then I should be able to test the scheme AppTests
+    Then I should be able to build the scheme Framework1
+    Then I should be able to test the scheme Framework1Tests
+    Then I should be able to build the scheme Framework2
+    Then I should be able to test the scheme Framework2Tests
+    Then I should be able to build the scheme Framework3
+    Then I should be able to test the scheme Framework3Tests
+    Then I should be able to build the scheme Framework4
+    Then I should be able to test the scheme Framework4Tests

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -77,3 +77,34 @@ Workspace:
 Dependencies:
   - App -> A
   - A -> B
+
+## ios_app_with_framework_linking_static_framework
+
+An example project demonstrating an iOS application linking a dynamic framework which itself depends on a static framework with transitive static dependencies.
+
+Only Framework1.framework should be linked and included into App, everything else should be statically linked into the Framework1 executable.
+
+```
+Workspace:
+  - App:
+    - MainApp (iOS app)
+    - MainAppTests (iOS unit tests)
+  - Framework1:
+    - Framework1 (dynamic iOS framework)
+    - Framework1Tests (iOS unit tests)
+  - Framework2:
+    - Framework2 (static iOS framework)
+    - Framework2Tests (iOS unit tests)
+  - Framework3:
+    - Framework3 (static iOS framework)
+    - Framework3Tests (iOS unit tests)
+  - Framework4:
+    - Framework4 (static iOS framework)
+    - Framework4Tests (iOS unit tests)
+```
+
+Dependencies:
+  - App -> Framework1
+  - Framework1 -> Framework2
+  - Framework1 -> Framework3
+  - Framework3 -> Framework4

--- a/fixtures/ios_app_with_framework_linking_static_framework/App/Config/App-Info.plist
+++ b/fixtures/ios_app_with_framework_linking_static_framework/App/Config/App-Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright Tuist©. All rights reserved.</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_framework_linking_static_framework/App/Config/AppTests-Info.plist
+++ b/fixtures/ios_app_with_framework_linking_static_framework/App/Config/AppTests-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_framework_linking_static_framework/App/Project.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/App/Project.swift
@@ -1,0 +1,23 @@
+import ProjectDescription
+
+let project = Project(name: "MainApp",
+                      targets: [
+                          Target(name: "App",
+                                 platform: .iOS,
+                                 product: .app,
+                                 bundleId: "io.tuist.App",
+                                 infoPlist: "Config/App-Info.plist",
+                                 sources: "Sources/**",
+                                 dependencies: [
+                                     .project(target: "Framework1", path: "../Framework1")
+                          ]),
+                          Target(name: "AppTests",
+                                 platform: .iOS,
+                                 product: .unitTests,
+                                 bundleId: "io.tuist.AppTests",
+                                 infoPlist: "Config/AppTests-Info.plist",
+                                 sources: "Tests/**",
+                                 dependencies: [
+                                     .target(name: "App"),
+                          ]),
+])

--- a/fixtures/ios_app_with_framework_linking_static_framework/App/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/App/Sources/AppDelegate.swift
@@ -1,5 +1,4 @@
 import Framework1
-import Framework2
 import UIKit
 
 @UIApplicationMain
@@ -8,14 +7,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationDidFinishLaunching(_: UIApplication) {
         let framework1 = Framework1File()
-        let framework2 = Framework2File()
 
         print(hello())
         print("AppDelegate -> \(framework1.hello())")
         print("AppDelegate -> \(framework1.helloFromFramework2())")
         print("AppDelegate -> \(framework1.helloFromFramework3())")
         print("AppDelegate -> \(framework1.helloFromFramework4())")
-        print("AppDelegate -> \(framework2.hello())")
     }
 
     func hello() -> String {

--- a/fixtures/ios_app_with_framework_linking_static_framework/App/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/App/Sources/AppDelegate.swift
@@ -1,0 +1,24 @@
+import Framework1
+import Framework2
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func applicationDidFinishLaunching(_: UIApplication) {
+        let framework1 = Framework1File()
+        let framework2 = Framework2File()
+
+        print(hello())
+        print("AppDelegate -> \(framework1.hello())")
+        print("AppDelegate -> \(framework1.helloFromFramework2())")
+        print("AppDelegate -> \(framework1.helloFromFramework3())")
+        print("AppDelegate -> \(framework1.helloFromFramework4())")
+        print("AppDelegate -> \(framework2.hello())")
+    }
+
+    func hello() -> String {
+        return "AppDelegate.hello()"
+    }
+}

--- a/fixtures/ios_app_with_framework_linking_static_framework/App/Tests/AppDelegateTests.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/App/Tests/AppDelegateTests.swift
@@ -1,0 +1,12 @@
+// @testable import App
+import XCTest
+
+// Generated project does not set "Host Application" and "Allow testing Host Application APIs",
+// what leads to "ld: symbol(s) not found for architecture x86_64" linker error.
+class AppDelegateTests: XCTestCase {
+//    func testHello() {
+//        let sut = AppDelegate()
+//
+//        XCTAssertEqual("AppDelegate.hello()", sut.hello())
+//    }
+}

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework1/Config/Framework1-Info.plist
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework1/Config/Framework1-Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright Tuist©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework1/Config/Framework1Tests-Info.plist
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework1/Config/Framework1Tests-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework1/Project.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework1/Project.swift
@@ -1,0 +1,25 @@
+import ProjectDescription
+
+let project = Project(name: "Framework1",
+                      targets: [
+                          Target(name: "Framework1",
+                                 platform: .iOS,
+                                 product: .framework,
+                                 bundleId: "io.tuist.Framework1",
+                                 infoPlist: "Config/Framework1-Info.plist",
+                                 sources: "Sources/**",
+                                 dependencies: [
+                                     .project(target: "Framework2", path: "../Framework2"),
+                                     .project(target: "Framework3", path: "../Framework3"),
+                          ]),
+
+                          Target(name: "Framework1Tests",
+                                 platform: .iOS,
+                                 product: .unitTests,
+                                 bundleId: "io.tuist.Framework1Tests",
+                                 infoPlist: "Config/Framework1Tests-Info.plist",
+                                 sources: "Tests/**",
+                                 dependencies: [
+                                     .target(name: "Framework1"),
+                          ]),
+])

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework1/Sources/Framework1File.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework1/Sources/Framework1File.swift
@@ -5,7 +5,7 @@ import Framework4
 
 public class Framework1File {
     private let framework2File = Framework2File()
-    private let framework3File = Framework2File()
+    private let framework3File = Framework3File()
     private let framework4File = Framework4File()
 
     public init() {}

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework1/Sources/Framework1File.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework1/Sources/Framework1File.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Framework2
+import Framework3
+import Framework4
+
+public class Framework1File {
+    private let framework2File = Framework2File()
+    private let framework3File = Framework2File()
+    private let framework4File = Framework4File()
+
+    public init() {}
+
+    public func hello() -> String {
+        return "Framework1File.hello()"
+    }
+
+    public func helloFromFramework2() -> String {
+        return "Framework1File -> \(framework2File.hello())"
+    }
+
+    public func helloFromFramework3() -> String {
+        return "Framework1File -> \(framework3File.hello())"
+    }
+
+    public func helloFromFramework4() -> String {
+        return "Framework1File -> \(framework4File.hello())"
+    }
+}

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework1/Tests/Framework1FileTests.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework1/Tests/Framework1FileTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import Framework1
+
+class Framework1Tests: XCTestCase {
+    func testHello() {
+        let sut = Framework1File()
+
+        XCTAssertEqual("Framework1File.hello()", sut.hello())
+    }
+
+    func testHelloFromFramework2() {
+        let sut = Framework1File()
+
+        XCTAssertEqual("Framework1File -> Framework2File.hello()", sut.helloFromFramework2())
+    }
+}

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework2/Config/Framework2-Info.plist
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework2/Config/Framework2-Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright Tuist©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework2/Config/Framework2Tests-Info.plist
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework2/Config/Framework2Tests-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework2/Project.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework2/Project.swift
@@ -1,0 +1,22 @@
+import ProjectDescription
+
+let project = Project(name: "Framework2",
+                      targets: [
+                          Target(name: "Framework2",
+                                 platform: .iOS,
+                                 product: .staticFramework,
+                                 bundleId: "io.tuist.Framework2",
+                                 infoPlist: "Config/Framework2-Info.plist",
+                                 sources: "Sources/**",
+                                 dependencies: []),
+
+                          Target(name: "Framework2Tests",
+                                 platform: .iOS,
+                                 product: .unitTests,
+                                 bundleId: "io.tuist.Framework2Tests",
+                                 infoPlist: "Config/Framework2Tests-Info.plist",
+                                 sources: "Tests/**",
+                                 dependencies: [
+                                     .target(name: "Framework2"),
+                          ]),
+])

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework2/Sources/Framework2File.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework2/Sources/Framework2File.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public class Framework2File {
+    public init() {}
+
+    public func hello() -> String {
+        return "Framework2File.hello()"
+    }
+}

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework2/Tests/Framework2FileTests.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework2/Tests/Framework2FileTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import Framework2
+
+class Framework2Tests: XCTestCase {
+    func testHello() {
+        let sut = Framework2File()
+
+        XCTAssertEqual("Framework2File.hello()", sut.hello())
+    }
+}

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework3/Config/Framework3-Info.plist
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework3/Config/Framework3-Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright Tuist©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework3/Config/Framework3Tests-Info.plist
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework3/Config/Framework3Tests-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework3/Project.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework3/Project.swift
@@ -1,0 +1,24 @@
+import ProjectDescription
+
+let project = Project(name: "Framework3",
+                      targets: [
+                          Target(name: "Framework3",
+                                 platform: .iOS,
+                                 product: .staticFramework,
+                                 bundleId: "io.tuist.Framework3",
+                                 infoPlist: "Config/Framework3-Info.plist",
+                                 sources: "Sources/**",
+                                 dependencies: [
+                                     .project(target: "Framework4", path: "../Framework4"),
+                          ]),
+
+                          Target(name: "Framework3Tests",
+                                 platform: .iOS,
+                                 product: .unitTests,
+                                 bundleId: "io.tuist.Framework3Tests",
+                                 infoPlist: "Config/Framework3Tests-Info.plist",
+                                 sources: "Tests/**",
+                                 dependencies: [
+                                     .target(name: "Framework3"),
+                          ]),
+])

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework3/Sources/Framework3File.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework3/Sources/Framework3File.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public class Framework3File {
+    public init() {}
+
+    public func hello() -> String {
+        return "Framework3File.hello()"
+    }
+}

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework3/Tests/Framework3FileTests.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework3/Tests/Framework3FileTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import Framework3
+
+class Framework3Tests: XCTestCase {
+    func testHello() {
+        let sut = Framework3File()
+
+        XCTAssertEqual("Framework3File.hello()", sut.hello())
+    }
+}

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework4/Config/Framework4-Info.plist
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework4/Config/Framework4-Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright Tuist©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework4/Config/Framework4Tests-Info.plist
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework4/Config/Framework4Tests-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework4/Project.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework4/Project.swift
@@ -1,0 +1,22 @@
+import ProjectDescription
+
+let project = Project(name: "Framework4",
+                      targets: [
+                          Target(name: "Framework4",
+                                 platform: .iOS,
+                                 product: .staticFramework,
+                                 bundleId: "io.tuist.Framework4",
+                                 infoPlist: "Config/Framework4-Info.plist",
+                                 sources: "Sources/**",
+                                 dependencies: []),
+
+                          Target(name: "Framework4Tests",
+                                 platform: .iOS,
+                                 product: .unitTests,
+                                 bundleId: "io.tuist.Framework4Tests",
+                                 infoPlist: "Config/Framework4Tests-Info.plist",
+                                 sources: "Tests/**",
+                                 dependencies: [
+                                     .target(name: "Framework4"),
+                          ]),
+])

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework4/Sources/Framework4File.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework4/Sources/Framework4File.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public class Framework4File {
+    public init() {}
+
+    public func hello() -> String {
+        return "Framework4File.hello()"
+    }
+}

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework4/Tests/Framework4FileTests.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework4/Tests/Framework4FileTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import Framework4
+
+class Framework4Tests: XCTestCase {
+    func testHello() {
+        let sut = Framework4File()
+
+        XCTAssertEqual("Framework4File.hello()", sut.hello())
+    }
+}

--- a/fixtures/ios_app_with_framework_linking_static_framework/Workspace.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Workspace.swift
@@ -1,0 +1,4 @@
+import ProjectDescription
+
+let workspace = Workspace(name: "Workspace",
+                          projects: ["App", "Framework1", "Framework2"])

--- a/fixtures/ios_app_with_framework_linking_static_framework/Workspace.xcworkspace/contents.xcworkspacedata
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Workspace.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Workspace.swift">
+   </FileRef>
+   <FileRef
+      location = "group:App/MainApp.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Framework1/Framework1.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Framework2/Framework2.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Framework3/Framework3.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Framework4/Framework4.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/fixtures/ios_app_with_framework_linking_static_framework/Workspace.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Workspace.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/175

### Short description 📝

Tuist prevents dynamic frameworks from linking static libraries or frameworks. This was reported [here](https://github.com/tuist/tuist/issues/172). This pull request lifts those linter warnings and ensure's that the frameworks are allowed to link static dependencies as well as any transitive static dependencies.

### Solution 📦

When we traverse the graph for linkable dependencies we used to traverse the whole graph for static products and include them at the top level bundle. 

We now traverse the graph and stop looking for any more static products when we reach a dynamic framework, and the work is then handed off to the framework to decide what it links during it's pass of linkableDependencies.

I created a fixture called `ios_app_with_framework_linking_static_framework` which demonstrates the logic described above.

Todo:

- [x] Update changelog
- [x] Update fixture Readme
- [x] Create fixture test to ensure test compiles
