### PR TITLE
Fixing graph node equality

### DIFF
--- a/Sources/TuistGenerator/Graph/GraphNode.swift
+++ b/Sources/TuistGenerator/Graph/GraphNode.swift
@@ -16,7 +16,11 @@ class GraphNode: Equatable, Hashable {
     // MARK: - Equatable
 
     static func == (lhs: GraphNode, rhs: GraphNode) -> Bool {
-        return lhs.path == rhs.path
+        return lhs.isEqual(to: rhs) && rhs.isEqual(to: lhs)
+    }
+    
+    func isEqual(to otherNode: GraphNode) -> Bool {
+        return path == otherNode.path
     }
 
     func hash(into hasher: inout Hasher) {
@@ -43,12 +47,20 @@ class TargetNode: GraphNode {
     }
 
     override func hash(into hasher: inout Hasher) {
-        hasher.combine(path)
+        super.hash(into: &hasher)
         hasher.combine(target.name)
     }
 
     static func == (lhs: TargetNode, rhs: TargetNode) -> Bool {
-        return lhs.path == rhs.path && lhs.target == rhs.target
+        return lhs.isEqual(to: rhs) && rhs.isEqual(to: lhs)
+    }
+    
+    override func isEqual(to otherNode: GraphNode) -> Bool {
+        guard let otherTagetNode = otherNode as? TargetNode else {
+            return false
+        }
+        return path == otherTagetNode.path
+                && target == otherTagetNode.target
     }
 
     static func read(name: String,
@@ -205,13 +217,22 @@ class LibraryNode: PrecompiledNode {
     }
 
     override func hash(into hasher: inout Hasher) {
-        hasher.combine(path)
-        hasher.combine(swiftModuleMap)
+        super.hash(into: &hasher)
         hasher.combine(publicHeaders)
+        hasher.combine(swiftModuleMap)
     }
 
     static func == (lhs: LibraryNode, rhs: LibraryNode) -> Bool {
-        return lhs.path == rhs.path && lhs.swiftModuleMap == rhs.swiftModuleMap && lhs.publicHeaders == rhs.publicHeaders
+        return lhs.isEqual(to: rhs) && rhs.isEqual(to: lhs)
+    }
+    
+    override func isEqual(to otherNode: GraphNode) -> Bool {
+        guard let otherLibraryNode = otherNode as? LibraryNode else {
+            return false
+        }
+        return path == otherLibraryNode.path
+                && swiftModuleMap == otherLibraryNode.swiftModuleMap
+                && publicHeaders == otherLibraryNode.publicHeaders
     }
 
     static func parse(publicHeaders: RelativePath,

--- a/Sources/TuistGenerator/Graph/GraphNode.swift
+++ b/Sources/TuistGenerator/Graph/GraphNode.swift
@@ -18,7 +18,7 @@ class GraphNode: Equatable, Hashable {
     static func == (lhs: GraphNode, rhs: GraphNode) -> Bool {
         return lhs.isEqual(to: rhs) && rhs.isEqual(to: lhs)
     }
-    
+
     func isEqual(to otherNode: GraphNode) -> Bool {
         return path == otherNode.path
     }
@@ -54,13 +54,13 @@ class TargetNode: GraphNode {
     static func == (lhs: TargetNode, rhs: TargetNode) -> Bool {
         return lhs.isEqual(to: rhs) && rhs.isEqual(to: lhs)
     }
-    
+
     override func isEqual(to otherNode: GraphNode) -> Bool {
         guard let otherTagetNode = otherNode as? TargetNode else {
             return false
         }
         return path == otherTagetNode.path
-                && target == otherTagetNode.target
+            && target == otherTagetNode.target
     }
 
     static func read(name: String,
@@ -225,14 +225,14 @@ class LibraryNode: PrecompiledNode {
     static func == (lhs: LibraryNode, rhs: LibraryNode) -> Bool {
         return lhs.isEqual(to: rhs) && rhs.isEqual(to: lhs)
     }
-    
+
     override func isEqual(to otherNode: GraphNode) -> Bool {
         guard let otherLibraryNode = otherNode as? LibraryNode else {
             return false
         }
         return path == otherLibraryNode.path
-                && swiftModuleMap == otherLibraryNode.swiftModuleMap
-                && publicHeaders == otherLibraryNode.publicHeaders
+            && swiftModuleMap == otherLibraryNode.swiftModuleMap
+            && publicHeaders == otherLibraryNode.publicHeaders
     }
 
     static func parse(publicHeaders: RelativePath,

--- a/Tests/TuistGeneratorTests/Graph/GraphNodeTests.swift
+++ b/Tests/TuistGeneratorTests/Graph/GraphNodeTests.swift
@@ -13,11 +13,11 @@ final class GraphNodeTests: XCTestCase {
                             target: .test(name: "c1"),
                             dependencies: [])
         let c2 = TargetNode(project: .test(path: "/path/c"),
-                           target: .test(name: "c2"),
-                           dependencies: [])
+                            target: .test(name: "c2"),
+                            dependencies: [])
         let d = LibraryNode(path: "/path/a", publicHeaders: "/path/to/headers")
         let e = LibraryNode(path: "/path/c", publicHeaders: "/path/to/headers")
-        
+
         // When
         var set = Set<GraphNode>()
         set.insert(a)
@@ -26,35 +26,35 @@ final class GraphNodeTests: XCTestCase {
         set.insert(c2)
         set.insert(d)
         set.insert(e)
-        
+
         // Then
         XCTAssertEqual(set.count, 6)
     }
-    
+
     func test_equality() {
         // Given
         let a1 = GraphNode(path: "/a")
         let a2 = GraphNode(path: "/a")
         let b = GraphNode(path: "/b")
-        
+
         // When / Then
         XCTAssertEqual(a1, a2)
         XCTAssertNotEqual(a2, b)
         XCTAssertEqual(b, b)
     }
-    
+
     func test_subclass_equality() {
         // Given
         let a = GraphNode(path: "/a")
         let b = TargetNode(project: .test(path: "/a"), target: .test(), dependencies: [])
         let c = LibraryNode(path: "/a", publicHeaders: "/path/to/headers")
-        
+
         // When / Then
         let all = [a, b, c]
         XCTAssertEqual(a, a)
         XCTAssertEqual(b, b)
         XCTAssertEqual(c, c)
-        
+
         for lhs in all.enumerated() {
             for rhs in all.enumerated() where lhs.offset != rhs.offset {
                 XCTAssertNotEqual(lhs.element, rhs.element)
@@ -76,31 +76,31 @@ final class TargetNodeTests: XCTestCase {
                             target: .test(name: "c3"),
                             dependencies: [])
         let d = TargetNode(project: .test(path: "/d"),
-                            target: .test(name: "c"),
-                            dependencies: [])
-        
+                           target: .test(name: "c"),
+                           dependencies: [])
+
         // When / Then
         XCTAssertEqual(c1, c2)
         XCTAssertNotEqual(c2, c3)
         XCTAssertNotEqual(c1, d)
         XCTAssertEqual(d, d)
     }
-    
+
     func test_equality_asGraphNodes() {
         // Given
         let c1: GraphNode = TargetNode(project: .test(path: "/c"),
-                            target: .test(name: "c"),
-                            dependencies: [])
+                                       target: .test(name: "c"),
+                                       dependencies: [])
         let c2: GraphNode = TargetNode(project: .test(path: "/c"),
-                            target: .test(name: "c"),
-                            dependencies: [])
+                                       target: .test(name: "c"),
+                                       dependencies: [])
         let c3: GraphNode = TargetNode(project: .test(path: "/c"),
-                            target: .test(name: "c3"),
-                            dependencies: [])
+                                       target: .test(name: "c3"),
+                                       dependencies: [])
         let d: GraphNode = TargetNode(project: .test(path: "/d"),
-                           target: .test(name: "c"),
-                           dependencies: [])
-        
+                                      target: .test(name: "c"),
+                                      dependencies: [])
+
         // When / Then
         XCTAssertEqual(c1, c2)
         XCTAssertNotEqual(c2, c3)
@@ -184,13 +184,13 @@ final class LibraryNodeTests: XCTestCase {
         system.succeedCommand("/usr/bin/file", "/test.a", output: "whatever dynamically linked")
         try XCTAssertEqual(subject.linking(system: system), .dynamic)
     }
-    
+
     func test_equality() {
         // Given
         let a1 = LibraryNode(path: "/a", publicHeaders: "/a/header", swiftModuleMap: "/a/swiftmodulemap")
         let a2 = LibraryNode(path: "/a", publicHeaders: "/a/header/2", swiftModuleMap: "/a/swiftmodulemap")
         let b = LibraryNode(path: "/b", publicHeaders: "/b/header", swiftModuleMap: "/b/swiftmodulemap")
-        
+
         // When / Then
         XCTAssertEqual(a1, a1)
         XCTAssertNotEqual(a1, a2)


### PR DESCRIPTION
### Short description 📝

Different subclasses of `GraphNode`s stored in a set can mistakenly be flagged as duplicates. 

This is due to `Equatable`'s requirement of static `==` methods which don't allow for an override in subclasses. 

Reference: https://forums.swift.org/t/implement-equatable-protocol-in-a-class-hierarchy/13844

### Solution 📦

Add an `isEqual` method which is consulted to determine equality of `GraphNode`s. All subclasses have to override this method to ensure correct equality.

Additionally we need to perform a second equality check reversing the sides to ensure we call the subclass implementation should a comparison take place between different subclass types.

### Test Plan ⚒

- Verify unit tests pass