### PR TITLE
Add HTTPClient utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Added
+
+- `HTTPClient` utility class to `TuistEnvKit` https://github.com/tuist/tuist/pull/508 by @pepibumur.
+
 ## 0.18.1
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ The list of actions will likely grow as we get feedback from you.
 
 ```bash
 bash <(curl -Ls https://tuist.io/install)
-
 ```
 
 ## Bootstrap your first project 🌀

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,7 @@ require "google/cloud/storage"
 require "encrypted/environment"
 require 'colorize'
 require 'highline'
+require 'tmpdir'
 
 Cucumber::Rake::Task.new(:features) do |t|
   t.cucumber_opts = "--format pretty"
@@ -110,6 +111,11 @@ def release
 
   bucket.create_file("build/tuist.zip", "latest/tuist.zip").acl.public!
   bucket.create_file("build/tuistenv.zip", "latest/tuistenv.zip").acl.public!
+  Dir.mktmpdir do |tmp_dir|
+    version_path = File.join(tmp_dir, "version")
+    File.write(version_path, version)
+    bucket.create_file(version_path, "latest/version").acl.public!
+  end
 end
 
 def system(*args)

--- a/Sources/TuistCore/Constants.swift
+++ b/Sources/TuistCore/Constants.swift
@@ -13,4 +13,8 @@ public class Constants {
     public class EnvironmentVariables {
         public static let colouredOutput = "TUIST_COLOURED_OUTPUT"
     }
+
+    public class GoogleCloud {
+        public static let relasesBucketURL = "https://storage.googleapis.com/tuist-releases/"
+    }
 }

--- a/Sources/TuistCoreTesting/Extensions/URL+TestData.swift
+++ b/Sources/TuistCoreTesting/Extensions/URL+TestData.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public extension URL {
+    static func test() -> URL {
+        return URL(string: "https://test.tuist.io")!
+    }
+}

