### PR TITLE
Upgrade XcodeProj to 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Ensuring the correct platform SDK dependencies path is set https://github.com/tuist/tuist/pull/419 by @kwridan
 
+### Changed
+- Update XcodeProj to 7.0.0 https://github.com/tuist/tuist/pull/421 by @pepibumur.
+
 ## 0.16.0
 
 ### Added

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/tuist/Shell",
         "state": {
           "branch": null,
-          "revision": "ab06e1ae3fa52c26b076ff11dde60e950f6bbc7c",
-          "version": "2.0.1"
+          "revision": "d38121f89401db902b0d0bfc30b987e2c84c254e",
+          "version": "2.0.3"
         }
       },
       {
@@ -57,11 +57,11 @@
       },
       {
         "package": "XcodeProj",
-        "repositoryURL": "https://github.com/tuist/xcodeproj.git",
+        "repositoryURL": "https://github.com/tuist/XcodeProj",
         "state": {
           "branch": null,
-          "revision": "59b3f099b4b56fd30b6ed090cbf6e09fbb45563c",
-          "version": null
+          "revision": "b951777f42e9acbfb8f19da623b43aaa604422f9",
+          "version": "7.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
                  targets: ["TuistGenerator"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tuist/xcodeproj.git", .revision("59b3f099b4b56fd30b6ed090cbf6e09fbb45563c")),
+        .package(url: "https://github.com/tuist/XcodeProj", .upToNextMinor(from: "7.0.0")),
         .package(url: "https://github.com/apple/swift-package-manager", .branch("swift-5.0-RELEASE")),
     ],
     targets: [


### PR DESCRIPTION
### Short description 📝
Xcode's 7.0.0 [has been released](https://github.com/tuist/xcodeproj). This PR updates the `Project.swift` manifest to point to that version. Since we were already pointing to a recent commit from master, the change doesn't require code changes. 
