### PR TITLE
Multiline settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Support custom .xcodeproj name at the model level https://github.com/tuist/tuist/pull/462 by @adamkhazi
 - `TuistConfig.compatibleXcodeVersions` support https://github.com/tuist/tuist/pull/476 by @pepibumur.
 - Expose the `.bundle` product type https://github.com/tuist/tuist/pull/479 by @kwridan
+- Support for multi-line settings https://github.com/tuist/tuist/pull/464 by @marciniwanicki
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - New InfoPlist type, `.extendingDefault([:])` https://github.com/tuist/tuist/pull/448 by @pepibumur
 - Forward the output of the `codesign` command to make debugging easier when the copy frameworks command fails https://github.com/tuist/tuist/pull/492 by @pepibumur.
+- **Breaking** Support for multi-line settings (see [how to migrate](https://github.com/tuist/tuist/pull/464#issuecomment-529673717)) https://github.com/tuist/tuist/pull/464 by @marciniwanicki
 
 ### Fixed
 
@@ -31,7 +32,6 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Support custom .xcodeproj name at the model level https://github.com/tuist/tuist/pull/462 by @adamkhazi
 - `TuistConfig.compatibleXcodeVersions` support https://github.com/tuist/tuist/pull/476 by @pepibumur.
 - Expose the `.bundle` product type https://github.com/tuist/tuist/pull/479 by @kwridan
-- Support for multi-line settings https://github.com/tuist/tuist/pull/464 by @marciniwanicki
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - New InfoPlist type, `.extendingDefault([:])` https://github.com/tuist/tuist/pull/448 by @pepibumur
 - Forward the output of the `codesign` command to make debugging easier when the copy frameworks command fails https://github.com/tuist/tuist/pull/492 by @pepibumur.
-- **Breaking** Support for multi-line settings (see [how to migrate](https://github.com/tuist/tuist/pull/464#issuecomment-529673717)) https://github.com/tuist/tuist/pull/464 by @marciniwanicki
+- Support for multi-line settings (see [how to migrate](https://github.com/tuist/tuist/pull/464#issuecomment-529673717)) https://github.com/tuist/tuist/pull/464 by @marciniwanicki
 
 ### Fixed
 

--- a/Sources/ProjectDescription/Settings.swift
+++ b/Sources/ProjectDescription/Settings.swift
@@ -43,14 +43,9 @@ public enum SettingValue: ExpressibleByStringLiteral, ExpressibleByArrayLiteral,
 
 // MARK: - Configuration
 
-public class Configuration: Codable {
+public struct Configuration: Equatable, Codable {
     public let settings: [String: SettingValue]
     public let xcconfig: String?
-
-    public enum CodingKeys: String, CodingKey {
-        case settings
-        case xcconfig
-    }
 
     public init(settings: [String: SettingValue] = [:], xcconfig: String? = nil) {
         self.settings = settings
@@ -93,7 +88,7 @@ public extension CustomConfiguration {
     ///   - settings: The base build settings to apply
     ///   - xcconfig: The xcconfig file to associate with this configuration
     /// - Returns: A debug `CustomConfiguration`
-    static func debug(name: String, settings: [String: String] = [:], xcconfig: String? = nil) -> CustomConfiguration {
+    static func debug(name: String, settings: [String: SettingValue] = [:], xcconfig: String? = nil) -> CustomConfiguration {
         let configuration = Configuration(settings: settings, xcconfig: xcconfig)
         return CustomConfiguration(name: name, variant: .debug, configuration: configuration)
     }
@@ -105,7 +100,7 @@ public extension CustomConfiguration {
     ///   - settings: The base build settings to apply
     ///   - xcconfig: The xcconfig file to associate with this configuration
     /// - Returns: A release `CustomConfiguration`
-    static func release(name: String, settings: [String: String] = [:], xcconfig: String? = nil) -> CustomConfiguration {
+    static func release(name: String, settings: [String: SettingValue] = [:], xcconfig: String? = nil) -> CustomConfiguration {
         let configuration = Configuration(settings: settings, xcconfig: xcconfig)
         return CustomConfiguration(name: name, variant: .release, configuration: configuration)
     }
@@ -126,12 +121,24 @@ public enum DefaultSettings: String, Codable {
 
 // MARK: - Settings
 
-public class Settings: Codable {
+public struct Settings: Equatable, Codable {
     public let base: [String: SettingValue]
-    public let debug: Configuration?
-    public let release: Configuration?
+    public let configurations: [CustomConfiguration]
     public let defaultSettings: DefaultSettings
 
+    /// Creates settings with the default `Debug` and `Release` configurations.
+    ///
+    /// - Parameters:
+    ///   - base: Base build settings to use
+    ///   - debug: The debug configuration
+    ///   - release: The release configuration
+    ///   - defaultSettings: The default settings to apply during generation
+    ///
+    /// - Note: To specify additional custom configurations, you can use the
+    ///         alternate initializer `init(base:configurations:defaultSettings:)`.
+    ///
+    /// - seealso: Configuration
+    /// - seealso: DefaultSettings
     public init(base: [String: SettingValue] = [:],
                 debug: Configuration? = nil,
                 release: Configuration? = nil,
@@ -157,7 +164,7 @@ public class Settings: Codable {
     ///
     /// - seealso: CustomConfiguration
     /// - seealso: DefaultSettings
-    public init(base: [String: String] = [:],
+    public init(base: [String: SettingValue] = [:],
                 configurations: [CustomConfiguration],
                 defaultSettings: DefaultSettings = .recommended) {
         self.base = base

--- a/Sources/ProjectDescription/Settings.swift
+++ b/Sources/ProjectDescription/Settings.swift
@@ -63,7 +63,7 @@ public struct Configuration: Equatable, Codable {
     }
 
     @available(*, deprecated, message: "Please use settings(_ settings: [String: SettingValue], xcconfig: String?)")
-    public static func settings(_ settings:  [String: String], xcconfig: String? = nil) -> Configuration {
+    public static func settings(_ settings: [String: String], xcconfig: String? = nil) -> Configuration {
         return Configuration(settings: settings, xcconfig: xcconfig)
     }
 }
@@ -105,7 +105,7 @@ public extension CustomConfiguration {
     }
 
     @available(*, deprecated, message: "Please use debug(name: String, settings: [String: SettingValue], xcconfig: String?) instead")
-    static func debug(name: String, settings:  [String: String], xcconfig: String? = nil) -> CustomConfiguration {
+    static func debug(name: String, settings: [String: String], xcconfig: String? = nil) -> CustomConfiguration {
         let configuration = Configuration(settings: settings.mapValues { .string($0) }, xcconfig: xcconfig)
         return CustomConfiguration(name: name, variant: .debug, configuration: configuration)
     }
@@ -123,7 +123,7 @@ public extension CustomConfiguration {
     }
 
     @available(*, deprecated, message: "Please use release(name: String, settings: [String: SettingValue], xcconfig: String?) instead")
-    static func release(name: String, settings:  [String: String], xcconfig: String? = nil) -> CustomConfiguration {
+    static func release(name: String, settings: [String: String], xcconfig: String? = nil) -> CustomConfiguration {
         let configuration = Configuration(settings: settings.mapValues { .string($0) }, xcconfig: xcconfig)
         return CustomConfiguration(name: name, variant: .release, configuration: configuration)
     }
@@ -174,6 +174,7 @@ public struct Settings: Equatable, Codable {
         self.defaultSettings = defaultSettings
     }
 
+    // swiftlint:disable:next line_length
     @available(*, deprecated, message: "Please use init(base: [String: SettingValue], debug: Configuration?, release: Configuration?, defaultSettings: DefaultSettings) instead")
     public init(base: [String: String],
                 debug: Configuration? = nil,
@@ -208,6 +209,7 @@ public struct Settings: Equatable, Codable {
         self.defaultSettings = defaultSettings
     }
 
+    // swiftlint:disable:next line_length
     @available(*, deprecated, message: "Please use init(base: [String: SettingValue], configurations: [CustomConfiguration], defaultSettings: DefaultSettings) instead")
     public init(base: [String: String],
                 configurations: [CustomConfiguration],

--- a/Sources/ProjectDescription/Settings.swift
+++ b/Sources/ProjectDescription/Settings.swift
@@ -3,7 +3,6 @@ import Foundation
 // MARK: - Configuration
 
 public class Configuration: Codable {
-
     public enum Value: ExpressibleByStringLiteral, ExpressibleByArrayLiteral, Equatable, Codable {
         case string(String)
         case array([String])
@@ -24,7 +23,7 @@ public class Configuration: Codable {
                 self = .string(value)
                 return
             }
-            if let value: Array<String> = try? singleValueContainer.decode([String].self) {
+            if let value: [String] = try? singleValueContainer.decode([String].self) {
                 self = .array(value)
                 return
             }
@@ -42,10 +41,6 @@ public class Configuration: Codable {
             }
         }
     }
-
-
-
-
 
     public let settings: [String: Value]
     public let xcconfig: String?

--- a/Sources/ProjectDescription/Settings.swift
+++ b/Sources/ProjectDescription/Settings.swift
@@ -27,7 +27,7 @@ public enum SettingValue: ExpressibleByStringLiteral, ExpressibleByArrayLiteral,
             return
         }
 
-        preconditionFailure("Unsupported encoded type")
+        fatalError("Unsupported encoded type")
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/Sources/ProjectDescription/Settings.swift
+++ b/Sources/ProjectDescription/Settings.swift
@@ -52,7 +52,18 @@ public struct Configuration: Equatable, Codable {
         self.xcconfig = xcconfig
     }
 
+    @available(*, deprecated, message: "Please use init(settings: [String: SettingValue], xcconfig: String?) instead")
+    public init(settings: [String: String], xcconfig: String? = nil) {
+        self.settings = settings.mapValues { .string($0) }
+        self.xcconfig = xcconfig
+    }
+
     public static func settings(_ settings: [String: SettingValue], xcconfig: String? = nil) -> Configuration {
+        return Configuration(settings: settings, xcconfig: xcconfig)
+    }
+
+    @available(*, deprecated, message: "Please use settings(_ settings: [String: SettingValue], xcconfig: String?)")
+    public static func settings(_ settings:  [String: String], xcconfig: String? = nil) -> Configuration {
         return Configuration(settings: settings, xcconfig: xcconfig)
     }
 }
@@ -93,6 +104,12 @@ public extension CustomConfiguration {
         return CustomConfiguration(name: name, variant: .debug, configuration: configuration)
     }
 
+    @available(*, deprecated, message: "Please use debug(name: String, settings: [String: SettingValue], xcconfig: String?) instead")
+    static func debug(name: String, settings:  [String: String], xcconfig: String? = nil) -> CustomConfiguration {
+        let configuration = Configuration(settings: settings.mapValues { .string($0) }, xcconfig: xcconfig)
+        return CustomConfiguration(name: name, variant: .debug, configuration: configuration)
+    }
+
     /// Creates a custom release configuration
     ///
     /// - Parameters:
@@ -102,6 +119,12 @@ public extension CustomConfiguration {
     /// - Returns: A release `CustomConfiguration`
     static func release(name: String, settings: [String: SettingValue] = [:], xcconfig: String? = nil) -> CustomConfiguration {
         let configuration = Configuration(settings: settings, xcconfig: xcconfig)
+        return CustomConfiguration(name: name, variant: .release, configuration: configuration)
+    }
+
+    @available(*, deprecated, message: "Please use release(name: String, settings: [String: SettingValue], xcconfig: String?) instead")
+    static func release(name: String, settings:  [String: String], xcconfig: String? = nil) -> CustomConfiguration {
+        let configuration = Configuration(settings: settings.mapValues { .string($0) }, xcconfig: xcconfig)
         return CustomConfiguration(name: name, variant: .release, configuration: configuration)
     }
 }
@@ -151,6 +174,19 @@ public struct Settings: Equatable, Codable {
         self.defaultSettings = defaultSettings
     }
 
+    @available(*, deprecated, message: "Please use init(base: [String: SettingValue], debug: Configuration?, release: Configuration?, defaultSettings: DefaultSettings) instead")
+    public init(base: [String: String],
+                debug: Configuration? = nil,
+                release: Configuration? = nil,
+                defaultSettings: DefaultSettings = .recommended) {
+        configurations = [
+            CustomConfiguration(name: "Debug", variant: .debug, configuration: debug),
+            CustomConfiguration(name: "Release", variant: .release, configuration: release),
+        ]
+        self.base = base.mapValues { .string($0) }
+        self.defaultSettings = defaultSettings
+    }
+
     /// Creates settings with any number of custom configurations.
     ///
     /// - Parameters:
@@ -168,6 +204,15 @@ public struct Settings: Equatable, Codable {
                 configurations: [CustomConfiguration],
                 defaultSettings: DefaultSettings = .recommended) {
         self.base = base
+        self.configurations = configurations
+        self.defaultSettings = defaultSettings
+    }
+
+    @available(*, deprecated, message: "Please use init(base: [String: SettingValue], configurations: [CustomConfiguration], defaultSettings: DefaultSettings) instead")
+    public init(base: [String: String],
+                configurations: [CustomConfiguration],
+                defaultSettings: DefaultSettings = .recommended) {
+        self.base = base.mapValues { .string($0) }
         self.configurations = configurations
         self.defaultSettings = defaultSettings
     }

--- a/Sources/ProjectDescription/Settings.swift
+++ b/Sources/ProjectDescription/Settings.swift
@@ -41,7 +41,6 @@ public enum SettingValue: ExpressibleByStringLiteral, ExpressibleByArrayLiteral,
     }
 }
 
-
 // MARK: - Configuration
 
 public class Configuration: Codable {

--- a/Sources/TuistCoreTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistCoreTesting/Extensions/XCTestCase+Extras.swift
@@ -57,9 +57,6 @@ public extension XCTestCase {
         let decoded = XCTTry(try decoder.decode(C.self, from: json.data(using: .utf8)!), file: file, line: line)
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
-        if #available(macOS 10.13, *) {
-            encoder.outputFormatting = .sortedKeys
-        }
         let jsonData = XCTTry(try encoder.encode(decoded), file: file, line: line)
         let subjectData = XCTTry(try encoder.encode(subject), file: file, line: line)
 

--- a/Sources/TuistCoreTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistCoreTesting/Extensions/XCTestCase+Extras.swift
@@ -42,16 +42,6 @@ public extension XCTestCase {
         """, file: file, line: line)
     }
 
-    func XCTAssertDictionary<T: Hashable>(_ first: [T: Any],
-                                          containsAll second: [T: Any],
-                                          file: StaticString = #file,
-                                          line: UInt = #line) {
-        let filteredFirst = first.filter { second.keys.contains($0.key) }
-        let firstDictionary = NSDictionary(dictionary: filteredFirst)
-        let secondDictioanry = NSDictionary(dictionary: second)
-        XCTAssertEqual(firstDictionary, secondDictioanry, file: file, line: line)
-    }
-
     func XCTTry<T>(_ closure: @autoclosure @escaping () throws -> T, file: StaticString = #file, line: UInt = #line) -> T {
         var value: T!
         do {

--- a/Sources/TuistCoreTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistCoreTesting/Extensions/XCTestCase+Extras.swift
@@ -57,6 +57,9 @@ public extension XCTestCase {
         let decoded = XCTTry(try decoder.decode(C.self, from: json.data(using: .utf8)!), file: file, line: line)
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
+        if #available(macOS 10.13, *) {
+            encoder.outputFormatting = .sortedKeys
+        }
         let jsonData = XCTTry(try encoder.encode(decoded), file: file, line: line)
         let subjectData = XCTTry(try encoder.encode(subject), file: file, line: line)
 

--- a/Sources/TuistGenerator/Extensions/Array+Extras.swift
+++ b/Sources/TuistGenerator/Extensions/Array+Extras.swift
@@ -1,0 +1,5 @@
+extension Array where Element == String {
+    func uniqued() -> [String] {
+        return Set(self).sorted { $0.compare($1, options: .caseInsensitive) == .orderedAscending }
+    }
+}

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -149,7 +149,7 @@ final class ConfigGenerator: ConfigGenerating {
         configurationList.buildConfigurations.append(variantBuildConfiguration)
     }
 
-    private func updateTargetDerived(buildSettings settings: inout [String: Configuration.Value],
+    private func updateTargetDerived(buildSettings settings: inout [String: SettingValue],
                                      target: Target,
                                      graph: Graphing,
                                      sourceRootPath: AbsolutePath) {

--- a/Sources/TuistGenerator/Models/Settings.swift
+++ b/Sources/TuistGenerator/Models/Settings.swift
@@ -2,28 +2,28 @@ import Basic
 import Foundation
 import TuistCore
 
-public class Configuration: Equatable {
-    public enum Value: ExpressibleByStringLiteral, ExpressibleByArrayLiteral, Equatable {
-        case string(String)
-        case array([String])
+public enum SettingValue: ExpressibleByStringLiteral, ExpressibleByArrayLiteral, Equatable {
+    case string(String)
+    case array([String])
 
-        public init(stringLiteral value: String) {
-            self = .string(value)
-        }
-
-        public init(arrayLiteral elements: String...) {
-            self = .array(elements)
-        }
+    public init(stringLiteral value: String) {
+        self = .string(value)
     }
 
+    public init(arrayLiteral elements: String...) {
+        self = .array(elements)
+    }
+}
+
+public class Configuration: Equatable {
     // MARK: - Attributes
 
-    public let settings: [String: Value]
+    public let settings: [String: SettingValue]
     public let xcconfig: AbsolutePath?
 
     // MARK: - Init
 
-    public init(settings: [String: Value] = [:], xcconfig: AbsolutePath? = nil) {
+    public init(settings: [String: SettingValue] = [:], xcconfig: AbsolutePath? = nil) {
         self.settings = settings
         self.xcconfig = xcconfig
     }
@@ -47,13 +47,13 @@ public class Settings: Equatable {
 
     // MARK: - Attributes
 
-    public let base: [String: Configuration.Value]
+    public let base: [String: SettingValue]
     public let configurations: [BuildConfiguration: Configuration?]
     public let defaultSettings: DefaultSettings
 
     // MARK: - Init
 
-    public init(base: [String: Configuration.Value] = [:],
+    public init(base: [String: SettingValue] = [:],
                 configurations: [BuildConfiguration: Configuration?],
                 defaultSettings: DefaultSettings = .recommended) {
         self.base = base
@@ -104,7 +104,7 @@ extension Dictionary where Key == BuildConfiguration, Value == Configuration? {
     }
 }
 
-extension Dictionary where Key == String, Value == Configuration.Value {
+extension Dictionary where Key == String, Value == SettingValue {
     func toAny() -> [String: Any] {
         return mapValues { value in
             switch value {

--- a/Sources/TuistGenerator/Models/Settings.swift
+++ b/Sources/TuistGenerator/Models/Settings.swift
@@ -3,7 +3,6 @@ import Foundation
 import TuistCore
 
 public class Configuration: Equatable {
-
     public enum Value: ExpressibleByStringLiteral, ExpressibleByArrayLiteral, Equatable {
         case string(String)
         case array([String])
@@ -43,7 +42,6 @@ public enum DefaultSettings {
 }
 
 public class Settings: Equatable {
-
     public static let `default` = Settings(configurations: [.release: nil, .debug: nil],
                                            defaultSettings: .recommended)
 
@@ -55,7 +53,7 @@ public class Settings: Equatable {
 
     // MARK: - Init
 
-    public init(base: [String:  Configuration.Value] = [:],
+    public init(base: [String: Configuration.Value] = [:],
                 configurations: [BuildConfiguration: Configuration?],
                 defaultSettings: DefaultSettings = .recommended) {
         self.base = base
@@ -107,7 +105,7 @@ extension Dictionary where Key == BuildConfiguration, Value == Configuration? {
 }
 
 extension Dictionary where Key == String, Value == Configuration.Value {
-    func toAny() ->  [String: Any] {
+    func toAny() -> [String: Any] {
         return mapValues { value in
             switch value {
             case let .array(array):

--- a/Sources/TuistGenerator/Models/Settings.swift
+++ b/Sources/TuistGenerator/Models/Settings.swift
@@ -13,6 +13,18 @@ public enum SettingValue: ExpressibleByStringLiteral, ExpressibleByArrayLiteral,
     public init(arrayLiteral elements: String...) {
         self = .array(elements)
     }
+
+    public func normalize() -> SettingValue {
+        switch self {
+        case let .array(currentValue):
+            if currentValue.count == 1 {
+                return .string(currentValue[0])
+            }
+            return self
+        case .string:
+            return self
+        }
+    }
 }
 
 public class Configuration: Equatable {

--- a/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
+++ b/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
@@ -1,6 +1,6 @@
 import Foundation
-import XcodeProj
 import TuistCore
+import XcodeProj
 
 public protocol DefaultSettingsProviding {
     func projectSettings(project: Project,
@@ -136,13 +136,12 @@ enum BuildSettingsError: FatalError {
 }
 
 private extension BuildSettings {
-
     func toConfiguration() throws -> [String: Configuration.Value] {
         return try mapValues { value in
             switch value {
             case let value as String:
                 return .string(value)
-            case let value as Array<String>:
+            case let value as [String]:
                 return .array(value)
             default:
                 throw BuildSettingsError.invalidValue(value)

--- a/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
+++ b/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
@@ -117,13 +117,13 @@ public final class DefaultSettingsProvider: DefaultSettingsProviding {
     }
 }
 
-private enum BuildSettingsError: FatalError {
+enum BuildSettingsError: FatalError {
     case invalidValue(Any)
 
     var description: String {
         switch self {
         case let .invalidValue(value):
-            return "Cannot convert \"\(value)\" to Configuration.Value type"
+            return "Cannot convert \"\(value)\" to SettingValue type"
         }
     }
 
@@ -135,7 +135,7 @@ private enum BuildSettingsError: FatalError {
     }
 }
 
-private extension BuildSettings {
+extension BuildSettings {
     func toSettings() throws -> [String: SettingValue] {
         return try mapValues { value in
             switch value {

--- a/Sources/TuistGenerator/Utils/SettingsHelper.swift
+++ b/Sources/TuistGenerator/Utils/SettingsHelper.swift
@@ -2,8 +2,8 @@ import Foundation
 import XcodeProj
 
 final class SettingsHelper {
-    func extend(buildSettings: inout [String: Configuration.Value],
-                with other: [String: Configuration.Value]) {
+    func extend(buildSettings: inout [String: SettingValue],
+                with other: [String: SettingValue]) {
         other.forEach { key, newValue in
             buildSettings[key] = resolveValue(oldValue: buildSettings[key], newValue: newValue)
         }
@@ -41,7 +41,7 @@ final class SettingsHelper {
 
     // MARK: - Private
 
-    private func resolveValue(oldValue: Configuration.Value?, newValue: Configuration.Value) -> Configuration.Value {
+    private func resolveValue(oldValue: SettingValue?, newValue: SettingValue) -> SettingValue {
         guard let oldValue = oldValue else {
             return newValue
         }

--- a/Sources/TuistGenerator/Utils/SettingsHelper.swift
+++ b/Sources/TuistGenerator/Utils/SettingsHelper.swift
@@ -5,8 +5,15 @@ final class SettingsHelper {
     func extend(buildSettings: inout [String: SettingValue],
                 with other: [String: SettingValue]) {
         other.forEach { key, newValue in
-            buildSettings[key] = resolveValue(oldValue: buildSettings[key], newValue: newValue)
+            buildSettings[key] = resolveValue(oldValue: buildSettings[key], newValue: newValue).normalize()
         }
+    }
+
+    func extend(buildSettings: inout [String: Any],
+                with other: [String: SettingValue]) throws {
+        var settings = try buildSettings.toSettings()
+        extend(buildSettings: &settings, with: other)
+        buildSettings = settings.toAny()
     }
 
     func settingsProviderPlatform(_ target: Target) -> BuildSettingsProvider.Platform? {
@@ -66,6 +73,6 @@ final class SettingsHelper {
 
 private extension Array where Element == String {
     func uniqued() -> [String] {
-        return Set(self).sorted()
+        return Set(self).sorted { $0.compare($1, options: .caseInsensitive) == .orderedAscending }
     }
 }

--- a/Sources/TuistGenerator/Utils/SettingsHelper.swift
+++ b/Sources/TuistGenerator/Utils/SettingsHelper.swift
@@ -83,4 +83,3 @@ final class SettingsHelper {
         }
     }
 }
-

--- a/Sources/TuistGenerator/Utils/SettingsHelper.swift
+++ b/Sources/TuistGenerator/Utils/SettingsHelper.swift
@@ -51,15 +51,22 @@ final class SettingsHelper {
 
         switch (oldValue, newValue) {
         case let (.string(old), .string(new)) where new.contains("$(inherited)"):
-            return .array([old, new])
+            return .array([old, new].uniqued())
         case let (.string(old), .array(new)) where new.contains("$(inherited)"):
-            return .array([old] + new)
+            return .array(([old] + new).uniqued())
         case let (.array(old), .string(new)) where new.contains("$(inherited)"):
-            return .array(old + [new])
+            return .array((old + [new]).uniqued())
         case let (.array(old), .array(new)) where new.contains("$(inherited)"):
-            return .array(old + new)
+            return .array((old + new).uniqued())
         default:
             return newValue
         }
+    }
+}
+
+private extension Array where Element == String {
+
+    func uniqued() -> Array<String> {
+        return Set(self).sorted()
     }
 }

--- a/Sources/TuistGenerator/Utils/SettingsHelper.swift
+++ b/Sources/TuistGenerator/Utils/SettingsHelper.swift
@@ -5,7 +5,7 @@ final class SettingsHelper {
     func extend(buildSettings: inout [String: SettingValue],
                 with other: [String: SettingValue]) {
         other.forEach { key, newValue in
-            buildSettings[key] = resolveValue(oldValue: buildSettings[key], newValue: newValue).normalize()
+            buildSettings[key] = merge(oldValue: buildSettings[key], newValue: newValue).normalize()
         }
     }
 
@@ -48,7 +48,7 @@ final class SettingsHelper {
 
     // MARK: - Private
 
-    private func resolveValue(oldValue: SettingValue?, newValue: SettingValue) -> SettingValue {
+    private func merge(oldValue: SettingValue?, newValue: SettingValue) -> SettingValue {
         guard let oldValue = oldValue else {
             return newValue
         }
@@ -71,8 +71,3 @@ final class SettingsHelper {
     }
 }
 
-private extension Array where Element == String {
-    func uniqued() -> [String] {
-        return Set(self).sorted { $0.compare($1, options: .caseInsensitive) == .orderedAscending }
-    }
-}

--- a/Sources/TuistGenerator/Utils/SettingsHelper.swift
+++ b/Sources/TuistGenerator/Utils/SettingsHelper.swift
@@ -17,14 +17,12 @@ final class SettingsHelper {
     }
 
     func settingsProviderPlatform(_ target: Target) -> BuildSettingsProvider.Platform? {
-        var platform: BuildSettingsProvider.Platform?
         switch target.platform {
-        case .iOS: platform = .iOS
-        case .macOS: platform = .macOS
-        case .tvOS: platform = .tvOS
-            // case .watchOS: platform = .watchOS
+        case .iOS: return .iOS
+        case .macOS: return .macOS
+        case .tvOS: return .tvOS
+            // case .watchOS: return .watchOS
         }
-        return platform
     }
 
     func settingsProviderProduct(_ target: Target) -> BuildSettingsProvider.Product? {
@@ -70,13 +68,23 @@ final class SettingsHelper {
         // would result in ["$(inherited)", "$(inherited)", "VALUE_1", "VALUE_2"] if .uniqued() was not used.
         switch (oldValue, newValue) {
         case let (.string(old), .string(new)) where new.contains("$(inherited)"):
+            // Example: ("OLD", "$(inherited) NEW") -> ["$(inherited) NEW", "OLD"]
+            // This case shouldn't happen as all default multi-value settings are defined as NSArray<NSString>
             return .array([old, new].uniqued())
+
         case let (.string(old), .array(new)) where new.contains("$(inherited)"):
+            // Example: ("OLD", ["$(inherited)", "NEW"]) -> ["$(inherited)", "NEW", "OLD"]
             return .array(([old] + new).uniqued())
+
         case let (.array(old), .string(new)) where new.contains("$(inherited)"):
+            // Example: (["OLD", "OLD_2"], "$(inherited) NEW") -> ["$(inherited) NEW", "OLD", "OLD_2"]
+            // This case shouldn't happen as all default multi-value settings are defined as NSArray<NSString>
             return .array((old + [new]).uniqued())
+
         case let (.array(old), .array(new)) where new.contains("$(inherited)"):
+            // Example: (["OLD", "OLD_2"], ["$(inherited)", "NEW"]) -> ["$(inherited)", "NEW", "OLD", OLD_2"]
             return .array((old + new).uniqued())
+
         default:
             // The newValue does not contain $(inherited) so the oldValue should be omitted
             return newValue

--- a/Sources/TuistGenerator/Utils/SettingsHelper.swift
+++ b/Sources/TuistGenerator/Utils/SettingsHelper.swift
@@ -65,8 +65,7 @@ final class SettingsHelper {
 }
 
 private extension Array where Element == String {
-
-    func uniqued() -> Array<String> {
+    func uniqued() -> [String] {
         return Set(self).sorted()
     }
 }

--- a/Sources/TuistGenerator/Utils/SettingsHelper.swift
+++ b/Sources/TuistGenerator/Utils/SettingsHelper.swift
@@ -49,13 +49,25 @@ final class SettingsHelper {
     // MARK: - Private
 
     private func merge(oldValue: SettingValue?, newValue: SettingValue) -> SettingValue {
+        // No need to merge, just return newValue when the oldValue is nil (buildSettings[key] == nil).
         guard let oldValue = oldValue else {
             return newValue
         }
+
+        // No need to merge, just return oldValue when the newValue is exactly the same.
         guard oldValue != newValue else {
             return oldValue
         }
 
+        // Both the oldValue and newValue are not nil. If the newValue contains $(inherited),
+        // it will need to be merged with the oldValue, otherwise the oldValue will be discarded
+        // and the newValue returned without merging.
+        //
+        // The .uniqued() method ensures the result of merging does not contain duplicates
+        // and all the elements are sorted, i.e. merging the following values:
+        // oldValue = ["$(inherited)", "VALUE_1"]
+        // newValue = ["$(inherited)", "VALUE_2"]
+        // would result in ["$(inherited)", "$(inherited)", "VALUE_1", "VALUE_2"] if .uniqued() was not used.
         switch (oldValue, newValue) {
         case let (.string(old), .string(new)) where new.contains("$(inherited)"):
             return .array([old, new].uniqued())
@@ -66,6 +78,7 @@ final class SettingsHelper {
         case let (.array(old), .array(new)) where new.contains("$(inherited)"):
             return .array((old + new).uniqued())
         default:
+            // The newValue does not contain $(inherited) so the oldValue should be omitted
             return newValue
         }
     }

--- a/Sources/TuistGenerator/Utils/SettingsHelper.swift
+++ b/Sources/TuistGenerator/Utils/SettingsHelper.swift
@@ -41,7 +41,7 @@ final class SettingsHelper {
 
     // MARK: - Private
 
-    private func resolveValue(oldValue: Configuration.Value?, newValue: Configuration.Value)  -> Configuration.Value {
+    private func resolveValue(oldValue: Configuration.Value?, newValue: Configuration.Value) -> Configuration.Value {
         guard let oldValue = oldValue else {
             return newValue
         }

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -387,7 +387,7 @@ extension TuistGenerator.Settings {
     typealias BuildConfigurationTuple = (TuistGenerator.BuildConfiguration, TuistGenerator.Configuration?)
 
     static func from(manifest: ProjectDescription.Settings, path: AbsolutePath) -> TuistGenerator.Settings {
-        let base = manifest.base.mapValues(TuistGenerator.Configuration.Value.from)
+        let base = manifest.base.mapValues(TuistGenerator.SettingValue.from)
         let debug = manifest.debug.flatMap { TuistGenerator.Configuration.from(manifest: $0, path: path) }
         let release = manifest.release.flatMap { TuistGenerator.Configuration.from(manifest: $0, path: path) }
         let defaultSettings = TuistGenerator.DefaultSettings.from(manifest: manifest.defaultSettings)
@@ -415,8 +415,8 @@ extension TuistGenerator.DefaultSettings {
     }
 }
 
-extension TuistGenerator.Configuration.Value {
-    static func from(manifest: ProjectDescription.Configuration.Value) -> TuistGenerator.Configuration.Value {
+extension TuistGenerator.SettingValue {
+    static func from(manifest: ProjectDescription.SettingValue) -> TuistGenerator.SettingValue {
         switch manifest {
         case let .string(value):
             return .string(value)
@@ -428,7 +428,7 @@ extension TuistGenerator.Configuration.Value {
 
 extension TuistGenerator.Configuration {
     static func from(manifest: ProjectDescription.Configuration, path: AbsolutePath) -> TuistGenerator.Configuration {
-        let settings = manifest.settings.mapValues(TuistGenerator.Configuration.Value.from)
+        let settings = manifest.settings.mapValues(TuistGenerator.SettingValue.from)
         let xcconfig = manifest.xcconfig.flatMap { path.appending(RelativePath($0)) }
         return Configuration(settings: settings, xcconfig: xcconfig)
     }

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -394,7 +394,7 @@ extension TuistGenerator.Settings {
                 let variant = TuistGenerator.BuildConfiguration.from(manifest: val)
                 result[variant] = TuistGenerator.Configuration.from(manifest: val.configuration, path: path)
                 return result
-        }
+            }
         let defaultSettings = TuistGenerator.DefaultSettings.from(manifest: manifest.defaultSettings)
         return TuistGenerator.Settings(base: base,
                                        configurations: configurations,

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -388,8 +388,13 @@ extension TuistGenerator.Settings {
 
     static func from(manifest: ProjectDescription.Settings, path: AbsolutePath) -> TuistGenerator.Settings {
         let base = manifest.base.mapValues(TuistGenerator.SettingValue.from)
-        let debug = manifest.debug.flatMap { TuistGenerator.Configuration.from(manifest: $0, path: path) }
-        let release = manifest.release.flatMap { TuistGenerator.Configuration.from(manifest: $0, path: path) }
+        let configurations = manifest.configurations
+            .reduce([TuistGenerator.BuildConfiguration: TuistGenerator.Configuration?]()) { acc, val in
+                var result = acc
+                let variant = TuistGenerator.BuildConfiguration.from(manifest: val)
+                result[variant] = TuistGenerator.Configuration.from(manifest: val.configuration, path: path)
+                return result
+        }
         let defaultSettings = TuistGenerator.DefaultSettings.from(manifest: manifest.defaultSettings)
         return TuistGenerator.Settings(base: base,
                                        configurations: configurations,
@@ -399,7 +404,9 @@ extension TuistGenerator.Settings {
     private static func buildConfigurationTuple(from customConfiguration: CustomConfiguration,
                                                 path: AbsolutePath) -> BuildConfigurationTuple {
         let buildConfiguration = TuistGenerator.BuildConfiguration.from(manifest: customConfiguration)
-        let configuration = customConfiguration.configuration.map { TuistGenerator.Configuration.from(manifest: $0, path: path) }
+        let configuration = customConfiguration.configuration.flatMap {
+            TuistGenerator.Configuration.from(manifest: $0, path: path)
+        }
         return (buildConfiguration, configuration)
     }
 }
@@ -427,7 +434,10 @@ extension TuistGenerator.SettingValue {
 }
 
 extension TuistGenerator.Configuration {
-    static func from(manifest: ProjectDescription.Configuration, path: AbsolutePath) -> TuistGenerator.Configuration {
+    static func from(manifest: ProjectDescription.Configuration?, path: AbsolutePath) -> TuistGenerator.Configuration? {
+        guard let manifest = manifest else {
+            return nil
+        }
         let settings = manifest.settings.mapValues(TuistGenerator.SettingValue.from)
         let xcconfig = manifest.xcconfig.flatMap { path.appending(RelativePath($0)) }
         return Configuration(settings: settings, xcconfig: xcconfig)

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -387,9 +387,9 @@ extension TuistGenerator.Settings {
     typealias BuildConfigurationTuple = (TuistGenerator.BuildConfiguration, TuistGenerator.Configuration?)
 
     static func from(manifest: ProjectDescription.Settings, path: AbsolutePath) -> TuistGenerator.Settings {
-        let base = manifest.base
-        let configurationTuples = manifest.configurations.map { buildConfigurationTuple(from: $0, path: path) }
-        let configurations = Dictionary(configurationTuples, uniquingKeysWith: { $1 })
+        let base = manifest.base.mapValues(TuistGenerator.Configuration.Value.from)
+        let debug = manifest.debug.flatMap { TuistGenerator.Configuration.from(manifest: $0, path: path) }
+        let release = manifest.release.flatMap { TuistGenerator.Configuration.from(manifest: $0, path: path) }
         let defaultSettings = TuistGenerator.DefaultSettings.from(manifest: manifest.defaultSettings)
         return TuistGenerator.Settings(base: base,
                                        configurations: configurations,
@@ -415,9 +415,20 @@ extension TuistGenerator.DefaultSettings {
     }
 }
 
+extension TuistGenerator.Configuration.Value {
+    static func from(manifest: ProjectDescription.Configuration.Value) -> TuistGenerator.Configuration.Value {
+        switch manifest {
+        case let .string(value):
+            return .string(value)
+        case let .array(value):
+            return .array(value)
+        }
+    }
+}
+
 extension TuistGenerator.Configuration {
     static func from(manifest: ProjectDescription.Configuration, path: AbsolutePath) -> TuistGenerator.Configuration {
-        let settings = manifest.settings
+        let settings = manifest.settings.mapValues(TuistGenerator.Configuration.Value.from)
         let xcconfig = manifest.xcconfig.flatMap { path.appending(RelativePath($0)) }
         return Configuration(settings: settings, xcconfig: xcconfig)
     }

--- a/Sources/TuistKit/Generator/ManifestTargetGenerator.swift
+++ b/Sources/TuistKit/Generator/ManifestTargetGenerator.swift
@@ -7,7 +7,7 @@ protocol ManifestTargetGenerating {
     func generateManifestTarget(for project: String, at path: AbsolutePath) throws -> Target
 }
 
-class ManifestTargetGenerator: ManifestTargetGenerating {
+final class ManifestTargetGenerator: ManifestTargetGenerating {
     private let manifestLoader: GraphManifestLoading
     private let resourceLocator: ResourceLocating
 
@@ -34,13 +34,15 @@ class ManifestTargetGenerator: ManifestTargetGenerating {
                       filesGroup: .group(name: "Manifest"))
     }
 
-    func manifestTargetBuildSettings() throws -> [String: String] {
+    // MARK: - Private
+
+    private func manifestTargetBuildSettings() throws -> [String: Configuration.Value] {
         let frameworkParentDirectory = try resourceLocator.projectDescription().parentDirectory
-        var buildSettings = [String: String]()
-        buildSettings["FRAMEWORK_SEARCH_PATHS"] = frameworkParentDirectory.pathString
-        buildSettings["LIBRARY_SEARCH_PATHS"] = frameworkParentDirectory.pathString
-        buildSettings["SWIFT_INCLUDE_PATHS"] = frameworkParentDirectory.pathString
-        buildSettings["SWIFT_VERSION"] = Constants.swiftVersion
+        var buildSettings = [String: Configuration.Value]()
+        buildSettings["FRAMEWORK_SEARCH_PATHS"] = .string(frameworkParentDirectory.pathString)
+        buildSettings["LIBRARY_SEARCH_PATHS"] = .string(frameworkParentDirectory.pathString)
+        buildSettings["SWIFT_INCLUDE_PATHS"] = .string(frameworkParentDirectory.pathString)
+        buildSettings["SWIFT_VERSION"] = .string(Constants.swiftVersion)
         return buildSettings
     }
 }

--- a/Sources/TuistKit/Generator/ManifestTargetGenerator.swift
+++ b/Sources/TuistKit/Generator/ManifestTargetGenerator.swift
@@ -36,9 +36,9 @@ final class ManifestTargetGenerator: ManifestTargetGenerating {
 
     // MARK: - Private
 
-    private func manifestTargetBuildSettings() throws -> [String: Configuration.Value] {
+    private func manifestTargetBuildSettings() throws -> [String: SettingValue] {
         let frameworkParentDirectory = try resourceLocator.projectDescription().parentDirectory
-        var buildSettings = [String: Configuration.Value]()
+        var buildSettings = [String: SettingValue]()
         buildSettings["FRAMEWORK_SEARCH_PATHS"] = .string(frameworkParentDirectory.pathString)
         buildSettings["LIBRARY_SEARCH_PATHS"] = .string(frameworkParentDirectory.pathString)
         buildSettings["SWIFT_INCLUDE_PATHS"] = .string(frameworkParentDirectory.pathString)

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -98,9 +98,9 @@ final class LinkGeneratorErrorTests: XCTestCase {
                                              pbxTarget: pbxTarget,
                                              sourceRootPath: sourceRootPath)
 
-        let expected = "$(inherited) $(SRCROOT)/Dependencies $(SRCROOT)/Dependencies/C"
-        XCTAssertEqual(debugConfig.buildSettings["FRAMEWORK_SEARCH_PATHS"] as? String, expected)
-        XCTAssertEqual(releaseConfig.buildSettings["FRAMEWORK_SEARCH_PATHS"] as? String, expected)
+        let expected = ["$(inherited)", "$(SRCROOT)/Dependencies", "$(SRCROOT)/Dependencies/C"]
+        XCTAssertEqual(debugConfig.buildSettings["FRAMEWORK_SEARCH_PATHS"] as? [String], expected)
+        XCTAssertEqual(releaseConfig.buildSettings["FRAMEWORK_SEARCH_PATHS"] as? [String], expected)
     }
 
     func test_setupHeadersSearchPath() throws {
@@ -124,7 +124,8 @@ final class LinkGeneratorErrorTests: XCTestCase {
                                            pbxTarget: pbxTarget,
                                            sourceRootPath: sourceRootPath)
 
-        XCTAssertEqual(config.buildSettings["HEADER_SEARCH_PATHS"] as? String, "$(inherited) $(SRCROOT)/headers")
+        let expected = ["$(inherited)", "$(SRCROOT)/headers"]
+        XCTAssertEqual(config.buildSettings["HEADER_SEARCH_PATHS"] as? [String], expected)
     }
 
     func test_setupHeadersSearchPath_throws_whenTheConfigurationListIsMissing() throws {
@@ -158,8 +159,8 @@ final class LinkGeneratorErrorTests: XCTestCase {
 
         // Then
         let config = xcodeprojElements.config
-        XCTAssertEqual(config.buildSettings["LIBRARY_SEARCH_PATHS"] as? String,
-                       "$(inherited) $(SRCROOT)/to/libraries $(SRCROOT)/to/other/libraries")
+        let expected = ["$(inherited)", "$(SRCROOT)/to/libraries", "$(SRCROOT)/to/other/libraries"]
+        XCTAssertEqual(config.buildSettings["LIBRARY_SEARCH_PATHS"] as? [String], expected)
     }
 
     func test_setupLibrarySearchPaths_noPaths() throws {
@@ -194,8 +195,8 @@ final class LinkGeneratorErrorTests: XCTestCase {
 
         // Then
         let config = xcodeprojElements.config
-        XCTAssertEqual(config.buildSettings["SWIFT_INCLUDE_PATHS"] as? String,
-                       "$(inherited) $(SRCROOT)/to/libraries $(SRCROOT)/to/other/libraries")
+        let expected = ["$(inherited)", "$(SRCROOT)/to/libraries", "$(SRCROOT)/to/other/libraries"]
+        XCTAssertEqual(config.buildSettings["SWIFT_INCLUDE_PATHS"] as? [String], expected)
     }
 
     func test_setupSwiftIncludePaths_noPaths() throws {

--- a/Tests/TuistGeneratorTests/Models/SettingsTests.swift
+++ b/Tests/TuistGeneratorTests/Models/SettingsTests.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import XCTest
 import TuistCoreTesting
+import XCTest
 @testable import TuistGenerator
 
 final class ConfigurationTests: XCTestCase {
@@ -195,18 +195,17 @@ final class SettingsTests: XCTestCase {
 }
 
 final class ConfigurationValueTests: XCTestCase {
-
     func testToAny() {
         // Given
         let buildConfig: [String: Configuration.Value] = [
             "A": ["A_VALUE_1", "A_VALUE_2"],
             "B": "B_VALUE",
-            "C": ["C_VALUE"]
+            "C": ["C_VALUE"],
         ]
         let expected: [String: Any] = [
             "A": ["A_VALUE_1", "A_VALUE_2"],
             "B": "B_VALUE",
-            "C": ["C_VALUE"]
+            "C": ["C_VALUE"],
         ]
 
         // When

--- a/Tests/TuistGeneratorTests/Models/SettingsTests.swift
+++ b/Tests/TuistGeneratorTests/Models/SettingsTests.swift
@@ -1,6 +1,7 @@
 import Basic
 import Foundation
 import XCTest
+import TuistCoreTesting
 @testable import TuistGenerator
 
 final class ConfigurationTests: XCTestCase {
@@ -190,5 +191,28 @@ final class SettingsTests: XCTestCase {
 
     private func emptyConfiguration() -> Configuration {
         return Configuration(settings: [:], xcconfig: nil)
+    }
+}
+
+final class ConfigurationValueTests: XCTestCase {
+
+    func testToAny() {
+        // Given
+        let buildConfig: [String: Configuration.Value] = [
+            "A": ["A_VALUE_1", "A_VALUE_2"],
+            "B": "B_VALUE",
+            "C": ["C_VALUE"]
+        ]
+        let expected: [String: Any] = [
+            "A": ["A_VALUE_1", "A_VALUE_2"],
+            "B": "B_VALUE",
+            "C": ["C_VALUE"]
+        ]
+
+        // When
+        let got = buildConfig.toAny()
+
+        // Then
+        XCTAssertEqualDictionaries(got, expected)
     }
 }

--- a/Tests/TuistGeneratorTests/Models/SettingsTests.swift
+++ b/Tests/TuistGeneratorTests/Models/SettingsTests.swift
@@ -197,7 +197,7 @@ final class SettingsTests: XCTestCase {
 final class ConfigurationValueTests: XCTestCase {
     func testToAny() {
         // Given
-        let buildConfig: [String: Configuration.Value] = [
+        let buildConfig: [String: SettingValue] = [
             "A": ["A_VALUE_1", "A_VALUE_2"],
             "B": "B_VALUE",
             "C": ["C_VALUE"],

--- a/Tests/TuistGeneratorTests/Models/SettingsTests.swift
+++ b/Tests/TuistGeneratorTests/Models/SettingsTests.swift
@@ -194,7 +194,7 @@ final class SettingsTests: XCTestCase {
     }
 }
 
-final class ConfigurationValueTests: XCTestCase {
+final class DictionaryStringSettingValueExtensionTests: XCTestCase {
     func testToAny() {
         // Given
         let buildConfig: [String: SettingValue] = [

--- a/Tests/TuistGeneratorTests/Models/TestData/Settings+TestData.swift
+++ b/Tests/TuistGeneratorTests/Models/TestData/Settings+TestData.swift
@@ -3,21 +3,21 @@ import Foundation
 @testable import TuistGenerator
 
 extension Configuration {
-    static func test(settings: [String: String] = [:],
+    static func test(settings: [String: Value] = [:],
                      xcconfig: AbsolutePath? = AbsolutePath("/Config.xcconfig")) -> Configuration {
         return Configuration(settings: settings, xcconfig: xcconfig)
     }
 }
 
 extension Settings {
-    static func test(base: [String: String] = [:],
+    static func test(base: [String: Configuration.Value] = [:],
                      debug: Configuration = Configuration(settings: [:], xcconfig: AbsolutePath("/Debug.xcconfig")),
                      release: Configuration = Configuration(settings: [:], xcconfig: AbsolutePath("/Release.xcconfig"))) -> Settings {
         return Settings(base: base,
                         configurations: [.debug: debug, .release: release])
     }
 
-    static func test(base: [String: String] = [:],
+    static func test(base: [String: Configuration.Value] = [:],
                      configurations: [BuildConfiguration: Configuration?] = [:]) -> Settings {
         return Settings(base: base, configurations: configurations)
     }

--- a/Tests/TuistGeneratorTests/Models/TestData/Settings+TestData.swift
+++ b/Tests/TuistGeneratorTests/Models/TestData/Settings+TestData.swift
@@ -3,21 +3,21 @@ import Foundation
 @testable import TuistGenerator
 
 extension Configuration {
-    static func test(settings: [String: Value] = [:],
+    static func test(settings: [String: SettingValue] = [:],
                      xcconfig: AbsolutePath? = AbsolutePath("/Config.xcconfig")) -> Configuration {
         return Configuration(settings: settings, xcconfig: xcconfig)
     }
 }
 
 extension Settings {
-    static func test(base: [String: Configuration.Value] = [:],
+    static func test(base: [String: SettingValue] = [:],
                      debug: Configuration = Configuration(settings: [:], xcconfig: AbsolutePath("/Debug.xcconfig")),
                      release: Configuration = Configuration(settings: [:], xcconfig: AbsolutePath("/Release.xcconfig"))) -> Settings {
         return Settings(base: base,
                         configurations: [.debug: debug, .release: release])
     }
 
-    static func test(base: [String: Configuration.Value] = [:],
+    static func test(base: [String: SettingValue] = [:],
                      configurations: [BuildConfiguration: Configuration?] = [:]) -> Settings {
         return Settings(base: base, configurations: configurations)
     }

--- a/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -204,7 +204,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
 
         // Then
 
-        XCTAssertBuildConfig(got, containsAll: projectEssentialDebugSettings)
+        XCTAssertSettings(got, containsAll: projectEssentialDebugSettings)
         XCTAssertEqual(got.count, 47)
     }
 
@@ -221,7 +221,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
                                               buildConfiguration: buildConfiguration)
 
         // Then
-        XCTAssertBuildConfig(got, containsAll: projectEssentialReleaseSettings)
+        XCTAssertSettings(got, containsAll: projectEssentialReleaseSettings)
         XCTAssertEqual(got.count, 43)
     }
 
@@ -270,7 +270,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
                                              buildConfiguration: buildConfiguration)
 
         // Then
-        XCTAssertBuildConfig(got, containsAll: appTargetEssentialDebugSettings)
+        XCTAssertSettings(got, containsAll: appTargetEssentialDebugSettings)
         XCTAssertEqual(got.count, 8)
     }
 
@@ -287,7 +287,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
                                              buildConfiguration: buildConfiguration)
 
         // Then
-        XCTAssertBuildConfig(got, containsAll: appTargetEssentialReleaseSettings)
+        XCTAssertSettings(got, containsAll: appTargetEssentialReleaseSettings)
         XCTAssertEqual(got.count, 8)
     }
 
@@ -304,7 +304,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
                                              buildConfiguration: buildConfiguration)
 
         // Then
-        XCTAssertBuildConfig(got, containsAll: frameworkTargetEssentialDebugSettings)
+        XCTAssertSettings(got, containsAll: frameworkTargetEssentialDebugSettings)
         XCTAssertEqual(got.count, 17)
     }
 
@@ -321,7 +321,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
                                              buildConfiguration: buildConfiguration)
 
         // Then
-        XCTAssertBuildConfig(got, containsAll: frameworkTargetEssentialReleaseSettings)
+        XCTAssertSettings(got, containsAll: frameworkTargetEssentialReleaseSettings)
         XCTAssertEqual(got.count, 17)
     }
 
@@ -359,7 +359,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
 }
 
 private extension XCTestCase {
-    func XCTAssertBuildConfig(_ first: [String: Configuration.Value],
+    func XCTAssertSettings(_ first: [String: Configuration.Value],
                               containsAll second: [String: Configuration.Value],
                               file: StaticString = #file,
                               line: UInt = #line) {

--- a/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -359,7 +359,6 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
 }
 
 private extension XCTestCase {
-
     func XCTAssertBuildConfig(_ first: [String: Configuration.Value],
                               containsAll second: [String: Configuration.Value],
                               file: StaticString = #file,

--- a/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class DefaultSettingsProvider_iOSTests: XCTestCase {
     private var subject: DefaultSettingsProvider!
 
-    private let projectEssentialDebugSettings: [String: Any] = [
+    private let projectEssentialDebugSettings: [String: Configuration.Value] = [
         "CLANG_CXX_LIBRARY": "libc++",
         "GCC_PREPROCESSOR_DEFINITIONS": ["DEBUG=1", "$(inherited)"],
         "CLANG_ENABLE_OBJC_ARC": "YES",
@@ -28,7 +28,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         "GCC_NO_COMMON_BLOCKS": "YES",
     ]
 
-    private let projectEssentialReleaseSettings: [String: Any] = [
+    private let projectEssentialReleaseSettings: [String: Configuration.Value] = [
         "PRODUCT_NAME": "$(TARGET_NAME)",
         "GCC_C_LANGUAGE_STANDARD": "gnu11",
         "ENABLE_STRICT_OBJC_MSGSEND": "YES",
@@ -47,7 +47,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         "CLANG_CXX_LANGUAGE_STANDARD": "gnu++14",
     ]
 
-    private let appTargetEssentialDebugSettings: [String: Any] = [
+    private let appTargetEssentialDebugSettings: [String: Configuration.Value] = [
         "SDKROOT": "iphoneos",
         "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/Frameworks",
         "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -56,7 +56,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         "TARGETED_DEVICE_FAMILY": "1,2",
     ]
 
-    private let appTargetEssentialReleaseSettings: [String: Any] = [
+    private let appTargetEssentialReleaseSettings: [String: Configuration.Value] = [
         "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/Frameworks",
         "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
         "TARGETED_DEVICE_FAMILY": "1,2",
@@ -67,7 +67,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         "SWIFT_OPTIMIZATION_LEVEL": "-Owholemodule",
     ]
 
-    private let frameworkTargetEssentialDebugSettings: [String: Any] = [
+    private let frameworkTargetEssentialDebugSettings: [String: Configuration.Value] = [
         "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
         "SKIP_INSTALL": "YES",
         "CODE_SIGN_IDENTITY": "",
@@ -86,7 +86,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         "DYLIB_COMPATIBILITY_VERSION": "1",
     ]
 
-    private let frameworkTargetEssentialReleaseSettings: [String: Any] = [
+    private let frameworkTargetEssentialReleaseSettings: [String: Configuration.Value] = [
         "SWIFT_OPTIMIZATION_LEVEL": "-Owholemodule",
         "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/Frameworks @loader_path/Frameworks",
         "DEFINES_MODULE": "YES",
@@ -110,7 +110,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         subject = DefaultSettingsProvider()
     }
 
-    func testProjectSettings_whenEssentialDebug() {
+    func testProjectSettings_whenEssentialDebug() throws {
         // Given
         let buildConfiguration: BuildConfiguration = .debug
         let settings = Settings(base: [:],
@@ -119,14 +119,14 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         let project = Project.test(settings: settings)
 
         // When
-        let got = subject.projectSettings(project: project,
-                                          buildConfiguration: buildConfiguration)
+        let got = try subject.projectSettings(project: project,
+                                              buildConfiguration: buildConfiguration)
 
         // Then
-        XCTAssertEqualDictionaries(got, projectEssentialDebugSettings)
+        XCTAssertEqual(got, projectEssentialDebugSettings)
     }
 
-    func testProjectSettings_whenEssentialRelease_iOS() {
+    func testProjectSettings_whenEssentialRelease_iOS() throws {
         // Given
         let buildConfiguration: BuildConfiguration = .release
         let settings = Settings(base: [:],
@@ -135,14 +135,14 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         let project = Project.test(settings: settings)
 
         // When
-        let got = subject.projectSettings(project: project,
-                                          buildConfiguration: buildConfiguration)
+        let got = try subject.projectSettings(project: project,
+                                              buildConfiguration: buildConfiguration)
 
         // Then
-        XCTAssertEqualDictionaries(got, projectEssentialReleaseSettings)
+        XCTAssertEqual(got, projectEssentialReleaseSettings)
     }
 
-    func testTargetSettings_whenEssentialDebug_App() {
+    func testTargetSettings_whenEssentialDebug_App() throws {
         // Given
         let buildConfiguration: BuildConfiguration = .debug
         let settings = Settings(base: [:],
@@ -151,14 +151,14 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         let target = Target.test(product: .app, settings: settings)
 
         // When
-        let got = subject.targetSettings(target: target,
-                                         buildConfiguration: buildConfiguration)
+        let got = try subject.targetSettings(target: target,
+                                             buildConfiguration: buildConfiguration)
 
         // Then
-        XCTAssertEqualDictionaries(got, appTargetEssentialDebugSettings)
+        XCTAssertEqual(got, appTargetEssentialDebugSettings)
     }
 
-    func testTargetSettings_whenEssentialDebug_Framework() {
+    func testTargetSettings_whenEssentialDebug_Framework() throws {
         // Given
         let buildConfiguration: BuildConfiguration = .debug
         let settings = Settings(base: [:],
@@ -167,14 +167,14 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         let target = Target.test(product: .framework, settings: settings)
 
         // When
-        let got = subject.targetSettings(target: target,
-                                         buildConfiguration: buildConfiguration)
+        let got = try subject.targetSettings(target: target,
+                                             buildConfiguration: buildConfiguration)
 
         // Then
-        XCTAssertEqualDictionaries(got, frameworkTargetEssentialDebugSettings)
+        XCTAssertEqual(got, frameworkTargetEssentialDebugSettings)
     }
 
-    func testTargetSettings_whenEssentialRelease_Framework() {
+    func testTargetSettings_whenEssentialRelease_Framework() throws {
         // Given
         let buildConfiguration: BuildConfiguration = .release
         let settings = Settings(base: [:],
@@ -183,14 +183,14 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         let target = Target.test(product: .framework, settings: settings)
 
         // When
-        let got = subject.targetSettings(target: target,
-                                         buildConfiguration: buildConfiguration)
+        let got = try subject.targetSettings(target: target,
+                                             buildConfiguration: buildConfiguration)
 
         // Then
-        XCTAssertEqualDictionaries(got, frameworkTargetEssentialReleaseSettings)
+        XCTAssertEqual(got, frameworkTargetEssentialReleaseSettings)
     }
 
-    func testProjectSettings_whenRecommendedDebug() {
+    func testProjectSettings_whenRecommendedDebug() throws {
         // Given
         let buildConfiguration: BuildConfiguration = .debug
         let settings = Settings(base: [:],
@@ -199,15 +199,16 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         let project = Project.test(settings: settings)
 
         // When
-        let got = subject.projectSettings(project: project,
-                                          buildConfiguration: buildConfiguration)
+        let got = try subject.projectSettings(project: project,
+                                              buildConfiguration: buildConfiguration)
 
         // Then
-        XCTAssertDictionary(got, containsAll: projectEssentialDebugSettings)
+
+        XCTAssertBuildConfig(got, containsAll: projectEssentialDebugSettings)
         XCTAssertEqual(got.count, 47)
     }
 
-    func testProjectSettings_whenRecommendedRelease() {
+    func testProjectSettings_whenRecommendedRelease() throws {
         // Given
         let buildConfiguration: BuildConfiguration = .release
         let settings = Settings(base: [:],
@@ -216,15 +217,15 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         let project = Project.test(settings: settings)
 
         // When
-        let got = subject.projectSettings(project: project,
-                                          buildConfiguration: buildConfiguration)
+        let got = try subject.projectSettings(project: project,
+                                              buildConfiguration: buildConfiguration)
 
         // Then
-        XCTAssertDictionary(got, containsAll: projectEssentialReleaseSettings)
+        XCTAssertBuildConfig(got, containsAll: projectEssentialReleaseSettings)
         XCTAssertEqual(got.count, 43)
     }
 
-    func testProjectSettings_whenNoneDebug() {
+    func testProjectSettings_whenNoneDebug() throws {
         // Given
         let buildConfiguration: BuildConfiguration = .debug
         let settings = Settings(base: [:],
@@ -233,14 +234,14 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         let project = Project.test(settings: settings)
 
         // When
-        let got = subject.projectSettings(project: project,
-                                          buildConfiguration: buildConfiguration)
+        let got = try subject.projectSettings(project: project,
+                                              buildConfiguration: buildConfiguration)
 
         // Then
         XCTAssertEqual(got.count, 0)
     }
 
-    func testProjectSettings_whenNoneRelease() {
+    func testProjectSettings_whenNoneRelease() throws {
         // Given
         let buildConfiguration: BuildConfiguration = .release
         let settings = Settings(base: [:],
@@ -249,14 +250,14 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         let project = Project.test(settings: settings)
 
         // When
-        let got = subject.projectSettings(project: project,
-                                          buildConfiguration: buildConfiguration)
+        let got = try subject.projectSettings(project: project,
+                                              buildConfiguration: buildConfiguration)
 
         // Then
         XCTAssertEqual(got.count, 0)
     }
 
-    func testTargetSettings_whenRecommendedDebug() {
+    func testTargetSettings_whenRecommendedDebug() throws {
         // Given
         let buildConfiguration: BuildConfiguration = .debug
         let settings = Settings(base: [:],
@@ -265,15 +266,15 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         let target = Target.test(settings: settings)
 
         // When
-        let got = subject.targetSettings(target: target,
-                                         buildConfiguration: buildConfiguration)
+        let got = try subject.targetSettings(target: target,
+                                             buildConfiguration: buildConfiguration)
 
         // Then
-        XCTAssertDictionary(got, containsAll: appTargetEssentialDebugSettings)
+        XCTAssertBuildConfig(got, containsAll: appTargetEssentialDebugSettings)
         XCTAssertEqual(got.count, 8)
     }
 
-    func testTargetSettings_whenRecommendedRelease_App() {
+    func testTargetSettings_whenRecommendedRelease_App() throws {
         // Given
         let buildConfiguration: BuildConfiguration = .release
         let settings = Settings(base: [:],
@@ -282,15 +283,15 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         let target = Target.test(product: .app, settings: settings)
 
         // When
-        let got = subject.targetSettings(target: target,
-                                         buildConfiguration: buildConfiguration)
+        let got = try subject.targetSettings(target: target,
+                                             buildConfiguration: buildConfiguration)
 
         // Then
-        XCTAssertDictionary(got, containsAll: appTargetEssentialReleaseSettings)
+        XCTAssertBuildConfig(got, containsAll: appTargetEssentialReleaseSettings)
         XCTAssertEqual(got.count, 8)
     }
 
-    func testTargetSettings_whenRecommendedDebug_Framework() {
+    func testTargetSettings_whenRecommendedDebug_Framework() throws {
         // Given
         let buildConfiguration: BuildConfiguration = .debug
         let settings = Settings(base: [:],
@@ -299,15 +300,15 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         let target = Target.test(product: .framework, settings: settings)
 
         // When
-        let got = subject.targetSettings(target: target,
-                                         buildConfiguration: buildConfiguration)
+        let got = try subject.targetSettings(target: target,
+                                             buildConfiguration: buildConfiguration)
 
         // Then
-        XCTAssertDictionary(got, containsAll: frameworkTargetEssentialDebugSettings)
+        XCTAssertBuildConfig(got, containsAll: frameworkTargetEssentialDebugSettings)
         XCTAssertEqual(got.count, 17)
     }
 
-    func testTargetSettings_whenRecommendedRelease_Framework() {
+    func testTargetSettings_whenRecommendedRelease_Framework() throws {
         // Given
         let buildConfiguration: BuildConfiguration = .release
         let settings = Settings(base: [:],
@@ -316,15 +317,15 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         let target = Target.test(product: .framework, settings: settings)
 
         // When
-        let got = subject.targetSettings(target: target,
-                                         buildConfiguration: buildConfiguration)
+        let got = try subject.targetSettings(target: target,
+                                             buildConfiguration: buildConfiguration)
 
         // Then
-        XCTAssertDictionary(got, containsAll: frameworkTargetEssentialReleaseSettings)
+        XCTAssertBuildConfig(got, containsAll: frameworkTargetEssentialReleaseSettings)
         XCTAssertEqual(got.count, 17)
     }
 
-    func testTargetSettings_whenNoneDebug_Framework() {
+    func testTargetSettings_whenNoneDebug_Framework() throws {
         // Given
         let buildConfiguration: BuildConfiguration = .debug
         let settings = Settings(base: [:],
@@ -333,14 +334,14 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         let target = Target.test(product: .framework, settings: settings)
 
         // When
-        let got = subject.targetSettings(target: target,
-                                         buildConfiguration: buildConfiguration)
+        let got = try subject.targetSettings(target: target,
+                                             buildConfiguration: buildConfiguration)
 
         // Then
         XCTAssertEqual(got.count, 0)
     }
 
-    func testTargetSettings_whenNoneRelease_Framework() {
+    func testTargetSettings_whenNoneRelease_Framework() throws {
         // Given
         let buildConfiguration: BuildConfiguration = .release
         let settings = Settings(base: [:],
@@ -349,10 +350,21 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         let target = Target.test(product: .framework, settings: settings)
 
         // When
-        let got = subject.targetSettings(target: target,
-                                         buildConfiguration: buildConfiguration)
+        let got = try subject.targetSettings(target: target,
+                                             buildConfiguration: buildConfiguration)
 
         // Then
         XCTAssertEqual(got.count, 0)
+    }
+}
+
+private extension XCTestCase {
+
+    func XCTAssertBuildConfig(_ first: [String: Configuration.Value],
+                              containsAll second: [String: Configuration.Value],
+                              file: StaticString = #file,
+                              line: UInt = #line) {
+        let filteredFirst = first.filter { second.keys.contains($0.key) }
+        XCTAssertEqual(filteredFirst, second, file: file, line: line)
     }
 }

--- a/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class DefaultSettingsProvider_iOSTests: XCTestCase {
     private var subject: DefaultSettingsProvider!
 
-    private let projectEssentialDebugSettings: [String: Configuration.Value] = [
+    private let projectEssentialDebugSettings: [String: SettingValue] = [
         "CLANG_CXX_LIBRARY": "libc++",
         "GCC_PREPROCESSOR_DEFINITIONS": ["DEBUG=1", "$(inherited)"],
         "CLANG_ENABLE_OBJC_ARC": "YES",
@@ -28,7 +28,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         "GCC_NO_COMMON_BLOCKS": "YES",
     ]
 
-    private let projectEssentialReleaseSettings: [String: Configuration.Value] = [
+    private let projectEssentialReleaseSettings: [String: SettingValue] = [
         "PRODUCT_NAME": "$(TARGET_NAME)",
         "GCC_C_LANGUAGE_STANDARD": "gnu11",
         "ENABLE_STRICT_OBJC_MSGSEND": "YES",
@@ -47,7 +47,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         "CLANG_CXX_LANGUAGE_STANDARD": "gnu++14",
     ]
 
-    private let appTargetEssentialDebugSettings: [String: Configuration.Value] = [
+    private let appTargetEssentialDebugSettings: [String: SettingValue] = [
         "SDKROOT": "iphoneos",
         "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/Frameworks",
         "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -56,7 +56,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         "TARGETED_DEVICE_FAMILY": "1,2",
     ]
 
-    private let appTargetEssentialReleaseSettings: [String: Configuration.Value] = [
+    private let appTargetEssentialReleaseSettings: [String: SettingValue] = [
         "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/Frameworks",
         "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
         "TARGETED_DEVICE_FAMILY": "1,2",
@@ -67,7 +67,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         "SWIFT_OPTIMIZATION_LEVEL": "-Owholemodule",
     ]
 
-    private let frameworkTargetEssentialDebugSettings: [String: Configuration.Value] = [
+    private let frameworkTargetEssentialDebugSettings: [String: SettingValue] = [
         "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
         "SKIP_INSTALL": "YES",
         "CODE_SIGN_IDENTITY": "",
@@ -86,7 +86,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         "DYLIB_COMPATIBILITY_VERSION": "1",
     ]
 
-    private let frameworkTargetEssentialReleaseSettings: [String: Configuration.Value] = [
+    private let frameworkTargetEssentialReleaseSettings: [String: SettingValue] = [
         "SWIFT_OPTIMIZATION_LEVEL": "-Owholemodule",
         "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/Frameworks @loader_path/Frameworks",
         "DEFINES_MODULE": "YES",
@@ -359,8 +359,8 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
 }
 
 private extension XCTestCase {
-    func XCTAssertSettings(_ first: [String: Configuration.Value],
-                              containsAll second: [String: Configuration.Value],
+    func XCTAssertSettings(_ first: [String: SettingValue],
+                              containsAll second: [String: SettingValue],
                               file: StaticString = #file,
                               line: UInt = #line) {
         let filteredFirst = first.filter { second.keys.contains($0.key) }

--- a/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -1,6 +1,6 @@
 import TuistCoreTesting
-@testable import TuistGenerator
 import XCTest
+@testable import TuistGenerator
 
 final class DefaultSettingsProvider_iOSTests: XCTestCase {
     private var subject: DefaultSettingsProvider!
@@ -359,7 +359,6 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
 }
 
 final class DictionaryStringAnyExtensionTests: XCTestCase {
-
     func testToSettings_whenOnlyStrings() throws {
         // Given
         let subject: [String: Any] = ["A": "A_VALUE",
@@ -422,9 +421,9 @@ final class DictionaryStringAnyExtensionTests: XCTestCase {
 
 private extension XCTestCase {
     func XCTAssertSettings(_ first: [String: SettingValue],
-                              containsAll second: [String: SettingValue],
-                              file: StaticString = #file,
-                              line: UInt = #line) {
+                           containsAll second: [String: SettingValue],
+                           file: StaticString = #file,
+                           line: UInt = #line) {
         let filteredFirst = first.filter { second.keys.contains($0.key) }
         XCTAssertEqual(filteredFirst, second, file: file, line: line)
     }

--- a/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class SettingsHelpersTests: XCTestCase {
     private var subject = SettingsHelper()
-    private var settings: [String: Configuration.Value] = [:]
+    private var settings: [String: SettingValue] = [:]
 
     override func setUp() {
         super.setUp()

--- a/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class SettingsHelpersTests: XCTestCase {
     private var subject = SettingsHelper()
-    private var settings: [String: Any] = [:]
+    private var settings: [String: Configuration.Value] = [:]
 
     override func setUp() {
         super.setUp()
@@ -18,7 +18,7 @@ final class SettingsHelpersTests: XCTestCase {
         subject.extend(buildSettings: &settings, with: [:])
 
         // Then
-        XCTAssertEqualDictionaries(settings, [:])
+        XCTAssertEqual(settings, [:])
     }
 
     func testExtend_whenNoSettingsAndNewSettings() {
@@ -26,7 +26,7 @@ final class SettingsHelpersTests: XCTestCase {
         subject.extend(buildSettings: &settings, with: ["A": "A_VALUE"])
 
         // Then
-        XCTAssertEqualDictionaries(settings, ["A": "A_VALUE"])
+        XCTAssertEqual(settings, ["A": "A_VALUE"])
     }
 
     func testExtend_whenExistingSettingsAndNewSettings() {
@@ -37,7 +37,7 @@ final class SettingsHelpersTests: XCTestCase {
         subject.extend(buildSettings: &settings, with: ["B": "B_VALUE"])
 
         // Then
-        XCTAssertEqualDictionaries(settings, ["A": "A_VALUE", "B": "B_VALUE"])
+        XCTAssertEqual(settings, ["A": "A_VALUE", "B": "B_VALUE"])
     }
 
     func testExtend_whenExistingSettingsAndNewWithDifferentValues() {
@@ -49,7 +49,7 @@ final class SettingsHelpersTests: XCTestCase {
         subject.extend(buildSettings: &settings, with: ["A": "A_VALUE_2", "C": "C_VALUE"])
 
         // Then
-        XCTAssertEqualDictionaries(settings, ["A": "A_VALUE_2", "B": "B_VALUE", "C": "C_VALUE"])
+        XCTAssertEqual(settings, ["A": "A_VALUE_2", "B": "B_VALUE", "C": "C_VALUE"])
     }
 
     func testExtend_whenExistingSettingsAndNewWithInheritedDeclaration() {
@@ -61,7 +61,21 @@ final class SettingsHelpersTests: XCTestCase {
         subject.extend(buildSettings: &settings, with: ["A": "$(inherited) A_VALUE_2", "C": "C_VALUE"])
 
         // Then
-        XCTAssertEqualDictionaries(settings, ["A": "A_VALUE $(inherited) A_VALUE_2", "B": "B_VALUE", "C": "C_VALUE"])
+        XCTAssertEqual(settings, ["A": ["A_VALUE", "$(inherited) A_VALUE_2"],
+                                  "B": "B_VALUE",
+                                  "C": "C_VALUE"])
+    }
+
+    func testExtend_whenArraySettings() {
+        // Given
+        settings["A"] = "A_VALUE"
+        settings["B"] = "B_VALUE"
+
+        // When
+        subject.extend(buildSettings: &settings, with: ["A": ["$(inherited)", "A_VALUE_2"], "C": "C_VALUE"])
+
+        // Then
+        XCTAssertEqual(settings, ["A": ["A_VALUE", "$(inherited)", "A_VALUE_2"], "B": "B_VALUE", "C": "C_VALUE"])
     }
 
     func testNotExtend_whenExistingSettingsAndNewWithSameValues() {
@@ -73,7 +87,7 @@ final class SettingsHelpersTests: XCTestCase {
         subject.extend(buildSettings: &settings, with: ["A": "A_VALUE"])
 
         // Then
-        XCTAssertEqualDictionaries(settings, ["A": "A_VALUE", "B": "B_VALUE"])
+        XCTAssertEqual(settings, ["A": "A_VALUE", "B": "B_VALUE"])
     }
 
     func testNotExtend_whenExistingSettingsAndNewWithInheritedDeclarationAndSameValues() {
@@ -84,7 +98,51 @@ final class SettingsHelpersTests: XCTestCase {
         subject.extend(buildSettings: &settings, with: ["A": "$(inherited) A_VALUE"])
 
         // Then
-        XCTAssertEqualDictionaries(settings, ["A": "$(inherited) A_VALUE"])
+        XCTAssertEqual(settings, ["A": "$(inherited) A_VALUE"])
+    }
+
+    func testExtend_whenExistingSettingsArrayAndNewWithSomeStringValue() {
+        // Given
+        settings["A"] = ["A_VALUE"]
+
+        // When
+        subject.extend(buildSettings: &settings, with: ["A": "A_VALUE_2 A_VALUE_3"])
+
+        // Then
+        XCTAssertEqual(settings, ["A": "A_VALUE_2 A_VALUE_3"])
+    }
+
+    func testExtend_whenExistingSettingsArrayAndNewWithInheritedDeclarationAndSomeStringValue() {
+        // Given
+        settings["A"] = ["A_VALUE"]
+
+        // When
+        subject.extend(buildSettings: &settings, with: ["A": "$(inherited) A_VALUE_2 A_VALUE_3"])
+
+        // Then
+        XCTAssertEqual(settings, ["A": ["A_VALUE", "$(inherited) A_VALUE_2 A_VALUE_3"]])
+    }
+
+    func testExtend_whenExistingSettingsArrayAndNewWithSomeArrayValue() {
+        // Given
+        settings["A"] = ["A_VALUE"]
+
+        // When
+        subject.extend(buildSettings: &settings, with: ["A": ["A_VALUE_2", "A_VALUE_3"]])
+
+        // Then
+        XCTAssertEqual(settings, ["A": ["A_VALUE_2", "A_VALUE_3"]])
+    }
+
+    func testExtend_whenExistingSettingsArrayAndNewWithInheritedDeclarationAndSomeArrayValue() {
+        // Given
+        settings["A"] = ["A_VALUE"]
+
+        // When
+        subject.extend(buildSettings: &settings, with: ["A": ["$(inherited)", "A_VALUE_2", "A_VALUE_3"]])
+
+        // Then
+        XCTAssertEqual(settings, ["A": ["A_VALUE", "$(inherited)", "A_VALUE_2", "A_VALUE_3"]])
     }
 
     func testSettingsProviderPlatform() {

--- a/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
@@ -61,7 +61,7 @@ final class SettingsHelpersTests: XCTestCase {
         subject.extend(buildSettings: &settings, with: ["A": "$(inherited) A_VALUE_2", "C": "C_VALUE"])
 
         // Then
-        XCTAssertEqual(settings, ["A": ["A_VALUE", "$(inherited) A_VALUE_2"],
+        XCTAssertEqual(settings, ["A": ["$(inherited) A_VALUE_2", "A_VALUE"],
                                   "B": "B_VALUE",
                                   "C": "C_VALUE"])
     }
@@ -75,7 +75,7 @@ final class SettingsHelpersTests: XCTestCase {
         subject.extend(buildSettings: &settings, with: ["A": ["$(inherited)", "A_VALUE_2"], "C": "C_VALUE"])
 
         // Then
-        XCTAssertEqual(settings, ["A": ["A_VALUE", "$(inherited)", "A_VALUE_2"], "B": "B_VALUE", "C": "C_VALUE"])
+        XCTAssertEqual(settings, ["A": ["$(inherited)", "A_VALUE", "A_VALUE_2"], "B": "B_VALUE", "C": "C_VALUE"])
     }
 
     func testNotExtend_whenExistingSettingsAndNewWithSameValues() {
@@ -120,7 +120,7 @@ final class SettingsHelpersTests: XCTestCase {
         subject.extend(buildSettings: &settings, with: ["A": "$(inherited) A_VALUE_2 A_VALUE_3"])
 
         // Then
-        XCTAssertEqual(settings, ["A": ["A_VALUE", "$(inherited) A_VALUE_2 A_VALUE_3"]])
+        XCTAssertEqual(settings, ["A": ["$(inherited) A_VALUE_2 A_VALUE_3", "A_VALUE"]])
     }
 
     func testExtend_whenExistingSettingsArrayAndNewWithSomeArrayValue() {
@@ -142,7 +142,18 @@ final class SettingsHelpersTests: XCTestCase {
         subject.extend(buildSettings: &settings, with: ["A": ["$(inherited)", "A_VALUE_2", "A_VALUE_3"]])
 
         // Then
-        XCTAssertEqual(settings, ["A": ["A_VALUE", "$(inherited)", "A_VALUE_2", "A_VALUE_3"]])
+        XCTAssertEqual(settings, ["A": ["$(inherited)", "A_VALUE", "A_VALUE_2", "A_VALUE_3"]])
+    }
+
+    func testExtend_whenExistingSettingsArrayAndNewWithInheritedDeclarationAndArrayWithInheritedDeclaration() {
+        // Given
+        settings["A"] = ["$(inherited)", "A_VALUE"]
+
+        // When
+        subject.extend(buildSettings: &settings, with: ["A": ["$(inherited)", "A_VALUE_2", "A_VALUE_3"]])
+
+        // Then
+        XCTAssertEqual(settings, ["A": ["$(inherited)", "A_VALUE", "A_VALUE_2", "A_VALUE_3"]])
     }
 
     func testSettingsProviderPlatform() {

--- a/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
+++ b/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
@@ -703,7 +703,7 @@ class GeneratorModelLoaderTest: XCTestCase {
                 at path: AbsolutePath,
                 file: StaticString = #file,
                 line: UInt = #line) {
-        XCTAssertEqual(settings.base, manifest.base, file: file, line: line)
+        XCTAssertEqual(settings.base.count, manifest.base.count, file: file, line: line)
 
         let sortedConfigurations = settings.configurations.sorted { (l, r) -> Bool in l.key.name < r.key.name }
         let sortedManifsetConfigurations = manifest.configurations.sorted(by: { $0.name < $1.name })
@@ -718,8 +718,8 @@ class GeneratorModelLoaderTest: XCTestCase {
                 file: StaticString = #file,
                 line: UInt = #line) {
         XCTAssertTrue(configuration.0 == manifest, file: file, line: line)
-        XCTAssertEqual(configuration.1?.settings, manifest.configuration?.settings, file: file, line: line)
-        XCTAssertEqual(configuration.1?.xcconfig, manifest.configuration?.xcconfig.map { path.appending(RelativePath($0)) }, file: file, line: line)
+        XCTAssertEqual(configuration.1?.settings.count, manifest.settings.count, file: file, line: line)
+        XCTAssertEqual(configuration.1?.xcconfig, manifest.xcconfig.map { path.appending(RelativePath($0)) }, file: file, line: line)
     }
 
     func assert(coreDataModels: [TuistGenerator.CoreDataModel],

--- a/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
+++ b/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
@@ -718,8 +718,12 @@ class GeneratorModelLoaderTest: XCTestCase {
                 file: StaticString = #file,
                 line: UInt = #line) {
         XCTAssertTrue(configuration.0 == manifest, file: file, line: line)
-        XCTAssertEqual(configuration.1?.settings.count, manifest.settings.count, file: file, line: line)
-        XCTAssertEqual(configuration.1?.xcconfig, manifest.xcconfig.map { path.appending(RelativePath($0)) }, file: file, line: line)
+        XCTAssertEqual(configuration.1?.settings.count,
+                       manifest.configuration?.settings.count,
+                       file: file, line: line)
+        XCTAssertEqual(configuration.1?.xcconfig,
+                       manifest.configuration?.xcconfig.map { path.appending(RelativePath($0)) },
+                       file: file, line: line)
     }
 
     func assert(coreDataModels: [TuistGenerator.CoreDataModel],

--- a/Tests/TuistKitTests/Generator/ManifestTargetGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/ManifestTargetGeneratorTests.swift
@@ -74,9 +74,9 @@ final class ManifestTargetGeneratorTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(settings.base["FRAMEWORK_SEARCH_PATHS"], expectedSearchPath)
-        XCTAssertEqual(settings.base["LIBRARY_SEARCH_PATHS"], expectedSearchPath)
-        XCTAssertEqual(settings.base["SWIFT_INCLUDE_PATHS"], expectedSearchPath)
-        XCTAssertEqual(settings.base["SWIFT_VERSION"], Constants.swiftVersion)
+        XCTAssertEqual(settings.base["FRAMEWORK_SEARCH_PATHS"], .string(expectedSearchPath))
+        XCTAssertEqual(settings.base["LIBRARY_SEARCH_PATHS"], .string(expectedSearchPath))
+        XCTAssertEqual(settings.base["SWIFT_INCLUDE_PATHS"], .string(expectedSearchPath))
+        XCTAssertEqual(settings.base["SWIFT_VERSION"], .string(Constants.swiftVersion))
     }
 }

--- a/docs/usage/project.swift.mdx
+++ b/docs/usage/project.swift.mdx
@@ -824,7 +824,8 @@ A `Settings` object contains an optional dictionary with build settings and rela
       name: 'Base',
       description:
         'A dictionary with build settings that are inherited from all the configurations.',
-      type: '[String: String]',
+      type: '[String: SettingValue]',
+      typeLink: '#settingvalue',
       optional: true,
       default: '[:]',
     },
@@ -901,7 +902,8 @@ A `Configuration` object describes the build settings and the `.xcconfig` file o
     {
       name: 'Settings',
       description: 'A dictionary that contains the build settings',
-      type: '[String: String]',
+      type: '[String: SettingValue]',
+      typeLink: '#settingvalue',
       optional: true,
       default: '[:]',
     },
@@ -934,6 +936,23 @@ For example, a `.debug` configuration would get `SWIFT_OPTIMIZATION_LEVEL = -Ono
       case:
         '.release(name: String, settings: [String: String], xcconfig: String?)',
       description: 'A custom release configuration',
+    },
+  ]}
+/>
+
+### SettingValue
+
+A `SettingValue` can be one of the following options:
+
+<EnumTable
+  cases={[
+    {
+      case: '.string(String)',
+      description: 'A single setting value for example "DEBUG=1".',
+    },
+    {
+      case: '.array([String])',
+      description: 'Multi-value setting value for example ["${inherited}", "DEBUG=1"].',
     },
   ]}
 />

--- a/docs/usage/project.swift.mdx
+++ b/docs/usage/project.swift.mdx
@@ -952,7 +952,7 @@ A `SettingValue` can be one of the following options:
     },
     {
       case: '.array([String])',
-      description: 'Multi-value setting value for example ["${inherited}", "DEBUG=1"].',
+      description: 'Multi-value setting value for example ["$(inherited)", "DEBUG=1"].',
     },
   ]}
 />

--- a/docs/usage/project.swift.mdx
+++ b/docs/usage/project.swift.mdx
@@ -957,6 +957,8 @@ A `SettingValue` can be one of the following options:
   ]}
 />
 
+It conforms the `ExpressibleByStringLiteral` and `ExpressibleByArrayLiteral` protocols and therefore it can be initialized with a string or an array directly.
+
 ## FileElement
 
 A `FileElement` can be one of the following options:


### PR DESCRIPTION
Partially resolves https://github.com/tuist/tuist/issues/425

### Short description 📝

All individual settings are currently represented by strings. Xcode can read and interpret the values correctly but once the project is modified, it serializes multi-value settings as arrays what can result in an unexpected diff.

### Solution 📦

By using an enum, we can control how settings will be serialized. 

```
public enum SettingValue {
    case string(String)
    case array([String])

   // ...
}
```

Thanks to `ExpressibleByStringLiteral`, the change won't break existing Manifests.

### Implementation 👩‍💻👨‍💻

- [x] Update xcodeproj `BuildSettingsProvider` to return `LD_RUNPATH_SEARCH_PATHS` as an array (https://github.com/tuist/xcodeproj/pull/463)
- [x] Update documentation
- [x] Update CHANGELOG