### PR TITLE
Set TEST_HOST and BUNDLE_LOADER for app unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Build settings not being generated properly https://github.com/tuist/tuist/pull/282 by @pepibumur
 - Fix `instance method nearly matches optional requirements` warning in generated `AppDelegate.swift` in iOS projects https://github.com/tuist/tuist/pull/291 by @BalestraPatrick
 - Fix Header & Framework search paths override project or xcconfig settings https://github.com/tuist/tuist/pull/301 by @ollieatkinson
+- Unit tests bundle for an app target compile & run https://github.com/tuist/tuist/pull/300 by @ollieatkinson
 
 ## 0.12.0
 

--- a/Sources/TuistKit/Generator/ConfigGenerator.swift
+++ b/Sources/TuistKit/Generator/ConfigGenerator.swift
@@ -170,17 +170,24 @@ final class ConfigGenerator: ConfigGenerating {
             settings["MACH_O_TYPE"] = "staticlib"
         }
 
-        if target.product.isTest {
+        if target.product.testsBundle {
+            
             let appDependencies = graph.targetDependencies(path: sourceRootPath, name: target.name).filter { targetNode in
                 targetNode.target.product == .app
             }
 
             if let app = appDependencies.first {
-                settings["TEST_HOST"] = "$(BUILT_PRODUCTS_DIR)/\(app.target.productName)/\(app.target.name)"
-                settings["BUNDLE_LOADER"] = "$(TEST_HOST)"
+                
+                settings["TEST_TARGET_NAME"] = "\(app.target.name)"
+                
+                if target.product == .unitTests {
+                    settings["TEST_HOST"] = "$(BUILT_PRODUCTS_DIR)/\(app.target.productName)/\(app.target.name)"
+                    settings["BUNDLE_LOADER"] = "$(TEST_HOST)"
+                }
+                
             }
         }
-
+        
         variantBuildConfiguration.buildSettings = settings
         pbxproj.add(object: variantBuildConfiguration)
         configurationList.buildConfigurations.append(variantBuildConfiguration)

--- a/Sources/TuistKit/Generator/ConfigGenerator.swift
+++ b/Sources/TuistKit/Generator/ConfigGenerator.swift
@@ -169,18 +169,16 @@ final class ConfigGenerator: ConfigGenerating {
         if target.product == .staticFramework {
             settings["MACH_O_TYPE"] = "staticlib"
         }
-        
+
         if target.product.isTest {
-            
             let appDependencies = graph.targetDependencies(path: sourceRootPath, name: target.name).filter { targetNode in
                 targetNode.target.product == .app
             }
-            
+
             if let app = appDependencies.first {
                 settings["TEST_HOST"] = "$(BUILT_PRODUCTS_DIR)/\(app.target.productName)/\(app.target.name)"
                 settings["BUNDLE_LOADER"] = "$(TEST_HOST)"
             }
-            
         }
 
         variantBuildConfiguration.buildSettings = settings

--- a/Sources/TuistKit/Generator/ConfigGenerator.swift
+++ b/Sources/TuistKit/Generator/ConfigGenerator.swift
@@ -171,17 +171,19 @@ final class ConfigGenerator: ConfigGenerating {
         }
 
         if target.product.testsBundle {
-            let appDependencies = graph.targetDependencies(path: sourceRootPath, name: target.name).filter { targetNode in
+            let appDependency = graph.targetDependencies(path: sourceRootPath, name: target.name).first { targetNode in
                 targetNode.target.product == .app
             }
 
-            if let app = appDependencies.first {
+            if let app = appDependency {
+                
                 settings["TEST_TARGET_NAME"] = "\(app.target.name)"
-
+                
                 if target.product == .unitTests {
                     settings["TEST_HOST"] = "$(BUILT_PRODUCTS_DIR)/\(app.target.productName)/\(app.target.name)"
                     settings["BUNDLE_LOADER"] = "$(TEST_HOST)"
                 }
+                
             }
         }
 

--- a/Sources/TuistKit/Generator/ConfigGenerator.swift
+++ b/Sources/TuistKit/Generator/ConfigGenerator.swift
@@ -171,23 +171,20 @@ final class ConfigGenerator: ConfigGenerating {
         }
 
         if target.product.testsBundle {
-            
             let appDependencies = graph.targetDependencies(path: sourceRootPath, name: target.name).filter { targetNode in
                 targetNode.target.product == .app
             }
 
             if let app = appDependencies.first {
-                
                 settings["TEST_TARGET_NAME"] = "\(app.target.name)"
-                
+
                 if target.product == .unitTests {
                     settings["TEST_HOST"] = "$(BUILT_PRODUCTS_DIR)/\(app.target.productName)/\(app.target.name)"
                     settings["BUNDLE_LOADER"] = "$(TEST_HOST)"
                 }
-                
             }
         }
-        
+
         variantBuildConfiguration.buildSettings = settings
         pbxproj.add(object: variantBuildConfiguration)
         configurationList.buildConfigurations.append(variantBuildConfiguration)

--- a/Sources/TuistKit/Generator/ConfigGenerator.swift
+++ b/Sources/TuistKit/Generator/ConfigGenerator.swift
@@ -176,14 +176,12 @@ final class ConfigGenerator: ConfigGenerating {
             }
 
             if let app = appDependency {
-                
                 settings["TEST_TARGET_NAME"] = "\(app.target.name)"
-                
+
                 if target.product == .unitTests {
                     settings["TEST_HOST"] = "$(BUILT_PRODUCTS_DIR)/\(app.target.productName)/\(app.target.name)"
                     settings["BUNDLE_LOADER"] = "$(TEST_HOST)"
                 }
-                
             }
         }
 

--- a/Sources/TuistKit/Generator/ConfigGenerator.swift
+++ b/Sources/TuistKit/Generator/ConfigGenerator.swift
@@ -13,6 +13,7 @@ protocol ConfigGenerating: AnyObject {
                               pbxTarget: PBXTarget,
                               pbxproj: PBXProj,
                               fileElements: ProjectFileElements,
+                              graph: Graphing,
                               options: GenerationOptions,
                               sourceRootPath: AbsolutePath) throws
 }
@@ -58,6 +59,7 @@ final class ConfigGenerator: ConfigGenerating {
                               pbxTarget: PBXTarget,
                               pbxproj: PBXProj,
                               fileElements: ProjectFileElements,
+                              graph: Graphing,
                               options _: GenerationOptions,
                               sourceRootPath: AbsolutePath) throws {
         let configurationList = XCConfigurationList(buildConfigurations: [])
@@ -68,6 +70,7 @@ final class ConfigGenerator: ConfigGenerating {
                                       buildConfiguration: .debug,
                                       configuration: target.settings?.debug,
                                       fileElements: fileElements,
+                                      graph: graph,
                                       pbxproj: pbxproj,
                                       configurationList: configurationList,
                                       sourceRootPath: sourceRootPath)
@@ -76,6 +79,7 @@ final class ConfigGenerator: ConfigGenerating {
                                       buildConfiguration: .release,
                                       configuration: target.settings?.release,
                                       fileElements: fileElements,
+                                      graph: graph,
                                       pbxproj: pbxproj,
                                       configurationList: configurationList,
                                       sourceRootPath: sourceRootPath)
@@ -117,6 +121,7 @@ final class ConfigGenerator: ConfigGenerating {
                                                buildConfiguration: BuildConfiguration,
                                                configuration: Configuration?,
                                                fileElements: ProjectFileElements,
+                                               graph: Graphing,
                                                pbxproj: PBXProj,
                                                configurationList: XCConfigurationList,
                                                sourceRootPath: AbsolutePath) throws {
@@ -163,6 +168,19 @@ final class ConfigGenerator: ConfigGenerating {
 
         if target.product == .staticFramework {
             settings["MACH_O_TYPE"] = "staticlib"
+        }
+        
+        if target.product.isTest {
+            
+            let appDependencies = graph.targetDependencies(path: sourceRootPath, name: target.name).filter { targetNode in
+                targetNode.target.product == .app
+            }
+            
+            if let app = appDependencies.first {
+                settings["TEST_HOST"] = "$(BUILT_PRODUCTS_DIR)/\(app.target.productName)/\(app.target.name)"
+                settings["BUNDLE_LOADER"] = "$(TEST_HOST)"
+            }
+            
         }
 
         variantBuildConfiguration.buildSettings = settings

--- a/Sources/TuistKit/Generator/GeneratedProject.swift
+++ b/Sources/TuistKit/Generator/GeneratedProject.swift
@@ -1,8 +1,13 @@
 import Basic
 import Foundation
+import PathKit
 import xcodeproj
 
 final class GeneratedProject {
+    
+    /// A reference to the .xcodeproj which was generated.
+    let pbxproj: PBXProj
+
     /// Path to the project .xcodeproj directory
     let path: AbsolutePath
 
@@ -18,9 +23,11 @@ final class GeneratedProject {
     ///   - path: Dictionary whose keys are the target names and the value the Xcode targets.
     ///   - targets: Dictionary whose keys are the target names and the value the Xcode targets.
     ///   - name: Project name with .xcodeproj extension
-    init(path: AbsolutePath,
+    init(pbxproj: PBXProj,
+         path: AbsolutePath,
          targets: [String: PBXNativeTarget],
          name: String) {
+        self.pbxproj = pbxproj
         self.path = path
         self.targets = targets
         self.name = name
@@ -30,8 +37,11 @@ final class GeneratedProject {
     ///
     /// - Parameter path: Path to the project (.xcodeproj)
     /// - Returns: GeneratedProject instance.
-    func at(path: AbsolutePath) -> GeneratedProject {
-        return GeneratedProject(path: path,
+    func at(path: AbsolutePath) throws -> GeneratedProject {
+        let xcode = try XcodeProj(pathString: path.asString)
+
+        return GeneratedProject(pbxproj: xcode.pbxproj,
+                                path: path,
                                 targets: targets,
                                 name: name)
     }

--- a/Sources/TuistKit/Generator/GeneratedProject.swift
+++ b/Sources/TuistKit/Generator/GeneratedProject.swift
@@ -4,7 +4,6 @@ import PathKit
 import xcodeproj
 
 final class GeneratedProject {
-    
     /// A reference to the .xcodeproj which was generated.
     let pbxproj: PBXProj
 

--- a/Sources/TuistKit/Generator/ProjectGenerator.swift
+++ b/Sources/TuistKit/Generator/ProjectGenerator.swift
@@ -103,7 +103,7 @@ final class ProjectGenerator: ProjectGenerating {
                                                 sourceRootPath: sourceRootPath,
                                                 options: options,
                                                 graph: graph)
-        
+
         generateTestTargetIdentity(project: project,
                                    pbxproj: pbxproj,
                                    pbxProject: pbxProject)
@@ -170,38 +170,33 @@ final class ProjectGenerator: ProjectGenerating {
                                                        graph: graph)
         return nativeTargets
     }
-    
-    fileprivate func generateTestTargetIdentity(project: Project,
+
+    fileprivate func generateTestTargetIdentity(project _: Project,
                                                 pbxproj: PBXProj,
                                                 pbxProject: PBXProject) {
-        
         func testTargetName(_ target: PBXTarget) -> String? {
-            
             guard let buildConfigurations = target.buildConfigurationList?.buildConfigurations else {
                 return nil
             }
-            
+
             return buildConfigurations
                 .compactMap { $0.buildSettings["TEST_TARGET_NAME"] as? String }
                 .first
         }
-        
-        let testTargets = pbxproj.nativeTargets.filter{ $0.productType == .uiTestBundle || $0.productType == .unitTestBundle }
-        
+
+        let testTargets = pbxproj.nativeTargets.filter { $0.productType == .uiTestBundle || $0.productType == .unitTestBundle }
+
         for testTarget in testTargets {
-            
             guard let name = testTargetName(testTarget) else {
                 continue
             }
-            
+
             guard let target = pbxproj.targets(named: name).first else {
                 continue
             }
-            
-            pbxProject.setTargetAttributes([ "TestTargetID": target ], target: testTarget)
-            
+
+            pbxProject.setTargetAttributes(["TestTargetID": target], target: testTarget)
         }
-        
     }
 
     fileprivate func write(xcodeprojPath: AbsolutePath,

--- a/Sources/TuistKit/Generator/ProjectGenerator.swift
+++ b/Sources/TuistKit/Generator/ProjectGenerator.swift
@@ -195,7 +195,11 @@ final class ProjectGenerator: ProjectGenerating {
                 continue
             }
 
-            pbxProject.setTargetAttributes(["TestTargetID": target], target: testTarget)
+            var attributes = pbxProject.targetAttributes[testTarget] ?? [:]
+
+            attributes["TestTargetID"] = target
+
+            pbxProject.setTargetAttributes(attributes, target: testTarget)
         }
     }
 
@@ -212,7 +216,8 @@ final class ProjectGenerator: ProjectGenerating {
             try writeXcodeproj(workspace: workspace,
                                pbxproj: pbxproj,
                                xcodeprojPath: temporaryPath)
-            generatedProject = GeneratedProject(path: temporaryPath,
+            generatedProject = GeneratedProject(pbxproj: pbxproj,
+                                                path: temporaryPath,
                                                 targets: nativeTargets,
                                                 name: xcodeprojPath.components.last!)
             try writeSchemes(project: project,
@@ -221,7 +226,7 @@ final class ProjectGenerator: ProjectGenerating {
             try fileHandler.replace(xcodeprojPath, with: temporaryPath)
         }
 
-        return generatedProject.at(path: xcodeprojPath)
+        return try generatedProject.at(path: xcodeprojPath)
     }
 
     fileprivate func writeXcodeproj(workspace: XCWorkspace,

--- a/Sources/TuistKit/Generator/TargetGenerator.swift
+++ b/Sources/TuistKit/Generator/TargetGenerator.swift
@@ -74,6 +74,7 @@ final class TargetGenerator: TargetGenerating {
                                                  pbxTarget: pbxTarget,
                                                  pbxproj: pbxproj,
                                                  fileElements: fileElements,
+                                                 graph: graph,
                                                  options: options,
                                                  sourceRootPath: sourceRootPath)
 

--- a/Sources/TuistKit/Models/Product.swift
+++ b/Sources/TuistKit/Models/Product.swift
@@ -186,13 +186,11 @@ extension Product {
 }
 
 extension Product {
-    
     var isStatic: Bool {
         return [.staticLibrary, .staticFramework].contains(self)
     }
-    
+
     var isTest: Bool {
         return [.unitTests, .uiTests].contains(self)
     }
-    
 }

--- a/Sources/TuistKit/Models/Product.swift
+++ b/Sources/TuistKit/Models/Product.swift
@@ -186,7 +186,13 @@ extension Product {
 }
 
 extension Product {
+    
     var isStatic: Bool {
         return [.staticLibrary, .staticFramework].contains(self)
     }
+    
+    var isTest: Bool {
+        return [.unitTests, .uiTests].contains(self)
+    }
+    
 }

--- a/Sources/TuistKit/Models/Product.swift
+++ b/Sources/TuistKit/Models/Product.swift
@@ -189,8 +189,4 @@ extension Product {
     var isStatic: Bool {
         return [.staticLibrary, .staticFramework].contains(self)
     }
-
-    var isTest: Bool {
-        return [.unitTests, .uiTests].contains(self)
-    }
 }

--- a/Tests/TuistKitTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/ConfigGeneratorTests.swift
@@ -96,6 +96,22 @@ final class ConfigGeneratorTests: XCTestCase {
         assert(config: releaseConfig, contains: testHostSettings)
     }
 
+    func test_generateUITestTargetConfiguration() throws {
+        // Given / When
+        try generateTestTargetConfig(uiTest: true)
+
+        let configurationList = pbxTarget.buildConfigurationList
+        let debugConfig = configurationList?.configuration(name: "Debug")
+        let releaseConfig = configurationList?.configuration(name: "Release")
+
+        let testHostSettings = [
+            "TEST_TARGET_NAME": "App",
+        ]
+
+        assert(config: debugConfig, contains: testHostSettings)
+        assert(config: releaseConfig, contains: testHostSettings)
+    }
+
     private func generateProjectConfig(config _: BuildConfiguration) throws {
         let dir = try TemporaryDirectory(removeTreeOnDeinit: true)
         let xcconfigsDir = dir.path.appending(component: "xcconfigs")
@@ -152,12 +168,12 @@ final class ConfigGeneratorTests: XCTestCase {
                                              sourceRootPath: AbsolutePath("/"))
     }
 
-    private func generateTestTargetConfig() throws {
+    private func generateTestTargetConfig(uiTest: Bool = false) throws {
         let dir = try TemporaryDirectory(removeTreeOnDeinit: true)
 
         let appTarget = Target.test(name: "App", platform: .iOS, product: .app)
 
-        let target = Target.test(name: "Test", product: .unitTests)
+        let target = Target.test(name: "Test", product: uiTest ? .uiTests : .unitTests)
         let project = Project.test(path: dir.path, name: "Project", targets: [target])
 
         let appTargetNode = TargetNode(project: project, target: appTarget, dependencies: [])

--- a/Tests/TuistKitTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/ConfigGeneratorTests.swift
@@ -69,7 +69,7 @@ final class ConfigGeneratorTests: XCTestCase {
         let releaseSettings = [
             "SWIFT_OPTIMIZATION_LEVEL": "-Owholemodule",
         ]
-        
+
         assert(config: debugConfig, contains: commonSettings)
         assert(config: debugConfig, contains: debugSettings)
         assert(config: debugConfig, hasXcconfig: "debug.xcconfig")
@@ -78,24 +78,22 @@ final class ConfigGeneratorTests: XCTestCase {
         assert(config: releaseConfig, contains: releaseSettings)
         assert(config: releaseConfig, hasXcconfig: "release.xcconfig")
     }
-    
+
     func test_generateTestTargetConfiguration() throws {
-        
         // Given / When
         try generateTestTargetConfig()
-        
+
         let configurationList = pbxTarget.buildConfigurationList
         let debugConfig = configurationList?.configuration(name: "Debug")
         let releaseConfig = configurationList?.configuration(name: "Release")
-        
+
         let testHostSettings = [
             "TEST_HOST": "$(BUILT_PRODUCTS_DIR)/App.app/App",
-            "BUNDLE_LOADER": "$(TEST_HOST)"
+            "BUNDLE_LOADER": "$(TEST_HOST)",
         ]
-        
+
         assert(config: debugConfig, contains: testHostSettings)
         assert(config: releaseConfig, contains: testHostSettings)
-
     }
 
     private func generateProjectConfig(config _: BuildConfiguration) throws {
@@ -153,20 +151,19 @@ final class ConfigGeneratorTests: XCTestCase {
                                              options: options,
                                              sourceRootPath: AbsolutePath("/"))
     }
-    
+
     private func generateTestTargetConfig() throws {
-        
         let dir = try TemporaryDirectory(removeTreeOnDeinit: true)
-        
+
         let appTarget = Target.test(name: "App", platform: .iOS, product: .app)
-        
+
         let target = Target.test(name: "Test", product: .unitTests)
         let project = Project.test(path: dir.path, name: "Project", targets: [target])
-        
-        let appTargetNode = TargetNode(project: project, target: appTarget, dependencies: [ ])
-        let testTargetNode = TargetNode(project: project, target: target, dependencies: [ appTargetNode ])
-        
-        let graph = Graph.test(entryNodes: [ appTargetNode, testTargetNode ])
+
+        let appTargetNode = TargetNode(project: project, target: appTarget, dependencies: [])
+        let testTargetNode = TargetNode(project: project, target: target, dependencies: [appTargetNode])
+
+        let graph = Graph.test(entryNodes: [appTargetNode, testTargetNode])
 
         _ = try subject.generateTargetConfig(target,
                                              pbxTarget: pbxTarget,

--- a/Tests/TuistKitTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/ProjectGeneratorTests.swift
@@ -57,8 +57,7 @@ final class ProjectGeneratorTests: XCTestCase {
                               product: .app)
         let test = Target.test(name: "Tests",
                                platform: .iOS,
-                               product: .unitTests,
-                               settings: Settings.test(base: ["TEST_TARGET_NAME": "App"], debug: nil, release: nil))
+                               product: .unitTests)
         let project = Project.test(path: fileHandler.currentPath,
                                    name: "Project",
                                    targets: [app, test])

--- a/Tests/TuistKitTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/ProjectGeneratorTests.swift
@@ -48,6 +48,5 @@ final class ProjectGeneratorTests: XCTestCase {
         let targetScheme = schemesPath.appending(component: "Target.xcscheme")
         XCTAssertTrue(fileHandler.exists(projectScheme))
         XCTAssertTrue(fileHandler.exists(targetScheme))
-                
     }
 }

--- a/Tests/TuistKitTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/ProjectGeneratorTests.swift
@@ -48,5 +48,6 @@ final class ProjectGeneratorTests: XCTestCase {
         let targetScheme = schemesPath.appending(component: "Target.xcscheme")
         XCTAssertTrue(fileHandler.exists(projectScheme))
         XCTAssertTrue(fileHandler.exists(targetScheme))
+                
     }
 }

--- a/Tests/TuistKitTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/ProjectGeneratorTests.swift
@@ -49,4 +49,47 @@ final class ProjectGeneratorTests: XCTestCase {
         XCTAssertTrue(fileHandler.exists(projectScheme))
         XCTAssertTrue(fileHandler.exists(targetScheme))
     }
+
+    func test_generate_testTargetIdentity() throws {
+        // Given
+        let app = Target.test(name: "App",
+                              platform: .iOS,
+                              product: .app)
+        let test = Target.test(name: "Tests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               settings: Settings.test(base: ["TEST_TARGET_NAME": "App"], debug: nil, release: nil))
+        let project = Project.test(path: fileHandler.currentPath,
+                                   name: "Project",
+                                   targets: [app, test])
+
+        let cache = GraphLoaderCache()
+        cache.add(project: project)
+        let graph = Graph.test(entryPath: fileHandler.currentPath,
+                               cache: cache,
+                               entryNodes: [TargetNode(project: project,
+                                                       target: test,
+                                                       dependencies: [
+                                                           TargetNode(project: project, target: app, dependencies: []),
+                                                       ])])
+
+        // When
+        let generatedProject = try subject.generate(project: project,
+                                                    options: GenerationOptions(),
+                                                    graph: graph)
+
+        // Then
+        let pbxproject = try generatedProject.pbxproj.rootProject()
+        let nativeTargets = generatedProject.targets
+        let attributes = pbxproject?.targetAttributes ?? [:]
+        XCTAssertTrue(attributes.contains { attribute in
+
+            guard let appUUID = nativeTargets["App"]?.uuid, let testTargetID = attribute.value["TestTargetID"] as? String else {
+                return false
+            }
+
+            return attribute.key.name == "Tests" && testTargetID == appUUID
+
+        }, "Test target is missing from target attributes.")
+    }
 }

--- a/Tests/TuistKitTests/Generator/SchemesGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/SchemesGeneratorTests.swift
@@ -274,6 +274,6 @@ final class SchemeGeneratorTests: XCTestCase {
     private func generatedProject(targets: [Target]) -> GeneratedProject {
         var pbxTargets: [String: PBXNativeTarget] = [:]
         targets.forEach { pbxTargets[$0.name] = PBXNativeTarget(name: $0.name) }
-        return GeneratedProject(path: AbsolutePath("/project.xcodeproj"), targets: pbxTargets, name: "project.xcodeproj")
+        return GeneratedProject(pbxproj: .init(), path: AbsolutePath("/project.xcodeproj"), targets: pbxTargets, name: "project.xcodeproj")
     }
 }

--- a/Tests/TuistKitTests/Generator/TestData/GeneratedProject+TestData.swift
+++ b/Tests/TuistKitTests/Generator/TestData/GeneratedProject+TestData.swift
@@ -4,9 +4,10 @@ import xcodeproj
 @testable import TuistKit
 
 extension GeneratedProject {
-    static func test(path: AbsolutePath = AbsolutePath("/project.xcodeproj"),
+    static func test(pbxproj: PBXProj = .init(),
+                     path: AbsolutePath = AbsolutePath("/project.xcodeproj"),
                      targets: [String: PBXNativeTarget] = [:],
                      name: String = "project.xcodeproj") -> GeneratedProject {
-        return GeneratedProject(path: path, targets: targets, name: name)
+        return GeneratedProject(pbxproj: pbxproj, path: path, targets: targets, name: name)
     }
 }

--- a/features/generate.feature
+++ b/features/generate.feature
@@ -7,6 +7,7 @@ Feature: Generate a new project using Tuist
     Then tuist generates the project
     Then I should be able to build the scheme App
     Then I should be able to test the scheme AppTests
+    Then I should be able to test the scheme AppUITests
     Then I should be able to build the scheme App-Manifest
 
   Scenario: The project is an iOS application with frameworks and tests (ios_app_with_frameworks)

--- a/fixtures/app_with_framework_and_tests/App/AppDelegate.swift
+++ b/fixtures/app_with_framework_and_tests/App/AppDelegate.swift
@@ -14,4 +14,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.makeKeyAndVisible()
         return true
     }
+    
+    func hello() -> String {
+        return "AppDelegate.hello()"
+    }
+    
 }

--- a/fixtures/app_with_framework_and_tests/AppTests/AppTests.swift
+++ b/fixtures/app_with_framework_and_tests/AppTests/AppTests.swift
@@ -3,4 +3,12 @@ import XCTest
 
 @testable import App
 
-final class AppTests: XCTestCase {}
+final class AppTests: XCTestCase {
+    
+    func testHello() {
+        let sut = AppDelegate()
+        
+        XCTAssertEqual("AppDelegate.hello()", sut.hello())
+    }
+    
+}

--- a/fixtures/ios_app_with_framework_and_resources/App/Tests/AppDelegateTests.swift
+++ b/fixtures/ios_app_with_framework_and_resources/App/Tests/AppDelegateTests.swift
@@ -1,12 +1,10 @@
-// @testable import App
+@testable import App
 import XCTest
 
-// Generated project does not set "Host Application" and "Allow testing Host Application APIs",
-// what leads to "ld: symbol(s) not found for architecture x86_64" linker error.
 class AppDelegateTests: XCTestCase {
-//    func testHello() {
-//        let sut = AppDelegate()
-//
-//        XCTAssertEqual("AppDelegate.hello()", sut.hello())
-//    }
+    func testHello() {
+        let sut = AppDelegate()
+
+        XCTAssertEqual("AppDelegate.hello()", sut.hello())
+    }
 }

--- a/fixtures/ios_app_with_frameworks/App/Tests/AppDelegateTests.swift
+++ b/fixtures/ios_app_with_frameworks/App/Tests/AppDelegateTests.swift
@@ -1,12 +1,10 @@
-// @testable import App
+@testable import App
 import XCTest
 
-// Generated project does not set "Host Application" and "Allow testing Host Application APIs",
-// what leads to "ld: symbol(s) not found for architecture x86_64" linker error.
 class AppDelegateTests: XCTestCase {
-//    func testHello() {
-//        let sut = AppDelegate()
-//
-//        XCTAssertEqual("AppDelegate.hello()", sut.hello())
-//    }
+    func testHello() {
+        let sut = AppDelegate()
+
+        XCTAssertEqual("AppDelegate.hello()", sut.hello())
+    }
 }

--- a/fixtures/ios_app_with_setup/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_setup/Sources/AppDelegate.swift
@@ -12,4 +12,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.makeKeyAndVisible()
         return true
     }
+    
+    func hello() -> String {
+        return "AppDelegate.hello()"
+    }
+    
 }

--- a/fixtures/ios_app_with_setup/Tests/AppTests.swift
+++ b/fixtures/ios_app_with_setup/Tests/AppTests.swift
@@ -3,4 +3,12 @@ import XCTest
 
 @testable import App
 
-final class AppTests: XCTestCase {}
+final class AppTests: XCTestCase {
+    
+    func testHello() {
+        let sut = AppDelegate()
+        
+        XCTAssertEqual("AppDelegate.hello()", sut.hello())
+    }
+    
+}

--- a/fixtures/ios_app_with_static_frameworks/Tests/AppTests.swift
+++ b/fixtures/ios_app_with_static_frameworks/Tests/AppTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import App
 
 final class AppTests: XCTestCase {
-    // func test_application() {
-    //     XCTAssertEqual(App.AClassInThisBundle.value, "aValue")
-    // }
+    func test_application() {
+        XCTAssertEqual(App.AClassInThisBundle.value, "aValue")
+    }
 }

--- a/fixtures/ios_app_with_static_libraries/Tests/AppTests.swift
+++ b/fixtures/ios_app_with_static_libraries/Tests/AppTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import App
 
 final class AppTests: XCTestCase {
-    // func test_application() {
-    //     XCTAssertEqual(App.AClassInThisBundle.value, "aValue")
-    // }
+    func test_application() {
+        XCTAssertEqual(App.AClassInThisBundle.value, "aValue")
+    }
 }

--- a/fixtures/ios_app_with_tests/Project.swift
+++ b/fixtures/ios_app_with_tests/Project.swift
@@ -25,4 +25,13 @@ let project = Project(name: "App",
                                  ],
                                  settings: Settings(base: ["CODE_SIGN_IDENTITY": "",
                                                            "CODE_SIGNING_REQUIRED": "NO"])),
+                          Target(name: "AppUITests",
+                                 platform: .iOS,
+                                 product: .uiTests,
+                                 bundleId: "io.tuist.AppUITests",
+                                 infoPlist: "Tests.plist",
+                                 sources: "UITests/**",
+                                 dependencies: [
+                                    .target(name: "App"),
+                                    ])
 ])

--- a/fixtures/ios_app_with_tests/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_tests/Sources/AppDelegate.swift
@@ -12,4 +12,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.makeKeyAndVisible()
         return true
     }
+    
+    func hello() -> String {
+        return "AppDelegate.hello()"
+    }
+    
 }

--- a/fixtures/ios_app_with_tests/Tests/AppTests.swift
+++ b/fixtures/ios_app_with_tests/Tests/AppTests.swift
@@ -3,4 +3,12 @@ import XCTest
 
 @testable import App
 
-final class AppTests: XCTestCase {}
+final class AppTests: XCTestCase {
+    
+    func testHello() {
+        let sut = AppDelegate()
+        
+        XCTAssertEqual("AppDelegate.hello()", sut.hello())
+    }
+    
+}

--- a/fixtures/ios_app_with_tests/UITests/AppUITest.swift
+++ b/fixtures/ios_app_with_tests/UITests/AppUITest.swift
@@ -1,0 +1,28 @@
+//Copyright © 2019 Sky. All rights reserved.
+
+import XCTest
+
+class AppUITest: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
+        XCUIApplication().launch()
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() {
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+}

--- a/fixtures/ios_app_with_transitive_framework/App/Tests/AppDelegateTests.swift
+++ b/fixtures/ios_app_with_transitive_framework/App/Tests/AppDelegateTests.swift
@@ -1,12 +1,10 @@
-// @testable import App
+@testable import App
 import XCTest
 
-// Generated project does not set "Host Application" and "Allow testing Host Application APIs",
-// what leads to "ld: symbol(s) not found for architecture x86_64" linker error.
 class AppDelegateTests: XCTestCase {
-//    func testHello() {
-//        let sut = AppDelegate()
-//
-//        XCTAssertEqual("AppDelegate.hello()", sut.hello())
-//    }
+    func testHello() {
+        let sut = AppDelegate()
+
+        XCTAssertEqual("AppDelegate.hello()", sut.hello())
+    }
 }


### PR DESCRIPTION
 set `TEST_HOST` and `BUNDLE_LOADER` for Unit tests bundle for an app target so that the default generated test target runs

Resolves https://github.com/tuist/tuist/issues/204

### Short description 📝

The default generated project did not set these two build configurations which meant that the app unit test target was not able to resolve the symbols stores inside of the application.

### Solution 📦

By setting `TEST_HOST` and `BUNDLE_LOADER` ld is able to link the symbols and run the unit tests.

The implementation will look at the dependencies for the test target and the find the app to set as the test host. Currently this selects the first app, but we can expand on this in the future as and when we better understand peoples requirements.

### Test Plan 👩‍💻👨‍💻

- [x] Enable all unit tests for applications inside of fixtures
- [x] `bundle exec rake features`
- [x] `swift test`
