### PR TITLE
Update manifest target name such that its product has a valid name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Ensuring the correct platform SDK dependencies path is set https://github.com/tuist/tuist/pull/419 by @kwridan
+- Update manifest target name such that its product has a valid name https://github.com/tuist/tuist/pull/426 by @kwridan
 
 ### Changed
 - Update XcodeProj to 7.0.0 https://github.com/tuist/tuist/pull/421 by @pepibumur.

--- a/Sources/TuistKit/Generator/ManifestTargetGenerator.swift
+++ b/Sources/TuistKit/Generator/ManifestTargetGenerator.swift
@@ -23,7 +23,7 @@ class ManifestTargetGenerator: ManifestTargetGenerating {
                                 configurations: Settings.default.configurations,
                                 defaultSettings: .recommended)
         let manifest = try manifestLoader.manifestPath(at: path, manifest: .project)
-        return Target(name: "\(project)-Manifest",
+        return Target(name: "\(project)_Manifest",
                       platform: .macOS,
                       product: .staticFramework,
                       bundleId: "io.tuist.manifests.${PRODUCT_NAME:rfc1034identifier}",

--- a/Tests/TuistKitTests/Generator/ManifestTargetGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/ManifestTargetGeneratorTests.swift
@@ -24,7 +24,7 @@ final class ManifestTargetGeneratorTests: XCTestCase {
         let target = try subject.generateManifestTarget(for: "MyProject", at: path)
 
         // Then
-        XCTAssertEqual(target.name, "MyProject-Manifest")
+        XCTAssertEqual(target.name, "MyProject_Manifest")
         XCTAssertEqual(target.product, .staticFramework)
         XCTAssertEqual(target.sources.map { $0.path.pathString }, ["/test/Project.swift"])
         XCTAssertNil(target.infoPlist)

--- a/features/generate.feature
+++ b/features/generate.feature
@@ -8,7 +8,7 @@ Feature: Generate a new project using Tuist
     Then I should be able to build the scheme App
     Then I should be able to test the scheme AppTests
     Then I should be able to test the scheme AppUITests
-    Then I should be able to build the scheme App-Manifest
+    Then I should be able to build the scheme App_Manifest
 
   Scenario: The project is an iOS application with frameworks and tests (ios_app_with_frameworks)
     Given that tuist is available
@@ -21,9 +21,9 @@ Feature: Generate a new project using Tuist
     Then I should be able to test the scheme Framework1Tests
     Then I should be able to build the scheme Framework2
     Then I should be able to test the scheme Framework2Tests
-    Then I should be able to build the scheme MainApp-Manifest
-    Then I should be able to build the scheme Framework1-Manifest
-    Then I should be able to build the scheme Framework2-Manifest
+    Then I should be able to build the scheme MainApp_Manifest
+    Then I should be able to build the scheme Framework1_Manifest
+    Then I should be able to build the scheme Framework2_Manifest
 
   Scenario: The project is a directory without valid manifest file (invalid_workspace_manifest_name)
     Given that tuist is available


### PR DESCRIPTION
Part of https://github.com/tuist/tuist/issues/425

### Short description 📝

The generated manifest target's product name automatically gets re-named by Xcode when opening the project to replace the `-` with an `_` (e.g. `App-manifest` > `App_manifest`).

### Solution 📦

- Update the generated manifest target name to be compatible

### Implementation 👩‍💻👨‍💻

- [x] Update the manifest target name
- [x] Update change log

### Test Plan 🛠:

- Generate `fixtures/ios_app_with_tests` via `tuist generate`
- Run `git add . -f` to stage the generated project
- Open the project in Xcode
- Verify the manifest target `App_manifest` doesn't get renamed by Xcode within the Scheme and project
- Verify the manifest target can still build successfully
