### PR TITLE
Prevent generation of redundant file elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Product name linting failing when it contains variables https://github.com/tuist/tuist/pull/494 by @dcvz
 - Build phases not generated in the right position https://github.com/tuist/tuist/pull/506 by @pepibumur
 - Remove \$(SRCROOT) from being included in `Info.plist` path https://github.com/tuist/tuist/pull/511 by @dcvz
+- Prevent generation of redundant file elements https://github.com/tuist/tuist/pull/515 by @kwridan
 
 ## 0.17.0
 

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -33,15 +33,18 @@ class ProjectFileElements {
     var sdks: [AbsolutePath: PBXFileReference] = [:]
     let playgrounds: Playgrounding
     let filesSortener: ProjectFilesSortening
+    private let system: Systeming
 
     // MARK: - Init
 
     init(_ elements: [AbsolutePath: PBXFileElement] = [:],
          playgrounds: Playgrounding = Playgrounds(),
-         filesSortener: ProjectFilesSortening = ProjectFilesSortener()) {
+         filesSortener: ProjectFilesSortening = ProjectFilesSortener(),
+         system: Systeming = System()) {
         self.elements = elements
         self.playgrounds = playgrounds
         self.filesSortener = filesSortener
+        self.system = system
     }
 
     func generateProjectFiles(project: Project,
@@ -50,10 +53,9 @@ class ProjectFileElements {
                               pbxproj: PBXProj,
                               sourceRootPath: AbsolutePath) throws {
         var files = Set<GroupFileElement>()
-        var products = Set<String>()
-        project.targets.forEach { target in
-            files.formUnion(targetFiles(target: target, sourceRootPath: sourceRootPath))
-            products.formUnion(targetProducts(target: target))
+
+        try project.targets.forEach { target in
+            try files.formUnion(targetFiles(target: target, projectPath: project.path, graph: graph))
         }
         let projectFileElements = projectFiles(project: project)
         files.formUnion(projectFileElements)
@@ -75,17 +77,15 @@ class ProjectFileElements {
                             pbxproj: pbxproj,
                             sourceRootPath: sourceRootPath)
 
-        let dependencies = graph.findAll(path: project.path)
+        // Products
+        let directProducts = project.targets.map {
+            DependencyReference.product(target: $0.name, productName: $0.productNameWithExtension)
+        }
 
-        /// Products
-        try generateProducts(project: project,
-                             dependencies: dependencies,
-                             groups: groups,
-                             pbxproj: pbxproj)
+        // Dependencies
+        let dependencies = try graph.allDependencyReferences(for: project, system: system)
 
-        /// Dependencies
-        try generate(dependencies: dependencies,
-                     path: project.path,
+        try generate(dependencyReferences: Set(directProducts + dependencies),
                      groups: groups,
                      pbxproj: pbxproj,
                      sourceRootPath: sourceRootPath,
@@ -112,13 +112,7 @@ class ProjectFileElements {
         return fileElements
     }
 
-    func targetProducts(target: Target) -> Set<String> {
-        var products: Set<String> = Set()
-        products.insert(target.productNameWithExtension)
-        return products
-    }
-
-    func targetFiles(target: Target, sourceRootPath _: AbsolutePath) -> Set<GroupFileElement> {
+    func targetFiles(target: Target, projectPath: AbsolutePath, graph: Graphing) throws -> Set<GroupFileElement> {
         var files = Set<AbsolutePath>()
         files.formUnion(target.sources.map { $0.path })
         files.formUnion(target.coreDataModels.map { $0.path })
@@ -153,6 +147,20 @@ class ProjectFileElements {
                              isReference: $0.isReference)
         })
 
+        // Local Packages
+        elements.formUnion(
+            try graph.packages(path: projectPath, name: target.name).compactMap { node -> GroupFileElement? in
+                switch node.packageType {
+                case let .local(path: packagePath, productName: _):
+                    return GroupFileElement(path: projectPath.appending(packagePath),
+                                            group: target.filesGroup,
+                                            isReference: true)
+                default:
+                    return nil
+                }
+            }
+        )
+
         return elements
     }
 
@@ -184,84 +192,48 @@ class ProjectFileElements {
         }
     }
 
-    func generateProducts(project: Project,
-                          dependencies: Set<GraphNode>,
-                          groups: ProjectGroups,
-                          pbxproj: PBXProj) throws {
-        try prepareProductsFileReferences(project: project, dependencies: dependencies).forEach { pair in
-            guard self.products[pair.targetName] == nil else { return }
-            pbxproj.add(object: pair.fileReference)
-            groups.products.children.append(pair.fileReference)
-            self.products[pair.targetName] = pair.fileReference
-        }
-    }
-
-    func prepareProductsFileReferences(project: Project, dependencies: Set<GraphNode>)
-        throws -> [(targetName: String, fileReference: PBXFileReference)] {
-        let targetsProducts = project.targets
-            .map { ($0, $0.product) }
-        let dependenciesProducts = dependencies
-            .compactMap { $0 as? TargetNode }
-            .map { $0.target }
-            .map { ($0, $0.product) }
-        let mergeStrategy: (Product, Product) -> Product = { first, _ in first }
-        let sortByName: ((Target, Product), (Target, Product)) -> Bool = { first, second in
-            first.0.productNameWithExtension < second.0.productNameWithExtension
-        }
-
-        let targetsProductsDictionary = Dictionary(targetsProducts, uniquingKeysWith: mergeStrategy)
-        let dependenciesProductsDictionary = Dictionary(dependenciesProducts, uniquingKeysWith: mergeStrategy)
-        let productsDictionary = targetsProductsDictionary.merging(dependenciesProductsDictionary,
-                                                                   uniquingKeysWith: mergeStrategy)
-        return productsDictionary
-            .sorted(by: sortByName)
-            .map { target, product in
-                let fileType = Xcode.filetype(extension: product.xcodeValue.fileExtension!)
-                return (targetName: target.name,
-                        fileReference: PBXFileReference(sourceTree: .buildProductsDir,
-                                                        explicitFileType: fileType,
-                                                        path: target.productNameWithExtension,
-                                                        includeInIndex: false))
-            }
-    }
-
-    func generate(dependencies: Set<GraphNode>,
-                  path _: AbsolutePath,
+    func generate(dependencyReferences: Set<DependencyReference>,
                   groups: ProjectGroups,
                   pbxproj: PBXProj,
                   sourceRootPath: AbsolutePath,
                   filesGroup: ProjectGroup) throws {
-        let sortedDependencies = dependencies.sorted(by: { $0.path < $1.path })
-        try sortedDependencies.forEach { node in
-            switch node {
-            case let precompiledNode as PrecompiledNode:
-                let fileElement = GroupFileElement(path: precompiledNode.path,
+        let sortedDependencies = dependencyReferences.sorted()
+        try sortedDependencies.forEach { dependency in
+            switch dependency {
+            case let .absolute(dependencyPath):
+                let fileElement = GroupFileElement(path: dependencyPath,
                                                    group: filesGroup)
                 try generate(fileElement: fileElement,
                              groups: groups,
                              pbxproj: pbxproj,
                              sourceRootPath: sourceRootPath)
-            case let sdkNode as SDKNode:
-                generateSDKFileElement(node: sdkNode,
+            case let .sdk(sdkNodePath, _):
+                generateSDKFileElement(sdkNodePath: sdkNodePath,
                                        toGroup: groups.frameworks,
                                        pbxproj: pbxproj)
-            case let packageNode as PackageNode:
-                switch packageNode.packageType {
-                case let .local(path: packagePath, productName: _):
-                    let fileElement = GroupFileElement(path: sourceRootPath.appending(packagePath),
-                                                       group: filesGroup)
-                    try generate(fileElement: fileElement,
-                                 groups: groups,
-                                 pbxproj: pbxproj,
-                                 sourceRootPath: sourceRootPath)
-                case .remote:
-                    // Only local packages need group, remote are handled by Xcode itself
-                    break
-                }
-            default:
-                return
+            case let .product(target: target, productName: productName):
+                generateProduct(targetName: target,
+                                productName: productName,
+                                groups: groups,
+                                pbxproj: pbxproj)
             }
         }
+    }
+
+    private func generateProduct(targetName: String,
+                                 productName: String,
+                                 groups: ProjectGroups,
+                                 pbxproj: PBXProj) {
+        guard products[targetName] == nil else { return }
+        let fileType = RelativePath(productName).extension.flatMap { Xcode.filetype(extension: $0) }
+        let fileReference = PBXFileReference(sourceTree: .buildProductsDir,
+                                             explicitFileType: fileType,
+                                             path: productName,
+                                             includeInIndex: false)
+
+        pbxproj.add(object: fileReference)
+        groups.products.children.append(fileReference)
+        products[targetName] = fileReference
     }
 
     func generate(fileElement: GroupFileElement,
@@ -469,20 +441,20 @@ class ProjectFileElements {
         elements[fileAbsolutePath] = file
     }
 
-    private func generateSDKFileElement(node: SDKNode,
+    private func generateSDKFileElement(sdkNodePath: AbsolutePath,
                                         toGroup: PBXGroup,
                                         pbxproj: PBXProj) {
-        guard sdks[node.path] == nil else {
+        guard sdks[sdkNodePath] == nil else {
             return
         }
 
-        addSDKElement(node: node, toGroup: toGroup, pbxproj: pbxproj)
+        addSDKElement(sdkNodePath: sdkNodePath, toGroup: toGroup, pbxproj: pbxproj)
     }
 
-    private func addSDKElement(node: SDKNode,
+    private func addSDKElement(sdkNodePath: AbsolutePath,
                                toGroup: PBXGroup,
                                pbxproj: PBXProj) {
-        let sdkPath = node.path.relative(to: AbsolutePath("/")) // SDK paths are relative
+        let sdkPath = sdkNodePath.relative(to: AbsolutePath("/")) // SDK paths are relative
 
         let lastKnownFileType = sdkPath.extension.flatMap { Xcode.filetype(extension: $0) }
         let file = PBXFileReference(sourceTree: .developerDir,
@@ -491,7 +463,7 @@ class ProjectFileElements {
                                     path: sdkPath.pathString)
         pbxproj.add(object: file)
         toGroup.children.append(file)
-        sdks[node.path] = file
+        sdks[sdkNodePath] = file
     }
 
     func group(path: AbsolutePath) -> PBXGroup? {

--- a/Sources/TuistGenerator/Graph/Graph.swift
+++ b/Sources/TuistGenerator/Graph/Graph.swift
@@ -104,7 +104,11 @@ protocol Graphing: AnyObject, Encodable {
     func targetDependencies(path: AbsolutePath, name: String) -> [TargetNode]
     func staticDependencies(path: AbsolutePath, name: String) -> [DependencyReference]
     func resourceBundleDependencies(path: AbsolutePath, name: String) -> [TargetNode]
+
+    /// Products that are added to a dummy copy files phase to enforce build order between dependencies that Xcode doesn't usually respect (e.g. Resouce Bundles)
     func copyProductDependencies(path: AbsolutePath, target: Target) -> [DependencyReference]
+
+    /// All dependency referrences expected to present within a Project
     func allDependencyReferences(for project: Project, system: Systeming) throws -> [DependencyReference]
 
     // MARK: - Depth First Search

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -27,7 +27,7 @@ final class LinkGeneratorErrorTests: XCTestCase {
     func test_generateEmbedPhase() throws {
         var dependencies: [DependencyReference] = []
         dependencies.append(DependencyReference.absolute(AbsolutePath("/test.framework")))
-        dependencies.append(DependencyReference.product(target: "Test"))
+        dependencies.append(DependencyReference.product(target: "Test", productName: "Test.framework"))
         let pbxproj = PBXProj()
         let pbxTarget = PBXNativeTarget(name: "Test")
         let fileElements = ProjectFileElements()
@@ -58,7 +58,7 @@ final class LinkGeneratorErrorTests: XCTestCase {
 
     func test_generateEmbedPhase_throws_when_aProductIsMissing() throws {
         var dependencies: [DependencyReference] = []
-        dependencies.append(DependencyReference.product(target: "Test"))
+        dependencies.append(DependencyReference.product(target: "Test", productName: "Test.framework"))
         let pbxproj = PBXProj()
         let pbxTarget = PBXNativeTarget(name: "Test")
         let fileElements = ProjectFileElements()
@@ -218,7 +218,7 @@ final class LinkGeneratorErrorTests: XCTestCase {
     func test_generateLinkingPhase() throws {
         var dependencies: [DependencyReference] = []
         dependencies.append(DependencyReference.absolute(AbsolutePath("/test.framework")))
-        dependencies.append(DependencyReference.product(target: "Test"))
+        dependencies.append(DependencyReference.product(target: "Test", productName: "Test.framework"))
         let pbxproj = PBXProj()
         let pbxTarget = PBXNativeTarget(name: "Test")
         let fileElements = ProjectFileElements()
@@ -260,7 +260,7 @@ final class LinkGeneratorErrorTests: XCTestCase {
 
     func test_generateLinkingPhase_throws_whenProductIsMissing() throws {
         var dependencies: [DependencyReference] = []
-        dependencies.append(DependencyReference.product(target: "Test"))
+        dependencies.append(DependencyReference.product(target: "Test", productName: "Test.framework"))
         let pbxproj = PBXProj()
         let pbxTarget = PBXNativeTarget(name: "Test")
         let fileElements = ProjectFileElements()

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -215,13 +215,8 @@ final class ProjectFileElementsTests: XCTestCase {
         ])
     }
 
-    func test_targetProducts() {
-        let target = Target.test()
-        let products = subject.targetProducts(target: target).sorted()
-        XCTAssertEqual(products.first, "Target.app")
-    }
-
-    func test_targetFiles() {
+    func test_targetFiles() throws {
+        // Given
         let sourceRootPath = AbsolutePath("/a/project/")
 
         let settings = Settings.test(
@@ -250,7 +245,10 @@ final class ProjectFileElementsTests: XCTestCase {
                                                   project: [AbsolutePath("/project/project.h")]),
                                  dependencies: [])
 
-        let files = subject.targetFiles(target: target, sourceRootPath: sourceRootPath)
+        // When
+        let files = try subject.targetFiles(target: target, projectPath: sourceRootPath, graph: Graph.test())
+
+        // Then
         XCTAssertTrue(files.isSuperset(of: [
             GroupFileElement(path: "/project/debug.xcconfig", group: target.filesGroup),
             GroupFileElement(path: "/project/release.xcconfig", group: target.filesGroup),
@@ -266,130 +264,92 @@ final class ProjectFileElementsTests: XCTestCase {
     }
 
     func test_generateProduct() throws {
-        let pbxproj = PBXProj()
-        let project = Project.test()
-        let sourceRootPath = AbsolutePath("/a/project/")
-        let groups = ProjectGroups.generate(project: project,
-                                            pbxproj: pbxproj,
-                                            sourceRootPath: sourceRootPath)
-        try subject.generateProducts(project: project,
-                                     dependencies: [],
-                                     groups: groups,
-                                     pbxproj: pbxproj)
-        XCTAssertEqual(groups.products.children.count, 1)
-        let fileReference = subject.product(target: "Target")
-        XCTAssertNotNil(fileReference)
-        XCTAssertEqual(fileReference?.sourceTree, .buildProductsDir)
-        XCTAssertEqual(fileReference?.path, "Target.app")
-        XCTAssertNil(fileReference?.name)
-        XCTAssertEqual(fileReference?.includeInIndex, false)
-    }
-
-    func test_generateProducts_secondTime() throws {
         // Given
-        let project = Project.test()
-        let sourceRootPath = AbsolutePath("/a/project/")
+        let pbxproj = PBXProj()
+        let project = Project.test(targets: [
+            .test(name: "App", product: .app),
+            .test(name: "Framework", product: .framework),
+            .test(name: "Library", product: .staticLibrary),
+        ])
+        let graph = Graph.test()
         let groups = ProjectGroups.generate(project: project,
                                             pbxproj: pbxproj,
-                                            sourceRootPath: sourceRootPath)
-        try subject.generateProducts(project: project,
-                                     dependencies: [],
-                                     groups: groups,
-                                     pbxproj: pbxproj)
-        let products = groups.products.children
+                                            sourceRootPath: project.path)
 
         // When
-        try subject.generateProducts(project: project,
-                                     dependencies: [],
-                                     groups: groups,
-                                     pbxproj: pbxproj)
+        try subject.generateProjectFiles(project: project,
+                                         graph: graph,
+                                         groups: groups,
+                                         pbxproj: pbxproj,
+                                         sourceRootPath: project.path)
 
         // Then
-        XCTAssertEqual(groups.products.children, products) // we don't get duplicates
+        XCTAssertEqual(groups.products.flattenedChildren, [
+            "App.app",
+            "Framework.framework",
+            "libLibrary.a",
+        ])
     }
 
     func test_generateProducts_stableOrder() throws {
         for _ in 0 ..< 5 {
-            // Given
-            let subject = ProjectFileElements(playgrounds: playgrounds)
             let pbxproj = PBXProj()
-            let project = Project.test()
-            let sourceRootPath = AbsolutePath("/a/project/")
+            let subject = ProjectFileElements()
+            let targets: [Target] = [
+                .test(name: "App1", product: .app),
+                .test(name: "App2", product: .app),
+                .test(name: "Framework1", product: .framework),
+                .test(name: "Framework2", product: .framework),
+                .test(name: "Library1", product: .staticLibrary),
+                .test(name: "Library2", product: .staticLibrary),
+            ].shuffled()
+
+            let project = Project.test(targets: targets)
+            let graph = Graph.test()
             let groups = ProjectGroups.generate(project: project,
                                                 pbxproj: pbxproj,
-                                                sourceRootPath: sourceRootPath)
-            let dependencies: Set<TargetNode> = Set((1 ... 5).map {
-                let target = Target.test(name: "Target\($0)", product: .framework)
-                return TargetNode(project: project,
-                                  target: target,
-                                  dependencies: [])
-            })
+                                                sourceRootPath: project.path)
 
             // When
-            try subject.generateProducts(project: project,
-                                         dependencies: dependencies,
-                                         groups: groups,
-                                         pbxproj: pbxproj)
+            try subject.generateProjectFiles(project: project,
+                                             graph: graph,
+                                             groups: groups,
+                                             pbxproj: pbxproj,
+                                             sourceRootPath: project.path)
 
             // Then
-            let expected = ["Target.app",
-                            "Target1.framework",
-                            "Target2.framework",
-                            "Target3.framework",
-                            "Target4.framework",
-                            "Target5.framework"]
-            XCTAssertEqual(groups.products.children.map { $0.path }, expected)
+            XCTAssertEqual(groups.products.flattenedChildren, [
+                "App1.app",
+                "App2.app",
+                "Framework1.framework",
+                "Framework2.framework",
+                "libLibrary1.a",
+                "libLibrary2.a",
+            ])
         }
     }
 
-    func test_generateDependencies_whenTargetNode_thatHasAlreadyBeenAdded() throws {
+    func test_generateProduct_fileReferencesProperties() throws {
+        // Given
         let pbxproj = PBXProj()
-        let sourceRootPath = AbsolutePath("/a/project/")
-        let path = AbsolutePath("/test")
-        let target = Target.test()
-        let project = Project.test(path: path, targets: [target])
+        let project = Project.test(targets: [
+            .test(name: "App", product: .app),
+        ])
+        let graph = Graph.test()
         let groups = ProjectGroups.generate(project: project,
                                             pbxproj: pbxproj,
-                                            sourceRootPath: sourceRootPath)
-        var dependencies: Set<GraphNode> = Set()
-        let targetNode = TargetNode(project: project,
-                                    target: target,
-                                    dependencies: [])
-        dependencies.insert(targetNode)
+                                            sourceRootPath: project.path)
 
-        try subject.generate(dependencies: dependencies,
-                             path: path,
-                             groups: groups,
-                             pbxproj: pbxproj,
-                             sourceRootPath: sourceRootPath,
-                             filesGroup: .group(name: "Project"))
+        // When
+        try subject.generateProjectFiles(project: project,
+                                         graph: graph,
+                                         groups: groups,
+                                         pbxproj: pbxproj,
+                                         sourceRootPath: project.path)
 
-        XCTAssertEqual(groups.products.children.count, 0)
-    }
-
-    func test_generateDependencies_whenTargetNode() throws {
-        let pbxproj = PBXProj()
-        let sourceRootPath = AbsolutePath("/a/project/")
-        let path = AbsolutePath("/test")
-        let target = Target.test()
-        let project = Project.test(path: AbsolutePath("/waka"), targets: [target])
-        let groups = ProjectGroups.generate(project: project,
-                                            pbxproj: pbxproj,
-                                            sourceRootPath: sourceRootPath)
-        var dependencies: Set<GraphNode> = Set()
-        let targetNode = TargetNode(project: project,
-                                    target: target,
-                                    dependencies: [])
-        dependencies.insert(targetNode)
-
-        try subject.generate(dependencies: dependencies,
-                             path: path,
-                             groups: groups,
-                             pbxproj: pbxproj,
-                             sourceRootPath: sourceRootPath,
-                             filesGroup: .group(name: "Project"))
-
-        XCTAssertTrue(groups.products.children.isEmpty)
+        // Then
+        let fileReference = subject.product(target: "App")
+        XCTAssertEqual(fileReference?.sourceTree, .buildProductsDir)
     }
 
     func test_generateDependencies_whenPrecompiledNode() throws {
@@ -402,16 +362,15 @@ final class ProjectFileElementsTests: XCTestCase {
         let groups = ProjectGroups.generate(project: project,
                                             pbxproj: pbxproj,
                                             sourceRootPath: sourceRootPath)
-        var dependencies: Set<GraphNode> = Set()
-        let precompiledNode = FrameworkNode(path: project.path.appending(component: "waka.framework"))
+        var dependencies: Set<DependencyReference> = Set()
+        let precompiledNode = DependencyReference.absolute(project.path.appending(component: "waka.framework"))
         dependencies.insert(precompiledNode)
 
-        try subject.generate(dependencies: dependencies,
-                             path: project.path,
+        try subject.generate(dependencyReferences: dependencies,
                              groups: groups,
                              pbxproj: pbxproj,
                              sourceRootPath: sourceRootPath,
-                             filesGroup: .group(name: "Project"))
+                             filesGroup: project.filesGroup)
 
         let fileReference = groups.main.group(named: projectGroupName)?.children.first as? PBXFileReference
         XCTAssertEqual(fileReference?.path, "waka.framework")
@@ -605,10 +564,10 @@ final class ProjectFileElementsTests: XCTestCase {
         let sdk = try SDKNode(name: "ARKit.framework",
                               platform: .iOS,
                               status: .required)
+        let sdkDependency = DependencyReference.sdk(sdk.path, sdk.status)
 
         // When
-        try subject.generate(dependencies: [sdk],
-                             path: sourceRootPath,
+        try subject.generate(dependencyReferences: [sdkDependency],
                              groups: groups, pbxproj: pbxproj,
                              sourceRootPath: sourceRootPath,
                              filesGroup: .group(name: "Project"))
@@ -628,21 +587,24 @@ final class ProjectFileElementsTests: XCTestCase {
     func test_generateDependencies_localSwiftPackage() throws {
         // Given
         let pbxproj = PBXProj()
-        let sourceRootPath = AbsolutePath("/a/project/")
+        let target = Target.empty(name: "TargetA")
+        let project = Project.empty(path: "/a/project",
+                                    targets: [target])
         let groups = ProjectGroups.generate(project: .test(),
                                             pbxproj: pbxproj,
-                                            sourceRootPath: sourceRootPath)
+                                            sourceRootPath: project.path)
 
         let package = PackageNode(packageType: .local(path: RelativePath("packages/A"),
                                                       productName: "A"),
                                   path: "/a/project/packages/A")
+        let graph = createGraph(project: project, target: target, dependencies: [package])
 
         // When
-        try subject.generate(dependencies: [package],
-                             path: sourceRootPath,
-                             groups: groups, pbxproj: pbxproj,
-                             sourceRootPath: sourceRootPath,
-                             filesGroup: .group(name: "Project"))
+        try subject.generateProjectFiles(project: project,
+                                         graph: graph,
+                                         groups: groups,
+                                         pbxproj: pbxproj,
+                                         sourceRootPath: project.path)
 
         // Then
         let projectGroup = groups.main.group(named: "Project")
@@ -654,26 +616,39 @@ final class ProjectFileElementsTests: XCTestCase {
     func test_generateDependencies_remoteSwiftPackage_doNotGenerateElements() throws {
         // Given
         let pbxproj = PBXProj()
-        let sourceRootPath = AbsolutePath("/a/project/")
+        let target = Target.empty(name: "TargetA")
+        let project = Project.empty(path: "/a/project",
+                                    targets: [target])
         let groups = ProjectGroups.generate(project: .test(),
                                             pbxproj: pbxproj,
-                                            sourceRootPath: sourceRootPath)
+                                            sourceRootPath: project.path)
 
         let package = PackageNode(packageType: .remote(url: "url",
                                                        productName: "A",
                                                        versionRequirement: .branch("master")),
                                   path: "/packages/url")
 
+        let graph = createGraph(project: project, target: target, dependencies: [package])
+
         // When
-        try subject.generate(dependencies: [package],
-                             path: sourceRootPath,
-                             groups: groups, pbxproj: pbxproj,
-                             sourceRootPath: sourceRootPath,
-                             filesGroup: .group(name: "Project"))
+        try subject.generateProjectFiles(project: project,
+                                         graph: graph,
+                                         groups: groups,
+                                         pbxproj: pbxproj,
+                                         sourceRootPath: project.path)
 
         // Then
         let projectGroup = groups.main.group(named: "Project")
         XCTAssertEqual(projectGroup?.flattenedChildren, [])
+    }
+
+    // MARK: -
+
+    private func createGraph(project: Project, target: Target, dependencies: [GraphNode]) -> Graph {
+        let targetNode = TargetNode(project: project, target: target, dependencies: dependencies)
+        let cache = GraphLoaderCache()
+        cache.add(targetNode: targetNode)
+        return Graph.test(cache: cache)
     }
 }
 

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -46,6 +46,12 @@ Workspace:
   - Framework2:
     - Framework2 (dynamic iOS framework)
     - Framework2Tests (iOS unit tests)
+  - Framework3:
+    - Framework3 (dynamic iOS framework)
+  - Framework4:
+    - Framework4 (dynamic iOS framework)
+  - Framework5:
+    - Framework5 (dynamic iOS framework)
 ```
 
 Dependencies:
@@ -53,6 +59,9 @@ Dependencies:
 - App -> Framework1
 - App -> Framework2
 - Framework1 -> Framework2
+- Framework2 -> Framework3
+- Framework3 -> Framework4
+- Framework4 -> Framework5
 
 ## ios_app_with_framework_and_resources
 

--- a/fixtures/ios_app_with_frameworks/Framework2/Project.swift
+++ b/fixtures/ios_app_with_frameworks/Framework2/Project.swift
@@ -12,7 +12,9 @@ let project = Project(name: "Framework2",
                                  headers: Headers(public: "Sources/Public/**", 
                                                   private: "Sources/Private/**", 
                                                   project: "Sources/Project/**"),
-                                 dependencies: []),
+                                 dependencies: [
+                                        .project(target: "Framework3", path: "../Framework3")
+                                 ]),
                           Target(name: "Framework2-macOS",
                                  platform: .macOS,
                                  product: .framework,

--- a/fixtures/ios_app_with_frameworks/Framework3/Config/Framework3-Info.plist
+++ b/fixtures/ios_app_with_frameworks/Framework3/Config/Framework3-Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright Tuist©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_frameworks/Framework3/Project.swift
+++ b/fixtures/ios_app_with_frameworks/Framework3/Project.swift
@@ -1,0 +1,16 @@
+import ProjectDescription
+
+let project = Project(
+    name: "Framework3",
+    targets: [
+        Target(name: "Framework3",
+               platform: .iOS,
+               product: .framework,
+               bundleId: "io.tuist.Framework3",
+               infoPlist: "Config/Framework3-Info.plist",
+               sources: "Sources/**",
+               dependencies: [
+                   .project(target: "Framework4", path: "../Framework4")
+        ]),
+    ]
+)

--- a/fixtures/ios_app_with_frameworks/Framework3/Sources/Framework3File.swift
+++ b/fixtures/ios_app_with_frameworks/Framework3/Sources/Framework3File.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public class Framework3File {
+    public init() {}
+
+    public func hello() -> String {
+        return "Framework3File.hello()"
+    }
+}

--- a/fixtures/ios_app_with_frameworks/Framework4/Config/Framework4-Info.plist
+++ b/fixtures/ios_app_with_frameworks/Framework4/Config/Framework4-Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright Tuist©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_frameworks/Framework4/Project.swift
+++ b/fixtures/ios_app_with_frameworks/Framework4/Project.swift
@@ -1,0 +1,16 @@
+import ProjectDescription
+
+let project = Project(
+    name: "Framework4",
+    targets: [
+        Target(name: "Framework4",
+               platform: .iOS,
+               product: .framework,
+               bundleId: "io.tuist.Framework4",
+               infoPlist: "Config/Framework4-Info.plist",
+               sources: "Sources/**",
+               dependencies: [
+                   .project(target: "Framework5", path: "../Framework5")
+        ]),
+    ]
+)

--- a/fixtures/ios_app_with_frameworks/Framework4/Sources/Framework4File.swift
+++ b/fixtures/ios_app_with_frameworks/Framework4/Sources/Framework4File.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public class Framework4File {
+    public init() {}
+
+    public func hello() -> String {
+        return "Framework4File.hello()"
+    }
+}

--- a/fixtures/ios_app_with_frameworks/Framework5/Config/Framework5-Info.plist
+++ b/fixtures/ios_app_with_frameworks/Framework5/Config/Framework5-Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright Tuist©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_frameworks/Framework5/Project.swift
+++ b/fixtures/ios_app_with_frameworks/Framework5/Project.swift
@@ -1,0 +1,16 @@
+import ProjectDescription
+
+let project = Project(
+    name: "Framework5",
+    targets: [
+        Target(name: "Framework5",
+               platform: .iOS,
+               product: .framework,
+               bundleId: "io.tuist.Framework5",
+               infoPlist: "Config/Framework5-Info.plist",
+               sources: "Sources/**",
+               dependencies: [
+                   .sdk(name: "ARKit.framework")
+        ]),
+    ]
+)

--- a/fixtures/ios_app_with_frameworks/Framework5/Sources/Framework5File.swift
+++ b/fixtures/ios_app_with_frameworks/Framework5/Sources/Framework5File.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public class Framework5File {
+    public init() {}
+
+    public func hello() -> String {
+        return "Framework5File.hello()"
+    }
+}

--- a/fixtures/ios_app_with_local_swift_package/Frameworks/FrameworkA/Config/FrameworkA-Info.plist
+++ b/fixtures/ios_app_with_local_swift_package/Frameworks/FrameworkA/Config/FrameworkA-Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright Tuist©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_local_swift_package/Frameworks/FrameworkA/Project.swift
+++ b/fixtures/ios_app_with_local_swift_package/Frameworks/FrameworkA/Project.swift
@@ -1,0 +1,16 @@
+import ProjectDescription
+
+let project = Project(
+    name: "FrameworkA",
+    targets: [
+        Target(name: "FrameworkA",
+               platform: .iOS,
+               product: .staticFramework,
+               bundleId: "io.tuist.FrameworkA",
+               infoPlist: "Config/FrameworkA-Info.plist",
+               sources: "Sources/**",
+               dependencies: [
+                   .package(path: "../../Packages/PackageA", productName: "LibraryA"),
+        ]),
+    ]
+)

--- a/fixtures/ios_app_with_local_swift_package/Frameworks/FrameworkA/Sources/FrameworkAClass.swift
+++ b/fixtures/ios_app_with_local_swift_package/Frameworks/FrameworkA/Sources/FrameworkAClass.swift
@@ -1,0 +1,10 @@
+import Foundation
+import LibraryA
+
+public class FrameworkAClass {
+    public let text: String
+    public init() {
+        let libraryAClass = LibraryAClass()
+        text = "FrameworkAClass::\(libraryAClass.text)"
+    }
+}

--- a/fixtures/ios_app_with_local_swift_package/Project.swift
+++ b/fixtures/ios_app_with_local_swift_package/Project.swift
@@ -13,6 +13,7 @@ let project = Project(name: "App",
                                        // "Resources/**"
                                ],
                                dependencies: [
+                                    .project(target: "FrameworkA", path: "Frameworks/FrameworkA"),
                                     .package(path: "Packages/PackageA", productName: "LibraryA"),
                                     .package(path: "Packages/PackageA", productName: "LibraryB"),
                                 ]),

--- a/fixtures/ios_app_with_local_swift_package/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_local_swift_package/Sources/AppDelegate.swift
@@ -1,6 +1,7 @@
 import UIKit
 import LibraryA
 import LibraryB
+import FrameworkA
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -12,6 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
     ) -> Bool {
 
+        useFrameworkCode()
         usePackageCode()
 
         window = UIWindow(frame: UIScreen.main.bounds)
@@ -22,6 +24,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
+    private func useFrameworkCode() {
+        print(FrameworkAClass().text)
+    }
+    
     private func usePackageCode() {
         print(LibraryAClass().text)
         print(LibraryBClass().text)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/514

### Short description 📝

File elements for all dependencies and products within a graph were always generated and included in projects without applying any filtering.
This led to the inclusion of redundant file elements in top level projects (for products & dependencies that they didn't require)

In this example:

Dependencies:
- Framework2 -> Framework3
- Framework4 -> Framework4
- Framework5 -> `ARKit.framework` however

The highlighted elements are redundant 

<img width="244" alt="Screenshot 2019-09-28 at 16 22 45" src="https://user-images.githubusercontent.com/11914919/65818741-790eaa80-e20c-11e9-9a61-b7af72e98689.png">


### Solution 📦

Leverage the business logic with the `Graph` to determine which file references are needed.


### Implementation 👩‍💻👨‍💻

- [x] Update `DependencyReference.product` to include product name
- [x] Add helper methods to `Graph` to allow listing all dependency references for a project
- [x] Update `ProjectFileElements` to leverage new helper
- [x] Update helpers to also resolve local swift packages
- [x] Add fixture
- [x] Update change log

### Test Plan 🛠:

- Generate the fixture `fixtures/ios_app_with_frameworks` via `tuist generate`
- Open the generated Workspace
- Verify the `Framework3` project doesn't contain file references for `Framework5`
- Verify the `Framework3` project doesn't contain file references for `ARKit.framework`
- Verify the `Framework4` project doesn't contain file references for `ARKit.framework`

