### PR TITLE
Define Archive Action on Scheme

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -77,7 +77,7 @@ def release_scripts
   bucket.create_file("script/uninstall", "scripts/uninstall").acl.public!
 end
 
-def package
+def :package
   print_section("Building tuist")
   FileUtils.mkdir_p("build")
   system("swift", "build", "--product", "tuist", "--configuration", "release")

--- a/Rakefile
+++ b/Rakefile
@@ -77,7 +77,7 @@ def release_scripts
   bucket.create_file("script/uninstall", "scripts/uninstall").acl.public!
 end
 
-def :package
+def package
   print_section("Building tuist")
   FileUtils.mkdir_p("build")
   system("swift", "build", "--product", "tuist", "--configuration", "release")

--- a/Sources/ProjectDescription/Scheme.swift
+++ b/Sources/ProjectDescription/Scheme.swift
@@ -8,17 +8,20 @@ public struct Scheme: Equatable, Codable {
     public let buildAction: BuildAction?
     public let testAction: TestAction?
     public let runAction: RunAction?
+    public let archiveAction: ArchiveAction?
 
     public init(name: String,
                 shared: Bool = true,
                 buildAction: BuildAction? = nil,
                 testAction: TestAction? = nil,
-                runAction: RunAction? = nil) {
+                runAction: RunAction? = nil,
+                archiveAction: ArchiveAction? = nil) {
         self.name = name
         self.shared = shared
         self.buildAction = buildAction
         self.testAction = testAction
         self.runAction = runAction
+        self.archiveAction = archiveAction
     }
 }
 
@@ -130,5 +133,29 @@ public struct RunAction: Equatable, Codable {
         self.init(configurationName: config.name,
                   executable: executable,
                   arguments: arguments)
+    }
+}
+
+// MARK: - Archive Action
+
+public struct ArchiveAction: Equatable, Codable {
+    public let configurationName: String
+    public let revealArchiveInOrganizer: Bool
+    public let customArchiveName: String?
+    public let preActions: [ExecutionAction]
+    public let postActions: [ExecutionAction]
+
+    public init(
+        configurationName: String,
+        revealArchiveInOrganizer: Bool = true,
+        customArchiveName: String? = nil,
+        preActions: [ExecutionAction] = [],
+        postActions: [ExecutionAction] = []
+    ) {
+        self.configurationName = configurationName
+        self.revealArchiveInOrganizer = revealArchiveInOrganizer
+        self.customArchiveName = customArchiveName
+        self.preActions = preActions
+        self.postActions = postActions
     }
 }

--- a/Sources/TuistCore/Models/Scheme.swift
+++ b/Sources/TuistCore/Models/Scheme.swift
@@ -195,7 +195,8 @@ public class ArchiveAction: Equatable {
         revealArchiveInOrganizer: Bool = true,
         customArchiveName: String? = nil,
         preActions: [ExecutionAction] = [],
-        postActions: [ExecutionAction] = []) {
+        postActions: [ExecutionAction] = []
+    ) {
         self.configurationName = configurationName
         self.revealArchiveInOrganizer = revealArchiveInOrganizer
         self.customArchiveName = customArchiveName

--- a/Sources/TuistCore/Models/Scheme.swift
+++ b/Sources/TuistCore/Models/Scheme.swift
@@ -9,6 +9,7 @@ public class Scheme: Equatable {
     public let buildAction: BuildAction?
     public let testAction: TestAction?
     public let runAction: RunAction?
+    public let archiveAction: ArchiveAction?
 
     // MARK: - Init
 
@@ -16,12 +17,14 @@ public class Scheme: Equatable {
                 shared: Bool = false,
                 buildAction: BuildAction? = nil,
                 testAction: TestAction? = nil,
-                runAction: RunAction? = nil) {
+                runAction: RunAction? = nil,
+                archiveAction: ArchiveAction? = nil) {
         self.name = name
         self.shared = shared
         self.buildAction = buildAction
         self.testAction = testAction
         self.runAction = runAction
+        self.archiveAction = archiveAction
     }
 
     // MARK: - Equatable
@@ -31,7 +34,8 @@ public class Scheme: Equatable {
             lhs.shared == rhs.shared &&
             lhs.buildAction == rhs.buildAction &&
             lhs.testAction == rhs.testAction &&
-            lhs.runAction == rhs.runAction
+            lhs.runAction == rhs.runAction &&
+            lhs.archiveAction == rhs.archiveAction
     }
 }
 
@@ -172,5 +176,40 @@ public class RunAction: Equatable {
         return lhs.configurationName == rhs.configurationName &&
             lhs.executable == rhs.executable &&
             lhs.arguments == rhs.arguments
+    }
+}
+
+public class ArchiveAction: Equatable {
+    // MARK: - Attributes
+
+    public let configurationName: String
+    public let revealArchiveInOrganizer: Bool
+    public let customArchiveName: String?
+    public let preActions: [ExecutionAction]
+    public let postActions: [ExecutionAction]
+
+    // MARK: - Init
+
+    public init(
+        configurationName: String,
+        revealArchiveInOrganizer: Bool = true,
+        customArchiveName: String? = nil,
+        preActions: [ExecutionAction] = [],
+        postActions: [ExecutionAction] = []) {
+        self.configurationName = configurationName
+        self.revealArchiveInOrganizer = revealArchiveInOrganizer
+        self.customArchiveName = customArchiveName
+        self.preActions = preActions
+        self.postActions = postActions
+    }
+
+    // MARK: - Equatable
+
+    public static func == (lhs: ArchiveAction, rhs: ArchiveAction) -> Bool {
+        return lhs.configurationName == rhs.configurationName
+            && lhs.revealArchiveInOrganizer == rhs.revealArchiveInOrganizer
+            && lhs.customArchiveName == rhs.customArchiveName
+            && lhs.preActions == rhs.preActions
+            && lhs.postActions == rhs.postActions
     }
 }

