### PR TITLE
[codesign-frameworks] if CODE_SIGNING_IDENTITY is defined ensure the framework is signed when embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fixing build settings repeated same value https://github.com/tuist/tuist/pull/391 @platonsi
 - Duplicated files in the sources build phase when different glob patterns match the same files https://github.com/tuist/tuist/pull/388 by @pepibumur.
 - Support `.d` source files https://github.com/tuist/tuist/pull/396 by @pepibumur.
+- Codesign frameworks when copying during the embed phase https://github.com/tuist/tuist/issues/328 by @ollieatkinson
 
 ## 0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fixing build settings repeated same value https://github.com/tuist/tuist/pull/391 @platonsi
 - Duplicated files in the sources build phase when different glob patterns match the same files https://github.com/tuist/tuist/pull/388 by @pepibumur.
 - Support `.d` source files https://github.com/tuist/tuist/pull/396 by @pepibumur.
-- Codesign frameworks when copying during the embed phase https://github.com/tuist/tuist/issues/328 by @ollieatkinson
+- Codesign frameworks when copying during the embed phase https://github.com/tuist/tuist/pull/398 by @ollieatkinson
 
 ## 0.15.0
 

--- a/Sources/TuistKit/Embed/FrameworkEmbedder.swift
+++ b/Sources/TuistKit/Embed/FrameworkEmbedder.swift
@@ -66,20 +66,20 @@ final class FrameworkEmbedder: FrameworkEmbedding {
         try copyBCSymbolMaps(action: action, frameworkAbsolutePath: frameworkAbsolutePath, builtProductsDir: builtProductsDir)
         
         if let codeSigningIdentity = environment.codeSigningIdentity {
-            try codesignFramework(frameworkPath: copiedFramework, codeSigningIdentify: codeSigningIdentity)
+            try codesignFramework(frameworkPath: copiedFramework, codeSigningIdentity: codeSigningIdentity)
         }
         
     }
 
     // MARK: - Fileprivate
     
