### PR TITLE
Don't generate settings attribute when compiler flags are not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,15 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Ensuring the correct default settings provider dependency is used https://github.com/tuist/tuist/pull/389 by @kwridan
-- Fixing build settings repeated same value https://github.com/tuist/tuist/pull/391 @platonsi
+- Fixing build settings repeated same value https://github.com/tuist/tuist/pull/391 by @platonsi
 - Duplicated files in the sources build phase when different glob patterns match the same files https://github.com/tuist/tuist/pull/388 by @pepibumur.
 - Support `.d` source files https://github.com/tuist/tuist/pull/396 by @pepibumur.
 - Codesign frameworks when copying during the embed phase https://github.com/tuist/tuist/pull/398 by @ollieatkinson
 - 'tuist local' failed when trying to install from source https://github.com/tuist/tuist/pull/402 by @ollieatkinson
 - Omitting unzip logs during installation https://github.com/tuist/tuist/pull/404 by @kwridan
-- Fix "The file couldn’t be saved." error https://github.com/tuist/tuist/pull/408 @marciniwanicki
+- Fix "The file couldn’t be saved." error https://github.com/tuist/tuist/pull/408 by @marciniwanicki
 - Ensure generated projects are stable https://github.com/tuist/tuist/pull/410 by @kwridan
+- Stop generating empty `PBXBuildFile` settings https://github.com/tuist/tuist/pull/415 by @marciniwanicki
 
 ## 0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Omitting unzip logs during installation https://github.com/tuist/tuist/pull/404 by @kwridan
 - Fix "The file couldn’t be saved." error https://github.com/tuist/tuist/pull/408 by @marciniwanicki
 - Ensure generated projects are stable https://github.com/tuist/tuist/pull/410 by @kwridan
-- Stop generating empty `PBXBuildFile` settings https://github.com/tuist/tuist/pull/415 by @marciniwanicki
+- Stop generating empty `PBXBuildFile` settings https://github.com/tuist/tuist/pull/415 by @marciniwanicki 
 
 ## 0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Omitting unzip logs during installation https://github.com/tuist/tuist/pull/404 by @kwridan
 - Fix "The file couldn’t be saved." error https://github.com/tuist/tuist/pull/408 by @marciniwanicki
 - Ensure generated projects are stable https://github.com/tuist/tuist/pull/410 by @kwridan
-- Stop generating empty `PBXBuildFile` settings https://github.com/tuist/tuist/pull/415 by @marciniwanicki 
+- Stop generating empty `PBXBuildFile` settings https://github.com/tuist/tuist/pull/415 by @marciniwanicki
 
 ## 0.15.0
 

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -109,9 +109,11 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
             guard let fileReference = fileElements.file(path: buildFile.path) else {
                 throw BuildPhaseGenerationError.missingFileReference(buildFile.path)
             }
-            var settings: [String: Any] = [:]
+            var settings: [String: Any]?
             if let compilerFlags = buildFile.compilerFlags {
-                settings["COMPILER_FLAGS"] = compilerFlags
+                settings = [
+                    "COMPILER_FLAGS": compilerFlags,
+                ]
             }
 
             let pbxBuildFile = PBXBuildFile(file: fileReference, settings: settings)

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -63,27 +63,42 @@ final class BuildPhaseGeneratorTests: XCTestCase {
     }
 
     func test_generateSourcesBuildPhase() throws {
-        let path = AbsolutePath("/test/file.swift")
         let target = PBXNativeTarget(name: "Test")
         let pbxproj = PBXProj()
         pbxproj.add(object: target)
         let fileElements = ProjectFileElements()
-        let fileReference = PBXFileReference(sourceTree: .group, name: "Test")
-        pbxproj.add(object: fileReference)
-        fileElements.elements[path] = fileReference
 
-        try subject.generateSourcesBuildPhase(files: [(path: path, compilerFlags: "flag")],
+        let path1 = AbsolutePath("/test/file1.swift")
+        let fileReference1 = PBXFileReference(sourceTree: .group, name: "Test1")
+        pbxproj.add(object: fileReference1)
+        fileElements.elements[path1] = fileReference1
+
+        let path2 = AbsolutePath("/test/file2.swift")
+        let fileReference2 = PBXFileReference(sourceTree: .group, name: "Test2")
+        pbxproj.add(object: fileReference2)
+        fileElements.elements[path2] = fileReference2
+
+        try subject.generateSourcesBuildPhase(files: [(path: path1, compilerFlags: "flag"),
+                                                      (path: path2, compilerFlags: nil)],
                                               pbxTarget: target,
                                               fileElements: fileElements,
                                               pbxproj: pbxproj)
 
         let buildPhase: PBXBuildPhase? = target.buildPhases.first
+
         XCTAssertNotNil(buildPhase)
         XCTAssertTrue(buildPhase is PBXSourcesBuildPhase)
-        let pbxBuildFile: PBXBuildFile? = buildPhase?.files?.first
-        XCTAssertNotNil(pbxBuildFile)
-        XCTAssertEqual(pbxBuildFile?.file, fileReference)
-        XCTAssertEqual(pbxBuildFile?.settings?["COMPILER_FLAGS"] as? String, "flag")
+        XCTAssertEqual(buildPhase?.files?.count, 2)
+
+        let pbxBuildFile1 = buildPhase?.files?[0]
+        XCTAssertNotNil(pbxBuildFile1)
+        XCTAssertEqual(pbxBuildFile1?.file, fileReference1)
+        XCTAssertEqual(pbxBuildFile1?.settings?["COMPILER_FLAGS"] as? String, "flag")
+
+        let pbxBuildFile2 = buildPhase?.files?[1]
+        XCTAssertNotNil(pbxBuildFile2)
+        XCTAssertEqual(pbxBuildFile2?.file, fileReference2)
+        XCTAssertNil(pbxBuildFile2?.settings)
     }
 
     func test_generateSourcesBuildPhase_throws_when_theFileReferenceIsMissing() {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/414

`BuildPhaseGenerator` will not generate empty `settings` attribute for source `PBXBuildFile` elements when compiler flags are not specified.

Test Plan:
 - Close Xcode
 - Generate `fixtures/ios_app_with_frameworks` fixture
 - Open generated .xcodeproj in a non-Xcode editor (i..e vim), ensure empty `settings ={}` attributes have not been generated