### PR TITLE
Configure the pipeline to run jobs only when they are affected by the file changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,13 @@ jobs:
       - run-job-for-paths:
           paths:
             - Sources/
+            - .circleci/
+            - Gemfile
+            - Gemfile.lock
+            - Rakefile
+            - Package.swift
+            - Package.resolved
+            - script/
       - run:
           name: Install Tuist
           command: |
@@ -67,6 +74,12 @@ jobs:
       - run-job-for-paths:
           paths:
             - Sources/
+            - .circleci/
+            - Gemfile
+            - Gemfile.lock
+            - Rakefile
+            - Package.swift
+            - Package.resolved
       - run:
           name: Build for release
           command: |
@@ -107,6 +120,12 @@ jobs:
             - Tests/
             - fixtures/
             - features/
+            - .circleci/
+            - Gemfile
+            - Gemfile.lock
+            - Rakefile
+            - Package.swift
+            - Package.resolved
       - restore_cache:
           key: bundler-{{ checksum "Gemfile.lock" }}
       - run:
@@ -152,6 +171,12 @@ jobs:
           paths:
             - Sources/
             - Tests/
+            - .circleci/
+            - Gemfile
+            - Gemfile.lock
+            - Rakefile
+            - Package.swift
+            - Package.resolved
       - run-job-for-paths:
           paths:
             - Sources/
@@ -191,6 +216,7 @@ jobs:
       - run-job-for-paths:
           paths:
             - galaxy/
+            - .circleci/
 
       - run:
           name: Update Bundler
@@ -233,6 +259,7 @@ jobs:
       - run-job-for-paths:
           paths:
             - galaxy/
+            - .circleci/
       - run:
           name: Deploy Master to Heroku
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
       xcode: '11.0.0'
     steps:
       - checkout
-      - multirepo/run-job-for-paths:
+      - multirepo:
           paths:
             - Sources/
             - .circleci/
@@ -71,7 +71,7 @@ jobs:
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout
-      - multirepo/run-job-for-paths:
+      - multirepo:
           paths:
             - Sources/
             - .circleci/
@@ -114,7 +114,7 @@ jobs:
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout
-      - multirepo/run-job-for-paths:
+      - multirepo:
           paths:
             - Sources/
             - Tests/
@@ -167,7 +167,7 @@ jobs:
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout
-      - multirepo/run-job-for-paths:
+      - multirepo:
           paths:
             - Sources/
             - Tests/
@@ -177,7 +177,7 @@ jobs:
             - Rakefile
             - Package.swift
             - Package.resolved
-      - multirepo/run-job-for-paths:
+      - multirepo:
           paths:
             - Sources/
       - run:
@@ -213,7 +213,7 @@ jobs:
       - checkout:
           path: ~/repo
 
-      - multirepo/run-job-for-paths:
+      - multirepo:
           paths:
             - galaxy/
             - .circleci/
@@ -256,7 +256,7 @@ jobs:
     steps:
       - checkout:
           path: ~/repo
-      - multirepo/run-job-for-paths:
+      - multirepo:
           paths:
             - galaxy/
             - .circleci/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
       xcode: '11.0.0'
     steps:
       - checkout
-      - run-job-for-paths:
+      - multirepo/run-job-for-paths:
           paths:
             - Sources/
             - .circleci/
@@ -71,7 +71,7 @@ jobs:
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout
-      - run-job-for-paths:
+      - multirepo/run-job-for-paths:
           paths:
             - Sources/
             - .circleci/
@@ -114,7 +114,7 @@ jobs:
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout
-      - run-job-for-paths:
+      - multirepo/run-job-for-paths:
           paths:
             - Sources/
             - Tests/
@@ -167,7 +167,7 @@ jobs:
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout
-      - run-job-for-paths:
+      - multirepo/run-job-for-paths:
           paths:
             - Sources/
             - Tests/
