### PR TITLE
Add compatible Xcodes option to the TuistConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Add linting for mismatching build configurations in a workspace https://github.com/tuist/tuist/pull/474 by @kwridan
 - Support for CocoaPods dependencies https://github.com/tuist/tuist/pull/465 by @pepibumur
 - Support custom .xcodeproj name at the model level https://github.com/tuist/tuist/pull/462 by @adamkhazi
+- `TuistConfig.compatibleXcodeVersions` support https://github.com/tuist/tuist/pull/476 by @pepibumur.
 
 ### Fixed
 

--- a/Sources/ProjectDescription/CompatibleXcodeVersions.swift
+++ b/Sources/ProjectDescription/CompatibleXcodeVersions.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Enum that represents all the Xcode versions that a project or set of projects is compatible with.
+public enum CompatibleXcodeVersions: ExpressibleByArrayLiteral, Codable, Equatable {
+    /// The project supports all Xcode versions.
+    case all
+
+    /// List of versions that are supported by the project.
+    case list([String])
+
+    // MARK: - ExpressibleByArrayLiteral
+
+    public init(arrayLiteral elements: [String]) {
+        self = .list(elements)
+    }
+
+    public init(arrayLiteral elements: String...) {
+        self = .list(elements)
+    }
+
+    enum CodignKeys: String, CodingKey {
+        case type
+        case value
+    }
+
+    // MARK: - Codable
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodignKeys.self)
+        switch self {
+        case .all:
+            try container.encode("all", forKey: .type)
+        case let .list(versions):
+            try container.encode("list", forKey: .type)
+            try container.encode(versions, forKey: .value)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodignKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+
+        switch type {
+        case "all":
+            self = .all
+        case "list":
+            self = .list(try container.decode([String].self, forKey: .value))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: CodignKeys.type, in: container, debugDescription: "Invalid type \(type)")
+        }
+    }
+}

