### PR TITLE
Handle the scenario where several sources glob patterns match the same paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Ensuring the correct default settings provider dependency is used https://github.com/tuist/tuist/pull/389 by @kwridan
 - Fixing build settings repeated same value https://github.com/tuist/tuist/pull/391 @platonsi
+- Duplicated files in the sources build phase when different glob patterns match the same files https://github.com/tuist/tuist/pull/388 by @pepibumur.
 
 ## 0.15.0
 

--- a/Sources/TuistGenerator/Models/Target.swift
+++ b/Sources/TuistGenerator/Models/Target.swift
@@ -95,14 +95,16 @@ public class Target: Equatable {
     }
 
     public static func sources(projectPath: AbsolutePath, sources: [(glob: String, compilerFlags: String?)]) throws -> [Target.SourceFile] {
-        return sources.flatMap { source in
+        var sourceFiles: [AbsolutePath: Target.SourceFile] = [:]
+        sources.forEach { source in
             projectPath.glob(source.glob).filter { path in
                 if let `extension` = path.extension, Target.validSourceExtensions.contains(`extension`) {
                     return true
                 }
                 return false
-            }.map { (path: $0, compilerFlags: source.compilerFlags) }
+            }.forEach { sourceFiles[$0] = (path: $0, compilerFlags: source.compilerFlags) }
         }
+        return Array(sourceFiles.values)
     }
 
     public static func isResource(path: AbsolutePath, fileHandler: FileHandling) -> Bool {

--- a/Tests/TuistGeneratorTests/Models/TargetTests.swift
+++ b/Tests/TuistGeneratorTests/Models/TargetTests.swift
@@ -62,17 +62,19 @@ final class TargetTests: XCTestCase {
 
         // When
         let sources = try Target.sources(projectPath: fileHandler.currentPath,
-                                         sources: [(glob: "sources/**", compilerFlags: nil)])
+                                         sources: [
+                                             (glob: "sources/**", compilerFlags: nil),
+                                             (glob: "sources/**", compilerFlags: nil),
+                                         ])
 
         // Then
         let relativeSources = sources.map { $0.path.relative(to: fileHandler.currentPath).pathString }
-        XCTAssertEqual(relativeSources, [
-            "sources/a.swift",
-            "sources/b.m",
-            "sources/c.mm",
-            "sources/d.c",
-            "sources/e.cpp",
-        ])
+        XCTAssertEqual(relativeSources.count, 5)
+        XCTAssertTrue(relativeSources.contains("sources/e.cpp"))
+        XCTAssertTrue(relativeSources.contains("sources/c.mm"))
+        XCTAssertTrue(relativeSources.contains("sources/b.m"))
+        XCTAssertTrue(relativeSources.contains("sources/d.c"))
+        XCTAssertTrue(relativeSources.contains("sources/a.swift"))
     }
 
     func test_resources() throws {

--- a/Tests/TuistGeneratorTests/Models/TargetTests.swift
+++ b/Tests/TuistGeneratorTests/Models/TargetTests.swift
@@ -69,12 +69,14 @@ final class TargetTests: XCTestCase {
 
         // Then
         let relativeSources = sources.map { $0.path.relative(to: fileHandler.currentPath).pathString }
-        XCTAssertEqual(relativeSources.count, 5)
-        XCTAssertTrue(relativeSources.contains("sources/e.cpp"))
-        XCTAssertTrue(relativeSources.contains("sources/c.mm"))
-        XCTAssertTrue(relativeSources.contains("sources/b.m"))
-        XCTAssertTrue(relativeSources.contains("sources/d.c"))
-        XCTAssertTrue(relativeSources.contains("sources/a.swift"))
+        
+        XCTAssertEqual(Set(relativeSources), Set([
+            "sources/a.swift",
+            "sources/b.m",
+            "sources/c.mm",
+            "sources/d.c",
+            "sources/e.cpp",
+            ]))
     }
 
     func test_resources() throws {

--- a/docs/usage/2-manifest.mdx
+++ b/docs/usage/2-manifest.mdx
@@ -229,6 +229,8 @@ default: ""
 
 <Message info title="ExpressibleByStringLiteral and ExpressibleByArrayLiteral" description="The list of source files can be initialized with a string that represents the glob pattern, or an array of strings, which represents a list of glob patterns. In both cases the comiler flags will have no value."/>
 
+<Message info title="Patterns matching the same paths" description="If multiple patterns match the same paths, the latest one takes preference over the others. That also means that the latest compiler flags will be applied."/>
+
 ### Source file glob
 
 It represents a glob pattern that refers to source files and the compiler flags *(if any)* to be set in the build phase:


### PR DESCRIPTION
### Short description 📝
If two sources glob patterns match the same files, they end up being duplicated in the sources build phase. This PR fixes it.

### Solution 📦
The latest pattern takes preference over the others.

### Implementation 👩‍💻👨‍💻
- [x] Change the logic that flatmaps the patterns.
- [x] Update documentation.
- [x] Add a test.

cc @RomainBoulay