### PR TITLE
Remove SRCROOT from generated project plist path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Output losing its format when tuist is run through `tuistenv` https://github.com/tuist/tuist/pull/493 by @pepibumur
 - Product name linting failing when it contains variables https://github.com/tuist/tuist/pull/494 by @dcvz
 - Build phases not generated in the right position https://github.com/tuist/tuist/pull/506 by @pepibumur
+- Remove \$(SRCROOT) from being included in `Info.plist` path https://github.com/tuist/tuist/pull/511 by @dcvz
 
 ## 0.17.0
 

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -158,7 +158,7 @@ final class ConfigGenerator: ConfigGenerating {
         // Info.plist
         if let infoPlist = target.infoPlist, let path = infoPlist.path {
             let relativePath = path.relative(to: sourceRootPath).pathString
-            settings["INFOPLIST_FILE"] = .string("$(SRCROOT)/\(relativePath)")
+            settings["INFOPLIST_FILE"] = .string("\(relativePath)")
         }
 
         if let entitlements = target.entitlements {

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -57,7 +57,7 @@ final class ConfigGeneratorTests: XCTestCase {
         // Given
         let commonSettings = [
             "Base": "Base",
-            "INFOPLIST_FILE": "$(SRCROOT)/Info.plist",
+            "INFOPLIST_FILE": "Info.plist",
             "PRODUCT_BUNDLE_IDENTIFIER": "com.test.bundle_id",
             "CODE_SIGN_ENTITLEMENTS": "$(SRCROOT)/Test.entitlements",
             "SWIFT_VERSION": Constants.swiftVersion,


### PR DESCRIPTION
### Short description 📝

As far as I understand the `$(SRCROOT)` isn't necessary in the path.. project compiles fine and runs as it should. Furthermore, the reason I update this is because it causes problems with Fastlane's `increment_build_number` which erros when `$(SRCROOT)` is present.

fastlane issue here: https://github.com/fastlane/fastlane/pull/12540

### Solution 📦

As the build tools already works with paths relative to the source, including `(SRCROOT)` isn't necessary.