@@ -177,7 +177,7 @@ jobs:
             - Rakefile
             - Package.swift
             - Package.resolved
-      - run-job-for-paths:
+      - multirepo/run-job-for-paths:
           paths:
             - Sources/
       - run:
@@ -213,7 +213,7 @@ jobs:
       - checkout:
           path: ~/repo
 
-      - run-job-for-paths:
+      - multirepo/run-job-for-paths:
           paths:
             - galaxy/
             - .circleci/
@@ -256,7 +256,7 @@ jobs:
     steps:
       - checkout:
           path: ~/repo
-      - run-job-for-paths:
+      - multirepo/run-job-for-paths:
           paths:
             - galaxy/
             - .circleci/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,16 +45,8 @@ jobs:
       xcode: '11.0.0'
     steps:
       - checkout
-      - multirepo:
-          paths:
-            - Sources/
-            - .circleci/
-            - Gemfile
-            - Gemfile.lock
-            - Rakefile
-            - Package.swift
-            - Package.resolved
-            - script/
+      - multirepo/run-job-for-paths:
+          paths: Sources/**/* .circleci/* Gemfile Gemfile.lock Rakefile Package.swift Package.resolved script/**/*
       - run:
           name: Install Tuist
           command: |
@@ -71,15 +63,8 @@ jobs:
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout
-      - multirepo:
-          paths:
-            - Sources/
-            - .circleci/
-            - Gemfile
-            - Gemfile.lock
-            - Rakefile
-            - Package.swift
-            - Package.resolved
+      - multirepo/run-job-for-paths:
+          paths: Sources/**/* .circleci/* Gemfile Gemfile.lock Rakefile Package.swift Package.resolved script/**/*
       - run:
           name: Build for release
           command: |
@@ -114,18 +99,8 @@ jobs:
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout
-      - multirepo:
-          paths:
-            - Sources/
-            - Tests/
-            - fixtures/
-            - features/
-            - .circleci/
-            - Gemfile
-            - Gemfile.lock
-            - Rakefile
-            - Package.swift
-            - Package.resolved
+      - multirepo/run-job-for-paths:
+          paths: Sources/**/* .circleci/* Gemfile Gemfile.lock Rakefile Package.swift Package.resolved script/**/* fixtures/**/* features/**/*
       - restore_cache:
           key: bundler-{{ checksum "Gemfile.lock" }}
       - run:
@@ -167,17 +142,9 @@ jobs:
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout
-      - multirepo:
-          paths:
-            - Sources/
-            - Tests/
-            - .circleci/
-            - Gemfile
-            - Gemfile.lock
-            - Rakefile
-            - Package.swift
-            - Package.resolved
-      - multirepo:
+      - multirepo/run-job-for-paths:
+          paths: Sources/**/* Tests/**/* .circleci/* Gemfile Gemfile.lock Rakefile Package.swift Package.resolved
+      - multirepo/run-job-for-paths:
           paths:
             - Sources/
       - run:
@@ -213,10 +180,8 @@ jobs:
       - checkout:
           path: ~/repo
 
-      - multirepo:
-          paths:
-            - galaxy/
-            - .circleci/
+      - multirepo/run-job-for-paths:
+          paths: galaxy/**/* .circleci/**/*
 
       - run:
           name: Update Bundler
@@ -256,10 +221,8 @@ jobs:
     steps:
       - checkout:
           path: ~/repo
-      - multirepo:
-          paths:
-            - galaxy/
-            - .circleci/
+      - multirepo/run-job-for-paths:
+          paths: galaxy/**/* .circleci/**/*
       - run:
           name: Deploy Master to Heroku
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
     steps:
       - checkout
       - multirepo/run-job-for-paths:
-          paths: Sources/**/* .circleci/* Gemfile Gemfile.lock Rakefile Package.swift Package.resolved script/**/*
+          paths: 'Sources/**/* .circleci/* Gemfile Gemfile.lock Rakefile Package.swift Package.resolved script/**/*'
       - run:
           name: Build for release
           command: |
