### PR TITLE
Support Scheme `shared` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Adding generate command timer https://github.com/tuist/tuist/pull/335 by @kwridan
 - Support Scheme manifest with pre/post action https://github.com/tuist/tuist/pull/336 by @dangthaison91
+- Support local Scheme (not shared) flag https://github.com/tuist/tuist/pull/341 by @dangthaison91
 
 ### Removed
 

--- a/Sources/TuistGenerator/Generator/SchemesGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemesGenerator.swift
@@ -437,7 +437,7 @@ final class SchemesGenerator: SchemesGenerating {
             path = projectPath.appending(RelativePath("xcshareddata/xcschemes"))
         } else {
             let username = NSUserName()
-            path = projectPath.appending(RelativePath("\(username).xcuserdatad/xcschemes"))
+            path = projectPath.appending(RelativePath("xcuserdata/\(username).xcuserdatad/xcschemes"))
         }
         if !fileHandler.exists(path) {
             try fileHandler.createFolder(path)

--- a/Sources/TuistGenerator/Generator/SchemesGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemesGenerator.swift
@@ -75,7 +75,7 @@ final class SchemesGenerator: SchemesGenerating {
     func generateScheme(scheme: Scheme,
                         project: Project,
                         generatedProject: GeneratedProject) throws {
-        let schemesDirectory = try createSchemesDirectory(projectPath: generatedProject.path)
+        let schemesDirectory = try createSchemesDirectory(projectPath: generatedProject.path, shared: scheme.shared)
         let schemePath = schemesDirectory.appending(component: "\(scheme.name).xcscheme")
         
         let generatedBuildAction = schemeBuildAction(scheme: scheme, project: project, generatedProject: generatedProject)
@@ -428,10 +428,17 @@ final class SchemesGenerator: SchemesGenerating {
     ///
     /// - Parameters:
     ///   - projectPath: Path to the Xcode project.
+    ///   - shared: Scheme should be shared or not
     /// - Returns: Path to the schemes directory.
     /// - Throws: A FatalError if the creation of the directory fails.
-    private func createSchemesDirectory(projectPath: AbsolutePath) throws -> AbsolutePath {
-        let path = projectPath.appending(RelativePath("xcshareddata/xcschemes"))
+    private func createSchemesDirectory(projectPath: AbsolutePath, shared: Bool = true) throws -> AbsolutePath {
+        var path: AbsolutePath!
+        if shared {
+            path = projectPath.appending(RelativePath("xcshareddata/xcschemes"))
+        } else {
+            let username = NSUserName()
+            path = projectPath.appending(RelativePath("\(username).xcuserdatad/xcschemes"))
+        }
         if !fileHandler.exists(path) {
             try fileHandler.createFolder(path)
         }

--- a/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
@@ -77,7 +77,7 @@ final class ProjectGeneratorTests: XCTestCase {
         XCTAssertTrue(fileHandler.exists(scheme))
         
         let username = NSUserName()
-        let userSchemesPath = got.path.appending(RelativePath("\(username).xcuserdatad/xcschemes"))
+        let userSchemesPath = got.path.appending(RelativePath("xcuserdata/\(username).xcuserdatad/xcschemes"))
         let userScheme = userSchemesPath.appending(component: "Target-Local.xcscheme")
         XCTAssertTrue(fileHandler.exists(userScheme))
     }

--- a/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
@@ -80,11 +80,6 @@ final class ProjectGeneratorTests: XCTestCase {
         let userSchemesPath = got.path.appending(RelativePath("\(username).xcuserdatad/xcschemes"))
         let userScheme = userSchemesPath.appending(component: "Target-Local.xcscheme")
         XCTAssertTrue(fileHandler.exists(userScheme))
-        
-        // It doensn't generate Target Scheme
-        let targetSchemesPath = got.path.appending(RelativePath("xcshareddata/xcschemes"))
-        let targetScheme = targetSchemesPath.appending(component: "Target.xcscheme")
-        XCTAssertFalse(fileHandler.exists(targetScheme))
     }
 
     func test_generate_testTargetIdentity() throws {

--- a/features/generate.feature
+++ b/features/generate.feature
@@ -106,6 +106,7 @@ Scenario: The project is an iOS application that has resources (ios_app_with_cus
     Then tuist generates the project
     Then I should be able to build the scheme App-Debug
     Then I should be able to build the scheme App-Release
+    Then I should be able to build the scheme App-Local
     Then I should be able to test the scheme AppTests
     Then I should be able to build the scheme Framework1
     Then I should be able to test the scheme Framework1Tests

--- a/fixtures/ios_app_with_custom_scheme/App/Project.swift
+++ b/fixtures/ios_app_with_custom_scheme/App/Project.swift
@@ -14,6 +14,12 @@ let releaseScheme = Scheme(name: "App-Release",
                            testAction: TestAction(targets: ["AppTests"]),
                            runAction: RunAction(executable: "App"))
 
+let userScheme = Scheme(name: "App-Local",
+                        shared: false,
+                        buildAction: BuildAction(targets: ["App"], preActions: [debugAction]),
+                        testAction: TestAction(targets: ["AppTests"]),
+                        runAction: RunAction(executable: "App"))
+
 let project = Project(name: "MainApp",
                       targets: [
                           Target(name: "App",
@@ -35,6 +41,6 @@ let project = Project(name: "MainApp",
                                  dependencies: [
                                      .target(name: "App"),
                           ])],
-                      schemes: [debugScheme, releaseScheme])
+                      schemes: [debugScheme, releaseScheme, userScheme])
 
 


### PR DESCRIPTION
Continue from PR #336 

### Short description 📝

Previously, Scheme will always generated as Shared Scheme despite of shared is set to false.

### Solution 📦
If Scheme is shared, Xcode will generate xcscheme file in folder `xcshareddata/xcschemes` while scheme is not shared, it will be put in `xcuserdata/user_name.xcuserdatad/xcschemes

As @kwridan share about `NSUsername()`, we can use this function for appending write path for local scheme.

### Implementation 👩‍💻👨‍💻

- [x] Update function create scheme directory
- [x] Update tests and fixture