### PR TITLE
Fix false positive cycle detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Introduce `Systems.shared`, `TuistTestCase`, and `TuistUnitTestCase` https://github.com/tuist/tuist/pull/519 by @pepibumur.
 
+### Fixed
+
+- Fix false positive cycle detection https://github.com/tuist/tuist/pull/546 by @kwridan
+
 ## 0.18.1
 
 ### Removed

--- a/Sources/TuistCoreTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistCoreTesting/Extensions/XCTestCase+Extras.swift
@@ -59,9 +59,12 @@ public extension XCTestCase {
             _ = try closure()
         } catch let closureError as Error {
             XCTAssertEqual(error, closureError, file: file, line: line)
+            return
         } catch let closureError {
             XCTFail("\(error) is not equal to: \(closureError)", file: file, line: line)
+            return
         }
+        XCTFail("No error was thrown", file: file, line: line)
     }
 
     func XCTAssertCodableEqualToJson<C: Codable>(_ subject: C, _ json: String, file: StaticString = #file, line: UInt = #line) {

--- a/Sources/TuistGenerator/Graph/GraphCircularDetector.swift
+++ b/Sources/TuistGenerator/Graph/GraphCircularDetector.swift
@@ -6,32 +6,98 @@ struct GraphCircularDetectorNode: Hashable {
     let name: String
 }
 
+extension GraphCircularDetectorNode: CustomDebugStringConvertible {
+    var debugDescription: String {
+        return "\(path).\(name)"
+    }
+}
+
 protocol GraphCircularDetecting: AnyObject {
-    func start(from: GraphCircularDetectorNode, to: GraphCircularDetectorNode) throws
-    func complete(_ node: GraphCircularDetectorNode)
+    func start(from: GraphCircularDetectorNode, to: GraphCircularDetectorNode)
+    func complete() throws
 }
 
 final class GraphCircularDetector: GraphCircularDetecting {
     // MARK: - Attributes
 
-    var edges: [GraphCircularDetectorNode: [GraphCircularDetectorNode]] = [:]
+    private var nodes = Set<Node>()
 
     // MARK: - Internal
 
-    func start(from: GraphCircularDetectorNode, to: GraphCircularDetectorNode) throws {
-        if edges[to] != nil {
-            throw GraphLoadingError.circularDependency(from, to)
-        } else {
-            var nodes = edges[from]
-            if nodes == nil { nodes = [] }
-            nodes?.append(to)
-            edges[from] = nodes
+    func start(from: GraphCircularDetectorNode, to: GraphCircularDetectorNode) {
+        let (_, fromNode) = nodes.insert(Node(element: from))
+        let (_, toNode) = nodes.insert(Node(element: to))
+        fromNode.add(dependency: toNode)
+    }
+
+    func complete() throws {
+        var inspectedNodes = Set<Node>([])
+        while let node = nodes.popFirst() {
+            try visit(node: node, inspectedNodes: &inspectedNodes)
         }
     }
 
-    func complete(_ node: GraphCircularDetectorNode) {
-        let nodes = edges[node]
-        edges.removeValue(forKey: node)
-        nodes?.forEach { complete($0) }
+    // MARK: - Private
+
+    /// Depth first search to detect cycles
+    ///
+    /// For a given node, a full path through adjacent nodes is explored one by one.
+    ///  - The history of visited nodes along a path is stored in `currentPath`
+    ///  - In the event a node we are visiting already exists in `currentPath` we have a cycle!
+    ///
+    /// To optimize this process, we also keep a list of nodes that had all outgoing paths inspected to completion
+    ///  - Nodes that have had all adjacent nodes traversed are added to `inspectedNodes`
+    ///  - In the event a node we are visiting already exists in `inspectedNodes` we can skip it
+    ///
+    /// - Parameter node: The node to visit
+    /// - Parameter currentPath: The current path of nodes we are inspecting
+    /// - Parameter inspectedNodes: History of nodes that have had all their adjacent nodes traversed to completion
+    private func visit(node: Node,
+                       currentPath: OrderedSet<Node> = OrderedSet(),
+                       inspectedNodes: inout Set<Node>) throws {
+        guard !inspectedNodes.contains(node) else {
+            return
+        }
+
+        if currentPath.contains(node) {
+            let cyclePath = currentPath + [node]
+            throw GraphLoadingError.circularDependency(cyclePath.map { $0.element })
+        }
+
+        var currentPath = currentPath
+        currentPath.append(node)
+
+        for nextNode in node.to {
+            try visit(node: nextNode,
+                      currentPath: currentPath,
+                      inspectedNodes: &inspectedNodes)
+        }
+
+        inspectedNodes.insert(node)
+    }
+
+    private final class Node: Hashable, CustomDebugStringConvertible {
+        let element: GraphCircularDetectorNode
+        private(set) var to: Set<Node> = Set([])
+
+        init(element: GraphCircularDetectorNode) {
+            self.element = element
+        }
+
+        func add(dependency: Node) {
+            to.insert(dependency)
+        }
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(element)
+        }
+
+        static func == (lhs: GraphCircularDetector.Node, rhs: GraphCircularDetector.Node) -> Bool {
+            return lhs.element == rhs.element
+        }
+
+        var debugDescription: String {
+            return "\(element.debugDescription)"
+        }
     }
 }

--- a/Sources/TuistGenerator/Graph/TargetNode.swift
+++ b/Sources/TuistGenerator/Graph/TargetNode.swift
@@ -59,6 +59,9 @@ class TargetNode: GraphNode {
             throw GraphLoadingError.targetNotFound(name, path)
         }
 
+        let targetNode = TargetNode(project: project, target: target, dependencies: [])
+        cache.add(targetNode: targetNode)
+
         let dependencies: [GraphNode] = try target.dependencies.map {
             try node(for: $0,
                      path: path,
@@ -69,9 +72,10 @@ class TargetNode: GraphNode {
                      modelLoader: modelLoader)
         }
 
-        let targetNode = TargetNode(project: project, target: target, dependencies: dependencies)
-        circularDetector.complete(GraphCircularDetectorNode(path: path, name: name))
-        cache.add(targetNode: targetNode)
+        targetNode.dependencies = dependencies
+
+        try circularDetector.complete()
+
         return targetNode
     }
 
@@ -109,13 +113,13 @@ class TargetNode: GraphNode {
         case let .target(target):
             let circularFrom = GraphCircularDetectorNode(path: path, name: name)
             let circularTo = GraphCircularDetectorNode(path: path, name: target)
-            try circularDetector.start(from: circularFrom, to: circularTo)
+            circularDetector.start(from: circularFrom, to: circularTo)
             return try TargetNode.read(name: target, path: path, cache: cache, circularDetector: circularDetector, modelLoader: modelLoader)
         case let .project(target, projectRelativePath):
             let circularFrom = GraphCircularDetectorNode(path: path, name: name)
             let projectPath = path.appending(projectRelativePath)
             let circularTo = GraphCircularDetectorNode(path: projectPath, name: target)
-            try circularDetector.start(from: circularFrom, to: circularTo)
+            circularDetector.start(from: circularFrom, to: circularTo)
             return try TargetNode.read(name: target, path: projectPath, cache: cache, circularDetector: circularDetector, modelLoader: modelLoader)
         case let .framework(frameworkPath):
             return try FrameworkNode.parse(projectPath: path,

--- a/Tests/TuistGeneratorTests/Graph/GraphCircularDetectorTests.swift
+++ b/Tests/TuistGeneratorTests/Graph/GraphCircularDetectorTests.swift
@@ -4,25 +4,190 @@ import XCTest
 @testable import TuistGenerator
 
 final class GraphCircularDetectorTests: XCTestCase {
-    var subject: GraphCircularDetecting!
+    var subject: GraphCircularDetector!
 
     override func setUp() {
         super.setUp()
         subject = GraphCircularDetector()
     }
 
-    func test_start_throws_when_a_circular_dependency_is_found() throws {
-        try subject.start(from: node("a"), to: node("b"))
-        try subject.start(from: node("b"), to: node("c"))
-        XCTAssertThrowsSpecific(try subject.start(from: node("c"), to: node("a")),
-                                GraphLoadingError.circularDependency(node("c"), node("a")))
+    func test_cycleDetected_1() throws {
+        // Given
+        let a = node("a")
+        let b = node("b")
+        let c = node("c")
+
+        // When
+        subject.start(from: a, to: b)
+        subject.start(from: b, to: c)
+        subject.start(from: c, to: a)
+
+        // Then
+        XCTAssertThrowsSpecific(try subject.complete(), GraphLoadingError.circularDependency([a, b, c]))
     }
 
-    func test_complete() throws {
-        try subject.start(from: node("a"), to: node("b"))
-        try subject.start(from: node("b"), to: node("c"))
-        try subject.start(from: node("b"), to: node("d"))
-        subject.complete(node("a"))
+    func test_cycleDetected_2() throws {
+        // Given
+        let a = node("a")
+        let b = node("b")
+        let c = node("c")
+        let d = node("d")
+        let e = node("e")
+
+        // When
+        subject.start(from: a, to: c)
+        subject.start(from: c, to: d)
+        subject.start(from: d, to: e)
+        subject.start(from: e, to: b)
+        subject.start(from: b, to: c)
+
+        // Then
+        XCTAssertThrowsError(try subject.complete())
+    }
+
+    func test_cycleDetected_3() throws {
+        // Given
+        let a = node("a")
+        let b = node("b")
+        let c = node("c")
+        let d = node("d")
+        let e = node("e")
+
+        // When
+        subject.start(from: a, to: c)
+        subject.start(from: c, to: d)
+        subject.start(from: d, to: e)
+        subject.start(from: d, to: b)
+        subject.start(from: e, to: a)
+
+        // Then
+        XCTAssertThrowsError(try subject.complete())
+    }
+
+    func test_noCycleDetected_1() throws {
+        // Given
+        let a = node("a")
+        let b = node("b")
+        let c = node("c")
+        let d = node("d")
+
+        // When
+        subject.start(from: a, to: b)
+        subject.start(from: b, to: c)
+        subject.start(from: b, to: d)
+
+        // Then
+        XCTAssertNoThrow(try subject.complete())
+    }
+
+    func test_noCycleDetected_2() throws {
+        // Given
+        let a = node("a")
+        let b = node("b")
+        let c = node("c")
+
+        // When
+        subject.start(from: a, to: b)
+        subject.start(from: c, to: b)
+        subject.start(from: c, to: a)
+
+        // Then
+        XCTAssertNoThrow(try subject.complete())
+    }
+
+    func test_noCycleDetected_3() throws {
+        // Given
+        let a = node("a")
+        let b = node("b")
+        let c = node("c")
+        let d = node("d")
+        let e = node("e")
+
+        // When
+        subject.start(from: a, to: b)
+        subject.start(from: a, to: c)
+        subject.start(from: a, to: d)
+        subject.start(from: a, to: e)
+
+        subject.start(from: b, to: c)
+        subject.start(from: b, to: d)
+        subject.start(from: b, to: e)
+
+        subject.start(from: c, to: d)
+        subject.start(from: c, to: e)
+
+        subject.start(from: d, to: e)
+
+        // Then
+        XCTAssertNoThrow(try subject.complete())
+    }
+
+    func test_noCycleDetected_detachedGraphs() throws {
+        // Given
+        let a = node("a")
+        let b = node("b")
+        let c = node("c")
+        let d = node("d")
+        let e = node("e")
+
+        // When
+        subject.start(from: a, to: b)
+        subject.start(from: a, to: c)
+        subject.start(from: b, to: c)
+
+        subject.start(from: d, to: e)
+
+        // Then
+        XCTAssertNoThrow(try subject.complete())
+    }
+
+    func test_cycleDetected_detachedGraphs() throws {
+        // Given
+        let a = node("a")
+        let b = node("b")
+        let c = node("c")
+        let d = node("d")
+        let e = node("e")
+        let f = node("f")
+
+        // When
+        subject.start(from: a, to: b)
+        subject.start(from: a, to: c)
+        subject.start(from: b, to: c)
+
+        subject.start(from: d, to: e)
+        subject.start(from: e, to: f)
+        subject.start(from: f, to: d)
+
+        // Then
+        XCTAssertThrowsError(try subject.complete())
+    }
+
+    // MARK: -
+
+    // MARK: - Performance
+
+    func test_performance() throws {
+        // ~ <200ms
+        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
+            // Given
+            var nodes = (0 ..< 1000).map { node("\($0)") }.shuffled()
+
+            while let node = nodes.popLast() {
+                nodes.forEach {
+                    subject.start(from: $0, to: node)
+                }
+            }
+
+            // When / Then
+            startMeasuring()
+            do {
+                try subject.complete()
+            } catch {
+                XCTFail()
+            }
+            stopMeasuring()
+        }
     }
 
     private func node(_ name: String) -> GraphCircularDetectorNode {

--- a/Tests/TuistGeneratorTests/Graph/GraphCircularDetectorTests.swift
+++ b/Tests/TuistGeneratorTests/Graph/GraphCircularDetectorTests.swift
@@ -160,7 +160,7 @@ final class GraphCircularDetectorTests: XCTestCase {
         subject.start(from: f, to: d)
 
         // Then
-        XCTAssertThrowsError(try subject.complete())
+        XCTAssertThrowsSpecific(try subject.complete(), GraphLoadingError.circularDependency([d, e, f]))
     }
 
     // MARK: -

--- a/Tests/TuistGeneratorTests/Graph/GraphLoadingErrorTests.swift
+++ b/Tests/TuistGeneratorTests/Graph/GraphLoadingErrorTests.swift
@@ -26,7 +26,9 @@ final class GraphLoadingErrorTests: XCTestCase {
     func test_description_returns_the_right_value_when_circularDependency() {
         let from = GraphCircularDetectorNode(path: AbsolutePath("/from"), name: "FromTarget")
         let to = GraphCircularDetectorNode(path: AbsolutePath("/to"), name: "ToTarget")
-        let error = GraphLoadingError.circularDependency(from, to)
-        XCTAssertEqual(error.description, "Found circular dependency between the target 'FromTarget' at '/from' and the target 'ToTarget' at '/to'")
+        let error = GraphLoadingError.circularDependency([from, to])
+        XCTAssertEqual(error.description, """
+        Found circular dependency between targets: /from:FromTarget -> /to:ToTarget
+        """)
     }
 }

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -256,3 +256,7 @@ An iOS application with remote Swift package
 An iOS application that depends on static library that depends on Swift package where static library is defined first
 
 Note: to re-create `PrebuiltStaticFramework.framework` run `fixtures/ios_app_with_static_library_and_package/Prebuilt/build.sh`
+
+## ios_workspace_with_dependency_cycle
+
+An example of a workspace that has a dependency cycle between targets in different projects.

--- a/fixtures/ios_workspace_with_dependency_cycle/App/Info.plist
+++ b/fixtures/ios_workspace_with_dependency_cycle/App/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/fixtures/ios_workspace_with_dependency_cycle/App/Project.swift
+++ b/fixtures/ios_workspace_with_dependency_cycle/App/Project.swift
@@ -1,0 +1,29 @@
+import ProjectDescription
+
+let project = Project(name: "App",
+                      targets: [
+                        Target(name: "App",
+                               platform: .iOS,
+                               product: .app,
+                               bundleId: "io.tuist.App",
+                               infoPlist: "Info.plist",
+                               sources: ["Sources/**"],
+                               resources: [
+                                       /* Path to resouces can be defined here */
+                                       // "Resources/**"
+                               ],
+                               dependencies: [
+                                    /* Target dependencies can be defined here */
+                                    // .framework(path: "Frameworks/MyFramework.framework")
+                                    .project(target: "FrameworkA", path: "../Frameworks/FrameworkA")
+                                ]),
+                        Target(name: "AppTests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               bundleId: "io.tuist.AppTests",
+                               infoPlist: "Tests.plist",
+                               sources: "Tests/**",
+                               dependencies: [
+                                    .target(name: "App")
+                               ])
+                      ])

--- a/fixtures/ios_workspace_with_dependency_cycle/App/Sources/AppDelegate.swift
+++ b/fixtures/ios_workspace_with_dependency_cycle/App/Sources/AppDelegate.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
+    ) -> Bool {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        let viewController = UIViewController()
+        viewController.view.backgroundColor = .white
+        window?.rootViewController = viewController
+        window?.makeKeyAndVisible()
+        return true
+    }
+
+}

--- a/fixtures/ios_workspace_with_dependency_cycle/App/Tests.plist
+++ b/fixtures/ios_workspace_with_dependency_cycle/App/Tests.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_workspace_with_dependency_cycle/App/Tests/AppTests.swift
+++ b/fixtures/ios_workspace_with_dependency_cycle/App/Tests/AppTests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+@testable import App
+
+final class AppTests: XCTestCase {
+
+}

--- a/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkA/Info.plist
+++ b/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkA/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkA/Project.swift
+++ b/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkA/Project.swift
@@ -1,0 +1,29 @@
+import ProjectDescription
+
+let project = Project(name: "FrameworkA",
+                      targets: [
+                        Target(name: "FrameworkA",
+                               platform: .iOS,
+                               product: .framework,
+                               bundleId: "io.tuist.FrameworkA",
+                               infoPlist: "Info.plist",
+                               sources: ["Sources/**"],
+                               resources: [
+                                       /* Path to resouces can be defined here */
+                                       // "Resources/**"
+                               ],
+                               dependencies: [
+                                    /* Target dependencies can be defined here */
+                                    // .framework(path: "Frameworks/MyFramework.framework")
+                                    .project(target: "FrameworkB", path: "../FrameworkB")
+                                ]),
+                        Target(name: "FrameworkATests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               bundleId: "io.tuist.FrameworkATests",
+                               infoPlist: "Tests.plist",
+                               sources: "Tests/**",
+                               dependencies: [
+                                    .target(name: "FrameworkA")
+                               ])
+                      ])

--- a/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkA/Sources/FrameworkA.swift
+++ b/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkA/Sources/FrameworkA.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+class FrameworkA {
+
+}

--- a/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkA/Tests.plist
+++ b/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkA/Tests.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkA/Tests/FrameworkATests.swift
+++ b/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkA/Tests/FrameworkATests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+@testable import FrameworkA
+
+final class FrameworkATests: XCTestCase {
+
+}

--- a/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkB/Info.plist
+++ b/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkB/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkB/Project.swift
+++ b/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkB/Project.swift
@@ -1,0 +1,29 @@
+import ProjectDescription
+
+let project = Project(name: "FrameworkB",
+                      targets: [
+                        Target(name: "FrameworkB",
+                               platform: .iOS,
+                               product: .framework,
+                               bundleId: "io.tuist.FrameworkB",
+                               infoPlist: "Info.plist",
+                               sources: ["Sources/**"],
+                               resources: [
+                                       /* Path to resouces can be defined here */
+                                       // "Resources/**"
+                               ],
+                               dependencies: [
+                                    /* Target dependencies can be defined here */
+                                    // .framework(path: "Frameworks/MyFramework.framework")
+                                    .project(target: "FrameworkA", path: "../FrameworkA")
+                                ]),
+                        Target(name: "FrameworkBTests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               bundleId: "io.tuist.FrameworkBTests",
+                               infoPlist: "Tests.plist",
+                               sources: "Tests/**",
+                               dependencies: [
+                                    .target(name: "FrameworkB")
+                               ])
+                      ])

--- a/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkB/Sources/FrameworkB.swift
+++ b/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkB/Sources/FrameworkB.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+class FrameworkB {
+
+}

--- a/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkB/Tests.plist
+++ b/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkB/Tests.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkB/Tests/FrameworkBTests.swift
+++ b/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkB/Tests/FrameworkBTests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+@testable import FrameworkB
+
+final class FrameworkBTests: XCTestCase {
+
+}

--- a/fixtures/ios_workspace_with_dependency_cycle/Workspace.swift
+++ b/fixtures/ios_workspace_with_dependency_cycle/Workspace.swift
@@ -1,0 +1,7 @@
+import ProjectDescription
+
+let workspace = Workspace(name: "Workspace",
+                          projects: [
+                              "App", 
+                              "Frameworks/**", 
+                            ])


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/460

### Short description 📝

In some cases false cycle errors were being thrown during project generation:

- A -> B
- C -> A
- C -> B

### Solution 📦

- Implemented depth first search to check for cycles once the graph is fully constructed
- Changed the order in which target nodes are added to the cache to prevent infinite loops in the event of cycles being present

### Implementation 👩‍💻👨‍💻

- [x] Update `GraphCircularDetecting`
- [x] Update `GraphCircularDetectorTests`
- [x] Update graph loading error to cache nodes ahead of traversing their dependencies (to avoid infinite loops!)
- [x] Add fixture
- [x] Update change log

### Test Plan 🛠

- Run `tuist generate` within `fixtures/ios_workspace_with_dependency_cycle`
- Verify a cycle error is displayed
- Verify generating other fixtures still works as before
