### PR TITLE
Add intentdefinition to valid source extensions

### DIFF
--- a/Sources/TuistGenerator/Models/Target.swift
+++ b/Sources/TuistGenerator/Models/Target.swift
@@ -7,7 +7,7 @@ public class Target: Equatable, Hashable {
 
     // MARK: - Static
 
-    static let validSourceExtensions: [String] = ["m", "swift", "mm", "cpp", "c", "d"]
+    static let validSourceExtensions: [String] = ["m", "swift", "mm", "cpp", "c", "d", "intentdefinition"]
     static let validFolderExtensions: [String] = ["framework", "bundle", "app", "xcassets", "appiconset"]
 
     // MARK: - Attributes

--- a/Tests/TuistGeneratorTests/Models/TargetTests.swift
+++ b/Tests/TuistGeneratorTests/Models/TargetTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class TargetTests: TuistUnitTestCase {
     func test_validSourceExtensions() {
-        XCTAssertEqual(Target.validSourceExtensions, ["m", "swift", "mm", "cpp", "c", "d"])
+        XCTAssertEqual(Target.validSourceExtensions, ["m", "swift", "mm", "cpp", "c", "d", "intentdefinition"])
     }
 
     func test_productName_when_staticLibrary() {


### PR DESCRIPTION
### Short description 📝

Currently tuist ignores `.intentdefinition` files. PR adds `intentdefinition` to valid source extensions so that those files are added to `Compile Sources` phase.