### PR TITLE
Ensuring the correct default settings provider dependency is used

### DIFF
--- a/Sources/TuistGenerator/Generator.swift
+++ b/Sources/TuistGenerator/Generator.swift
@@ -62,9 +62,12 @@ public class Generator: Generating {
                             modelLoader: GeneratorModelLoading) {
         let graphLoader = GraphLoader(printer: printer, modelLoader: modelLoader)
         let configGenerator = ConfigGenerator(defaultSettingsProvider: defaultSettingsProvider)
-        let projectGenerator = ProjectGenerator(configGenerator: configGenerator,
+        let targetGenerator = TargetGenerator(configGenerator: configGenerator)
+        let projectGenerator = ProjectGenerator(targetGenerator: targetGenerator,
+                                                configGenerator: configGenerator,
                                                 printer: printer,
-                                                system: system)
+                                                system: system,
+                                                fileHandler: fileHandler)
         let workspaceStructureGenerator = WorkspaceStructureGenerator(fileHandler: fileHandler)
         let workspaceGenerator = WorkspaceGenerator(system: system,
                                                     printer: printer,

--- a/Sources/TuistGenerator/Generator/WorkspaceGenerator.swift
+++ b/Sources/TuistGenerator/Generator/WorkspaceGenerator.swift
@@ -51,7 +51,8 @@ final class WorkspaceGenerator: WorkspaceGenerating {
         let projectGenerator = ProjectGenerator(targetGenerator: targetGenerator,
                                                 configGenerator: configGenerator,
                                                 printer: printer,
-                                                system: system)
+                                                system: system,
+                                                fileHandler: fileHandler)
         self.init(system: system,
                   printer: printer,
                   projectDirectoryHelper: projectDirectoryHelper,


### PR DESCRIPTION
### Short description 📝

- The `defaultSettingsProvider` passed to the `Generator` wasn't being passed along to the `ProjectGenerator`
- This led to having 2 different implementations running side by side
- Sadly this got missed in a previous fix https://github.com/tuist/tuist/pull/389 

### Solution 📦

- The target generator is now created and injected to the project generator

### Implementation 👩‍💻👨‍💻

- [x] Update project generator dependency

### Test Plan 🛠

- Verify unit tests pass via `swift tests`
- Verify acceptance tests pass via `bundle exec rake features`