--- a/Sources/ProjectDescription/CompatibleXcodeVersions.swift
+++ b/Sources/ProjectDescription/CompatibleXcodeVersions.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Enum that represents all the Xcode versions that a project or set of projects is compatible with.
-public enum CompatibleXcodeVersions: ExpressibleByArrayLiteral, Codable, Equatable {
+public enum CompatibleXcodeVersions: ExpressibleByArrayLiteral, ExpressibleByStringLiteral, Codable, Equatable {
     /// The project supports all Xcode versions.
     case all
 
@@ -21,6 +21,12 @@ public enum CompatibleXcodeVersions: ExpressibleByArrayLiteral, Codable, Equatab
     enum CodignKeys: String, CodingKey {
         case type
         case value
+    }
+
+    // MARK: - ExpressibleByStringLiteral
+
+    public init(stringLiteral value: String) {
+        self = .list([value])
     }
 
     // MARK: - Codable

--- a/Sources/ProjectDescription/TuistConfig.swift
+++ b/Sources/ProjectDescription/TuistConfig.swift
@@ -14,11 +14,18 @@ public class TuistConfig: Encodable, Decodable, Equatable {
     /// Generation options.
     public let generationOptions: [GenerationOptions]
 
+    /// List of Xcode versions that the project supports.
+    public let compatibleXcodeVersions: CompatibleXcodeVersions
+
     /// Initializes the tuist cofiguration.
     ///
-    /// - Parameter generationOptions: Generation options.
-    public init(generationOptions: [GenerationOptions]) {
+    /// - Parameters:
+    ///   - compatibleXcodeVersions: .
+    ///   - generationOptions: List of Xcode versions that the project supports. An empty list means that
+    public init(compatibleXcodeVersions: CompatibleXcodeVersions = .all,
+                generationOptions: [GenerationOption]) {
         self.generationOptions = generationOptions
+        self.compatibleXcodeVersions = compatibleXcodeVersions
         dumpIfNeeded(self)
     }
 }

--- a/Sources/ProjectDescription/TuistConfig.swift
+++ b/Sources/ProjectDescription/TuistConfig.swift
@@ -23,7 +23,7 @@ public class TuistConfig: Encodable, Decodable, Equatable {
     ///   - compatibleXcodeVersions: .
     ///   - generationOptions: List of Xcode versions that the project supports. An empty list means that
     public init(compatibleXcodeVersions: CompatibleXcodeVersions = .all,
-                generationOptions: [GenerationOption]) {
+                generationOptions: [GenerationOptions]) {
         self.generationOptions = generationOptions
         self.compatibleXcodeVersions = compatibleXcodeVersions
         dumpIfNeeded(self)

--- a/Sources/TuistCore/Linter/LintingIssue.swift
+++ b/Sources/TuistCore/Linter/LintingIssue.swift
@@ -55,7 +55,7 @@ public extension Array where Element == LintingIssue {
 
         if !errorIssues.isEmpty {
             let prefix = !warningIssues.isEmpty ? "\n" : ""
-            printer.print("\(prefix)The following critical issues have been found:", color: .red)
+            printer.print("\(prefix)The following critical issues have been found:", output: .standardError)
             let message = errorIssues.map { "  - \($0.description)" }.joined(separator: "\n")
             printer.print(message, output: .standardError)
 

--- a/Sources/TuistCore/Linter/LintingIssue.swift
+++ b/Sources/TuistCore/Linter/LintingIssue.swift
@@ -57,7 +57,7 @@ public extension Array where Element == LintingIssue {
             let prefix = !warningIssues.isEmpty ? "\n" : ""
             printer.print("\(prefix)The following critical issues have been found:", color: .red)
             let message = errorIssues.map { "  - \($0.description)" }.joined(separator: "\n")
-            printer.print(message)
+            printer.print(message, output: .standardError)
 
             throw LintingError()
         }

--- a/Sources/TuistCore/Utils/Printer.swift
+++ b/Sources/TuistCore/Utils/Printer.swift
@@ -31,9 +31,9 @@ public class Printer: Printing {
     // MARK: - Public
 
     public func print(_ text: String) {
-        self.print(text, output: .standardOputput)
+        print(text, output: .standardOputput)
     }
-    
+
     public func print(_ text: String, output: PrinterOutput) {
         var writer: InteractiveWriter!
         if output == .standardOputput {
@@ -41,7 +41,7 @@ public class Printer: Printing {
         } else {
             writer = .stderr
         }
-        
+
         writer.write(text)
         writer.write("\n")
     }
@@ -72,21 +72,21 @@ public class Printer: Printing {
     public func print(deprecation: String) {
         let writer = InteractiveWriter.stdout
         writer.write("Deprecated: ", inColor: .yellow, bold: true)
-        writer.write(deprecation, inColor: .yellow, bold: false)
+        writer.write(deprecation, inColor: .yellow, bold: true)
         writer.write("\n")
     }
 
     public func print(warning: String) {
         let writer = InteractiveWriter.stdout
         writer.write("Warning: ", inColor: .yellow, bold: true)
-        writer.write(warning, inColor: .yellow, bold: false)
+        writer.write(warning, inColor: .yellow, bold: true)
         writer.write("\n")
     }
 
     public func print(errorMessage: String) {
         let writer = InteractiveWriter.stderr
         writer.write("Error: ", inColor: .red, bold: true)
-        writer.write(errorMessage, inColor: .red, bold: false)
+        writer.write(errorMessage, inColor: .red, bold: true)
         writer.write("\n")
     }
 

--- a/Sources/TuistCore/Utils/Printer.swift
+++ b/Sources/TuistCore/Utils/Printer.swift
@@ -1,8 +1,14 @@
 import Basic
 import Foundation
 
+public enum PrinterOutput {
+    case standardOputput
+    case standardError
+}
+
 public protocol Printing: AnyObject {
     func print(_ text: String)
+    func print(_ text: String, output: PrinterOutput)
     func print(_ text: String, color: TerminalController.Color)
     func print(section: String)
     func print(subsection: String)
@@ -25,7 +31,17 @@ public class Printer: Printing {
     // MARK: - Public
 
     public func print(_ text: String) {
-        let writer = InteractiveWriter.stdout
+        self.print(text, output: .standardOputput)
+    }
+    
+    public func print(_ text: String, output: PrinterOutput) {
+        var writer: InteractiveWriter!
+        if output == .standardOputput {
+            writer = .stdout
+        } else {
+            writer = .stderr
+        }
+        
         writer.write(text)
         writer.write("\n")
     }
@@ -91,7 +107,7 @@ public class Printer: Printing {
 ///
 /// If underlying stream is a not tty, the string will be written in without any
 /// formatting.
-private final class InteractiveWriter {
+final class InteractiveWriter {
     /// The standard error writer.
     static let stderr = InteractiveWriter(stream: stderrStream)
 

--- a/Sources/TuistCore/Utils/Printer.swift
+++ b/Sources/TuistCore/Utils/Printer.swift
@@ -35,7 +35,7 @@ public class Printer: Printing {
     }
 
     public func print(_ text: String, output: PrinterOutput) {
-        var writer: InteractiveWriter!
+        let writer: InteractiveWriter!
         if output == .standardOputput {
             writer = .stdout
         } else {

--- a/Sources/TuistCore/Xcode/Xcode.swift
+++ b/Sources/TuistCore/Xcode/Xcode.swift
@@ -1,0 +1,44 @@
+import Basic
+import Foundation
+
+public struct Xcode {
+    /// It represents the content of the Info.plist file inside the Xcode app bundle.
+    struct InfoPlist: Codable {
+        /// App version number (e.g. 10.3)
+        let version: String
+
+        enum CodingKeys: String, CodingKey {
+            case version = "CFBundleShortVersionString"
+        }
+    }
+
+    /// Path to the Xcode app bundle.
+    let path: AbsolutePath
+
+    /// Info plist content.
+    let infoPlist: InfoPlist
+
+    /// Initializes an Xcode instance by reading it from a local Xcode.app bundle.
+    ///
+    /// - Parameter path: Path to a local Xcode.app bundle.
+    /// - Returns: Initialized Xcode instance.
+    /// - Throws: An error if the local installation can't be read.
+    static func read(path: AbsolutePath) throws -> Xcode {
+        let infoPlistPath = path.appending(RelativePath("Contents/Info.plist"))
+        let plistDecoder = PropertyListDecoder()
+        let data = try Data(contentsOf: infoPlistPath.url)
+        let infoPlist = try plistDecoder.decode(InfoPlist.self, from: data)
+
+        return Xcode(path: path, infoPlist: infoPlist)
+    }
+
+    /// Initializes an instance of Xcode which represents a local installation of Xcode
+    ///
+    /// - Parameters:
+    ///     - path: Path to the Xcode app bundle.
+    init(path: AbsolutePath,
+         infoPlist: InfoPlist) {
+        self.path = path
+        self.infoPlist = infoPlist
+    }
+}

--- a/Sources/TuistCore/Xcode/Xcode.swift
+++ b/Sources/TuistCore/Xcode/Xcode.swift
@@ -6,7 +6,7 @@ public struct Xcode {
     public struct InfoPlist: Codable {
         /// App version number (e.g. 10.3)
         public let version: String
-        
+
         /// Initializes the InfoPlist object with its attributes.
         ///
         /// - Parameter version: Version.
@@ -44,7 +44,7 @@ public struct Xcode {
     /// - Parameters:
     ///     - path: Path to the Xcode app bundle.
     public init(path: AbsolutePath,
-         infoPlist: InfoPlist) {
+                infoPlist: InfoPlist) {
         self.path = path
         self.infoPlist = infoPlist
     }

--- a/Sources/TuistCore/Xcode/Xcode.swift
+++ b/Sources/TuistCore/Xcode/Xcode.swift
@@ -6,6 +6,13 @@ public struct Xcode {
     public struct InfoPlist: Codable {
         /// App version number (e.g. 10.3)
         public let version: String
+        
+        /// Initializes the InfoPlist object with its attributes.
+        ///
+        /// - Parameter version: Version.
+        public init(version: String) {
+            self.version = version
+        }
 
         enum CodingKeys: String, CodingKey {
             case version = "CFBundleShortVersionString"
@@ -36,7 +43,7 @@ public struct Xcode {
     ///
     /// - Parameters:
     ///     - path: Path to the Xcode app bundle.
-    init(path: AbsolutePath,
+    public init(path: AbsolutePath,
          infoPlist: InfoPlist) {
         self.path = path
         self.infoPlist = infoPlist

--- a/Sources/TuistCore/Xcode/Xcode.swift
+++ b/Sources/TuistCore/Xcode/Xcode.swift
@@ -3,9 +3,9 @@ import Foundation
 
 public struct Xcode {
     /// It represents the content of the Info.plist file inside the Xcode app bundle.
-    struct InfoPlist: Codable {
+    public struct InfoPlist: Codable {
         /// App version number (e.g. 10.3)
-        let version: String
+        public let version: String
 
         enum CodingKeys: String, CodingKey {
             case version = "CFBundleShortVersionString"
@@ -13,10 +13,10 @@ public struct Xcode {
     }
 
     /// Path to the Xcode app bundle.
-    let path: AbsolutePath
+    public let path: AbsolutePath
 
     /// Info plist content.
-    let infoPlist: InfoPlist
+    public let infoPlist: InfoPlist
 
     /// Initializes an Xcode instance by reading it from a local Xcode.app bundle.
     ///

--- a/Sources/TuistCore/Xcode/XcodeController.swift
+++ b/Sources/TuistCore/Xcode/XcodeController.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 
-protocol XcodeControlling {
+public protocol XcodeControlling {
     /// Returns the selected Xcode. It uses xcode-select to determine
     /// the Xcode that is selected in the environment.
     ///
@@ -10,7 +10,7 @@ protocol XcodeControlling {
     func selected() throws -> Xcode?
 }
 
-class XcodeController: XcodeControlling {
+public class XcodeController: XcodeControlling {
     /// Instance to run commands in the system.
     let system: Systeming
 
@@ -18,7 +18,7 @@ class XcodeController: XcodeControlling {
     ///
     /// - Parameters:
     ///     - system: Instance to run commands in the system.
-    init(system: Systeming = System()) {
+    public init(system: Systeming = System()) {
         self.system = system
     }
 
@@ -27,7 +27,7 @@ class XcodeController: XcodeControlling {
     ///
     /// - Returns: Selected Xcode.
     /// - Throws: An error if it can't be obtained.
-    func selected() throws -> Xcode? {
+    public func selected() throws -> Xcode? {
         // e.g. /Applications/Xcode.app/Contents/Developer
         guard let path = try? system.capture(["xcode-select", "-p"]).spm_chomp() else {
             return nil

--- a/Sources/TuistCore/Xcode/XcodeController.swift
+++ b/Sources/TuistCore/Xcode/XcodeController.swift
@@ -1,0 +1,37 @@
+import Basic
+import Foundation
+
+protocol XcodeControlling {
+    /// Returns the selected Xcode. It uses xcode-select to determine
+    /// the Xcode that is selected in the environment.
+    ///
+    /// - Returns: Selected Xcode.
+    /// - Throws: An error if it can't be obtained.
+    func selected() throws -> Xcode?
+}
+
+class XcodeController: XcodeControlling {
+    /// Instance to run commands in the system.
+    let system: Systeming
+
+    /// Initializes the controller with its attributes
+    ///
+    /// - Parameters:
+    ///     - system: Instance to run commands in the system.
+    init(system: Systeming = System()) {
+        self.system = system
+    }
+
+    /// Returns the selected Xcode. It uses xcode-select to determine
+    /// the Xcode that is selected in the environment.
+    ///
+    /// - Returns: Selected Xcode.
+    /// - Throws: An error if it can't be obtained.
+    func selected() throws -> Xcode? {
+        // e.g. /Applications/Xcode.app/Contents/Developer
+        guard let path = try? system.capture(["xcode-select", "-p"]).spm_chomp() else {
+            return nil
+        }
+        return try Xcode.read(path: AbsolutePath(path).parentDirectory.parentDirectory)
+    }
+}

--- a/Sources/TuistCoreTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistCoreTesting/Extensions/XCTestCase+Extras.swift
@@ -119,4 +119,8 @@ public extension XCTestCase {
             XCTFail("Failed comparing the subject to the given JSON. Has the JSON the right format?")
         }
     }
+
+    func XCTEmpty<S>(_ array: [S], file: StaticString = #file, line: UInt = #line) {
+        XCTAssertTrue(array.isEmpty, "Expected array to be empty but it's not. It contains the following elements: \(array)", file: file, line: line)
+    }
 }

--- a/Sources/TuistCoreTesting/Utils/MockPrinter.swift
+++ b/Sources/TuistCoreTesting/Utils/MockPrinter.swift
@@ -3,6 +3,7 @@ import Foundation
 import TuistCore
 
 public final class MockPrinter: Printing {
+    
     var standardOutput: String = ""
     var standardError: String = ""
 
@@ -17,8 +18,17 @@ public final class MockPrinter: Printing {
     public var printDeprecationArgs: [String] = []
 
     public func print(_ text: String) {
+        self.print(text, output: .standardOputput)
+    }
+    
+    public func print(_ text: String, output: PrinterOutput) {
         printArgs.append(text)
-        standardOutput.append(text)
+
+        if output == .standardOputput {
+            standardOutput.append(text)
+        } else {
+            standardError.append(text)
+        }
     }
 
     public func print(_ text: String, color: TerminalController.Color) {

--- a/Sources/TuistCoreTesting/Utils/MockPrinter.swift
+++ b/Sources/TuistCoreTesting/Utils/MockPrinter.swift
@@ -3,7 +3,6 @@ import Foundation
 import TuistCore
 
 public final class MockPrinter: Printing {
-    
     var standardOutput: String = ""
     var standardError: String = ""
 
@@ -18,9 +17,9 @@ public final class MockPrinter: Printing {
     public var printDeprecationArgs: [String] = []
 
     public func print(_ text: String) {
-        self.print(text, output: .standardOputput)
+        print(text, output: .standardOputput)
     }
-    
+
     public func print(_ text: String, output: PrinterOutput) {
         printArgs.append(text)
 

--- a/Sources/TuistCoreTesting/Utils/MockPrinter.swift
+++ b/Sources/TuistCoreTesting/Utils/MockPrinter.swift
@@ -24,9 +24,9 @@ public final class MockPrinter: Printing {
         printArgs.append(text)
 
         if output == .standardOputput {
-            standardOutput.append(text)
+            standardOutput.append("\(text)\n")
         } else {
-            standardError.append(text)
+            standardError.append("\(text)\n")
         }
     }
 

--- a/Sources/TuistCoreTesting/Xcode/Mocks/MockXcodeController.swift
+++ b/Sources/TuistCoreTesting/Xcode/Mocks/MockXcodeController.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-@testable import TuistCore
+import TuistCore
 
 final class MockXcodeController: XcodeControlling {
     var selectedStub: Result<Xcode, Error>?

--- a/Sources/TuistCoreTesting/Xcode/Mocks/MockXcodeController.swift
+++ b/Sources/TuistCoreTesting/Xcode/Mocks/MockXcodeController.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+@testable import TuistCore
+
+final class MockXcodeController: XcodeControlling {
+    var selectedStub: Result<Xcode, Error>?
+
+    func selected() throws -> Xcode? {
+        guard let selectedStub = selectedStub else { return nil }
+
+        switch selectedStub {
+        case let .failure(error): throw error
+        case let .success(xcode): return xcode
+        }
+    }
+}

--- a/Sources/TuistCoreTesting/Xcode/TestData/Xcode+TestData.swift
+++ b/Sources/TuistCoreTesting/Xcode/TestData/Xcode+TestData.swift
@@ -1,0 +1,17 @@
+import Basic
+import Foundation
+
+@testable import TuistCore
+
+extension Xcode {
+    static func test(path: AbsolutePath = AbsolutePath("/Applications/Xcode.app"),
+                     infoPlist: Xcode.InfoPlist = .test()) -> Xcode {
+        return Xcode(path: path, infoPlist: infoPlist)
+    }
+}
+
+extension Xcode.InfoPlist {
+    static func test(version: String = "3.2.1") -> Xcode.InfoPlist {
+        return Xcode.InfoPlist(version: version)
+    }
+}

--- a/Sources/TuistCoreTesting/Xcode/TestData/Xcode+TestData.swift
+++ b/Sources/TuistCoreTesting/Xcode/TestData/Xcode+TestData.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
 
-@testable import TuistCore
+import TuistCore
 
 extension Xcode {
     static func test(path: AbsolutePath = AbsolutePath("/Applications/Xcode.app"),

--- a/Sources/TuistGenerator/Generator/Generator.swift
+++ b/Sources/TuistGenerator/Generator/Generator.swift
@@ -52,7 +52,7 @@ public class Generator: Generating {
     private let projectGenerator: ProjectGenerating
 
     /// Instance to lint the Tuist configuration against the system.
-    private let tuistConfigLinter: TuistConfigLinting
+    private let environmentLinter: EnvironmentLinting
 
     public convenience init(system: Systeming = System(),
                             printer: Printing = Printer(),
@@ -68,7 +68,7 @@ public class Generator: Generating {
                                                 printer: printer,
                                                 system: system,
                                                 fileHandler: fileHandler)
-        let tuistConfigLinter = TuistConfigLinter()
+        let environmentLinter = EnvironmentLinter()
         let workspaceStructureGenerator = WorkspaceStructureGenerator(fileHandler: fileHandler)
         let cocoapodsInteractor = CocoaPodsInteractor()
         let workspaceGenerator = WorkspaceGenerator(system: system,
@@ -80,22 +80,22 @@ public class Generator: Generating {
         self.init(graphLoader: graphLoader,
                   workspaceGenerator: workspaceGenerator,
                   projectGenerator: projectGenerator,
-                  tuistConfigLinter: tuistConfigLinter)
+                  environmentLinter: environmentLinter)
     }
 
     init(graphLoader: GraphLoading,
          workspaceGenerator: WorkspaceGenerating,
          projectGenerator: ProjectGenerating,
-         tuistConfigLinter: TuistConfigLinting) {
+         environmentLinter: EnvironmentLinting) {
         self.graphLoader = graphLoader
         self.workspaceGenerator = workspaceGenerator
         self.projectGenerator = projectGenerator
-        self.tuistConfigLinter = tuistConfigLinter
+        self.environmentLinter = environmentLinter
     }
 
     public func generateProject(at path: AbsolutePath) throws -> AbsolutePath {
         let tuistConfig = try graphLoader.loadTuistConfig(path: path)
-        try tuistConfigLinter.lint(config: tuistConfig)
+        try environmentLinter.lint(config: tuistConfig)
 
         let (graph, project) = try graphLoader.loadProject(path: path)
         let generatedProject = try projectGenerator.generate(project: project,
@@ -107,7 +107,7 @@ public class Generator: Generating {
     public func generateProjectWorkspace(at path: AbsolutePath,
                                          workspaceFiles: [AbsolutePath]) throws -> AbsolutePath {
         let tuistConfig = try graphLoader.loadTuistConfig(path: path)
-        try tuistConfigLinter.lint(config: tuistConfig)
+        try environmentLinter.lint(config: tuistConfig)
 
         let (graph, project) = try graphLoader.loadProject(path: path)
         let workspace = Workspace(name: project.name,
@@ -123,7 +123,7 @@ public class Generator: Generating {
     public func generateWorkspace(at path: AbsolutePath,
                                   workspaceFiles: [AbsolutePath]) throws -> AbsolutePath {
         let tuistConfig = try graphLoader.loadTuistConfig(path: path)
-        try tuistConfigLinter.lint(config: tuistConfig)
+        try environmentLinter.lint(config: tuistConfig)
         let (graph, workspace) = try graphLoader.loadWorkspace(path: path)
 
         let updatedWorkspace = workspace

--- a/Sources/TuistGenerator/Generator/Generator.swift
+++ b/Sources/TuistGenerator/Generator/Generator.swift
@@ -51,6 +51,9 @@ public class Generator: Generating {
     private let workspaceGenerator: WorkspaceGenerating
     private let projectGenerator: ProjectGenerating
 
+    /// Instance to lint the Tuist configuration against the system.
+    private let tuistConfigLinter: TuistConfigLinting
+
     public convenience init(system: Systeming = System(),
                             printer: Printing = Printer(),
                             fileHandler: FileHandling = FileHandler(),
@@ -65,6 +68,7 @@ public class Generator: Generating {
                                                 printer: printer,
                                                 system: system,
                                                 fileHandler: fileHandler)
+        let tuistConfigLinter = TuistConfigLinter()
         let workspaceStructureGenerator = WorkspaceStructureGenerator(fileHandler: fileHandler)
         let cocoapodsInteractor = CocoaPodsInteractor()
         let workspaceGenerator = WorkspaceGenerator(system: system,
@@ -75,15 +79,18 @@ public class Generator: Generating {
                                                     cocoapodsInteractor: cocoapodsInteractor)
         self.init(graphLoader: graphLoader,
                   workspaceGenerator: workspaceGenerator,
-                  projectGenerator: projectGenerator)
+                  projectGenerator: projectGenerator,
+                  tuistConfigLinter: tuistConfigLinter)
     }
 
     init(graphLoader: GraphLoading,
          workspaceGenerator: WorkspaceGenerating,
-         projectGenerator: ProjectGenerating) {
+         projectGenerator: ProjectGenerating,
+         tuistConfigLinter: TuistConfigLinting) {
         self.graphLoader = graphLoader
         self.workspaceGenerator = workspaceGenerator
         self.projectGenerator = projectGenerator
+        self.tuistConfigLinter = tuistConfigLinter
     }
 
     public func generateProject(at path: AbsolutePath) throws -> AbsolutePath {
@@ -99,7 +106,9 @@ public class Generator: Generating {
         let tuistConfig = try graphLoader.loadTuistConfig(path: path)
         let (graph, project) = try graphLoader.loadProject(path: path)
 
-        let workspace = Workspace(name: project.fileName,
+        try tuistConfigLinter.lint(config: tuistConfig)
+
+        let workspace = Workspace(name: project.name,
                                   projects: graph.projectPaths,
                                   additionalFiles: workspaceFiles.map(FileElement.file))
 
@@ -113,6 +122,8 @@ public class Generator: Generating {
                                   workspaceFiles: [AbsolutePath]) throws -> AbsolutePath {
         let (graph, workspace) = try graphLoader.loadWorkspace(path: path)
         let tuistConfig = try graphLoader.loadTuistConfig(path: path)
+        try tuistConfigLinter.lint(config: tuistConfig)
+
         let updatedWorkspace = workspace
             .merging(projects: graph.projectPaths)
             .adding(files: workspaceFiles)

--- a/Sources/TuistGenerator/Generator/Generator.swift
+++ b/Sources/TuistGenerator/Generator/Generator.swift
@@ -94,6 +94,9 @@ public class Generator: Generating {
     }
 
     public func generateProject(at path: AbsolutePath) throws -> AbsolutePath {
+        let tuistConfig = try graphLoader.loadTuistConfig(path: path)
+        try tuistConfigLinter.lint(config: tuistConfig)
+
         let (graph, project) = try graphLoader.loadProject(path: path)
         let generatedProject = try projectGenerator.generate(project: project,
                                                              graph: graph,
@@ -104,10 +107,9 @@ public class Generator: Generating {
     public func generateProjectWorkspace(at path: AbsolutePath,
                                          workspaceFiles: [AbsolutePath]) throws -> AbsolutePath {
         let tuistConfig = try graphLoader.loadTuistConfig(path: path)
-        let (graph, project) = try graphLoader.loadProject(path: path)
-
         try tuistConfigLinter.lint(config: tuistConfig)
 
+        let (graph, project) = try graphLoader.loadProject(path: path)
         let workspace = Workspace(name: project.name,
                                   projects: graph.projectPaths,
                                   additionalFiles: workspaceFiles.map(FileElement.file))
@@ -120,9 +122,9 @@ public class Generator: Generating {
 
     public func generateWorkspace(at path: AbsolutePath,
                                   workspaceFiles: [AbsolutePath]) throws -> AbsolutePath {
-        let (graph, workspace) = try graphLoader.loadWorkspace(path: path)
         let tuistConfig = try graphLoader.loadTuistConfig(path: path)
         try tuistConfigLinter.lint(config: tuistConfig)
+        let (graph, workspace) = try graphLoader.loadWorkspace(path: path)
 
         let updatedWorkspace = workspace
             .merging(projects: graph.projectPaths)

--- a/Sources/TuistGenerator/Linter/EnvironmentLinter.swift
+++ b/Sources/TuistGenerator/Linter/EnvironmentLinter.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TuistCore
 
-protocol TuistConfigLinting {
+protocol EnvironmentLinting {
     /// Lints a given Tuist configuration.
     ///
     /// - Parameter config: Tuist configuration to be linted against the system.
@@ -9,7 +9,7 @@ protocol TuistConfigLinting {
     func lint(config: TuistConfig) throws
 }
 
-class TuistConfigLinter: TuistConfigLinting {
+class EnvironmentLinter: EnvironmentLinting {
     /// Xcode controller.
     let xcodeController: XcodeControlling
 

--- a/Sources/TuistGenerator/Linter/TuistConfigLinter.swift
+++ b/Sources/TuistGenerator/Linter/TuistConfigLinter.swift
@@ -1,0 +1,46 @@
+import Foundation
+import TuistCore
+
+protocol TuistConfigLinting {
+    /// Lints a given Tuist configuration.
+    ///
+    /// - Parameter config: Tuist configuration to be linted against the system.
+    /// - Throws: An error if the validation fails.
+    func lint(config: TuistConfig) throws
+}
+
+class TuistConfigLinter: TuistConfigLinting {
+    /// Instance to run system commands.
+    let system: Systeming
+
+    /// Instance to output messages to the user.
+    let printer: Printing
+
+    /// Initializes the linter.
+    ///
+    /// - Parameters
+    ///   - system: Instance to run system commands.
+    ///   - printer: Instance to output messages to the user.
+    init(system: Systeming = System(),
+         printer: Printing = Printer()) {
+        self.system = system
+        self.printer = printer
+    }
+
+    /// Lints a given Tuist configuration.
+    ///
+    /// - Parameter config: Tuist configuration to be linted against the system.
+    /// - Throws: An error if the validation fails.
+    func lint(config: TuistConfig) throws {
+        var issues = [LintingIssue]()
+
+        issues.append(contentsOf: lintXcodeVersion(config: config))
+
+        try issues.printAndThrowIfNeeded(printer: printer)
+    }
+
+    func lintXcodeVersion(config _: TuistConfig) -> [LintingIssue] {
+        // TODO:
+        return []
+    }
+}

--- a/Sources/TuistGenerator/Models/CompatibleXcodeVersions.swift
+++ b/Sources/TuistGenerator/Models/CompatibleXcodeVersions.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Enum that represents all the Xcode versions that a project or set of projects is compatible with.
+public enum CompatibleXcodeVersions: Equatable, Hashable {
+    /// The project supports all Xcode versions.
+    case all
+
+    /// List of versions that are supported by the project.
+    case list([String])
+
+    // MARK: - ExpressibleByArrayLiteral
+
+    public init(arrayLiteral elements: [String]) {
+        self = .list(elements)
+    }
+
+    public init(arrayLiteral elements: String...) {
+        self = .list(elements)
+    }
+}

--- a/Sources/TuistGenerator/Models/CompatibleXcodeVersions.swift
+++ b/Sources/TuistGenerator/Models/CompatibleXcodeVersions.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Enum that represents all the Xcode versions that a project or set of projects is compatible with.
-public enum CompatibleXcodeVersions: Equatable, Hashable {
+public enum CompatibleXcodeVersions: Equatable, Hashable, ExpressibleByArrayLiteral {
     /// The project supports all Xcode versions.
     case all
 

--- a/Sources/TuistGenerator/Models/TuistConfig.swift
+++ b/Sources/TuistGenerator/Models/TuistConfig.swift
@@ -15,16 +15,23 @@ public class TuistConfig: Equatable, Hashable {
     /// Generation options.
     public let generationOptions: [GenerationOption]
 
+    /// List of Xcode versions the project or set of projects is compatible with.
+    public let compatibleXcodeVersions: CompatibleXcodeVersions
+
     /// Returns the default Tuist configuration.
     public static var `default`: TuistConfig {
-        return TuistConfig(generationOptions: [.generateManifest])
+        return TuistConfig(compatibleXcodeVersions: .all,
+                           generationOptions: [.generateManifest])
     }
 
     /// Initializes the tuist cofiguration.
     ///
     /// - Parameters:
+    ///   - compatibleXcodeVersions: List of Xcode versions the project or set of projects is compatible with.
     ///   - generationOptions: Generation options.
-    public init(generationOptions: [GenerationOption]) {
+    public init(compatibleXcodeVersions: CompatibleXcodeVersions,
+                generationOptions: [GenerationOption]) {
+        self.compatibleXcodeVersions = compatibleXcodeVersions
         self.generationOptions = generationOptions
     }
 

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -150,7 +150,10 @@ extension TuistGenerator.TuistConfig {
     static func from(manifest: ProjectDescription.TuistConfig,
                      path: AbsolutePath) throws -> TuistGenerator.TuistConfig {
         let generationOptions = try manifest.generationOptions.map { try TuistGenerator.TuistConfig.GenerationOption.from(manifest: $0, path: path) }
-        return TuistGenerator.TuistConfig(generationOptions: generationOptions)
+        let compatibleXcodeVersions = TuistGenerator.CompatibleXcodeVersions.from(manifest: manifest.compatibleXcodeVersions)
+
+        return TuistGenerator.TuistConfig(compatibleXcodeVersions: compatibleXcodeVersions,
+                                          generationOptions: generationOptions)
     }
 }
 
@@ -162,6 +165,17 @@ extension TuistGenerator.TuistConfig.GenerationOption {
             return .generateManifest
         case let .xcodeProjectName(templateString):
             return .xcodeProjectName(templateString.description)
+        }
+    }
+}
+
+extension TuistGenerator.CompatibleXcodeVersions {
+    static func from(manifest: ProjectDescription.CompatibleXcodeVersions) -> TuistGenerator.CompatibleXcodeVersions {
+        switch manifest {
+        case .all:
+            return .all
+        case let .list(versions):
+            return .list(versions)
         }
     }
 }

--- a/Tests/ProjectDescriptionTests/CompatibleXcodeVersionsTests.swift
+++ b/Tests/ProjectDescriptionTests/CompatibleXcodeVersionsTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import XCTest
+
+@testable import ProjectDescription
+@testable import TuistCoreTesting
+
+final class CompatibleXcodeVersionsTests: XCTestCase {
+    func test_codable_when_all() {
+        // Given
+        let subject = CompatibleXcodeVersions.all
+
+        // Then
+        XCTAssertCodable(subject)
+    }
+
+    func test_codable_when_list() {
+        // Given
+        let subject = CompatibleXcodeVersions.list(["10.3"])
+
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistCoreTests/Linter/LintingIssueTests.swift
+++ b/Tests/TuistCoreTests/Linter/LintingIssueTests.swift
@@ -25,13 +25,14 @@ final class LintingIssueTests: XCTestCase {
 
         XCTAssertThrowsError(try [first, second].printAndThrowIfNeeded(printer: printer))
 
-        XCTAssertEqual(printer.printWithColorArgs.first?.0, "The following issues have been found:")
-        XCTAssertEqual(printer.printWithColorArgs.first?.1, .yellow)
-        XCTAssertEqual(printer.printArgs.first, "  - warning")
-
-        XCTAssertEqual(printer.printWithColorArgs.last?.0, "\nThe following critical issues have been found:")
-        XCTAssertEqual(printer.printWithColorArgs.last?.1, .red)
-        XCTAssertEqual(printer.printArgs.last, "  - error")
+        XCTAssertTrue(printer.standardOutput.contains("""
+        The following issues have been found:
+          - warning
+        """))
+        XCTAssertTrue(printer.standardError.contains("""
+        The following critical issues have been found:
+          - error
+        """))
     }
 
     func test_printAndThrowIfNeeded_whenErrorsOnly() throws {
@@ -40,8 +41,9 @@ final class LintingIssueTests: XCTestCase {
 
         XCTAssertThrowsError(try [first].printAndThrowIfNeeded(printer: printer))
 
-        XCTAssertEqual(printer.printWithColorArgs.last?.0, "The following critical issues have been found:")
-        XCTAssertEqual(printer.printWithColorArgs.last?.1, .red)
-        XCTAssertEqual(printer.printArgs.last, "  - error")
+        XCTAssertTrue(printer.standardError.contains("""
+        The following critical issues have been found:
+          - error
+        """))
     }
 }

--- a/Tests/TuistCoreTests/Xcode/XcodeControllerTests.swift
+++ b/Tests/TuistCoreTests/Xcode/XcodeControllerTests.swift
@@ -32,11 +32,12 @@ final class XcodeControllerTests: XCTestCase {
         let contentsPath = fileHandler.currentPath.appending(component: "Contents")
         try fileHandler.createFolder(contentsPath)
         let infoPlistPath = contentsPath.appending(component: "Info.plist")
+        let developerPath = contentsPath.appending(component: "Developer")
         let infoPlist = Xcode.InfoPlist(version: "3.2.1")
         let infoPlistData = try PropertyListEncoder().encode(infoPlist)
         try infoPlistData.write(to: infoPlistPath.url)
 
-        system.succeedCommand(["xcode-select", "-p"], output: infoPlistPath.pathString)
+        system.succeedCommand(["xcode-select", "-p"], output: developerPath.pathString)
 
         // When
         let xcode = try subject.selected()

--- a/Tests/TuistCoreTests/Xcode/XcodeControllerTests.swift
+++ b/Tests/TuistCoreTests/Xcode/XcodeControllerTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import XCTest
+
+@testable import TuistCore
+@testable import TuistCoreTesting
+
+final class XcodeControllerTests: XCTestCase {
+    var system: MockSystem!
+    var subject: XcodeController!
+    var fileHandler: MockFileHandler!
+
+    override func setUp() {
+        super.setUp()
+        system = MockSystem()
+        fileHandler = try! MockFileHandler()
+        subject = XcodeController(system: system)
+    }
+
+    func test_selected_when_xcodeSelectDoesntReturnThePath() throws {
+        // Given
+        system.errorCommand(["xcode-select", "-p"])
+
+        // When
+        let xcode = try subject.selected()
+
+        // Then
+        XCTAssertNil(xcode)
+    }
+
+    func test_selected_when_xcodeSelectReturnsThePath() throws {
+        // Given
+        let contentsPath = fileHandler.currentPath.appending(component: "Contents")
+        try fileHandler.createFolder(contentsPath)
+        let infoPlistPath = contentsPath.appending(component: "Info.plist")
+        let infoPlist = Xcode.InfoPlist(version: "3.2.1")
+        let infoPlistData = try PropertyListEncoder().encode(infoPlist)
+        try infoPlistData.write(to: infoPlistPath.url)
+
+        system.succeedCommand(["xcode-select", "-p"], output: infoPlistPath.pathString)
+
+        // When
+        let xcode = try subject.selected()
+
+        // Then
+        XCTAssertNotNil(xcode)
+    }
+}

--- a/Tests/TuistCoreTests/Xcode/XcodeTests.swift
+++ b/Tests/TuistCoreTests/Xcode/XcodeTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import XCTest
+
+@testable import TuistCore
+@testable import TuistCoreTesting
+
+final class XcodeTests: XCTestCase {
+    var plistEncoder: PropertyListEncoder!
+    var fileHandler: MockFileHandler!
+
+    override func setUp() {
+        super.setUp()
+        plistEncoder = PropertyListEncoder()
+        fileHandler = try! MockFileHandler()
+    }
+
+    func test_read() throws {
+        // Given
+        let infoPlist = Xcode.InfoPlist(version: "3.2.1")
+        let infoPlistData = try plistEncoder.encode(infoPlist)
+        let contentsPath = fileHandler.currentPath.appending(component: "Contents")
+        try fileHandler.createFolder(contentsPath)
+        let infoPlistPath = contentsPath.appending(component: "Info.plist")
+        try infoPlistData.write(to: infoPlistPath.url)
+
+        // When
+        let xcode = try Xcode.read(path: fileHandler.currentPath)
+
+        // Then
+        XCTAssertEqual(xcode.infoPlist.version, "3.2.1")
+        XCTAssertEqual(xcode.path, fileHandler.currentPath)
+    }
+}

--- a/Tests/TuistGeneratorTests/GeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/GeneratorTests.swift
@@ -7,19 +7,19 @@ class GeneratorTests: XCTestCase {
     var workspaceGenerator: MockWorkspaceGenerator!
     var projectGenerator: MockProjectGenerator!
     var graphLoader: MockGraphLoader!
-    var tuistConfigLinter: MockTuistConfigLinter!
+    var environmentLinter: MockEnvironmentLinter!
     var subject: Generator!
 
     override func setUp() {
         graphLoader = MockGraphLoader()
         workspaceGenerator = MockWorkspaceGenerator()
         projectGenerator = MockProjectGenerator()
-        tuistConfigLinter = MockTuistConfigLinter()
+        environmentLinter = MockEnvironmentLinter()
 
         subject = Generator(graphLoader: graphLoader,
                             workspaceGenerator: workspaceGenerator,
                             projectGenerator: projectGenerator,
-                            tuistConfigLinter: tuistConfigLinter)
+                            environmentLinter: environmentLinter)
     }
 
     // MARK: - Tests

--- a/Tests/TuistGeneratorTests/GeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/GeneratorTests.swift
@@ -7,16 +7,19 @@ class GeneratorTests: XCTestCase {
     var workspaceGenerator: MockWorkspaceGenerator!
     var projectGenerator: MockProjectGenerator!
     var graphLoader: MockGraphLoader!
+    var tuistConfigLinter: MockTuistConfigLinter!
     var subject: Generator!
 
     override func setUp() {
         graphLoader = MockGraphLoader()
         workspaceGenerator = MockWorkspaceGenerator()
         projectGenerator = MockProjectGenerator()
+        tuistConfigLinter = MockTuistConfigLinter()
 
         subject = Generator(graphLoader: graphLoader,
                             workspaceGenerator: workspaceGenerator,
-                            projectGenerator: projectGenerator)
+                            projectGenerator: projectGenerator,
+                            tuistConfigLinter: tuistConfigLinter)
     }
 
     // MARK: - Tests

--- a/Tests/TuistGeneratorTests/Linter/EnvironmentLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/EnvironmentLinterTests.swift
@@ -9,7 +9,7 @@ final class EnvironmentLinterTests: XCTestCase {
     var xcodeController: MockXcodeController!
     var printer: MockPrinter!
     var subject: EnvironmentLinter!
-    
+
     override func setUp() {
         super.setUp()
         xcodeController = MockXcodeController()
@@ -17,49 +17,49 @@ final class EnvironmentLinterTests: XCTestCase {
         subject = EnvironmentLinter(xcodeController: xcodeController,
                                     printer: printer)
     }
-    
+
     func test_lintXcodeVersion_returnsALintingIssue_when_theVersionsOfXcodeAreIncompatible() throws {
         // Given
         let config = TuistConfig.test(compatibleXcodeVersions: .list(["3.2.1"]))
         xcodeController.selectedStub = .success(Xcode.test(infoPlist: .test(version: "4.3.2")))
-        
+
         // When
         let got = try subject.lintXcodeVersion(config: config)
-        
+
         // Then
         let expectedMessage = "The project, which only supports the versions of Xcode 3.2.1, is not compatible with your selected version of Xcode, 4.3.2"
         XCTAssertTrue(got.contains(LintingIssue(reason: expectedMessage, severity: .error)))
     }
-    
+
     func test_lintXcodeVersion_doesntReturnIssues_whenAllVersionsAreSupported() throws {
         // Given
         let config = TuistConfig.test(compatibleXcodeVersions: .all)
         xcodeController.selectedStub = .success(Xcode.test(infoPlist: .test(version: "4.3.2")))
-        
+
         // When
         let got = try subject.lintXcodeVersion(config: config)
-        
+
         // Then
         XCTEmpty(got)
     }
-    
+
     func test_lintXcodeVersion_doesntReturnIssues_whenThereIsNoSelectedXcode() throws {
         // Given
         let config = TuistConfig.test(compatibleXcodeVersions: .list(["3.2.1"]))
-        
+
         // When
         let got = try subject.lintXcodeVersion(config: config)
-        
+
         // Then
         XCTEmpty(got)
     }
-    
+
     func test_lintXcodeVersion_throws_when_theSelectedXcodeCantBeObtained() throws {
         // Given
         let config = TuistConfig.test(compatibleXcodeVersions: .list(["3.2.1"]))
         let error = NSError.test()
         xcodeController.selectedStub = .failure(error)
-        
+
         // Then
         XCTAssertThrowsError(try subject.lintXcodeVersion(config: config)) {
             XCTAssertEqual($0 as NSError, error)

--- a/Tests/TuistGeneratorTests/Linter/EnvironmentLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/EnvironmentLinterTests.swift
@@ -5,61 +5,61 @@ import XCTest
 @testable import TuistCoreTesting
 @testable import TuistGenerator
 
-final class TuistConfigLinterTests: XCTestCase {
+final class EnvironmentLinterTests: XCTestCase {
     var xcodeController: MockXcodeController!
     var printer: MockPrinter!
-    var subject: TuistConfigLinter!
-
+    var subject: EnvironmentLinter!
+    
     override func setUp() {
         super.setUp()
         xcodeController = MockXcodeController()
         printer = MockPrinter()
-        subject = TuistConfigLinter(xcodeController: xcodeController,
+        subject = EnvironmentLinter(xcodeController: xcodeController,
                                     printer: printer)
     }
-
+    
     func test_lintXcodeVersion_returnsALintingIssue_when_theVersionsOfXcodeAreIncompatible() throws {
         // Given
         let config = TuistConfig.test(compatibleXcodeVersions: .list(["3.2.1"]))
         xcodeController.selectedStub = .success(Xcode.test(infoPlist: .test(version: "4.3.2")))
-
+        
         // When
         let got = try subject.lintXcodeVersion(config: config)
-
+        
         // Then
         let expectedMessage = "The project, which only supports the versions of Xcode 3.2.1, is not compatible with your selected version of Xcode, 4.3.2"
         XCTAssertTrue(got.contains(LintingIssue(reason: expectedMessage, severity: .error)))
     }
-
+    
     func test_lintXcodeVersion_doesntReturnIssues_whenAllVersionsAreSupported() throws {
         // Given
         let config = TuistConfig.test(compatibleXcodeVersions: .all)
         xcodeController.selectedStub = .success(Xcode.test(infoPlist: .test(version: "4.3.2")))
-
+        
         // When
         let got = try subject.lintXcodeVersion(config: config)
-
+        
         // Then
         XCTEmpty(got)
     }
-
+    
     func test_lintXcodeVersion_doesntReturnIssues_whenThereIsNoSelectedXcode() throws {
         // Given
         let config = TuistConfig.test(compatibleXcodeVersions: .list(["3.2.1"]))
-
+        
         // When
         let got = try subject.lintXcodeVersion(config: config)
-
+        
         // Then
         XCTEmpty(got)
     }
-
+    
     func test_lintXcodeVersion_throws_when_theSelectedXcodeCantBeObtained() throws {
         // Given
         let config = TuistConfig.test(compatibleXcodeVersions: .list(["3.2.1"]))
         let error = NSError.test()
         xcodeController.selectedStub = .failure(error)
-
+        
         // Then
         XCTAssertThrowsError(try subject.lintXcodeVersion(config: config)) {
             XCTAssertEqual($0 as NSError, error)

--- a/Tests/TuistGeneratorTests/Linter/Mocks/MockEnvironmentLinter.swift
+++ b/Tests/TuistGeneratorTests/Linter/Mocks/MockEnvironmentLinter.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @testable import TuistGenerator
 
-final class MockTuistConfigLinter: TuistConfigLinting {
+final class MockEnvironmentLinter: EnvironmentLinting {
     var lintStub: Error?
     var lintArgs: [TuistConfig] = []
 

--- a/Tests/TuistGeneratorTests/Linter/Mocks/MockTuistConfigLinter.swift
+++ b/Tests/TuistGeneratorTests/Linter/Mocks/MockTuistConfigLinter.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+@testable import TuistGenerator
+
+final class MockTuistConfigLinter: TuistConfigLinting {
+    var lintStub: Error?
+    var lintArgs: [TuistConfig] = []
+
+    func lint(config: TuistConfig) throws {
+        lintArgs.append(config)
+        if let error = lintStub {
+            throw error
+        }
+    }
+}

--- a/Tests/TuistGeneratorTests/Linter/TuistConfigLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TuistConfigLinterTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import TuistCore
+import XCTest
+
+@testable import TuistCoreTesting
+@testable import TuistGenerator
+
+final class TuistConfigLinterTests: XCTestCase {
+    var xcodeController: MockXcodeController!
+    var printer: MockPrinter!
+    var subject: TuistConfigLinter!
+
+    override func setUp() {
+        super.setUp()
+        xcodeController = MockXcodeController()
+        printer = MockPrinter()
+        subject = TuistConfigLinter(xcodeController: xcodeController,
+                                    printer: printer)
+    }
+
+    func test_lintXcodeVersion_returnsALintingIssue_when_theVersionsOfXcodeAreIncompatible() throws {
+        // Given
+        let config = TuistConfig.test(compatibleXcodeVersions: .list(["3.2.1"]))
+        xcodeController.selectedStub = .success(Xcode.test(infoPlist: .test(version: "4.3.2")))
+
+        // When
+        let got = try subject.lintXcodeVersion(config: config)
+
+        // Then
+        let expectedMessage = "The project, which only supports the versions of Xcode 3.2.1, is not compatible with your selected version of Xcode, 4.3.2"
+        XCTAssertTrue(got.contains(LintingIssue(reason: expectedMessage, severity: .error)))
+    }
+
+    func test_lintXcodeVersion_doesntReturnIssues_whenAllVersionsAreSupported() throws {
+        // Given
+        let config = TuistConfig.test(compatibleXcodeVersions: .all)
+        xcodeController.selectedStub = .success(Xcode.test(infoPlist: .test(version: "4.3.2")))
+
+        // When
+        let got = try subject.lintXcodeVersion(config: config)
+
+        // Then
+        XCTEmpty(got)
+    }
+
+    func test_lintXcodeVersion_doesntReturnIssues_whenThereIsNoSelectedXcode() throws {
+        // Given
+        let config = TuistConfig.test(compatibleXcodeVersions: .list(["3.2.1"]))
+
+        // When
+        let got = try subject.lintXcodeVersion(config: config)
+
+        // Then
+        XCTEmpty(got)
+    }
+
+    func test_lintXcodeVersion_throws_when_theSelectedXcodeCantBeObtained() throws {
+        // Given
+        let config = TuistConfig.test(compatibleXcodeVersions: .list(["3.2.1"]))
+        let error = NSError.test()
+        xcodeController.selectedStub = .failure(error)
+
+        // Then
+        XCTAssertThrowsError(try subject.lintXcodeVersion(config: config)) {
+            XCTAssertEqual($0 as NSError, error)
+        }
+    }
+}

--- a/Tests/TuistGeneratorTests/Models/TestData/TuistConfig+TestData.swift
+++ b/Tests/TuistGeneratorTests/Models/TestData/TuistConfig+TestData.swift
@@ -3,7 +3,9 @@ import Foundation
 @testable import TuistGenerator
 
 extension TuistConfig {
-    static func test(generationOptions: [GenerationOption] = []) -> TuistConfig {
-        return TuistConfig(generationOptions: generationOptions)
+    static func test(compatibleXcodeVersions: CompatibleXcodeVersions = .all,
+                     generationOptions: [GenerationOption] = []) -> TuistConfig {
+        return TuistConfig(compatibleXcodeVersions: compatibleXcodeVersions,
+                           generationOptions: generationOptions)
     }
 }

--- a/Tests/TuistIntegrationTests/Generator/Mocks/MockPrinter.swift
+++ b/Tests/TuistIntegrationTests/Generator/Mocks/MockPrinter.swift
@@ -3,6 +3,8 @@ import Foundation
 import TuistCore
 
 class MockPrinter: Printing {
+    func print(_: String, output _: PrinterOutput) {}
+
     func print(_: String) {}
 
     func print(_: String, color _: TerminalController.Color) {}

--- a/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -324,7 +324,8 @@ final class MultipleConfigurationsIntegrationTests: XCTestCase {
     }
 
     private func createTuistConfig() -> TuistConfig {
-        return TuistConfig(generationOptions: [])
+        return TuistConfig(compatibleXcodeVersions: .all,
+                           generationOptions: [])
     }
 
     private func createWorkspace(projects: [String]) -> Workspace {

--- a/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
@@ -96,7 +96,8 @@ final class StableXcodeProjIntegrationTests: XCTestCase {
     }
 
     private func createTuistConfig() -> TuistConfig {
-        return TuistConfig(generationOptions: [])
+        return TuistConfig(compatibleXcodeVersions: .all,
+                           generationOptions: [])
     }
 
     private func createWorkspace(projects: [String]) -> Workspace {

--- a/Tests/TuistKitTests/Setup/SetupLoaderTests.swift
+++ b/Tests/TuistKitTests/Setup/SetupLoaderTests.swift
@@ -120,11 +120,13 @@ final class SetupLoaderTests: XCTestCase {
         let expectedOutput = """
         The following issues have been found:
           - mockup2 warning
+        """
+        let expectedError = """
         The following critical issues have been found:
           - mockup1 error
           - mockup3 error
         """
-        XCTAssertEqual(printer.standardOutput, expectedOutput)
-        XCTAssertEqual(printer.standardError, "")
+        XCTAssertTrue(printer.standardOutput.contains(expectedOutput))
+        XCTAssertTrue(printer.standardError.contains(expectedError))
     }
 }

--- a/docs/usage/tuistconfig.swift.mdx
+++ b/docs/usage/tuistconfig.swift.mdx
@@ -30,6 +30,7 @@ The structure is similar to the project manifest. We need to create a root varia
 import ProjectDescription
 
 let config = TuistConfig(
+  compatibleXcodeVersions: ["10.3"],
   generationOptions: [
     .generateManifest,
     .xcodeProjectName("SomePrefix-\(.projectName)-SomeSuffix")
@@ -44,6 +45,15 @@ It allows configuring Tuist and share the configuration across several projects.
 <PropertiesTable
   props={[
     {
+      name: 'Compatible Xcode versions',
+      description:
+        'Set the versions of Xcode that the project is compatible with.',
+      type: 'CompatibleXcodeVersions',
+      typeLink: '#compatible-xcode-versions',
+      optional: true,
+      default: '.all',
+    },
+    {
       name: 'Generation options',
       description: 'Options to configure the generation of Xcode projects',
       type: '[GenerationOption]',
@@ -52,6 +62,29 @@ It allows configuring Tuist and share the configuration across several projects.
       default: '[]',
     },
   ]}
+/>
+
+## Compatible Xcode versions
+
+This object represents the versions of Xcode the project is compatible with. If a developer tries to generate a project and its selected Xcode version is not compatible with the project, Tuist will yield an error:
+
+<EnumTable
+  cases={[
+    {
+      case: '.all',
+      description: 'The project is compatible with any version of Xcode.',
+    },
+    {
+      case: '.list([String])',
+      description: 'The project is compatible with a list of Xcode versions.',
+    },
+  ]}
+/>
+
+<Message
+  info
+  title="ExpressibleByArrayLiteral and ExpressibleByStringLiteral"
+  description="Note that 'CompatibleXcodeVersions' can also be initialized with a string or array of strings that represent the supported Xcode versions."
 />
 
 ## GenerationOption

--- a/features/generate.feature
+++ b/features/generate.feature
@@ -167,3 +167,9 @@ Scenario: The project is an iOS application with CocoaPods dependencies (ios_app
   Then I copy the fixture ios_app_with_pods into the working directory
   Then tuist generates the project
   Then I should be able to build the scheme App
+    
+Scenario: The project is an iOS application with an incompatible Xcode version (ios_app_with_incompatible_xcode)
+    Given that tuist is available
+    And I have a working directory
+    Then I copy the fixture ios_app_with_incompatible_xcode into the working directory
+    Then tuist generates yields error "The project, which only supports the versions of Xcode 3.2.1, is not compatible with your selected version of Xcode, 10.3"

--- a/features/generate.feature
+++ b/features/generate.feature
@@ -172,4 +172,4 @@ Scenario: The project is an iOS application with an incompatible Xcode version (
     Given that tuist is available
     And I have a working directory
     Then I copy the fixture ios_app_with_incompatible_xcode into the working directory
-    Then tuist generates yields error "The project, which only supports the versions of Xcode 3.2.1, is not compatible with your selected version of Xcode, 10.3"
+    Then tuist generates yields error "The project, which only supports the versions of Xcode 3.2.1, is not compatible with your selected version of Xcode, 10.2.1"

--- a/features/generate.feature
+++ b/features/generate.feature
@@ -172,4 +172,4 @@ Scenario: The project is an iOS application with an incompatible Xcode version (
     Given that tuist is available
     And I have a working directory
     Then I copy the fixture ios_app_with_incompatible_xcode into the working directory
-    Then tuist generates yields error "The project, which only supports the versions of Xcode 3.2.1, is not compatible with your selected version of Xcode, 10.2.1"
+    Then tuist generates yields error "The project, which only supports the versions of Xcode 3.2.1, is not compatible with your selected version of Xcode"

--- a/features/step_definitions/shared/tuist.rb
+++ b/features/step_definitions/shared/tuist.rb
@@ -14,13 +14,21 @@ Then(/tuist sets up the project/) do
   @workspace_path = Dir.glob(File.join(@dir, "*.xcworkspace")).first
 end
 
-Then(/tuist generates reports error "(.+)"/) do |error|
+Then(/tuist generates yields error "(.+)"/) do |error|
   expected_msg = error.sub!("${ARG_PATH}", @dir)
   system("swift", "build")
-  _, _, stderr, wait_thr = Open3.popen3("swift", "run", "--skip-build", "tuist", "generate", "--path", @dir)
-  actual_msg = stderr.gets.to_s.strip
-  assert_equal(actual_msg, expected_msg)
-  assert_equal(wait_thr.value.exitstatus, 1)
+  _, stderr, status = Open3.capture3("swift", "run", "--skip-build", "tuist", "generate", "--path", @dir)
+  actual_msg = stderr.strip
+
+  error_message = <<~EOD
+    The output error message:
+      #{actual_msg}
+
+    Does not contain the expected:
+      #{error}
+  EOD
+  assert actual_msg.include?(error), error_message
+  refute status.success?
 end
 
 Then(/tuistenv should succeed in installing "(.+)"/) do |ref|

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -209,3 +209,7 @@ Note: to re-create `Framework2.framework` run `fixtures/ios_app_with_transitive_
 ## ios_app_with_pods
 
 An iOS application with CocoaPods dependencies
+
+## ios_app_with_incompatible_xcode
+
+An iOS app whose TuistConfig file requires an Xcode version that is not available in the system.

--- a/fixtures/ios_app_with_incompatible_xcode/.gitignore
+++ b/fixtures/ios_app_with_incompatible_xcode/.gitignore
@@ -1,0 +1,63 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two 
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace

--- a/fixtures/ios_app_with_incompatible_xcode/Info.plist
+++ b/fixtures/ios_app_with_incompatible_xcode/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_incompatible_xcode/Project.swift
+++ b/fixtures/ios_app_with_incompatible_xcode/Project.swift
@@ -1,0 +1,11 @@
+import ProjectDescription
+
+let project = Project(name: "App",
+                      targets: [
+                          Target(name: "App",
+                                 platform: .iOS,
+                                 product: .app,
+                                 bundleId: "io.tuist.App",
+                                 infoPlist: "Info.plist",
+                                 sources: "Sources/**")
+])

--- a/fixtures/ios_app_with_incompatible_xcode/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_incompatible_xcode/Sources/AppDelegate.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        let viewController = UIViewController()
+        viewController.view.backgroundColor = .white
+        window?.rootViewController = viewController
+        window?.makeKeyAndVisible()
+        return true
+    }
+    
+    func hello() -> String {
+        return "AppDelegate.hello()"
+    }
+    
+}

--- a/fixtures/ios_app_with_incompatible_xcode/TuistConfig.swift
+++ b/fixtures/ios_app_with_incompatible_xcode/TuistConfig.swift
@@ -1,7 +1,7 @@
 import ProjectDescription
 
 let config = TuistConfig(
-    compatibleXcodeVersions: ["3.2.1"],
+    compatibleXcodeVersions: ["10.2.1"],
     generationOptions: [
         .generateManifest
     ]

--- a/fixtures/ios_app_with_incompatible_xcode/TuistConfig.swift
+++ b/fixtures/ios_app_with_incompatible_xcode/TuistConfig.swift
@@ -1,0 +1,8 @@
+import ProjectDescription
+
+let config = TuistConfig(
+    compatibleXcodeVersions: ["3.2.1"],
+    generationOptions: [
+        .generateManifest
+    ]
+)

--- a/fixtures/ios_app_with_incompatible_xcode/TuistConfig.swift
+++ b/fixtures/ios_app_with_incompatible_xcode/TuistConfig.swift
@@ -1,7 +1,7 @@
 import ProjectDescription
 
 let config = TuistConfig(
-    compatibleXcodeVersions: ["10.2.1"],
+    compatibleXcodeVersions: ["3.2.1"],
     generationOptions: [
         .generateManifest
     ]


### PR DESCRIPTION
### Short description 📝
Xcode doesn't support binding projects to a specific version of Xcode. Since new versions of Xcode come with new versions of Swift, which often break projects, it might be useful for teams to have a way that prevents developers in the team from using the projects with a version of Xcode that is not compatible with the project in hands.

### Solution 📦
Add a new setting to the `TuistConfig` object:

```swift
let config = TuistConfig(compatibleXcodeVersions: ["10.3"])
```

When a project gets generated, Tuist runs a validation against the Xcode version selected in the system. If the project is not compatible, Tuist yields the following output:

![incompatible-xcode](https://user-images.githubusercontent.com/663605/62422641-2d310080-b6b6-11e9-9e65-d2afcd6d7c2a.gif)

### Implementation 👩‍💻👨‍💻
- [x] Add `XcodeController` to `TuistCore`.
- [x] Add `CompatibleXcodeVersions` to `TuistGenerator` and `ProjectDescription`.
- [x] Add `TuistConfigLinter` and run it as part of the project generation.
- [x] Unit tests all the changes.
- [x] Add an acceptance test that fails because the Xcode version is not compatible.