### PR TITLE
Don't ask for CHANGELOG entries when the developer is not modifying source code

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -2,7 +2,7 @@
 all_files = git.modified_files + git.added_files
 
 # Changelog
-unless git.modified_files.include?("CHANGELOG.md")
+if !git.modified_files.include?("CHANGELOG.md") && all_files.any? { |f| f.include?("Sources/") }
   message = <<~MESSAGE
     Please include a CHANGELOG entry.
     You can find it at [CHANGELOG.md](https://github.com/tuist/tuist/blob/master/CHANGELOG.md).


### PR DESCRIPTION
### Short description 📝
Just saw [on this PR](https://github.com/tuist/tuist/pull/340) that Danger was asking for updating the CHANGELOG when the only changes in that PR are documentation changes.

I think the CHANGELOG should be updated only when the changes include changes in the `Sources/` directory.

### Solution 📦

Change the logic in the `Dangerfile`.
