### PR TITLE
Adding ability to re-generate individual projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Adding support for static products depending on dynamic frameworks https://github.com/tuist/tuist/pull/439 by @kwridan
 - Support for executing Tuist by running `swift project ...` https://github.com/tuist/tuist/pull/447 by @pepibumur.
 - New manifest model, `TuistConfig`, to easily configure Tuist's functionalities https://github.com/tuist/tuist/pull/446 by @pepibumur.
+- Adding ability to re-generate individual projects https://github.com/tuist/tuist/pull/457 by @kwridan
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The list of actions will likely grow as we get feedback from you.
 
 ```bash
 tuist init --platform ios --product application
-tuist generate # Generates Xcode project
+tuist generate # Generates Xcode project & workspace
 ```
 
 [Check out](https://docs.tuist.io) the project "Getting Started" guide to learn more about Tuist and all its features.

--- a/Sources/TuistKit/Commands/FocusCommand.swift
+++ b/Sources/TuistKit/Commands/FocusCommand.swift
@@ -81,7 +81,9 @@ class FocusCommand: NSObject, Command {
     func run(with _: ArgumentParser.Result) throws {
         let path = fileHandler.currentPath
 
-        let workspacePath = try generator.generate(at: path, manifestLoader: manifestLoader)
+        let workspacePath = try generator.generate(at: path,
+                                                   manifestLoader: manifestLoader,
+                                                   projectOnly: false)
 
         try opener.open(path: workspacePath)
     }

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -19,6 +19,7 @@ class GenerateCommand: NSObject, Command {
     private let clock: Clock
 
     let pathArgument: OptionArgument<String>
+    let projectOnlyArgument: OptionArgument<Bool>
 
     // MARK: - Init
 
@@ -66,13 +67,20 @@ class GenerateCommand: NSObject, Command {
                                      kind: String.self,
                                      usage: "The path where the project will be generated.",
                                      completion: .filename)
+
+        projectOnlyArgument = subParser.add(option: "--project-only",
+                                            kind: Bool.self,
+                                            usage: "Only generate the local project (without generating its dependencies).")
     }
 
     func run(with arguments: ArgumentParser.Result) throws {
         let timer = clock.startTimer()
         let path = self.path(arguments: arguments)
+        let projectOnly = arguments.get(projectOnlyArgument) ?? false
 
-        _ = try generator.generate(at: path, manifestLoader: manifestLoader)
+        _ = try generator.generate(at: path,
+                                   manifestLoader: manifestLoader,
+                                   projectOnly: projectOnly)
 
         let time = String(format: "%.3f", timer.stop())
         printer.print(success: "Project generated.")

--- a/Sources/TuistKit/Generator/Generator.swift
+++ b/Sources/TuistKit/Generator/Generator.swift
@@ -11,7 +11,7 @@ extension Generating {
         if manifests.contains(.workspace) {
             return try generateWorkspace(at: path, workspaceFiles: workspaceFiles)
         } else if manifests.contains(.project) {
-            return try generateProject(at: path, workspaceFiles: workspaceFiles)
+            return try generateProjectWorkspace(at: path, workspaceFiles: workspaceFiles)
         } else {
             throw GraphManifestLoaderError.manifestNotFound(path)
         }

--- a/Sources/TuistKit/Generator/Generator.swift
+++ b/Sources/TuistKit/Generator/Generator.swift
@@ -3,7 +3,18 @@ import TuistGenerator
 
 extension Generating {
     func generate(at path: AbsolutePath,
-                  manifestLoader: GraphManifestLoading) throws -> AbsolutePath {
+                  manifestLoader: GraphManifestLoading,
+                  projectOnly: Bool) throws -> AbsolutePath {
+        if projectOnly {
+            return try generateProject(at: path)
+        } else {
+            return try generateWorkspace(at: path,
+                                         manifestLoader: manifestLoader)
+        }
+    }
+
+    func generateWorkspace(at path: AbsolutePath,
+                           manifestLoader: GraphManifestLoading) throws -> AbsolutePath {
         let manifests = manifestLoader.manifests(at: path)
         let workspaceFiles: [AbsolutePath] = [Manifest.workspace, Manifest.setup]
             .compactMap { try? manifestLoader.manifestPath(at: path, manifest: $0) }

--- a/Tests/TuistGeneratorTests/Generator/Mocks/MockProjectGenerator.swift
+++ b/Tests/TuistGeneratorTests/Generator/Mocks/MockProjectGenerator.swift
@@ -4,11 +4,13 @@ import TuistCore
 @testable import TuistGenerator
 
 final class MockProjectGenerator: ProjectGenerating {
+    var generatedProjects: [Project] = []
     var generateStub: ((Project, Graphing, AbsolutePath?) throws -> GeneratedProject)?
 
     func generate(project: Project,
                   graph: Graphing,
                   sourceRootPath: AbsolutePath?) throws -> GeneratedProject {
+        generatedProjects.append(project)
         return try generateStub?(project, graph, sourceRootPath) ?? GeneratedProject.test()
     }
 }

--- a/Tests/TuistKitTests/Commands/FocusCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/FocusCommandTests.swift
@@ -44,7 +44,7 @@ final class FocusCommandTests: XCTestCase {
         manifestLoader.manifestsAtStub = { _ in
             Set([.project])
         }
-        generator.generateProjectStub = { _, _ in
+        generator.generateProjectWorkspaceStub = { _, _ in
             throw error
         }
         XCTAssertThrowsError(try subject.run(with: result)) {
@@ -58,7 +58,7 @@ final class FocusCommandTests: XCTestCase {
         manifestLoader.manifestsAtStub = { _ in
             Set([.project])
         }
-        generator.generateProjectStub = { _, _ in
+        generator.generateProjectWorkspaceStub = { _, _ in
             workspacePath
         }
         try subject.run(with: result)

--- a/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
@@ -99,7 +99,7 @@ final class GenerateCommandTests: XCTestCase {
         manifestLoader.manifestsAtStub = { _ in
             Set([.project])
         }
-        generator.generateProjectStub = { path, _ in
+        generator.generateProjectWorkspaceStub = { path, _ in
             generationPath = path
             return path.appending(component: "project.xcworkspace")
         }
@@ -118,7 +118,7 @@ final class GenerateCommandTests: XCTestCase {
         manifestLoader.manifestsAtStub = { _ in
             Set([.project])
         }
-        generator.generateProjectStub = { path, _ in
+        generator.generateProjectWorkspaceStub = { path, _ in
             generationPath = path
             return path.appending(component: "project.xcworkspace")
         }
@@ -137,7 +137,7 @@ final class GenerateCommandTests: XCTestCase {
         manifestLoader.manifestsAtStub = { _ in
             Set([.project])
         }
-        generator.generateProjectStub = { path, _ in
+        generator.generateProjectWorkspaceStub = { path, _ in
             generationPath = path
             return path.appending(component: "project.xcworkspace")
         }
@@ -170,7 +170,7 @@ final class GenerateCommandTests: XCTestCase {
         manifestLoader.manifestsAtStub = { _ in
             Set([.project])
         }
-        generator.generateProjectStub = { _, _ in
+        generator.generateProjectWorkspaceStub = { _, _ in
             throw error
         }
 

--- a/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
@@ -149,6 +149,25 @@ final class GenerateCommandTests: XCTestCase {
         XCTAssertEqual(generationPath, fileHandler.currentPath)
     }
 
+    func test_run_withProjectOnlyParameter() throws {
+        // Given
+        let result = try parser.parse([GenerateCommand.command, "--project-only"])
+        var generationPath: AbsolutePath?
+        manifestLoader.manifestsAtStub = { _ in
+            Set([.project])
+        }
+        generator.generateProjectStub = { path in
+            generationPath = path
+            return path.appending(component: "project.xcodeproj")
+        }
+
+        // When
+        try subject.run(with: result)
+
+        // Then
+        XCTAssertEqual(generationPath, fileHandler.currentPath)
+    }
+
     func test_run_withMissingManifest_throws() throws {
         // Given
         let path = fileHandler.currentPath

--- a/Tests/TuistKitTests/Generator/Mocks/MockGenerator.swift
+++ b/Tests/TuistKitTests/Generator/Mocks/MockGenerator.swift
@@ -3,9 +3,14 @@ import Foundation
 import TuistGenerator
 
 class MockGenerator: Generating {
-    var generateProjectStub: ((AbsolutePath, [AbsolutePath]) throws -> AbsolutePath)?
-    func generateProject(at path: AbsolutePath, workspaceFiles: [AbsolutePath]) throws -> AbsolutePath {
-        return try generateProjectStub?(path, workspaceFiles) ?? AbsolutePath("/test")
+    var generateProjectStub: ((AbsolutePath) throws -> AbsolutePath)?
+    func generateProject(at path: AbsolutePath) throws -> AbsolutePath {
+        return try generateProjectStub?(path) ?? AbsolutePath("/test")
+    }
+
+    var generateProjectWorkspaceStub: ((AbsolutePath, [AbsolutePath]) throws -> AbsolutePath)?
+    func generateProjectWorkspace(at path: AbsolutePath, workspaceFiles: [AbsolutePath]) throws -> AbsolutePath {
+        return try generateProjectWorkspaceStub?(path, workspaceFiles) ?? AbsolutePath("/test")
     }
 
     var generateWorkspaceStub: ((AbsolutePath, [AbsolutePath]) throws -> AbsolutePath)?

--- a/docs/usage/1-getting-started.md
+++ b/docs/usage/1-getting-started.md
@@ -82,6 +82,14 @@ tuist generate
 We'll get a `MyApp.xcodeproj`and `MyApp.xcworkspace` files. As we'll see in the dependencies section, the workspace is necessary to add other projects `MyApp` project is depending on.  
 If you open `MyApp.xcworkspace` and try to run the `MyApp` scheme, it should build the app and run it on the simulator 📱 successfully 🎉.
 
+By default all projects that `MyApp` depends on will also be generated, this ensures the generated workspace is complete. Sometimes we may want to only re-generate individual projects in our workspace without re-generating all their dependencies too. Tuist supports this workflow via including the `--project-only` flag:
+
+```bash
+tuist generate --project-only
+```
+
+This will generate an Xcode project for the local project only.
+
 ### Editing the Project.swift
 
-Did you realize that there's a target, `MyAppDescription`, which contains the manifest file? Thanks to the Swift types system and Xcode, you can edit the manifest file from Xcode and get syntax auto**-**completion, documentation and errors while you are modifying the definition. Isn't it great?
+Did you realize that there's a target, `MyApp_Manifest`, which contains the manifest file? Thanks to the Swift types system and Xcode, you can edit the manifest file from Xcode and get syntax auto**-**completion, documentation and errors while you are modifying the definition. Isn't it great?


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/452 

### Short description 📝

To support workflows where only the local project needs to be re-generated without re-generating all its dependencies a new generation option is needed (see https://github.com/tuist/tuist/issues/452 for full rationale)

### Solution 📦

Add a new option to generate the local project only.

usage:

```bash
tuist generate --project-only
```


### Implementation 👩‍💻👨‍💻

- [x] Expose new generator method that generates a single project
- [x] Expose new option via command line argument `--project-only`
- [x] Update documentation
- [x] Update changelog 

### Test Plan 🛠

- Run `tuist generate` within `fixtures/ios_app_with_custom_workspace`
- Verify the workspace is still generated with all the dependencies as before
- Run `tuist generate` within `fixtures/ios_app_with_custom_workspace/App`
- Verify the project workspace is still generated with all the dependencies as before
- Run `tuist generate --project-only` within `fixtures/ios_app_with_custom_workspace/App`
- Verify only the `App`'s project re-generated (this can be done by either doing a git clean before running the command and then verifying that the only Xcode project is for `App` or by manually modifying any of the projects and verifying they don't update)
