### PR TITLE
Reformat static json strings in some of the tests to simplify git merge conflicts resolution

### DIFF
--- a/Tests/ProjectDescriptionTests/SchemeTests.swift
+++ b/Tests/ProjectDescriptionTests/SchemeTests.swift
@@ -24,7 +24,72 @@ final class SchemeTests: XCTestCase {
                                                   arguments: Arguments(environment: ["run": "b"],
                                                                        launch: ["run": true])))
 
-        let expected = "{\"build_action\": {\"targets\": [\"target\"], \"pre_actions\": [{\"title\": \"Run Script\", \"script_text\": \"echo build_action\", \"target\": \"target\"}], \"post_actions\": [{\"title\": \"Run Script\", \"script_text\": \"echo build_action\", \"target\": \"target\"}]}, \"name\": \"scheme\", \"run_action\": {\"arguments\": {\"environment\": {\"run\": \"b\"}, \"launch\": {\"run\": true}}, \"config\": \"debug\", \"executable\": \"executable\"}, \"shared\": true, \"test_action\": {\"arguments\": {\"environment\": {\"test\": \"b\"}, \"launch\": {\"test\": true}}, \"config\": \"debug\", \"coverage\": true, \"targets\": [\"target\"],  \"pre_actions\": [{\"title\": \"Run Script\", \"script_text\": \"echo test_action\", \"target\": \"target\"}], \"post_actions\": [{\"title\": \"Run Script\", \"script_text\": \"echo test_action\", \"target\": \"target\"}]}}"
+        let expected = """
+        {
+            "build_action": {
+                "targets": [
+                    "target"
+                ],
+                "pre_actions": [
+                    {
+                        "title": "Run Script",
+                        "script_text": "echo build_action",
+                        "target": "target"
+                    }
+                ],
+                "post_actions": [
+                    {
+                        "title": "Run Script",
+                        "script_text": "echo build_action",
+                        "target": "target"
+                    }
+                ]
+            },
+            "name": "scheme",
+            "run_action": {
+                "arguments": {
+                    "environment": {
+                        "run": "b"
+                    },
+                    "launch": {
+                        "run": true
+                    }
+                },
+                "config": "debug",
+                "executable": "executable"
+            },
+            "shared": true,
+            "test_action": {
+                "arguments": {
+                    "environment": {
+                        "test": "b"
+                    },
+                    "launch": {
+                        "test": true
+                    }
+                },
+                "config": "debug",
+                "coverage": true,
+                "targets": [
+                    "target"
+                ],
+                "pre_actions": [
+                    {
+                        "title": "Run Script",
+                        "script_text": "echo test_action",
+                        "target": "target"
+                    }
+                ],
+                "post_actions": [
+                    {
+                        "title": "Run Script",
+                        "script_text": "echo test_action",
+                        "target": "target"
+                    }
+                ]
+            }
+        }
+        """
         assertCodableEqualToJson(subject, expected)
     }
 }

--- a/Tests/ProjectDescriptionTests/TargetTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetTests.swift
@@ -32,7 +32,92 @@ final class TargetTests: XCTestCase {
                              coreDataModels: [CoreDataModel("pat", currentVersion: "version")],
                              environment: ["a": "b"])
 
-        let expected = "{\"headers\":{\"public\":\"public\\/*\",\"private\":\"private\\/*\",\"project\":\"project\\/*\"},\"bundle_id\":\"bundle_id\",\"core_data_models\":[{\"path\":\"pat\",\"current_version\":\"version\"}],\"actions\":[{\"arguments\":[\"arg\"],\"path\":\"path\",\"order\":\"post\",\"name\":\"name\"}],\"product\":\"app\",\"sources\":{\"globs\":[\"sources\\/*\"]},\"settings\":{\"base\":{\"a\":\"b\"},\"debug\":{\"xcconfig\":\"config\",\"settings\":{\"a\":\"b\"}},\"release\":{\"xcconfig\":\"config\",\"settings\":{\"a\":\"b\"}}},\"resources\":[{\"type\":\"glob\",\"pattern\":\"resources\\/*\"}],\"platform\":\"ios\",\"entitlements\":\"entitlement\",\"info_plist\":{\"type\": \"file\",\"path\":\"info.plist\"},\"dependencies\":[{\"type\":\"framework\",\"path\":\"path\"},{\"path\":\"path\",\"public_headers\":\"public\",\"swift_module_map\":\"module\",\"type\":\"library\"},{\"type\":\"project\",\"target\":\"target\",\"path\":\"path\"},{\"type\":\"target\",\"name\":\"name\"}],\"environment\":{\"a\":\"b\"},\"name\":\"name\"}"
+        let expected = """
+        {
+            "headers": {
+                "public": "public\\/*",
+                "private": "private\\/*",
+                "project": "project\\/*"
+            },
+            "bundle_id": "bundle_id",
+            "core_data_models": [
+                {
+                    "path": "pat",
+                    "current_version": "version"
+                }
+            ],
+            "actions": [
+                {
+                    "arguments": [
+                        "arg"
+                    ],
+                    "path": "path",
+                    "order": "post",
+                    "name": "name"
+                }
+            ],
+            "product": "app",
+            "sources": {
+                "globs": [
+                    "sources\\/*"
+                ]
+            },
+            "settings": {
+                "base": {
+                    "a": "b"
+                },
+                "debug": {
+                    "xcconfig": "config",
+                    "settings": {
+                        "a": "b"
+                    }
+                },
+                "release": {
+                    "xcconfig": "config",
+                    "settings": {
+                        "a": "b"
+                    }
+                }
+            },
+            "resources": [
+                {
+                    "type": "glob",
+                    "pattern": "resources\\/*"
+                }
+            ],
+            "platform": "ios",
+            "entitlements": "entitlement",
+            "info_plist": {
+                "type": "file",
+                "path": "info.plist"
+            },
+            "dependencies": [
+                {
+                    "type": "framework",
+                    "path": "path"
+                },
+                {
+                    "path": "path",
+                    "public_headers": "public",
+                    "swift_module_map": "module",
+                    "type": "library"
+                },
+                {
+                    "type": "project",
+                    "target": "target",
+                    "path": "path"
+                },
+                {
+                    "type": "target",
+                    "name": "name"
+                }
+            ],
+            "environment": {
+                "a": "b"
+            },
+            "name": "name"
+        }
+        """
         assertCodableEqualToJson(subject, expected)
     }
 
