### PR TITLE
Adding generate command timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next version
 
-## 0.14.0
+## 0.15.0
 
 ### Added
+
+- Adding generate command timer https://github.com/tuist/tuist/pull/335 by @kwridan
 
 ### Removed
 

--- a/Sources/TuistCore/Utils/Clock.swift
+++ b/Sources/TuistCore/Utils/Clock.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+public protocol ClockTimer {
+    func stop() -> TimeInterval
+}
+
+public protocol Clock {
+    var now: Date { get }
+    func startTimer() -> ClockTimer
+}
+
+public class WallClock: Clock {
+    public var now: Date {
+        return Date()
+    }
+
+    public init() {}
+
+    public func startTimer() -> ClockTimer {
+        return Timer(clock: self)
+    }
+
+    private class Timer: ClockTimer {
+        private let start: Date
+        private let clock: Clock
+
+        fileprivate init(clock: Clock) {
+            self.clock = clock
+            start = clock.now
+        }
+
+        func stop() -> TimeInterval {
+            return clock.now.timeIntervalSince(start)
+        }
+    }
+}

--- a/Sources/TuistCore/Utils/Clock.swift
+++ b/Sources/TuistCore/Utils/Clock.swift
@@ -1,14 +1,26 @@
 import Foundation
 
-public protocol ClockTimer {
-    func stop() -> TimeInterval
-}
-
+/// A clock can be used to obtain the current date
+/// as well as create `ClockTimers` to measure
+/// time intervals between events.
 public protocol Clock {
     var now: Date { get }
     func startTimer() -> ClockTimer
 }
 
