### PR TITLE
Fix custom debug variant settings generation

### DIFF
--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -98,7 +98,7 @@ final class ConfigGenerator: ConfigGenerating {
                                             fileElements: ProjectFileElements,
                                             pbxproj: PBXProj,
                                             configurationList: XCConfigurationList) throws {
-        let variant: BuildSettingsProvider.Variant = (buildConfiguration == .debug) ? .debug : .release
+        let variant: BuildSettingsProvider.Variant = (buildConfiguration.variant == .debug) ? .debug : .release
         let defaultConfigSettings = BuildSettingsProvider.projectDefault(variant: variant)
         let defaultSettingsAll = BuildSettingsProvider.projectDefault(variant: .all)
 
@@ -132,7 +132,7 @@ final class ConfigGenerator: ConfigGenerating {
                                            sourceRootPath: AbsolutePath) throws {
         let product = settingsProviderProduct(target)
         let platform = settingsProviderPlatform(target)
-        let variant: BuildSettingsProvider.Variant = (buildConfiguration == .debug) ? .debug : .release
+        let variant: BuildSettingsProvider.Variant = (buildConfiguration.variant == .debug) ? .debug : .release
 
         var settings: [String: Any] = [:]
         extend(buildSettings: &settings, with: BuildSettingsProvider.targetDefault(variant: .all,

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -155,7 +155,7 @@ final class ConfigGeneratorTests: XCTestCase {
                                               options: options)
     }
 
-    private func generateTargetConfig(additionalConfigurations: [BuildConfiguration: Configuration?] = [:]) throws {
+    private func generateTargetConfig() throws {
         let dir = try TemporaryDirectory(removeTreeOnDeinit: true)
         let xcconfigsDir = dir.path.appending(component: "xcconfigs")
         try fileHandler.createFolder(xcconfigsDir)

--- a/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -272,17 +272,21 @@ final class MultipleConfigurationsIntegrationTests: XCTestCase {
 
         let debug = try extractWorkspaceSettings(configuration: "Debug")
         let customDebug = try extractWorkspaceSettings(configuration: "CustomDebug")
-//        let release = try extractWorkspaceSettings(configuration: "Release")
-//        let customRelease = try extractWorkspaceSettings(configuration: "CustomRelease")
+        let release = try extractWorkspaceSettings(configuration: "Release")
+        let customRelease = try extractWorkspaceSettings(configuration: "CustomRelease")
 
         XCTAssertTrue(debug.contains("GCC_PREPROCESSOR_DEFINITIONS", "DEBUG=1"))
         XCTAssertTrue(customDebug.contains("GCC_PREPROCESSOR_DEFINITIONS", "DEBUG=1"))
 
-//      TODO: Waiting for tuist/xcodeproj#417 
-//        XCTAssertTrue(debug.contains("SWIFT_COMPILATION_MODE", "singlefile"))
-//        XCTAssertTrue(customDebug.contains("SWIFT_COMPILATION_MODE", "singlefile"))
-//        XCTAssertTrue(release.contains("SWIFT_COMPILATION_MODE", "wholemodule"))
-//        XCTAssertTrue(customRelease.contains("SWIFT_COMPILATION_MODE", "wholemodule"))
+        XCTAssertTrue(debug.contains("SWIFT_ACTIVE_COMPILATION_CONDITIONS", "DEBUG"))
+        XCTAssertTrue(customDebug.contains("SWIFT_ACTIVE_COMPILATION_CONDITIONS", "DEBUG"))
+        XCTAssertFalse(release.contains("SWIFT_ACTIVE_COMPILATION_CONDITIONS", "DEBUG"))
+        XCTAssertFalse(customRelease.contains("SWIFT_ACTIVE_COMPILATION_CONDITIONS", "DEBUG"))
+
+        XCTAssertTrue(debug.contains("SWIFT_COMPILATION_MODE", "singlefile"))
+        XCTAssertTrue(customDebug.contains("SWIFT_COMPILATION_MODE", "singlefile"))
+        XCTAssertTrue(release.contains("SWIFT_COMPILATION_MODE", "wholemodule"))
+        XCTAssertTrue(customRelease.contains("SWIFT_COMPILATION_MODE", "wholemodule"))
     }
 
     // MARK: - Helpers

--- a/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -250,6 +250,29 @@ final class MultipleConfigurationsIntegrationTests: XCTestCase {
         XCTAssertTrue(debug.contains("TARGET", "YES")) // from target settings
     }
 
+    func testGenerateWhenCustomDebugVariant() throws {
+        // Given
+        let projectDebugConfiguration = Configuration(settings: ["A": "A_PROJECT_DEBUG",
+                                                                 "B": "B_PROJECT_DEBUG"])
+        let projectReleaseConfiguration = Configuration(settings: ["A": "A_PROJECT_RELEASE",
+                                                                   "C": "C_PROJECT_RELEASE"])
+        let projectSettings = Settings(configurations: [.debug: projectDebugConfiguration,
+                                                        .debug("CustomDebug"): projectReleaseConfiguration])
+
+        // When
+        try generateWorkspace(projectSettings: projectSettings, targetSettings: nil)
+
+        // Then
+        assertProject(expectedConfigurations: ["Debug", "CustomDebug"])
+        assertTarget(expectedConfigurations: ["Debug", "CustomDebug"])
+
+        let debug = try extractWorkspaceSettings(configuration: "Debug")
+        let customDebug = try extractWorkspaceSettings(configuration: "CustomDebug")
+
+        XCTAssertTrue(debug.contains("GCC_PREPROCESSOR_DEFINITIONS", "DEBUG=1"))
+        XCTAssertTrue(customDebug.contains("GCC_PREPROCESSOR_DEFINITIONS", "DEBUG=1"))
+    }
+
     // MARK: - Helpers
 
     private func generateWorkspace(projectSettings: Settings, targetSettings: Settings?) throws {

--- a/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -250,27 +250,39 @@ final class MultipleConfigurationsIntegrationTests: XCTestCase {
         XCTAssertTrue(debug.contains("TARGET", "YES")) // from target settings
     }
 
-    func testGenerateWhenCustomDebugVariant() throws {
+    func testGenerateWhenCustomConfigurations() throws {
         // Given
         let projectDebugConfiguration = Configuration(settings: ["A": "A_PROJECT_DEBUG",
                                                                  "B": "B_PROJECT_DEBUG"])
-        let projectReleaseConfiguration = Configuration(settings: ["A": "A_PROJECT_RELEASE",
-                                                                   "C": "C_PROJECT_RELEASE"])
+        let projectCustomDebugConfiguration = Configuration(settings: ["A": "A_PROJECT_RELEASE",
+                                                                       "C": "C_PROJECT_RELEASE"])
+        let projectReleaseConfiguration = Configuration(settings: [:])
+        let projectCustomReleaseConfiguration = Configuration(settings: ["E": "E_PROJECT_RELEASE"])
         let projectSettings = Settings(configurations: [.debug: projectDebugConfiguration,
-                                                        .debug("CustomDebug"): projectReleaseConfiguration])
+                                                        .debug("CustomDebug"): projectCustomDebugConfiguration,
+                                                        .release: projectReleaseConfiguration,
+                                                        .release("CustomRelease"): projectCustomReleaseConfiguration])
 
         // When
         try generateWorkspace(projectSettings: projectSettings, targetSettings: nil)
 
         // Then
-        assertProject(expectedConfigurations: ["Debug", "CustomDebug"])
-        assertTarget(expectedConfigurations: ["Debug", "CustomDebug"])
+        assertProject(expectedConfigurations: ["CustomDebug", "CustomRelease", "Debug", "Release"])
+        assertTarget(expectedConfigurations: ["CustomDebug", "CustomRelease", "Debug", "Release"])
 
         let debug = try extractWorkspaceSettings(configuration: "Debug")
         let customDebug = try extractWorkspaceSettings(configuration: "CustomDebug")
+//        let release = try extractWorkspaceSettings(configuration: "Release")
+//        let customRelease = try extractWorkspaceSettings(configuration: "CustomRelease")
 
         XCTAssertTrue(debug.contains("GCC_PREPROCESSOR_DEFINITIONS", "DEBUG=1"))
         XCTAssertTrue(customDebug.contains("GCC_PREPROCESSOR_DEFINITIONS", "DEBUG=1"))
+
+//      TODO: Waiting for tuist/xcodeproj#417 
+//        XCTAssertTrue(debug.contains("SWIFT_COMPILATION_MODE", "singlefile"))
+//        XCTAssertTrue(customDebug.contains("SWIFT_COMPILATION_MODE", "singlefile"))
+//        XCTAssertTrue(release.contains("SWIFT_COMPILATION_MODE", "wholemodule"))
+//        XCTAssertTrue(customRelease.contains("SWIFT_COMPILATION_MODE", "wholemodule"))
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
### Short description 📝

Custom debug settings were populated with release default settings (provided by XcodeProj). The issue was introduced while implementing custom configurations (https://github.com/tuist/tuist/pull/320). It does not affect Tuist users as we still do offer only `.debug` and `.release` configurations.

### Solution 📦

Fixed incorrect code converting build configuration into XcodeProj variant in `ConfigGenerator`, also added some unit and integration tests.