### PR TITLE
Ensuring the correct default settings provider dependency is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next version
 
+### Fixed
+
+- Ensuring the correct default settings provider dependency is used https://github.com/tuist/tuist/pull/389 by @kwridan
+
 ## 0.15.0
 
 ### Changed

--- a/Sources/TuistGenerator/Generator/WorkspaceGenerator.swift
+++ b/Sources/TuistGenerator/Generator/WorkspaceGenerator.swift
@@ -47,7 +47,9 @@ final class WorkspaceGenerator: WorkspaceGenerating {
                      fileHandler: FileHandling = FileHandler(),
                      defaultSettingsProvider: DefaultSettingsProviding = DefaultSettingsProvider()) {
         let configGenerator = ConfigGenerator(defaultSettingsProvider: defaultSettingsProvider)
-        let projectGenerator = ProjectGenerator(configGenerator: configGenerator,
+        let targetGenerator = TargetGenerator(configGenerator: configGenerator)
+        let projectGenerator = ProjectGenerator(targetGenerator: targetGenerator,
+                                                configGenerator: configGenerator,
                                                 printer: printer,
                                                 system: system)
         self.init(system: system,


### PR DESCRIPTION
### Short description 📝

- The `defaultSettingsProvider` passed to the `WorkspaceGenerator` wasn't being passed along to the `TargetGenerator`
- This led to having 2 different implementations running side by side

### Solution 📦

- The target generator is now created and injected to the project generator

### Implementation 👩‍💻👨‍💻

- [x] Update target generator dependency 
- [x] Update change log

### Test Plan 🛠

- Verify unit tests pass via `swift tests`
- Verify acceptance tests pass via `bundle exec rake features`