### PR TITLE
Remove "-Project" scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Removed
 
+- Removed "-Project" shared scheme from being generated https://github.com/tuist/tuist/pull/303 by @ollieatkinson
+
 ### Fixed
 
 - Fix duplicated embedded frameworks https://github.com/tuist/tuist/pull/280 by @pepibumur

--- a/Sources/TuistKit/Generator/ManifestTargetGenerator.swift
+++ b/Sources/TuistKit/Generator/ManifestTargetGenerator.swift
@@ -28,8 +28,7 @@ class ManifestTargetGenerator: ManifestTargetGenerating {
                       bundleId: "io.tuist.manifests.${PRODUCT_NAME:rfc1034identifier}",
                       settings: settings,
                       sources: [manifest],
-                      filesGroup: .group(name: "Manifest"),
-                      includeInProjectScheme: false)
+                      filesGroup: .group(name: "Manifest"))
     }
 
     func manifestTargetBuildSettings() throws -> [String: String] {

--- a/Sources/TuistKit/Generator/ProjectGenerator.swift
+++ b/Sources/TuistKit/Generator/ProjectGenerator.swift
@@ -203,8 +203,5 @@ final class ProjectGenerator: ProjectGenerating {
                                   graph: Graphing) throws {
         try schemesGenerator.generateTargetSchemes(project: project,
                                                    generatedProject: generatedProject)
-        try schemesGenerator.generateProjectScheme(project: project,
-                                                   generatedProject: generatedProject,
-                                                   graph: graph)
     }
 }

--- a/Sources/TuistKit/Generator/ProjectGenerator.swift
+++ b/Sources/TuistKit/Generator/ProjectGenerator.swift
@@ -171,7 +171,7 @@ final class ProjectGenerator: ProjectGenerating {
                            workspace: XCWorkspace,
                            pbxproj: PBXProj,
                            project: Project,
-                           graph: Graphing) throws -> GeneratedProject {
+                           graph _: Graphing) throws -> GeneratedProject {
         var generatedProject: GeneratedProject!
 
         try fileHandler.inTemporaryDirectory { temporaryPath in
@@ -183,8 +183,7 @@ final class ProjectGenerator: ProjectGenerating {
                                                 targets: nativeTargets,
                                                 name: xcodeprojPath.components.last!)
             try writeSchemes(project: project,
-                             generatedProject: generatedProject,
-                             graph: graph)
+                             generatedProject: generatedProject)
             try fileHandler.replace(xcodeprojPath, with: temporaryPath)
         }
 
@@ -199,8 +198,7 @@ final class ProjectGenerator: ProjectGenerating {
     }
 
     fileprivate func writeSchemes(project: Project,
-                                  generatedProject: GeneratedProject,
-                                  graph: Graphing) throws {
+                                  generatedProject: GeneratedProject) throws {
         try schemesGenerator.generateTargetSchemes(project: project,
                                                    generatedProject: generatedProject)
     }

