### PR TITLE
Build settings have the same values repeated multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Ensuring the correct default settings provider dependency is used https://github.com/tuist/tuist/pull/389 by @kwridan
+- Fixing build settings repeated same value https://github.com/tuist/tuist/pull/391 @platonsi
 
 ## 0.15.0
 
@@ -23,7 +24,6 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
-- Fixing build settings repeated same value https://github.com/tuist/tuist/pull/391 @platonsi
 - Fixing unstable diff (products and embedded frameworks) https://github.com/tuist/tuist/pull/357 by @marciniwanicki
 - Set Code Sign On Copy to true for Embed Frameworks https://github.com/tuist/tuist/pull/333 by @dangthaison91
 - Fixing files getting mistaken for folders https://github.com/tuist/tuist/pull/338 by @kwridan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
+- Fixing build settings repeated same value https://github.com/tuist/tuist/pull/391 @platonsi
 - Fixing unstable diff (products and embedded frameworks) https://github.com/tuist/tuist/pull/357 by @marciniwanicki
 - Set Code Sign On Copy to true for Embed Frameworks https://github.com/tuist/tuist/pull/333 by @dangthaison91
 - Fixing files getting mistaken for folders https://github.com/tuist/tuist/pull/338 by @kwridan

--- a/Sources/TuistGenerator/Utils/SettingsHelper.swift
+++ b/Sources/TuistGenerator/Utils/SettingsHelper.swift
@@ -6,7 +6,8 @@ final class SettingsHelper {
         other.forEach { key, value in
             if buildSettings[key] == nil || (value as? String)?.contains("$(inherited)") == false {
                 buildSettings[key] = value
-            } else if let previousValueString = buildSettings[key] as? String, let newValueString = value as? String {
+            } else if let previousValueString = buildSettings[key] as? String, let newValueString = value as? String,
+                previousValueString != newValueString {
                 buildSettings[key] = "\(previousValueString) \(newValueString)"
             } else {
                 buildSettings[key] = value

--- a/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -49,7 +49,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
 
     private let appTargetEssentialDebugSettings: [String: Any] = [
         "SDKROOT": "iphoneos",
-        "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/Frameworks $(inherited) @executable_path/Frameworks",
+        "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/Frameworks",
         "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
         "CODE_SIGN_IDENTITY": "iPhone Developer",
         "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -57,7 +57,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
     ]
 
     private let appTargetEssentialReleaseSettings: [String: Any] = [
-        "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/Frameworks $(inherited) @executable_path/Frameworks",
+        "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/Frameworks",
         "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
         "TARGETED_DEVICE_FAMILY": "1,2",
         "SWIFT_COMPILATION_MODE": "wholemodule",
@@ -77,7 +77,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
         "TARGETED_DEVICE_FAMILY": "1,2",
         "SDKROOT": "iphoneos",
-        "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(inherited) @executable_path/Frameworks @loader_path/Frameworks",
+        "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/Frameworks @loader_path/Frameworks",
         "DEFINES_MODULE": "YES",
         "VERSION_INFO_PREFIX": "",
         "CURRENT_PROJECT_VERSION": "1",
@@ -88,7 +88,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
 
     private let frameworkTargetEssentialReleaseSettings: [String: Any] = [
         "SWIFT_OPTIMIZATION_LEVEL": "-Owholemodule",
-        "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(inherited) @executable_path/Frameworks @loader_path/Frameworks",
+        "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/Frameworks @loader_path/Frameworks",
         "DEFINES_MODULE": "YES",
         "DYLIB_INSTALL_NAME_BASE": "@rpath",
         "INSTALL_PATH": "$(LOCAL_LIBRARY_DIR)/Frameworks",

--- a/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
@@ -64,6 +64,29 @@ final class SettingsHelpersTests: XCTestCase {
         XCTAssertEqualDictionaries(settings, ["A": "A_VALUE $(inherited) A_VALUE_2", "B": "B_VALUE", "C": "C_VALUE"])
     }
 
+    func testNotExtend_whenExistingSettingsAndNewWithSameValues() {
+        // Given
+        settings["A"] = "A_VALUE"
+        settings["B"] = "B_VALUE"
+
+        // When
+        subject.extend(buildSettings: &settings, with: ["A": "A_VALUE"])
+
+        // Then
+        XCTAssertEqualDictionaries(settings, ["A": "A_VALUE", "B": "B_VALUE"])
+    }
+
+    func testNotExtend_whenExistingSettingsAndNewWithInheritedDeclarationAndSameValues() {
+        // Given
+        settings["A"] = "$(inherited) A_VALUE"
+
+        // When
+        subject.extend(buildSettings: &settings, with: ["A": "$(inherited) A_VALUE",])
+
+        // Then
+        XCTAssertEqualDictionaries(settings, ["A": "$(inherited) A_VALUE"])
+    }
+
     func testSettingsProviderPlatform() {
         XCTAssertEqual(subject.settingsProviderPlatform(.test(platform: .iOS)), .iOS)
         XCTAssertEqual(subject.settingsProviderPlatform(.test(platform: .macOS)), .macOS)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/390

### Short description 📝

The `DefaultSettingsProvider` `targetSettings` combines the build settings for the specified build variant with the build settings for variants. If there is a common build setting with `$(inherited)` in its value, the value is appended twice.

### Solution 📦

In the `SettingsHelper` before combining build settings by appending the new value to the existing one check if the value are equal

### Implementation 👩‍💻👨‍💻

- [ ] Change `SettingsHelper` to check if setting values are equal before appending
- [ ] Add unit test to cover this case

###  Test Plan 🛠
- Verify unit tests pass via swift tests
