### PR TITLE
Ensure generated projects are stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Codesign frameworks when copying during the embed phase https://github.com/tuist/tuist/pull/398 by @ollieatkinson
 - 'tuist local' failed when trying to install from source https://github.com/tuist/tuist/pull/402 by @ollieatkinson
 - Omitting unzip logs during installation https://github.com/tuist/tuist/pull/404 by @kwridan
+- Ensure generated projects are stable https://github.com/tuist/tuist/pull/410 by @kwridan
 
 ## 0.15.0
 

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -228,7 +228,8 @@ class ProjectFileElements {
                   pbxproj: PBXProj,
                   sourceRootPath: AbsolutePath,
                   filesGroup: ProjectGroup) throws {
-        try dependencies.forEach { node in
+        let sortedDependencies = dependencies.sorted(by: { $0.path < $1.path })
+        try sortedDependencies.forEach { node in
             if let precompiledNode = node as? PrecompiledNode {
                 let fileElement = GroupFileElement(path: precompiledNode.path,
                                                    group: filesGroup)

--- a/Sources/TuistGenerator/Protocols/ProjectFilesSortener.swift
+++ b/Sources/TuistGenerator/Protocols/ProjectFilesSortener.swift
@@ -44,7 +44,7 @@ class ProjectFilesSortener: ProjectFilesSortening {
         let commonPaths = lhsPathsSet.intersection(rhsPathsSet)
 
         guard let lhsPathFirst = lhsPathsSet.subtracting(commonPaths).sorted().first else { return false }
-        guard let rhsPathFirst = rhsPathsSet.subtracting(commonPaths).sorted().first else { return false }
+        guard let rhsPathFirst = rhsPathsSet.subtracting(commonPaths).sorted().first else { return true }
 
         let lhsIsDirectory = isDirectory(lhsPathFirst)
         let rhsIsDirectory = isDirectory(rhsPathFirst)

--- a/Tests/TuistGeneratorTests/Utils/ProjectFilesSortenerTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/ProjectFilesSortenerTests.swift
@@ -35,4 +35,77 @@ final class ProjectFilesSortenerTests: XCTestCase {
         XCTAssertEqual(got[2], file1)
         XCTAssertEqual(got[3], file2)
     }
+
+    func test_sort_isStable() throws {
+        // Given
+        let folders = try fileHandler.createFolders([
+            "Root/A",
+            "Root/A/A1",
+            "Root/B",
+            "Root/B/B1",
+        ])
+
+        let files = try fileHandler.createFiles([
+            "Root/A/a.md",
+            "Root/A/z.md",
+            "Root/A/A1/a.md",
+            "Root/A/A1/z.md",
+            "Root/B/b.md",
+            "Root/B/z.md",
+            "Root/B/B1/b.md",
+            "Root/B/B1/z.md",
+        ])
+
+        let paths = (files + folders)
+
+        // When
+        let got = (0 ..< 10).map { _ in paths.shuffled().sorted(by: subject.sort) }
+
+        // Then
+        let unstable = got.dropFirst().filter { $0 != got.first }
+        XCTAssertTrue(unstable.isEmpty)
+    }
+
+    func test_sort_filesBeforeDirectories() throws {
+        // Given
+        let folders = try fileHandler.createFolders([
+            "Root/A",
+            "Root/A/A1",
+            "Root/B",
+            "Root/B/B1",
+        ])
+
+        let files = try fileHandler.createFiles([
+            "Root/A/a.md",
+            "Root/A/z.md",
+            "Root/A/A1/a.md",
+            "Root/A/A1/z.md",
+            "Root/B/b.md",
+            "Root/B/z.md",
+            "Root/B/B1/b.md",
+            "Root/B/B1/z.md",
+        ])
+
+        let paths = (files + folders).shuffled()
+
+        // When
+        let got = paths.sorted(by: subject.sort)
+
+        // Then
+        let raltivePaths = got.map { $0.relative(to: fileHandler.currentPath).pathString }
+        XCTAssertEqual(raltivePaths, [
+            "Root/A/a.md",
+            "Root/A/z.md",
+            "Root/A/A1/a.md",
+            "Root/A/A1/z.md",
+            "Root/A/A1",
+            "Root/A",
+            "Root/B/b.md",
+            "Root/B/z.md",
+            "Root/B/B1/b.md",
+            "Root/B/B1/z.md",
+            "Root/B/B1",
+            "Root/B",
+        ])
+    }
 }

--- a/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
@@ -161,11 +161,23 @@ final class StableXcodeProjIntegrationTests: XCTestCase {
             .map { "/App/Files/File\($0).md" }
             .map { FileElement.file(path: AbsolutePath($0)) }
 
+        // When using ** glob patterns (e.g. `Documentation/**`)
+        // the results will include the folders in addition to the files
+        //
+        // e.g.
+        //    Documentation
+        //    Documentation/a.md
+        //    Documentation/Subfolder
+        //    Documentation/Subfolder/a.md
+        let filesWithFolderPaths = files + [
+            .file(path: AbsolutePath("/App/Files")),
+        ]
+
         let folderReferences = (0 ..< 10)
             .map { "/App/Documentation\($0)" }
             .map { FileElement.folderReference(path: AbsolutePath($0)) }
 
-        return (files + folderReferences).shuffled()
+        return (filesWithFolderPaths + folderReferences).shuffled()
     }
 
     private func createFrameworkTarget(name: String) -> Target {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/409

### Short description 📝

Calling `tuist generate` on the same project multiple times can yield a different `.xcodeproj` file each time. 

### Solution 📦

Sort elements ahead of adding them to their corresponding xcodeproj container.

### Implementation 👩‍💻👨‍💻

- [x] Update generator integration tests to shuffle sources / headers 
- [x] Sort files added within `BuildPhaseGenerator`
- [x] Update generator integration tests to shuffle additional files
- [x] Update `ProjectFilesSortener` to be stable
- [x] Update `LinkGenerator` to sort dependencies 
- [x] Update changelog 

### Test Plan 🛠

- Ensure unit tests pass via `swift test`
- Ensure acceptance tests pass via `bundle exec rake features`

Generate the fixture `fixtures/ios_app_with_tests/` and verify the generated project is identical each time

```
$ cd fixtures/ios_app_with_tests/
$ touch Sources/Source{A..Z}.swift
$ for i in {1..5}; do tuist generate > /dev/null && md5 App.xcodeproj/project.pbxproj; done
```