--- a/Sources/TuistKit/Generator/SchemesGenerator.swift
+++ b/Sources/TuistKit/Generator/SchemesGenerator.swift
@@ -61,9 +61,7 @@ final class SchemesGenerator: SchemesGenerating {
                             generatedProject: GeneratedProject,
                             graph: Graphing) -> XCScheme.BuildAction {
         let targets = project.sortedTargetsForProjectScheme(graph: graph)
-        let entries: [XCScheme.BuildAction.Entry] = targets
-            .filter(\.includeInProjectScheme)
-            .map { (target) -> XCScheme.BuildAction.Entry in
+        let entries: [XCScheme.BuildAction.Entry] = targets.map { (target) -> XCScheme.BuildAction.Entry in
 
                 let pbxTarget = generatedProject.targets[target.name]!
                 let buildableReference = targetBuildableReference(target: target,

--- a/Sources/TuistKit/Generator/SchemesGenerator.swift
+++ b/Sources/TuistKit/Generator/SchemesGenerator.swift
@@ -14,16 +14,6 @@ protocol SchemesGenerating {
     func generateTargetSchemes(project: Project,
                                generatedProject: GeneratedProject) throws
 
-    /// Generates a project scheme to build & test the all the project targets.
-    ///
-    /// - Parameters:
-    ///   - project: Project manifest.
-    ///   - generatedProject: Generated Xcode project.
-    ///   - graph: Dependencies graph.
-    /// - Throws: An error if the generation of the scheme fails.
-    func generateProjectScheme(project: Project,
-                               generatedProject: GeneratedProject,
-                               graph: Graphing) throws
 }
 
 final class SchemesGenerator: SchemesGenerating {
@@ -58,32 +48,6 @@ final class SchemesGenerator: SchemesGenerating {
                                      projectName: generatedProject.name,
                                      projectPath: generatedProject.path)
         }
-    }
-
-    /// Generates a project scheme to build & test the all the project targets.
-    ///
-    /// - Parameters:
-    ///   - project: Project manifest.
-    ///   - generatedProject: Generated Xcode project.
-    ///   - graph: Dependencies graph.
-    /// - Throws: An error if the generation of the scheme fails.
-    func generateProjectScheme(project: Project,
-                               generatedProject: GeneratedProject,
-                               graph: Graphing) throws {
-        let name = "\(project.name)-Project"
-        let schemesDirectory = try createSchemesDirectory(projectPath: generatedProject.path)
-        let path = schemesDirectory.appending(component: "\(name).xcscheme")
-
-        let scheme = XCScheme(name: name,
-                              lastUpgradeVersion: SchemesGenerator.defaultLastUpgradeVersion,
-                              version: SchemesGenerator.defaultVersion,
-                              buildAction: projectBuildAction(project: project,
-                                                              generatedProject: generatedProject,
-                                                              graph: graph),
-                              testAction: projectTestAction(project: project,
-                                                            generatedProject: generatedProject))
-
-        try scheme.write(path: path.path, override: true)
     }
 
     /// Returns the build action for the project scheme.

--- a/Sources/TuistKit/Generator/SchemesGenerator.swift
+++ b/Sources/TuistKit/Generator/SchemesGenerator.swift
@@ -13,7 +13,6 @@ protocol SchemesGenerating {
     /// - Throws: A FatalError if the generation of the schemes fails.
     func generateTargetSchemes(project: Project,
                                generatedProject: GeneratedProject) throws
-
 }
 
 final class SchemesGenerator: SchemesGenerating {
@@ -63,20 +62,20 @@ final class SchemesGenerator: SchemesGenerating {
         let targets = project.sortedTargetsForProjectScheme(graph: graph)
         let entries: [XCScheme.BuildAction.Entry] = targets.map { (target) -> XCScheme.BuildAction.Entry in
 
-                let pbxTarget = generatedProject.targets[target.name]!
-                let buildableReference = targetBuildableReference(target: target,
-                                                                  pbxTarget: pbxTarget,
-                                                                  projectName: generatedProject.name)
-                var buildFor: [XCScheme.BuildAction.Entry.BuildFor] = []
-                if target.product.testsBundle {
-                    buildFor.append(.testing)
-                } else {
-                    buildFor.append(contentsOf: [.analyzing, .archiving, .profiling, .running, .testing])
-                }
-
-                return XCScheme.BuildAction.Entry(buildableReference: buildableReference,
-                                                  buildFor: buildFor)
+            let pbxTarget = generatedProject.targets[target.name]!
+            let buildableReference = targetBuildableReference(target: target,
+                                                              pbxTarget: pbxTarget,
+                                                              projectName: generatedProject.name)
+            var buildFor: [XCScheme.BuildAction.Entry.BuildFor] = []
+            if target.product.testsBundle {
+                buildFor.append(.testing)
+            } else {
+                buildFor.append(contentsOf: [.analyzing, .archiving, .profiling, .running, .testing])
             }
+
+            return XCScheme.BuildAction.Entry(buildableReference: buildableReference,
+                                              buildFor: buildFor)
+        }
 
         return XCScheme.BuildAction(buildActionEntries: entries,
                                     parallelizeBuild: true,

--- a/Sources/TuistKit/Models/Target.swift
+++ b/Sources/TuistKit/Models/Target.swift
@@ -28,7 +28,6 @@ class Target: Equatable {
     let actions: [TargetAction]
     let environment: [String: String]
     let filesGroup: ProjectGroup
-    let includeInProjectScheme: Bool
 
     // MARK: - Init
 
@@ -46,8 +45,7 @@ class Target: Equatable {
          actions: [TargetAction] = [],
          environment: [String: String] = [:],
          filesGroup: ProjectGroup,
-         dependencies: [Dependency] = [],
-         includeInProjectScheme: Bool = true) {
+         dependencies: [Dependency] = []) {
         self.name = name
         self.product = product
         self.platform = platform
@@ -63,7 +61,6 @@ class Target: Equatable {
         self.environment = environment
         self.filesGroup = filesGroup
         self.dependencies = dependencies
-        self.includeInProjectScheme = includeInProjectScheme
     }
 
     func isLinkable() -> Bool {

--- a/Tests/TuistKitTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/ProjectGeneratorTests.swift
@@ -44,9 +44,7 @@ final class ProjectGeneratorTests: XCTestCase {
 
         // Then
         let schemesPath = got.path.appending(RelativePath("xcshareddata/xcschemes"))
-        let projectScheme = schemesPath.appending(component: "Project-Project.xcscheme")
         let targetScheme = schemesPath.appending(component: "Target.xcscheme")
-        XCTAssertTrue(fileHandler.exists(projectScheme))
         XCTAssertTrue(fileHandler.exists(targetScheme))
     }
 }

--- a/Tests/TuistKitTests/Generator/SchemesGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/SchemesGeneratorTests.swift
@@ -246,29 +246,6 @@ final class SchemeGeneratorTests: XCTestCase {
         XCTAssertEqual(got.revealArchiveInOrganizer, true)
     }
 
-    func test_projectBuildAction_includeInProjectScheme_false() {
-        let app = Target.test(name: "App", product: .app)
-        let excluded = Target.test(name: "Excluded", product: .framework, includeInProjectScheme: false)
-
-        let targets = [app, excluded]
-
-        let project = Project.test(targets: targets)
-        let graphCache = GraphLoaderCache()
-        let graph = Graph.test(cache: graphCache)
-
-        let got = subject.projectBuildAction(project: project,
-                                             generatedProject: generatedProject(targets: targets),
-                                             graph: graph)
-
-        XCTAssertTrue(got.parallelizeBuild)
-        XCTAssertEqual(got.buildActionEntries.count, 1)
-
-        let appEntry = got.buildActionEntries[0]
-
-        XCTAssertEqual(appEntry.buildableReference.buildableName, app.productName)
-        XCTAssertEqual(appEntry.buildableReference.blueprintName, app.name)
-    }
-
     // MARK: - Private
 
     private func generatedProject(targets: [Target]) -> GeneratedProject {

--- a/Tests/TuistKitTests/Models/TestData/Target+TestData.swift
+++ b/Tests/TuistKitTests/Models/TestData/Target+TestData.swift
@@ -17,8 +17,7 @@ extension Target {
                      actions: [TargetAction] = [],
                      environment: [String: String] = [:],
                      filesGroup: ProjectGroup = .group(name: "Project"),
-                     dependencies: [Dependency] = [],
-                     includeInProjectScheme: Bool = true) -> Target {
+                     dependencies: [Dependency] = []) -> Target {
         return Target(name: name,
                       platform: platform,
                       product: product,
@@ -33,7 +32,6 @@ extension Target {
                       actions: actions,
                       environment: environment,
                       filesGroup: filesGroup,
-                      dependencies: dependencies,
-                      includeInProjectScheme: includeInProjectScheme)
+                      dependencies: dependencies)
     }
 }


### PR DESCRIPTION
### Short description 📝

The project scheme was introduced to match the behaviour of SwiftPM by having a scheme which builds all targets inside of the project. This is not really required for Tuist projects as currently it does not offer any benefits - we _may_ introduce this again in the future, when required.

### Solution 📦

Remove code which generates the "-Project" scheme.
