### PR TITLE
Fix main.yml syntax error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,4 +10,3 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: jzweifel/gatsby-cli-github-action@master
-      args: build


### PR DESCRIPTION
`main.yml` looks incomplete, fix the syntax to make sure the CI passes.
