### PR TITLE
Add "tuist graph" command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Added
+- `tuist graph` command https://github.com/tuist/tuist/pull/427 by @pepibumur.
+
 ### Fixed
 
 - Ensuring the correct platform SDK dependencies path is set https://github.com/tuist/tuist/pull/419 by @kwridan

--- a/Sources/TuistCoreTesting/Utils/MockFileHandler.swift
+++ b/Sources/TuistCoreTesting/Utils/MockFileHandler.swift
@@ -54,6 +54,10 @@ public final class MockFileHandler: FileHandling {
     public func isFolder(_ path: AbsolutePath) -> Bool {
         return fileHandler.isFolder(path)
     }
+
+    public func write(_ content: String, path: AbsolutePath, atomically: Bool) throws {
+        return try fileHandler.write(content, path: path, atomically: atomically)
+    }
 }
 
 extension MockFileHandler {

--- a/Sources/TuistGenerator/Dot/DotGraph.swift
+++ b/Sources/TuistGenerator/Dot/DotGraph.swift
@@ -31,7 +31,7 @@ struct DotGraph: Equatable, CustomStringConvertible {
         digraph \"\(name)\" {
         \(sortedNodes.map { "  \($0.description)" }.joined(separator: "\n"))
         
-        \(sortedDependencies.map { "  \($0.from) \(edgeCharacter) \($0.to)" }.joined(separator: "\n"))
+        \(sortedDependencies.map { "  \"\($0.from)\" \(edgeCharacter) \"\($0.to)\"" }.joined(separator: "\n"))
         }
         """
     }

--- a/Sources/TuistGenerator/Dot/DotGraphGenerator.swift
+++ b/Sources/TuistGenerator/Dot/DotGraphGenerator.swift
@@ -1,0 +1,72 @@
+import Basic
+import Foundation
+import TuistCore
+
+public protocol DotGraphGenerating {
+    /// Generates the dot graph from the project in the current directory and returns it.
+    ///
+    /// - Parameter path: Path to the folder that contains the project.
+    /// - Returns: Dot graph representation.
+    /// - Throws: An error if the project can't be loaded.
+    func generateProject(at path: AbsolutePath) throws -> String
+
+    /// Generates the dot graph from the workspace in the current directory and returns it.
+    ///
+    /// - Parameter path: Path to the folder that contains the workspace.
+    /// - Returns: Dot graph representation.
+    /// - Throws: An error if the workspace can't be loaded.
+    func generateWorkspace(at path: AbsolutePath) throws -> String
+}
+
+public final class DotGraphGenerator: DotGraphGenerating {
+    /// Graph loader.
+    private let graphLoader: GraphLoading
+
+    /// Mapper to map graphs into a dot graphs.
+    private let graphToDotGraphMapper: GraphToDotGraphMapping
+
+    /// Initializes the dot graph generator by taking its dependencies.
+    ///
+    /// - Parameters:
+    ///   - modelLoader: Instance to load the models.
+    ///   - system: Instance to run commands in the system.
+    ///   - printer: Instance to print outputs to the user.
+    ///   - fileHandler: Instance to handle files.
+    public convenience init(modelLoader: GeneratorModelLoading,
+                            system _: Systeming = System(),
+                            printer: Printing = Printer(),
+                            fileHandler: FileHandling = FileHandler()) {
+        let graphLinter = GraphLinter(fileHandler: fileHandler)
+        let graphLoader = GraphLoader(linter: graphLinter, printer: printer, fileHandler: fileHandler, modelLoader: modelLoader)
+        self.init(graphLoader: graphLoader)
+    }
+
+    /// Initializes the generator with an instance to load the graph.
+    ///
+    /// - Parameter graphLoader: Graph loader instance.
+    init(graphLoader: GraphLoading,
+         graphToDotGraphMapper: GraphToDotGraphMapping = GraphToDotGraphMapper()) {
+        self.graphLoader = graphLoader
+        self.graphToDotGraphMapper = graphToDotGraphMapper
+    }
+
+    /// Generates the dot graph from the project in the current directory and returns it.
+    ///
+    /// - Parameter path: Path to the folder that contains the project.
+    /// - Returns: Dot graph representation.
+    /// - Throws: An error if the project can't be loaded.
+    public func generateProject(at path: AbsolutePath) throws -> String {
+        let (graph, _) = try graphLoader.loadProject(path: path)
+        return graphToDotGraphMapper.map(graph: graph).description
+    }
+
+    /// Generates the dot graph from the workspace in the current directory and returns it.
+    ///
+    /// - Parameter path: Path to the folder that contains the workspace.
+    /// - Returns: Dot graph representation.
+    /// - Throws: An error if the workspace can't be loaded.
+    public func generateWorkspace(at path: AbsolutePath) throws -> String {
+        let (graph, _) = try graphLoader.loadWorkspace(path: path)
+        return graphToDotGraphMapper.map(graph: graph).description
+    }
+}

--- a/Sources/TuistGenerator/Dot/DotGraphGenerator.swift
+++ b/Sources/TuistGenerator/Dot/DotGraphGenerator.swift
@@ -29,23 +29,23 @@ public final class DotGraphGenerator: DotGraphGenerating {
     ///
     /// - Parameters:
     ///   - modelLoader: Instance to load the models.
-    ///   - system: Instance to run commands in the system.
     ///   - printer: Instance to print outputs to the user.
     ///   - fileHandler: Instance to handle files.
     public convenience init(modelLoader: GeneratorModelLoading,
-                            system _: Systeming = System(),
                             printer: Printing = Printer(),
                             fileHandler: FileHandling = FileHandler()) {
         let graphLinter = GraphLinter(fileHandler: fileHandler)
         let graphLoader = GraphLoader(linter: graphLinter, printer: printer, fileHandler: fileHandler, modelLoader: modelLoader)
-        self.init(graphLoader: graphLoader)
+        self.init(graphLoader: graphLoader, graphToDotGraphMapper: GraphToDotGraphMapper())
     }
 
     /// Initializes the generator with an instance to load the graph.
     ///
-    /// - Parameter graphLoader: Graph loader instance.
+    /// - Parameters:
+    ///   - graphLoader: Graph loader instance.
+    ///   - graphToDotGraphMapper: Mapper to map the graph into a dot graph.
     init(graphLoader: GraphLoading,
-         graphToDotGraphMapper: GraphToDotGraphMapping = GraphToDotGraphMapper()) {
+         graphToDotGraphMapper: GraphToDotGraphMapping) {
         self.graphLoader = graphLoader
         self.graphToDotGraphMapper = graphToDotGraphMapper
     }

--- a/Sources/TuistGenerator/Dot/DotGraphNode.swift
+++ b/Sources/TuistGenerator/Dot/DotGraphNode.swift
@@ -11,7 +11,7 @@ struct DotGraphNode: CustomStringConvertible, Hashable, Equatable {
     var description: String {
         let sortedAttributes = attributes.sorted(by: { $0.description < $1.description })
         let attributesString = "[\(sortedAttributes.map { $0.description }.joined(separator: ", "))]"
-        return "\(name) \(attributesString)"
+        return "\"\(name)\" \(attributesString)"
     }
 
     /// Initializes the node with its attributes.

--- a/Sources/TuistGenerator/Graph/GraphLoader.swift
+++ b/Sources/TuistGenerator/Graph/GraphLoader.swift
@@ -10,7 +10,7 @@ protocol GraphLoading: AnyObject {
 class GraphLoader: GraphLoading {
     // MARK: - Attributes
 
-    let linter: GraphLinting
+    let linter: GraphLinting?
     let printer: Printing
     let fileHandler: FileHandling
     let modelLoader: GeneratorModelLoading
@@ -24,7 +24,7 @@ class GraphLoader: GraphLoading {
                   modelLoader: modelLoader)
     }
 
-    init(linter: GraphLinting,
+    init(linter: GraphLinting? = nil,
          printer: Printing,
          fileHandler: FileHandling,
          modelLoader: GeneratorModelLoading) {
@@ -71,6 +71,6 @@ class GraphLoader: GraphLoading {
     }
 
     private func lint(graph: Graph) throws {
-        try linter.lint(graph: graph).printAndThrowIfNeeded(printer: printer)
+        try linter?.lint(graph: graph).printAndThrowIfNeeded(printer: printer)
     }
 }

--- a/Sources/TuistKit/Commands/CommandRegistry.swift
+++ b/Sources/TuistKit/Commands/CommandRegistry.swift
@@ -25,6 +25,7 @@ public final class CommandRegistry {
         register(command: CreateIssueCommand.self)
         register(command: FocusCommand.self)
         register(command: UpCommand.self)
+        register(command: GraphCommand.self)
         register(hiddenCommand: EmbedCommand.self)
         register(rawCommand: BuildCommand.self)
     }

--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -21,6 +21,9 @@ class GraphCommand: NSObject, Command {
     /// Dot graph generator.
     let dotGraphGenerator: DotGraphGenerating
 
+    /// Manifest loader.
+    let manifestLoader: GraphManifestLoading
+    
     required convenience init(parser: ArgumentParser) {
         let fileHandler = FileHandler()
         let system = System()
@@ -37,21 +40,28 @@ class GraphCommand: NSObject, Command {
                                                manifestTargetGenerator: manifestTargetGenerator)
 
         let dotGraphGenerator = DotGraphGenerator(modelLoader: modelLoader, printer: printer, fileHandler: fileHandler)
-        self.init(parser: parser, fileHandler: fileHandler, printer: printer, dotGraphGenerator: dotGraphGenerator)
+        self.init(parser: parser,
+                  fileHandler: fileHandler,
+                  printer: printer,
+                  dotGraphGenerator: dotGraphGenerator,
+                  manifestLoader: manifestLoader)
     }
 
     init(parser: ArgumentParser,
          fileHandler: FileHandling,
          printer: Printing,
-         dotGraphGenerator: DotGraphGenerating) {
+         dotGraphGenerator: DotGraphGenerating,
+         manifestLoader: GraphManifestLoading) {
         parser.add(subparser: GraphCommand.command, overview: GraphCommand.overview)
         self.fileHandler = fileHandler
         self.printer = printer
         self.dotGraphGenerator = dotGraphGenerator
+        self.manifestLoader = manifestLoader
     }
 
     func run(with _: ArgumentParser.Result) throws {
-        let graph = try dotGraphGenerator.generateProject(at: fileHandler.currentPath)
+        let graph = try dotGraphGenerator.generate(at: fileHandler.currentPath,
+                                                   manifestLoader: manifestLoader)
 
         let path = fileHandler.currentPath.appending(component: "graph.dot")
         if fileHandler.exists(path) {

--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -33,11 +33,8 @@ class GraphCommand: NSObject, Command {
                                                  system: system,
                                                  resourceLocator: resourceLocator,
                                                  deprecator: Deprecator(printer: printer))
-        let manifestTargetGenerator = ManifestTargetGenerator(manifestLoader: manifestLoader,
-                                                              resourceLocator: resourceLocator)
         let modelLoader = GeneratorModelLoader(fileHandler: fileHandler,
-                                               manifestLoader: manifestLoader,
-                                               manifestTargetGenerator: manifestTargetGenerator)
+                                               manifestLoader: manifestLoader)
 
         let dotGraphGenerator = DotGraphGenerator(modelLoader: modelLoader, printer: printer, fileHandler: fileHandler)
         self.init(parser: parser,

--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -23,7 +23,7 @@ class GraphCommand: NSObject, Command {
 
     /// Manifest loader.
     let manifestLoader: GraphManifestLoading
-    
+
     required convenience init(parser: ArgumentParser) {
         let fileHandler = FileHandler()
         let system = System()

--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -1,0 +1,19 @@
+import Basic
+import Foundation
+import SPMUtility
+import TuistCore
+
+/// Command that generates and exports a dot graph from the workspace or project in the current directory.
+class GraphCommand: NSObject, Command {
+    /// Command name.
+    static var command: String = "graph"
+
+    /// Command description.
+    static var overview: String = "Generates a dot graph from the workspace or project in the current directory."
+
+    required init(parser: ArgumentParser) {
+        let subParser = parser.add(subparser: GraphCommand.command, overview: GraphCommand.overview)
+    }
+
+    func run(with _: ArgumentParser.Result) throws {}
+}

--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -2,6 +2,7 @@ import Basic
 import Foundation
 import SPMUtility
 import TuistCore
+import TuistGenerator
 
 /// Command that generates and exports a dot graph from the workspace or project in the current directory.
 class GraphCommand: NSObject, Command {
@@ -11,9 +12,54 @@ class GraphCommand: NSObject, Command {
     /// Command description.
     static var overview: String = "Generates a dot graph from the workspace or project in the current directory."
 
-    required init(parser: ArgumentParser) {
-        let subParser = parser.add(subparser: GraphCommand.command, overview: GraphCommand.overview)
+    /// File handler.
+    let fileHandler: FileHandling
+
+    /// Printer.
+    let printer: Printing
+
+    /// Dot graph generator.
+    let dotGraphGenerator: DotGraphGenerating
+
+    required convenience init(parser: ArgumentParser) {
+        let fileHandler = FileHandler()
+        let system = System()
+        let printer = Printer()
+        let resourceLocator = ResourceLocator(fileHandler: fileHandler)
+        let manifestLoader = GraphManifestLoader(fileHandler: fileHandler,
+                                                 system: system,
+                                                 resourceLocator: resourceLocator,
+                                                 deprecator: Deprecator(printer: printer))
+        let manifestTargetGenerator = ManifestTargetGenerator(manifestLoader: manifestLoader,
+                                                              resourceLocator: resourceLocator)
+        let modelLoader = GeneratorModelLoader(fileHandler: fileHandler,
+                                               manifestLoader: manifestLoader,
+                                               manifestTargetGenerator: manifestTargetGenerator)
+
+        let dotGraphGenerator = DotGraphGenerator(modelLoader: modelLoader, printer: printer, fileHandler: fileHandler)
+        self.init(parser: parser, fileHandler: fileHandler, printer: printer, dotGraphGenerator: dotGraphGenerator)
     }
 
-    func run(with _: ArgumentParser.Result) throws {}
+    init(parser: ArgumentParser,
+         fileHandler: FileHandling,
+         printer: Printing,
+         dotGraphGenerator: DotGraphGenerating) {
+        parser.add(subparser: GraphCommand.command, overview: GraphCommand.overview)
+        self.fileHandler = fileHandler
+        self.printer = printer
+        self.dotGraphGenerator = dotGraphGenerator
+    }
+
+    func run(with _: ArgumentParser.Result) throws {
+        let graph = try dotGraphGenerator.generateProject(at: fileHandler.currentPath)
+
+        let path = fileHandler.currentPath.appending(component: "graph.dot")
+        if fileHandler.exists(path) {
+            printer.print("Deleting existing graph at \(path.pathString)")
+            try fileHandler.delete(path)
+        }
+
+        try fileHandler.write(graph, path: path, atomically: true)
+        printer.print(success: "Graph exported to \(path.pathString)")
+    }
 }

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -238,6 +238,9 @@ class InitCommand: NSObject, Command {
         ### Projects ###
         *.xcodeproj
         *.xcworkspace
+
+        ### Tuist derived files ###
+        graph.dot
         """
         try content.write(to: path.url, atomically: true, encoding: .utf8)
     }

