### PR TITLE
Adding support for static products depending on dynamic frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Added
 - `tuist graph` command https://github.com/tuist/tuist/pull/427 by @pepibumur.
 - Allow customisation of `productName` in the project Manifest https://github.com/tuist/tuist/pull/435 by @ollieatkinson
+- Adding support for static products depending on dynamic frameworks https://github.com/tuist/tuist/pull/439 by @kwridan
 
 ### Fixed
 

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -170,10 +170,12 @@ class GraphLinter: GraphLinting {
         LintableTarget(platform: .iOS, product: .staticLibrary): [
             LintableTarget(platform: .iOS, product: .staticLibrary),
             LintableTarget(platform: .iOS, product: .staticFramework),
+            LintableTarget(platform: .iOS, product: .framework),
         ],
         LintableTarget(platform: .iOS, product: .staticFramework): [
             LintableTarget(platform: .iOS, product: .staticLibrary),
             LintableTarget(platform: .iOS, product: .staticFramework),
+            LintableTarget(platform: .iOS, product: .framework),
         ],
         LintableTarget(platform: .iOS, product: .dynamicLibrary): [
             LintableTarget(platform: .iOS, product: .dynamicLibrary),
@@ -231,11 +233,13 @@ class GraphLinter: GraphLinting {
         ],
         LintableTarget(platform: .macOS, product: .staticLibrary): [
             LintableTarget(platform: .macOS, product: .staticLibrary),
-            LintableTarget(platform: .iOS, product: .staticFramework),
+            LintableTarget(platform: .macOS, product: .staticFramework),
+            LintableTarget(platform: .macOS, product: .framework),
         ],
         LintableTarget(platform: .macOS, product: .staticFramework): [
             LintableTarget(platform: .macOS, product: .staticLibrary),
-            LintableTarget(platform: .iOS, product: .staticFramework),
+            LintableTarget(platform: .macOS, product: .staticFramework),
+            LintableTarget(platform: .macOS, product: .framework),
         ],
         LintableTarget(platform: .macOS, product: .dynamicLibrary): [
             LintableTarget(platform: .macOS, product: .dynamicLibrary),

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -155,6 +155,8 @@ Workspace:
   - C:
     - C (static framework iOS)
     - CTests (iOS unit tests)
+  - D:
+    - D (dynamic framework iOS)
 ```
 
 Dependencies:
@@ -162,6 +164,7 @@ Dependencies:
   - App -> C
   - A -> B
   - A -> C
+  - C -> D
 
 ## ios_app_with_tests
 

--- a/fixtures/ios_app_with_static_frameworks/Modules/C/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks/Modules/C/Project.swift
@@ -11,6 +11,7 @@ let project = Project(name: "C",
                                  dependencies: [
                                      /* Target dependencies can be defined here */
                                      /* .framework(path: "framework") */
+                                     .project(target: "D", path: "../D")
                           ]),
                           Target(name: "CTests",
                                  platform: .iOS,

--- a/fixtures/ios_app_with_static_frameworks/Modules/C/Sources/C.swift
+++ b/fixtures/ios_app_with_static_frameworks/Modules/C/Sources/C.swift
@@ -1,9 +1,10 @@
 import Foundation
-
+import D
 public class C {
     public static let value: String = "cValue"
 
     public static func printFromC() {
         print("print from C")
+        D.printFromD()
     }
 }

--- a/fixtures/ios_app_with_static_frameworks/Modules/D/Info.plist
+++ b/fixtures/ios_app_with_static_frameworks/Modules/D/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_static_frameworks/Modules/D/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks/Modules/D/Project.swift
@@ -1,0 +1,13 @@
+import ProjectDescription
+
+let project = Project(name: "D",
+                      targets: [
+                          Target(name: "D",
+                                 platform: .iOS,
+                                 product: .framework,
+                                 bundleId: "io.tuist.D",
+                                 infoPlist: "Info.plist",
+                                 sources: "Sources/**",
+                                 dependencies: [
+                          ])
+])

--- a/fixtures/ios_app_with_static_frameworks/Modules/D/Sources/D.swift
+++ b/fixtures/ios_app_with_static_frameworks/Modules/D/Sources/D.swift
@@ -1,0 +1,8 @@
+
+public class D {
+    public static let value: String = "dValue"
+
+    public static func printFromD() {
+        print("print from D")
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/437

### Short description 📝

Adding support for having static products depend on dynamic frameworks

### Implementation 👩‍💻👨‍💻

- [x] Update lint rules
- [x] Update fixture
- [x] Update changelog

### Test Plan 🛠

- Verify unit tests pass via `swift tests`
- Verify acceptance tests pass via `bundle exec rake tests`

Manually:
- Run `tuist generate` within `fixtures/ios_app_with_static_frameworks`
- Verify the generation is successful
- Open the generated workspace
- Verify D is embedded in App and CTests
- Verify the app compiles runs