### PR TITLE
Print the codesign output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 - New InfoPlist type, `.extendingDefault([:])` https://github.com/tuist/tuist/pull/448 by @pepibumur
+- Forward the output of the `codesign` command to make debugging easier when the copy frameworks command fails https://github.com/tuist/tuist/pull/492 by @pepibumur.
 
 ### Fixed
 

--- a/Sources/TuistKit/Embed/FrameworkEmbedder.swift
+++ b/Sources/TuistKit/Embed/FrameworkEmbedder.swift
@@ -74,7 +74,7 @@ final class FrameworkEmbedder: FrameworkEmbedding {
         /// We need to ensure the frameworks are codesigned after being copied to the built products directory.
         /// Passing `preserve-metadata=identifier,entitlements` ensures any signatures or entitlements which are
         /// already there are preserved.
-        try system.run([
+        try system.runAndPrint([
             "/usr/bin/xcrun",
             "codesign", "--force", "--sign", codeSigningIdentity, "--preserve-metadata=identifier,entitlements", frameworkPath.pathString,
         ])


### PR DESCRIPTION
### Short description 📝
Yesterday, while debugging an issue with @asalom  that caused the copy frameworks phase to fail, we found that we are not printing the output of the `codesign`. Due to that, when the command fails for whatever reason, it's really hard to debug.

### Solution 📦
Use `runAndPrint` instead of just `run`, which will show the output of the `codesign` command.