### PR TITLE
Omitting unzip logs during installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Support `.d` source files https://github.com/tuist/tuist/pull/396 by @pepibumur.
 - Codesign frameworks when copying during the embed phase https://github.com/tuist/tuist/pull/398 by @ollieatkinson
 - 'tuist local' failed when trying to install from source https://github.com/tuist/tuist/pull/402 by @ollieatkinson
+- Omitting unzip logs during installation https://github.com/tuist/tuist/pull/404 by @kwridan
 
 ## 0.15.0
 

--- a/Sources/TuistEnvKit/Installer/Installer.swift
+++ b/Sources/TuistEnvKit/Installer/Installer.swift
@@ -156,7 +156,7 @@ final class Installer: Installing {
 
             // Unzip
             printer.print("Installing...")
-            try system.run("/usr/bin/unzip", downloadPath.pathString, "-d", installationDirectory.pathString)
+            try system.run("/usr/bin/unzip", "-q", downloadPath.pathString, "-d", installationDirectory.pathString)
 
             try createTuistVersionFile(version: version, path: installationDirectory)
             printer.print("Version \(version) installed")

--- a/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
+++ b/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
@@ -76,7 +76,9 @@ final class InstallerTests: XCTestCase {
         system.succeedCommand("/usr/bin/curl", "-LSs",
                               "--output", downloadPath.pathString,
                               downloadURL.absoluteString)
-        system.succeedCommand("/usr/bin/unzip", downloadPath.pathString,
+        system.succeedCommand("/usr/bin/unzip",
+                              "-q",
+                              downloadPath.pathString,
                               "-d", fileHandler.currentPath.pathString)
 
         try subject.install(version: version,


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/387

### Short description 📝

While running `tuist update`, the unzip command output was being displayed which adds unnecessary noise to the console.

### Solution 📦

We now pass the `-q` (quiet mode) option to `unzip` to suppress the verbose output

```
$ tuistenv update
Checking for updates...
Installing new version available 0.15.0
Verifying the Swift version is compatible with your version 5.0
Downloading version from https://github.com/tuist/tuist/releases/download/0.15.0/tuist.zip
Installing...
Version 0.15.0 installed
```

### Implementation 👩‍💻👨‍💻

> Detail in a checklist the steps that you took to implement the PR.

- [x] Update the unzip command
- [x] Update changelog

### Test Plan 🛠

- build this version locally
- run `swift run tuistenv update`
- Verify the logs don't display the unzipped files