### PR TITLE
Update static dependency lint rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fixing generation failures due to asset catalog & `**/*.png` glob patterns handling https://github.com/tuist/tuist/pull/346 by @kwridan 
 - Supporting bundle target dependencies that reside in different projects (in `TuistGenerator`) https://github.com/tuist/tuist/pull/348 by @kwridan 
 - Fixing header paths including folders and non-header files https://github.com/tuist/tuist/pull/356 by @kwridan
+- Update static dependency lint rule https://github.com/tuist/tuist/pull/360 by @kwridan
 
 ## 0.14.0
 

--- a/Sources/TuistGenerator/Graph/Graph.swift
+++ b/Sources/TuistGenerator/Graph/Graph.swift
@@ -143,7 +143,7 @@ class Graph: Graphing {
 
         var references: [DependencyReference] = []
 
-        /// Precompiled libraries and frameworks
+        // Precompiled libraries and frameworks
 
         let precompiledLibrariesAndFrameworks = targetNode.precompiledDependencies
             .map(\.path)
@@ -151,12 +151,9 @@ class Graph: Graphing {
 
         references.append(contentsOf: precompiledLibrariesAndFrameworks)
 
-        switch targetNode.target.product {
-        case .staticLibrary, .dynamicLibrary, .staticFramework, .bundle:
-            // Ignore the products, they do not want to directly link the static libraries, the top level bundles will be responsible.
-            break
-        case .app, .unitTests, .uiTests, .framework:
+        // Static libraries and frameworks
 
+        if targetNode.target.canLinkStaticProducts() {
             let staticLibraries = findAll(targetNode: targetNode, test: isStaticLibrary, skip: isFramework)
                 .lazy
                 .map(\.target.productNameWithExtension)

--- a/Sources/TuistGenerator/Models/Target.swift
+++ b/Sources/TuistGenerator/Models/Target.swift
@@ -63,8 +63,14 @@ public class Target: Equatable {
         self.dependencies = dependencies
     }
 
+    /// Target can be included in the link phase of other targets
     func isLinkable() -> Bool {
         return [.dynamicLibrary, .staticLibrary, .framework, .staticFramework].contains(product)
+    }
+
+    /// Target can link staitc products (e.g. an app can link a staticLibrary)
+    func canLinkStaticProducts() -> Bool {
+        return [.framework, .app, .unitTests, .uiTests].contains(product)
     }
 
     /// Returns the product name including the extension.

--- a/Tests/TuistGeneratorTests/Graph/TestData/Graph+TestData.swift
+++ b/Tests/TuistGeneratorTests/Graph/TestData/Graph+TestData.swift
@@ -44,7 +44,7 @@ extension Graph {
     /// Note: For the purposes of testing, to reduce complexity of resolving dependencies
     ///       The `dependencies` property is used to define the dependencies explicitly.
     ///       All targets need to be listed even if they don't have any dependencies.
-    static func create(projects: [Project],
+    static func create(projects: [Project] = [],
                        dependencies: [(project: Project, target: Target, dependencies: [Target])]) -> Graph {
         let targetNodes = createTargetNodes(dependencies: dependencies)
 

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -133,7 +133,7 @@ Dependencies:
 
 ## ios_app_with_static_frameworks
 
-Same as `ios_app_with_static_libraries` except using static frameworks instead of libraries.
+This fixture contains an application that depends on static frameworks, both directly and transitively.
 
 ```
 Workspace:
@@ -141,16 +141,21 @@ Workspace:
     - MainApp (iOS app)
     - MainAppTests (iOS unit tests)
   - A:
-    - A (static library iOS)
+    - A (static framework iOS)
     - ATests (iOS unit tests)
   - B:
-    - B (static library iOS)
+    - B (static framework iOS)
     - BTests (iOS unit tests)
+  - C:
+    - C (static framework iOS)
+    - CTests (iOS unit tests)
 ```
 
 Dependencies:
   - App -> A
+  - App -> C
   - A -> B
+  - A -> C
 
 ## ios_app_with_tests
 

--- a/fixtures/ios_app_with_static_frameworks/Modules/A/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks/Modules/A/Project.swift
@@ -10,6 +10,7 @@ let project = Project(name: "A",
                                  sources: "Sources/**",
                                  dependencies: [
                                      .project(target: "B", path: "../B"),
+                                     .project(target: "C", path: "../C"),
                           ]),
                           Target(name: "ATests",
                                  platform: .iOS,

--- a/fixtures/ios_app_with_static_frameworks/Modules/A/Sources/A.swift
+++ b/fixtures/ios_app_with_static_frameworks/Modules/A/Sources/A.swift
@@ -1,4 +1,5 @@
 import B
+import C
 
 public class A {
     public static let value: String = "aValue"
@@ -6,5 +7,7 @@ public class A {
     public static func printFromA() {
         print("print from A")
         B.printFromB()
+        C.printFromC()
+        print("---")
     }
 }

--- a/fixtures/ios_app_with_static_frameworks/Modules/C/Info.plist
+++ b/fixtures/ios_app_with_static_frameworks/Modules/C/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_static_frameworks/Modules/C/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks/Modules/C/Project.swift
@@ -1,24 +1,24 @@
 import ProjectDescription
 
-let project = Project(name: "iOSAppWithTransistiveStaticFrameworks",
+let project = Project(name: "C",
                       targets: [
-                          Target(name: "App",
+                          Target(name: "C",
                                  platform: .iOS,
-                                 product: .app,
-                                 bundleId: "io.tuist.App",
+                                 product: .staticFramework,
+                                 bundleId: "io.tuist.C",
                                  infoPlist: "Info.plist",
                                  sources: "Sources/**",
                                  dependencies: [
-                                     .project(target: "A", path: "Modules/A"),
-                                     .project(target: "C", path: "Modules/C"),
+                                     /* Target dependencies can be defined here */
+                                     /* .framework(path: "framework") */
                           ]),
-                          Target(name: "AppTests",
+                          Target(name: "CTests",
                                  platform: .iOS,
                                  product: .unitTests,
-                                 bundleId: "io.tuist.AppTests",
+                                 bundleId: "io.tuist.CTests",
                                  infoPlist: "Tests.plist",
                                  sources: "Tests/**",
                                  dependencies: [
-                                     .target(name: "App"),
+                                     .target(name: "C"),
                           ]),
 ])

--- a/fixtures/ios_app_with_static_frameworks/Modules/C/Sources/C.swift
+++ b/fixtures/ios_app_with_static_frameworks/Modules/C/Sources/C.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public class C {
+    public static let value: String = "cValue"
+
+    public static func printFromC() {
+        print("print from C")
+    }
+}

--- a/fixtures/ios_app_with_static_frameworks/Modules/C/Tests.plist
+++ b/fixtures/ios_app_with_static_frameworks/Modules/C/Tests.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_static_frameworks/Modules/C/Tests/CTests.swift
+++ b/fixtures/ios_app_with_static_frameworks/Modules/C/Tests/CTests.swift
@@ -1,0 +1,10 @@
+import Foundation
+import XCTest
+
+@testable import C
+
+final class CTests: XCTestCase {
+    func test_value() {
+        XCTAssertEqual(C.value, "cValue")
+    }
+}

--- a/fixtures/ios_app_with_static_frameworks/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_static_frameworks/Sources/AppDelegate.swift
@@ -1,4 +1,5 @@
 import A
+import C
 import UIKit
 
 @UIApplicationMain
@@ -13,6 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.makeKeyAndVisible()
 
         A.printFromA()
+        C.printFromC()
 
         return true
     }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/337

### Short description 📝

- The graph linter didn't account for which targets could link static products
- This led to raising an incorrect lint warning

### Solution 📦

Only flag a warning in the event a static product is linked twice (to targets that can link static products)

### Implementation 👩‍💻👨‍💻

- [x] Add a `canLinkStaticProducts` method to share link rules between the linter and graph linkable dependencies
- [x] Update fixture
- [x] Update changelog 

### Test Plan 🛠

- Run unit tests via `swift lint`
- Run acceptance tests via `bundle exec rake features`
- Manually generate `fixtures/ios_app_with_static_frameworks` via `tuist generate`
- Verify no lint warnings are displayed