+/// A clock timer can be used to measure
+/// time intervals between events
+///
+/// A timer can be obtaine from a `Clock`
+/// by calling `startTimer()`. Calling
+/// `stop()` on the timer will return
+/// the time interval since the start.
+public protocol ClockTimer {
+    func stop() -> TimeInterval
+}
+
+/// A wall clock is the default implementation of
+/// the `Clock` interface
 public class WallClock: Clock {
     public var now: Date {
         return Date()

--- a/Sources/TuistCoreTesting/Utils/StubClock.swift
+++ b/Sources/TuistCoreTesting/Utils/StubClock.swift
@@ -1,0 +1,48 @@
+import Foundation
+import TuistCore
+
+/// A stub clock that can be primed with
+/// multiple dates and timers.
+public class StubClock: Clock {
+    /// Returns primed dates in the order they
+    /// were added to `primedDates`.
+    ///
+    /// In the event there are no primed dates, `Date.distantPast`
+    /// is returned.
+    public var now: Date {
+        if let first = primedDates.first {
+            primedDates.removeFirst()
+            return first
+        }
+        return .distantPast
+    }
+
+    public var primedDates: [Date] = []
+    public var primedTimers: [TimeInterval] = []
+
+    public init() {}
+
+    /// Returns stub timers that are primed with time intervals in the
+    /// the order they were defined in `primedTimers`.
+    ///
+    /// In the event there are no primed time intervals, A stub timer
+    /// with a time interval of `0` is returned.
+    public func startTimer() -> ClockTimer {
+        if let first = primedTimers.first {
+            primedTimers.removeFirst()
+            return Timer(timeInterval: first)
+        }
+        return Timer(timeInterval: 0.0)
+    }
+
+    private class Timer: ClockTimer {
+        private let timeInterval: TimeInterval
+        fileprivate init(timeInterval: TimeInterval) {
+            self.timeInterval = timeInterval
+        }
+
+        func stop() -> TimeInterval {
+            return timeInterval
+        }
+    }
+}

--- a/Sources/TuistCoreTesting/Utils/StubClock.swift
+++ b/Sources/TuistCoreTesting/Utils/StubClock.swift
@@ -1,5 +1,6 @@
 import Foundation
 import TuistCore
+import XCTest
 
 /// A stub clock that can be primed with
 /// multiple dates and timers.
@@ -17,8 +18,18 @@ public class StubClock: Clock {
         return .distantPast
     }
 
+    /// The dates to return when calling `now`
+    /// in the order they are specified.
     public var primedDates: [Date] = []
+
+    /// The time intervals to return from timers
+    /// obtained when calling `startTimer()` in the
+    /// order they are specified.
     public var primedTimers: [TimeInterval] = []
+
+    /// Asserts when the stub methods are called
+    /// while there is no more stubbed data
+    public var assertOnUnexpectedCalls: Bool = false
 
     public init() {}
 
@@ -32,16 +43,28 @@ public class StubClock: Clock {
             primedTimers.removeFirst()
             return Timer(timeInterval: first)
         }
+        if assertOnUnexpectedCalls {
+            XCTFail("Trying to get more timers than the ones stubbed")
+        }
         return Timer(timeInterval: 0.0)
     }
 
     private class Timer: ClockTimer {
         private let timeInterval: TimeInterval
+        private var stopCount = 0
         fileprivate init(timeInterval: TimeInterval) {
             self.timeInterval = timeInterval
         }
 
         func stop() -> TimeInterval {
+            defer {
+                stopCount += 1
+            }
+
+            if stopCount >= 1 {
+                XCTFail("Attempting to stop a timer more than once")
+            }
+
             return timeInterval
         }
     }

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -78,7 +78,7 @@ class GenerateCommand: NSObject, Command {
 
         let time = String(format: "%.3f", timer.stop())
         printer.print(success: "Project generated.")
-        printer.print("Total time: \(time)s", color: .white)
+        printer.print("Total time taken: \(time)s", color: .white)
     }
 
     // MARK: - Fileprivate

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -16,6 +16,7 @@ class GenerateCommand: NSObject, Command {
     private let printer: Printing
     private let fileHandler: FileHandling
     private let manifestLoader: GraphManifestLoading
+    private let clock: Clock
 
     let pathArgument: OptionArgument<String>
 
@@ -43,19 +44,22 @@ class GenerateCommand: NSObject, Command {
                   printer: printer,
                   fileHandler: fileHandler,
                   generator: generator,
-                  manifestLoader: manifestLoader)
+                  manifestLoader: manifestLoader,
+                  clock: WallClock())
     }
 
     init(parser: ArgumentParser,
          printer: Printing,
          fileHandler: FileHandling,
          generator: Generating,
-         manifestLoader: GraphManifestLoading) {
+         manifestLoader: GraphManifestLoading,
+         clock: Clock) {
         let subParser = parser.add(subparser: GenerateCommand.command, overview: GenerateCommand.overview)
         self.generator = generator
         self.printer = printer
         self.fileHandler = fileHandler
         self.manifestLoader = manifestLoader
+        self.clock = clock
 
         pathArgument = subParser.add(option: "--path",
                                      shortName: "-p",
@@ -65,13 +69,16 @@ class GenerateCommand: NSObject, Command {
     }
 
     func run(with arguments: ArgumentParser.Result) throws {
+        let timer = clock.startTimer()
         let path = self.path(arguments: arguments)
 
         _ = try generator.generate(at: path,
                                    config: .default,
                                    manifestLoader: manifestLoader)
 
+        let time = String(format: "%.3f", timer.stop())
         printer.print(success: "Project generated.")
+        printer.print("Total time: \(time)s", color: .white)
     }
 
     // MARK: - Fileprivate

--- a/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
@@ -14,6 +14,7 @@ final class GenerateCommandTests: XCTestCase {
     var printer: MockPrinter!
     var fileHandler: MockFileHandler!
     var manifestLoader: MockGraphManifestLoader!
+    var clock: StubClock!
 
     override func setUp() {
         super.setUp()
@@ -23,12 +24,14 @@ final class GenerateCommandTests: XCTestCase {
             parser = ArgumentParser.test()
             fileHandler = try MockFileHandler()
             manifestLoader = MockGraphManifestLoader()
+            clock = StubClock()
 
             subject = GenerateCommand(parser: parser,
                                       printer: printer,
                                       fileHandler: fileHandler,
                                       generator: generator,
-                                      manifestLoader: manifestLoader)
+                                      manifestLoader: manifestLoader,
+                                      clock: clock)
         } catch {
             XCTFail("failed to setup test: \(error.localizedDescription)")
         }
@@ -68,6 +71,23 @@ final class GenerateCommandTests: XCTestCase {
 
         // Then
         XCTAssertEqual(printer.printSuccessArgs.first, "Project generated.")
+    }
+
+    func test_run_timeIsPrinted() throws {
+        // Given
+        let result = try parser.parse([GenerateCommand.command])
+        manifestLoader.manifestsAtStub = { _ in
+            Set([.project])
+        }
+        clock.primedTimers = [
+            0.234,
+        ]
+
+        // When
+        try subject.run(with: result)
+
+        // Then
+        XCTAssertEqual(printer.printWithColorArgs.first?.0, "Total time: 0.234s")
     }
 
     func test_run_withRelativePathParameter() throws {

--- a/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
@@ -79,6 +79,7 @@ final class GenerateCommandTests: XCTestCase {
         manifestLoader.manifestsAtStub = { _ in
             Set([.project])
         }
+        clock.assertOnUnexpectedCalls = true
         clock.primedTimers = [
             0.234,
         ]

--- a/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
@@ -88,7 +88,7 @@ final class GenerateCommandTests: XCTestCase {
         try subject.run(with: result)
 
         // Then
-        XCTAssertEqual(printer.printWithColorArgs.first?.0, "Total time: 0.234s")
+        XCTAssertEqual(printer.printWithColorArgs.first?.0, "Total time taken: 0.234s")
     }
 
     func test_run_withRelativePathParameter() throws {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/329

### Short description 📝

To keep an eye on how long the generation process takes as users add more dependencies to their projects and as Tuist developers add more features to Tuist itself, it would be useful to print out the total generation time.

### Solution 📦

Print out the total time taken to generate a project within the generate command.

### Implementation 👩‍💻👨‍💻

- [x] Introduce `Clock` and `ClockTimers` to allow obtaining current date and time differences
- [x] Time the generate process within the generate command
- [x] Update changelog

### Test Plan 🛠

- Verify unit tests and acceptance tests pass
- Run `tuist generate` within any of the fixtures in `fixtures`
- Verify the generation time is displayed in the console output
