### PR TITLE
Check to see if contents.xcworkspacedata exists before writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fix Header & Framework search paths override project or xcconfig settings https://github.com/tuist/tuist/pull/301 by @ollieatkinson
 - Unit tests bundle for an app target compile & run https://github.com/tuist/tuist/pull/300 by @ollieatkinson
 - `LIBRARY_SEARCH_PATHS` and `SWIFT_INCLUDE_PATHS` are now set https://github.com/tuist/tuist/pull/308 by @kwridan
+- Fix Generation fails in the event an empty .xcworkspace directory exists https://github.com/tuist/tuist/pull/312 by @ollieatkinson
 
 ## 0.12.0
 

--- a/Sources/TuistKit/Generator/WorkspaceGenerator.swift
+++ b/Sources/TuistKit/Generator/WorkspaceGenerator.swift
@@ -118,7 +118,7 @@ final class WorkspaceGenerator: WorkspaceGenerating {
     private func write(xcworkspace: XCWorkspace, to: AbsolutePath) throws {
         // If the workspace doesn't exist we can write it because there isn't any
         // Xcode instance that might depend on it.
-        if !fileHandler.exists(to) {
+        if !fileHandler.exists(to.appending(component: "contents.xcworkspacedata")) {
             try xcworkspace.write(path: to.path)
             return
         }

--- a/Tests/TuistKitTests/Generator/WorkspaceGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/WorkspaceGeneratorTests.swift
@@ -69,6 +69,31 @@ final class WorkspaceGeneratorTests: XCTestCase {
         ])
     }
 
+    func test_generate_workspaceStructure_noWorkspaceData() throws {
+        let name = "test"
+
+        // Given
+        try fileHandler.createFolder(fileHandler.currentPath.appending(component: "\(name).xcworkspace"))
+
+        let graph = Graph.test(entryPath: path)
+        let workspace = Workspace.test(name: name)
+
+        let workspacePath: AbsolutePath?
+
+        // When
+        do {
+            workspacePath = try subject.generate(workspace: workspace,
+                                                 path: path,
+                                                 graph: graph,
+                                                 options: GenerationOptions())
+        } catch {
+            workspacePath = nil
+            XCTFail(error.localizedDescription)
+        }
+
+        XCTAssertNotNil(workspacePath)
+    }
+
     func test_generate_workspaceStructureWithProjects() throws {
         // Given
         let target = anyTarget()

--- a/Tests/TuistKitTests/Generator/WorkspaceGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/WorkspaceGeneratorTests.swift
@@ -78,20 +78,13 @@ final class WorkspaceGeneratorTests: XCTestCase {
         let graph = Graph.test(entryPath: path)
         let workspace = Workspace.test(name: name)
 
-        let workspacePath: AbsolutePath?
-
         // When
-        do {
-            workspacePath = try subject.generate(workspace: workspace,
-                                                 path: path,
-                                                 graph: graph,
-                                                 options: GenerationOptions())
-        } catch {
-            workspacePath = nil
-            XCTFail(error.localizedDescription)
-        }
-
-        XCTAssertNotNil(workspacePath)
+        XCTAssertNoThrow(
+            try subject.generate(workspace: workspace,
+                                 path: path,
+                                 graph: graph,
+                                 options: GenerationOptions())
+        )
     }
 
     func test_generate_workspaceStructureWithProjects() throws {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/309

### Short description 📝

Check for the existence of `contents.xcworkspacedata` before trying to write over the workspace.

### Test Plan 🧪

1. Unit test to ensure we do not throw an error in the result of a failure
2. Generate a workspace for `fixtures/ios_app_with_custom_workspace/`, delete `contents.xcworkspacedata` and try to generate again

I did not deem it necessary to introduce _another_ fixture test here, but if you feel like it is necessary I can go back and add one in.