### PR TITLE
Fix "The file couldn’t be saved." error in unit tests caused by rdar://50553219

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Codesign frameworks when copying during the embed phase https://github.com/tuist/tuist/pull/398 by @ollieatkinson
 - 'tuist local' failed when trying to install from source https://github.com/tuist/tuist/pull/402 by @ollieatkinson
 - Omitting unzip logs during installation https://github.com/tuist/tuist/pull/404 by @kwridan
+- Fix "The file couldn’t be saved." error https://github.com/tuist/tuist/pull/408 @marciniwanicki
 
 ## 0.15.0
 

--- a/Sources/TuistCore/Utils/FileHandler.swift
+++ b/Sources/TuistCore/Utils/FileHandler.swift
@@ -90,11 +90,13 @@ public final class FileHandler: FileHandling {
         // References:
         // - https://developer.apple.com/documentation/foundation/filemanager/2293212-replaceitemat
         // - https://developer.apple.com/documentation/foundation/filemanager/1407693-url
-        let tempUrl = try fileManager.url(for: .itemReplacementDirectory,
-                                          in: .userDomainMask,
-                                          appropriateFor: to.url,
-                                          create: true).appendingPathComponent("temp")
-        defer { try? fileManager.removeItem(at: tempUrl) }
+        // - https://openradar.appspot.com/50553219
+        let rootTempDir = try fileManager.url(for: .itemReplacementDirectory,
+                                              in: .userDomainMask,
+                                              appropriateFor: to.url,
+                                              create: true)
+        let tempUrl = rootTempDir.appendingPathComponent("temp")
+        defer { try? fileManager.removeItem(at: rootTempDir) }
         try fileManager.copyItem(at: with.url, to: tempUrl)
         _ = try fileManager.replaceItemAt(to.url, withItemAt: tempUrl)
     }

--- a/Tests/TuistCoreTests/Utils/FileHandlerTests.swift
+++ b/Tests/TuistCoreTests/Utils/FileHandlerTests.swift
@@ -1,12 +1,10 @@
-import XCTest
-import Foundation
 import Basic
+import Foundation
+import XCTest
 @testable import TuistCore
 
 final class FileHandlerTests: XCTestCase {
-
     private let fileManager = FileManager.default
-
 
     func test_replace_cleans_up_temp() throws {
         // Given

--- a/Tests/TuistCoreTests/Utils/FileHandlerTests.swift
+++ b/Tests/TuistCoreTests/Utils/FileHandlerTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+import Foundation
+import Basic
+@testable import TuistCore
+
+final class FileHandlerTests: XCTestCase {
+
+    private let fileManager = FileManager.default
+
+
+    func test_replace_cleans_up_temp() throws {
+        // Given
+        let subject = FileHandler()
+        let tempFile = try TemporaryFile()
+        let destFile = try TemporaryFile()
+        let count = try countItemsInRootTempDirectory(appropriateFor: destFile.path.asURL)
+
+        // When
+        try subject.replace(destFile.path, with: tempFile.path)
+
+        // Then
+        XCTAssertEqual(count, try countItemsInRootTempDirectory(appropriateFor: destFile.path.asURL))
+    }
+
+    // MARK: - Private
+
+    private func countItemsInRootTempDirectory(appropriateFor url: URL) throws -> Int {
+        let tempPath = AbsolutePath(try fileManager.url(for: .itemReplacementDirectory,
+                                                        in: .userDomainMask,
+                                                        appropriateFor: url,
+                                                        create: false).path)
+        let rootTempPath = tempPath.parentDirectory
+        try fileManager.removeItem(at: tempPath.asURL)
+        let content = try fileManager.contentsOfDirectory(atPath: rootTempPath.pathString)
+        return content.count
+    }
+}

--- a/Tests/TuistCoreTests/Utils/FileHandlerTests.swift
+++ b/Tests/TuistCoreTests/Utils/FileHandlerTests.swift
@@ -28,7 +28,7 @@ final class FileHandlerTests: XCTestCase {
 
         // Then
         let content = try String(contentsOf: destFile.path.asURL)
-        XCTAssertEqual("content", content)
+        XCTAssertEqual(content, "content")
     }
 
     func test_replace_cleans_up_temp() throws {

--- a/Tests/TuistCoreTests/Utils/FileHandlerTests.swift
+++ b/Tests/TuistCoreTests/Utils/FileHandlerTests.swift
@@ -4,11 +4,35 @@ import XCTest
 @testable import TuistCore
 
 final class FileHandlerTests: XCTestCase {
+    private var subject: FileHandler!
     private let fileManager = FileManager.default
+
+    // MARK: - Setup
+
+    override func setUp() {
+        super.setUp()
+
+        subject = FileHandler()
+    }
+
+    // MARK: - Tests
+
+    func test_replace() throws {
+        // Given
+        let tempFile = try TemporaryFile()
+        let destFile = try TemporaryFile()
+        try "content".write(to: tempFile.path.asURL, atomically: true, encoding: .utf8)
+
+        // When
+        try subject.replace(destFile.path, with: tempFile.path)
+
+        // Then
+        let content = try String(contentsOf: destFile.path.asURL)
+        XCTAssertEqual("content", content)
+    }
 
     func test_replace_cleans_up_temp() throws {
         // Given
-        let subject = FileHandler()
         let tempFile = try TemporaryFile()
         let destFile = try TemporaryFile()
         let count = try countItemsInRootTempDirectory(appropriateFor: destFile.path.asURL)


### PR DESCRIPTION
### Short description 📝

The `FileManager` `url(for:in:appropriateFor:create:)` method, when configured to create a temporary directory, fails after 1000 calls with: Error Domain=NSCocoaErrorDomain Code=512 "The file couldn’t be saved."

http://openradar.appspot.com/50553219

### Solution 📦

We need to make sure we remove the temporary directory, we only removed the content of the temporary directory which wasn't enough and left over temp directories.

```
drwxr-xr-x    2 miwanicki  ***     64 Jun 14 09:01 (A Document Being Saved By xctest 978)
drwxr-xr-x    2 miwanicki  ***     64 Jun 14 09:01 (A Document Being Saved By xctest 979)
drwxr-xr-x    2 miwanicki  ***     64 Jun 14 09:01 (A Document Being Saved By xctest 98)
drwxr-xr-x    2 miwanicki  ***     64 Jun 14 09:01 (A Document Being Saved By xctest 980)
drwxr-xr-x    2 miwanicki  ***     64 Jun 14 09:01 (A Document Being Saved By xctest 99)
```
