### PR TITLE
Fixing generation failures due to asset catalog & `**/*.png` glob patterns handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Set Code Sign On Copy to true for Embed Frameworks https://github.com/tuist/tuist/pull/333 by @dangthaison91
 - Fixing files getting mistaken for folders https://github.com/tuist/tuist/pull/338 by @kwridan
 - Updating init template to avoid warnings https://github.com/tuist/tuist/pull/339 by @kwridan 
+- Fixing generation failures due to asset catalog & `**/*.png` glob patterns handling https://github.com/tuist/tuist/pull/346 by @kwridan 
 
 ## 0.14.0
 

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -317,7 +317,7 @@ class ProjectFileElements {
                                           name: name,
                                           toGroup: toGroup,
                                           pbxproj: pbxproj)
-        } else if !isLeaf {
+        } else if !(isXcassets(path: absolutePath) || isLeaf) {
             return addGroupElement(from: from,
                                    folderAbsolutePath: absolutePath,
                                    folderRelativePath: relativePath,
@@ -429,6 +429,10 @@ class ProjectFileElements {
 
     func isVersionGroup(path: AbsolutePath) -> Bool {
         return path.extension == "xcdatamodeld"
+    }
+
+    func isXcassets(path: AbsolutePath) -> Bool {
+        return path.extension == "xcassets"
     }
 
     /// Normalizes a path. Some paths have no direct representation in Xcode,

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -129,6 +129,54 @@ final class ProjectFileElementsTests: XCTestCase {
         ])
     }
 
+    func test_addElement_xcassets() throws {
+        // Given
+        let element = GroupFileElement(path: "/path/myfolder/resources/assets.xcassets/foo/bar.png",
+                                       group: .group(name: "Project"),
+                                       isReference: true)
+
+        // When
+        try subject.generate(fileElement: element,
+                             groups: groups,
+                             pbxproj: pbxproj,
+                             sourceRootPath: "/path")
+
+        // Then
+        let projectGroup = groups.main.group(named: "Project")
+        XCTAssertEqual(projectGroup?.debugChildPaths, [
+            "myfolder/resources/assets.xcassets",
+        ])
+    }
+
+    func test_addElement_xcassets_multiple_files() throws {
+        // Given
+        let resouces = [
+            "/path/myfolder/resources/assets.xcassets/foo/a.png",
+            "/path/myfolder/resources/assets.xcassets/foo/abc/b.png",
+            "/path/myfolder/resources/assets.xcassets/foo/def/c.png",
+            "/path/myfolder/resources/assets.xcassets",
+        ]
+        let elements = resouces.map {
+            GroupFileElement(path: AbsolutePath($0),
+                             group: .group(name: "Project"),
+                             isReference: true)
+        }
+
+        // When
+        try elements.forEach {
+            try subject.generate(fileElement: $0,
+                                 groups: groups,
+                                 pbxproj: pbxproj,
+                                 sourceRootPath: "/path")
+        }
+
+        // Then
+        let projectGroup = groups.main.group(named: "Project")
+        XCTAssertEqual(projectGroup?.debugChildPaths, [
+            "myfolder/resources/assets.xcassets",
+        ])
+    }
+
     func test_targetProducts() {
         let target = Target.test()
         let products = subject.targetProducts(target: target).sorted()

--- a/fixtures/ios_app_with_framework_and_resources/App/Project.swift
+++ b/fixtures/ios_app_with_framework_and_resources/App/Project.swift
@@ -11,7 +11,7 @@ let project = Project(
             infoPlist: "Config/App-Info.plist",
             sources: "Sources/**",
             resources: [
-                "Resources/*.png",
+                "Resources/**/*.png",
                 "Resources/*.xcassets",
                 "Resources/**/*.txt",
                 "Resources/resource_without_extension",


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/345

### Short description 📝

- Using the `**/*` style patterns are "eager" they will list out files recursively including ones within `.xcassets`
- The order in which the `ProjectFileElements` elements are processes isn't guaranteed
- If a file within the `.xcassets` is encountered first, e.g. `App/Resources/Assets.xcassets/assetCatalogLogo.imageset/tuist.png` before `App/Resources/Assets.xcassets`, `App/Resources/Assets.xcassets` is mistaken for a group and isn't added as a file element

### Solution 📦

- To mitigate this, the logic that determines if a group or file is added checks for `.xcassets` files

### Implementation 👩‍💻👨‍💻

> Detail in a checklist the steps that you took to implement the PR.

- [x] Update fixtures
- [x] Update unit tests
- [x] Add logic to check for `.xcassets`
- [x] Update changelog

### Test Plan 🛠

- Verify unit tests pass
- Verify acceptance tests pass
- Run `tuist generate` within `fixtures/ios_app_with_framework_and_resources`
- Verify the generation passes
- Verify the asset catalog is included in the generated `MainApp` within the workspace