### PR TITLE
Set the correct lastKnownFileType for localized files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Ensuring the correct platform SDK dependencies path is set https://github.com/tuist/tuist/pull/419 by @kwridan
 - Update manifest target name such that its product has a valid name https://github.com/tuist/tuist/pull/426 by @kwridan
 - Do not create `Derived/InfoPlists` folder when no InfoPlist dictionary is specified https://github.com/tuist/tuist/pull/456 by @adamkhazi
+- Set the correct lastKnownFileType for localized files https://github.com/tuist/tuist/pull/478 by @kwridan
 
 ### Changed
 

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -401,7 +401,7 @@ class ProjectFileElements {
                                          localizedContainer: AbsolutePath,
                                          pbxproj: PBXProj) {
         let localizedFilePath = localizedFile.relative(to: localizedContainer.parentDirectory)
-        let lastKnownFileType = Xcode.filetype(extension: localizedFile.basename)
+        let lastKnownFileType = localizedFile.extension.flatMap { Xcode.filetype(extension: $0) }
         let name = localizedContainer.basename.split(separator: ".").first
         let localizedFileReference = PBXFileReference(sourceTree: .group,
                                                       name: name.map { String($0) },

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -470,6 +470,9 @@ final class ProjectFileElementsTests: XCTestCase {
         XCTAssertNil(variantGroup?.path)
         XCTAssertEqual(variantGroup?.children.map { $0.name }, ["en"])
         XCTAssertEqual(variantGroup?.children.map { $0.path }, ["en.lproj/App.strings"])
+        XCTAssertEqual(variantGroup?.children.map { ($0 as? PBXFileReference)?.lastKnownFileType }, [
+            Xcode.filetype(extension: "strings"),
+        ])
     }
 
     func test_addVersionGroupElement() throws {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/424

### Short description 📝

The `lastKnownFileType` wasn't being set for localized files.

### Solution 📦

Use the localized file extension to determine `lastKnownFileType`

### Implementation 👩‍💻👨‍💻

- [x] Update `ProjectFileElements`
- [x] Update change log

### Test Plan 🛠

- Run `tuist generate` within `fixtures/ios_app_with_framework_and_resources`
- Verify the `lastKnownFileType` of the strings files are set (inspect `App/MainApp.xcodeproj/project.pbxproj`)