### PR TITLE
Do Not Create `Derived/InfoPlists` Folder When No InfoPlist Dictionary Specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Ensuring transitive SDK dependencies are added correctly https://github.com/tuist/tuist/pull/441 by @adamkhazi
 - Ensuring the correct platform SDK dependencies path is set https://github.com/tuist/tuist/pull/419 by @kwridan
 - Update manifest target name such that its product has a valid name https://github.com/tuist/tuist/pull/426 by @kwridan
+- Do not create `Derived/InfoPlists` folder when no InfoPlist dictionary is specified https://github.com/tuist/tuist/pull/456 by @adamkhazi
 
 ### Changed
 

--- a/Sources/TuistGenerator/Generator/DerivedFileGenerator.swift
+++ b/Sources/TuistGenerator/Generator/DerivedFileGenerator.swift
@@ -70,7 +70,7 @@ final class DerivedFileGenerator: DerivedFileGenerating {
         }
         let toDelete = Set(existing).subtracting(new)
 
-        if !fileHandler.exists(infoPlistsPath) {
+        if !fileHandler.exists(infoPlistsPath) && !targetsWithGeneratableInfoPlists.isEmpty {
             try fileHandler.createFolder(infoPlistsPath)
         }
 

--- a/Sources/TuistGenerator/Generator/DerivedFileGenerator.swift
+++ b/Sources/TuistGenerator/Generator/DerivedFileGenerator.swift
@@ -70,7 +70,7 @@ final class DerivedFileGenerator: DerivedFileGenerating {
         }
         let toDelete = Set(existing).subtracting(new)
 
-        if !fileHandler.exists(infoPlistsPath) && !targetsWithGeneratableInfoPlists.isEmpty {
+        if !fileHandler.exists(infoPlistsPath), !targetsWithGeneratableInfoPlists.isEmpty {
             try fileHandler.createFolder(infoPlistsPath)
         }
 

--- a/Tests/TuistGeneratorTests/Generator/DerivedFileGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/DerivedFileGeneratorTests.swift
@@ -54,7 +54,7 @@ final class DerivedFileGeneratorTests: XCTestCase {
         // Then
         XCTAssertFalse(fileHandler.exists(oldPlistPath))
     }
-    
+
     func test_generate_checkFolderNotCreated_whenNoGeneratedInfoPlist() throws {
         // Given
         let sourceRootPath = fileHandler.currentPath
@@ -62,11 +62,11 @@ final class DerivedFileGeneratorTests: XCTestCase {
         let project = Project.test(name: "App", targets: [target])
         let infoPlistsPath = DerivedFileGenerator.infoPlistsPath(sourceRootPath: sourceRootPath)
         let path = infoPlistsPath.appending(component: "Target.plist")
-        
+
         // When
         _ = try subject.generate(project: project,
                                  sourceRootPath: sourceRootPath)
-        
+
         // Then
         XCTAssertFalse(fileHandler.exists(path))
         XCTAssertFalse(fileHandler.exists(infoPlistsPath))

--- a/Tests/TuistGeneratorTests/Generator/DerivedFileGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/DerivedFileGeneratorTests.swift
@@ -54,4 +54,21 @@ final class DerivedFileGeneratorTests: XCTestCase {
         // Then
         XCTAssertFalse(fileHandler.exists(oldPlistPath))
     }
+    
+    func test_generate_checkFolderNotCreated_whenNoGeneratedInfoPlist() throws {
+        // Given
+        let sourceRootPath = fileHandler.currentPath
+        let target = Target.test(name: "Target")
+        let project = Project.test(name: "App", targets: [target])
+        let infoPlistsPath = DerivedFileGenerator.infoPlistsPath(sourceRootPath: sourceRootPath)
+        let path = infoPlistsPath.appending(component: "Target.plist")
+        
+        // When
+        _ = try subject.generate(project: project,
+                                 sourceRootPath: sourceRootPath)
+        
+        // Then
+        XCTAssertFalse(fileHandler.exists(path))
+        XCTAssertFalse(fileHandler.exists(infoPlistsPath))
+    }
 }

--- a/Tests/TuistGeneratorTests/Generator/DerivedFileGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/DerivedFileGeneratorTests.swift
@@ -58,7 +58,7 @@ final class DerivedFileGeneratorTests: XCTestCase {
     func test_generate_checkFolderNotCreated_whenNoGeneratedInfoPlist() throws {
         // Given
         let sourceRootPath = fileHandler.currentPath
-        let target = Target.test(name: "Target")
+        let target = Target.test(name: "Target", infoPlist: .file(path: "/Info.plist"))
         let project = Project.test(name: "App", targets: [target])
         let infoPlistsPath = DerivedFileGenerator.infoPlistsPath(sourceRootPath: sourceRootPath)
         let path = infoPlistsPath.appending(component: "Target.plist")


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/449

### Short description 📝

> Running tuist generate will always create a Derived/InfoPlists folder on disk even if it isn't required.

This pull request should fix creating the `Derived/InfoPlists` unnecessarily when an InfoPlist dictionary is not specified.

### Solution 📦

Check `targetsWithGeneratableInfoPlists` is not empty before creating the `Derived/InfoPlists` folder otherwise do not create the folder.

### Implementation 👩‍💻👨‍💻

> Detail in a checklist the steps that you took to implement the PR.

- [X] Add check for `targetsWithGeneratableInfoPlists` not being empty before creating `Derived/InfoPlists` folder
- [X] Add test inside `DerivedFileGeneratorTests` that checks that when an InfoPlist file is specified no folder is created on disk

### Test Plan

- Use `tuist generate` within `fixtures/ios_app_with_frameworks` 
- Verify that `App` has no `Derived/InfoPlists` folder
- Verify that `Framework1` has `Derived/InfoPlists` folder
- Verify that `Framework2` has no `Derived/InfoPlists` folder