--- a/Sources/TuistCoreTesting/Models/Scheme+TestData.swift
+++ b/Sources/TuistCoreTesting/Models/Scheme+TestData.swift
@@ -47,7 +47,7 @@ public extension BuildAction {
 }
 
 extension ArchiveAction {
-    static func test(configurationName: String = "Beta Relase",
+    static func test(configurationName: String = "Beta Release",
                      revealArchiveInOrganizer: Bool = true,
                      customArchiveName: String? = nil,
                      preActions: [ExecutionAction] = [],

--- a/Sources/TuistCoreTesting/Models/Scheme+TestData.swift
+++ b/Sources/TuistCoreTesting/Models/Scheme+TestData.swift
@@ -46,16 +46,32 @@ public extension BuildAction {
     }
 }
 
-public extension Scheme {
+extension ArchiveAction {
+    static func test(configurationName: String = "Beta Relase",
+                     revealArchiveInOrganizer: Bool = true,
+                     customArchiveName: String? = nil,
+                     preActions: [ExecutionAction] = [],
+                     postActions: [ExecutionAction] = []) -> ArchiveAction {
+        return ArchiveAction(configurationName: configurationName,
+                             revealArchiveInOrganizer: revealArchiveInOrganizer,
+                             customArchiveName: customArchiveName,
+                             preActions: preActions,
+                             postActions: postActions)
+    }
+}
+
+extension Scheme {
     static func test(name: String = "Test",
                      shared: Bool = false,
                      buildAction: BuildAction? = BuildAction.test(),
                      testAction: TestAction? = TestAction.test(),
-                     runAction: RunAction? = RunAction.test()) -> Scheme {
+                     runAction: RunAction? = RunAction.test(),
+                     archiveAction: ArchiveAction? = ArchiveAction.test()) -> Scheme {
         return Scheme(name: name,
                       shared: shared,
                       buildAction: buildAction,
                       testAction: testAction,
-                      runAction: runAction)
+                      runAction: runAction,
+                      archiveAction: archiveAction)
     }
 }

--- a/Sources/TuistGenerator/Generator/SchemesGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemesGenerator.swift
@@ -148,10 +148,14 @@ final class SchemesGenerator: SchemesGenerating {
                                    testables: testables)
     }
 
+    /// Generates the scheme archive action.
+    /// - Parameter scheme: Scheme manifest.
+    /// - Parameter project: Project manifest.
+    /// - Parameter generatedProject: Generated Xcode project.
+    /// - Returns: Scheme archive action.
     func schemeArchiveAction(scheme: Scheme,
                              project: Project,
                              generatedProject: GeneratedProject) -> XCScheme.ArchiveAction? {
-
         guard let archiveAction = scheme.archiveAction else {
             return defaultSchemeArchiveAction(for: project)
         }

--- a/Sources/TuistGenerator/Generator/SchemesGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemesGenerator.swift
@@ -155,7 +155,7 @@ final class SchemesGenerator: SchemesGenerating {
     /// - Returns: Scheme archive action.
     func schemeArchiveAction(scheme: Scheme,
                              project: Project,
-                             generatedProject: GeneratedProject) -> XCScheme.ArchiveAction? {
+                             generatedProject: GeneratedProject) -> XCScheme.ArchiveAction {
         guard let archiveAction = scheme.archiveAction else {
             return defaultSchemeArchiveAction(for: project)
         }

--- a/Sources/TuistGenerator/Generator/SchemesGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemesGenerator.swift
@@ -73,6 +73,7 @@ final class SchemesGenerator: SchemesGenerating {
         let generatedTestAction = schemeTestAction(scheme: scheme, project: project, generatedProject: generatedProject)
         let generatedLaunchAction = schemeLaunchAction(scheme: scheme, project: project, generatedProject: generatedProject)
         let generatedProfileAction = schemeProfileAction(scheme: scheme, project: project, generatedProject: generatedProject)
+        let generatedArchiveAction = schemeArchiveAction(scheme: scheme, project: project, generatedProject: generatedProject)
 
         let scheme = XCScheme(name: scheme.name,
                               lastUpgradeVersion: SchemesGenerator.defaultLastUpgradeVersion,
@@ -82,7 +83,7 @@ final class SchemesGenerator: SchemesGenerating {
                               launchAction: generatedLaunchAction,
                               profileAction: generatedProfileAction,
                               analyzeAction: schemeAnalyzeAction(for: project),
-                              archiveAction: schemeArchiveAction(for: project))
+                              archiveAction: generatedArchiveAction)
         try scheme.write(path: schemePath.path, override: true)
     }
 
@@ -146,6 +147,25 @@ final class SchemesGenerator: SchemesGenerating {
                                    macroExpansion: nil,
                                    testables: testables)
     }
+
+    func schemeArchiveAction(scheme: Scheme,
+                             project: Project,
+                             generatedProject: GeneratedProject) -> XCScheme.ArchiveAction? {
+
+        guard let archiveAction = scheme.archiveAction else {
+            return defaultSchemeArchiveAction(for: project)
+        }
+
+        return XCScheme.ArchiveAction(buildConfiguration: archiveAction.configurationName,
+                                      revealArchiveInOrganizer: archiveAction.revealArchiveInOrganizer,
+                                      customArchiveName: archiveAction.customArchiveName,
+                                      preActions: schemeExecutionActions(actions: archiveAction.preActions,
+                                                                         project: project,
+                                                                         generatedProject: generatedProject),
+                                      postActions: schemeExecutionActions(actions: archiveAction.postActions,
+                                                                          project: project,
+                                                                          generatedProject: generatedProject))
+	}
 
     /// Generates the array of BuildableReference for targets that the
     /// coverage report should be generated for them.
@@ -439,7 +459,7 @@ final class SchemesGenerator: SchemesGenerating {
     /// Returns the scheme archive action
     ///
     /// - Returns: Scheme archive action.
-    func schemeArchiveAction(for project: Project) -> XCScheme.ArchiveAction {
+    func defaultSchemeArchiveAction(for project: Project) -> XCScheme.ArchiveAction {
         let buildConfiguration = defaultReleaseBuildConfigurationName(in: project)
         return XCScheme.ArchiveAction(buildConfiguration: buildConfiguration,
                                       revealArchiveInOrganizer: true)

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -584,6 +584,7 @@ extension TuistCore.Scheme {
         let buildAction = manifest.buildAction.map { TuistCore.BuildAction.from(manifest: $0) }
         let testAction = manifest.testAction.map { TuistCore.TestAction.from(manifest: $0) }
         let runAction = manifest.runAction.map { TuistCore.RunAction.from(manifest: $0) }
+        let archiveAction = manifest.archiveAction.map { TuistCore.ArchiveAction.from(manifest: $0) }
 
         return Scheme(name: name,
                       shared: shared,
@@ -631,6 +632,22 @@ extension TuistCore.RunAction {
         return RunAction(configurationName: configurationName,
                          executable: executable,
                          arguments: arguments)
+    }
+}
+
+extension TuistCore.ArchiveAction {
+    static func from(manifest: ProjectDescription.ArchiveAction) -> TuistCore.ArchiveAction {
+        let configurationName = manifest.configurationName
+        let revealArchiveInOrganizer = manifest.revealArchiveInOrganizer
+        let customArchiveName = manifest.customArchiveName
+        let preActions = manifest.preActions.map { TuistCore.ExecutionAction.from(manifest: $0) }
+        let postActions = manifest.postActions.map { TuistCore.ExecutionAction.from(manifest: $0) }
+
+        return TuistCore.ArchiveAction(configurationName: configurationName,
+                                            revealArchiveInOrganizer: revealArchiveInOrganizer,
+                                            customArchiveName: customArchiveName,
+                                            preActions: preActions,
+                                            postActions: postActions)
     }
 }
 

--- a/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
@@ -374,9 +374,9 @@ final class SchemeGeneratorTests: XCTestCase {
 
         let got = subject.schemeArchiveAction(scheme: scheme, project: project, generatedProject: generatedProject)
 
-        XCTAssertEqual(got?.buildConfiguration, "Beta Release")
-        XCTAssertEqual(got?.customArchiveName, "App [Beta]")
-        XCTAssertEqual(got?.revealArchiveInOrganizer, true)
+        XCTAssertEqual(got.buildConfiguration, "Beta Release")
+        XCTAssertEqual(got.customArchiveName, "App [Beta]")
+        XCTAssertEqual(got.revealArchiveInOrganizer, true)
     }
 
     // MARK: - Private

--- a/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
@@ -364,7 +364,19 @@ final class SchemeGeneratorTests: XCTestCase {
     }
 
     func test_schemeArchiveAction() {
-        // TODO: test new method
+        let target = Target.test(name: "App", platform: .iOS, product: .app)
+        let scheme = Scheme.test(archiveAction: ArchiveAction.test(configurationName: "Beta Release",
+                                                                   revealArchiveInOrganizer: true,
+                                                                   customArchiveName: "App [Beta]"))
+        let pbxTarget = PBXNativeTarget(name: "App")
+        let project = Project.test(path: AbsolutePath("/project.xcodeproj"), targets: [target])
+        let generatedProject = GeneratedProject.test(targets: ["App": pbxTarget])
+
+        let got = subject.schemeArchiveAction(scheme: scheme, project: project, generatedProject: generatedProject)
+
+        XCTAssertEqual(got?.buildConfiguration, "Beta Release")
+        XCTAssertEqual(got?.customArchiveName, "App [Beta]")
+        XCTAssertEqual(got?.revealArchiveInOrganizer, true)
     }
 
     // MARK: - Private

--- a/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
@@ -357,10 +357,14 @@ final class SchemeGeneratorTests: XCTestCase {
         XCTAssertEqual(got.buildConfiguration, "Debug")
     }
 
-    func test_schemeArchiveAction() {
-        let got = subject.schemeArchiveAction(for: .test())
+    func test_defaultSchemeArchiveAction() {
+        let got = subject.defaultSchemeArchiveAction(for: .test())
         XCTAssertEqual(got.buildConfiguration, "Release")
         XCTAssertEqual(got.revealArchiveInOrganizer, true)
+    }
+
+    func test_schemeArchiveAction() {
+        // TODO: test new method
     }
 
     // MARK: - Private

--- a/docs/usage/2-projectswift.mdx
+++ b/docs/usage/2-projectswift.mdx
@@ -673,6 +673,14 @@ A `Scheme` defines a collection of targets to `Build, Run, Test, Profile, Analyz
       optional: true,
       default: 'nil',
     },
+    {
+      name: 'Archive action',
+      description: 'Action that runs the project archive.',
+      type: 'ArchiveAction',
+      typeLink: '#archive-action',
+      optional: true,
+      default: 'nil',
+    },
   ]}
 />
 
@@ -904,6 +912,53 @@ Arguments contain commandline arguments passed on launch and Environment variabl
       type: '[String: Bool]',
       optional: true,
       default: '[:]',
+    },
+  ]}
+/>
+
+### Archive Action
+
+<PropertiesTable
+  props={[
+    {
+      name: 'Configuration Name',
+      description:
+        'Indicates the build configuration to run the archive with.',
+      type: 'String',
+      optional: false,
+      default: '',
+    },
+    {
+      name: 'Reveal Archive in Organizer',
+      description:
+        "Indicates if the archive should revealed in Organizer on completion.",
+      type: 'Bool',
+      optional: true,
+      default: 'true',
+    },
+    {
+      name: 'Custom Archive Name',
+      description:
+        "Indicates the custom archive name to be used.",
+      type: 'String',
+      optional: true,
+      default: 'nil',
+    },
+    {
+      name: 'Pre-actions',
+      description:
+        "A list of actions that are executed before starting the archive process.",
+      type: '[ExecutionAction]',
+      optional: true,
+      default: '[]',
+    },
+    {
+      name: 'Post-actions',
+      description:
+        "A list of actions that are executed after the archive process.",
+      type: '[ExecutionAction]',
+      optional: true,
+      default: '[]',
     },
   ]}
 />

--- a/docs/usage/2-projectswift.mdx
+++ b/docs/usage/2-projectswift.mdx
@@ -931,7 +931,7 @@ Arguments contain commandline arguments passed on launch and Environment variabl
     {
       name: 'Reveal Archive in Organizer',
       description:
-        "Indicates if the archive should revealed in Organizer on completion.",
+        'If set to true, Xcode will reveal the Organizer on completion.',
       type: 'Bool',
       optional: true,
       default: 'true',
@@ -939,7 +939,7 @@ Arguments contain commandline arguments passed on launch and Environment variabl
     {
       name: 'Custom Archive Name',
       description:
-        "Indicates the custom archive name to be used.",
+        'Set if you want to override Xcode's default archive name.',
       type: 'String',
       optional: true,
       default: 'nil',
@@ -947,7 +947,7 @@ Arguments contain commandline arguments passed on launch and Environment variabl
     {
       name: 'Pre-actions',
       description:
-        "A list of actions that are executed before starting the archive process.",
+        'A list of actions that are executed before starting the archive process.',
       type: '[ExecutionAction]',
       optional: true,
       default: '[]',
@@ -955,7 +955,7 @@ Arguments contain commandline arguments passed on launch and Environment variabl
     {
       name: 'Post-actions',
       description:
-        "A list of actions that are executed after the archive process.",
+        'A list of actions that are executed after the archive process.',
       type: '[ExecutionAction]',
       optional: true,
       default: '[]',

--- a/features/generate.feature
+++ b/features/generate.feature
@@ -180,6 +180,7 @@ Scenario: The project is an iOS application with multiple configurations (ios_ap
     Then the scheme Framework2 has a build setting CUSTOM_FLAG with value "Debug" for the configuration Debug
     Then the scheme Framework2 has a build setting CUSTOM_FLAG with value "Target.Beta" for the configuration Beta
     Then the scheme Framework2 has a build setting CUSTOM_FLAG with value "Release" for the configuration Release
+    Then I should be able to archive for iOS the scheme App
 
 Scenario: The project is an iOS application with CocoaPods dependencies (ios_app_with_pods)
   Given that tuist is available
@@ -226,6 +227,7 @@ Scenario: The project is an iOS application with extensions (ios_app_with_extens
     Then tuist generates the project
     Then I should be able to build for iOS the scheme App
     Then the product 'App.app' with destination 'Debug-iphoneos' contains extension 'StickersPackExtension'
+    Then the product 'App.app' with destination 'Debug-iphoneos' contains extension 'NotificationServiceExtension' 
     Then the product 'App.app' with destination 'Debug-iphoneos' contains extension 'NotificationServiceExtension' 
 
 Scenario: The project is an iOS application with watch app (ios_app_with_watchapp2)

--- a/fixtures/ios_app_with_multi_configs/App/Project.swift
+++ b/fixtures/ios_app_with_multi_configs/App/Project.swift
@@ -11,9 +11,10 @@ let settings = Settings(base: [
 ], configurations: configurations)
 
 let betaScheme = Scheme(name: "App-Beta",
-                         shared: true,
-                         buildAction: BuildAction(targets: ["App"]),
-                         runAction: RunAction(configurationName: "Beta", executable: "App"))
+                        shared: true,
+                        buildAction: BuildAction(targets: ["App"]),
+                        runAction: RunAction(configurationName: "Beta", executable: "App"),
+                        archiveAction: ArchiveAction(configurationName: "Beta"))
 
 let project = Project(name: "MainApp",
                       settings: settings,


### PR DESCRIPTION
### Short description 📝

The purpose of this PR is to add support for defining a custom archive action when defining a scheme, so that we're able to provide a configuration when running the archive job.

### Solution 📦

The solution I propose is to follow the same implementation that is already being used on the other action's definitions.

### Implementation 👩‍💻👨‍💻

- [x] Create class ArchiveAction
- [x] Add archiveAction attribute to Scheme class
- [x] Implement method for generating a `XCScheme.ArchiveAction` from an ArchiveAction
- [x] Implement unit tests
- [x] Update documentation
