### PR TITLE
🚧 Add Multi Platform support for Targets 

### DIFF
--- a/Sources/ProjectDescription/Platform.swift
+++ b/Sources/ProjectDescription/Platform.swift
@@ -2,9 +2,19 @@ import Foundation
 
 // MARK: - Platform
 
-public enum Platform: String, Codable {
-    case iOS = "ios"
-    case macOS = "macos"
-    case watchOS = "watchos"
-    case tvOS = "tvos"
+public struct Platform: OptionSet, Codable {
+
+    public let rawValue: Int
+    
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+    
+    public static let iOS     = Platform(rawValue: 1 << 0)
+    public static let macOS   = Platform(rawValue: 1 << 1)
+    public static let watchOS = Platform(rawValue: 1 << 2)
+    public static let tvOS    = Platform(rawValue: 1 << 3)
+    
+    public static let all: Platform = [ .iOS, .macOS, .watchOS, .tvOS ]
+
 }

--- a/Sources/ProjectDescription/Platform.swift
+++ b/Sources/ProjectDescription/Platform.swift
@@ -3,18 +3,16 @@ import Foundation
 // MARK: - Platform
 
 public struct Platform: OptionSet, Codable {
-
     public let rawValue: Int
-    
+
     public init(rawValue: Int) {
         self.rawValue = rawValue
     }
-    
-    public static let iOS     = Platform(rawValue: 1 << 0)
-    public static let macOS   = Platform(rawValue: 1 << 1)
-    public static let watchOS = Platform(rawValue: 1 << 2)
-    public static let tvOS    = Platform(rawValue: 1 << 3)
-    
-    public static let all: Platform = [ .iOS, .macOS, .watchOS, .tvOS ]
 
+    public static let iOS = Platform(rawValue: 1 << 0)
+    public static let macOS = Platform(rawValue: 1 << 1)
+    public static let watchOS = Platform(rawValue: 1 << 2)
+    public static let tvOS = Platform(rawValue: 1 << 3)
+
+    public static let all: Platform = [.iOS, .macOS, .watchOS, .tvOS]
 }

--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -7,7 +7,7 @@ public class Target: Codable {
     public let name: String
 
     /// Product platform.
-    public let platform: [Platform]
+    public let platform: Platform
 
     /// Product type.
     public let product: Product
@@ -80,7 +80,7 @@ public class Target: Codable {
     ///   - coreDataModels: CoreData models.
     ///   - environment: Environment variables to be exposed to the target.
     public init(name: String,
-                platform: Platform...,
+                platform: Platform,
                 product: Product,
                 bundleId: String,
                 infoPlist: InfoPlist,

--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -7,7 +7,7 @@ public class Target: Codable {
     public let name: String
 
     /// Product platform.
-    public let platform: Platform
+    public let platform: [Platform]
 
     /// Product type.
     public let product: Product
@@ -80,7 +80,7 @@ public class Target: Codable {
     ///   - coreDataModels: CoreData models.
     ///   - environment: Environment variables to be exposed to the target.
     public init(name: String,
-                platform: Platform,
+                platform: Platform...,
                 product: Product,
                 bundleId: String,
                 infoPlist: InfoPlist,

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -164,8 +164,14 @@ final class ConfigGenerator: ConfigGenerating {
         if let entitlements = target.entitlements {
             settings["CODE_SIGN_ENTITLEMENTS"] = "$(SRCROOT)/\(entitlements.relative(to: sourceRootPath).pathString)"
         }
-        settings["SDKROOT"] = target.platform.xcodeSdkRoot
-        settings["SUPPORTED_PLATFORMS"] = target.platform.xcodeSupportedPlatforms
+        
+        for platform in target.platform {
+            for supported in platform.xcodeSupportedPlatforms {
+                settings["SDKROOT[sdk=\(supported)*]"] = platform.xcodeSdkRoot
+            }
+            settings["SUPPORTED_PLATFORMS"] = platform.xcodeSupportedPlatforms
+        }
+        
         // TODO: We should show a warning here
         if settings["SWIFT_VERSION"] == nil {
             settings["SWIFT_VERSION"] = Constants.swiftVersion

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -164,14 +164,14 @@ final class ConfigGenerator: ConfigGenerating {
         if let entitlements = target.entitlements {
             settings["CODE_SIGN_ENTITLEMENTS"] = "$(SRCROOT)/\(entitlements.relative(to: sourceRootPath).pathString)"
         }
-        
+
         for platform in target.platform {
             for supported in platform.xcodeSupportedPlatforms {
                 settings["SDKROOT[sdk=\(supported)*]"] = platform.xcodeSdkRoot
             }
             settings["SUPPORTED_PLATFORMS"] = platform.xcodeSupportedPlatforms
         }
-        
+
         // TODO: We should show a warning here
         if settings["SWIFT_VERSION"] == nil {
             settings["SWIFT_VERSION"] = Constants.swiftVersion

--- a/Sources/TuistGenerator/Graph/TargetNode.swift
+++ b/Sources/TuistGenerator/Graph/TargetNode.swift
@@ -60,7 +60,7 @@ class TargetNode: GraphNode {
         }
 
         let dependencies: [GraphNode] = try target.dependencies.flatMap { dependency in
-            return try target.platform.map { platform in
+            try target.platform.map { platform in
                 try node(for: dependency,
                          path: path,
                          name: name,

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -105,20 +105,21 @@ class GraphLinter: GraphLinting {
                                 linkedStaticProducts: inout Set<StaticDepedencyWarning>) -> [LintingIssue] {
         var issues: [LintingIssue] = []
 
-        let fromTarget = LintableTarget(platform: from.target.platform,
+        // TODO FIX LINTINGsupported
+        let fromTarget = LintableTarget(platform: from.target.platform.first!,
                                         product: from.target.product)
-        let toTarget = LintableTarget(platform: to.target.platform,
+        let toTarget = LintableTarget(platform: to.target.platform.first!,
                                       product: to.target.product)
 
         if !GraphLinter.validLinks.keys.contains(fromTarget) {
-            let reason = "Target \(from.target.name) has a platform '\(from.target.platform)' and product '\(from.target.product)' invalid or not supported yet."
+            let reason = "Target \(from.target.name) has a platform '\(from.target.platform.map(\.rawValue))' and product '\(from.target.product)' invalid or not supported yet."
             let issue = LintingIssue(reason: reason, severity: .error)
             issues.append(issue)
         }
         let supportedTargets = GraphLinter.validLinks[fromTarget]!
 
         if !supportedTargets.contains(toTarget) {
-            let reason = "Target \(from.target.name) has a dependency with target \(to.target.name) of type \(to.target.product) for platform '\(to.target.platform)' which is invalid or not supported yet."
+            let reason = "Target \(from.target.name) has a dependency with target \(to.target.name) of type \(to.target.product) for platform '\(to.target.platform.map(\.caseValue))' which is invalid or not supported yet."
             let issue = LintingIssue(reason: reason, severity: .error)
             issues.append(issue)
         }

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -104,37 +104,33 @@ class GraphLinter: GraphLinting {
                                 to: TargetNode,
                                 linkedStaticProducts: inout Set<StaticDepedencyWarning>) -> [LintingIssue] {
         var issues: [LintingIssue] = []
-        
-        var validLinks: [Bool] = [ ]
-        
+
+        var validLinks: [Bool] = []
+
         for fromPlatform in from.target.platform {
-            
             let fromTarget = LintableTarget(platform: fromPlatform,
                                             product: from.target.product)
-            
+
             if !GraphLinter.validLinks.keys.contains(fromTarget) {
                 let reason = "Target \(from.target.name) has a platform '\(fromPlatform.caseValue)' and product '\(from.target.product)' invalid or not supported yet."
                 let issue = LintingIssue(reason: reason, severity: .error)
                 issues.append(issue)
             }
-            
+
             for toPlatform in to.target.platform {
-                
                 let toTarget = LintableTarget(platform: toPlatform,
                                               product: to.target.product)
-  
+
                 let supportedTargets = GraphLinter.validLinks[fromTarget]!
-                
+
                 if supportedTargets.contains(toTarget) {
                     validLinks.append(true)
                 } else {
                     validLinks.append(false)
                 }
-                
             }
-            
         }
-        
+
         if validLinks.contains(true) == false {
             let reason = "Target \(from.target.name) has a dependency with target \(to.target.name) of type \(to.target.product) for the platforms '\(to.target.platform.map(\.caseValue))' which is invalid or not supported yet."
             let issue = LintingIssue(reason: reason, severity: .error)

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -69,7 +69,7 @@ class TargetLinter: TargetLinting {
         if supportsSources, sources.isEmpty {
             return [LintingIssue(reason: "The target \(target.name) doesn't contain source files.", severity: .warning)]
         } else if !supportsSources, !sources.isEmpty {
-            return [LintingIssue(reason: "Target \(target.name) cannot contain sources. \(target.platform) \(target.product) targets don't support source files", severity: .error)]
+            return [LintingIssue(reason: "Target \(target.name) cannot contain sources. \(target.platform.map(\.caseValue)) \(target.product) targets don't support source files", severity: .error)]
         }
 
         return []

--- a/Sources/TuistGenerator/Models/Platform.swift
+++ b/Sources/TuistGenerator/Models/Platform.swift
@@ -26,14 +26,14 @@ extension Platform {
         }
     }
 
-    var xcodeSupportedPlatforms: String {
+    var xcodeSupportedPlatforms: [String] {
         switch self {
         case .tvOS:
-            return "appletvsimulator appletvos"
+            return ["appletvsimulator", "appletvos"]
         case .iOS:
-            return "iphonesimulator iphoneos"
+            return ["iphonesimulator", "iphoneos"]
         case .macOS:
-            return "macosx"
+            return ["macosx"]
         }
     }
 

--- a/Sources/TuistGenerator/Models/Target.swift
+++ b/Sources/TuistGenerator/Models/Target.swift
@@ -13,7 +13,7 @@ public class Target: Equatable {
     // MARK: - Attributes
 
     public let name: String
-    public let platform: Platform
+    public let platform: [Platform]
     public let product: Product
     public let bundleId: String
 
@@ -35,6 +35,38 @@ public class Target: Equatable {
 
     public init(name: String,
                 platform: Platform,
+                product: Product,
+                bundleId: String,
+                infoPlist: InfoPlist? = nil,
+                entitlements: AbsolutePath? = nil,
+                settings: Settings? = nil,
+                sources: [SourceFile] = [],
+                resources: [FileElement] = [],
+                headers: Headers? = nil,
+                coreDataModels: [CoreDataModel] = [],
+                actions: [TargetAction] = [],
+                environment: [String: String] = [:],
+                filesGroup: ProjectGroup,
+                dependencies: [Dependency] = []) {
+        self.name = name
+        self.product = product
+        self.platform = [ platform ]
+        self.bundleId = bundleId
+        self.infoPlist = infoPlist
+        self.entitlements = entitlements
+        self.settings = settings
+        self.sources = sources
+        self.resources = resources
+        self.headers = headers
+        self.coreDataModels = coreDataModels
+        self.actions = actions
+        self.environment = environment
+        self.filesGroup = filesGroup
+        self.dependencies = dependencies
+    }
+    
+    public init(name: String,
+                platform: [Platform],
                 product: Product,
                 bundleId: String,
                 infoPlist: InfoPlist? = nil,
@@ -86,12 +118,7 @@ public class Target: Equatable {
     }
 
     var supportsSources: Bool {
-        switch (platform, product) {
-        case (.iOS, .bundle):
-            return false
-        default:
-            return true
-        }
+        return !(platform.contains(.iOS) && product == .bundle)
     }
 
     public static func sources(projectPath: AbsolutePath, sources: [(glob: String, compilerFlags: String?)]) throws -> [Target.SourceFile] {

--- a/Sources/TuistGenerator/Models/Target.swift
+++ b/Sources/TuistGenerator/Models/Target.swift
@@ -32,38 +32,6 @@ public class Target: Equatable {
     public let filesGroup: ProjectGroup
 
     // MARK: - Init
-
-    public init(name: String,
-                platform: Platform,
-                product: Product,
-                bundleId: String,
-                infoPlist: InfoPlist? = nil,
-                entitlements: AbsolutePath? = nil,
-                settings: Settings? = nil,
-                sources: [SourceFile] = [],
-                resources: [FileElement] = [],
-                headers: Headers? = nil,
-                coreDataModels: [CoreDataModel] = [],
-                actions: [TargetAction] = [],
-                environment: [String: String] = [:],
-                filesGroup: ProjectGroup,
-                dependencies: [Dependency] = []) {
-        self.name = name
-        self.product = product
-        self.platform = [ platform ]
-        self.bundleId = bundleId
-        self.infoPlist = infoPlist
-        self.entitlements = entitlements
-        self.settings = settings
-        self.sources = sources
-        self.resources = resources
-        self.headers = headers
-        self.coreDataModels = coreDataModels
-        self.actions = actions
-        self.environment = environment
-        self.filesGroup = filesGroup
-        self.dependencies = dependencies
-    }
     
     public init(name: String,
                 platform: [Platform],

--- a/Sources/TuistGenerator/Models/Target.swift
+++ b/Sources/TuistGenerator/Models/Target.swift
@@ -32,7 +32,7 @@ public class Target: Equatable {
     public let filesGroup: ProjectGroup
 
     // MARK: - Init
-    
+
     public init(name: String,
                 platform: [Platform],
                 product: Product,

--- a/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
+++ b/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
@@ -84,39 +84,36 @@ public final class DefaultSettingsProvider: DefaultSettingsProviding {
         let defaultSettings = target.settings?.defaultSettings ?? .recommended
         let product = settingsHelper.settingsProviderProduct(target)
         let variant = settingsHelper.variant(buildConfiguration)
-        
+
         var settings: [String: Any] = [:]
-        
+
         for platform in target.platform {
-            
             let buildPlatform = settingsHelper.settingsProviderPlatform(platform)
-            
+
             let targetDefaultAll = BuildSettingsProvider.targetDefault(variant: .all,
                                                                        platform: buildPlatform,
                                                                        product: product,
                                                                        swift: true)
-            
+
             let targetDefaultVariant = BuildSettingsProvider.targetDefault(variant: variant,
                                                                            platform: buildPlatform,
                                                                            product: product,
                                                                            swift: true)
             let filter = createFilter(defaultSettings: defaultSettings,
                                       essentialKeys: DefaultSettingsProvider.essentialTargetSettings)
-            
+
             for supported in platform.xcodeSupportedPlatforms {
-                
                 // If we support more than one SDK, we should ensure the build settings are keyed
                 // on the supported platform.
                 let sdk = target.platform.count > 1 ? supported : nil
-                
+
                 settingsHelper.extend(buildSettings: &settings, with: targetDefaultAll, sdk: sdk)
                 settingsHelper.extend(buildSettings: &settings, with: targetDefaultVariant, sdk: sdk)
             }
-            
+
             settings = settings.filter(filter)
-            
         }
-        
+
         return settings
     }
 

--- a/Sources/TuistGenerator/Utils/SettingsHelper.swift
+++ b/Sources/TuistGenerator/Utils/SettingsHelper.swift
@@ -2,8 +2,17 @@ import Foundation
 import XcodeProj
 
 final class SettingsHelper {
-    func extend(buildSettings: inout [String: Any], with other: [String: Any]) {
-        other.forEach { key, value in
+    func extend(buildSettings: inout [String: Any], with other: [String: Any], sdk: String? = nil) {
+        other.forEach { _key, value in
+            
+            let key: String
+            
+            if let sdk = sdk {
+                key = "\(_key)[sdk=\(sdk)*]"
+            } else {
+                key = _key
+            }
+
             if buildSettings[key] == nil || (value as? String)?.contains("$(inherited)") == false {
                 buildSettings[key] = value
             } else if let previousValueString = buildSettings[key] as? String, let newValueString = value as? String,
@@ -15,15 +24,12 @@ final class SettingsHelper {
         }
     }
 
-    func settingsProviderPlatform(_ target: Target) -> BuildSettingsProvider.Platform? {
-        var platform: BuildSettingsProvider.Platform?
-        switch target.platform {
-        case .iOS: platform = .iOS
-        case .macOS: platform = .macOS
-        case .tvOS: platform = .tvOS
-            // case .watchOS: platform = .watchOS
+    func settingsProviderPlatform(_ platform: Platform) -> BuildSettingsProvider.Platform {
+        switch platform {
+        case .iOS: return .iOS
+        case .macOS: return .macOS
+        case .tvOS: return .tvOS
         }
-        return platform
     }
 
     func settingsProviderProduct(_ target: Target) -> BuildSettingsProvider.Product? {

--- a/Sources/TuistGenerator/Utils/SettingsHelper.swift
+++ b/Sources/TuistGenerator/Utils/SettingsHelper.swift
@@ -4,9 +4,9 @@ import XcodeProj
 final class SettingsHelper {
     func extend(buildSettings: inout [String: Any], with other: [String: Any], sdk: String? = nil) {
         other.forEach { _key, value in
-            
+
             let key: String
-            
+
             if let sdk = sdk {
                 key = "\(_key)[sdk=\(sdk)*]"
             } else {

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -190,7 +190,6 @@ extension TuistGenerator.Project {
 }
 
 extension TuistGenerator.Target {
-
     static func from(manifest: ProjectDescription.Target,
                      path: AbsolutePath,
                      fileHandler: FileHandling,
@@ -246,37 +245,30 @@ extension TuistGenerator.Target {
                                      filesGroup: .group(name: "Project"),
                                      dependencies: dependencies)
     }
-    
-
-    
 }
 
 extension Array where Element == TuistGenerator.Platform {
-    
     static func from(manifest platform: ProjectDescription.Platform) throws -> [TuistGenerator.Platform] {
-        
-        var platforms: [TuistGenerator.Platform] = [ ]
-        
+        var platforms: [TuistGenerator.Platform] = []
+
         if platform.contains(.iOS) {
             platforms.append(.iOS)
         }
-        
+
         if platform.contains(.macOS) {
             platforms.append(.macOS)
         }
-        
+
         if platform.contains(.tvOS) {
             platforms.append(.tvOS)
         }
-        
+
         if platform.contains(.watchOS) {
             throw GeneratorModelLoaderError.featureNotYetSupported("watchOS platform")
         }
-        
+
         return platforms
-        
     }
-    
 }
 
 extension TuistGenerator.InfoPlist {

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -195,7 +195,7 @@ extension TuistGenerator.Target {
                      fileHandler: FileHandling,
                      printer: Printing) throws -> TuistGenerator.Target {
         let name = manifest.name
-        let platform = try TuistGenerator.Platform.from(manifest: manifest.platform)
+        let platform = try manifest.platform.map(TuistGenerator.Platform.from)
         let product = TuistGenerator.Product.from(manifest: manifest.product)
 
         let bundleId = manifest.bundleId

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -190,12 +190,13 @@ extension TuistGenerator.Project {
 }
 
 extension TuistGenerator.Target {
+
     static func from(manifest: ProjectDescription.Target,
                      path: AbsolutePath,
                      fileHandler: FileHandling,
                      printer: Printing) throws -> TuistGenerator.Target {
         let name = manifest.name
-        let platform = try manifest.platform.map(TuistGenerator.Platform.from)
+        let platform = try [TuistGenerator.Platform].from(manifest: manifest.platform)
         let product = TuistGenerator.Product.from(manifest: manifest.product)
 
         let bundleId = manifest.bundleId
@@ -245,6 +246,37 @@ extension TuistGenerator.Target {
                                      filesGroup: .group(name: "Project"),
                                      dependencies: dependencies)
     }
+    
+
+    
+}
+
+extension Array where Element == TuistGenerator.Platform {
+    
+    static func from(manifest platform: ProjectDescription.Platform) throws -> [TuistGenerator.Platform] {
+        
+        var platforms: [TuistGenerator.Platform] = [ ]
+        
+        if platform.contains(.iOS) {
+            platforms.append(.iOS)
+        }
+        
+        if platform.contains(.macOS) {
+            platforms.append(.macOS)
+        }
+        
+        if platform.contains(.tvOS) {
+            platforms.append(.tvOS)
+        }
+        
+        if platform.contains(.watchOS) {
+            throw GeneratorModelLoaderError.featureNotYetSupported("watchOS platform")
+        }
+        
+        return platforms
+        
+    }
+    
 }
 
 extension TuistGenerator.InfoPlist {
@@ -471,21 +503,6 @@ extension TuistGenerator.Product {
             return .unitTests
         case .uiTests:
             return .uiTests
-        }
-    }
-}
-
-extension TuistGenerator.Platform {
-    static func from(manifest: ProjectDescription.Platform) throws -> TuistGenerator.Platform {
-        switch manifest {
-        case .macOS:
-            return .macOS
-        case .iOS:
-            return .iOS
-        case .tvOS:
-            return .tvOS
-        case .watchOS:
-            throw GeneratorModelLoaderError.featureNotYetSupported("watchOS platform")
         }
     }
 }

--- a/Sources/TuistKit/Generator/ManifestTargetGenerator.swift
+++ b/Sources/TuistKit/Generator/ManifestTargetGenerator.swift
@@ -24,7 +24,7 @@ class ManifestTargetGenerator: ManifestTargetGenerating {
                                 defaultSettings: .recommended)
         let manifest = try manifestLoader.manifestPath(at: path, manifest: .project)
         return Target(name: "\(project)-Manifest",
-                      platform: .macOS,
+                      platform: [.macOS],
                       product: .staticFramework,
                       bundleId: "io.tuist.manifests.${PRODUCT_NAME:rfc1034identifier}",
                       settings: settings,

--- a/Tests/ProjectDescriptionTests/PlatformTests .swift
+++ b/Tests/ProjectDescriptionTests/PlatformTests .swift
@@ -6,9 +6,9 @@ import XCTest
 
 final class PlatformTests: XCTestCase {
     func test_toJSON() {
-        XCTAssertCodableEqualToJson([Platform.iOS], "[\"ios\"]")
-        XCTAssertCodableEqualToJson([Platform.macOS], "[\"macos\"]")
-        XCTAssertCodableEqualToJson([Platform.watchOS], "[\"watchos\"]")
-        XCTAssertCodableEqualToJson([Platform.tvOS], "[\"tvos\"]")
+        XCTAssertCodableEqualToJson([Platform.iOS], "[1]")
+        XCTAssertCodableEqualToJson([Platform.macOS], "[2]")
+        XCTAssertCodableEqualToJson([Platform.watchOS], "[4]")
+        XCTAssertCodableEqualToJson([Platform.tvOS], "[8]")
     }
 }

--- a/Tests/ProjectDescriptionTests/TargetTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetTests.swift
@@ -88,7 +88,7 @@ final class TargetTests: XCTestCase {
                     "pattern": "resources\\/*"
                 }
             ],
-            "platform": "ios",
+            "platform": [ "ios" ],
             "entitlements": "entitlement",
             "info_plist": {
                 "type": "file",
@@ -207,7 +207,7 @@ final class TargetTests: XCTestCase {
                     "pattern": "resources\\/*"
                 }
             ],
-            "platform": "ios",
+            "platform": [ "ios" ],
             "entitlements": "entitlement",
             "info_plist": {
                 "type": "file",

--- a/Tests/ProjectDescriptionTests/TargetTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetTests.swift
@@ -88,7 +88,7 @@ final class TargetTests: XCTestCase {
                     "pattern": "resources\\/*"
                 }
             ],
-            "platform": [ "ios" ],
+            "platform": 1,
             "entitlements": "entitlement",
             "info_plist": {
                 "type": "file",
@@ -207,7 +207,7 @@ final class TargetTests: XCTestCase {
                     "pattern": "resources\\/*"
                 }
             ],
-            "platform": [ "ios" ],
+            "platform": 1,
             "entitlements": "entitlement",
             "info_plist": {
                 "type": "file",

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -197,7 +197,7 @@ final class ConfigGeneratorTests: XCTestCase {
     private func generateTestTargetConfig(uiTest: Bool = false) throws {
         let dir = try TemporaryDirectory(removeTreeOnDeinit: true)
 
-        let appTarget = Target.test(name: "App", platform: .iOS, product: .app)
+        let appTarget = Target.test(name: "App", platform: [.iOS], product: .app)
 
         let target = Target.test(name: "Test", product: uiTest ? .uiTests : .unitTests)
         let project = Project.test(path: dir.path, name: "Project", targets: [target])

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -227,7 +227,7 @@ final class ProjectFileElementsTests: XCTestCase {
         )
 
         let target = Target.test(name: "name",
-                                 platform: .iOS,
+                                 platform: [.iOS],
                                  product: .app,
                                  bundleId: "com.bundle.id",
                                  infoPlist: .file(path: AbsolutePath("/project/info.plist")),

--- a/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
@@ -24,7 +24,7 @@ final class ProjectGeneratorTests: XCTestCase {
 
     func test_generate() throws {
         // Given
-        let target = Target.test(name: "Target", platform: .iOS, product: .framework)
+        let target = Target.test(name: "Target", platform: [.iOS], product: .framework)
         let targets = [target]
         let project = Project.test(path: fileHandler.currentPath, name: "Project", targets: targets)
         try fileHandler.touch(fileHandler.currentPath.appending(component: "Project.swift"))
@@ -50,7 +50,7 @@ final class ProjectGeneratorTests: XCTestCase {
 
     func test_generate_scheme() throws {
         // Given
-        let target = Target.test(name: "Target", platform: .iOS, product: .framework)
+        let target = Target.test(name: "Target", platform: [.iOS], product: .framework)
         let sharedScheme = Scheme.test(name: "Target-Scheme", shared: true, buildAction: BuildAction(targets: ["Target"]))
 
         let targets = [target]
@@ -78,7 +78,7 @@ final class ProjectGeneratorTests: XCTestCase {
 
     func test_generate_local_scheme() throws {
         // Given
-        let target = Target.test(name: "Target", platform: .iOS, product: .framework)
+        let target = Target.test(name: "Target", platform: [.iOS], product: .framework)
         let localScheme = Scheme.test(name: "Target-Local", shared: false, buildAction: BuildAction(targets: ["Target"]))
 
         let targets = [target]
@@ -108,10 +108,10 @@ final class ProjectGeneratorTests: XCTestCase {
     func test_generate_testTargetIdentity() throws {
         // Given
         let app = Target.test(name: "App",
-                              platform: .iOS,
+                              platform: [.iOS],
                               product: .app)
         let test = Target.test(name: "Tests",
-                               platform: .iOS,
+                               platform: [.iOS],
                                product: .unitTests)
         let project = Project.test(path: fileHandler.currentPath,
                                    name: "Project",

--- a/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
@@ -238,7 +238,7 @@ final class SchemeGeneratorTests: XCTestCase {
     }
 
     func test_schemeLaunchAction_when_notRunnableTarget() {
-        let target = Target.test(name: "Library", platform: .iOS, product: .dynamicLibrary)
+        let target = Target.test(name: "Library", platform: [.iOS], product: .dynamicLibrary)
         let pbxTarget = PBXNativeTarget(name: "App")
 
         let buildAction = BuildAction.test(targets: ["Library"])
@@ -261,7 +261,7 @@ final class SchemeGeneratorTests: XCTestCase {
     }
 
     func test_schemeProfileAction_when_runnableTarget() {
-        let target = Target.test(name: "App", platform: .iOS, product: .app)
+        let target = Target.test(name: "App", platform: [.iOS], product: .app)
         let scheme = Scheme.test()
         let pbxTarget = PBXNativeTarget(name: "App")
         let project = Project.test(path: AbsolutePath("/project.xcodeproj"), targets: [target])
@@ -292,7 +292,7 @@ final class SchemeGeneratorTests: XCTestCase {
     }
 
     func test_schemeProfileAction_when_notRunnableTarget() {
-        let target = Target.test(name: "Library", platform: .iOS, product: .dynamicLibrary)
+        let target = Target.test(name: "Library", platform: [.iOS], product: .dynamicLibrary)
 
         let buildAction = BuildAction.test(targets: ["Library"])
         let testAction = TestAction.test(targets: ["Library"])

--- a/Tests/TuistGeneratorTests/Graph/GraphTests.swift
+++ b/Tests/TuistGeneratorTests/Graph/GraphTests.swift
@@ -389,7 +389,7 @@ final class GraphTests: XCTestCase {
             {
               "product" : "\(target.target.product.rawValue)",
               "bundle_id" : "\(target.target.bundleId)",
-              "platform" : "\(target.target.platform.rawValue)",
+              "platform" : \(target.target.platform.map(\.caseValue)),
               "path" : "\(target.path)",
               "dependencies" : [
                 "xpm",

--- a/Tests/TuistGeneratorTests/Graph/TargetNodeTests.swift
+++ b/Tests/TuistGeneratorTests/Graph/TargetNodeTests.swift
@@ -68,7 +68,7 @@ final class TargetNodeTests: XCTestCase {
         "\(library.name)",
         "\(framework.name)"
         ],
-        "platform" : "\(node.target.platform.rawValue)"
+        "platform" : \(node.target.platform.map(\.caseValue))
         }
         """
 

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -205,8 +205,8 @@ final class GraphLinterTests: XCTestCase {
         // Then
         let sortedResults = result.sorted { $0.reason < $1.reason }
         XCTAssertEqual(sortedResults, [
-            LintingIssue(reason: "Target staticFramework has a dependency with target bundle of type bundle for platform '[\"iOS\"]' which is invalid or not supported yet.", severity: .error),
-            LintingIssue(reason: "Target staticLibrary has a dependency with target bundle of type bundle for platform '[\"iOS\"]' which is invalid or not supported yet.", severity: .error),
+            LintingIssue(reason: "Target staticFramework has a dependency with target bundle of type bundle for the platforms '[\"iOS\"]' which is invalid or not supported yet.", severity: .error),
+            LintingIssue(reason: "Target staticLibrary has a dependency with target bundle of type bundle for the platforms '[\"iOS\"]' which is invalid or not supported yet.", severity: .error),
         ])
     }
 }

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -205,8 +205,8 @@ final class GraphLinterTests: XCTestCase {
         // Then
         let sortedResults = result.sorted { $0.reason < $1.reason }
         XCTAssertEqual(sortedResults, [
-            LintingIssue(reason: "Target staticFramework has a dependency with target bundle of type bundle for platform 'iOS' which is invalid or not supported yet.", severity: .error),
-            LintingIssue(reason: "Target staticLibrary has a dependency with target bundle of type bundle for platform 'iOS' which is invalid or not supported yet.", severity: .error),
+            LintingIssue(reason: "Target staticFramework has a dependency with target bundle of type bundle for platform '[\"iOS\"]' which is invalid or not supported yet.", severity: .error),
+            LintingIssue(reason: "Target staticLibrary has a dependency with target bundle of type bundle for platform '[\"iOS\"]' which is invalid or not supported yet.", severity: .error),
         ])
     }
 }

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -106,7 +106,7 @@ final class TargetLinterTests: XCTestCase {
         // Then
         let sortedResults = result.sorted(by: { $0.reason < $1.reason })
         XCTAssertEqual(sortedResults, [
-            LintingIssue(reason: "Target \(bundle.name) cannot contain sources. iOS bundle targets don't support source files", severity: .error),
+            LintingIssue(reason: "Target \(bundle.name) cannot contain sources. [iOS] bundle targets don't support source files", severity: .error),
         ])
     }
 

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -93,7 +93,7 @@ final class TargetLinterTests: XCTestCase {
 
     func test_lint_when_ios_bundle_has_sources() {
         // Given
-        let bundle = Target.empty(platform: .iOS,
+        let bundle = Target.empty(platform: [.iOS],
                                   product: .bundle,
                                   sources: [
                                       (path: "/path/to/some/source.swift", compilerFlags: nil),
@@ -106,13 +106,13 @@ final class TargetLinterTests: XCTestCase {
         // Then
         let sortedResults = result.sorted(by: { $0.reason < $1.reason })
         XCTAssertEqual(sortedResults, [
-            LintingIssue(reason: "Target \(bundle.name) cannot contain sources. [iOS] bundle targets don't support source files", severity: .error),
+            LintingIssue(reason: "Target \(bundle.name) cannot contain sources. [\"iOS\"] bundle targets don't support source files", severity: .error),
         ])
     }
 
     func test_lint_valid_ios_bundle() {
         // Given
-        let bundle = Target.empty(platform: .iOS,
+        let bundle = Target.empty(platform: [.iOS],
                                   product: .bundle,
                                   resources: [
                                       .file(path: "/path/to/some/asset.png"),

--- a/Tests/TuistGeneratorTests/Models/PlatformTests.swift
+++ b/Tests/TuistGeneratorTests/Models/PlatformTests.swift
@@ -10,9 +10,9 @@ final class PlatformTests: XCTestCase {
     }
 
     func test_xcodeSupportedPLatforms_returns_the_right_value() {
-        XCTAssertEqual(Platform.macOS.xcodeSupportedPlatforms, "macosx")
-        XCTAssertEqual(Platform.iOS.xcodeSupportedPlatforms, "iphonesimulator iphoneos")
-        XCTAssertEqual(Platform.tvOS.xcodeSupportedPlatforms, "appletvsimulator appletvos")
+        XCTAssertEqual(Platform.macOS.xcodeSupportedPlatforms, ["macosx"])
+        XCTAssertEqual(Platform.iOS.xcodeSupportedPlatforms, ["iphonesimulator", "iphoneos"])
+        XCTAssertEqual(Platform.tvOS.xcodeSupportedPlatforms, ["appletvsimulator", "appletvos"])
     }
 
     func test_xcodeSdkRootPath() {

--- a/Tests/TuistGeneratorTests/Models/TestData/Target+TestData.swift
+++ b/Tests/TuistGeneratorTests/Models/TestData/Target+TestData.swift
@@ -6,7 +6,7 @@ extension Target {
     /// Creates a Target with test data
     /// Note: Referenced paths may not exist
     static func test(name: String = "Target",
-                     platform: Platform = .iOS,
+                     platform: [Platform] = [.iOS],
                      product: Product = .app,
                      bundleId: String = "com.test.bundle_id",
                      infoPlist: InfoPlist? = .file(path: AbsolutePath("/Info.plist")),
@@ -21,7 +21,7 @@ extension Target {
                      filesGroup: ProjectGroup = .group(name: "Project"),
                      dependencies: [Dependency] = []) -> Target {
         return Target(name: name,
-                      platform: [ platform ],
+                      platform: platform,
                       product: product,
                       bundleId: bundleId,
                       infoPlist: infoPlist,
@@ -39,7 +39,7 @@ extension Target {
     
     /// Creates a bare bones Target with as little data as possible
     static func empty(name: String = "Target",
-                      platform: Platform = .iOS,
+                      platform: [Platform] = [.iOS],
                       product: Product = .app,
                       bundleId: String = "com.test.bundleId",
                       infoPlist: InfoPlist? = nil,
@@ -54,7 +54,7 @@ extension Target {
                       filesGroup: ProjectGroup = .group(name: "Project"),
                       dependencies: [Dependency] = []) -> Target {
         return Target(name: name,
-                      platform: [platform],
+                      platform: platform,
                       product: product,
                       bundleId: bundleId,
                       infoPlist: infoPlist,

--- a/Tests/TuistGeneratorTests/Models/TestData/Target+TestData.swift
+++ b/Tests/TuistGeneratorTests/Models/TestData/Target+TestData.swift
@@ -21,7 +21,7 @@ extension Target {
                      filesGroup: ProjectGroup = .group(name: "Project"),
                      dependencies: [Dependency] = []) -> Target {
         return Target(name: name,
-                      platform: platform,
+                      platform: [ platform ],
                       product: product,
                       bundleId: bundleId,
                       infoPlist: infoPlist,
@@ -36,7 +36,7 @@ extension Target {
                       filesGroup: filesGroup,
                       dependencies: dependencies)
     }
-
+    
     /// Creates a bare bones Target with as little data as possible
     static func empty(name: String = "Target",
                       platform: Platform = .iOS,
@@ -54,7 +54,7 @@ extension Target {
                       filesGroup: ProjectGroup = .group(name: "Project"),
                       dependencies: [Dependency] = []) -> Target {
         return Target(name: name,
-                      platform: platform,
+                      platform: [platform],
                       product: product,
                       bundleId: bundleId,
                       infoPlist: infoPlist,
@@ -69,4 +69,5 @@ extension Target {
                       filesGroup: filesGroup,
                       dependencies: dependencies)
     }
+    
 }

--- a/Tests/TuistGeneratorTests/Models/TestData/Target+TestData.swift
+++ b/Tests/TuistGeneratorTests/Models/TestData/Target+TestData.swift
@@ -36,7 +36,7 @@ extension Target {
                       filesGroup: filesGroup,
                       dependencies: dependencies)
     }
-    
+
     /// Creates a bare bones Target with as little data as possible
     static func empty(name: String = "Target",
                       platform: [Platform] = [.iOS],
@@ -69,5 +69,4 @@ extension Target {
                       filesGroup: filesGroup,
                       dependencies: dependencies)
     }
-    
 }

--- a/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -355,4 +355,44 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         // Then
         XCTAssertEqual(got.count, 0)
     }
+    
+    let targetMultiPlatformSettingsForMacOSiOS = [
+        "SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=macosx*]": "DEBUG",
+        "CODE_SIGN_IDENTITY[sdk=iphoneos*]": "iPhone Developer",
+        "SDKROOT[sdk=macosx*]": "macosx",
+        "COMBINE_HIDPI_IMAGES[sdk=macosx*]": "YES",
+        "ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphonesimulator*]": "AppIcon",
+        "TARGETED_DEVICE_FAMILY[sdk=iphonesimulator*]": "1,2",
+        "SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=iphoneos*]": "DEBUG",
+        "LD_RUNPATH_SEARCH_PATHS[sdk=iphoneos*]": "$(inherited) @executable_path/Frameworks",
+        "CODE_SIGN_IDENTITY[sdk=iphonesimulator*]": "iPhone Developer",
+        "SDKROOT[sdk=iphoneos*]": "iphoneos",
+        "SWIFT_OPTIMIZATION_LEVEL[sdk=iphonesimulator*]": "-Onone",
+        "SWIFT_COMPILATION_MODE[sdk=iphoneos*]": "singlefile",
+        "CODE_SIGN_IDENTITY[sdk=macosx*]": "-",
+        "SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=iphonesimulator*]": "DEBUG",
+        "LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]": "$(inherited) @executable_path/../Frameworks",
+        "SWIFT_OPTIMIZATION_LEVEL[sdk=macosx*]": "-Onone",
+        "TARGETED_DEVICE_FAMILY[sdk=iphoneos*]": "1,2",
+        "ASSETCATALOG_COMPILER_APPICON_NAME[sdk=macosx*]": "AppIcon",
+        "ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphoneos*]": "AppIcon",
+        "SDKROOT[sdk=iphonesimulator*]": "iphoneos",
+        "SWIFT_COMPILATION_MODE[sdk=iphonesimulator*]": "singlefile",
+        "SWIFT_OPTIMIZATION_LEVEL[sdk=iphoneos*]": "-Onone",
+        "LD_RUNPATH_SEARCH_PATHS[sdk=iphonesimulator*]": "$(inherited) @executable_path/Frameworks",
+        "SWIFT_COMPILATION_MODE[sdk=macosx*]": "singlefile"
+    ]
+    
+    func testTargetSettings_when_multi_platform() {
+        // Given
+
+        let target = Target.test(platform: [.iOS, .macOS])
+        
+        // When
+        let got = subject.targetSettings(target: target,
+                                         buildConfiguration: .debug)
+        
+        // Then
+        XCTAssertDictionary(got, containsAll: targetMultiPlatformSettingsForMacOSiOS)
+    }
 }

--- a/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -355,7 +355,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         // Then
         XCTAssertEqual(got.count, 0)
     }
-    
+
     let targetMultiPlatformSettingsForMacOSiOS = [
         "SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=macosx*]": "DEBUG",
         "CODE_SIGN_IDENTITY[sdk=iphoneos*]": "iPhone Developer",
@@ -380,18 +380,18 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         "SWIFT_COMPILATION_MODE[sdk=iphonesimulator*]": "singlefile",
         "SWIFT_OPTIMIZATION_LEVEL[sdk=iphoneos*]": "-Onone",
         "LD_RUNPATH_SEARCH_PATHS[sdk=iphonesimulator*]": "$(inherited) @executable_path/Frameworks",
-        "SWIFT_COMPILATION_MODE[sdk=macosx*]": "singlefile"
+        "SWIFT_COMPILATION_MODE[sdk=macosx*]": "singlefile",
     ]
-    
+
     func testTargetSettings_when_multi_platform() {
         // Given
 
         let target = Target.test(platform: [.iOS, .macOS])
-        
+
         // When
         let got = subject.targetSettings(target: target,
                                          buildConfiguration: .debug)
-        
+
         // Then
         XCTAssertDictionary(got, containsAll: targetMultiPlatformSettingsForMacOSiOS)
     }

--- a/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
@@ -88,9 +88,9 @@ final class SettingsHelpersTests: XCTestCase {
     }
 
     func testSettingsProviderPlatform() {
-        XCTAssertEqual(subject.settingsProviderPlatform(.test(platform: .iOS)), .iOS)
-        XCTAssertEqual(subject.settingsProviderPlatform(.test(platform: .macOS)), .macOS)
-        XCTAssertEqual(subject.settingsProviderPlatform(.test(platform: .tvOS)), .tvOS)
+        XCTAssertEqual(subject.settingsProviderPlatform(.iOS), .iOS)
+        XCTAssertEqual(subject.settingsProviderPlatform(.macOS), .macOS)
+        XCTAssertEqual(subject.settingsProviderPlatform(.tvOS), .tvOS)
     }
 
     func testSettingsProviderProduct() {

--- a/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -334,7 +334,7 @@ final class MultipleConfigurationsIntegrationTests: XCTestCase {
 
     private func createAppTarget(settings: Settings?) -> Target {
         return Target(name: "AppTarget",
-                      platform: .iOS,
+                      platform: [.iOS],
                       product: .app,
                       bundleId: "test.bundle",
                       settings: settings,

--- a/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
@@ -108,7 +108,7 @@ final class StableXcodeProjIntegrationTests: XCTestCase {
 
     private func createAppTarget(settings: Settings?, dependencies: [String]) -> Target {
         return Target(name: "AppTarget",
-                      platform: .iOS,
+                      platform: [.iOS],
                       product: .app,
                       bundleId: "test.bundle",
                       settings: settings,
@@ -184,7 +184,7 @@ final class StableXcodeProjIntegrationTests: XCTestCase {
 
     private func createFrameworkTarget(name: String, depenendencies: [Dependency] = []) throws -> Target {
         return Target(name: name,
-                      platform: .iOS,
+                      platform: [.iOS],
                       product: .framework,
                       bundleId: "test.bundle.\(name)",
                       settings: nil,

--- a/Tests/TuistKitTests/Generator/GeneratorModelLoaderTest.swift
+++ b/Tests/TuistKitTests/Generator/GeneratorModelLoaderTest.swift
@@ -534,9 +534,8 @@ class GeneratorModelLoaderTest: XCTestCase {
                 line: UInt = #line) {
         XCTAssertEqual(target.name, manifest.name, file: file, line: line)
         XCTAssertEqual(target.bundleId, manifest.bundleId, file: file, line: line)
-        
+
         for platform in target.platform {
-            
             switch platform {
             case .iOS:
                 XCTAssertTrue(manifest.platform.contains(.iOS), file: file, line: line)
@@ -545,7 +544,6 @@ class GeneratorModelLoaderTest: XCTestCase {
             case .tvOS:
                 XCTAssertTrue(manifest.platform.contains(.tvOS), file: file, line: line)
             }
-            
         }
 
         XCTAssertTrue(target.product == manifest.product, file: file, line: line)

--- a/Tests/TuistKitTests/Generator/GeneratorModelLoaderTest.swift
+++ b/Tests/TuistKitTests/Generator/GeneratorModelLoaderTest.swift
@@ -534,7 +534,7 @@ class GeneratorModelLoaderTest: XCTestCase {
                 line: UInt = #line) {
         XCTAssertEqual(target.name, manifest.name, file: file, line: line)
         XCTAssertEqual(target.bundleId, manifest.bundleId, file: file, line: line)
-        XCTAssertTrue(target.platform == manifest.platform, file: file, line: line)
+        XCTAssertTrue(target.platform.map(\.rawValue) == manifest.platform.map(\.rawValue), file: file, line: line)
         XCTAssertTrue(target.product == manifest.product, file: file, line: line)
         XCTAssertEqual(target.infoPlist?.path, path.appending(RelativePath(manifest.infoPlist.path)), file: file, line: line)
         XCTAssertEqual(target.entitlements, manifest.entitlements.map { path.appending(RelativePath($0)) }, file: file, line: line)

--- a/Tests/TuistKitTests/Generator/GeneratorModelLoaderTest.swift
+++ b/Tests/TuistKitTests/Generator/GeneratorModelLoaderTest.swift
@@ -395,7 +395,7 @@ class GeneratorModelLoaderTest: XCTestCase {
 
     func test_platform_watchOSNotSupported() {
         XCTAssertThrowsError(
-            try TuistGenerator.Platform.from(manifest: .watchOS)
+            try [TuistGenerator.Platform].from(manifest: .watchOS)
         ) { error in
             XCTAssertEqual(error as? GeneratorModelLoaderError, GeneratorModelLoaderError.featureNotYetSupported("watchOS platform"))
         }
@@ -534,7 +534,20 @@ class GeneratorModelLoaderTest: XCTestCase {
                 line: UInt = #line) {
         XCTAssertEqual(target.name, manifest.name, file: file, line: line)
         XCTAssertEqual(target.bundleId, manifest.bundleId, file: file, line: line)
-        XCTAssertTrue(target.platform.map(\.rawValue) == manifest.platform.map(\.rawValue), file: file, line: line)
+        
+        for platform in target.platform {
+            
+            switch platform {
+            case .iOS:
+                XCTAssertTrue(manifest.platform.contains(.iOS), file: file, line: line)
+            case .macOS:
+                XCTAssertTrue(manifest.platform.contains(.macOS), file: file, line: line)
+            case .tvOS:
+                XCTAssertTrue(manifest.platform.contains(.tvOS), file: file, line: line)
+            }
+            
+        }
+
         XCTAssertTrue(target.product == manifest.product, file: file, line: line)
         XCTAssertEqual(target.infoPlist?.path, path.appending(RelativePath(manifest.infoPlist.path)), file: file, line: line)
         XCTAssertEqual(target.entitlements, manifest.entitlements.map { path.appending(RelativePath($0)) }, file: file, line: line)

--- a/Tests/TuistKitTests/Generator/Mocks/MockManifestTargetGenerator.swift
+++ b/Tests/TuistKitTests/Generator/Mocks/MockManifestTargetGenerator.swift
@@ -12,7 +12,7 @@ final class MockManifestTargetGenerator: ManifestTargetGenerating {
 
     private func dummyTarget(name: String) -> Target {
         return Target(name: name,
-                      platform: .iOS,
+                      platform: [.iOS],
                       product: .framework,
                       bundleId: "io.tuist.testing",
                       infoPlist: nil,

--- a/fixtures/ios_app_with_frameworks/Framework1/Project.swift
+++ b/fixtures/ios_app_with_frameworks/Framework1/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(name: "Framework1",
                       targets: [
                           Target(name: "Framework1",
-                                 platform: .iOS,
+                                 platform: .iOS, .macOS,
                                  product: .framework,
                                  bundleId: "io.tuist.Framework1",
                                  infoPlist: "Config/Framework1-Info.plist",

--- a/fixtures/ios_app_with_frameworks/Framework1/Project.swift
+++ b/fixtures/ios_app_with_frameworks/Framework1/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(name: "Framework1",
                       targets: [
                           Target(name: "Framework1",
-                                 platform: .iOS, .macOS,
+                                 platform: [ .iOS, .macOS ],
                                  product: .framework,
                                  bundleId: "io.tuist.Framework1",
                                  infoPlist: "Config/Framework1-Info.plist",
@@ -13,7 +13,7 @@ let project = Project(name: "Framework1",
                           ]),
 
                           Target(name: "Framework1Tests",
-                                 platform: .iOS,
+                                 platform: [ .iOS, .macOS ],
                                  product: .unitTests,
                                  bundleId: "io.tuist.Framework1Tests",
                                  infoPlist: "Config/Framework1Tests-Info.plist",

--- a/fixtures/ios_app_with_frameworks/Framework2/Project.swift
+++ b/fixtures/ios_app_with_frameworks/Framework2/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(name: "Framework2",
                       targets: [
                           Target(name: "Framework2",
-                                 platform: .iOS,
+                                 platform: [ .iOS, .macOS ],
                                  product: .framework,
                                  bundleId: "io.tuist.Framework2",
                                  infoPlist: "Config/Framework2-Info.plist",
@@ -14,7 +14,7 @@ let project = Project(name: "Framework2",
                                  dependencies: []),
 
                           Target(name: "Framework2Tests",
-                                 platform: .iOS,
+                                 platform: [ .iOS, .macOS ],
                                  product: .unitTests,
                                  bundleId: "io.tuist.Framework2Tests",
                                  infoPlist: "Config/Framework2Tests-Info.plist",


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/397

### Short description 📝

Following the blog post from Dave De Long (https://davedelong.com/blog/2018/11/15/building-a-crossplatform-framework/) we are adding support into the manifest for defining a target which supports multiple platforms.

```swift
import ProjectDescription

let project = Project(name: "Framework2",
                      targets: [
                          Target(name: "Framework2",
                                 platform: [ .iOS, .macOS ],
                                 product: .framework,
                                 bundleId: "io.tuist.Framework2",
                                 infoPlist: "Config/Framework2-Info.plist",
                                 sources: "Sources/**",
                                 headers: Headers(public: "Sources/Public/**", 
                                                  private: "Sources/Private/**", 
                                                  project: "Sources/Project/**"),
                                 dependencies: []),

                          Target(name: "Framework2Tests",
                                 platform: [ .iOS, .macOS ],
                                 product: .unitTests,
                                 bundleId: "io.tuist.Framework2Tests",
                                 infoPlist: "Config/Framework2Tests-Info.plist",
                                 sources: "Tests/**",
                                 dependencies: [
                                     .target(name: "Framework2"),
                          ]),
])
```

### Solution 📦

- Use an OptionSet in the manifest to allow _one_ or _many_ platforms to be specified, this also means it's impossible to define duplicates.
- When generating the project settings if multiple platforms are specified ensure build settings include the `[sdk=_*]` syntax. e.g.

```
        "SWIFT_ACTIVE_COMPILATION_CONDITIONS[sdk=macosx*]": "DEBUG",
        "CODE_SIGN_IDENTITY[sdk=iphoneos*]": "iPhone Developer",
        "SDKROOT[sdk=macosx*]": "macosx",
        "COMBINE_HIDPI_IMAGES[sdk=macosx*]": "YES",
```

- Ensure the linter now checks that _any_ of the supported platforms can resolve the dependency graph.

### Implementation 👩‍💻👨‍💻

- [x] Add manifest API for platform
- [x] Change build settings per-platform
- [x] Linter for multi platform targets 
- [ ] Update documentation
- [ ] Update change log

### Test Plan 🛠:

- Generate `fixtures/ios_app_with_frameworks` via `tuist generate`
- Run the following:
```
xcrun xcodebuild -workspace Workspace.xcworkspace -scheme Framework1 -sdk macosx
xcrun xcodebuild -workspace Workspace.xcworkspace -scheme Framework2 -sdk macosx
xcrun xcodebuild -workspace Workspace.xcworkspace -scheme Framework1 -sdk iphoneos
xcrun xcodebuild -workspace Workspace.xcworkspace -scheme Framework2 -sdk iphoneos
xcrun xcodebuild -workspace Workspace.xcworkspace -scheme Framework1 -sdk iphonesimulator
xcrun xcodebuild -workspace Workspace.xcworkspace -scheme Framework2 -sdk iphonesimulator
```
- Ensure _all_ builds succeed
_optional_:
- Open the project in Xcode 
- Play with it