@@ -65,7 +150,92 @@ final class TargetTests: XCTestCase {
                              coreDataModels: [CoreDataModel("pat", currentVersion: "version")],
                              environment: ["a": "b"])
 
-        let expected = "{\"headers\":{\"public\":\"public\\/*\",\"private\":\"private\\/*\",\"project\":\"project\\/*\"},\"bundle_id\":\"bundle_id\",\"core_data_models\":[{\"path\":\"pat\",\"current_version\":\"version\"}],\"actions\":[{\"arguments\":[\"arg\"],\"path\":\"path\",\"order\":\"post\",\"name\":\"name\"}],\"product\":\"app\",\"sources\":{\"globs\":[\"sources\\/*\"]},\"settings\":{\"base\":{\"a\":\"b\"},\"debug\":{\"xcconfig\":\"config\",\"settings\":{\"a\":\"b\"}},\"release\":{\"xcconfig\":\"config\",\"settings\":{\"a\":\"b\"}}},\"resources\":[{\"type\":\"glob\",\"pattern\":\"resources\\/*\"}],\"platform\":\"ios\",\"entitlements\":\"entitlement\",\"info_plist\":{\"type\": \"file\",\"path\":\"info.plist\"},\"dependencies\":[{\"type\":\"framework\",\"path\":\"path\"},{\"path\":\"path\",\"public_headers\":\"public\",\"swift_module_map\":\"module\",\"type\":\"library\"},{\"type\":\"project\",\"target\":\"target\",\"path\":\"path\"},{\"type\":\"target\",\"name\":\"name\"}],\"environment\":{\"a\":\"b\"},\"name\":\"name\"}"
+        let expected = """
+        {
+            "headers": {
+                "public": "public\\/*",
+                "private": "private\\/*",
+                "project": "project\\/*"
+            },
+            "bundle_id": "bundle_id",
+            "core_data_models": [
+                {
+                    "path": "pat",
+                    "current_version": "version"
+                }
+            ],
+            "actions": [
+                {
+                    "arguments": [
+                        "arg"
+                    ],
+                    "path": "path",
+                    "order": "post",
+                    "name": "name"
+                }
+            ],
+            "product": "app",
+            "sources": {
+                "globs": [
+                    "sources\\/*"
+                ]
+            },
+            "settings": {
+                "base": {
+                    "a": "b"
+                },
+                "debug": {
+                    "xcconfig": "config",
+                    "settings": {
+                        "a": "b"
+                    }
+                },
+                "release": {
+                    "xcconfig": "config",
+                    "settings": {
+                        "a": "b"
+                    }
+                }
+            },
+            "resources": [
+                {
+                    "type": "glob",
+                    "pattern": "resources\\/*"
+                }
+            ],
+            "platform": "ios",
+            "entitlements": "entitlement",
+            "info_plist": {
+                "type": "file",
+                "path": "info.plist"
+            },
+            "dependencies": [
+                {
+                    "type": "framework",
+                    "path": "path"
+                },
+                {
+                    "path": "path",
+                    "public_headers": "public",
+                    "swift_module_map": "module",
+                    "type": "library"
+                },
+                {
+                    "type": "project",
+                    "target": "target",
+                    "path": "path"
+                },
+                {
+                    "type": "target",
+                    "name": "name"
+                }
+            ],
+            "environment": {
+                "a": "b"
+            },
+            "name": "name"
+        }
+        """
         assertCodableEqualToJson(subject, expected)
     }
 }

--- a/Tests/ProjectDescriptionTests/assertCodableEqualToJson.swift
+++ b/Tests/ProjectDescriptionTests/assertCodableEqualToJson.swift
@@ -1,7 +1,7 @@
 import Foundation
 import XCTest
 
-func assertCodableEqualToJson<C: Codable>(_ subject: C, _ json: String) {
+func assertCodableEqualToJson<C: Codable>(_ subject: C, _ json: String, file: StaticString = #file, line: UInt = #line) {
     let decoder = JSONDecoder()
     let decoded = try! decoder.decode(C.self, from: json.data(using: .utf8)!)
     let encoder = JSONEncoder()
@@ -9,5 +9,5 @@ func assertCodableEqualToJson<C: Codable>(_ subject: C, _ json: String) {
     let jsonData = try! encoder.encode(decoded)
     let subjectData = try! encoder.encode(subject)
 
-    XCTAssert(jsonData == subjectData, "JSON does not match the encoded \(String(describing: subject))")
+    XCTAssert(jsonData == subjectData, "JSON does not match the encoded \(String(describing: subject))", file: file, line: line)
 }


### PR DESCRIPTION
### Short description 📝

Small refactoring of some of `ProjectDescription` tests to ease the process of resolving git merge conflict

### Implementation 👩‍💻👨‍💻

- Use multiline strings to allow to use json without escaping characters (`\"`)
- Add `file` and `line` parameters to `assertCodableEqualToJson` to improve error reporting