-    private func codesignFramework(frameworkPath: AbsolutePath, codeSigningIdentify: String) throws {
+    private func codesignFramework(frameworkPath: AbsolutePath, codeSigningIdentity: String) throws {
         /// We need to ensure the frameworks are codesigned after being copied to the built products directory.
         /// Passing `preserve-metadata=identifier,entitlements` ensures any signatures or entitlements which are
         /// already there are preserved.
         try system.run([
             "/usr/bin/xcrun",
-            "codesign", "--force", "--sign", codeSigningIdentify, "--preserve-metadata=identifier,entitlements", frameworkPath.pathString
+            "codesign", "--force", "--sign", codeSigningIdentity, "--preserve-metadata=identifier,entitlements", frameworkPath.pathString
         ])
     }
 

--- a/Sources/TuistKit/Embed/FrameworkEmbedder.swift
+++ b/Sources/TuistKit/Embed/FrameworkEmbedder.swift
@@ -65,7 +65,7 @@ final class FrameworkEmbedder: FrameworkEmbedding {
         try copySymbols(frameworkDsymPath: frameworkDsymPath, destinationPath: destinationPath, validArchs: validArchs)
         try copyBCSymbolMaps(action: action, frameworkAbsolutePath: frameworkAbsolutePath, builtProductsDir: builtProductsDir)
         
-        if let codeSigningIdentity = environment.codeSigningIdentity {
+        if environment.codeSigningAllowed, let codeSigningIdentity = environment.codeSigningIdentity {
             try codesignFramework(frameworkPath: copiedFramework, codeSigningIdentity: codeSigningIdentity)
         }
         

--- a/Sources/TuistKit/Embed/XcodeBuild.swift
+++ b/Sources/TuistKit/Embed/XcodeBuild.swift
@@ -103,7 +103,7 @@ class XcodeBuild {
             }
         }
 
-        internal func frameworksPath() -> AbsolutePath {
+        func frameworksPath() -> AbsolutePath {
             return destinationPath().appending(RelativePath(frameworksFolderPath))
         }
     }

--- a/Sources/TuistKit/Embed/XcodeBuild.swift
+++ b/Sources/TuistKit/Embed/XcodeBuild.swift
@@ -37,6 +37,7 @@ class XcodeBuild {
         public let validArchs: [String]
         public let srcRoot: String
         public let action: Action
+        public let codeSigningIdentity: String?
 
         public init(configuration: String,
                     frameworksFolderPath: String,
@@ -44,7 +45,8 @@ class XcodeBuild {
                     targetBuildDir: String,
                     validArchs: [String],
                     srcRoot: String,
-                    action: Action) {
+                    action: Action,
+                    codeSigningIdentity: String?) {
             self.configuration = configuration
             self.frameworksFolderPath = frameworksFolderPath
             self.builtProductsDir = builtProductsDir
@@ -52,6 +54,7 @@ class XcodeBuild {
             self.validArchs = validArchs
             self.srcRoot = srcRoot
             self.action = action
+            self.codeSigningIdentity = codeSigningIdentity
         }
 
         public init(environment: [String: String] = ProcessInfo.processInfo.environment) throws {
@@ -83,6 +86,7 @@ class XcodeBuild {
             self.validArchs = validArchs.components(separatedBy: " ")
             self.srcRoot = srcRoot
             self.action = Action(rawValue: action) ?? .install
+            self.codeSigningIdentity = environment["CODE_SIGN_IDENTITY"]
         }
 
         // MARK: - Public

--- a/Sources/TuistKit/Embed/XcodeBuild.swift
+++ b/Sources/TuistKit/Embed/XcodeBuild.swift
@@ -38,6 +38,7 @@ class XcodeBuild {
         public let srcRoot: String
         public let action: Action
         public let codeSigningIdentity: String?
+        public let codeSigningAllowed: Bool
 
         public init(configuration: String,
                     frameworksFolderPath: String,
@@ -46,7 +47,8 @@ class XcodeBuild {
                     validArchs: [String],
                     srcRoot: String,
                     action: Action,
-                    codeSigningIdentity: String?) {
+                    codeSigningIdentity: String?,
+                    codeSigningAllowed: Bool) {
             self.configuration = configuration
             self.frameworksFolderPath = frameworksFolderPath
             self.builtProductsDir = builtProductsDir
@@ -55,6 +57,7 @@ class XcodeBuild {
             self.srcRoot = srcRoot
             self.action = action
             self.codeSigningIdentity = codeSigningIdentity
+            self.codeSigningAllowed = codeSigningAllowed
         }
 
         public init(environment: [String: String] = ProcessInfo.processInfo.environment) throws {
@@ -87,6 +90,7 @@ class XcodeBuild {
             self.srcRoot = srcRoot
             self.action = Action(rawValue: action) ?? .install
             self.codeSigningIdentity = environment["CODE_SIGN_IDENTITY"]
+            self.codeSigningAllowed = environment["CODE_SIGNING_ALLOWED"]?.uppercased() == "YES"
         }
 
         // MARK: - Public

--- a/Sources/TuistKit/Embed/XcodeBuild.swift
+++ b/Sources/TuistKit/Embed/XcodeBuild.swift
@@ -99,7 +99,7 @@ class XcodeBuild {
             }
         }
 
-        private func frameworksPath() -> AbsolutePath {
+        internal func frameworksPath() -> AbsolutePath {
             return destinationPath().appending(RelativePath(frameworksFolderPath))
         }
     }

--- a/Tests/TuistKitTests/Embed/FrameworkEmbedderTests.swift
+++ b/Tests/TuistKitTests/Embed/FrameworkEmbedderTests.swift
@@ -49,7 +49,7 @@ final class FrameworkEmbedderErrorTests: XCTestCase {
             let frameworkPath = universalFrameworkPath().relative(to: srcRoot)
             system.succeedCommand([
                 "/usr/bin/xcrun",
-                "codesign", "--force", "--sign", "iPhone Developer", "--preserve-metadata=identifier,entitlements", universalFrameworkPath().pathString
+                "codesign", "--force", "--sign", "iPhone Developer", "--preserve-metadata=identifier,entitlements", env.frameworksPath().appending(.init("xpm.framework")).pathString
             ])
             try subject.embed(frameworkPath: frameworkPath, environment: env)
         })
@@ -59,9 +59,11 @@ final class FrameworkEmbedderErrorTests: XCTestCase {
         XCTAssertNoThrow(try withEnvironment(codeSigningIdentity: nil) { srcRoot, env in
             let frameworkPath = universalFrameworkPath().relative(to: srcRoot)
             try subject.embed(frameworkPath: frameworkPath, environment: env)
+            XCTAssertFalse(
+                system.called("/usr/bin/xcrun",
+                              "codesign", "--force", "--sign", "iPhone Developer", "--preserve-metadata=identifier,entitlements", env.frameworksPath().appending(.init("xpm.framework")).pathString)
+            )
         })
-        XCTAssertFalse(system.called("/usr/bin/xcrun",
-                                      "codesign", "--force", "--sign", "iPhone Developer", "--preserve-metadata=identifier,entitlements", universalFrameworkPath().pathString))
     }
 
     private func universalFrameworkPath() -> AbsolutePath {

--- a/Tests/TuistKitTests/Embed/FrameworkEmbedderTests.swift
+++ b/Tests/TuistKitTests/Embed/FrameworkEmbedderTests.swift
@@ -2,14 +2,17 @@ import Basic
 import Foundation
 import XCTest
 @testable import TuistKit
+@testable import TuistCoreTesting
 
 final class FrameworkEmbedderErrorTests: XCTestCase {
     var subject: FrameworkEmbedder!
     var fm: FileManager!
+    var system: MockSystem!
 
     override func setUp() {
         super.setUp()
-        subject = FrameworkEmbedder()
+        system = MockSystem()
+        subject = FrameworkEmbedder(system: system)
         fm = FileManager.default
     }
 
@@ -40,6 +43,34 @@ final class FrameworkEmbedderErrorTests: XCTestCase {
             XCTAssertEqual(try Embeddable(path: outputDSYMPath).architectures(), ["arm64"])
         }
     }
+    
+    func test_embed_with_codesigning() throws {
+
+        XCTAssertNoThrow(try withEnvironment(codeSigningIdentity: "iPhone Developer") { srcRoot, env in
+            
+            let frameworkPath = universalFrameworkPath().relative(to: srcRoot)
+            
+            system.succeedCommand([
+                "/usr/bin/xcrun",
+                "codesign", "--force", "--sign", "iPhone Developer", "--preserve-metadata=identifier,entitlements", universalFrameworkPath().pathString
+            ])
+            
+            try subject.embed(frameworkPath: frameworkPath, environment: env)
+            
+        })
+            
+    }
+    
+    func test_embed_with_no_codesigning() {
+        
+        XCTAssertNoThrow(try withEnvironment(codeSigningIdentity: nil) { srcRoot, env in
+            let frameworkPath = universalFrameworkPath().relative(to: srcRoot)
+            try subject.embed(frameworkPath: frameworkPath, environment: env)
+        })
+        
+        XCTAssertFalse(system.called("/usr/bin/xcrun",
+                                      "codesign", "--force", "--sign", "iPhone Developer", "--preserve-metadata=identifier,entitlements", universalFrameworkPath().pathString))
+    }
 
     private func universalFrameworkPath() -> AbsolutePath {
         let testsPath = AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory
@@ -47,6 +78,7 @@ final class FrameworkEmbedderErrorTests: XCTestCase {
     }
 
     private func withEnvironment(action: XcodeBuild.Action = .install,
+                                 codeSigningIdentity: String? = nil,
                                  assert: (AbsolutePath, XcodeBuild.Environment) throws -> Void) throws {
         let tmpDir = try TemporaryDirectory(removeTreeOnDeinit: true)
         let frameworksPath = "frameworks"
@@ -68,7 +100,8 @@ final class FrameworkEmbedderErrorTests: XCTestCase {
                                                  targetBuildDir: targetBuildDir.pathString,
                                                  validArchs: validArchs,
                                                  srcRoot: srcRootPath.pathString,
-                                                 action: action)
+                                                 action: action,
+                                                 codeSigningIdentity: codeSigningIdentity)
         try assert(srcRootPath, environment)
     }
 }

--- a/Tests/TuistKitTests/Embed/FrameworkEmbedderTests.swift
+++ b/Tests/TuistKitTests/Embed/FrameworkEmbedderTests.swift
@@ -45,29 +45,21 @@ final class FrameworkEmbedderErrorTests: XCTestCase {
     }
     
     func test_embed_with_codesigning() throws {
-
         XCTAssertNoThrow(try withEnvironment(codeSigningIdentity: "iPhone Developer") { srcRoot, env in
-            
             let frameworkPath = universalFrameworkPath().relative(to: srcRoot)
-            
             system.succeedCommand([
                 "/usr/bin/xcrun",
                 "codesign", "--force", "--sign", "iPhone Developer", "--preserve-metadata=identifier,entitlements", universalFrameworkPath().pathString
             ])
-            
             try subject.embed(frameworkPath: frameworkPath, environment: env)
-            
         })
-            
     }
     
     func test_embed_with_no_codesigning() {
-        
         XCTAssertNoThrow(try withEnvironment(codeSigningIdentity: nil) { srcRoot, env in
             let frameworkPath = universalFrameworkPath().relative(to: srcRoot)
             try subject.embed(frameworkPath: frameworkPath, environment: env)
         })
-        
         XCTAssertFalse(system.called("/usr/bin/xcrun",
                                       "codesign", "--force", "--sign", "iPhone Developer", "--preserve-metadata=identifier,entitlements", universalFrameworkPath().pathString))
     }

--- a/Tests/TuistKitTests/Embed/FrameworkEmbedderTests.swift
+++ b/Tests/TuistKitTests/Embed/FrameworkEmbedderTests.swift
@@ -95,7 +95,8 @@ final class FrameworkEmbedderErrorTests: XCTestCase {
                                                  validArchs: validArchs,
                                                  srcRoot: srcRootPath.pathString,
                                                  action: action,
-                                                 codeSigningIdentity: codeSigningIdentity)
+                                                 codeSigningIdentity: codeSigningIdentity,
+                                                 codeSigningAllowed: true)
         try assert(srcRootPath, environment)
     }
 }

--- a/features/step_definitions/shared/xcode.rb
+++ b/features/step_definitions/shared/xcode.rb
@@ -18,5 +18,7 @@ Then(/I should be able to (.+) the scheme (.+)/) do |action, scheme|
   end
 
   args << "CODE_SIGNING_ALLOWED=NO"
+  args << "CODE_SIGNING_IDENTITY=\"iPhone Developer\""
+
   xcodebuild(*args)
 end


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/328

### Short description 📝

During embedding the framework was not being code signed which meant the app product was not able to be run on device.

### Solution 📦

If `CODE_SIGNING_IDENTITY` is defined in build settings ensure that frameworks are embedded are signed with that identity.
