### PR TITLE
Fixing files getting mistaken for folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Set Code Sign On Copy to true for Embed Frameworks https://github.com/tuist/tuist/pull/333 by @dangthaison91
+- Fixing files getting mistaken for folders https://github.com/tuist/tuist/pull/338 by @kwridan
 
 ## 0.14.0
 

--- a/features/generate.feature
+++ b/features/generate.feature
@@ -75,6 +75,8 @@ Scenario: The project is an iOS application that has resources (ios_app_with_fra
     Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'Examples/item.json'
     Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'Examples/list.json'
     Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'Assets.car'
+    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'resource.txt'
+    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'resource_without_extension'
     Then the product 'App.app' with destination 'Debug-iphoneos' does not contain resource 'do_not_include.dat'
 
 Scenario: The project is an iOS application with frameworks and tests (ios_app_with_framework_linking_static_framework)

--- a/fixtures/ios_app_with_custom_workspace/App/CHANGELOG
+++ b/fixtures/ios_app_with_custom_workspace/App/CHANGELOG
@@ -1,0 +1,1 @@
+# Changelog

--- a/fixtures/ios_app_with_custom_workspace/App/Project.swift
+++ b/fixtures/ios_app_with_custom_workspace/App/Project.swift
@@ -24,5 +24,6 @@ let project = Project(name: "MainApp",
                           additionalFiles: [
                                 "Dangerfile.swift",
                                 "Documentation/**",
+                                "CHANGELOG",
                                 .folderReference(path: "Responses"), 
                           ])

--- a/fixtures/ios_app_with_framework_and_resources/App/Project.swift
+++ b/fixtures/ios_app_with_framework_and_resources/App/Project.swift
@@ -13,6 +13,8 @@ let project = Project(
             resources: [
                 "Resources/*.png",
                 "Resources/*.xcassets",
+                "Resources/**/*.txt",
+                "Resources/resource_without_extension",
                 .folderReference(path: "Examples")
             ],
             dependencies: [

--- a/fixtures/ios_app_with_framework_and_resources/App/Resources/Folder.DotName/resource.txt
+++ b/fixtures/ios_app_with_framework_and_resources/App/Resources/Folder.DotName/resource.txt
@@ -1,0 +1,1 @@
+A resource

--- a/fixtures/ios_app_with_framework_and_resources/App/Resources/resource_without_extension
+++ b/fixtures/ios_app_with_framework_and_resources/App/Resources/resource_without_extension
@@ -1,0 +1,1 @@
+resource without extension


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/330 and https://github.com/tuist/tuist/issues/322

### Short description 📝

- This issue can occur when files like `README` without extensions exist within the project
- Additionally another issue can be encountered in the event folders contain a `.` in their name

### Solution 📦

- To solve this we now only create groups if the file element component being added is a leaf (i.e. `/path/to/a` when `path` and `to` are added, they will be added as groups, and `a` will be added as a file element)

### Implementation 👩‍💻👨‍💻

- [x] Update project file elements & tests
- [x] Update fixtures to allow testing manually
- [x] Update changelog 

## Test Plan 🛠:

- Verify unit tests pass `swift test`
- Verify acceptance tests pass `bundle rake features`
- Manually generate `fixtures/ios_app_with_framework_and_resources` via `tuist generate`
- Verify `resource_without_extension` and `resource.txt` are included as resources within the project
- Manually generate `fixtures/ios_app_with_custom_workspace` via `tuist generate`
- Verify the `CHANGELOG` file appears as a file and not a group