### PR TITLE
Fix release script

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,7 @@ This document describes the process of releasing new versions of tuist.
 5.  Update the `CHANGELOG.md` to include the version section.
 6.  Commit the changes and tag the commit with the version `git tag x.y.z`.
 7.  Package and upload the release to GCS by running `bundle exec rake release`.
-8.  Upload the installation scripts to GCS by running `bundle exec rake release_scripts`.
+8.  Upload the installation scripts to GCS 0.18.by running `bundle exec rake release_scripts`.
 9.  Create a release on GitHub with the version as a title, the body from the CHANGELOG file, and attach the artifacts in the `build/` directory.
 10. Deploy the documentation website to [Netlify](https://app.netlify.com/sites/peaceful-fermat-c0d5d7/deploys).
+11. Run `tuist update` and verify that the new version is installed and runs.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,7 +14,7 @@ This document describes the process of releasing new versions of tuist.
 5.  Update the `CHANGELOG.md` to include the version section.
 6.  Commit the changes and tag the commit with the version `git tag x.y.z`.
 7.  Package and upload the release to GCS by running `bundle exec rake release`.
-8.  Upload the installation scripts to GCS 0.18.by running `bundle exec rake release_scripts`.
+8.  Upload the installation scripts to GCS by running `bundle exec rake release_scripts`.
 9.  Create a release on GitHub with the version as a title, the body from the CHANGELOG file, and attach the artifacts in the `build/` directory.
 10. Deploy the documentation website to [Netlify](https://app.netlify.com/sites/peaceful-fermat-c0d5d7/deploys).
 11. Run `tuist update` and verify that the new version is installed and runs.

--- a/Rakefile
+++ b/Rakefile
@@ -87,7 +87,7 @@ def package
     system(
       "zip", "-q", "-r", "--symlinks",
       "tuist.zip", "tuist",
-      "ProjectDescription.swiftmodule", "ProjectDescription.swiftdoc", " libProjectDescription.dylib"
+      "ProjectDescription.swiftmodule", "ProjectDescription.swiftdoc", "libProjectDescription.dylib"
     )
     system("zip", "-q", "-r", "--symlinks", "tuistenv.zip", "tuistenv")
   end


### PR DESCRIPTION
### Short description 📝
After installing the latest version of Tuist by running `tuist update`, I noticed that I couldn't generate the project because the `ProjectDescription` framework was missing.

It turns out, the framework was missing from the released `tuist.zip` file. 

### Solution 📦
There was a bug in the release scripts that caused the framework not to be compressed. 

### Implementation 👩‍💻👨‍💻

- [x] Update the artifacts on GCS & the GitHub release.
- [x] Fix release script.
- [x] Add an extra step to the release process to test the new version.
