### PR TITLE
Resolve Swift 5 Warnings

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
         "package": "SwiftPM",
         "repositoryURL": "https://github.com/apple/swift-package-manager",
         "state": {
-          "branch": null,
-          "revision": "a107d28d1b40491cf505799a046fee53e7c422e1",
+          "branch": "swift-5.0-RELEASE",
+          "revision": "3a57975e10be0b1a8b87992ddf3a49701036f96c",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -27,12 +27,12 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/tuist/xcodeproj.git", .revision("86b5dd403c1fcf0a7325a65b6d6f10a8a3a369b9")),
-        .package(url: "https://github.com/apple/swift-package-manager", .revision("a107d28d1b40491cf505799a046fee53e7c422e1")),
+        .package(url: "https://github.com/apple/swift-package-manager", .branch("swift-5.0-RELEASE")),
     ],
     targets: [
         .target(
             name: "TuistKit",
-            dependencies: ["XcodeProj", "Utility", "TuistCore", "TuistGenerator", "ProjectDescription"]
+            dependencies: ["XcodeProj", "SPMUtility", "TuistCore", "TuistGenerator", "ProjectDescription"]
         ),
         .testTarget(
             name: "TuistKitTests",
@@ -44,7 +44,7 @@ let package = Package(
         ),
         .target(
             name: "TuistEnvKit",
-            dependencies: ["Utility", "TuistCore"]
+            dependencies: ["SPMUtility", "TuistCore"]
         ),
         .testTarget(
             name: "TuistEnvKitTests",
@@ -64,7 +64,7 @@ let package = Package(
         ),
         .target(
             name: "TuistCore",
-            dependencies: ["Utility"]
+            dependencies: ["SPMUtility"]
         ),
         .target(
             name: "TuistCoreTesting",
@@ -76,7 +76,7 @@ let package = Package(
         ),
         .target(
             name: "TuistGenerator",
-            dependencies: ["XcodeProj", "Utility", "TuistCore"]
+            dependencies: ["XcodeProj", "SPMUtility", "TuistCore"]
         ),
         .testTarget(
             name: "TuistGeneratorTests",

--- a/Sources/TuistCore/Commands/Command.swift
+++ b/Sources/TuistCore/Commands/Command.swift
@@ -1,4 +1,4 @@
-import Utility
+import SPMUtility
 
 /// Protocol that defines the interface a CLI command.
 public protocol Command {

--- a/Sources/TuistCore/Extensions/AbsolutePath+Extras.swift
+++ b/Sources/TuistCore/Extensions/AbsolutePath+Extras.swift
@@ -12,7 +12,7 @@ extension AbsolutePath {
 
     /// Returns the URL that references the absolute path.
     public var url: URL {
-        return URL(fileURLWithPath: asString)
+        return URL(fileURLWithPath: pathString)
     }
 
     /// Returns the list of paths that match the given glob pattern.
@@ -20,7 +20,7 @@ extension AbsolutePath {
     /// - Parameter pattern: Relative glob pattern used to match the paths.
     /// - Returns: List of paths that match the given pattern.
     public func glob(_ pattern: String) -> [AbsolutePath] {
-        return Glob(pattern: appending(RelativePath(pattern)).asString).paths.map { AbsolutePath($0) }
+        return Glob(pattern: appending(RelativePath(pattern)).pathString).paths.map { AbsolutePath($0) }
     }
 
     /// Returns the path with the last component removed. For example, given the path

--- a/Sources/TuistCore/Extensions/ArgumentParserError+FatalError.swift
+++ b/Sources/TuistCore/Extensions/ArgumentParserError+FatalError.swift
@@ -1,4 +1,4 @@
-import Utility
+import SPMUtility
 
 // MARK: - FatalError
 

--- a/Sources/TuistCore/Extensions/String+MD5.swift
+++ b/Sources/TuistCore/Extensions/String+MD5.swift
@@ -25,7 +25,6 @@ import Foundation
 public extension String {
     var md5: String {
         if let data = data(using: .utf8, allowLossyConversion: true) {
-            
             let message = data.withUnsafeBytes { (pointer) -> [UInt8] in
                 Array(pointer)
             }

--- a/Sources/TuistCore/Extensions/String+MD5.swift
+++ b/Sources/TuistCore/Extensions/String+MD5.swift
@@ -25,8 +25,9 @@ import Foundation
 public extension String {
     var md5: String {
         if let data = data(using: .utf8, allowLossyConversion: true) {
-            let message = data.withUnsafeBytes { bytes -> [UInt8] in
-                Array(UnsafeBufferPointer(start: bytes, count: data.count))
+            
+            let message = data.withUnsafeBytes { (pointer) -> [UInt8] in
+                Array(pointer)
             }
 
             let MD5Calculator = MD5(message)

--- a/Sources/TuistCore/Utils/FileHandler.swift
+++ b/Sources/TuistCore/Utils/FileHandler.swift
@@ -6,7 +6,7 @@ enum FileHandlerError: FatalError {
     var description: String {
         switch self {
         case let .invalidTextEncoding(path):
-            return "The file at \(path.asString) is not a utf8 text file"
+            return "The file at \(path.pathString) is not a utf8 text file"
         }
     }
 
@@ -98,7 +98,7 @@ public final class FileHandler: FileHandling {
     /// - Parameter path: Path to check.
     /// - Returns: True if there's a folder or file at the given path.
     public func exists(_ path: AbsolutePath) -> Bool {
-        return FileManager.default.fileExists(atPath: path.asString)
+        return FileManager.default.fileExists(atPath: path.pathString)
     }
 
     /// It copies a file or folder to another path.
@@ -108,7 +108,7 @@ public final class FileHandler: FileHandling {
     ///   - to: Path where the file/folder will be copied.
     /// - Throws: An error if from doesn't exist or to does.
     public func copy(from: AbsolutePath, to: AbsolutePath) throws {
-        try FileManager.default.copyItem(atPath: from.asString, toPath: to.asString)
+        try FileManager.default.copyItem(atPath: from.pathString, toPath: to.pathString)
     }
 
     /// Reads a text file at the given path and returns it.
@@ -136,7 +136,7 @@ public final class FileHandler: FileHandling {
     }
 
     public func delete(_ path: AbsolutePath) throws {
-        try FileManager.default.removeItem(atPath: path.asString)
+        try FileManager.default.removeItem(atPath: path.pathString)
     }
 
     public func touch(_ path: AbsolutePath) throws {
@@ -148,7 +148,7 @@ public final class FileHandler: FileHandling {
 
     public func isFolder(_ path: AbsolutePath) -> Bool {
         var isDirectory = ObjCBool(true)
-        let exists = FileManager.default.fileExists(atPath: path.asString, isDirectory: &isDirectory)
+        let exists = FileManager.default.fileExists(atPath: path.pathString, isDirectory: &isDirectory)
         return exists && isDirectory.boolValue
     }
 }

--- a/Sources/TuistCore/Utils/Opener.swift
+++ b/Sources/TuistCore/Utils/Opener.swift
@@ -14,7 +14,7 @@ enum OpeningError: FatalError, Equatable {
     var description: String {
         switch self {
         case let .notFound(path):
-            return "Couldn't open file at path \(path.asString)"
+            return "Couldn't open file at path \(path.pathString)"
         }
     }
 
@@ -50,6 +50,6 @@ public class Opener: Opening {
         if !fileHandler.exists(path) {
             throw OpeningError.notFound(path)
         }
-        try system.runAndPrint("/usr/bin/open", path.asString)
+        try system.runAndPrint("/usr/bin/open", path.pathString)
     }
 }

--- a/Sources/TuistCore/Utils/System.swift
+++ b/Sources/TuistCore/Utils/System.swift
@@ -307,9 +307,9 @@ public final class System: Systeming {
         let process = Process(arguments: arguments,
                               environment: environment,
                               outputRedirection: .stream(stdout: { bytes in
-                                  FileHandle.standardOutput.write(Data(bytes: bytes))
+                                  FileHandle.standardOutput.write(Data(bytes))
                               }, stderr: { bytes in
-                                  FileHandle.standardError.write(Data(bytes: bytes))
+                                  FileHandle.standardError.write(Data(bytes))
                               }), verbose: verbose,
                               startNewProcessGroup: false)
         try process.launch()

--- a/Sources/TuistCoreTesting/Commands/MockCommand.swift
+++ b/Sources/TuistCoreTesting/Commands/MockCommand.swift
@@ -1,6 +1,6 @@
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 public final class MockCommand: Command {
     public static let command: String = "command"

--- a/Sources/TuistCoreTesting/Commands/MockCommand.swift
+++ b/Sources/TuistCoreTesting/Commands/MockCommand.swift
@@ -1,6 +1,6 @@
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 public final class MockCommand: Command {
     public static let command: String = "command"

--- a/Sources/TuistCoreTesting/Commands/MockHiddenCommand.swift
+++ b/Sources/TuistCoreTesting/Commands/MockHiddenCommand.swift
@@ -1,6 +1,6 @@
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 public final class MockHiddenCommand: HiddenCommand {
     public static var command: String = "hidden"

--- a/Sources/TuistCoreTesting/Commands/MockHiddenCommand.swift
+++ b/Sources/TuistCoreTesting/Commands/MockHiddenCommand.swift
@@ -1,6 +1,6 @@
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 public final class MockHiddenCommand: HiddenCommand {
     public static var command: String = "hidden"

--- a/Sources/TuistCoreTesting/Commands/MockRawCommand.swift
+++ b/Sources/TuistCoreTesting/Commands/MockRawCommand.swift
@@ -1,6 +1,6 @@
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 public final class MockRawCommand: RawCommand {
     public static var command: String = "raw"

--- a/Sources/TuistCoreTesting/Commands/MockRawCommand.swift
+++ b/Sources/TuistCoreTesting/Commands/MockRawCommand.swift
@@ -1,6 +1,6 @@
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 public final class MockRawCommand: RawCommand {
     public static var command: String = "raw"

--- a/Sources/TuistEnvKit/Commands/BundleCommand.swift
+++ b/Sources/TuistEnvKit/Commands/BundleCommand.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 enum BundleCommandError: FatalError, Equatable {
     case missingVersionFile(AbsolutePath)
@@ -16,7 +16,7 @@ enum BundleCommandError: FatalError, Equatable {
     var description: String {
         switch self {
         case let .missingVersionFile(path):
-            return "Couldn't find a .tuist-version file in the directory \(path.asString)"
+            return "Couldn't find a .tuist-version file in the directory \(path.pathString)"
         }
     }
 
@@ -74,7 +74,7 @@ final class BundleCommand: Command {
         }
 
         let version = try String(contentsOf: versionFilePath.url)
-        printer.print(section: "Bundling the version \(version) in the directory \(binFolderPath.asString)")
+        printer.print(section: "Bundling the version \(version) in the directory \(binFolderPath.pathString)")
 
         let versionPath = versionsController.path(version: version)
 
@@ -90,6 +90,6 @@ final class BundleCommand: Command {
         }
         try fileHandler.copy(from: versionPath, to: binFolderPath)
 
-        printer.print(success: "tuist bundled successfully at \(binFolderPath.asString)")
+        printer.print(success: "tuist bundled successfully at \(binFolderPath.pathString)")
     }
 }

--- a/Sources/TuistEnvKit/Commands/BundleCommand.swift
+++ b/Sources/TuistEnvKit/Commands/BundleCommand.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 enum BundleCommandError: FatalError, Equatable {
     case missingVersionFile(AbsolutePath)

--- a/Sources/TuistEnvKit/Commands/CommandRegistry.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRegistry.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 public final class CommandRegistry {
     // MARK: - Attributes

--- a/Sources/TuistEnvKit/Commands/CommandRegistry.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRegistry.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 public final class CommandRegistry {
     // MARK: - Attributes

--- a/Sources/TuistEnvKit/Commands/CommandRunner.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRunner.swift
@@ -69,9 +69,9 @@ class CommandRunner: CommandRunning {
 
         switch resolvedVersion {
         case let .bin(path):
-            printer.print("Using bundled version at path \(path.asString)")
+            printer.print("Using bundled version at path \(path.pathString)")
         case let .versionFile(path, value):
-            printer.print("Using version \(value) defined at \(path.asString)")
+            printer.print("Using version \(value) defined at \(path.pathString)")
         default:
             break
         }
@@ -115,7 +115,7 @@ class CommandRunner: CommandRunning {
     }
 
     func runAtPath(_ path: AbsolutePath) throws {
-        var args = [path.appending(component: Constants.binName).asString]
+        var args = [path.appending(component: Constants.binName).pathString]
         args.append(contentsOf: Array(arguments().dropFirst()))
 
         try system.runAndPrint(args, verbose: false, environment: ProcessInfo.processInfo.environment)

--- a/Sources/TuistEnvKit/Commands/InstallCommand.swift
+++ b/Sources/TuistEnvKit/Commands/InstallCommand.swift
@@ -1,6 +1,6 @@
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 /// Command that installs new versions of Tuist in the system.
 final class InstallCommand: Command {

--- a/Sources/TuistEnvKit/Commands/InstallCommand.swift
+++ b/Sources/TuistEnvKit/Commands/InstallCommand.swift
@@ -1,6 +1,6 @@
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 /// Command that installs new versions of Tuist in the system.
 final class InstallCommand: Command {

--- a/Sources/TuistEnvKit/Commands/LocalCommand.swift
+++ b/Sources/TuistEnvKit/Commands/LocalCommand.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 class LocalCommand: Command {
     // MARK: - Command

--- a/Sources/TuistEnvKit/Commands/LocalCommand.swift
+++ b/Sources/TuistEnvKit/Commands/LocalCommand.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 class LocalCommand: Command {
     // MARK: - Command
@@ -64,9 +64,9 @@ class LocalCommand: Command {
         let currentPath = fileHandler.currentPath
         printer.print(section: "Generating \(Constants.versionFileName) file with version \(version)")
         let tuistVersionPath = currentPath.appending(component: Constants.versionFileName)
-        try "\(version)".write(to: URL(fileURLWithPath: tuistVersionPath.asString),
+        try "\(version)".write(to: URL(fileURLWithPath: tuistVersionPath.pathString),
                                atomically: true,
                                encoding: .utf8)
-        printer.print(success: "File generated at path \(tuistVersionPath.asString)")
+        printer.print(success: "File generated at path \(tuistVersionPath.pathString)")
     }
 }

--- a/Sources/TuistEnvKit/Commands/UninstallCommand.swift
+++ b/Sources/TuistEnvKit/Commands/UninstallCommand.swift
@@ -1,6 +1,6 @@
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 final class UninstallCommand: Command {
     // MARK: - Command

--- a/Sources/TuistEnvKit/Commands/UninstallCommand.swift
+++ b/Sources/TuistEnvKit/Commands/UninstallCommand.swift
@@ -1,6 +1,6 @@
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 final class UninstallCommand: Command {
     // MARK: - Command

--- a/Sources/TuistEnvKit/Commands/UpdateCommand.swift
+++ b/Sources/TuistEnvKit/Commands/UpdateCommand.swift
@@ -1,6 +1,6 @@
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 /// Command that updates the version of Tuist in the environment.
 final class UpdateCommand: Command {

--- a/Sources/TuistEnvKit/Commands/UpdateCommand.swift
+++ b/Sources/TuistEnvKit/Commands/UpdateCommand.swift
@@ -1,6 +1,6 @@
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 /// Command that updates the version of Tuist in the environment.
 final class UpdateCommand: Command {

--- a/Sources/TuistEnvKit/GitHub/GitHubClient.swift
+++ b/Sources/TuistEnvKit/GitHub/GitHubClient.swift
@@ -1,6 +1,6 @@
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 protocol GitHubClienting: AnyObject {
     func releases() throws -> [Release]

--- a/Sources/TuistEnvKit/GitHub/GitHubClient.swift
+++ b/Sources/TuistEnvKit/GitHub/GitHubClient.swift
@@ -1,6 +1,6 @@
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 protocol GitHubClienting: AnyObject {
     func releases() throws -> [Release]

--- a/Sources/TuistEnvKit/GitHub/Release.swift
+++ b/Sources/TuistEnvKit/GitHub/Release.swift
@@ -1,6 +1,6 @@
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 enum ReleaseDecodeError: FatalError, Equatable {
     case invalidVersionFormat(String)

--- a/Sources/TuistEnvKit/GitHub/Release.swift
+++ b/Sources/TuistEnvKit/GitHub/Release.swift
@@ -1,6 +1,6 @@
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 enum ReleaseDecodeError: FatalError, Equatable {
     case invalidVersionFormat(String)

--- a/Sources/TuistEnvKit/Installer/BuildCopier.swift
+++ b/Sources/TuistEnvKit/Installer/BuildCopier.swift
@@ -36,9 +36,9 @@ class BuildCopier: BuildCopying {
             let filePath = from.appending(component: file)
             let toPath = to.appending(component: file)
             if !fileHandler.exists(filePath) { return }
-            try system.run("/bin/cp", "-rf", filePath.asString, toPath.asString)
+            try system.run("/bin/cp", "-rf", filePath.pathString, toPath.pathString)
             if file == "tuist" {
-                try system.run("/bin/chmod", "+x", toPath.asString)
+                try system.run("/bin/chmod", "+x", toPath.pathString)
             }
         }
     }

--- a/Sources/TuistEnvKit/Installer/Installer.swift
+++ b/Sources/TuistEnvKit/Installer/Installer.swift
@@ -152,11 +152,11 @@ final class Installer: Installing {
             // Download bundle
             printer.print("Downloading version from \(bundleURL.absoluteString)")
             let downloadPath = temporaryDirectory.path.appending(component: Constants.bundleName)
-            try system.run("/usr/bin/curl", "-LSs", "--output", downloadPath.asString, bundleURL.absoluteString)
+            try system.run("/usr/bin/curl", "-LSs", "--output", downloadPath.pathString, bundleURL.absoluteString)
 
             // Unzip
             printer.print("Installing...")
-            try system.run("/usr/bin/unzip", downloadPath.asString, "-d", installationDirectory.asString)
+            try system.run("/usr/bin/unzip", downloadPath.pathString, "-d", installationDirectory.pathString)
 
             try createTuistVersionFile(version: version, path: installationDirectory)
             printer.print("Version \(version) installed")
@@ -171,10 +171,10 @@ final class Installer: Installing {
 
             // Cloning and building
             printer.print("Pulling source code")
-            try system.run("/usr/bin/env", "git", "clone", Constants.gitRepositoryURL, temporaryDirectory.path.asString)
+            try system.run("/usr/bin/env", "git", "clone", Constants.gitRepositoryURL, temporaryDirectory.path.pathString)
 
             do {
-                try system.run("/usr/bin/env", "git", "-C", temporaryDirectory.path.asString, "checkout", version)
+                try system.run("/usr/bin/env", "git", "-C", temporaryDirectory.path.pathString, "checkout", version)
             } catch let error as SystemError {
                 if error.description.contains("did not match any file(s) known to git") {
                     throw InstallerError.versionNotFound(version)
@@ -187,12 +187,12 @@ final class Installer: Installing {
 
             try system.run(swiftPath, "build",
                            "--product", "tuist",
-                           "--package-path", temporaryDirectory.path.asString,
+                           "--package-path", temporaryDirectory.path.pathString,
                            "--configuration", "release",
                            "-Xswiftc", "-static-stdlib")
             try system.run(swiftPath, "build",
                            "--product", "ProjectDescription",
-                           "--package-path", temporaryDirectory.path.asString,
+                           "--package-path", temporaryDirectory.path.pathString,
                            "--configuration", "release")
 
             if fileHandler.exists(installationDirectory) {

--- a/Sources/TuistEnvKit/Settings/SettingsController.swift
+++ b/Sources/TuistEnvKit/Settings/SettingsController.swift
@@ -44,7 +44,7 @@ class SettingsController: SettingsControlling {
     func settings() throws -> Settings {
         let path = environmentController.settingsPath
         if !fileHandler.exists(path) { return Settings() }
-        let data = try Data(contentsOf: URL(fileURLWithPath: path.asString))
+        let data = try Data(contentsOf: URL(fileURLWithPath: path.pathString))
         let decoder = JSONDecoder()
         return try decoder.decode(Settings.self, from: data)
     }
@@ -58,7 +58,7 @@ class SettingsController: SettingsControlling {
         let data = try encoder.encode(settings)
         let path = environmentController.settingsPath
         if fileHandler.exists(path) { try fileHandler.delete(path) }
-        let url = URL(fileURLWithPath: path.asString)
+        let url = URL(fileURLWithPath: path.pathString)
         try data.write(to: url, options: Data.WritingOptions.atomic)
     }
 }

--- a/Sources/TuistEnvKit/Updater/EnvUpdater.swift
+++ b/Sources/TuistEnvKit/Updater/EnvUpdater.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 /// Protocol that defines the interface to update the environment.
 protocol EnvUpdating {

--- a/Sources/TuistEnvKit/Updater/EnvUpdater.swift
+++ b/Sources/TuistEnvKit/Updater/EnvUpdater.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 /// Protocol that defines the interface to update the environment.
 protocol EnvUpdating {
@@ -49,8 +49,8 @@ final class EnvUpdater: EnvUpdating {
             // Download
             let fileName = asset.downloadURL.lastPathComponent
             let downloadPath = directory.appending(component: fileName)
-            try system.run("/usr/bin/curl", "-LSs", "--output", downloadPath.asString, asset.downloadURL.absoluteString)
-            try system.run("/usr/bin/unzip", "-o", downloadPath.asString, "-d", "/tmp/")
+            try system.run("/usr/bin/curl", "-LSs", "--output", downloadPath.pathString, asset.downloadURL.absoluteString)
+            try system.run("/usr/bin/unzip", "-o", downloadPath.pathString, "-d", "/tmp/")
             let binaryPath = "/tmp/tuistenv"
             try system.run(["/bin/chmod", "+x", binaryPath])
 

--- a/Sources/TuistEnvKit/Versions/VersionResolver.swift
+++ b/Sources/TuistEnvKit/Versions/VersionResolver.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 enum ResolvedVersion: Equatable {
     case bin(AbsolutePath)
@@ -38,7 +38,7 @@ enum VersionResolverError: FatalError, Equatable {
     var description: String {
         switch self {
         case let .readError(path):
-            return "Cannot read the version file at path \(path.asString)."
+            return "Cannot read the version file at path \(path.pathString)."
         }
     }
 
@@ -73,9 +73,9 @@ class VersionResolver: VersionResolving {
     private func resolveTraversing(from path: AbsolutePath) throws -> ResolvedVersion {
         let versionPath = path.appending(component: Constants.versionFileName)
         let binPath = path.appending(component: Constants.binFolderName)
-        if fileManager.fileExists(atPath: binPath.asString) {
+        if fileManager.fileExists(atPath: binPath.pathString) {
             return .bin(binPath)
-        } else if fileManager.fileExists(atPath: versionPath.asString) {
+        } else if fileManager.fileExists(atPath: versionPath.pathString) {
             return try resolveVersionFile(path: versionPath)
         }
         if path.components.count > 1 {
@@ -87,7 +87,7 @@ class VersionResolver: VersionResolving {
     private func resolveVersionFile(path: AbsolutePath) throws -> ResolvedVersion {
         var value: String!
         do {
-            value = try String(contentsOf: URL(fileURLWithPath: path.asString))
+            value = try String(contentsOf: URL(fileURLWithPath: path.pathString))
         } catch {
             throw VersionResolverError.readError(path: path)
         }

--- a/Sources/TuistEnvKit/Versions/VersionResolver.swift
+++ b/Sources/TuistEnvKit/Versions/VersionResolver.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 enum ResolvedVersion: Equatable {
     case bin(AbsolutePath)

--- a/Sources/TuistEnvKit/Versions/VersionsController.swift
+++ b/Sources/TuistEnvKit/Versions/VersionsController.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 protocol VersionsControlling: AnyObject {
     typealias Installation = (AbsolutePath) throws -> Void

--- a/Sources/TuistEnvKit/Versions/VersionsController.swift
+++ b/Sources/TuistEnvKit/Versions/VersionsController.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 protocol VersionsControlling: AnyObject {
     typealias Installation = (AbsolutePath) throws -> Void

--- a/Sources/TuistGenerator/Extensions/AbsolutePath+Extras.swift
+++ b/Sources/TuistGenerator/Extensions/AbsolutePath+Extras.swift
@@ -4,6 +4,6 @@ import PathKit
 
 extension AbsolutePath {
     var path: Path {
-        return Path(asString)
+        return Path(pathString)
     }
 }

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -9,7 +9,7 @@ enum BuildPhaseGenerationError: FatalError, Equatable {
     var description: String {
         switch self {
         case let .missingFileReference(path):
-            return "Trying to add a file at path \(path.asString) to a build phase that hasn't been added to the project."
+            return "Trying to add a file at path \(path.pathString) to a build phase that hasn't been added to the project."
         }
     }
 
@@ -159,7 +159,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
                                             pbxproj: PBXProj,
                                             resourcesBuildPhase: PBXResourcesBuildPhase) throws {
         try files.forEach { buildFilePath in
-            let pathString = buildFilePath.asString
+            let pathString = buildFilePath.pathString
             let pathRange = NSRange(location: 0, length: pathString.count)
             let isLocalized = ProjectFileElements.localizedRegex.firstMatch(in: pathString, options: [], range: pathRange) != nil
             let isLproj = buildFilePath.extension == "lproj"

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -154,10 +154,10 @@ final class ConfigGenerator: ConfigGenerating {
         /// Target attributes
         settings["PRODUCT_BUNDLE_IDENTIFIER"] = target.bundleId
         if let infoPlist = target.infoPlist {
-            settings["INFOPLIST_FILE"] = "$(SRCROOT)/\(infoPlist.relative(to: sourceRootPath).asString)"
+            settings["INFOPLIST_FILE"] = "$(SRCROOT)/\(infoPlist.relative(to: sourceRootPath).pathString)"
         }
         if let entitlements = target.entitlements {
-            settings["CODE_SIGN_ENTITLEMENTS"] = "$(SRCROOT)/\(entitlements.relative(to: sourceRootPath).asString)"
+            settings["CODE_SIGN_ENTITLEMENTS"] = "$(SRCROOT)/\(entitlements.relative(to: sourceRootPath).pathString)"
         }
         settings["SDKROOT"] = target.platform.xcodeSdkRoot
         settings["SUPPORTED_PLATFORMS"] = target.platform.xcodeSupportedPlatforms

--- a/Sources/TuistGenerator/Generator/GeneratedProject.swift
+++ b/Sources/TuistGenerator/Generator/GeneratedProject.swift
@@ -37,7 +37,7 @@ final class GeneratedProject {
     /// - Parameter path: Path to the project (.xcodeproj)
     /// - Returns: GeneratedProject instance.
     func at(path: AbsolutePath) throws -> GeneratedProject {
-        let xcode = try XcodeProj(pathString: path.asString)
+        let xcode = try XcodeProj(pathString: path.pathString)
 
         return GeneratedProject(pbxproj: xcode.pbxproj,
                                 path: path,

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -13,7 +13,7 @@ enum LinkGeneratorError: FatalError, Equatable {
         case let .missingProduct(name):
             return "Couldn't find a reference for the product \(name)."
         case let .missingReference(path):
-            return "Couldn't find a reference for the file at path \(path.asString)."
+            return "Couldn't find a reference for the file at path \(path.pathString)."
         case let .missingConfigurationList(targetName):
             return "The target \(targetName) doesn't have a configuration list."
         }
@@ -148,9 +148,9 @@ final class LinkGenerator: LinkGenerating {
 
         try dependencies.forEach { dependency in
             if case let DependencyReference.absolute(path) = dependency {
-                let relativePath = "$(SRCROOT)/\(path.relative(to: sourceRootPath).asString)"
+                let relativePath = "$(SRCROOT)/\(path.relative(to: sourceRootPath).pathString)"
                 let binary = binaryLocator.copyFrameworksBinary()
-                script.append("\(binary) embed \(path.relative(to: sourceRootPath).asString)")
+                script.append("\(binary) embed \(path.relative(to: sourceRootPath).pathString)")
                 precompiledEmbedPhase.inputPaths.append(relativePath)
                 precompiledEmbedPhase.outputPaths.append("$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/\(path.components.last!)")
 
@@ -218,7 +218,7 @@ final class LinkGenerator: LinkGenerating {
                        pbxTarget: PBXTarget,
                        sourceRootPath: AbsolutePath) throws {
         let relativePaths = paths
-            .map { $0.relative(to: sourceRootPath).asString }
+            .map { $0.relative(to: sourceRootPath).pathString }
             .map { "$(SRCROOT)/\($0)" }
         guard let configurationList = pbxTarget.buildConfigurationList else {
             throw LinkGeneratorError.missingConfigurationList(targetName: pbxTarget.name)

--- a/Sources/TuistGenerator/Generator/ProjectDirectoryHelper.swift
+++ b/Sources/TuistGenerator/Generator/ProjectDirectoryHelper.swift
@@ -72,7 +72,7 @@ class ProjectDirectoryHelper: ProjectDirectoryHelping {
     func setupDirectory(name: String, path: AbsolutePath, directory: GenerationDirectory) throws -> AbsolutePath {
         switch directory {
         case .derivedProjects:
-            let md5 = path.asString.md5
+            let md5 = path.pathString.md5
             let path = environmentController.derivedProjectsDirectory.appending(component: "\(name)-\(md5)")
             if !fileHandler.exists(path) {
                 try fileHandler.createFolder(path)

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -380,7 +380,7 @@ class ProjectFileElements {
                                 pbxproj: PBXProj) -> (element: PBXFileElement, path: AbsolutePath) {
         let versionGroupType = Xcode.filetype(extension: folderRelativePath.extension!)
         let group = XCVersionGroup(currentVersion: nil,
-                                   path: folderRelativePath.asString,
+                                   path: folderRelativePath.pathString,
                                    name: name,
                                    sourceTree: .group,
                                    versionGroupType: versionGroupType)
@@ -396,7 +396,7 @@ class ProjectFileElements {
                          name: String?,
                          toGroup: PBXGroup,
                          pbxproj: PBXProj) -> (element: PBXFileElement, path: AbsolutePath) {
-        let group = PBXGroup(children: [], sourceTree: .group, name: name, path: folderRelativePath.asString)
+        let group = PBXGroup(children: [], sourceTree: .group, name: name, path: folderRelativePath.pathString)
         pbxproj.add(object: group)
         toGroup.children.append(group)
         elements[folderAbsolutePath] = group
@@ -410,7 +410,7 @@ class ProjectFileElements {
                         toGroup: PBXGroup,
                         pbxproj: PBXProj) {
         let lastKnownFileType = fileAbsolutePath.extension.flatMap { Xcode.filetype(extension: $0) }
-        let file = PBXFileReference(sourceTree: .group, name: name, lastKnownFileType: lastKnownFileType, path: fileRelativePath.asString)
+        let file = PBXFileReference(sourceTree: .group, name: name, lastKnownFileType: lastKnownFileType, path: fileRelativePath.pathString)
         pbxproj.add(object: file)
         toGroup.children.append(file)
         elements[fileAbsolutePath] = file
@@ -447,7 +447,7 @@ class ProjectFileElements {
     /// - Example:
     ///   /test/es.lproj/Main.storyboard ~> /test/es.lproj
     func normalize(_ path: AbsolutePath) -> AbsolutePath {
-        let pathString = path.asString
+        let pathString = path.pathString
         let range = NSRange(location: 0, length: pathString.count)
         if let localizedMatch = ProjectFileElements.localizedRegex.firstMatch(in: pathString,
                                                                               options: [],

--- a/Sources/TuistGenerator/Generator/ProjectGroups.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGroups.swift
@@ -68,7 +68,7 @@ class ProjectGroups {
                          sourceRootPath: AbsolutePath,
                          playgrounds: Playgrounding = Playgrounds()) -> ProjectGroups {
         /// Main
-        let projectRelativePath = project.path.relative(to: sourceRootPath).asString
+        let projectRelativePath = project.path.relative(to: sourceRootPath).pathString
         let mainGroup = PBXGroup(children: [],
                                  sourceTree: .group,
                                  path: (projectRelativePath != ".") ? projectRelativePath : nil)

--- a/Sources/TuistGenerator/Generator/WorkspaceGenerator.swift
+++ b/Sources/TuistGenerator/Generator/WorkspaceGenerator.swift
@@ -147,7 +147,7 @@ final class WorkspaceGenerator: WorkspaceGenerating {
     ///
     /// - Parameter path: The relative path to the file
     private func workspaceFileElement(path: RelativePath) -> XCWorkspaceDataElement {
-        let location = XCWorkspaceDataElementLocationType.group(path.asString)
+        let location = XCWorkspaceDataElementLocationType.group(path.pathString)
         let fileRef = XCWorkspaceDataFileRef(location: location)
         return .file(fileRef)
     }
@@ -211,7 +211,7 @@ final class WorkspaceGenerator: WorkspaceGenerating {
             return workspaceFileElement(path: folderPath.relative(to: path))
 
         case let .group(name: name, path: groupPath, contents: contents):
-            let location = XCWorkspaceDataElementLocationType.group(groupPath.relative(to: path).asString)
+            let location = XCWorkspaceDataElementLocationType.group(groupPath.relative(to: path).pathString)
 
             let groupReference = XCWorkspaceDataGroup(
                 location: location,

--- a/Sources/TuistGenerator/Generator/WorkspaceStructureGenerator.swift
+++ b/Sources/TuistGenerator/Generator/WorkspaceStructureGenerator.swift
@@ -202,13 +202,13 @@ extension DirectoryStructure.Node: CustomDebugStringConvertible {
     var debugDescription: String {
         switch self {
         case let .file(path):
-            return "file: \(path.asString)"
+            return "file: \(path.pathString)"
         case let .project(path):
-            return "project: \(path.asString)"
+            return "project: \(path.pathString)"
         case let .directory(path, graph):
-            return "directory: \(path.asString) > \(graph.nodes)"
+            return "directory: \(path.pathString) > \(graph.nodes)"
         case let .folderReference(path):
-            return "folderReference: \(path.asString)"
+            return "folderReference: \(path.pathString)"
         }
     }
 }

--- a/Sources/TuistGenerator/Graph/GraphLoadingError.swift
+++ b/Sources/TuistGenerator/Graph/GraphLoadingError.swift
@@ -33,18 +33,18 @@ enum GraphLoadingError: FatalError, Equatable {
     var description: String {
         switch self {
         case let .manifestNotFound(path):
-            return "Couldn't find manifest at path: '\(path.asString)'"
+            return "Couldn't find manifest at path: '\(path.pathString)'"
         case let .targetNotFound(targetName, path):
-            return "Couldn't find target '\(targetName)' at '\(path.asString)'"
+            return "Couldn't find target '\(targetName)' at '\(path.pathString)'"
         case let .missingFile(path):
-            return "Couldn't find file at path '\(path.asString)'"
+            return "Couldn't find file at path '\(path.pathString)'"
         case let .unexpected(message):
             return message
         case let .circularDependency(from, to):
             var message = ""
             message.append("Found circular dependency between the target")
-            message.append(" '\(from.name)' at '\(from.path.asString)'")
-            message.append(" and the target '\(to.name)' at '\(to.path.asString)'")
+            message.append(" '\(from.name)' at '\(from.path.pathString)'")
+            message.append(" and the target '\(to.name)' at '\(to.path.pathString)'")
             return message
         }
     }

--- a/Sources/TuistGenerator/Graph/GraphNode.swift
+++ b/Sources/TuistGenerator/Graph/GraphNode.swift
@@ -126,7 +126,7 @@ enum PrecompiledNodeError: FatalError, Equatable {
     var description: String {
         switch self {
         case let .architecturesNotFound(path):
-            return "Couldn't find architectures for binary at path \(path.asString)"
+            return "Couldn't find architectures for binary at path \(path.pathString)"
         }
     }
 
@@ -164,7 +164,7 @@ class PrecompiledNode: GraphNode {
     }
 
     func architectures(system: Systeming = System()) throws -> [Architecture] {
-        let result = try system.capture("/usr/bin/lipo", "-info", binaryPath.asString).spm_chuzzle() ?? ""
+        let result = try system.capture("/usr/bin/lipo", "-info", binaryPath.pathString).spm_chuzzle() ?? ""
         let regex = try NSRegularExpression(pattern: ".+:\\s.+\\sis\\sarchitecture:\\s(.+)", options: [])
         guard let match = regex.firstMatch(in: result, options: [], range: NSRange(location: 0, length: result.count)) else {
             throw PrecompiledNodeError.architecturesNotFound(binaryPath)
@@ -174,7 +174,7 @@ class PrecompiledNode: GraphNode {
     }
 
     func linking(system: Systeming = System()) throws -> Linking {
-        let result = try system.capture("/usr/bin/file", binaryPath.asString).spm_chuzzle() ?? ""
+        let result = try system.capture("/usr/bin/file", binaryPath.pathString).spm_chuzzle() ?? ""
         return result.contains("dynamically linked") ? .dynamic : .static
     }
 }
@@ -191,7 +191,7 @@ class FrameworkNode: PrecompiledNode {
     }
 
     var isCarthage: Bool {
-        return path.asString.contains("Carthage/Build")
+        return path.pathString.contains("Carthage/Build")
     }
 
     override var binaryPath: AbsolutePath {

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -64,10 +64,10 @@ class GraphLinter: GraphLinting {
 
         let carthageIssues = carthageFrameworks
             .filter { !fileHandler.exists($0.path) }
-            .map { LintingIssue(reason: "Framework not found at path \($0.path.asString). The path might be wrong or Carthage dependencies not fetched", severity: .warning) }
+            .map { LintingIssue(reason: "Framework not found at path \($0.path.pathString). The path might be wrong or Carthage dependencies not fetched", severity: .warning) }
         let nonCarthageIssues = nonCarthageFrameworks
             .filter { !fileHandler.exists($0.path) }
-            .map { LintingIssue(reason: "Framework not found at path \($0.path.asString)", severity: .error) }
+            .map { LintingIssue(reason: "Framework not found at path \($0.path.pathString)", severity: .error) }
 
         var issues: [LintingIssue] = []
         issues.append(contentsOf: carthageIssues)

--- a/Sources/TuistGenerator/Linter/ProjectLinter.swift
+++ b/Sources/TuistGenerator/Linter/ProjectLinter.swift
@@ -47,7 +47,7 @@ class ProjectLinter: ProjectLinting {
             .filter { $0.value > 1 }
             .keys
         if !duplicatedTargets.isEmpty {
-            let issue = LintingIssue(reason: "Targets \(duplicatedTargets.joined(separator: ", ")) from project at \(project.path.asString) have duplicates.",
+            let issue = LintingIssue(reason: "Targets \(duplicatedTargets.joined(separator: ", ")) from project at \(project.path.pathString) have duplicates.",
                                      severity: .error)
             issues.append(issue)
         }

--- a/Sources/TuistGenerator/Linter/SettingsLinter.swift
+++ b/Sources/TuistGenerator/Linter/SettingsLinter.swift
@@ -32,7 +32,7 @@ final class SettingsLinter: SettingsLinting {
 
         let lintPath: (AbsolutePath) -> Void = { path in
             if !self.fileHandler.exists(path) {
-                issues.append(LintingIssue(reason: "Configuration file not found at path \(path.asString)", severity: .error))
+                issues.append(LintingIssue(reason: "Configuration file not found at path \(path.pathString)", severity: .error))
             }
         }
 

--- a/Sources/TuistGenerator/Linter/TargetActionLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetActionLinter.swift
@@ -55,7 +55,7 @@ class TargetActionLinter: TargetActionLinting {
     func lintPathExistence(_ action: TargetAction) -> [LintingIssue] {
         guard let path = action.path else { return [] }
         if fileHandler.exists(path) { return [] }
-        return [LintingIssue(reason: "The action path \(path.asString) doesn't exist",
+        return [LintingIssue(reason: "The action path \(path.pathString) doesn't exist",
                              severity: .error)]
     }
 }

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -77,15 +77,15 @@ class TargetLinter: TargetLinting {
         var issues: [LintingIssue] = []
 
         let files = target.resources.map(\.path)
-        let infoPlists = files.filter { $0.asString.contains("Info.plist") }
-        let entitlements = files.filter { $0.asString.contains(".entitlements") }
+        let infoPlists = files.filter { $0.pathString.contains("Info.plist") }
+        let entitlements = files.filter { $0.pathString.contains(".entitlements") }
 
         issues.append(contentsOf: infoPlists.map {
-            let reason = "Info.plist at path \($0.asString) being copied into the target \(target.name) product."
+            let reason = "Info.plist at path \($0.pathString) being copied into the target \(target.name) product."
             return LintingIssue(reason: reason, severity: .warning)
         })
         issues.append(contentsOf: entitlements.map {
-            let reason = "Entitlements file at path \($0.asString) being copied into the target \(target.name) product."
+            let reason = "Entitlements file at path \($0.pathString) being copied into the target \(target.name) product."
             return LintingIssue(reason: reason, severity: .warning)
         })
 
@@ -97,7 +97,7 @@ class TargetLinter: TargetLinting {
     private func lintInfoplistExists(target: Target) -> [LintingIssue] {
         var issues: [LintingIssue] = []
         if let infoPlist = target.infoPlist, !fileHandler.exists(infoPlist) {
-            issues.append(LintingIssue(reason: "Info.plist file not found at path \(infoPlist.asString)", severity: .error))
+            issues.append(LintingIssue(reason: "Info.plist file not found at path \(infoPlist.pathString)", severity: .error))
         }
         return issues
     }
@@ -105,7 +105,7 @@ class TargetLinter: TargetLinting {
     private func lintEntitlementsExist(target: Target) -> [LintingIssue] {
         var issues: [LintingIssue] = []
         if let path = target.entitlements, !fileHandler.exists(path) {
-            issues.append(LintingIssue(reason: "Entitlements file not found at path \(path.asString)", severity: .error))
+            issues.append(LintingIssue(reason: "Entitlements file not found at path \(path.pathString)", severity: .error))
         }
         return issues
     }

--- a/Sources/TuistGenerator/Models/TargetAction.swift
+++ b/Sources/TuistGenerator/Models/TargetAction.swift
@@ -58,7 +58,7 @@ public struct TargetAction {
     func shellScript(sourceRootPath: AbsolutePath,
                      system: Systeming = System()) throws -> String {
         if let path = path {
-            return "\(path.relative(to: sourceRootPath).asString) \(arguments.joined(separator: " "))"
+            return "\(path.relative(to: sourceRootPath).pathString) \(arguments.joined(separator: " "))"
         } else {
             return try "\(system.which(tool!).spm_chomp().spm_chuzzle()!) \(arguments.joined(separator: " "))"
         }

--- a/Sources/TuistGenerator/Utils/BinaryLocator.swift
+++ b/Sources/TuistGenerator/Utils/BinaryLocator.swift
@@ -27,7 +27,7 @@ final class BinaryLocator: BinaryLocating {
     func copyFrameworksBinary() -> String {
         let debugPathPatterns = [".build/", "DerivedData"]
         if let launchPath = CommandLine.arguments.first, debugPathPatterns.contains(where: { launchPath.contains($0) }) {
-            return AbsolutePath(launchPath, relativeTo: fileHandler.currentPath).asString
+            return AbsolutePath(launchPath, relativeTo: fileHandler.currentPath).pathString
         }
         return "tuist"
     }

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 enum BuildCommandError: FatalError {
     // Error description

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 enum BuildCommandError: FatalError {
     // Error description

--- a/Sources/TuistKit/Commands/CommandRegistry.swift
+++ b/Sources/TuistKit/Commands/CommandRegistry.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 public final class CommandRegistry {
     // MARK: - Attributes

--- a/Sources/TuistKit/Commands/CommandRegistry.swift
+++ b/Sources/TuistKit/Commands/CommandRegistry.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 public final class CommandRegistry {
     // MARK: - Attributes

--- a/Sources/TuistKit/Commands/CreateIssueCommand.swift
+++ b/Sources/TuistKit/Commands/CreateIssueCommand.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 class CreateIssueCommand: NSObject, Command {
     static let createIssueUrl: String = "https://github.com/tuist/tuist/issues/new"

--- a/Sources/TuistKit/Commands/CreateIssueCommand.swift
+++ b/Sources/TuistKit/Commands/CreateIssueCommand.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 class CreateIssueCommand: NSObject, Command {
     static let createIssueUrl: String = "https://github.com/tuist/tuist/issues/new"

--- a/Sources/TuistKit/Commands/DumpCommand.swift
+++ b/Sources/TuistKit/Commands/DumpCommand.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 class DumpCommand: NSObject, Command {
     // MARK: - Command

--- a/Sources/TuistKit/Commands/DumpCommand.swift
+++ b/Sources/TuistKit/Commands/DumpCommand.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 class DumpCommand: NSObject, Command {
     // MARK: - Command

--- a/Sources/TuistKit/Commands/EmbedCommand.swift
+++ b/Sources/TuistKit/Commands/EmbedCommand.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 enum EmbedCommandError: FatalError {
     case missingFrameworkPath
@@ -57,7 +57,7 @@ final class EmbedCommand: HiddenCommand {
             throw EmbedCommandError.missingFrameworkPath
         }
         let path = RelativePath(pathString)
-        printer.print("Embedding framework \(path.asString)")
+        printer.print("Embedding framework \(path.pathString)")
         try embedder.embed(path: path)
         printer.print(success: "Framework embedded")
     }

--- a/Sources/TuistKit/Commands/EmbedCommand.swift
+++ b/Sources/TuistKit/Commands/EmbedCommand.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 enum EmbedCommandError: FatalError {
     case missingFrameworkPath

--- a/Sources/TuistKit/Commands/FocusCommand.swift
+++ b/Sources/TuistKit/Commands/FocusCommand.swift
@@ -2,7 +2,7 @@ import Basic
 import Foundation
 import TuistCore
 import TuistGenerator
-import Utility
+import SPMUtility
 
 /// The focus command generates the Xcode workspace and launches it on Xcode.
 class FocusCommand: NSObject, Command {

--- a/Sources/TuistKit/Commands/FocusCommand.swift
+++ b/Sources/TuistKit/Commands/FocusCommand.swift
@@ -1,8 +1,8 @@
 import Basic
 import Foundation
+import SPMUtility
 import TuistCore
 import TuistGenerator
-import SPMUtility
 
 /// The focus command generates the Xcode workspace and launches it on Xcode.
 class FocusCommand: NSObject, Command {

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -1,8 +1,8 @@
 import Basic
 import Foundation
+import SPMUtility
 import TuistCore
 import TuistGenerator
-import SPMUtility
 
 class GenerateCommand: NSObject, Command {
     // MARK: - Static

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -2,7 +2,7 @@ import Basic
 import Foundation
 import TuistCore
 import TuistGenerator
-import Utility
+import SPMUtility
 
 class GenerateCommand: NSObject, Command {
     // MARK: - Static

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -1,8 +1,8 @@
 import Basic
 import Foundation
+import SPMUtility
 import TuistCore
 import TuistGenerator
-import SPMUtility
 
 private typealias Platform = TuistGenerator.Platform
 private typealias Product = TuistGenerator.Product

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -2,7 +2,7 @@ import Basic
 import Foundation
 import TuistCore
 import TuistGenerator
-import Utility
+import SPMUtility
 
 private typealias Platform = TuistGenerator.Platform
 private typealias Product = TuistGenerator.Product
@@ -18,9 +18,9 @@ enum InitCommandError: FatalError, Equatable {
     var description: String {
         switch self {
         case let .ungettableProjectName(path):
-            return "Couldn't infer the project name from path \(path.asString)."
+            return "Couldn't infer the project name from path \(path.pathString)."
         case let .nonEmptyDirectory(path):
-            return "Can't initialize a project in the non-empty directory at path \(path.asString)."
+            return "Can't initialize a project in the non-empty directory at path \(path.pathString)."
         }
     }
 
@@ -113,7 +113,7 @@ class InitCommand: NSObject, Command {
         try generatePlaygrounds(name: name, path: path, platform: platform)
         try generateGitIgnore(path: path)
         try generateSetup(path: path)
-        printer.print(success: "Project generated at path \(path.asString).")
+        printer.print(success: "Project generated at path \(path.pathString).")
     }
 
     // MARK: - Fileprivate

--- a/Sources/TuistKit/Commands/UpCommand.swift
+++ b/Sources/TuistKit/Commands/UpCommand.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 /// Command that configures the environment to work on the project.
 class UpCommand: NSObject, Command {

--- a/Sources/TuistKit/Commands/UpCommand.swift
+++ b/Sources/TuistKit/Commands/UpCommand.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 /// Command that configures the environment to work on the project.
 class UpCommand: NSObject, Command {

--- a/Sources/TuistKit/Commands/VersionCommand.swift
+++ b/Sources/TuistKit/Commands/VersionCommand.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 class VersionCommand: NSObject, Command {
     // MARK: - Command

--- a/Sources/TuistKit/Commands/VersionCommand.swift
+++ b/Sources/TuistKit/Commands/VersionCommand.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 class VersionCommand: NSObject, Command {
     // MARK: - Command

--- a/Sources/TuistKit/Embed/FrameworkEmbedder.swift
+++ b/Sources/TuistKit/Embed/FrameworkEmbedder.swift
@@ -51,7 +51,7 @@ final class FrameworkEmbedder: FrameworkEmbedding {
         }
         let builtProductsDir = AbsolutePath(environment.builtProductsDir)
         let frameworkAbsolutePath = srcRoot.appending(frameworkPath)
-        let frameworkDsymPath = AbsolutePath("\(frameworkAbsolutePath.asString).dSYM")
+        let frameworkDsymPath = AbsolutePath("\(frameworkAbsolutePath.pathString).dSYM")
         let productFrameworksPath = destinationPath.appending(frameworksPath)
         let embeddable = Embeddable(path: frameworkAbsolutePath)
 

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -21,7 +21,7 @@ enum GeneratorModelLoaderError: Error, Equatable, FatalError {
         case let .featureNotYetSupported(details):
             return "\(details) is not yet supported"
         case let .missingFile(path):
-            return "Couldn't find file at path '\(path.asString)'"
+            return "Couldn't find file at path '\(path.pathString)'"
         }
     }
 }

--- a/Sources/TuistKit/Generator/GraphManifestLoader.swift
+++ b/Sources/TuistKit/Generator/GraphManifestLoader.swift
@@ -15,11 +15,11 @@ enum GraphManifestLoaderError: FatalError, Equatable {
     var description: String {
         switch self {
         case let .projectDescriptionNotFound(path):
-            return "Couldn't find ProjectDescription.framework at path \(path.asString)"
+            return "Couldn't find ProjectDescription.framework at path \(path.pathString)"
         case let .unexpectedOutput(path):
-            return "Unexpected output trying to parse the manifest at path \(path.asString)"
+            return "Unexpected output trying to parse the manifest at path \(path.pathString)"
         case let .manifestNotFound(manifest, path):
-            return "\(manifest?.fileName ?? "Manifest") not found at path \(path.asString)"
+            return "\(manifest?.fileName ?? "Manifest") not found at path \(path.pathString)"
         }
     }
 
@@ -171,12 +171,12 @@ class GraphManifestLoader: GraphManifestLoading {
             "swiftc",
             "--driver-mode=swift",
             "-suppress-warnings",
-            "-I", projectDescriptionPath.parentDirectory.asString,
-            "-L", projectDescriptionPath.parentDirectory.asString,
-            "-F", projectDescriptionPath.parentDirectory.asString,
+            "-I", projectDescriptionPath.parentDirectory.pathString,
+            "-L", projectDescriptionPath.parentDirectory.pathString,
+            "-F", projectDescriptionPath.parentDirectory.pathString,
             "-lProjectDescription",
         ]
-        arguments.append(path.asString)
+        arguments.append(path.pathString)
         arguments.append("--dump")
 
         guard let jsonString = try system.capture(arguments).spm_chuzzle(),

--- a/Sources/TuistKit/Generator/ManifestTargetGenerator.swift
+++ b/Sources/TuistKit/Generator/ManifestTargetGenerator.swift
@@ -35,9 +35,9 @@ class ManifestTargetGenerator: ManifestTargetGenerating {
     func manifestTargetBuildSettings() throws -> [String: String] {
         let frameworkParentDirectory = try resourceLocator.projectDescription().parentDirectory
         var buildSettings = [String: String]()
-        buildSettings["FRAMEWORK_SEARCH_PATHS"] = frameworkParentDirectory.asString
-        buildSettings["LIBRARY_SEARCH_PATHS"] = frameworkParentDirectory.asString
-        buildSettings["SWIFT_INCLUDE_PATHS"] = frameworkParentDirectory.asString
+        buildSettings["FRAMEWORK_SEARCH_PATHS"] = frameworkParentDirectory.pathString
+        buildSettings["LIBRARY_SEARCH_PATHS"] = frameworkParentDirectory.pathString
+        buildSettings["SWIFT_INCLUDE_PATHS"] = frameworkParentDirectory.pathString
         buildSettings["SWIFT_VERSION"] = Constants.swiftVersion
         return buildSettings
     }

--- a/Sources/TuistKit/Models/Up/UpCustom.swift
+++ b/Sources/TuistKit/Models/Up/UpCustom.swift
@@ -48,7 +48,7 @@ class UpCustom: Up, GraphInitiatable {
     override func meet(system: Systeming, printer _: Printing, projectPath: AbsolutePath) throws {
         let launchPath = try self.launchPath(command: meet, projectPath: projectPath, system: system)
 
-        var arguments = [launchPath.asString]
+        var arguments = [launchPath.pathString]
         arguments.append(contentsOf: Array(meet.dropFirst()))
 
         try system.runAndPrint(arguments)
@@ -68,7 +68,7 @@ class UpCustom: Up, GraphInitiatable {
         } catch {
             return false
         }
-        var arguments = [launchPath.asString]
+        var arguments = [launchPath.pathString]
         arguments.append(contentsOf: Array(isMet.dropFirst()))
 
         do {

--- a/Sources/TuistKit/Playgrounds/PlaygroundGenerator.swift
+++ b/Sources/TuistKit/Playgrounds/PlaygroundGenerator.swift
@@ -9,7 +9,7 @@ enum PlaygroundGenerationError: FatalError, Equatable {
     var description: String {
         switch self {
         case let .alreadyExisting(path):
-            return "A playground already exists at path \(path.asString)"
+            return "A playground already exists at path \(path.pathString)"
         }
     }
 

--- a/Sources/TuistKit/Setup/SetupLoader.swift
+++ b/Sources/TuistKit/Setup/SetupLoader.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 
 /// Protocol that represents an entity that knows how to get the environment status
 /// for a given project and configure it.

--- a/Sources/TuistKit/Setup/SetupLoader.swift
+++ b/Sources/TuistKit/Setup/SetupLoader.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 
 /// Protocol that represents an entity that knows how to get the environment status
 /// for a given project and configure it.

--- a/Sources/TuistKit/Utils/Carthage.swift
+++ b/Sources/TuistKit/Utils/Carthage.swift
@@ -58,7 +58,7 @@ final class Carthage: Carthaging {
         var command: [String] = [carthagePath]
         command.append("update")
         command.append("--project-directory")
-        command.append(path.asString)
+        command.append(path.pathString)
 
         if !platforms.isEmpty {
             command.append("--platform")

--- a/Tests/TuistCoreTests/Extensions/String+MD5Tests.swift
+++ b/Tests/TuistCoreTests/Extensions/String+MD5Tests.swift
@@ -7,10 +7,10 @@ final class StringMD5Tests: XCTestCase {
     func test_md5() {
         // Given
         let string = "abc"
-        
+
         // When
         let md5 = string.md5
-        
+
         // Then
         XCTAssertEqual(md5, "900150983cd24fb0d6963f7d28e17f72")
     }

--- a/Tests/TuistCoreTests/Extensions/String+MD5Tests.swift
+++ b/Tests/TuistCoreTests/Extensions/String+MD5Tests.swift
@@ -1,0 +1,17 @@
+import Foundation
+import XCTest
+
+@testable import TuistCore
+
+final class StringMD5Tests: XCTestCase {
+    func test_md5() {
+        // Given
+        let string = "abc"
+        
+        // When
+        let md5 = string.md5
+        
+        // Then
+        XCTAssertEqual(md5, "900150983cd24fb0d6963f7d28e17f72")
+    }
+}

--- a/Tests/TuistCoreTests/Utils/OpenerTests.swift
+++ b/Tests/TuistCoreTests/Utils/OpenerTests.swift
@@ -41,7 +41,7 @@ final class OpenerTests: XCTestCase {
     func test_open() throws {
         let path = fileHandler.currentPath.appending(component: "tool")
         try fileHandler.touch(path)
-        system.succeedCommand("/usr/bin/open", path.asString)
+        system.succeedCommand("/usr/bin/open", path.pathString)
         try subject.open(path: path)
     }
 }

--- a/Tests/TuistEnvKitTests/Commands/BundleCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/BundleCommandTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import TuistCore
 @testable import TuistCoreTesting
 @testable import TuistEnvKit
-@testable import Utility
+@testable import SPMUtility
 
 final class BundleCommandErrorTests: XCTestCase {
     func test_type() {
@@ -14,7 +14,7 @@ final class BundleCommandErrorTests: XCTestCase {
 
     func test_description() {
         let path = AbsolutePath("/test")
-        XCTAssertEqual(BundleCommandError.missingVersionFile(path).description, "Couldn't find a .tuist-version file in the directory \(path.asString)")
+        XCTAssertEqual(BundleCommandError.missingVersionFile(path).description, "Couldn't find a .tuist-version file in the directory \(path.pathString)")
     }
 }
 
@@ -111,12 +111,12 @@ final class BundleCommandTests: XCTestCase {
         try subject.run(with: result)
 
         XCTAssertEqual(printer.printSectionArgs.count, 1)
-        XCTAssertEqual(printer.printSectionArgs.first, "Bundling the version 3.2.1 in the directory \(binPath.asString)")
+        XCTAssertEqual(printer.printSectionArgs.first, "Bundling the version 3.2.1 in the directory \(binPath.pathString)")
 
         XCTAssertEqual(printer.printArgs.count, 1)
         XCTAssertEqual(printer.printArgs.first, "Version 3.2.1 not available locally. Installing...")
 
         XCTAssertEqual(printer.printSuccessArgs.count, 1)
-        XCTAssertEqual(printer.printSuccessArgs.first, "tuist bundled successfully at \(binPath.asString)")
+        XCTAssertEqual(printer.printSuccessArgs.first, "tuist bundled successfully at \(binPath.pathString)")
     }
 }

--- a/Tests/TuistEnvKitTests/Commands/BundleCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/BundleCommandTests.swift
@@ -1,10 +1,10 @@
 import Basic
 import Foundation
 import XCTest
+@testable import SPMUtility
 @testable import TuistCore
 @testable import TuistCoreTesting
 @testable import TuistEnvKit
-@testable import SPMUtility
 
 final class BundleCommandErrorTests: XCTestCase {
     func test_type() {

--- a/Tests/TuistEnvKitTests/Commands/CommandRunnerTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/CommandRunnerTests.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 import XCTest
 @testable import TuistCoreTesting
 @testable import TuistEnvKit

--- a/Tests/TuistEnvKitTests/Commands/CommandRunnerTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/CommandRunnerTests.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 import XCTest
 @testable import TuistCoreTesting
 @testable import TuistEnvKit
@@ -53,7 +53,7 @@ final class CommandRunnerTests: XCTestCase {
         arguments = ["tuist", "--help"]
 
         versionResolver.resolveStub = { _ in ResolvedVersion.bin(self.fileHandler.currentPath) }
-        system.succeedCommand(binaryPath.asString, "--help", output: "output")
+        system.succeedCommand(binaryPath.pathString, "--help", output: "output")
         try subject.run()
     }
 
@@ -62,7 +62,7 @@ final class CommandRunnerTests: XCTestCase {
         arguments = ["tuist", "--help"]
 
         versionResolver.resolveStub = { _ in ResolvedVersion.bin(self.fileHandler.currentPath) }
-        system.errorCommand(binaryPath.asString, "--help", error: "error")
+        system.errorCommand(binaryPath.pathString, "--help", error: "error")
 
         XCTAssertThrowsError(try subject.run())
     }
@@ -80,12 +80,12 @@ final class CommandRunnerTests: XCTestCase {
 
         var installArgs: [(version: String, force: Bool)] = []
         installer.installStub = { version, force in installArgs.append((version: version, force: force)) }
-        system.succeedCommand(binaryPath.asString, "--help", output: "")
+        system.succeedCommand(binaryPath.pathString, "--help", output: "")
 
         try subject.run()
 
         XCTAssertEqual(printer.printArgs.count, 2)
-        XCTAssertEqual(printer.printArgs.first, "Using version 3.2.1 defined at \(fileHandler.currentPath.asString)")
+        XCTAssertEqual(printer.printArgs.first, "Using version 3.2.1 defined at \(fileHandler.currentPath.pathString)")
         XCTAssertEqual(printer.printArgs.last, "Version 3.2.1 not found locally. Installing...")
         XCTAssertEqual(installArgs.count, 1)
         XCTAssertEqual(installArgs.first?.version, "3.2.1")
@@ -116,7 +116,7 @@ final class CommandRunnerTests: XCTestCase {
         versionResolver.resolveStub = { _ in ResolvedVersion.versionFile(self.fileHandler.currentPath, "3.2.1")
         }
 
-        system.errorCommand(binaryPath.asString, "--help", error: "error")
+        system.errorCommand(binaryPath.pathString, "--help", error: "error")
 
         XCTAssertThrowsError(try subject.run())
     }
@@ -132,7 +132,7 @@ final class CommandRunnerTests: XCTestCase {
             $0 == "3.2.1" ? self.fileHandler.currentPath : AbsolutePath("/invalid")
         }
 
-        system.succeedCommand(binaryPath.asString, "--help", output: "")
+        system.succeedCommand(binaryPath.pathString, "--help", output: "")
 
         try subject.run()
     }
@@ -152,7 +152,7 @@ final class CommandRunnerTests: XCTestCase {
             $0 == "3.2.1" ? self.fileHandler.currentPath : AbsolutePath("/invalid")
         }
 
-        system.succeedCommand(binaryPath.asString, "--help", output: "")
+        system.succeedCommand(binaryPath.pathString, "--help", output: "")
 
         try subject.run()
     }
@@ -186,7 +186,7 @@ final class CommandRunnerTests: XCTestCase {
             $0 == "3.2.1" ? self.fileHandler.currentPath : AbsolutePath("/invalid")
         }
 
-        system.errorCommand(binaryPath.asString, "--help", error: "error")
+        system.errorCommand(binaryPath.pathString, "--help", error: "error")
 
         XCTAssertThrowsError(try subject.run())
     }

--- a/Tests/TuistEnvKitTests/Commands/InstallCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/InstallCommandTests.swift
@@ -2,9 +2,9 @@ import Basic
 import Foundation
 import TuistCore
 import XCTest
+@testable import SPMUtility
 @testable import TuistCoreTesting
 @testable import TuistEnvKit
-@testable import SPMUtility
 
 final class InstallCommandTests: XCTestCase {
     var parser: ArgumentParser!

--- a/Tests/TuistEnvKitTests/Commands/InstallCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/InstallCommandTests.swift
@@ -4,7 +4,7 @@ import TuistCore
 import XCTest
 @testable import TuistCoreTesting
 @testable import TuistEnvKit
-@testable import Utility
+@testable import SPMUtility
 
 final class InstallCommandTests: XCTestCase {
     var parser: ArgumentParser!

--- a/Tests/TuistEnvKitTests/Commands/LocalCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/LocalCommandTests.swift
@@ -2,9 +2,9 @@ import Basic
 import Foundation
 import TuistCore
 import XCTest
+@testable import SPMUtility
 @testable import TuistCoreTesting
 @testable import TuistEnvKit
-@testable import SPMUtility
 
 final class LocalCommandTests: XCTestCase {
     var argumentParser: ArgumentParser!

--- a/Tests/TuistEnvKitTests/Commands/LocalCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/LocalCommandTests.swift
@@ -4,7 +4,7 @@ import TuistCore
 import XCTest
 @testable import TuistCoreTesting
 @testable import TuistEnvKit
-@testable import Utility
+@testable import SPMUtility
 
 final class LocalCommandTests: XCTestCase {
     var argumentParser: ArgumentParser!
@@ -58,7 +58,7 @@ final class LocalCommandTests: XCTestCase {
         XCTAssertEqual(printer.printSectionArgs.first, "Generating \(Constants.versionFileName) file with version 3.2.1")
 
         XCTAssertEqual(printer.printSuccessArgs.count, 1)
-        XCTAssertEqual(printer.printSuccessArgs.last, "File generated at path \(versionPath.asString)")
+        XCTAssertEqual(printer.printSuccessArgs.last, "File generated at path \(versionPath.pathString)")
     }
 
     func test_run_prints_when_no_argument_is_passed() throws {

--- a/Tests/TuistEnvKitTests/Commands/UninstallCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/UninstallCommandTests.swift
@@ -4,7 +4,7 @@ import TuistCore
 import XCTest
 @testable import TuistCoreTesting
 @testable import TuistEnvKit
-@testable import Utility
+@testable import SPMUtility
 
 final class UninstallCommandTests: XCTestCase {
     var parser: ArgumentParser!

--- a/Tests/TuistEnvKitTests/Commands/UninstallCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/UninstallCommandTests.swift
@@ -2,9 +2,9 @@ import Basic
 import Foundation
 import TuistCore
 import XCTest
+@testable import SPMUtility
 @testable import TuistCoreTesting
 @testable import TuistEnvKit
-@testable import SPMUtility
 
 final class UninstallCommandTests: XCTestCase {
     var parser: ArgumentParser!

--- a/Tests/TuistEnvKitTests/Commands/UpdateCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/UpdateCommandTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import TuistCoreTesting
 @testable import TuistEnvKit
-@testable import Utility
+@testable import SPMUtility
 
 final class UpdateCommandTests: XCTestCase {
     var parser: ArgumentParser!

--- a/Tests/TuistEnvKitTests/Commands/UpdateCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/UpdateCommandTests.swift
@@ -1,9 +1,9 @@
 import Foundation
 import XCTest
 
+@testable import SPMUtility
 @testable import TuistCoreTesting
 @testable import TuistEnvKit
-@testable import SPMUtility
 
 final class UpdateCommandTests: XCTestCase {
     var parser: ArgumentParser!

--- a/Tests/TuistEnvKitTests/GitHub/ReleaseTests.swift
+++ b/Tests/TuistEnvKitTests/GitHub/ReleaseTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Utility
+import SPMUtility
 import XCTest
 @testable import TuistEnvKit
 

--- a/Tests/TuistEnvKitTests/GitHub/TestData/Release+TestData.swift
+++ b/Tests/TuistEnvKitTests/GitHub/TestData/Release+TestData.swift
@@ -1,6 +1,6 @@
 import Basic
 import Foundation
-import Utility
+import SPMUtility
 @testable import TuistEnvKit
 
 extension Release {

--- a/Tests/TuistEnvKitTests/Installer/BuildCopierTests.swift
+++ b/Tests/TuistEnvKitTests/Installer/BuildCopierTests.swift
@@ -41,6 +41,6 @@ final class BuildCopierTests: XCTestCase {
         try subject.copy(from: fromPath, to: toPath)
 
         XCTAssertEqual(toPath.glob("*").count, BuildCopier.files.count)
-        XCTAssertFalse(fileManager.fileExists(atPath: toPath.appending(component: "test").asString))
+        XCTAssertFalse(fileManager.fileExists(atPath: toPath.appending(component: "test").pathString))
     }
 }

--- a/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
+++ b/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 import XCTest
 @testable import TuistCoreTesting
 @testable import TuistEnvKit
@@ -74,10 +74,10 @@ final class InstallerTests: XCTestCase {
             .path
             .appending(component: Constants.bundleName)
         system.succeedCommand("/usr/bin/curl", "-LSs",
-                              "--output", downloadPath.asString,
+                              "--output", downloadPath.pathString,
                               downloadURL.absoluteString)
-        system.succeedCommand("/usr/bin/unzip", downloadPath.asString,
-                              "-d", fileHandler.currentPath.asString)
+        system.succeedCommand("/usr/bin/unzip", downloadPath.pathString,
+                              "-d", fileHandler.currentPath.pathString)
 
         try subject.install(version: version,
                             temporaryDirectory: temporaryDirectory)
@@ -113,7 +113,7 @@ final class InstallerTests: XCTestCase {
             .path
             .appending(component: Constants.bundleName)
         system.errorCommand("/usr/bin/curl", "-LSs",
-                            "--output", downloadPath.asString,
+                            "--output", downloadPath.pathString,
                             downloadURL.absoluteString,
                             error: "download_error")
 
@@ -141,10 +141,10 @@ final class InstallerTests: XCTestCase {
             .path
             .appending(component: Constants.bundleName)
         system.succeedCommand("/usr/bin/curl", "-LSs",
-                              "--output", downloadPath.asString,
+                              "--output", downloadPath.pathString,
                               downloadURL.absoluteString)
-        system.errorCommand("/usr/bin/unzip", downloadPath.asString,
-                            "-d", fileHandler.currentPath.asString,
+        system.errorCommand("/usr/bin/unzip", downloadPath.pathString,
+                            "-d", fileHandler.currentPath.pathString,
                             error: "unzip_error")
 
         XCTAssertThrowsError(try subject.install(version: version, temporaryDirectory: temporaryDirectory))
@@ -162,19 +162,19 @@ final class InstallerTests: XCTestCase {
 
         system.succeedCommand("/usr/bin/env", "git",
                               "clone", Constants.gitRepositoryURL,
-                              temporaryDirectory.path.asString)
-        system.succeedCommand("/usr/bin/env", "git", "-C", temporaryDirectory.path.asString,
+                              temporaryDirectory.path.pathString)
+        system.succeedCommand("/usr/bin/env", "git", "-C", temporaryDirectory.path.pathString,
                               "checkout", version)
         system.succeedCommand("/usr/bin/xcrun", "-f", "swift", output: "/path/to/swift")
 
         system.succeedCommand("/path/to/swift", "build",
                               "--product", "tuist",
-                              "--package-path", temporaryDirectory.path.asString,
+                              "--package-path", temporaryDirectory.path.pathString,
                               "--configuration", "release",
                               "-Xswiftc", "-static-stdlib")
         system.succeedCommand("/path/to/swift", "build",
                               "--product", "ProjectDescription",
-                              "--package-path", temporaryDirectory.path.asString,
+                              "--package-path", temporaryDirectory.path.pathString,
                               "--configuration", "release")
 
         try subject.install(version: version, temporaryDirectory: temporaryDirectory)
@@ -204,19 +204,19 @@ final class InstallerTests: XCTestCase {
 
         system.succeedCommand("/usr/bin/env", "git",
                               "clone", Constants.gitRepositoryURL,
-                              temporaryDirectory.path.asString)
-        system.succeedCommand("/usr/bin/env", "git", "-C", temporaryDirectory.path.asString,
+                              temporaryDirectory.path.pathString)
+        system.succeedCommand("/usr/bin/env", "git", "-C", temporaryDirectory.path.pathString,
                               "checkout", version)
         system.succeedCommand("/usr/bin/xcrun", "-f", "swift",
                               output: "/path/to/swift")
         system.succeedCommand("/path/to/swift", "build",
                               "--product", "tuist",
-                              "--package-path", temporaryDirectory.path.asString,
+                              "--package-path", temporaryDirectory.path.pathString,
                               "--configuration", "release",
                               "-Xswiftc", "-static-stdlib")
         system.succeedCommand("/path/to/swift", "build",
                               "--product", "ProjectDescription",
-                              "--package-path", temporaryDirectory.path.asString,
+                              "--package-path", temporaryDirectory.path.pathString,
                               "--configuration", "release")
 
         try subject.install(version: version, temporaryDirectory: temporaryDirectory, force: true)
@@ -242,8 +242,8 @@ final class InstallerTests: XCTestCase {
         }
         system.succeedCommand("/usr/bin/env", "git",
                               "clone", Constants.gitRepositoryURL,
-                              temporaryDirectory.path.asString)
-        system.errorCommand("/usr/bin/env", "git", "-C", temporaryDirectory.path.asString,
+                              temporaryDirectory.path.pathString)
+        system.errorCommand("/usr/bin/env", "git", "-C", temporaryDirectory.path.pathString,
                             "checkout", version,
                             error: "did not match any file(s) known to git ")
 

--- a/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
+++ b/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 import XCTest
 @testable import TuistCoreTesting
 @testable import TuistEnvKit

--- a/Tests/TuistEnvKitTests/Updater/EnvUpdaterTests.swift
+++ b/Tests/TuistEnvKitTests/Updater/EnvUpdaterTests.swift
@@ -28,8 +28,8 @@ final class EnvUpdaterTests: XCTestCase {
         githubClient.releasesStub = { [release] }
 
         let downloadPath = fileHandler.currentPath.appending(component: "tuistenv.zip")
-        system.succeedCommand(["/usr/bin/curl", "-LSs", "--output", downloadPath.asString, downloadURL.absoluteString])
-        system.succeedCommand(["/usr/bin/unzip", "-o", downloadPath.asString, "-d", "/tmp/"])
+        system.succeedCommand(["/usr/bin/curl", "-LSs", "--output", downloadPath.pathString, downloadURL.absoluteString])
+        system.succeedCommand(["/usr/bin/unzip", "-o", downloadPath.pathString, "-d", "/tmp/"])
         system.succeedCommand(["/bin/chmod", "+x", "/tmp/tuistenv"])
         system.succeedCommand(["/bin/cp", "-rf", "/tmp/tuistenv", "/usr/local/bin/tuist"])
         system.succeedCommand(["/bin/rm", "/tmp/tuistenv"])

--- a/Tests/TuistEnvKitTests/Versions/Mocks/MockVersionsController.swift
+++ b/Tests/TuistEnvKitTests/Versions/Mocks/MockVersionsController.swift
@@ -1,6 +1,6 @@
 import Basic
 import Foundation
-import Utility
+import SPMUtility
 @testable import TuistEnvKit
 
 final class MockVersionsController: VersionsControlling {

--- a/Tests/TuistEnvKitTests/Versions/VersionResolverTests.swift
+++ b/Tests/TuistEnvKitTests/Versions/VersionResolverTests.swift
@@ -32,11 +32,11 @@ final class VersionResolverTests: XCTestCase {
         let binPath = tmp_dir.path.appending(component: Constants.binFolderName)
 
         // /tmp/dir/.tuist-version
-        try "3.2.1".write(to: URL(fileURLWithPath: versionPath.asString),
+        try "3.2.1".write(to: URL(fileURLWithPath: versionPath.pathString),
                           atomically: true,
                           encoding: .utf8)
         // /tmp/dir/.tuist-bin
-        try FileManager.default.createDirectory(at: URL(fileURLWithPath: binPath.asString),
+        try FileManager.default.createDirectory(at: URL(fileURLWithPath: binPath.pathString),
                                                 withIntermediateDirectories: true,
                                                 attributes: nil)
 
@@ -49,7 +49,7 @@ final class VersionResolverTests: XCTestCase {
         let versionPath = tmp_dir.path.appending(component: Constants.versionFileName)
 
         // /tmp/dir/.tuist-version
-        try "3.2.1".write(to: URL(fileURLWithPath: versionPath.asString),
+        try "3.2.1".write(to: URL(fileURLWithPath: versionPath.pathString),
                           atomically: true,
                           encoding: .utf8)
 
@@ -62,7 +62,7 @@ final class VersionResolverTests: XCTestCase {
         let binPath = tmp_dir.path.appending(component: Constants.binFolderName)
 
         // /tmp/dir/.tuist-bin
-        try FileManager.default.createDirectory(at: URL(fileURLWithPath: binPath.asString),
+        try FileManager.default.createDirectory(at: URL(fileURLWithPath: binPath.pathString),
                                                 withIntermediateDirectories: true,
                                                 attributes: nil)
 
@@ -76,10 +76,10 @@ final class VersionResolverTests: XCTestCase {
         let childPath = tmp_dir.path.appending(component: "child")
 
         // /tmp/dir/.tuist-version
-        try "3.2.1".write(to: URL(fileURLWithPath: versionPath.asString),
+        try "3.2.1".write(to: URL(fileURLWithPath: versionPath.pathString),
                           atomically: true,
                           encoding: .utf8)
-        try FileManager.default.createDirectory(at: URL(fileURLWithPath: childPath.asString),
+        try FileManager.default.createDirectory(at: URL(fileURLWithPath: childPath.pathString),
                                                 withIntermediateDirectories: true,
                                                 attributes: nil)
 
@@ -93,10 +93,10 @@ final class VersionResolverTests: XCTestCase {
         let childPath = tmp_dir.path.appending(component: "child")
 
         // /tmp/dir/.tuist-bin
-        try FileManager.default.createDirectory(at: URL(fileURLWithPath: binPath.asString),
+        try FileManager.default.createDirectory(at: URL(fileURLWithPath: binPath.pathString),
                                                 withIntermediateDirectories: true,
                                                 attributes: nil)
-        try FileManager.default.createDirectory(at: URL(fileURLWithPath: childPath.asString),
+        try FileManager.default.createDirectory(at: URL(fileURLWithPath: childPath.pathString),
                                                 withIntermediateDirectories: true,
                                                 attributes: nil)
 

--- a/Tests/TuistEnvKitTests/Versions/VersionsControllerTests.swift
+++ b/Tests/TuistEnvKitTests/Versions/VersionsControllerTests.swift
@@ -1,6 +1,6 @@
 import Basic
 import Foundation
-import Utility
+import SPMUtility
 import XCTest
 @testable import TuistCoreTesting
 @testable import TuistEnvKit

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -8,7 +8,7 @@ import XCTest
 final class BuildPhaseGenerationErrorTests: XCTestCase {
     func test_description_when_missingFileReference() {
         let path = AbsolutePath("/test")
-        let expected = "Trying to add a file at path \(path.asString) to a build phase that hasn't been added to the project."
+        let expected = "Trying to add a file at path \(path.pathString) to a build phase that hasn't been added to the project."
         XCTAssertEqual(BuildPhaseGenerationError.missingFileReference(path).description, expected)
     }
 

--- a/Tests/TuistGeneratorTests/Generator/ProjectDirectoryHelperTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectDirectoryHelperTests.swift
@@ -21,7 +21,7 @@ final class ProjectDirectoryHelperTests: XCTestCase {
         let got = try subject.setupDirectory(name: "MyApp",
                                              path: path,
                                              directory: .derivedProjects)
-        let expected = environmentController.derivedProjectsDirectory.appending(component: "MyApp-\(path.asString.md5)")
+        let expected = environmentController.derivedProjectsDirectory.appending(component: "MyApp-\(path.pathString.md5)")
 
         XCTAssertEqual(got, expected)
         XCTAssertTrue(fileHandler.exists(expected))

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceGeneratorTests.swift
@@ -59,7 +59,7 @@ final class WorkspaceGeneratorTests: XCTestCase {
                                                  options: GenerationOptions())
 
         // Then
-        let xcworkspace = try XCWorkspace(pathString: workspacePath.asString)
+        let xcworkspace = try XCWorkspace(pathString: workspacePath.pathString)
         XCTAssertEqual(xcworkspace.data.children, [
             .group(.init(location: .group("Documentation"), name: "Documentation", children: [
                 .file(.init(location: .group("README.md"))),
@@ -105,7 +105,7 @@ final class WorkspaceGeneratorTests: XCTestCase {
                                                  options: GenerationOptions())
 
         // Then
-        let xcworkspace = try XCWorkspace(pathString: workspacePath.asString)
+        let xcworkspace = try XCWorkspace(pathString: workspacePath.pathString)
         XCTAssertEqual(xcworkspace.data.children, [
             .file(.init(location: .group("Test.xcodeproj"))),
         ])

--- a/Tests/TuistGeneratorTests/Graph/GraphNodeTests.swift
+++ b/Tests/TuistGeneratorTests/Graph/GraphNodeTests.swift
@@ -137,7 +137,7 @@ final class FrameworkNodeTests: XCTestCase {
     }
 
     func test_binaryPath() {
-        XCTAssertEqual(subject.binaryPath.asString, "/test.framework/test")
+        XCTAssertEqual(subject.binaryPath.pathString, "/test.framework/test")
     }
 
     func test_isCarthage() {
@@ -172,7 +172,7 @@ final class LibraryNodeTests: XCTestCase {
     }
 
     func test_binaryPath() {
-        XCTAssertEqual(subject.binaryPath.asString, "/test.a")
+        XCTAssertEqual(subject.binaryPath.pathString, "/test.a")
     }
 
     func test_architectures() throws {

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -32,7 +32,7 @@ final class GraphLinterTests: XCTestCase {
 
         let result = subject.lint(graph: graph)
 
-        XCTAssertTrue(result.contains(LintingIssue(reason: "Framework not found at path \(frameworkBPath.asString). The path might be wrong or Carthage dependencies not fetched", severity: .warning)))
+        XCTAssertTrue(result.contains(LintingIssue(reason: "Framework not found at path \(frameworkBPath.pathString). The path might be wrong or Carthage dependencies not fetched", severity: .warning)))
     }
 
     func test_lint_when_frameworks_are_missing() throws {
@@ -52,7 +52,7 @@ final class GraphLinterTests: XCTestCase {
 
         let result = subject.lint(graph: graph)
 
-        XCTAssertTrue(result.contains(LintingIssue(reason: "Framework not found at path \(frameworkBPath.asString)", severity: .error)))
+        XCTAssertTrue(result.contains(LintingIssue(reason: "Framework not found at path \(frameworkBPath.pathString)", severity: .error)))
     }
 
     func test_lint_when_static_product_linked_twice() throws {

--- a/Tests/TuistGeneratorTests/Linter/ProjectLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/ProjectLinterTests.swift
@@ -16,6 +16,6 @@ final class ProjectLinterTests: XCTestCase {
         let target = Target.test(name: "A")
         let project = Project.test(targets: [target, target])
         let got = subject.lint(project)
-        XCTAssertTrue(got.contains(LintingIssue(reason: "Targets A from project at \(project.path.asString) have duplicates.", severity: .error)))
+        XCTAssertTrue(got.contains(LintingIssue(reason: "Targets A from project at \(project.path.pathString) have duplicates.", severity: .error)))
     }
 }

--- a/Tests/TuistGeneratorTests/Linter/SettingsLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/SettingsLinterTests.swift
@@ -24,7 +24,7 @@ final class SettingsLinterTests: XCTestCase {
 
         let got = subject.lint(settings: settings)
 
-        XCTAssertTrue(got.contains(LintingIssue(reason: "Configuration file not found at path \(debugPath.asString)", severity: .error)))
-        XCTAssertTrue(got.contains(LintingIssue(reason: "Configuration file not found at path \(releasePath.asString)", severity: .error)))
+        XCTAssertTrue(got.contains(LintingIssue(reason: "Configuration file not found at path \(debugPath.pathString)", severity: .error)))
+        XCTAssertTrue(got.contains(LintingIssue(reason: "Configuration file not found at path \(releasePath.pathString)", severity: .error)))
     }
 }

--- a/Tests/TuistGeneratorTests/Linter/TargetActionLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetActionLinterTests.swift
@@ -35,7 +35,7 @@ final class TargetActionLinterTests: XCTestCase {
                                   path: fileHandler.currentPath.appending(component: "invalid.sh"))
         let got = subject.lint(action)
 
-        let expected = LintingIssue(reason: "The action path \(action.path!.asString) doesn't exist",
+        let expected = LintingIssue(reason: "The action path \(action.path!.pathString) doesn't exist",
                                     severity: .error)
         XCTAssertTrue(got.contains(expected))
     }

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -47,7 +47,7 @@ final class TargetLinterTests: XCTestCase {
 
         let got = subject.lint(target: target)
 
-        XCTAssertTrue(got.contains(LintingIssue(reason: "Info.plist at path \(path.asString) being copied into the target \(target.name) product.", severity: .warning)))
+        XCTAssertTrue(got.contains(LintingIssue(reason: "Info.plist at path \(path.pathString) being copied into the target \(target.name) product.", severity: .warning)))
     }
 
     func test_lint_when_a_entitlements_file_is_being_copied() {
@@ -56,7 +56,7 @@ final class TargetLinterTests: XCTestCase {
 
         let got = subject.lint(target: target)
 
-        XCTAssertTrue(got.contains(LintingIssue(reason: "Entitlements file at path \(path.asString) being copied into the target \(target.name) product.", severity: .warning)))
+        XCTAssertTrue(got.contains(LintingIssue(reason: "Entitlements file at path \(path.pathString) being copied into the target \(target.name) product.", severity: .warning)))
     }
 
     func test_lint_when_entitlements_not_missing() {
@@ -65,7 +65,7 @@ final class TargetLinterTests: XCTestCase {
 
         let got = subject.lint(target: target)
 
-        XCTAssertTrue(got.contains(LintingIssue(reason: "Info.plist file not found at path \(path.asString)", severity: .error)))
+        XCTAssertTrue(got.contains(LintingIssue(reason: "Info.plist file not found at path \(path.pathString)", severity: .error)))
     }
 
     func test_lint_when_infoplist_not_found() {
@@ -74,7 +74,7 @@ final class TargetLinterTests: XCTestCase {
 
         let got = subject.lint(target: target)
 
-        XCTAssertTrue(got.contains(LintingIssue(reason: "Entitlements file not found at path \(path.asString)", severity: .error)))
+        XCTAssertTrue(got.contains(LintingIssue(reason: "Entitlements file not found at path \(path.pathString)", severity: .error)))
     }
 
     func test_lint_when_library_has_resources() {

--- a/Tests/TuistGeneratorTests/Models/CoreDataModelTests.swift
+++ b/Tests/TuistGeneratorTests/Models/CoreDataModelTests.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 import XCTest
 @testable import TuistCoreTesting
 @testable import TuistGenerator

--- a/Tests/TuistGeneratorTests/Models/CoreDataModelTests.swift
+++ b/Tests/TuistGeneratorTests/Models/CoreDataModelTests.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 import XCTest
 @testable import TuistCoreTesting
 @testable import TuistGenerator

--- a/Tests/TuistGeneratorTests/Models/HeadersTests.swift
+++ b/Tests/TuistGeneratorTests/Models/HeadersTests.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 import XCTest
 @testable import TuistCoreTesting
 @testable import TuistGenerator

--- a/Tests/TuistGeneratorTests/Models/HeadersTests.swift
+++ b/Tests/TuistGeneratorTests/Models/HeadersTests.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 import XCTest
 @testable import TuistCoreTesting
 @testable import TuistGenerator

--- a/Tests/TuistGeneratorTests/Models/TargetTests.swift
+++ b/Tests/TuistGeneratorTests/Models/TargetTests.swift
@@ -66,7 +66,7 @@ final class TargetTests: XCTestCase {
                                          fileHandler: fileHandler)
 
         // Then
-        let relativeSources = sources.map { $0.relative(to: fileHandler.currentPath).asString }
+        let relativeSources = sources.map { $0.relative(to: fileHandler.currentPath).pathString }
         XCTAssertEqual(relativeSources, [
             "sources/a.swift",
             "sources/b.m",
@@ -98,7 +98,7 @@ final class TargetTests: XCTestCase {
         let resources = paths.filter { Target.isResource(path: $0, fileHandler: fileHandler) }
 
         // Then
-        let relativeResources = resources.map { $0.relative(to: fileHandler.currentPath).asString }
+        let relativeResources = resources.map { $0.relative(to: fileHandler.currentPath).pathString }
         XCTAssertEqual(relativeResources, [
             "resources/d.xcassets",
             "resources/g.bundle",

--- a/Tests/TuistKitTests/Commands/CreateIssueCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/CreateIssueCommandTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Utility
+import SPMUtility
 import XCTest
 @testable import TuistCoreTesting
 @testable import TuistKit

--- a/Tests/TuistKitTests/Commands/DumpCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/DumpCommandTests.swift
@@ -1,6 +1,6 @@
 import Basic
 import Foundation
-import Utility
+import SPMUtility
 import XCTest
 @testable import TuistCoreTesting
 @testable import TuistKit
@@ -35,7 +35,7 @@ final class DumpCommandTests: XCTestCase {
 
     func test_run_throws_when_file_doesnt_exist() throws {
         let tmpDir = try TemporaryDirectory(removeTreeOnDeinit: true)
-        let result = try parser.parse([DumpCommand.command, "-p", tmpDir.path.asString])
+        let result = try parser.parse([DumpCommand.command, "-p", tmpDir.path.pathString])
         XCTAssertThrowsError(try subject.run(with: result)) {
             XCTAssertEqual($0 as? GraphManifestLoaderError, GraphManifestLoaderError.manifestNotFound(.project, tmpDir.path))
         }
@@ -43,10 +43,10 @@ final class DumpCommandTests: XCTestCase {
 
     func test_run_throws_when_the_manifest_loading_fails() throws {
         let tmpDir = try TemporaryDirectory(removeTreeOnDeinit: true)
-        try "invalid config".write(toFile: tmpDir.path.appending(component: "Project.swift").asString,
+        try "invalid config".write(toFile: tmpDir.path.appending(component: "Project.swift").pathString,
                                    atomically: true,
                                    encoding: .utf8)
-        let result = try parser.parse([DumpCommand.command, "-p", tmpDir.path.asString])
+        let result = try parser.parse([DumpCommand.command, "-p", tmpDir.path.pathString])
         XCTAssertThrowsError(try subject.run(with: result))
     }
 
@@ -59,10 +59,10 @@ final class DumpCommandTests: XCTestCase {
               settings: nil,
               targets: [])
         """
-        try config.write(toFile: tmpDir.path.appending(component: "Project.swift").asString,
+        try config.write(toFile: tmpDir.path.appending(component: "Project.swift").pathString,
                          atomically: true,
                          encoding: .utf8)
-        let result = try parser.parse([DumpCommand.command, "-p", tmpDir.path.asString])
+        let result = try parser.parse([DumpCommand.command, "-p", tmpDir.path.pathString])
         try subject.run(with: result)
         let expected = "{\n  \"additionalFiles\": [\n\n  ],\n  \"name\": \"tuist\",\n  \"targets\": [\n\n  ]\n}\n"
         XCTAssertEqual(printer.printArgs.first, expected)

--- a/Tests/TuistKitTests/Commands/FocusCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/FocusCommandTests.swift
@@ -1,6 +1,6 @@
 import Basic
 import Foundation
-import Utility
+import SPMUtility
 import XcodeProj
 import XCTest
 @testable import TuistCoreTesting

--- a/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
-import Utility
+import SPMUtility
 import XcodeProj
 import XCTest
 @testable import TuistCoreTesting

--- a/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistCore
 import SPMUtility
+import TuistCore
 import XcodeProj
 import XCTest
 @testable import TuistCoreTesting

--- a/Tests/TuistKitTests/Commands/InitCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/InitCommandTests.swift
@@ -1,9 +1,9 @@
 import Basic
 import Foundation
 import XCTest
+@testable import SPMUtility
 @testable import TuistCoreTesting
 @testable import TuistKit
-@testable import SPMUtility
 
 final class InitCommandErrorTests: XCTestCase {
     func test_description() {

--- a/Tests/TuistKitTests/Commands/InitCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/InitCommandTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import XCTest
 @testable import TuistCoreTesting
 @testable import TuistKit
-@testable import Utility
+@testable import SPMUtility
 
 final class InitCommandErrorTests: XCTestCase {
     func test_description() {
@@ -92,7 +92,7 @@ final class InitCommandTests: XCTestCase {
         let path = fileHandler.currentPath
         try fileHandler.touch(path.appending(component: "dummy"))
 
-        let result = try parser.parse(["init", "--path", path.asString, "--name", "Test"])
+        let result = try parser.parse(["init", "--path", path.pathString, "--name", "Test"])
 
         XCTAssertThrowsError(try subject.run(with: result)) { error in
             let expected = InitCommandError.nonEmptyDirectory(path)
@@ -111,7 +111,7 @@ final class InitCommandTests: XCTestCase {
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Tests.plist")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(RelativePath("Sources/AppDelegate.swift"))))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(RelativePath("Tests/\(name)Tests.swift"))))
-        XCTAssertEqual(printer.printSuccessArgs.first, "Project generated at path \(fileHandler.currentPath.asString).")
+        XCTAssertEqual(printer.printSuccessArgs.first, "Project generated at path \(fileHandler.currentPath.pathString).")
 
         let playgroundsPath = fileHandler.currentPath.appending(component: "Playgrounds")
         XCTAssertTrue(fileHandler.exists(playgroundsPath))
@@ -133,7 +133,7 @@ final class InitCommandTests: XCTestCase {
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Tests.plist")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(RelativePath("Sources/AppDelegate.swift"))))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(RelativePath("Tests/\(name)Tests.swift"))))
-        XCTAssertEqual(printer.printSuccessArgs.first, "Project generated at path \(fileHandler.currentPath.asString).")
+        XCTAssertEqual(printer.printSuccessArgs.first, "Project generated at path \(fileHandler.currentPath.pathString).")
 
         let playgroundsPath = fileHandler.currentPath.appending(component: "Playgrounds")
         XCTAssertTrue(fileHandler.exists(playgroundsPath))
@@ -155,7 +155,7 @@ final class InitCommandTests: XCTestCase {
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Tests.plist")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(RelativePath("Sources/AppDelegate.swift"))))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(RelativePath("Tests/\(name)Tests.swift"))))
-        XCTAssertEqual(printer.printSuccessArgs.first, "Project generated at path \(fileHandler.currentPath.asString).")
+        XCTAssertEqual(printer.printSuccessArgs.first, "Project generated at path \(fileHandler.currentPath.pathString).")
 
         let playgroundsPath = fileHandler.currentPath.appending(component: "Playgrounds")
         XCTAssertTrue(fileHandler.exists(playgroundsPath))
@@ -177,7 +177,7 @@ final class InitCommandTests: XCTestCase {
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Tests.plist")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(RelativePath("Sources/\(name).swift"))))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(RelativePath("Tests/\(name)Tests.swift"))))
-        XCTAssertEqual(printer.printSuccessArgs.first, "Project generated at path \(fileHandler.currentPath.asString).")
+        XCTAssertEqual(printer.printSuccessArgs.first, "Project generated at path \(fileHandler.currentPath.pathString).")
 
         let playgroundsPath = fileHandler.currentPath.appending(component: "Playgrounds")
         XCTAssertTrue(fileHandler.exists(playgroundsPath))
@@ -200,7 +200,7 @@ final class InitCommandTests: XCTestCase {
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Tests.plist")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(RelativePath("Sources/\(name).swift"))))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(RelativePath("Tests/\(name)Tests.swift"))))
-        XCTAssertEqual(printer.printSuccessArgs.first, "Project generated at path \(fileHandler.currentPath.asString).")
+        XCTAssertEqual(printer.printSuccessArgs.first, "Project generated at path \(fileHandler.currentPath.pathString).")
 
         let playgroundsPath = fileHandler.currentPath.appending(component: "Playgrounds")
         XCTAssertTrue(fileHandler.exists(playgroundsPath))
@@ -222,7 +222,7 @@ final class InitCommandTests: XCTestCase {
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(component: "Tests.plist")))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(RelativePath("Sources/\(name).swift"))))
         XCTAssertTrue(fileHandler.exists(fileHandler.currentPath.appending(RelativePath("Tests/\(name)Tests.swift"))))
-        XCTAssertEqual(printer.printSuccessArgs.first, "Project generated at path \(fileHandler.currentPath.asString).")
+        XCTAssertEqual(printer.printSuccessArgs.first, "Project generated at path \(fileHandler.currentPath.pathString).")
 
         let playgroundsPath = fileHandler.currentPath.appending(component: "Playgrounds")
         XCTAssertTrue(fileHandler.exists(playgroundsPath))

--- a/Tests/TuistKitTests/Commands/UpCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/UpCommandTests.swift
@@ -1,6 +1,6 @@
 import Basic
 import Foundation
-import Utility
+import SPMUtility
 import XCTest
 
 @testable import TuistCoreTesting
@@ -33,11 +33,11 @@ final class UpCommandTests: XCTestCase {
 
     func test_run_configures_the_environment() throws {
         // given
-        let currentPath = fileHandler.currentPath.asString
+        let currentPath = fileHandler.currentPath.pathString
         let result = try parser.parse([UpCommand.command])
         var receivedPaths = [String]()
         setupLoader.meetStub = { path in
-            receivedPaths.append(path.asString)
+            receivedPaths.append(path.pathString)
         }
 
         // when
@@ -51,10 +51,10 @@ final class UpCommandTests: XCTestCase {
     func test_run_uses_the_given_path() throws {
         // given
         let path = AbsolutePath("/path")
-        let result = try parser.parse([UpCommand.command, "-p", path.asString])
+        let result = try parser.parse([UpCommand.command, "-p", path.pathString])
         var receivedPaths = [String]()
         setupLoader.meetStub = { path in
-            receivedPaths.append(path.asString)
+            receivedPaths.append(path.pathString)
         }
 
         // when

--- a/Tests/TuistKitTests/Embed/EmbeddableTests.swift
+++ b/Tests/TuistKitTests/Embed/EmbeddableTests.swift
@@ -75,17 +75,17 @@ final class EmbeddableTests: XCTestCase {
 
     func test_strip_whenFramework() throws {
         try withUniversalFramework {
-            XCTAssertTrue(fm.fileExists(atPath: $0.path.appending(component: "Headers").asString))
-            XCTAssertTrue(fm.fileExists(atPath: $0.path.appending(component: "PrivateHeaders").asString))
-            XCTAssertTrue(fm.fileExists(atPath: $0.path.appending(component: "Modules").asString))
+            XCTAssertTrue(fm.fileExists(atPath: $0.path.appending(component: "Headers").pathString))
+            XCTAssertTrue(fm.fileExists(atPath: $0.path.appending(component: "PrivateHeaders").pathString))
+            XCTAssertTrue(fm.fileExists(atPath: $0.path.appending(component: "Modules").pathString))
             try XCTAssertEqual($0.architectures(), ["x86_64", "arm64"])
 
             try $0.strip(keepingArchitectures: ["x86_64"])
 
             try XCTAssertEqual($0.architectures(), ["x86_64"])
-            XCTAssertFalse(fm.fileExists(atPath: $0.path.appending(component: "Headers").asString))
-            XCTAssertFalse(fm.fileExists(atPath: $0.path.appending(component: "PrivateHeaders").asString))
-            XCTAssertFalse(fm.fileExists(atPath: $0.path.appending(component: "Modules").asString))
+            XCTAssertFalse(fm.fileExists(atPath: $0.path.appending(component: "Headers").pathString))
+            XCTAssertFalse(fm.fileExists(atPath: $0.path.appending(component: "PrivateHeaders").pathString))
+            XCTAssertFalse(fm.fileExists(atPath: $0.path.appending(component: "Modules").pathString))
         }
     }
 
@@ -120,7 +120,7 @@ final class EmbeddableTests: XCTestCase {
             try $0.uuids().forEach {
                 let symbolMapPath = path.parentDirectory.appending(component: "\($0.uuidString).bcsymbolmap")
                 symbolMapsPaths.append(symbolMapPath)
-                fm.createFile(atPath: symbolMapPath.asString,
+                fm.createFile(atPath: symbolMapPath.pathString,
                               contents: nil,
                               attributes: [:])
             }
@@ -133,8 +133,8 @@ final class EmbeddableTests: XCTestCase {
         let testsPath = AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory
         let frameworkPath = testsPath.appending(RelativePath("Fixtures/xpm.framework"))
         let frameworkTmpPath = tmpDir.path.appending(component: "xpm.framework")
-        try fm.copyItem(atPath: frameworkPath.asString,
-                        toPath: frameworkTmpPath.asString)
+        try fm.copyItem(atPath: frameworkPath.pathString,
+                        toPath: frameworkTmpPath.pathString)
         let embeddable = Embeddable(path: frameworkTmpPath)
         try action(embeddable)
     }
@@ -144,8 +144,8 @@ final class EmbeddableTests: XCTestCase {
         let testsPath = AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory
         let frameworkPath = testsPath.appending(RelativePath("Fixtures/xpm.framework.dSYM"))
         let frameworkTmpPath = tmpDir.path.appending(component: "xpm.framework.dSYM")
-        try fm.copyItem(atPath: frameworkPath.asString,
-                        toPath: frameworkTmpPath.asString)
+        try fm.copyItem(atPath: frameworkPath.pathString,
+                        toPath: frameworkTmpPath.pathString)
         let embeddable = Embeddable(path: frameworkTmpPath)
         try action(embeddable)
     }

--- a/Tests/TuistKitTests/Embed/FrameworkEmbedderTests.swift
+++ b/Tests/TuistKitTests/Embed/FrameworkEmbedderTests.swift
@@ -20,8 +20,8 @@ final class FrameworkEmbedderErrorTests: XCTestCase {
                               environment: env)
             let outputFrameworkPath = srcRoot.appending(RelativePath("built_products_dir/frameworks/xpm.framework"))
             let outputDSYMPath = srcRoot.appending(RelativePath("built_products_dir/xpm.framework.dSYM"))
-            XCTAssertTrue(fm.fileExists(atPath: outputFrameworkPath.asString))
-            XCTAssertTrue(fm.fileExists(atPath: outputDSYMPath.asString))
+            XCTAssertTrue(fm.fileExists(atPath: outputFrameworkPath.pathString))
+            XCTAssertTrue(fm.fileExists(atPath: outputDSYMPath.pathString))
             XCTAssertEqual(try Embeddable(path: outputFrameworkPath).architectures(), ["arm64"])
             XCTAssertEqual(try Embeddable(path: outputDSYMPath).architectures(), ["arm64"])
         }
@@ -34,8 +34,8 @@ final class FrameworkEmbedderErrorTests: XCTestCase {
                               environment: env)
             let outputFrameworkPath = srcRoot.appending(RelativePath("target_build_dir/frameworks/xpm.framework"))
             let outputDSYMPath = srcRoot.appending(RelativePath("target_build_dir/xpm.framework.dSYM"))
-            XCTAssertTrue(fm.fileExists(atPath: outputFrameworkPath.asString))
-            XCTAssertTrue(fm.fileExists(atPath: outputDSYMPath.asString))
+            XCTAssertTrue(fm.fileExists(atPath: outputFrameworkPath.pathString))
+            XCTAssertTrue(fm.fileExists(atPath: outputDSYMPath.pathString))
             XCTAssertEqual(try Embeddable(path: outputFrameworkPath).architectures(), ["arm64"])
             XCTAssertEqual(try Embeddable(path: outputDSYMPath).architectures(), ["arm64"])
         }
@@ -55,7 +55,7 @@ final class FrameworkEmbedderErrorTests: XCTestCase {
         let targetBuildDir = tmpDir.path.appending(component: "target_build_dir")
         let validArchs = ["arm64"]
         func createDirectory(path: AbsolutePath) throws {
-            try FileManager.default.createDirectory(atPath: path.asString,
+            try FileManager.default.createDirectory(atPath: path.pathString,
                                                     withIntermediateDirectories: true,
                                                     attributes: nil)
         }
@@ -64,10 +64,10 @@ final class FrameworkEmbedderErrorTests: XCTestCase {
         try createDirectory(path: targetBuildDir)
         let environment = XcodeBuild.Environment(configuration: "Debug",
                                                  frameworksFolderPath: frameworksPath,
-                                                 builtProductsDir: builtProductsDir.asString,
-                                                 targetBuildDir: targetBuildDir.asString,
+                                                 builtProductsDir: builtProductsDir.pathString,
+                                                 targetBuildDir: targetBuildDir.pathString,
                                                  validArchs: validArchs,
-                                                 srcRoot: srcRootPath.asString,
+                                                 srcRoot: srcRootPath.pathString,
                                                  action: action)
         try assert(srcRootPath, environment)
     }

--- a/Tests/TuistKitTests/Extensions/TestData/AargumentParser+TestData.swift
+++ b/Tests/TuistKitTests/Extensions/TestData/AargumentParser+TestData.swift
@@ -1,5 +1,5 @@
 import Foundation
-@testable import Utility
+@testable import SPMUtility
 
 extension ArgumentParser {
     static func test(usage: String = "test",

--- a/Tests/TuistKitTests/Extensions/TestData/ArgumentParserResult+TestData.swift
+++ b/Tests/TuistKitTests/Extensions/TestData/ArgumentParserResult+TestData.swift
@@ -1,5 +1,5 @@
 import Foundation
-@testable import Utility
+@testable import SPMUtility
 
 extension ArgumentParser.Result {
     static func test(parser: ArgumentParser = ArgumentParser(usage: "test", overview: "overview")) -> ArgumentParser.Result {

--- a/Tests/TuistKitTests/Extensions/TestData/ShellCompletion+Equatable.swift
+++ b/Tests/TuistKitTests/Extensions/TestData/ShellCompletion+Equatable.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Utility
+import SPMUtility
 
 extension ShellCompletion: Equatable {
     public static func == (lhs: ShellCompletion, rhs: ShellCompletion) -> Bool {

--- a/Tests/TuistKitTests/Generator/ManifestTargetGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/ManifestTargetGeneratorTests.swift
@@ -26,7 +26,7 @@ final class ManifestTargetGeneratorTests: XCTestCase {
         // Then
         XCTAssertEqual(target.name, "MyProject-Manifest")
         XCTAssertEqual(target.product, .staticFramework)
-        XCTAssertEqual(target.sources.map { $0.asString }, ["/test/Project.swift"])
+        XCTAssertEqual(target.sources.map { $0.pathString }, ["/test/Project.swift"])
         XCTAssertNil(target.infoPlist)
         assertValidManifestBuildSettings(for: target,
                                          expectedSearchPath: "/test")

--- a/Tests/TuistKitTests/Setup/SetupLoaderTests.swift
+++ b/Tests/TuistKitTests/Setup/SetupLoaderTests.swift
@@ -32,7 +32,7 @@ final class SetupLoaderTests: XCTestCase {
         let projectPath = AbsolutePath("/test/test1")
         var receivedPaths = [String]()
         graphManifestLoader.loadSetupStub = { gotPath in
-            receivedPaths.append(gotPath.asString)
+            receivedPaths.append(gotPath.pathString)
             return []
         }
 

--- a/Tests/TuistKitTests/Utils/CarthageTests.swift
+++ b/Tests/TuistKitTests/Utils/CarthageTests.swift
@@ -26,7 +26,7 @@ final class CarthageTests: XCTestCase {
                 throw NSError.test()
             }
         }
-        system.succeedCommand("/path/to/carthage", "update", "--project-directory", fileHandler.currentPath.asString, "--platform", "iOS,macOS", "Alamofire",
+        system.succeedCommand("/path/to/carthage", "update", "--project-directory", fileHandler.currentPath.pathString, "--platform", "iOS,macOS", "Alamofire",
                               output: "")
 
         try subject.update(path: fileHandler.currentPath,


### PR DESCRIPTION
Part of https://github.com/tuist/tuist/issues/316

### Short description 📝

A few warnings are displayed when building Tuist with Swift 5. Most of the warnings are generated by the SwiftPM dependency.

e.g. 

```swift
.build/checkouts/swift-package-manager-7533872658195579349/Sources/Basic/ByteString.swift:95:16: warning: 'Hashable.hashValue' is deprecated as a protocol requirement; conform type 'ByteString' to 'Hashable' by implementing 'hash(into:)' instead
    public var hashValue: Int {

```

### Solution 📦

Update the revision the Swift PM dependency points to one that has been updated for Swift 5.

### Implementation 👩‍💻👨‍💻

- [x] Update `asString` to `pathString`
- [x] Update `import Utility` to `SPMUtility` 
- [x] Fix any remaining warnings

### Test Plan 🛠

- Verify unit tests pass `swift test`
- Verify acceptance tests pass `bundle exec rake features`