@@ -100,7 +100,7 @@ jobs:
     steps:
       - checkout
       - multirepo/run-job-for-paths:
-          paths: Sources/**/* .circleci/* Gemfile Gemfile.lock Rakefile Package.swift Package.resolved script/**/* fixtures/**/* features/**/*
+          paths: 'Sources/**/* .circleci/* Gemfile Gemfile.lock Rakefile Package.swift Package.resolved script/**/* fixtures/**/* features/**/*'
       - restore_cache:
           key: bundler-{{ checksum "Gemfile.lock" }}
       - run:
@@ -143,10 +143,7 @@ jobs:
     steps:
       - checkout
       - multirepo/run-job-for-paths:
-          paths: Sources/**/* Tests/**/* .circleci/* Gemfile Gemfile.lock Rakefile Package.swift Package.resolved
-      - multirepo/run-job-for-paths:
-          paths:
-            - Sources/
+          paths: 'Sources/**/* Tests/**/* .circleci/* Gemfile Gemfile.lock Rakefile Package.swift Package.resolved'
       - run:
           name: Generate Xcode project
           command: |
@@ -181,7 +178,7 @@ jobs:
           path: ~/repo
 
       - multirepo/run-job-for-paths:
-          paths: galaxy/**/* .circleci/**/*
+          paths: 'galaxy/**/* .circleci/**/*'
 
       - run:
           name: Update Bundler
@@ -222,7 +219,7 @@ jobs:
       - checkout:
           path: ~/repo
       - multirepo/run-job-for-paths:
-          paths: galaxy/**/* .circleci/**/*
+          paths: 'galaxy/**/* .circleci/**/*'
       - run:
           name: Deploy Master to Heroku
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
-version: 2
+version: 2.1
+orbs:
+  multirepo: dnephin/multirepo@0.0.7
 workflows:
-  version: 2
+  version: 2.1
   tuist-install:
     jobs:
       - tuist-install:
@@ -43,6 +45,9 @@ jobs:
       xcode: '11.0.0'
     steps:
       - checkout
+      - run-job-for-paths:
+          paths:
+            - Sources/
       - run:
           name: Install Tuist
           command: |
@@ -59,6 +64,9 @@ jobs:
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout
+      - run-job-for-paths:
+          paths:
+            - Sources/
       - run:
           name: Build for release
           command: |
@@ -93,6 +101,12 @@ jobs:
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout
+      - run-job-for-paths:
+          paths:
+            - Sources/
+            - Tests/
+            - fixtures/
+            - features/
       - restore_cache:
           key: bundler-{{ checksum "Gemfile.lock" }}
       - run:
@@ -134,6 +148,13 @@ jobs:
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout
+      - run-job-for-paths:
+          paths:
+            - Sources/
+            - Tests/
+      - run-job-for-paths:
+          paths:
+            - Sources/
       - run:
           name: Generate Xcode project
           command: |
@@ -166,6 +187,10 @@ jobs:
     steps:
       - checkout:
           path: ~/repo
+
+      - run-job-for-paths:
+          paths:
+            - galaxy/
 
       - run:
           name: Update Bundler
@@ -205,6 +230,9 @@ jobs:
     steps:
       - checkout:
           path: ~/repo
+      - run-job-for-paths:
+          paths:
+            - galaxy/
       - run:
           name: Deploy Master to Heroku
           command: |


### PR DESCRIPTION
### Short description 📝
After having turned this repository into a monorepo, the CircleCI pipelines are triggered regardless of them being impacted by the file changes. Although it doesn't cost us anything because the service is free for open source projects, it's not optimal and therefore developers have to wait unnecessary time for their PRs to be green.

### Solution 📦
Use [this CircleCI orb](https://circleci.com/orbs/registry/orb/dnephin/multirepo) that allows indicating which jobs are impacted by which paths.