### PR TITLE
Updating `XcodeProj` dependency version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -60,7 +60,7 @@
         "repositoryURL": "https://github.com/tuist/xcodeproj.git",
         "state": {
           "branch": null,
-          "revision": "6029dac06eb48cc29c762965efebddb5d6c2a496",
+          "revision": "59b3f099b4b56fd30b6ed090cbf6e09fbb45563c",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
                  targets: ["TuistGenerator"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tuist/xcodeproj.git", .revision("6029dac06eb48cc29c762965efebddb5d6c2a496")),
+        .package(url: "https://github.com/tuist/xcodeproj.git", .revision("59b3f099b4b56fd30b6ed090cbf6e09fbb45563c")),
         .package(url: "https://github.com/apple/swift-package-manager", .branch("swift-5.0-RELEASE")),
     ],
     targets: [

--- a/Sources/TuistGenerator/Generator/SchemesGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemesGenerator.swift
@@ -291,7 +291,7 @@ final class SchemesGenerator: SchemesGenerating {
             environments = environmentVariables(arguments.environment)
         }
 
-        return XCScheme.LaunchAction(buildableProductRunnable: buildableProductRunnable,
+        return XCScheme.LaunchAction(runnable: buildableProductRunnable,
                                      buildConfiguration: "Debug",
                                      macroExpansion: macroExpansion,
                                      commandlineArguments: commandlineArguments,

--- a/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
@@ -227,7 +227,7 @@ final class SchemeGeneratorTests: XCTestCase {
         let got = subject.schemeLaunchAction(scheme: scheme, project: project, generatedProject: generatedProject)
 
         XCTAssertNil(got?.macroExpansion)
-        let buildableReference = got?.buildableProductRunnable?.buildableReference
+        let buildableReference = got?.runnable?.buildableReference
 
         XCTAssertEqual(got?.buildConfiguration, "Debug")
         XCTAssertEqual(got?.environmentVariables, [XCScheme.EnvironmentVariable(variable: "a", value: "b", enabled: true)])
@@ -251,7 +251,7 @@ final class SchemeGeneratorTests: XCTestCase {
 
         let got = subject.schemeLaunchAction(scheme: scheme, project: project, generatedProject: generatedProject)
 
-        XCTAssertNil(got?.buildableProductRunnable?.buildableReference)
+        XCTAssertNil(got?.runnable?.buildableReference)
 
         XCTAssertEqual(got?.buildConfiguration, "Debug")
         XCTAssertEqual(got?.macroExpansion?.referencedContainer, "container:project.xcodeproj")


### PR DESCRIPTION
- Adding Xcode10 constants to maintain backwards compatibility (Xcode 11 is still in beta!)
- Without this update, generated projects would fail to load with Xcode 10

<img width="532" alt="Screenshot 2019-06-16 at 21 34 55" src="https://user-images.githubusercontent.com/11914919/59569436-47b90700-9081-11e9-8d82-90ade579df19.png">
Test Plan:

- Verify unit tests pass via `swift test`
- Verify acceptance tests pass via `bundle exec rake features`
- Verify generated projects can still be opened with Xcode 10