### PR TITLE
Improve CircleCI by caching gems and not updating homebrew

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,13 @@ jobs:
       xcode: '10.1.0'
     steps:
       - checkout
+      - restore_cache:
+          key: bundler-{{ checksum "Gemfile.lock" }}
       - run:
           name: Install Dependencies
           command: |
-            brew install swiftformat
-            bundle install
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install swiftformat
+            bundle install --local || bundle package
       - run:
           name: Run Danger
           command: bundle exec danger
@@ -37,3 +39,7 @@ jobs:
       - run:
           name: Send test coverage report
           command: bash <(curl -s https://codecov.io/bash)
+      - save_cache:
+          key: bundler-{{ checksum "Gemfile.lock" }}
+          paths:
+            - "vendor"


### PR DESCRIPTION
Typical build dependencies phase on CI
- without cache: **~3minutes** [ref](https://circleci.com/gh/tuist/tuist/879)
- with cache: **~25seconds** [ref](https://circleci.com/gh/tuist/tuist/884)