### PR TITLE
Supporting bundle target dependencies that reside in different projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fixing files getting mistaken for folders https://github.com/tuist/tuist/pull/338 by @kwridan
 - Updating init template to avoid warnings https://github.com/tuist/tuist/pull/339 by @kwridan 
 - Fixing generation failures due to asset catalog & `**/*.png` glob patterns handling https://github.com/tuist/tuist/pull/346 by @kwridan 
+- Supporting bundle target dependencies that reside in different projects (in `TuistGenerator`) https://github.com/tuist/tuist/pull/348 by @kwridan 
 
 ## 0.14.0
 

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -232,9 +232,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
                                         fileElements: ProjectFileElements,
                                         pbxproj: PBXProj,
                                         resourcesBuildPhase: PBXResourcesBuildPhase) {
-        let dependencies = graph.targetDependencies(path: path, name: target.name)
-        let bundles = dependencies.filter { $0.target.product == .bundle }
-
+        let bundles = graph.resourceBundleDependencies(path: path, name: target.name)
         let refs = bundles.compactMap { fileElements.product(name: $0.target.productNameWithExtension) }
         refs.forEach {
             let pbxBuildFile = PBXBuildFile(file: $0)

--- a/Sources/TuistGenerator/Graph/Graph.swift
+++ b/Sources/TuistGenerator/Graph/Graph.swift
@@ -59,6 +59,7 @@ protocol Graphing: AnyObject {
     func embeddableFrameworks(path: AbsolutePath, name: String, system: Systeming) throws -> Set<DependencyReference>
     func targetDependencies(path: AbsolutePath, name: String) -> [TargetNode]
     func staticDependencies(path: AbsolutePath, name: String) -> [DependencyReference]
+    func resourceBundleDependencies(path: AbsolutePath, name: String) -> [TargetNode]
 
     // MARK: - Depth First Search
 
@@ -124,6 +125,15 @@ class Graph: Graphing {
             .filter(isStaticLibrary)
             .map(\.target.productNameWithExtension)
             .map(DependencyReference.product)
+    }
+
+    func resourceBundleDependencies(path: AbsolutePath, name: String) -> [TargetNode] {
+        guard let targetNode = findTargetNode(path: path, name: name) else {
+            return []
+        }
+
+        return targetNode.targetDependencies
+            .filter { $0.target.product == .bundle }
     }
 
     func linkableDependencies(path: AbsolutePath, name: String) throws -> [DependencyReference] {

--- a/Tests/TuistGeneratorTests/Graph/GraphTests.swift
+++ b/Tests/TuistGeneratorTests/Graph/GraphTests.swift
@@ -281,4 +281,48 @@ final class GraphTests: XCTestCase {
         // Then
         XCTAssertEqual(got, [AbsolutePath("/test/modules")])
     }
+
+    func test_resourceBundleDependencies_fromTargetDependency() {
+        // Given
+        let bundle = Target.test(name: "Bundle1", product: .bundle)
+        let app = Target.test(name: "App", product: .bundle)
+        let projectA = Project.test(path: "/path/a")
+
+        let graph = Graph.create(project: projectA,
+                                 dependencies: [
+                                     (target: bundle, dependencies: []),
+                                     (target: app, dependencies: [bundle]),
+                                 ])
+
+        // When
+        let result = graph.resourceBundleDependencies(path: projectA.path, name: app.name)
+
+        // Then
+        XCTAssertEqual(result.map(\.target.name), [
+            "Bundle1",
+        ])
+    }
+
+    func test_resourceBundleDependencies_fromProjectDependency() {
+        // Given
+        let bundle = Target.test(name: "Bundle1", product: .bundle)
+        let projectA = Project.test(path: "/path/a")
+
+        let app = Target.test(name: "App", product: .app)
+        let projectB = Project.test(path: "/path/b")
+
+        let graph = Graph.create(projects: [projectA, projectB],
+                                 dependencies: [
+                                     (project: projectA, target: bundle, dependencies: []),
+                                     (project: projectB, target: app, dependencies: [bundle]),
+                                 ])
+
+        // When
+        let result = graph.resourceBundleDependencies(path: projectB.path, name: app.name)
+
+        // Then
+        XCTAssertEqual(result.map(\.target.name), [
+            "Bundle1",
+        ])
+    }
 }


### PR DESCRIPTION

Part of: https://github.com/tuist/tuist/issues/290

### Short description 📝

- Previously only bundle target dependencies within the same projects worked
- This was due to leveraging the `targetDependencies` method on `Graph` which only returns the target dependencies with the same project

### Solution 📦

- Update `Graph` to include a new method to return all bundle resource dependencies

### Test Plan 🛠

- Run unit tests via `swift test` and verify they pass
  - Tests now include scenarios where the bundle target reside in a different project 

### Notes 📝

Bundle resources are not yet exposed to the manifests as such can't be manually verified
