### PR TITLE
Fix `Product` & `Platform` sections in the documentation

### DIFF
--- a/docs/usage/project.swift.mdx
+++ b/docs/usage/project.swift.mdx
@@ -134,6 +134,7 @@ Each target in the list of project targets can be initialized with the following
       name: 'Product',
       description: 'The type of build product this target will output.',
       type: 'Product',
+      typeLink: '#product',
       optional: false,
       default: '',
     },
@@ -370,6 +371,27 @@ The `CoreDataModel` type represents a Core Data model:
 ## Platform
 
 The platform type represents the platform a target is built for. It can be any of the following types:
+
+<EnumTable
+  cases={[
+    {
+      case: '.iOS',
+      description: 'An iOS platform.',
+    },
+    {
+      case: '.macOS',
+      description: 'A macOS platorm.',
+    },  
+    {
+      case: '.tvOS',
+      description: 'A tvOS platform.',
+    },
+  ]}
+/>
+
+## Product
+
+The type of build product this target will output. It can be any of the following types:
 
 <EnumTable
   cases={[


### PR DESCRIPTION
### Short description 📝

I think currently there is a mistake in the documentation when the `Platform` section provides a table with available `Product` values. 

### Solution 📦

- added a correct list of values for the `Platform`
- added a section title & description for an existing `Product` values

Let me know if you think the description should be improved.

**Before:**

![Screenshot 2019-10-08 at 00 57 25](https://user-images.githubusercontent.com/4325222/66355564-074f0300-e968-11e9-9f78-99529fe48be3.png)

**After:**

![Screenshot 2019-10-08 at 00 57 05](https://user-images.githubusercontent.com/4325222/66355607-28afef00-e968-11e9-9a4d-c1ef2f8440b4.png)

