### PR TITLE
Updating init template to avoid warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Set Code Sign On Copy to true for Embed Frameworks https://github.com/tuist/tuist/pull/333 by @dangthaison91
 - Fixing files getting mistaken for folders https://github.com/tuist/tuist/pull/338 by @kwridan
+- Updating init template to avoid warnings https://github.com/tuist/tuist/pull/339 by @kwridan 
 
 ## 0.14.0
 

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -140,10 +140,13 @@ class InitCommand: NSObject, Command {
                                        bundleId: "io.tuist.\(name)",
                                        infoPlist: "Info.plist",
                                        sources: ["Sources/**"],
-                                       resources: ["Resources/**"],
+                                       resources: [
+                                               /* Path to resouces can be defined here */
+                                               // "Resources/**"
+                                       ],
                                        dependencies: [
                                             /* Target dependencies can be defined here */
-                                            /* .framework(path: "framework") */
+                                            // .framework(path: "Frameworks/MyFramework.framework")
                                         ]),
                                 Target(name: "\(name)Tests",
                                        platform: .\(platform.caseValue),


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/334

### Short description 📝

When initialising a new project via `tuist init` and then proceeding to generate the project, warnings were getting displayed due to missing resource files. 

### Solution 📦

- The path to resources paths is now commented out and left as an example to aid users get started defining their manifest

### Implementation 👩‍💻👨‍💻

- [x] Update the init template
- [x] Update changelog 

## Test Plan 🛠

- Create a new empty directory
- Run `tuist init`
- Run `tuist focus`
- Verify no warnings are displayed