### PR TITLE
[env-version] added version command with envversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Added
 - `DefaultSettings.none` to disable the generation of default build settings https://github.com/tuist/tuist/pull/395 by @pepibumur.
-- Version information for tuistenv # by @ollieatkinson
+- Version information for tuistenv https://github.com/tuist/tuist/pull/399 by @ollieatkinson
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Added
 - `DefaultSettings.none` to disable the generation of default build settings https://github.com/tuist/tuist/pull/395 by @pepibumur.
+- Version information for tuistenv # by @ollieatkinson
 
 ### Fixed
 

--- a/Sources/TuistCore/Constants.swift
+++ b/Sources/TuistCore/Constants.swift
@@ -6,7 +6,6 @@ public class Constants {
     public static let binName = "tuist"
     public static let gitRepositoryURL = "https://github.com/tuist/tuist.git"
     public static let version = "0.15.0"
-    public static let envVersion = "0.1.0"
     public static let swiftVersion: String = "5.0"
     public static let bundleName: String = "tuist.zip"
 }

--- a/Sources/TuistCore/Constants.swift
+++ b/Sources/TuistCore/Constants.swift
@@ -6,6 +6,7 @@ public class Constants {
     public static let binName = "tuist"
     public static let gitRepositoryURL = "https://github.com/tuist/tuist.git"
     public static let version = "0.15.0"
+    public static let envVersion = "0.1.0"
     public static let swiftVersion: String = "5.0"
     public static let bundleName: String = "tuist.zip"
 }

--- a/Sources/TuistEnvKit/Commands/CommandRegistry.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRegistry.swift
@@ -22,6 +22,7 @@ public final class CommandRegistry {
                       UpdateCommand.self,
                       InstallCommand.self,
                       UninstallCommand.self,
+                      VersionCommand.self,
                   ])
     }
 

--- a/Sources/TuistEnvKit/Commands/VersionCommand.swift
+++ b/Sources/TuistEnvKit/Commands/VersionCommand.swift
@@ -27,6 +27,6 @@ class VersionCommand: NSObject, Command {
     // MARK: - Command
     
     func run(with _: ArgumentParser.Result) {
-        printer.print(Constants.envVersion)
+        printer.print(Constants.version)
     }
 }

--- a/Sources/TuistEnvKit/Commands/VersionCommand.swift
+++ b/Sources/TuistEnvKit/Commands/VersionCommand.swift
@@ -1,0 +1,32 @@
+import Basic
+import Foundation
+import SPMUtility
+import TuistCore
+
+class VersionCommand: NSObject, Command {
+    // MARK: - Command
+    
+    static let command = "envversion"
+    static let overview = "Outputs the current version of tuist env."
+    
+    // MARK: - Attributes
+    
+    let printer: Printing
+    
+    // MARK: - Init
+    
+    required init(parser: ArgumentParser) {
+        parser.add(subparser: VersionCommand.command, overview: VersionCommand.overview)
+        printer = Printer()
+    }
+    
+    init(printer: Printing) {
+        self.printer = printer
+    }
+    
+    // MARK: - Command
+    
+    func run(with _: ArgumentParser.Result) {
+        printer.print(Constants.envVersion)
+    }
+}

--- a/docs/usage/6-managing-versions.md
+++ b/docs/usage/6-managing-versions.md
@@ -93,6 +93,15 @@ Installing...
 Version 0.4.0 installed
 ```
 
+### tuist envversion
+
+To check the current installed version of `tuistenv`, the command is:
+
+```sh
+tuist envversion
+0.15.0
+```
+
 ## Running Tuist
 
 As we mentioned earlier, Tuist version management works **transparently**. Any of the commands mentioned above are necessary to use Tuist.


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/383

### Short description 📝

tuistenv does not report it's version which makes it hard to determine which version clients are on when bugs are raised.

### Solution 📦

add `envversion` command to tuist so that it's easy to identify the version
