### PR TITLE
Ensure generate works on additional disk volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Ensuring target product names are consistent with Xcode https://github.com/tuist/tuist/pull/323 by @kwridan
+- Ensuring generate works on additional disk volumes https://github.com/tuist/tuist/pull/327 by @kwridan
 
 ## 0.13.0
 

--- a/Sources/TuistGenerator/Generator/GeneratedProject.swift
+++ b/Sources/TuistGenerator/Generator/GeneratedProject.swift
@@ -37,9 +37,7 @@ final class GeneratedProject {
     /// - Parameter path: Path to the project (.xcodeproj)
     /// - Returns: GeneratedProject instance.
     func at(path: AbsolutePath) throws -> GeneratedProject {
-        let xcode = try XcodeProj(pathString: path.pathString)
-
-        return GeneratedProject(pbxproj: xcode.pbxproj,
+        return GeneratedProject(pbxproj: pbxproj,
                                 path: path,
                                 targets: targets,
                                 name: name)

--- a/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
@@ -81,11 +81,11 @@ final class ProjectGeneratorTests: XCTestCase {
         let attributes = pbxproject?.targetAttributes ?? [:]
         XCTAssertTrue(attributes.contains { attribute in
 
-            guard let appUUID = nativeTargets["App"]?.uuid, let testTargetID = attribute.value["TestTargetID"] as? String else {
+            guard let app = nativeTargets["App"], let testTargetID = attribute.value["TestTargetID"] as? PBXNativeTarget else {
                 return false
             }
 
-            return attribute.key.name == "Tests" && testTargetID == appUUID
+            return attribute.key.name == "Tests" && testTargetID == app
 
         }, "Test target is missing from target attributes.")
     }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/324

### Short description 📝

Running `tuist generate` on external volumes fails:

e.g.

```
$ cd /Volumes/RAMDisk/Project
$ tuist generate
Generating workspace Workspace.xcworkspace
Generating project Framework2
❌ Error: The file “Framework2.xcodeproj” couldn’t be saved in the folder “Framework2”.
```

### Solution 📦

Using `replaceItemAt` has a caveat where it requires the item and its replacement to be on the same volume (see [`replaceItemAt` documentation](https://developer.apple.com/documentation/foundation/filemanager/2293212-replaceitemat))

To mitigate this, the documentation suggests creating a temporary file within that volume where the new item can be moved to first before performing the replace.

### Implementation 👩‍💻👨‍💻

- [x] Update `FileHandler.replace`
- [x] Update changelog

### Test Plan 🛠

- Manually create a RAM disk e.g.  
```
diskutil erasevolume HFS+ “RAMDisk” `hdiutil attach -nomount ram://524288`
```
(this creates a 250MB RAM disk)

- Create a new folder within that disk
- run `tuist init`
- run `tuist generate`
- Verify the generation succeeds