--- a/Sources/TuistKit/Dot/DotGraphGenerating+Extras.swift
+++ b/Sources/TuistKit/Dot/DotGraphGenerating+Extras.swift
@@ -2,7 +2,7 @@ import Basic
 import Foundation
 import TuistGenerator
 
-extension DotGraphGenerator {
+extension DotGraphGenerating {
     func generate(at path: AbsolutePath,
                   manifestLoader: GraphManifestLoading) throws -> String {
         let manifests = manifestLoader.manifests(at: path)

--- a/Sources/TuistKit/Dot/DotGraphGenerator+Extras.swift
+++ b/Sources/TuistKit/Dot/DotGraphGenerator+Extras.swift
@@ -1,0 +1,18 @@
+import Basic
+import Foundation
+import TuistGenerator
+
+extension DotGraphGenerator {
+    func generate(at path: AbsolutePath,
+                  manifestLoader: GraphManifestLoading) throws -> String {
+        let manifests = manifestLoader.manifests(at: path)
+
+        if manifests.contains(.workspace) {
+            return try generateWorkspace(at: path)
+        } else if manifests.contains(.project) {
+            return try generateProject(at: path)
+        } else {
+            throw GraphManifestLoaderError.manifestNotFound(path)
+        }
+    }
+}

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -29,12 +29,12 @@ enum GeneratorModelLoaderError: Error, Equatable, FatalError {
 class GeneratorModelLoader: GeneratorModelLoading {
     private let fileHandler: FileHandling
     private let manifestLoader: GraphManifestLoading
-    private let manifestTargetGenerator: ManifestTargetGenerating
+    private let manifestTargetGenerator: ManifestTargetGenerating?
     private let printer: Printing
 
     init(fileHandler: FileHandling,
          manifestLoader: GraphManifestLoading,
-         manifestTargetGenerator: ManifestTargetGenerating,
+         manifestTargetGenerator: ManifestTargetGenerating? = nil,
          printer: Printing = Printer()) {
         self.fileHandler = fileHandler
         self.manifestLoader = manifestLoader
@@ -49,10 +49,14 @@ class GeneratorModelLoader: GeneratorModelLoading {
                                                       fileHandler: fileHandler,
                                                       printer: printer)
 
-        let manifestTarget = try manifestTargetGenerator.generateManifestTarget(for: project.name,
-                                                                                at: path)
+        if let manifestTargetGenerator = manifestTargetGenerator {
+            let manifestTarget = try manifestTargetGenerator.generateManifestTarget(for: project.name,
+                                                                                    at: path)
+            return project.adding(target: manifestTarget)
 
-        return project.adding(target: manifestTarget)
+        } else {
+            return project
+        }
     }
 
     func loadWorkspace(at path: AbsolutePath) throws -> TuistGenerator.Workspace {

--- a/Tests/TuistCoreTests/Utils/FileHandlerTests.swift
+++ b/Tests/TuistCoreTests/Utils/FileHandlerTests.swift
@@ -3,6 +3,13 @@ import Foundation
 import XCTest
 @testable import TuistCore
 
+final class FileHandlerErrorTests: XCTestCase {
+    func test_description() {
+        XCTAssertEqual(FileHandlerError.invalidTextEncoding(AbsolutePath("/path")).description, "The file at /path is not a utf8 text file")
+        XCTAssertEqual(FileHandlerError.writingError(AbsolutePath("/path")).description, "Couldn't write to the file /path")
+    }
+}
+
 final class FileHandlerTests: XCTestCase {
     private var subject: FileHandler!
     private let fileManager = FileManager.default

--- a/Tests/TuistGeneratorTests/DotGraph/DotGraphNodeTests.swift
+++ b/Tests/TuistGeneratorTests/DotGraph/DotGraphNodeTests.swift
@@ -7,6 +7,6 @@ final class DotGraphNodeTests: XCTestCase {
     func test_description() {
         let subject = DotGraphNode(name: "node",
                                    attributes: Set(arrayLiteral: .label("carthage framework")))
-        XCTAssertEqual(subject.description, "node [label=\"carthage framework\"]")
+        XCTAssertEqual(subject.description, "\"node\" [label=\"carthage framework\"]")
     }
 }

--- a/Tests/TuistGeneratorTests/DotGraph/DotGraphTests.swift
+++ b/Tests/TuistGeneratorTests/DotGraph/DotGraphTests.swift
@@ -25,12 +25,12 @@ final class DotGraphTests: XCTestCase {
         // Then
         let expected = """
         digraph "TestGraph" {
-          App [label="App"]
-          Core [label="Core"]
-          Search [label="Search", shape="circle"]
+          "App" [label="App"]
+          "Core" [label="Core"]
+          "Search" [label="Search", shape="circle"]
 
-          App -> Search
-          Search -> Core
+          "App" -> "Search"
+          "Search" -> "Core"
         }
         """
         XCTAssertEqual(got, expected)

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
@@ -295,6 +295,10 @@ class WorkspaceStructureGeneratorTests: XCTestCase {
             return []
         }
 
+        func write(_: String, path _: AbsolutePath, atomically _: Bool) throws {
+            // Do nothing
+        }
+
         func createFolder(_ path: AbsolutePath) throws {
             var pathSoFar = AbsolutePath("/")
             for component in path.components.dropFirst() {

--- a/Tests/TuistKitTests/Commands/GraphCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/GraphCommandTests.swift
@@ -59,6 +59,7 @@ final class GraphCommandTests: XCTestCase {
         try subject.run(with: result)
 
         // Then
+        XCTAssertEqual(try fileHandler.readTextFile(graphPath), graph)
         XCTAssertTrue(printer.printArgs.contains("Deleting existing graph at \(graphPath.pathString)"))
         XCTAssertTrue(printer.printSuccessArgs.contains("Graph exported to \(graphPath.pathString)"))
     }

--- a/Tests/TuistKitTests/Commands/GraphCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/GraphCommandTests.swift
@@ -1,0 +1,65 @@
+import Basic
+import Foundation
+import SPMUtility
+import TuistCore
+import XcodeProj
+import XCTest
+@testable import TuistCoreTesting
+@testable import TuistKit
+
+final class GraphCommandTests: XCTestCase {
+    var subject: GraphCommand!
+    var dotGraphGenerator: MockDotGraphGenerator!
+    var fileHandler: MockFileHandler!
+    var printer: MockPrinter!
+    var manifestLoader: MockGraphManifestLoader!
+    var parser: ArgumentParser!
+
+    override func setUp() {
+        super.setUp()
+        dotGraphGenerator = MockDotGraphGenerator()
+        fileHandler = try! MockFileHandler()
+        printer = MockPrinter()
+        manifestLoader = MockGraphManifestLoader()
+        parser = ArgumentParser.test()
+
+        subject = GraphCommand(parser: parser,
+                               fileHandler: fileHandler,
+                               printer: printer,
+                               dotGraphGenerator: dotGraphGenerator,
+                               manifestLoader: manifestLoader)
+    }
+
+    func test_command() {
+        XCTAssertEqual(GraphCommand.command, "graph")
+    }
+
+    func test_overview() {
+        XCTAssertEqual(GraphCommand.overview, "Generates a dot graph from the workspace or project in the current directory.")
+    }
+
+    func test_run() throws {
+        // Given
+        let graphPath = fileHandler.currentPath.appending(component: "graph.dot")
+        let projectManifestPath = fileHandler.currentPath.appending(component: "Project.swift")
+
+        try fileHandler.touch(graphPath)
+        try fileHandler.touch(projectManifestPath)
+
+        manifestLoader.manifestsAtStub = {
+            if $0 == self.fileHandler.currentPath { return Set([.project]) }
+            else { return Set([]) }
+        }
+
+        let graph = "graph {}"
+        dotGraphGenerator.generateProjectStub = graph
+
+        // When
+        let result = try parser.parse([GraphCommand.command])
+        try subject.run(with: result)
+
+        // Then
+        XCTAssertTrue(printer.printArgs.contains("Deleting existing graph at \(graphPath.pathString)"))
+        XCTAssertTrue(printer.printSuccessArgs.contains("Graph exported to \(graphPath.pathString)"))
+    }
+}

--- a/Tests/TuistKitTests/Dot/MockDotGraphGenerator.swift
+++ b/Tests/TuistKitTests/Dot/MockDotGraphGenerator.swift
@@ -3,21 +3,17 @@ import Foundation
 import TuistGenerator
 
 final class MockDotGraphGenerator: DotGraphGenerating {
-    var generateProjectCallCount: UInt = 0
-    var generateWorkspaceCallCount: UInt = 0
     var generateProjectArgs: [AbsolutePath] = []
     var generateWorkspaceArgs: [AbsolutePath] = []
     var generateProjectStub: String = ""
     var generateWorkspaceStub: String = ""
 
     func generateProject(at path: AbsolutePath) throws -> String {
-        generateProjectCallCount += 1
         generateProjectArgs.append(path)
         return generateProjectStub
     }
 
     func generateWorkspace(at path: AbsolutePath) throws -> String {
-        generateWorkspaceCallCount += 1
         generateWorkspaceArgs.append(path)
         return generateWorkspaceStub
     }

--- a/Tests/TuistKitTests/Dot/MockDotGraphGenerator.swift
+++ b/Tests/TuistKitTests/Dot/MockDotGraphGenerator.swift
@@ -1,0 +1,24 @@
+import Basic
+import Foundation
+import TuistGenerator
+
+final class MockDotGraphGenerator: DotGraphGenerating {
+    var generateProjectCallCount: UInt = 0
+    var generateWorkspaceCallCount: UInt = 0
+    var generateProjectArgs: [AbsolutePath] = []
+    var generateWorkspaceArgs: [AbsolutePath] = []
+    var generateProjectStub: String = ""
+    var generateWorkspaceStub: String = ""
+
+    func generateProject(at path: AbsolutePath) throws -> String {
+        generateProjectCallCount += 1
+        generateProjectArgs.append(path)
+        return generateProjectStub
+    }
+
+    func generateWorkspace(at path: AbsolutePath) throws -> String {
+        generateWorkspaceCallCount += 1
+        generateWorkspaceArgs.append(path)
+        return generateWorkspaceStub
+    }
+}

--- a/docs/doczrc.js
+++ b/docs/doczrc.js
@@ -59,6 +59,7 @@ export default {
     'Manifest format',
     'Dependencies',
     'Up tasks',
+    'Graph',
     'Managing versions',
     'Frequently asked questions',
     {

--- a/docs/usage/5-graph.md
+++ b/docs/usage/5-graph.md
@@ -4,7 +4,7 @@ name: Graph
 
 # Graph
 
-When projects grow, it becomes hard to visualize the dependencies between all the targets that are part of the project. Fortunately, Tuist takes provides a command, `tuist generates`, that loads your project dependencies graph and exports it in a representable format.
+When projects grow, it becomes hard to visualize the dependencies between all the targets that are part of the project. Fortunately, Tuist provides a command, `tuist graph`, that loads your project dependencies graph and exports it in a representable format.
 
 Being in a directory that contains a workspace or project manifest, run the following command:
 
@@ -12,8 +12,7 @@ Being in a directory that contains a workspace or project manifest, run the foll
 tuist graph
 ```
 
-The command will output a human-readable file, `graph.dot` that describes the dependencies graph using the [DOT](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) description language.
-
+The command will output a human-readable file, `graph.dot` that describes the dependencies graph using the [DOT](<https://en.wikipedia.org/wiki/DOT_(graph_description_language)>) description language.
 
 ## A visual representation of the graph
 

--- a/docs/usage/5-graph.md
+++ b/docs/usage/5-graph.md
@@ -1,0 +1,27 @@
+---
+name: Graph
+---
+
+# Graph
+
+When projects grow, it becomes hard to visualize the dependencies between all the targets that are part of the project. Fortunately, Tuist takes provides a command, `tuist generates`, that loads your project dependencies graph and exports it in a representable format.
+
+Being in a directory that contains a workspace or project manifest, run the following command:
+
+```bash
+tuist graph
+```
+
+The command will output a human-readable file, `graph.dot` that describes the dependencies graph using the [DOT](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) description language.
+
+
+## A visual representation of the graph
+
+[Graphviz](https://formulae.brew.sh/formula/graphviz) is a command line tool that take the `.dot` graph and convert it into an image.
+
+```bash
+brew install graphviz
+dot -Tpng graph.dot > graph.png
+```
+
+Alternatively, you can use online services like [this one](https://dreampuf.github.io/GraphvizOnline) that renders your graph on a website.


### PR DESCRIPTION
### Short description 📝
Add a `tuist graph` command that generates a `graph.dot` of the project or workspace in the current directory.

### Implementation 👩‍💻👨‍💻
- [x] Add public `DotGraphGenerator` class to `TuistGenerator` that loads the project graph and turns it into a dot graph.
- [x] Implement and register `GraphCommand` command.
- [x] Add unit tests.
- [x] Add documentation.

Since the cases covered by the unit tests closely reflect users' expectations, I didn't add acceptance tests.

### PRs to follow
- Add support for a `--path` argument.
- Create subgraphs that group elements that belong to the same project.
- Support viewing the graph. For that , I plan to add an endpoint to galaxy, `https://galaxy.tuist.io/graph` that renders the graph on a web page.