### PR TITLE
Fix non-coloured tuistenv output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Transitively link static dependency's dynamic dependencies correctly https://github.com/tuist/tuist/pull/484 by @adamkhazi
 - Prevent embedding static frameworks https://github.com/tuist/tuist/pull/490 by @kwridan
+- Output losing its format when tuist is run through `tuistenv` https://github.com/tuist/tuist/pull/493 by @pepibumur
 
 ## 0.17.0
 

--- a/Sources/TuistCore/Constants.swift
+++ b/Sources/TuistCore/Constants.swift
@@ -8,6 +8,7 @@ public class Constants {
     public static let version = "0.17.0"
     public static let swiftVersion: String = "5.0"
     public static let bundleName: String = "tuist.zip"
+    public static let trueValues: [String] = ["1", "true", "TRUE", "yes", "YES"]
 
     public class EnvironmentVariables {
         public static let colouredOutput = "TUIST_COLOURED_OUTPUT"

--- a/Sources/TuistCore/Constants.swift
+++ b/Sources/TuistCore/Constants.swift
@@ -8,4 +8,8 @@ public class Constants {
     public static let version = "0.17.0"
     public static let swiftVersion: String = "5.0"
     public static let bundleName: String = "tuist.zip"
+
+    public class EnvironmentVariables {
+        public static let colouredOutput = "TUIST_COLOURED_OUTPUT"
+    }
 }

--- a/Sources/TuistCore/Linter/LintingIssue.swift
+++ b/Sources/TuistCore/Linter/LintingIssue.swift
@@ -48,16 +48,13 @@ public extension Array where Element == LintingIssue {
         let warningIssues = filter { $0.severity == .warning }
 
         if !warningIssues.isEmpty {
-            Printer.shared.print("The following issues have been found:", color: .yellow)
-            let message = warningIssues.map { "  - \($0.description)" }.joined(separator: "\n")
-            Printer.shared.print(message)
+            let message = warningIssues.map { "- \($0.description)" }.joined(separator: "\n")
+            Printer.shared.print(warning: message)
         }
 
         if !errorIssues.isEmpty {
-            let prefix = !warningIssues.isEmpty ? "\n" : ""
-            Printer.shared.print("\(prefix)The following critical issues have been found:", output: .standardError)
-            let message = errorIssues.map { "  - \($0.description)" }.joined(separator: "\n")
-            Printer.shared.print(message, output: .standardError)
+            let message = errorIssues.map { "- \($0.description)" }.joined(separator: "\n")
+            Printer.shared.print(errorMessage: message)
 
             throw LintingError()
         }

--- a/Sources/TuistCore/Utils/ColorizeSwift.swift
+++ b/Sources/TuistCore/Utils/ColorizeSwift.swift
@@ -5,6 +5,8 @@
 //  Created by Michał Tynior on 31/03/16.
 //  Copyright © 2016 Michal Tynior. All rights reserved.
 //
+// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name
 import Foundation
 
 public typealias TerminalStyleCode = (open: String, close: String)

--- a/Sources/TuistCore/Utils/ColorizeSwift.swift
+++ b/Sources/TuistCore/Utils/ColorizeSwift.swift
@@ -1,0 +1,515 @@
+//
+//  ColorizeSwift.swift
+//  ColorizeSwift
+//
+//  Created by Michał Tynior on 31/03/16.
+//  Copyright © 2016 Michal Tynior. All rights reserved.
+//
+import Foundation
+
+public typealias TerminalStyleCode = (open: String, close: String)
+
+public struct TerminalStyle {
+    public static let bold: TerminalStyleCode = ("\u{001B}[1m", "\u{001B}[22m")
+    public static let dim: TerminalStyleCode = ("\u{001B}[2m", "\u{001B}[22m")
+    public static let italic: TerminalStyleCode = ("\u{001B}[3m", "\u{001B}[23m")
+    public static let underline: TerminalStyleCode = ("\u{001B}[4m", "\u{001B}[24m")
+    public static let blink: TerminalStyleCode = ("\u{001B}[5m", "\u{001B}[25m")
+    public static let reverse: TerminalStyleCode = ("\u{001B}[7m", "\u{001B}[27m")
+    public static let hidden: TerminalStyleCode = ("\u{001B}[8m", "\u{001B}[28m")
+    public static let strikethrough: TerminalStyleCode = ("\u{001B}[9m", "\u{001B}[29m")
+    public static let reset: TerminalStyleCode = ("\u{001B}[0m", "")
+
+    public static let black: TerminalStyleCode = ("\u{001B}[30m", "\u{001B}[0m")
+    public static let red: TerminalStyleCode = ("\u{001B}[31m", "\u{001B}[0m")
+    public static let green: TerminalStyleCode = ("\u{001B}[32m", "\u{001B}[0m")
+    public static let yellow: TerminalStyleCode = ("\u{001B}[33m", "\u{001B}[0m")
+    public static let blue: TerminalStyleCode = ("\u{001B}[34m", "\u{001B}[0m")
+    public static let magenta: TerminalStyleCode = ("\u{001B}[35m", "\u{001B}[0m")
+    public static let cyan: TerminalStyleCode = ("\u{001B}[36m", "\u{001B}[0m")
+    public static let lightGray: TerminalStyleCode = ("\u{001B}[37m", "\u{001B}[0m")
+    public static let darkGray: TerminalStyleCode = ("\u{001B}[90m", "\u{001B}[0m")
+    public static let lightRed: TerminalStyleCode = ("\u{001B}[91m", "\u{001B}[0m")
+    public static let lightGreen: TerminalStyleCode = ("\u{001B}[92m", "\u{001B}[0m")
+    public static let lightYellow: TerminalStyleCode = ("\u{001B}[93m", "\u{001B}[0m")
+    public static let lightBlue: TerminalStyleCode = ("\u{001B}[94m", "\u{001B}[0m")
+    public static let lightMagenta: TerminalStyleCode = ("\u{001B}[95m", "\u{001B}[0m")
+    public static let lightCyan: TerminalStyleCode = ("\u{001B}[96m", "\u{001B}[0m")
+    public static let white: TerminalStyleCode = ("\u{001B}[97m", "\u{001B}[0m")
+
+    public static let onBlack: TerminalStyleCode = ("\u{001B}[40m", "\u{001B}[0m")
+    public static let onRed: TerminalStyleCode = ("\u{001B}[41m", "\u{001B}[0m")
+    public static let onGreen: TerminalStyleCode = ("\u{001B}[42m", "\u{001B}[0m")
+    public static let onYellow: TerminalStyleCode = ("\u{001B}[43m", "\u{001B}[0m")
+    public static let onBlue: TerminalStyleCode = ("\u{001B}[44m", "\u{001B}[0m")
+    public static let onMagenta: TerminalStyleCode = ("\u{001B}[45m", "\u{001B}[0m")
+    public static let onCyan: TerminalStyleCode = ("\u{001B}[46m", "\u{001B}[0m")
+    public static let onLightGray: TerminalStyleCode = ("\u{001B}[47m", "\u{001B}[0m")
+    public static let onDarkGray: TerminalStyleCode = ("\u{001B}[100m", "\u{001B}[0m")
+    public static let onLightRed: TerminalStyleCode = ("\u{001B}[101m", "\u{001B}[0m")
+    public static let onLightGreen: TerminalStyleCode = ("\u{001B}[102m", "\u{001B}[0m")
+    public static let onLightYellow: TerminalStyleCode = ("\u{001B}[103m", "\u{001B}[0m")
+    public static let onLightBlue: TerminalStyleCode = ("\u{001B}[104m", "\u{001B}[0m")
+    public static let onLightMagenta: TerminalStyleCode = ("\u{001B}[105m", "\u{001B}[0m")
+    public static let onLightCyan: TerminalStyleCode = ("\u{001B}[106m", "\u{001B}[0m")
+    public static let onWhite: TerminalStyleCode = ("\u{001B}[107m", "\u{001B}[0m")
+}
+
+extension String {
+    /// Enable/disable colorization
+    public static var isColorizationEnabled = true
+
+    public func bold() -> String {
+        return applyStyle(TerminalStyle.bold)
+    }
+
+    public func dim() -> String {
+        return applyStyle(TerminalStyle.dim)
+    }
+
+    public func italic() -> String {
+        return applyStyle(TerminalStyle.italic)
+    }
+
+    public func underline() -> String {
+        return applyStyle(TerminalStyle.underline)
+    }
+
+    public func blink() -> String {
+        return applyStyle(TerminalStyle.blink)
+    }
+
+    public func reverse() -> String {
+        return applyStyle(TerminalStyle.reverse)
+    }
+
+    public func hidden() -> String {
+        return applyStyle(TerminalStyle.hidden)
+    }
+
+    public func strikethrough() -> String {
+        return applyStyle(TerminalStyle.strikethrough)
+    }
+
+    public func reset() -> String {
+        guard String.isColorizationEnabled else { return self }
+        return "\u{001B}[0m" + self
+    }
+
+    public func foregroundColor(_ color: TerminalColor) -> String {
+        return applyStyle(color.foregroundStyleCode())
+    }
+
+    public func backgroundColor(_ color: TerminalColor) -> String {
+        return applyStyle(color.backgroundStyleCode())
+    }
+
+    public func colorize(_ foreground: TerminalColor, background: TerminalColor) -> String {
+        return applyStyle(foreground.foregroundStyleCode()).applyStyle(background.backgroundStyleCode())
+    }
+
+    fileprivate func applyStyle(_ codeStyle: TerminalStyleCode) -> String {
+        guard String.isColorizationEnabled else { return self }
+        let str = replacingOccurrences(of: TerminalStyle.reset.open, with: TerminalStyle.reset.open + codeStyle.open)
+
+        return codeStyle.open + str + TerminalStyle.reset.open
+    }
+}
+
+extension String {
+    public func black() -> String {
+        return applyStyle(TerminalStyle.black)
+    }
+
+    public func red() -> String {
+        return applyStyle(TerminalStyle.red)
+    }
+
+    public func green() -> String {
+        return applyStyle(TerminalStyle.green)
+    }
+
+    public func yellow() -> String {
+        return applyStyle(TerminalStyle.yellow)
+    }
+
+    public func blue() -> String {
+        return applyStyle(TerminalStyle.blue)
+    }
+
+    public func magenta() -> String {
+        return applyStyle(TerminalStyle.magenta)
+    }
+
+    public func cyan() -> String {
+        return applyStyle(TerminalStyle.cyan)
+    }
+
+    public func lightGray() -> String {
+        return applyStyle(TerminalStyle.lightGray)
+    }
+
+    public func darkGray() -> String {
+        return applyStyle(TerminalStyle.darkGray)
+    }
+
+    public func lightRed() -> String {
+        return applyStyle(TerminalStyle.lightRed)
+    }
+
+    public func lightGreen() -> String {
+        return applyStyle(TerminalStyle.lightGreen)
+    }
+
+    public func lightYellow() -> String {
+        return applyStyle(TerminalStyle.lightYellow)
+    }
+
+    public func lightBlue() -> String {
+        return applyStyle(TerminalStyle.lightBlue)
+    }
+
+    public func lightMagenta() -> String {
+        return applyStyle(TerminalStyle.lightMagenta)
+    }
+
+    public func lightCyan() -> String {
+        return applyStyle(TerminalStyle.lightCyan)
+    }
+
+    public func white() -> String {
+        return applyStyle(TerminalStyle.white)
+    }
+
+    public func onBlack() -> String {
+        return applyStyle(TerminalStyle.onBlack)
+    }
+
+    public func onRed() -> String {
+        return applyStyle(TerminalStyle.onRed)
+    }
+
+    public func onGreen() -> String {
+        return applyStyle(TerminalStyle.onGreen)
+    }
+
+    public func onYellow() -> String {
+        return applyStyle(TerminalStyle.onYellow)
+    }
+
+    public func onBlue() -> String {
+        return applyStyle(TerminalStyle.onBlue)
+    }
+
+    public func onMagenta() -> String {
+        return applyStyle(TerminalStyle.onMagenta)
+    }
+
+    public func onCyan() -> String {
+        return applyStyle(TerminalStyle.onCyan)
+    }
+
+    public func onLightGray() -> String {
+        return applyStyle(TerminalStyle.onLightGray)
+    }
+
+    public func onDarkGray() -> String {
+        return applyStyle(TerminalStyle.onDarkGray)
+    }
+
+    public func onLightRed() -> String {
+        return applyStyle(TerminalStyle.onLightRed)
+    }
+
+    public func onLightGreen() -> String {
+        return applyStyle(TerminalStyle.onLightGreen)
+    }
+
+    public func onLightYellow() -> String {
+        return applyStyle(TerminalStyle.onLightYellow)
+    }
+
+    public func onLightBlue() -> String {
+        return applyStyle(TerminalStyle.onLightBlue)
+    }
+
+    public func onLightMagenta() -> String {
+        return applyStyle(TerminalStyle.onLightMagenta)
+    }
+
+    public func onLightCyan() -> String {
+        return applyStyle(TerminalStyle.onLightCyan)
+    }
+
+    public func onWhite() -> String {
+        return applyStyle(TerminalStyle.onWhite)
+    }
+}
+
+// https://jonasjacek.github.io/colors/
+public enum TerminalColor: UInt8 {
+    case black = 0
+    case maroon
+    case green
+    case olive
+    case navy
+    case purple
+    case teal
+    case silver
+    case grey
+    case red
+    case lime
+    case yellow
+    case blue
+    case fuchsia
+    case aqua
+    case white
+    case grey0
+    case navyBlue
+    case darkBlue
+    case blue3
+    case blue3_2
+    case blue1
+    case darkGreen
+    case deepSkyBlue4
+    case deepSkyBlue4_2
+    case deepSkyBlue4_3
+    case dodgerBlue3
+    case dodgerBlue2
+    case green4
+    case springGreen4
+    case turquoise4
+    case deepSkyBlue3
+    case deepSkyBlue3_2
+    case dodgerBlue1
+    case green3
+    case springGreen3
+    case darkCyan
+    case lightSeaGreen
+    case deepSkyBlue2
+    case deepSkyBlue1
+    case green3_2
+    case springGreen3_2
+    case springGreen2
+    case cyan3
+    case darkTurquoise
+    case turquoise2
+    case green1
+    case springGreen2_2
+    case springGreen1
+    case mediumSpringGreen
+    case cyan2
+    case cyan1
+    case darkRed
+    case deepPink4
+    case purple4
+    case purple4_2
+    case purple3
+    case blueViolet
+    case orange4
+    case grey37
+    case mediumPurple4
+    case slateBlue3
+    case slateBlue3_2
+    case royalBlue1
+    case chartreuse4
+    case darkSeaGreen4
+    case paleTurquoise4
+    case steelBlue
+    case steelBlue3
+    case cornflowerBlue
+    case chartreuse3
+    case darkSeaGreen4_2
+    case cadetBlue
+    case cadetBlue_2
+    case skyBlue3
+    case steelBlue1
+    case chartreuse3_2
+    case paleGreen3
+    case seaGreen3
+    case aquamarine3
+    case mediumTurquoise
+    case steelBlue1_2
+    case chartreuse2
+    case seaGreen2
+    case seaGreen1
+    case seaGreen1_2
+    case aquamarine1
+    case darkSlateGray2
+    case darkRed_2
+    case deepPink4_2
+    case darkMagenta
+    case darkMagenta_2
+    case darkViolet
+    case purple_2
+    case orange4_2
+    case lightPink4
+    case plum4
+    case mediumPurple3
+    case mediumPurple3_2
+    case slateBlue1
+    case yellow4
+    case wheat4
+    case grey53
+    case lightSlateGrey
+    case mediumPurple
+    case lightSlateBlue
+    case yellow4_2
+    case darkOliveGreen3
+    case darkSeaGreen
+    case lightSkyBlue3
+    case lightSkyBlue3_2
+    case skyBlue2
+    case chartreuse2_2
+    case darkOliveGreen3_2
+    case paleGreen3_2
+    case darkSeaGreen3
+    case darkSlateGray3
+    case skyBlue1
+    case chartreuse1
+    case lightGreen
+    case lightGreen_2
+    case paleGreen1
+    case aquamarine1_2
+    case darkSlateGray1
+    case red3
+    case deepPink4_3
+    case mediumVioletRed
+    case magenta3
+    case darkViolet_2
+    case purple_3
+    case darkOrange3
+    case indianRed
+    case hotPink3
+    case mediumOrchid3
+    case mediumOrchid
+    case mediumPurple2
+    case darkGoldenrod
+    case lightSalmon3
+    case rosyBrown
+    case grey63
+    case mediumPurple2_2
+    case mediumPurple1
+    case gold3
+    case darkKhaki
+    case navajoWhite3
+    case grey69
+    case lightSteelBlue3
+    case lightSteelBlue
+    case yellow3
+    case darkOliveGreen3_3
+    case darkSeaGreen3_2
+    case darkSeaGreen2
+    case lightCyan3
+    case lightSkyBlue1
+    case greenYellow
+    case darkOliveGreen2
+    case paleGreen1_2
+    case darkSeaGreen2_2
+    case darkSeaGreen1
+    case paleTurquoise1
+    case red3_2
+    case deepPink3
+    case deepPink3_2
+    case magenta3_2
+    case magenta3_3
+    case magenta2
+    case darkOrange3_2
+    case indianRed_2
+    case hotPink3_2
+    case hotPink2
+    case orchid
+    case mediumOrchid1
+    case orange3
+    case lightSalmon3_2
+    case lightPink3
+    case pink3
+    case plum3
+    case violet
+    case gold3_2
+    case lightGoldenrod3
+    case tan
+    case mistyRose3
+    case thistle3
+    case plum2
+    case yellow3_2
+    case khaki3
+    case lightGoldenrod2
+    case lightYellow3
+    case grey84
+    case lightSteelBlue1
+    case yellow2
+    case darkOliveGreen1
+    case darkOliveGreen1_2
+    case darkSeaGreen1_2
+    case honeydew2
+    case lightCyan1
+    case red1
+    case deepPink2
+    case deepPink1
+    case deepPink1_2
+    case magenta2_2
+    case magenta1
+    case orangeRed1
+    case indianRed1
+    case indianRed1_2
+    case hotPink
+    case hotPink_2
+    case mediumOrchid1_2
+    case darkOrange
+    case salmon1
+    case lightCoral
+    case paleVioletRed1
+    case orchid2
+    case orchid1
+    case orange1
+    case sandyBrown
+    case lightSalmon1
+    case lightPink1
+    case pink1
+    case plum1
+    case gold1
+    case lightGoldenrod2_2
+    case lightGoldenrod2_3
+    case navajoWhite1
+    case mistyRose1
+    case thistle1
+    case yellow1
+    case lightGoldenrod1
+    case khaki1
+    case wheat1
+    case cornsilk1
+    case grey100
+    case grey3
+    case grey7
+    case grey11
+    case grey15
+    case grey19
+    case grey23
+    case grey27
+    case grey30
+    case grey35
+    case grey39
+    case grey42
+    case grey46
+    case grey50
+    case grey54
+    case grey58
+    case grey62
+    case grey66
+    case grey70
+    case grey74
+    case grey78
+    case grey82
+    case grey85
+    case grey89
+    case grey93
+
+    public func foregroundStyleCode() -> TerminalStyleCode {
+        return ("\u{001B}[38;5;\(rawValue)m", TerminalStyle.reset.open)
+    }
+
+    public func backgroundStyleCode() -> TerminalStyleCode {
+        return ("\u{001B}[48;5;\(rawValue)m", TerminalStyle.reset.open)
+    }
+}

--- a/Sources/TuistCore/Utils/Environment.swift
+++ b/Sources/TuistCore/Utils/Environment.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Protocol that defines the interface of a local environment controller.
 /// It manages the local directory where tuistenv stores the tuist versions and user settings.
-public protocol EnvironmentControlling: AnyObject {
+public protocol Environmenting: AnyObject {
     /// Returns the versions directory.
     var versionsDirectory: AbsolutePath { get }
 
@@ -15,7 +15,10 @@ public protocol EnvironmentControlling: AnyObject {
 }
 
 /// Local environment controller.
-public class EnvironmentController: EnvironmentControlling {
+public class Environment: Environmenting {
+    
+    public static var shared: Environmenting = Environment()
+    
     /// Returns the default local directory.
     static let defaultDirectory: AbsolutePath = AbsolutePath(URL(fileURLWithPath: NSHomeDirectory()).path).appending(component: ".tuist")
 
@@ -28,9 +31,9 @@ public class EnvironmentController: EnvironmentControlling {
     private let fileHandler: FileHandling
 
     /// Default public constructor.
-    public convenience init() {
-        self.init(directory: EnvironmentController.defaultDirectory,
-                  fileHandler: FileHandler())
+    convenience init() {
+        self.init(directory: Environment.defaultDirectory,
+                  fileHandler: FileHandler.shared)
     }
 
     /// Default environment constroller constructor.

--- a/Sources/TuistCore/Utils/Environment.swift
+++ b/Sources/TuistCore/Utils/Environment.swift
@@ -12,13 +12,15 @@ public protocol Environmenting: AnyObject {
 
     /// Returns the directory where all the derived projects are generated.
     var derivedProjectsDirectory: AbsolutePath { get }
+    
+    /// Returns true if the output of Tuist should be coloured.
+    var shouldOutputBeColoured: Bool { get }
 }
 
 /// Local environment controller.
 public class Environment: Environmenting {
-    
     public static var shared: Environmenting = Environment()
-    
+
     /// Returns the default local directory.
     static let defaultDirectory: AbsolutePath = AbsolutePath(URL(fileURLWithPath: NSHomeDirectory()).path).appending(component: ".tuist")
 
@@ -57,6 +59,20 @@ public class Environment: Environmenting {
                 try! fileHandler.createFolder($0)
             }
         }
+    }
+
+    /// Returns true if the output of Tuist should be coloured.
+    public var shouldOutputBeColoured: Bool {
+        let enabledValues = ["1", "true", "TRUE", "yes", "YES"]
+        guard let colouredValue = ProcessInfo.processInfo.environment.first(where: { $0.key == Constants.EnvironmentVariables.colouredOutput })?.value else {
+            return false
+        }
+        let ciValue = ProcessInfo.processInfo.environment.first(where: { $0.key == "CI" })?.value ?? "0"
+
+        let isCI = enabledValues.contains(ciValue)
+        let isEnabled = enabledValues.contains(colouredValue)
+
+        return isEnabled && !isCI
     }
 
     /// Returns the directory where all the versions are.

--- a/Sources/TuistCore/Utils/Environment.swift
+++ b/Sources/TuistCore/Utils/Environment.swift
@@ -64,10 +64,7 @@ public class Environment: Environmenting {
 
     /// Returns true if the output of Tuist should be coloured.
     public var shouldOutputBeColoured: Bool {
-        guard let colouredValue = ProcessInfo.processInfo.environment.first(where: { $0.key == Constants.EnvironmentVariables.colouredOutput })?.value else {
-            return false
-        }
-        return Constants.trueValues.contains(colouredValue) || isStandardOutputInteractive
+        return isStandardOutputInteractive || isColouredOutputEnvironmentTrue
     }
 
     /// Returns true if the standard output is interactive.
@@ -92,5 +89,16 @@ public class Environment: Environmenting {
     /// Settings path.
     public var settingsPath: AbsolutePath {
         return directory.appending(component: "settings.json")
+    }
+
+    // MARK: - Fileprivate
+
+    /// Return true if the the coloured output is forced through an environment variable.
+    fileprivate var isColouredOutputEnvironmentTrue: Bool {
+        let environment = ProcessInfo.processInfo.environment
+        return !environment
+            .filter { $0.key == Constants.EnvironmentVariables.colouredOutput }
+            .filter { Constants.trueValues.contains($0.value) }
+            .isEmpty
     }
 }

--- a/Sources/TuistCore/Utils/Environment.swift
+++ b/Sources/TuistCore/Utils/Environment.swift
@@ -16,9 +16,6 @@ public protocol Environmenting: AnyObject {
 
     /// Returns true if the output of Tuist should be coloured.
     var shouldOutputBeColoured: Bool { get }
-
-    /// Returns true if the standard output is interactive.
-    var isStandardOutputInteractive: Bool { get }
 }
 
 /// Local environment controller.
@@ -67,11 +64,10 @@ public class Environment: Environmenting {
 
     /// Returns true if the output of Tuist should be coloured.
     public var shouldOutputBeColoured: Bool {
-        let enabledValues = ["1", "true", "TRUE", "yes", "YES"]
         guard let colouredValue = ProcessInfo.processInfo.environment.first(where: { $0.key == Constants.EnvironmentVariables.colouredOutput })?.value else {
             return false
         }
-        return enabledValues.contains(colouredValue) || isStandardOutputInteractive
+        return Constants.trueValues.contains(colouredValue) || isStandardOutputInteractive
     }
 
     /// Returns true if the standard output is interactive.

--- a/Sources/TuistCore/Utils/Printer.swift
+++ b/Sources/TuistCore/Utils/Printer.swift
@@ -28,7 +28,7 @@ public class Printer: Printing {
 
     public func print(error: Error) {
         if Environment.shared.shouldOutputBeColoured {
-            printStandardErrorLine(error.localizedDescription.red().bold())
+            printStandardErrorLine("Error: \(error.localizedDescription)".localizedDescription.red().bold())
         } else {
             printStandardErrorLine("Error: \(error.localizedDescription)")
         }
@@ -36,7 +36,7 @@ public class Printer: Printing {
 
     public func print(success: String) {
         if Environment.shared.shouldOutputBeColoured {
-            printStandardOutputLine(success.green().bold())
+            printStandardOutputLine("Success: \(success)".green().bold())
         } else {
             printStandardOutputLine("Success: \(success)")
         }
@@ -47,7 +47,7 @@ public class Printer: Printing {
     /// - Parameter deprecation: Deprecation message.
     public func print(deprecation: String) {
         if Environment.shared.shouldOutputBeColoured {
-            printStandardOutputLine(deprecation.yellow().bold())
+            printStandardOutputLine("Deprecated: \(deprecation)".yellow().bold())
         } else {
             printStandardOutputLine("Deprecated: \(deprecation)")
         }
@@ -55,7 +55,7 @@ public class Printer: Printing {
 
     public func print(warning: String) {
         if Environment.shared.shouldOutputBeColoured {
-            printStandardOutputLine(warning.yellow().bold())
+            printStandardOutputLine("Warning: \(warning)".yellow().bold())
         } else {
             printStandardOutputLine("Warning: \(warning)")
         }
@@ -63,7 +63,7 @@ public class Printer: Printing {
 
     public func print(errorMessage: String) {
         if Environment.shared.shouldOutputBeColoured {
-            printStandardErrorLine(errorMessage.red().bold())
+            printStandardErrorLine("Error: \(errorMessage)".red().bold())
         } else {
             printStandardErrorLine("Error: \(errorMessage)")
         }

--- a/Sources/TuistCore/Utils/Printer.swift
+++ b/Sources/TuistCore/Utils/Printer.swift
@@ -1,25 +1,14 @@
 import Basic
 import Foundation
 
-public enum PrinterOutput {
-    case standardOputput
-    case standardError
-}
-
 public protocol Printing: AnyObject {
     func print(_ text: String)
-    func print(_ text: String, output: PrinterOutput)
-    func print(_ text: String, color: TerminalController.Color)
     func print(section: String)
     func print(subsection: String)
     func print(warning: String)
     func print(error: Error)
     func print(success: String)
     func print(errorMessage: String)
-
-    /// Prints a deprecation message (yellow color)
-    ///
-    /// - Parameter deprecation: Deprecation message.
     func print(deprecation: String)
 }
 
@@ -34,108 +23,81 @@ public class Printer: Printing {
     // MARK: - Public
 
     public func print(_ text: String) {
-        print(text, output: .standardOputput)
-    }
-
-    public func print(_ text: String, output: PrinterOutput) {
-        let writer: InteractiveWriter!
-        if output == .standardOputput {
-            writer = .stdout
-        } else {
-            writer = .stderr
-        }
-
-        writer.write(text)
-        writer.write("\n")
-    }
-
-    public func print(_ text: String, color: TerminalController.Color) {
-        let writer = InteractiveWriter.stdout
-        writer.write(text, inColor: color, bold: false)
-        writer.write("\n")
+        printStandardOutputLine(text)
     }
 
     public func print(error: Error) {
-        let writer = InteractiveWriter.stderr
-        writer.write("Error: ", inColor: .red, bold: true)
-        writer.write(error.localizedDescription)
-        writer.write("\n")
+        if Environment.shared.shouldOutputBeColoured {
+            printStandardErrorLine(error.localizedDescription.red().bold())
+        } else {
+            printStandardErrorLine("Error: \(error.localizedDescription)")
+        }
     }
 
     public func print(success: String) {
-        let writer = InteractiveWriter.stdout
-        writer.write("Success: ", inColor: .green, bold: true)
-        writer.write(success)
-        writer.write("\n")
+        if Environment.shared.shouldOutputBeColoured {
+            printStandardOutputLine(success.green().bold())
+        } else {
+            printStandardOutputLine("Success: \(success)")
+        }
     }
 
     /// Prints a deprecation message (yellow color)
     ///
     /// - Parameter deprecation: Deprecation message.
     public func print(deprecation: String) {
-        let writer = InteractiveWriter.stdout
-        writer.write("Deprecated: ", inColor: .yellow, bold: true)
-        writer.write(deprecation, inColor: .yellow, bold: true)
-        writer.write("\n")
+        if Environment.shared.shouldOutputBeColoured {
+            printStandardOutputLine(deprecation.yellow().bold())
+        } else {
+            printStandardOutputLine("Deprecated: \(deprecation)")
+        }
     }
 
     public func print(warning: String) {
-        let writer = InteractiveWriter.stdout
-        writer.write("Warning: ", inColor: .yellow, bold: true)
-        writer.write(warning, inColor: .yellow, bold: true)
-        writer.write("\n")
+        if Environment.shared.shouldOutputBeColoured {
+            printStandardOutputLine(warning.yellow().bold())
+        } else {
+            printStandardOutputLine("Warning: \(warning)")
+        }
     }
 
     public func print(errorMessage: String) {
-        let writer = InteractiveWriter.stderr
-        writer.write("Error: ", inColor: .red, bold: true)
-        writer.write(errorMessage, inColor: .red, bold: true)
-        writer.write("\n")
+        if Environment.shared.shouldOutputBeColoured {
+            printStandardErrorLine(errorMessage.red().bold())
+        } else {
+            printStandardErrorLine("Error: \(errorMessage)")
+        }
     }
 
     public func print(section: String) {
-        let writer = InteractiveWriter.stdout
-        writer.write("\(section)", inColor: .cyan, bold: true)
-        writer.write("\n")
+        if Environment.shared.shouldOutputBeColoured {
+            printStandardOutputLine(section.cyan().bold())
+        } else {
+            printStandardOutputLine(section)
+        }
     }
 
     public func print(subsection: String) {
-        let writer = InteractiveWriter.stdout
-        writer.write("\(subsection)", inColor: .cyan, bold: false)
-        writer.write("\n")
-    }
-}
-
-/// This class is used to write on the underlying stream.
-///
-/// If underlying stream is a not tty, the string will be written in without any
-/// formatting.
-final class InteractiveWriter {
-    /// The standard error writer.
-    static let stderr = InteractiveWriter(stream: stderrStream)
-
-    /// The standard output writer.
-    static let stdout = InteractiveWriter(stream: stdoutStream)
-
-    /// The terminal controller, if present.
-    let term: TerminalController?
-
-    /// The output byte stream reference.
-    let stream: OutputByteStream
-
-    /// Create an instance with the given stream.
-    init(stream: OutputByteStream) {
-        term = TerminalController(stream: stream)
-        self.stream = stream
-    }
-
-    /// Write the string to the contained terminal or stream.
-    func write(_ string: String, inColor color: TerminalController.Color = .noColor, bold: Bool = false) {
-        if let term = term {
-            term.write(string, inColor: color, bold: bold)
+        if Environment.shared.shouldOutputBeColoured {
+            printStandardOutputLine(subsection.cyan())
         } else {
-            stream <<< string
-            stream.flush()
+            printStandardOutputLine(subsection)
         }
+    }
+
+    // MARK: - Fileprivate
+
+    fileprivate func printStandardOutputLine(_ string: String) {
+        if let data = string.data(using: .utf8) {
+            FileHandle.standardOutput.write(data)
+        }
+        FileHandle.standardOutput.write("\n".data(using: .utf8)!)
+    }
+
+    fileprivate func printStandardErrorLine(_ string: String) {
+        if let data = string.data(using: .utf8) {
+            FileHandle.standardError.write(data)
+        }
+        FileHandle.standardError.write("\n".data(using: .utf8)!)
     }
 }

--- a/Sources/TuistCoreTesting/Extensions/XCTestCase+Mocks.swift
+++ b/Sources/TuistCoreTesting/Extensions/XCTestCase+Mocks.swift
@@ -17,7 +17,7 @@ extension XCTestCase {
         // swiftlint:disable force_try
         FileHandler.shared = try! MockFileHandler()
     }
-    
+
     func mockEnvironment() {
         // swiftlint:disable force_try
         Environment.shared = try! MockEnvironment()

--- a/Sources/TuistCoreTesting/Extensions/XCTestCase+Mocks.swift
+++ b/Sources/TuistCoreTesting/Extensions/XCTestCase+Mocks.swift
@@ -3,9 +3,10 @@ import TuistCore
 import XCTest
 
 extension XCTestCase {
-    func mockEnvironment() {
+    func mockAllSystemInteractions() {
         mockPrinter()
         mockFileHandler()
+        mockEnvironment()
     }
 
     func mockPrinter() {
@@ -15,5 +16,10 @@ extension XCTestCase {
     func mockFileHandler() {
         // swiftlint:disable force_try
         FileHandler.shared = try! MockFileHandler()
+    }
+    
+    func mockEnvironment() {
+        // swiftlint:disable force_try
+        Environment.shared = try! MockEnvironment()
     }
 }

--- a/Sources/TuistCoreTesting/Utils/MockEnvironment.swift
+++ b/Sources/TuistCoreTesting/Utils/MockEnvironment.swift
@@ -1,8 +1,9 @@
 import Basic
 import Foundation
 import TuistCore
+import XCTest
 
-public class MockEnvironmentController: EnvironmentControlling {
+public class MockEnvironment: Environmenting {
     let directory: TemporaryDirectory
     var setupCallCount: UInt = 0
     var setupErrorStub: Error?
@@ -28,5 +29,17 @@ public class MockEnvironmentController: EnvironmentControlling {
 
     func path(version: String) -> AbsolutePath {
         return versionsDirectory.appending(component: version)
+    }
+}
+
+extension XCTestCase {
+    func sharedMockEnvironment(file: StaticString = #file, line: UInt = #line) -> MockEnvironment? {
+        guard let mock = Environment.shared as? MockEnvironment else {
+            let message = "Environment hasn't been mocked." +
+            "You can call mockEnvironment(), or mockSharedInstances() to mock the file handler or the environment respectively."
+            XCTFail(message, file: file, line: line)
+            return nil
+        }
+        return mock
     }
 }

--- a/Sources/TuistCoreTesting/Utils/MockEnvironment.swift
+++ b/Sources/TuistCoreTesting/Utils/MockEnvironment.swift
@@ -15,6 +15,9 @@ public class MockEnvironment: Environmenting {
                                                 attributes: nil)
     }
 
+    public var shouldOutputBeColoured: Bool = false
+    public var isStandardOutputInteractive: Bool = false
+
     public var versionsDirectory: AbsolutePath {
         return directory.path.appending(component: "Versions")
     }

--- a/Sources/TuistCoreTesting/Utils/MockEnvironment.swift
+++ b/Sources/TuistCoreTesting/Utils/MockEnvironment.swift
@@ -36,7 +36,7 @@ extension XCTestCase {
     func sharedMockEnvironment(file: StaticString = #file, line: UInt = #line) -> MockEnvironment? {
         guard let mock = Environment.shared as? MockEnvironment else {
             let message = "Environment hasn't been mocked." +
-            "You can call mockEnvironment(), or mockSharedInstances() to mock the file handler or the environment respectively."
+                "You can call mockEnvironment(), or mockSharedInstances() to mock the file handler or the environment respectively."
             XCTFail(message, file: file, line: line)
             return nil
         }

--- a/Sources/TuistCoreTesting/Utils/MockFileHandler.swift
+++ b/Sources/TuistCoreTesting/Utils/MockFileHandler.swift
@@ -85,7 +85,7 @@ extension XCTestCase {
     func sharedMockFileHandler(file: StaticString = #file, line: UInt = #line) -> MockFileHandler? {
         guard let mock = FileHandler.shared as? MockFileHandler else {
             let message = "FileHandler.shared hasn't been mocked." +
-                "You can call mockFileHandler(), or mockEnvironment() to mock the file handler or the environment respectively."
+                "You can call mockFileHandler(), or mockSharedInstances() to mock the file handler or the environment respectively."
             XCTFail(message, file: file, line: line)
             return nil
         }

--- a/Sources/TuistCoreTesting/Utils/MockPrinter.swift
+++ b/Sources/TuistCoreTesting/Utils/MockPrinter.swift
@@ -8,18 +8,6 @@ public final class MockPrinter: Printing {
     var standardError: String = ""
 
     public func print(_ text: String) {
-        print(text, output: .standardOputput)
-    }
-
-    public func print(_ text: String, output: PrinterOutput) {
-        if output == .standardOputput {
-            standardOutput.append("\(text)\n")
-        } else {
-            standardError.append("\(text)\n")
-        }
-    }
-
-    public func print(_ text: String, color _: TerminalController.Color) {
         standardOutput.append("\(text)\n")
     }
 

--- a/Sources/TuistCoreTesting/Utils/MockPrinter.swift
+++ b/Sources/TuistCoreTesting/Utils/MockPrinter.swift
@@ -96,7 +96,7 @@ extension XCTestCase {
     fileprivate func sharedMockPrinter(file: StaticString = #file, line: UInt = #line) -> MockPrinter? {
         guard let mock = Printer.shared as? MockPrinter else {
             let message = "Printer.shared hasn't been mocked." +
-                "You can call mockPrinter(), or mockEnvironment() to mock the printer or the environment respectively."
+                "You can call mockPrinter(), or mockSharedInstances() to mock the printer or the environment respectively."
             XCTFail(message, file: file, line: line)
             return nil
         }

--- a/Sources/TuistCoreTesting/Utils/MockPrinter.swift
+++ b/Sources/TuistCoreTesting/Utils/MockPrinter.swift
@@ -40,12 +40,10 @@ public final class MockPrinter: Printing {
     }
 
     func standardOutputMatches(with pattern: String) -> Bool {
-        // swiftlint:disable:next force_try
         return standardOutput.contains(pattern)
     }
 
     func standardErrorMatches(with pattern: String) -> Bool {
-        // swiftlint:disable:next force_try
         return standardError.contains(pattern)
     }
 }

--- a/Sources/TuistEnvKit/Commands/CommandRunner.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRunner.swift
@@ -28,6 +28,7 @@ class CommandRunner: CommandRunning {
     // MARK: - Attributes
 
     let versionResolver: VersionResolving
+    let environment: Environmenting
     let system: Systeming
     let updater: Updating
     let versionsController: VersionsControlling
@@ -39,6 +40,7 @@ class CommandRunner: CommandRunning {
 
     init(versionResolver: VersionResolving = VersionResolver(),
          system: Systeming = System(),
+         environment: Environmenting = Environment.shared,
          updater: Updating = Updater(),
          installer: Installing = Installer(),
          versionsController: VersionsControlling = VersionsController(),
@@ -46,6 +48,7 @@ class CommandRunner: CommandRunning {
          exiter: @escaping (Int) -> Void = { exit(Int32($0)) }) {
         self.versionResolver = versionResolver
         self.system = system
+        self.environment = environment
         self.versionsController = versionsController
         self.arguments = arguments
         self.updater = updater
@@ -113,7 +116,7 @@ class CommandRunner: CommandRunning {
         args.append(contentsOf: Array(arguments().dropFirst()))
 
         var environment = ProcessInfo.processInfo.environment
-        environment[Constants.EnvironmentVariables.colouredOutput] = "1"
+        environment[Constants.EnvironmentVariables.colouredOutput] = "\(self.environment.shouldOutputBeColoured)"
 
         do {
             try system.runAndPrint(args, verbose: false, environment: environment)

--- a/Sources/TuistEnvKit/Commands/CommandRunner.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRunner.swift
@@ -112,7 +112,14 @@ class CommandRunner: CommandRunning {
         var args = [path.appending(component: Constants.binName).pathString]
         args.append(contentsOf: Array(arguments().dropFirst()))
 
-        try system.runAndPrint(args, verbose: false, environment: ProcessInfo.processInfo.environment)
+        var environment = ProcessInfo.processInfo.environment
+        environment[Constants.EnvironmentVariables.colouredOutput] = "1"
+
+        do {
+            try system.runAndPrint(args, verbose: false, environment: environment)
+        } catch {
+            exiter(1)
+        }
     }
 
     // MARK: - Static

--- a/Sources/TuistEnvKit/Settings/SettingsController.swift
+++ b/Sources/TuistEnvKit/Settings/SettingsController.swift
@@ -18,7 +18,6 @@ protocol SettingsControlling: AnyObject {
 
 /// Controller to manage user settings.
 class SettingsController: SettingsControlling {
-
     /// It fetches the current settings.
     ///
     /// - Returns: settings.

--- a/Sources/TuistEnvKit/Settings/SettingsController.swift
+++ b/Sources/TuistEnvKit/Settings/SettingsController.swift
@@ -18,25 +18,13 @@ protocol SettingsControlling: AnyObject {
 
 /// Controller to manage user settings.
 class SettingsController: SettingsControlling {
-    // MARK: - Attributes
-
-    /// Environment controller.
-    let environmentController: EnvironmentControlling
-
-    /// Default constructor.
-    ///
-    /// - Parameter environmentController: environment controller used to get the directory where
-    ///   the settings will be stored.
-    init(environmentController: EnvironmentControlling = EnvironmentController()) {
-        self.environmentController = environmentController
-    }
 
     /// It fetches the current settings.
     ///
     /// - Returns: settings.
     /// - Throws: an error if the settings cannot be fetched.
     func settings() throws -> Settings {
-        let path = environmentController.settingsPath
+        let path = Environment.shared.settingsPath
         if !FileHandler.shared.exists(path) { return Settings() }
         let data = try Data(contentsOf: URL(fileURLWithPath: path.pathString))
         let decoder = JSONDecoder()
@@ -50,7 +38,7 @@ class SettingsController: SettingsControlling {
     func set(settings: Settings) throws {
         let encoder = JSONEncoder()
         let data = try encoder.encode(settings)
-        let path = environmentController.settingsPath
+        let path = Environment.shared.settingsPath
         if FileHandler.shared.exists(path) { try FileHandler.shared.delete(path) }
         let url = URL(fileURLWithPath: path.pathString)
         try data.write(to: url, options: Data.WritingOptions.atomic)

--- a/Sources/TuistEnvKit/Versions/VersionsController.swift
+++ b/Sources/TuistEnvKit/Versions/VersionsController.swift
@@ -37,7 +37,6 @@ enum InstalledVersion: CustomStringConvertible, Equatable {
 }
 
 class VersionsController: VersionsControlling {
-
     // MARK: - VersionsControlling
 
     func install(version: String, installation: Installation) throws {

--- a/Sources/TuistEnvKit/Versions/VersionsController.swift
+++ b/Sources/TuistEnvKit/Versions/VersionsController.swift
@@ -37,15 +37,6 @@ enum InstalledVersion: CustomStringConvertible, Equatable {
 }
 
 class VersionsController: VersionsControlling {
-    // MARK: - Attributes
-
-    let environmentController: EnvironmentControlling
-
-    // MARK: - Init
-
-    init(environmentController: EnvironmentControlling = EnvironmentController()) {
-        self.environmentController = environmentController
-    }
 
     // MARK: - VersionsControlling
 
@@ -72,11 +63,11 @@ class VersionsController: VersionsControlling {
     }
 
     func path(version: String) -> AbsolutePath {
-        return environmentController.versionsDirectory.appending(component: version)
+        return Environment.shared.versionsDirectory.appending(component: version)
     }
 
     func versions() -> [InstalledVersion] {
-        return environmentController.versionsDirectory.glob("*").map { path in
+        return Environment.shared.versionsDirectory.glob("*").map { path in
             let versionStringValue = path.components.last!
             if let version = Version(string: versionStringValue) {
                 return InstalledVersion.semver(version)

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -70,7 +70,7 @@ class GenerateCommand: NSObject, Command {
 
         let time = String(format: "%.3f", timer.stop())
         Printer.shared.print(success: "Project generated.")
-        Printer.shared.print("Total time taken: \(time)s", color: .white)
+        Printer.shared.print("Total time taken: \(time)s")
     }
 
     // MARK: - Fileprivate

--- a/Tests/TuistCoreTests/Errors/ErrorHandlerTests.swift
+++ b/Tests/TuistCoreTests/Errors/ErrorHandlerTests.swift
@@ -14,7 +14,7 @@ final class ErrorHandlerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
 
         subject = ErrorHandler {
             self.exited = $0

--- a/Tests/TuistCoreTests/Linter/LintingIssueTests.swift
+++ b/Tests/TuistCoreTests/Linter/LintingIssueTests.swift
@@ -7,7 +7,7 @@ import XCTest
 final class LintingIssueTests: XCTestCase {
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
     }
 
     func test_description() {

--- a/Tests/TuistCoreTests/Linter/LintingIssueTests.swift
+++ b/Tests/TuistCoreTests/Linter/LintingIssueTests.swift
@@ -30,13 +30,11 @@ final class LintingIssueTests: XCTestCase {
         XCTAssertThrowsError(try [first, second].printAndThrowIfNeeded())
 
         XCTAssertPrinterOutputContains("""
-        The following issues have been found:
-          - warning
+        - warning
         """
         )
         XCTAssertPrinterErrorContains("""
-        The following critical issues have been found:
-          - error
+        - error
         """
         )
     }
@@ -47,8 +45,7 @@ final class LintingIssueTests: XCTestCase {
         XCTAssertThrowsError(try [first].printAndThrowIfNeeded())
 
         XCTAssertPrinterErrorContains("""
-        The following critical issues have been found:
-          - error
+        - error
         """
         )
     }

--- a/Tests/TuistCoreTests/Utils/DeprecatorTests.swift
+++ b/Tests/TuistCoreTests/Utils/DeprecatorTests.swift
@@ -9,7 +9,7 @@ final class DeprecatorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
 
         subject = Deprecator()
     }

--- a/Tests/TuistCoreTests/Utils/OpenerTests.swift
+++ b/Tests/TuistCoreTests/Utils/OpenerTests.swift
@@ -24,7 +24,7 @@ final class OpenerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         system = MockSystem()

--- a/Tests/TuistCoreTests/Xcode/XcodeControllerTests.swift
+++ b/Tests/TuistCoreTests/Xcode/XcodeControllerTests.swift
@@ -11,7 +11,7 @@ final class XcodeControllerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         system = MockSystem()

--- a/Tests/TuistCoreTests/Xcode/XcodeTests.swift
+++ b/Tests/TuistCoreTests/Xcode/XcodeTests.swift
@@ -10,7 +10,7 @@ final class XcodeTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         plistEncoder = PropertyListEncoder()

--- a/Tests/TuistEnvKitTests/Commands/BundleCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/BundleCommandTests.swift
@@ -28,7 +28,7 @@ final class BundleCommandTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         parser = ArgumentParser(usage: "test", overview: "overview")

--- a/Tests/TuistEnvKitTests/Commands/CommandRunnerTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/CommandRunnerTests.swift
@@ -29,7 +29,7 @@ final class CommandRunnerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         versionResolver = MockVersionResolver()

--- a/Tests/TuistEnvKitTests/Commands/CommandRunnerTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/CommandRunnerTests.swift
@@ -62,7 +62,8 @@ final class CommandRunnerTests: XCTestCase {
         versionResolver.resolveStub = { _ in ResolvedVersion.bin(self.fileHandler.currentPath) }
         system.errorCommand(binaryPath.pathString, "--help", error: "error")
 
-        XCTAssertThrowsError(try subject.run())
+        try subject.run()
+        XCTAssertTrue(exited == 1)
     }
 
     func test_when_version_file() throws {
@@ -117,7 +118,8 @@ final class CommandRunnerTests: XCTestCase {
 
         system.errorCommand(binaryPath.pathString, "--help", error: "error")
 
-        XCTAssertThrowsError(try subject.run())
+        try subject.run()
+        XCTAssertTrue(exited == 1)
     }
 
     func test_when_highest_local_version_and_version_exists() throws {
@@ -187,6 +189,7 @@ final class CommandRunnerTests: XCTestCase {
 
         system.errorCommand(binaryPath.pathString, "--help", error: "error")
 
-        XCTAssertThrowsError(try subject.run())
+        try subject.run()
+        XCTAssertTrue(exited == 1)
     }
 }

--- a/Tests/TuistEnvKitTests/Commands/InstallCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/InstallCommandTests.swift
@@ -14,7 +14,7 @@ final class InstallCommandTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
 
         parser = ArgumentParser(usage: "test", overview: "overview")
         versionsController = try! MockVersionsController()

--- a/Tests/TuistEnvKitTests/Commands/LocalCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/LocalCommandTests.swift
@@ -14,7 +14,7 @@ final class LocalCommandTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         argumentParser = ArgumentParser(usage: "test", overview: "overview")

--- a/Tests/TuistEnvKitTests/Commands/UninstallCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/UninstallCommandTests.swift
@@ -14,7 +14,7 @@ final class UninstallCommandTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
 
         parser = ArgumentParser(usage: "test", overview: "overview")
         versionsController = try! MockVersionsController()

--- a/Tests/TuistEnvKitTests/Commands/UpdateCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/UpdateCommandTests.swift
@@ -13,7 +13,7 @@ final class UpdateCommandTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
 
         parser = ArgumentParser(usage: "test", overview: "overview")
         updater = MockUpdater()

--- a/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
+++ b/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
@@ -17,7 +17,7 @@ final class InstallerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         system = MockSystem()

--- a/Tests/TuistEnvKitTests/Settings/SettingsControllerTests.swift
+++ b/Tests/TuistEnvKitTests/Settings/SettingsControllerTests.swift
@@ -6,12 +6,14 @@ import XCTest
 
 final class SettingsControllerTests: XCTestCase {
     var subject: SettingsController!
-    var environmentController: MockEnvironmentController!
+    var environment: MockEnvironment!
 
     override func setUp() {
         super.setUp()
-        environmentController = try! MockEnvironmentController()
-        subject = SettingsController(environmentController: environmentController)
+        mockAllSystemInteractions()
+        
+        environment = sharedMockEnvironment()
+        subject = SettingsController()
     }
 
     func test_settings_returns_the_default_settings_if_they_havent_been_set() throws {

--- a/Tests/TuistEnvKitTests/Settings/SettingsControllerTests.swift
+++ b/Tests/TuistEnvKitTests/Settings/SettingsControllerTests.swift
@@ -11,7 +11,7 @@ final class SettingsControllerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         mockAllSystemInteractions()
-        
+
         environment = sharedMockEnvironment()
         subject = SettingsController()
     }

--- a/Tests/TuistEnvKitTests/Updater/EnvUpdaterTests.swift
+++ b/Tests/TuistEnvKitTests/Updater/EnvUpdaterTests.swift
@@ -12,7 +12,7 @@ final class EnvUpdaterTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         system = MockSystem()

--- a/Tests/TuistEnvKitTests/Updater/UpdaterTests.swift
+++ b/Tests/TuistEnvKitTests/Updater/UpdaterTests.swift
@@ -14,7 +14,7 @@ final class UpdaterTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
 
         githubClient = MockGitHubClient()
         versionsController = try! MockVersionsController()

--- a/Tests/TuistEnvKitTests/Versions/VersionsControllerTests.swift
+++ b/Tests/TuistEnvKitTests/Versions/VersionsControllerTests.swift
@@ -13,17 +13,17 @@ final class InstalledVersionTests: XCTestCase {
 }
 
 final class VersionsControllerTests: XCTestCase {
-    var environmentController: MockEnvironmentController!
+    var environment: MockEnvironment!
     var fileHandler: MockFileHandler!
     var subject: VersionsController!
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
+        environment = sharedMockEnvironment()
 
-        environmentController = try! MockEnvironmentController()
-        subject = VersionsController(environmentController: environmentController)
+        subject = VersionsController()
     }
 
     func test_install() throws {
@@ -32,7 +32,7 @@ final class VersionsControllerTests: XCTestCase {
             try Data().write(to: testPath.url)
         }
 
-        let versionsPath = environmentController.versionsDirectory
+        let versionsPath = environment.versionsDirectory
         let testPath = versionsPath.appending(RelativePath("3.2.1/test"))
 
         XCTAssertTrue(fileHandler.exists(testPath))
@@ -41,12 +41,12 @@ final class VersionsControllerTests: XCTestCase {
     func test_path_for_version() {
         let got = subject.path(version: "ref")
 
-        XCTAssertEqual(got, environmentController.versionsDirectory.appending(component: "ref"))
+        XCTAssertEqual(got, environment.versionsDirectory.appending(component: "ref"))
     }
 
     func test_versions() throws {
-        try fileHandler.createFolder(environmentController.versionsDirectory.appending(component: "3.2.1"))
-        try fileHandler.createFolder(environmentController.versionsDirectory.appending(component: "ref"))
+        try fileHandler.createFolder(environment.versionsDirectory.appending(component: "3.2.1"))
+        try fileHandler.createFolder(environment.versionsDirectory.appending(component: "ref"))
 
         let versions = subject.versions()
 

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -15,7 +15,7 @@ final class ConfigGeneratorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         pbxproj = PBXProj()

--- a/Tests/TuistGeneratorTests/Generator/DerivedFileGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/DerivedFileGeneratorTests.swift
@@ -12,7 +12,7 @@ final class DerivedFileGeneratorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
 
         fileHandler = sharedMockFileHandler()
         infoPlistContentProvider = MockInfoPlistContentProvider()

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -16,7 +16,7 @@ final class ProjectFileElementsTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         playgrounds = MockPlaygrounds()

--- a/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
@@ -14,7 +14,7 @@ final class ProjectGeneratorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         system = MockSystem()

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceGeneratorTests.swift
@@ -13,7 +13,7 @@ final class WorkspaceGeneratorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         path = fileHandler.currentPath

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -11,7 +11,7 @@ final class GraphLinterTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         subject = GraphLinter()

--- a/Tests/TuistGeneratorTests/Linter/SettingsLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/SettingsLinterTests.swift
@@ -11,7 +11,7 @@ final class SettingsLinterTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         subject = SettingsLinter()

--- a/Tests/TuistGeneratorTests/Linter/TargetActionLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetActionLinterTests.swift
@@ -12,7 +12,7 @@ final class TargetActionLinterTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         system = System()

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -11,7 +11,7 @@ final class TargetLinterTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         subject = TargetLinter()

--- a/Tests/TuistGeneratorTests/Models/CoreDataModelTests.swift
+++ b/Tests/TuistGeneratorTests/Models/CoreDataModelTests.swift
@@ -11,7 +11,7 @@ final class CoreDataModelTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
     }
 }

--- a/Tests/TuistGeneratorTests/Models/HeadersTests.swift
+++ b/Tests/TuistGeneratorTests/Models/HeadersTests.swift
@@ -11,7 +11,7 @@ final class HeadersTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
     }
 }

--- a/Tests/TuistGeneratorTests/Models/TargetTests.swift
+++ b/Tests/TuistGeneratorTests/Models/TargetTests.swift
@@ -8,7 +8,7 @@ final class TargetTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
     }
 

--- a/Tests/TuistGeneratorTests/Utils/CocoaPodsInteractorTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/CocoaPodsInteractorTests.swift
@@ -23,7 +23,7 @@ final class CocoaPodsInteractorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
 
         system = MockSystem()
         subject = CocoaPodsInteractor(system: system)

--- a/Tests/TuistGeneratorTests/Utils/ProjectFilesSortenerTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/ProjectFilesSortenerTests.swift
@@ -12,7 +12,7 @@ final class ProjectFilesSortenerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         subject = ProjectFilesSortener()

--- a/Tests/TuistIntegrationTests/Generator/Mocks/MockPrinter.swift
+++ b/Tests/TuistIntegrationTests/Generator/Mocks/MockPrinter.swift
@@ -3,11 +3,7 @@ import Foundation
 import TuistCore
 
 class MockPrinter: Printing {
-    func print(_: String, output _: PrinterOutput) {}
-
     func print(_: String) {}
-
-    func print(_: String, color _: TerminalController.Color) {}
 
     func print(section _: String) {}
 

--- a/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -13,7 +13,7 @@ final class MultipleConfigurationsIntegrationTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         do {

--- a/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
@@ -13,7 +13,7 @@ final class StableXcodeProjIntegrationTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         do {

--- a/Tests/TuistKitTests/Commands/DumpCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/DumpCommandTests.swift
@@ -16,7 +16,7 @@ final class DumpCommandTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         errorHandler = MockErrorHandler()

--- a/Tests/TuistKitTests/Commands/FocusCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/FocusCommandTests.swift
@@ -17,7 +17,7 @@ final class FocusCommandTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         parser = ArgumentParser.test()

--- a/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
@@ -17,7 +17,7 @@ final class GenerateCommandTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         generator = MockGenerator()

--- a/Tests/TuistKitTests/Commands/GraphCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/GraphCommandTests.swift
@@ -16,7 +16,7 @@ final class GraphCommandTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         dotGraphGenerator = MockDotGraphGenerator()

--- a/Tests/TuistKitTests/Commands/InitCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/InitCommandTests.swift
@@ -28,7 +28,7 @@ final class InitCommandTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         parser = ArgumentParser.test()

--- a/Tests/TuistKitTests/Commands/UpCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/UpCommandTests.swift
@@ -14,7 +14,7 @@ final class UpCommandTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         parser = ArgumentParser.test()

--- a/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
+++ b/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
@@ -30,7 +30,7 @@ class GeneratorModelLoaderTest: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         manifestTargetGenerator = MockManifestTargetGenerator()

--- a/Tests/TuistKitTests/Generator/GraphManifestLoaderTests.swift
+++ b/Tests/TuistKitTests/Generator/GraphManifestLoaderTests.swift
@@ -35,7 +35,7 @@ final class GraphManifestLoaderTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         subject = GraphManifestLoader()

--- a/Tests/TuistKitTests/Models/Up/UpCarthageTests.swift
+++ b/Tests/TuistKitTests/Models/Up/UpCarthageTests.swift
@@ -16,7 +16,7 @@ final class UpCarthageTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         platforms = [.iOS, .macOS]

--- a/Tests/TuistKitTests/Models/Up/UpHomebrewTapTests.swift
+++ b/Tests/TuistKitTests/Models/Up/UpHomebrewTapTests.swift
@@ -13,7 +13,7 @@ final class UpHomebrewTapTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         system = MockSystem()

--- a/Tests/TuistKitTests/Models/Up/UpHomebrewTests.swift
+++ b/Tests/TuistKitTests/Models/Up/UpHomebrewTests.swift
@@ -12,7 +12,7 @@ final class UpHomebrewTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         system = MockSystem()

--- a/Tests/TuistKitTests/Models/Up/UpTests.swift
+++ b/Tests/TuistKitTests/Models/Up/UpTests.swift
@@ -11,7 +11,7 @@ final class UpTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
     }
 

--- a/Tests/TuistKitTests/Playgrounds/PlaygroundGeneratorTests.swift
+++ b/Tests/TuistKitTests/Playgrounds/PlaygroundGeneratorTests.swift
@@ -20,7 +20,7 @@ final class PlaygroundGeneratorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         subject = PlaygroundGenerator()

--- a/Tests/TuistKitTests/Setup/SetupLoaderTests.swift
+++ b/Tests/TuistKitTests/Setup/SetupLoaderTests.swift
@@ -112,13 +112,11 @@ final class SetupLoaderTests: XCTestCase {
         XCTAssertEqual(lintedUps.count, mockUps.count)
 
         let expectedOutput = """
-        The following issues have been found:
-          - mockup2 warning
+        - mockup2 warning
         """
         let expectedError = """
-        The following critical issues have been found:
-          - mockup1 error
-          - mockup3 error
+        - mockup1 error
+        - mockup3 error
         """
         XCTAssertPrinterOutputContains(expectedOutput)
         XCTAssertPrinterErrorContains(expectedError)

--- a/Tests/TuistKitTests/Setup/SetupLoaderTests.swift
+++ b/Tests/TuistKitTests/Setup/SetupLoaderTests.swift
@@ -13,7 +13,7 @@ final class SetupLoaderTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         upLinter = MockUpLinter()

--- a/Tests/TuistKitTests/Utils/CarthageTests.swift
+++ b/Tests/TuistKitTests/Utils/CarthageTests.swift
@@ -13,7 +13,7 @@ final class CarthageTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockEnvironment()
+        mockAllSystemInteractions()
         fileHandler = sharedMockFileHandler()
 
         system = MockSystem()


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/475

### Short description 📝
As @kwridan pointed out [here](https://github.com/tuist/tuist/issues/475), the format of Tuist is lost when we run it through `tuistenv`. After some investigation and the help from some folks in the community, it turns out the `Process` that we run in `tuistenv` is not recognized as a `tty` and therefore the formatting is trimmed.

### Solution 📦
Following a suggestion, this PR changes the implementation of the printer to apply colours if:
- The `TUIST_COLOURED_OUTPUT` env variable is set to true **OR**
- The standard output & error are a tty.

When `tuistenv` runs Tuist, we'll set those the `TUIST_COLOURED_OUTPUT` variable accordingly.

### Implementation 👩‍💻👨‍💻
- [x] Rename `EnvironmentController` to `Environment`.
- [x] Add `Environment.shouldOutputBeColoured` variable.
- [x] Update the printer to use the variable.
- [x] Update the `CommandRunner` to pass the `TUIST_COLOURED_OUTPUT` environment variable when triggering the process.