### PR TITLE
Revert product name variables support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Removed
+- Reverting https://github.com/tuist/tuist/pull/494 using variables in `productName` doesn't evaluate in all usage points within the generated project
+
+
 ## 0.18.0
 
 ### Added

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -61,15 +61,9 @@ class TargetLinter: TargetLinting {
     }
 
     private func lintProductName(target: Target) -> [LintingIssue] {
-        var productName = target.productName
-
-        // Remove any interpolated variables
-        productName = productName.replacingOccurrences(of: "\\$\\{.+\\}", with: "", options: .regularExpression)
-        productName = productName.replacingOccurrences(of: "\\$\\(.+\\)", with: "", options: .regularExpression)
-
         let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
 
-        if productName.unicodeScalars.allSatisfy(allowed.contains) == false {
+        if target.productName.unicodeScalars.allSatisfy(allowed.contains) == false {
             let reason = "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9) and underscore (_) characters."
 
             return [LintingIssue(reason: reason, severity: .error)]

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -37,7 +37,6 @@ final class TargetLinterTests: XCTestCase {
         XCTAssertInvalidProductName("ؼFramework")
         XCTAssertValidProductName("MyFramework_iOS")
         XCTAssertValidProductName("MyFramework")
-        XCTAssertValidProductName("${PRODUCT_DISPLAY_NAME}")
     }
 
     func test_lint_when_target_has_invalid_bundle_identifier() {


### PR DESCRIPTION
- Product name variables don't evaluate in all usage points 
- Variables support in product names was first introduced in https://github.com/tuist/tuist/pull/494
- For now to mitigate the bug this causes we are reverting the change
- Another solution will need to be devised to support this feature to ensure variables can be evaluated in all usage points