### PR TITLE
Add .d as a valid source extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Ensuring the correct default settings provider dependency is used https://github.com/tuist/tuist/pull/389 by @kwridan
 - Fixing build settings repeated same value https://github.com/tuist/tuist/pull/391 @platonsi
 - Duplicated files in the sources build phase when different glob patterns match the same files https://github.com/tuist/tuist/pull/388 by @pepibumur.
+- Support `.d` source files https://github.com/tuist/tuist/pull/396 by @pepibumur.
 
 ## 0.15.0
 

--- a/Sources/TuistGenerator/Models/Target.swift
+++ b/Sources/TuistGenerator/Models/Target.swift
@@ -7,7 +7,7 @@ public class Target: Equatable {
 
     // MARK: - Static
 
-    static let validSourceExtensions: [String] = ["m", "swift", "mm", "cpp", "c"]
+    static let validSourceExtensions: [String] = ["m", "swift", "mm", "cpp", "c", "d"]
     static let validFolderExtensions: [String] = ["framework", "bundle", "app", "xcassets", "appiconset"]
 
     // MARK: - Attributes

--- a/Tests/TuistGeneratorTests/Models/TargetTests.swift
+++ b/Tests/TuistGeneratorTests/Models/TargetTests.swift
@@ -14,7 +14,7 @@ final class TargetTests: XCTestCase {
     }
 
     func test_validSourceExtensions() {
-        XCTAssertEqual(Target.validSourceExtensions, ["m", "swift", "mm", "cpp", "c"])
+        XCTAssertEqual(Target.validSourceExtensions, ["m", "swift", "mm", "cpp", "c", "d"])
     }
 
     func test_productName_when_staticLibrary() {


### PR DESCRIPTION
### Short description 📝
We were filtering out `.d` files from the list of sources.

### Solution 📦
Change the `validSourceExtensions` value to include files with the `.d` extension.

### Implementation 👩‍💻👨‍💻
- [x] Update the value.
- [x] Fix the tests.
- [x] Update CHANGELOG.

cc @romainboulay