--- a/Sources/TuistEnvKit/HTTP/HTTPClient.swift
+++ b/Sources/TuistEnvKit/HTTP/HTTPClient.swift
@@ -73,9 +73,9 @@ final class HTTPClient: HTTPClienting {
         var error: Error?
 
         let semaphore = DispatchSemaphore(value: 0)
-        session.dataTask(with: url) { _data, _, _error in
-            data = _data
-            error = _error
+        session.dataTask(with: url) { responseData, _, responseError in
+            data = responseData
+            error = responseError
             semaphore.signal()
         }.resume()
         semaphore.wait()
@@ -83,10 +83,10 @@ final class HTTPClient: HTTPClienting {
         if let error = error {
             throw HTTPClientError.clientError(url, error)
         }
-        guard let _data = data else {
+        guard let resultData = data else {
             throw HTTPClientError.noData(url)
         }
-        return _data
+        return resultData
     }
 
     /// Downloads the resource from the given URL into the passed directory.

--- a/Sources/TuistEnvKit/HTTP/HTTPClient.swift
+++ b/Sources/TuistEnvKit/HTTP/HTTPClient.swift
@@ -1,0 +1,71 @@
+import Foundation
+import TuistCore
+
+enum HTTPClientError: FatalError {
+    case clientError(URL, Error)
+    case noData(URL)
+
+    /// Error type
+    var type: ErrorType {
+        switch self {
+        case .clientError:
+            return .abort
+        case .noData:
+            return .abort
+        }
+    }
+
+    /// Error description.
+    var description: String {
+        switch self {
+        case let .clientError(url, error):
+            return "The request to \(url.absoluteString) errored with: \(error.localizedDescription)"
+        case let .noData(url):
+            return "The request to \(url.absoluteString) returned no data"
+        }
+    }
+}
+
+protocol HTTPClienting {
+    /// Fetches the content from the given URL and returns it as a data.
+    ///
+    /// - Parameter url: URL to download the resource from.
+    /// - Returns: Response body as a data.
+    /// - Throws: An error if the request fails.
+    func read(url: URL) throws -> Data
+}
+
+final class HTTPClient: HTTPClienting {
+    // MARK: - Attributes
+
+    /// URL session.
+    let session: URLSession = .shared
+
+    // MARK: - HTTPClienting
+
+    /// Fetches the content from the given URL and returns it as a data.
+    ///
+    /// - Parameter url: URL to download the resource from.
+    /// - Returns: Response body as a data.
+    /// - Throws: An error if the request fails.
+    func read(url: URL) throws -> Data {
+        var data: Data?
+        var error: Error?
+
+        let semaphore = DispatchSemaphore(value: 0)
+        session.dataTask(with: url) { _data, _, _error in
+            data = _data
+            error = _error
+            semaphore.signal()
+        }.resume()
+        semaphore.wait()
+
+        if let error = error {
+            throw HTTPClientError.clientError(url, error)
+        } else if let data = data {
+            return data
+        } else {
+            throw HTTPClientError.noData(url)
+        }
+    }
+}

--- a/Tests/TuistEnvKitTests/HTTP/HTTPClientTests.swift
+++ b/Tests/TuistEnvKitTests/HTTP/HTTPClientTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import TuistCore
+import XCTest
+
+@testable import TuistCoreTesting
+@testable import TuistEnvKit
+
+final class HTTPClientErrorTests: XCTestCase {
+    func test_type() {
+        // Given
+        let error = NSError.test()
+        let url = URL.test()
+
+        // Then
+        XCTAssertEqual(HTTPClientError.clientError(url, error).type, .abort)
+        XCTAssertEqual(HTTPClientError.noData(url).type, .abort)
+    }
+
+    func test_description() {
+        // Given
+        let error = NSError.test()
+        let url = URL.test()
+
+        // Then
+        XCTAssertEqual(HTTPClientError.clientError(url, error).description, "The request to \(url.absoluteString) errored with: \(error.localizedDescription)")
+        XCTAssertEqual(HTTPClientError.noData(url).description, "The request to \(url.absoluteString) returned no data")
+    }
+}

--- a/Tests/TuistEnvKitTests/HTTP/Mocks/MockHTTPClient.swift
+++ b/Tests/TuistEnvKitTests/HTTP/Mocks/MockHTTPClient.swift
@@ -1,0 +1,29 @@
+import Foundation
+import TuistCore
+import XCTest
+
+@testable import TuistEnvKit
+
+final class MockHTTPClient: HTTPClienting {
+    fileprivate var stubs: [URL: Result<Data, Error>] = [:]
+
+    func succeed(url: URL, response: Data) {
+        stubs[url] = .success(response)
+    }
+
+    func fail(url: URL, error: Error) {
+        stubs[url] = .failure(error)
+    }
+
+    func read(url: URL) throws -> Data {
+        if let result = stubs[url] {
+            switch result {
+            case let .failure(error): throw error
+            case let .success(data): return data
+            }
+        } else {
+            XCTFail("Request to non-stubbed URL \(url)")
+            return Data()
+        }
+    }
+}

--- a/Tests/TuistEnvKitTests/HTTP/Mocks/MockHTTPClient.swift
+++ b/Tests/TuistEnvKitTests/HTTP/Mocks/MockHTTPClient.swift
@@ -29,12 +29,11 @@ final class MockHTTPClient: HTTPClienting {
         }
     }
 
-    func download(url: URL, into: AbsolutePath) throws {
+    func download(url: URL, to: AbsolutePath) throws {
         if let result = downloadStubs[url] {
             switch result {
             case let .failure(error): throw error
             case let .success(from):
-                let to = into.appending(component: from.components.last!)
                 do {
                     try FileHandler.shared.copy(from: from, to: to)
                 } catch {

--- a/script/install
+++ b/script/install
@@ -1,15 +1,6 @@
 #!/bin/bash
 
-URL=$( curl -s "https://api.github.com/repos/tuist/tuist/releases/latest" \
-   | jq -r '.assets[] | select(.name=="tuistenv.zip") | .browser_download_url' )
-if [ "$URL" != "" ]; then
-  echo "Downloading Tuist"
-else
-  echo "Couldn't find tuistenv on the latest release"
-  exit 1
-fi
-
-curl -LSs --output /tmp/tuistenv.zip "$URL"
+curl -LSs --output /tmp/tuistenv.zip https://storage.googleapis.com/tuist-releases/latest/tuistenv.zip
 
 echo "Installing Tuist"
 unzip -o /tmp/tuistenv.zip -d /tmp/tuistenv > /dev/null
@@ -21,3 +12,4 @@ rm -rf /tmp/tuistenv
 rm /tmp/tuistenv.zip
 
 echo "Tuist installed. Try running 'tuist'"
+echo "Check out the documentation at https://docs.tuist.io"

--- a/script/uninstall
+++ b/script/uninstall
@@ -1,2 +1,5 @@
 #!/bin/bash
 rm -rf /usr/local/bin/tuist
+rm -rf ~/.tuist
+
+echo "Tuist uninstalled"


### PR DESCRIPTION
### Short description 📝
I'm changing the installer and updater logic in `tuistenv` to download the releases from a Google Cloud Storage bucket. That should mitigate the issues that we are facing with GitHub endpoints returning errors because we are hitting their limits.

### Solution 📦
This PR does not change the logic of the installer or the updater but adds a utility class, `HTTPClient` with 2 simple methods:

- Read a URL resource and return it as a data.
- Download the resource from a URL into a given directory.

Notice that those methods use semaphores internally to block the thread execution while the request is being executed. In the future, we may need to introduce promises or signals that allow the combination of asynchronous processes easily.

Moreover, I've added a mock class that can be used from tests.