### PR TITLE
[tuist-local] 'tuist local' was failing to build master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Duplicated files in the sources build phase when different glob patterns match the same files https://github.com/tuist/tuist/pull/388 by @pepibumur.
 - Support `.d` source files https://github.com/tuist/tuist/pull/396 by @pepibumur.
 - Codesign frameworks when copying during the embed phase https://github.com/tuist/tuist/pull/398 by @ollieatkinson
+- 'tuist local' failed when trying to install from source https://github.com/tuist/tuist/pull/402 by @ollieatkinson
 
 ## 0.15.0
 

--- a/Sources/TuistEnvKit/Installer/Installer.swift
+++ b/Sources/TuistEnvKit/Installer/Installer.swift
@@ -188,8 +188,7 @@ final class Installer: Installing {
             try system.run(swiftPath, "build",
                            "--product", "tuist",
                            "--package-path", temporaryDirectory.path.pathString,
-                           "--configuration", "release",
-                           "-Xswiftc", "-static-stdlib")
+                           "--configuration", "release")
             try system.run(swiftPath, "build",
                            "--product", "ProjectDescription",
                            "--package-path", temporaryDirectory.path.pathString,

--- a/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
+++ b/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
@@ -170,8 +170,7 @@ final class InstallerTests: XCTestCase {
         system.succeedCommand("/path/to/swift", "build",
                               "--product", "tuist",
                               "--package-path", temporaryDirectory.path.pathString,
-                              "--configuration", "release",
-                              "-Xswiftc", "-static-stdlib")
+                              "--configuration", "release")
         system.succeedCommand("/path/to/swift", "build",
                               "--product", "ProjectDescription",
                               "--package-path", temporaryDirectory.path.pathString,
@@ -212,8 +211,7 @@ final class InstallerTests: XCTestCase {
         system.succeedCommand("/path/to/swift", "build",
                               "--product", "tuist",
                               "--package-path", temporaryDirectory.path.pathString,
-                              "--configuration", "release",
-                              "-Xswiftc", "-static-stdlib")
+                              "--configuration", "release")
         system.succeedCommand("/path/to/swift", "build",
                               "--product", "ProjectDescription",
                               "--package-path", temporaryDirectory.path.pathString,

--- a/features/env.feature
+++ b/features/env.feature
@@ -1,0 +1,4 @@
+Feature: The Tuist environment
+    Scenario: Installing tuist from source
+        Given that tuist is available
+        Then tuistenv should succeed in installing "master"

--- a/features/step_definitions/shared/tuist.rb
+++ b/features/step_definitions/shared/tuist.rb
@@ -22,3 +22,7 @@ Then(/tuist generates reports error "(.+)"/) do |error|
   assert_equal(actual_msg, expected_msg)
   assert_equal(wait_thr.value.exitstatus, 1)
 end
+
+Then(/tuistenv should succeed in installing "(.+)"/) do |ref|
+  system("swift", "run", "tuistenv", "install", ref)
+end


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/326

### Short description 📝

Tuist was not able to install any source from remote ref because it was using an invalid argument to swiftc "-static-stdlib"

### Solution 📦

Remove the argument and ensure there's a acceptance test covering tuistenv installing master
