### PR TITLE
Allow header and framework search paths to inherit from the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fix manifest target linker errors https://github.com/tuist/tuist/pull/287 by @kwridan
 - Build settings not being generated properly https://github.com/tuist/tuist/pull/282 by @pepibumur
 - Fix `instance method nearly matches optional requirements` warning in generated `AppDelegate.swift` in iOS projects https://github.com/tuist/tuist/pull/291 by @BalestraPatrick
+- Fix Header & Framework search paths override project or xcconfig settings TBC by @ollieatkinson
 
 ## 0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fix manifest target linker errors https://github.com/tuist/tuist/pull/287 by @kwridan
 - Build settings not being generated properly https://github.com/tuist/tuist/pull/282 by @pepibumur
 - Fix `instance method nearly matches optional requirements` warning in generated `AppDelegate.swift` in iOS projects https://github.com/tuist/tuist/pull/291 by @BalestraPatrick
-- Fix Header & Framework search paths override project or xcconfig settings TBC by @ollieatkinson
+- Fix Header & Framework search paths override project or xcconfig settings https://github.com/tuist/tuist/pull/301 by @ollieatkinson
 
 ## 0.12.0
 

--- a/Sources/TuistKit/Generator/LinkGenerator.swift
+++ b/Sources/TuistKit/Generator/LinkGenerator.swift
@@ -178,7 +178,7 @@ final class LinkGenerator: LinkGenerating {
 
         let pathsValue = Set(paths).sorted().joined(separator: " ")
         buildConfigurations?.forEach { buildConfiguration in
-            var frameworkSearchPaths = (buildConfiguration.buildSettings["FRAMEWORK_SEARCH_PATHS"] as? String) ?? ""
+            var frameworkSearchPaths = (buildConfiguration.buildSettings["FRAMEWORK_SEARCH_PATHS"] as? String) ?? "$(inherited)"
             if frameworkSearchPaths.isEmpty {
                 frameworkSearchPaths = pathsValue
             } else {
@@ -198,7 +198,7 @@ final class LinkGenerator: LinkGenerating {
             throw LinkGeneratorError.missingConfigurationList(targetName: pbxTarget.name)
         }
         configurationList.buildConfigurations.forEach {
-            var headers = ($0.buildSettings["HEADER_SEARCH_PATHS"] as? String) ?? ""
+            var headers = ($0.buildSettings["HEADER_SEARCH_PATHS"] as? String) ?? "$(inherited)"
             headers.append(" \(relativePaths.joined(separator: " "))")
             $0.buildSettings["HEADER_SEARCH_PATHS"] = headers
         }

--- a/Sources/TuistKit/Generator/SchemesGenerator.swift
+++ b/Sources/TuistKit/Generator/SchemesGenerator.swift
@@ -101,20 +101,20 @@ final class SchemesGenerator: SchemesGenerating {
             .filter(\.includeInProjectScheme)
             .map { (target) -> XCScheme.BuildAction.Entry in
 
-            let pbxTarget = generatedProject.targets[target.name]!
-            let buildableReference = targetBuildableReference(target: target,
-                                                              pbxTarget: pbxTarget,
-                                                              projectName: generatedProject.name)
-            var buildFor: [XCScheme.BuildAction.Entry.BuildFor] = []
-            if target.product.testsBundle {
-                buildFor.append(.testing)
-            } else {
-                buildFor.append(contentsOf: [.analyzing, .archiving, .profiling, .running, .testing])
-            }
+                let pbxTarget = generatedProject.targets[target.name]!
+                let buildableReference = targetBuildableReference(target: target,
+                                                                  pbxTarget: pbxTarget,
+                                                                  projectName: generatedProject.name)
+                var buildFor: [XCScheme.BuildAction.Entry.BuildFor] = []
+                if target.product.testsBundle {
+                    buildFor.append(.testing)
+                } else {
+                    buildFor.append(contentsOf: [.analyzing, .archiving, .profiling, .running, .testing])
+                }
 
-            return XCScheme.BuildAction.Entry(buildableReference: buildableReference,
-                                              buildFor: buildFor)
-        }
+                return XCScheme.BuildAction.Entry(buildableReference: buildableReference,
+                                                  buildFor: buildFor)
+            }
 
         return XCScheme.BuildAction(buildActionEntries: entries,
                                     parallelizeBuild: true,

--- a/Tests/TuistKitTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/LinkGeneratorTests.swift
@@ -96,7 +96,7 @@ final class LinkGeneratorErrorTests: XCTestCase {
                                              pbxTarget: pbxTarget,
                                              sourceRootPath: sourceRootPath)
 
-        let expected = "$(SRCROOT)/Dependencies $(SRCROOT)/Dependencies/C"
+        let expected = "$(inherited) $(SRCROOT)/Dependencies $(SRCROOT)/Dependencies/C"
         XCTAssertEqual(debugConfig.buildSettings["FRAMEWORK_SEARCH_PATHS"] as? String, expected)
         XCTAssertEqual(releaseConfig.buildSettings["FRAMEWORK_SEARCH_PATHS"] as? String, expected)
     }
@@ -122,7 +122,7 @@ final class LinkGeneratorErrorTests: XCTestCase {
                                            pbxTarget: pbxTarget,
                                            sourceRootPath: sourceRootPath)
 
-        XCTAssertEqual(config.buildSettings["HEADER_SEARCH_PATHS"] as? String, " $(SRCROOT)/headers")
+        XCTAssertEqual(config.buildSettings["HEADER_SEARCH_PATHS"] as? String, "$(inherited) $(SRCROOT)/headers")
     }
 
     func test_setupHeadersSearchPath_throws_whenTheConfigurationListIsMissing() throws {

--- a/Tests/TuistKitTests/Generator/SchemesGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/SchemesGeneratorTests.swift
@@ -245,29 +245,28 @@ final class SchemeGeneratorTests: XCTestCase {
         XCTAssertEqual(got.buildConfiguration, "Release")
         XCTAssertEqual(got.revealArchiveInOrganizer, true)
     }
-    
+
     func test_projectBuildAction_includeInProjectScheme_false() {
         let app = Target.test(name: "App", product: .app)
         let excluded = Target.test(name: "Excluded", product: .framework, includeInProjectScheme: false)
-       
+
         let targets = [app, excluded]
-        
+
         let project = Project.test(targets: targets)
         let graphCache = GraphLoaderCache()
         let graph = Graph.test(cache: graphCache)
-        
+
         let got = subject.projectBuildAction(project: project,
                                              generatedProject: generatedProject(targets: targets),
                                              graph: graph)
-        
+
         XCTAssertTrue(got.parallelizeBuild)
         XCTAssertEqual(got.buildActionEntries.count, 1)
-        
+
         let appEntry = got.buildActionEntries[0]
 
         XCTAssertEqual(appEntry.buildableReference.buildableName, app.productName)
         XCTAssertEqual(appEntry.buildableReference.blueprintName, app.name)
-        
     }
 
     // MARK: - Private

--- a/fixtures/ios_app_with_frameworks/App/Project.swift
+++ b/fixtures/ios_app_with_frameworks/App/Project.swift
@@ -1,6 +1,10 @@
 import ProjectDescription
 
+let settings = Settings(base: [
+    "HEADER_SEARCH_PATHS": "path/to/lib/include",
+])
 let project = Project(name: "MainApp",
+                      settings: settings,
                       targets: [
                           Target(name: "App",
                                  platform: .iOS,


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/255

### Solution 📦

Default to `$(inherited)` when no build settings for `FRAMEWORK_SEARCH_PATHS` and `HEADER_SEARCH_PATHS` are provided by target settings.

