### PR TITLE
[package-api] Refine API for Swift Packages

### DIFF
--- a/Sources/ProjectDescription/Package.swift
+++ b/Sources/ProjectDescription/Package.swift
@@ -1,0 +1,248 @@
+public enum Package: Equatable, Codable {
+    
+    case remote(url: String, requirement: Requirement)
+    case local(path: String)
+
+    private enum Kind: String, Codable {
+        case remote
+        case local
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case url
+        case productName
+        case requirement
+        case path
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .remote:
+            let url = try container.decode(String.self, forKey: .url)
+            let requirement = try container.decode(Requirement.self, forKey: .requirement)
+            self = .remote(url: url, requirement: requirement)
+        case .local:
+            let path = try container.decode(String.self, forKey: .path)
+            self = .local(path: path)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .remote(url, requirement):
+            try container.encode(Kind.remote, forKey: .kind)
+            try container.encode(url, forKey: .url)
+            try container.encode(requirement, forKey: .requirement)
+        case let .local(path):
+            try container.encode(Kind.local, forKey: .kind)
+            try container.encode(path, forKey: .path)
+        }
+    }
+}
+
+extension Package {
+    
+    public enum Requirement: Codable, Equatable {
+        case upToNextMajor(from: Version)
+        case upToNextMinor(from: Version)
+        case range(from: Version, to: Version)
+        case exact(Version)
+        case branch(String)
+        case revision(String)
+        
+        @available(*, unavailable, message: "use upToNextMajor(from:) instead.")
+        static func upToNextMajor(_: Version) {
+            fatalError()
+        }
+        
+        @available(*, unavailable, message: "use upToNextMinor(from:) instead.")
+        static func upToNextMinor(_: Version) {
+            fatalError()
+        }
+        
+        enum CodingKeys: String, CodingKey {
+            case kind
+            case revision
+            case branch
+            case minimumVersion
+            case maximumVersion
+        }
+        
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let kind: String = try container.decode(String.self, forKey: .kind)
+            if kind == "revision" {
+                let revision = try container.decode(String.self, forKey: .revision)
+                self = .revision(revision)
+            } else if kind == "branch" {
+                let branch = try container.decode(String.self, forKey: .branch)
+                self = .branch(branch)
+            } else if kind == "exactVersion" {
+                let version = try container.decode(Version.self, forKey: .minimumVersion)
+                self = .exact(version)
+            } else if kind == "versionRange" {
+                let minimumVersion = try container.decode(Version.self, forKey: .minimumVersion)
+                let maximumVersion = try container.decode(Version.self, forKey: .maximumVersion)
+                self = .range(from: minimumVersion, to: maximumVersion)
+            } else if kind == "upToNextMinor" {
+                let version = try container.decode(Version.self, forKey: .minimumVersion)
+                self = .upToNextMinor(from: version)
+            } else if kind == "upToNextMajor" {
+                let version = try container.decode(Version.self, forKey: .minimumVersion)
+                self = .upToNextMajor(from: version)
+            } else {
+                fatalError("XCRemoteSwiftPackageReference kind '\(kind)' not supported")
+            }
+        }
+        
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            
+            switch self {
+            case let .upToNextMajor(version):
+                try container.encode("upToNextMajor", forKey: .kind)
+                try container.encode(version, forKey: .minimumVersion)
+            case let .upToNextMinor(version):
+                try container.encode("upToNextMinor", forKey: .kind)
+                try container.encode(version, forKey: .minimumVersion)
+            case let .range(from, to):
+                try container.encode("versionRange", forKey: .kind)
+                try container.encode(from, forKey: .minimumVersion)
+                try container.encode(to, forKey: .maximumVersion)
+            case let .exact(version):
+                try container.encode("exactVersion", forKey: .kind)
+                try container.encode(version, forKey: .minimumVersion)
+            case let .branch(branch):
+                try container.encode("branch", forKey: .kind)
+                try container.encode(branch, forKey: .branch)
+            case let .revision(revision):
+                try container.encode("revision", forKey: .revision)
+                try container.encode(revision, forKey: .revision)
+            }
+        }
+    }
+    
+}
+
+extension Package {
+
+    /// Create a package dependency that uses the version requirement, starting with the given minimum version,
+    /// going up to the next major version.
+    ///
+    /// This is the recommended way to specify a remote package dependency.
+    /// It allows you to specify the minimum version you require, allows updates that include bug fixes
+    /// and backward-compatible feature updates, but requires you to explicitly update to a new major version of the dependency.
+    /// This approach provides the maximum flexibility on which version to use,
+    /// while making sure you don't update to a version with breaking changes,
+    /// and helps to prevent conflicts in your dependency graph.
+    ///
+    /// The following example allows the Swift package manager to select a version
+    /// like a  `1.2.3`, `1.2.4`, or `1.3.0`, but not `2.0.0`.
+    ///
+    ///    .package(url: "https://example.com/example-package.git", from: "1.2.3"),
+    ///
+    /// - Parameters:
+    ///     - url: The valid Git URL of the package.
+    ///     - version: The minimum version requirement.
+    public static func package(
+        url: String,
+        from version: Version
+    ) -> Package {
+        return .package(url: url, .upToNextMajor(from: version))
+    }
+
+    /// Add a remote package dependency given a version requirement.
+    ///
+    /// - Parameters:
+    ///     - url: The valid Git URL of the package.
+    ///     - requirement: A dependency requirement. See static methods on `Package.Dependency.Requirement` for available options.
+    public static func package(
+        url: String,
+        _ requirement: Package.Requirement
+    ) -> Package {
+        return .remote(url: url, requirement: requirement)
+    }
+
+    /// Add a package dependency starting with a specific minimum version, up to
+    /// but not including a specified maximum version.
+    ///
+    /// The following example allows the Swift package manager to pick
+    /// versions `1.2.3`, `1.2.4`, `1.2.5`, but not `1.2.6`.
+    ///
+    ///     .package(url: "https://example.com/example-package.git", "1.2.3"..<"1.2.6"),
+    ///
+    /// - Parameters:
+    ///     - url: The valid Git URL of the package.
+    ///     - range: The custom version range requirement.
+    public static func package(
+        url: String,
+        _ range: Range<Version>
+    ) -> Package {
+        return .remote(url: url, requirement: .range(from: range.lowerBound, to: range.upperBound))
+    }
+
+    /// Add a package dependency starting with a specific minimum version, going
+    /// up to and including a specific maximum version.
+    ///
+    /// The following example allows the Swift package manager to pick
+    /// versions 1.2.3, 1.2.4, 1.2.5, as well as 1.2.6.
+    ///
+    ///     .package(url: "https://example.com/example-package.git", "1.2.3"..."1.2.6"),
+    ///
+    /// - Parameters:
+    ///     - url: The valid Git URL of the package.
+    ///     - range: The closed version range requirement.
+    public static func package(
+        url: String,
+        _ range: ClosedRange<Version>
+    ) -> Package {
+        // Increase upperbound's patch version by one.
+        let upper = range.upperBound
+        let upperBound = Version(
+            upper.major, upper.minor, upper.patch + 1,
+            prereleaseIdentifiers: upper.prereleaseIdentifiers,
+            buildMetadataIdentifiers: upper.buildMetadataIdentifiers)
+        return .package(url: url, range.lowerBound..<upperBound)
+    }
+
+    /// Add a dependency to a local package on the filesystem.
+    ///
+    /// The Swift Package Manager uses the package dependency as-is
+    /// and does not perform any source control access. Local package dependencies
+    /// are especially useful during development of a new package or when working
+    /// on multiple tightly coupled packages.
+    ///
+    /// - Parameter path: The path of the package.
+    public static func package(
+        path: String
+    ) -> Package {
+        return .local(path: path)
+    }
+}
+
+// Mark common APIs used by mistake as unavailable to provide better error messages.
+extension Package {
+    @available(*, unavailable, message: "use package(url:_:) with the .exact(Version) initializer instead")
+    public static func package(url: String, version: Version) -> Package {
+        fatalError()
+    }
+
+    @available(*, unavailable, message: "use package(url:_:) with the .branch(String) initializer instead")
+    public static func package(url: String, branch: String) -> Package {
+        fatalError()
+    }
+
+    @available(*, unavailable, message: "use package(url:_:) with the .revision(String) initializer instead")
+    public static func package(url: String, revision: String) -> Package {
+        fatalError()
+    }
+
+    @available(*, unavailable, message: "use package(url:_:) without the range label instead")
+    public static func package(url: String, range: Range<Version>) -> Package {
+        fatalError()
+    }
+}

--- a/Sources/ProjectDescription/Project.swift
+++ b/Sources/ProjectDescription/Project.swift
@@ -4,17 +4,20 @@ import Foundation
 
 public class Project: Codable {
     public let name: String
+    public let packages: [Package]
     public let targets: [Target]
     public let schemes: [Scheme]
     public let settings: Settings?
     public let additionalFiles: [FileElement]
 
     public init(name: String,
+                packages: [Package] = [],
                 settings: Settings? = nil,
                 targets: [Target] = [],
                 schemes: [Scheme] = [],
                 additionalFiles: [FileElement] = []) {
         self.name = name
+        self.packages = packages
         self.targets = targets
         self.schemes = schemes
         self.settings = settings

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -76,7 +76,6 @@ final class LinkGenerator: LinkGenerating {
                        graph: Graphing) throws {
         let embeddableFrameworks = try graph.embeddableFrameworks(path: path, name: target.name)
         let linkableModules = try graph.linkableDependencies(path: path, name: target.name)
-        let packages = try graph.packages(path: path, name: target.name)
 
         try setupSearchAndIncludePaths(target: target,
                                        pbxTarget: pbxTarget,
@@ -105,8 +104,7 @@ final class LinkGenerator: LinkGenerating {
 
         try generatePackages(target: target,
                              pbxTarget: pbxTarget,
-                             pbxProject: pbxProject,
-                             packages: packages)
+                             pbxproj: pbxproj)
     }
 
     private func setupSearchAndIncludePaths(target: Target,
@@ -136,24 +134,37 @@ final class LinkGenerator: LinkGenerating {
                                    sourceRootPath: sourceRootPath)
     }
 
-    func generatePackages(target _: Target,
+    func generatePackages(target: Target,
                           pbxTarget: PBXTarget,
-                          pbxProject: PBXProject,
-                          packages: [PackageNode]) throws {
-        try packages.forEach { package in
-            switch package.packageType {
-            case let .local(path: packagePath, productName: productName):
-                _ = try pbxProject.addLocalSwiftPackage(path: Path(packagePath.pathString),
-                                                        productName: productName,
-                                                        targetName: pbxTarget.name,
-                                                        addFileReference: false)
-            case let .remote(url: url, productName: productName, versionRequirement: versionRequirement):
-                _ = try pbxProject.addSwiftPackage(repositoryURL: url,
-                                                   productName: productName,
-                                                   versionRequirement: versionRequirement.xcodeprojValue,
-                                                   targetName: pbxTarget.name)
+                          pbxproj: PBXProj) throws {
+
+        for dependency in target.dependencies {
+            
+            switch dependency {
+            case let .package(product: product):
+                
+                let productDependency = XCSwiftPackageProductDependency(productName: product)
+                pbxproj.add(object: productDependency)
+                pbxTarget.packageProductDependencies.append(productDependency)
+                
+                // Build file
+                let buildFile = PBXBuildFile(product: productDependency)
+                pbxproj.add(object: buildFile)
+                
+                // Link the product
+                guard let frameworksBuildPhase = try pbxTarget.frameworksBuildPhase() else {
+                    throw "No frameworks build phase"
+                }
+                
+                frameworksBuildPhase.files?.append(buildFile)
+                
+            default:
+                break
             }
+            
         }
+        
+
     }
 
     func generateEmbedPhase(dependencies: [DependencyReference],

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -144,20 +144,6 @@ class ProjectFileElements {
                              isReference: $0.isReference)
         })
 
-        // Local Packages
-        elements.formUnion(
-            try graph.packages(path: projectPath, name: target.name).compactMap { node -> GroupFileElement? in
-                switch node.packageType {
-                case let .local(path: packagePath, productName: _):
-                    return GroupFileElement(path: projectPath.appending(packagePath),
-                                            group: target.filesGroup,
-                                            isReference: true)
-                default:
-                    return nil
-                }
-            }
-        )
-
         return elements
     }
 

--- a/Sources/TuistGenerator/Generator/ProjectGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGenerator.swift
@@ -121,6 +121,10 @@ final class ProjectGenerator: ProjectGenerating {
         generateTestTargetIdentity(project: project,
                                    pbxproj: pbxproj,
                                    pbxProject: pbxProject)
+        
+        try generateSwiftPackageReferences(project: project,
+                                           pbxproj: pbxproj,
+                                           pbxProject: pbxProject)
 
         try deleteOldDerivedFiles()
 
@@ -212,6 +216,39 @@ final class ProjectGenerator: ProjectGenerating {
 
             pbxProject.setTargetAttributes(attributes, target: testTarget)
         }
+    }
+    
+    private func generateSwiftPackageReferences(project: Project, pbxproj: PBXProj, pbxProject: PBXProject) throws {
+        
+        var packageReferences: [String: XCRemoteSwiftPackageReference] = [:]
+        
+        for package in project.packages {
+            
+            switch package {
+            case let .local(path):
+                
+                let reference = PBXFileReference(
+                    sourceTree: .group,
+                    name: path.components.last,
+                    lastKnownFileType: "folder",
+                    path: path.pathString
+                )
+                
+                pbxproj.add(object: reference)
+                try pbxproj.rootGroup()?.children.append(reference)
+                
+            case let .remote(url: url, requirement: requirement):
+                let packageReference = XCRemoteSwiftPackageReference(
+                    repositoryURL: url,
+                    versionRequirement: requirement.xcodeprojValue
+                )
+                packageReferences[url] = packageReference
+                pbxproj.add(object: packageReference)
+            }
+        }
+        
+        pbxProject.packages = packageReferences.sorted { $0.key < $1.key }.map { $1 }
+        
     }
 
     private func write(xcodeprojPath: AbsolutePath,

--- a/Sources/TuistGenerator/Generator/WorkspaceGenerator.swift
+++ b/Sources/TuistGenerator/Generator/WorkspaceGenerator.swift
@@ -131,14 +131,14 @@ final class WorkspaceGenerator: WorkspaceGenerating {
         workspaceName: String,
         graph: Graphing
     ) throws {
-        let packages = try graph.targets.flatMap { try graph.packages(path: $0.path, name: $0.name) }
+        let packages = graph.packages
 
         if packages.isEmpty {
             return
         }
 
         let hasRemotePackage = packages.first(where: { package in
-            switch package.packageType {
+            switch package.package {
             case .remote: return true
             case .local: return false
             }

--- a/Sources/TuistGenerator/Graph/Graph.swift
+++ b/Sources/TuistGenerator/Graph/Graph.swift
@@ -158,7 +158,7 @@ class Graph: Graphing {
     }
 
     var packages: [PackageNode] {
-        return Array(cache.packageNodes.values)
+        return cache.packages.values.flatMap{ $0 }
     }
 
     /// Returns all the frameworks that are part of the graph
@@ -205,11 +205,7 @@ class Graph: Graphing {
     }
 
     func packages(path: AbsolutePath, name: String) throws -> [PackageNode] {
-        guard let targetNode = findTargetNode(path: path, name: name) else {
-            return []
-        }
-
-        return targetNode.packages
+        return cache.packages[path] ?? [ ]
     }
 
     func linkableDependencies(path: AbsolutePath, name: String) throws -> [DependencyReference] {
@@ -422,8 +418,8 @@ extension TargetNode {
         return dependencies.lazy.compactMap { $0 as? PrecompiledNode }
     }
 
-    fileprivate var packages: [PackageNode] {
-        return dependencies.lazy.compactMap { $0 as? PackageNode }
+    fileprivate var packages: [PackageDependencyNode] {
+        return dependencies.lazy.compactMap { $0 as? PackageDependencyNode }
     }
 
     fileprivate var libraryDependencies: [LibraryNode] {

--- a/Sources/TuistGenerator/Graph/GraphLoaderCache.swift
+++ b/Sources/TuistGenerator/Graph/GraphLoaderCache.swift
@@ -28,10 +28,12 @@ protocol GraphLoaderCaching: AnyObject {
     ///
     /// - Parameter cocoapods: Node to be added to the cache.
     func add(cocoapods: CocoaPodsNode)
+    
+    var packages: [AbsolutePath: [PackageNode]] { get }
 
-    var packageNodes: [AbsolutePath: PackageNode] { get }
-    func package(_ path: AbsolutePath) -> PackageNode?
-    func add(package: PackageNode)
+    var packageNodes: [AbsolutePath: PackageDependencyNode] { get }
+    func package(_ path: AbsolutePath) -> PackageDependencyNode?
+    func add(package: PackageDependencyNode)
 }
 
 /// Graph loader cache.
@@ -40,6 +42,7 @@ class GraphLoaderCache: GraphLoaderCaching {
 
     var tuistConfigs: [AbsolutePath: TuistConfig] = [:]
     var projects: [AbsolutePath: Project] = [:]
+    var packages: [AbsolutePath: [PackageNode]] = [:]
     var precompiledNodes: [AbsolutePath: PrecompiledNode] = [:]
     var targetNodes: [AbsolutePath: [String: TargetNode]] = [:]
 
@@ -62,20 +65,20 @@ class GraphLoaderCache: GraphLoaderCaching {
     }
 
     /// Cached SwiftPM package nodes
-    var packageNodes: [AbsolutePath: PackageNode] = [:]
+    var packageNodes: [AbsolutePath: PackageDependencyNode] = [:]
 
     /// Returns, if it exists, the Package node at the given path.
     ///
     /// - Parameter path: Path to the directory where the Podfile is defined.
     /// - Returns: The Package node if it exists in the cache.
-    func package(_ path: AbsolutePath) -> PackageNode? {
+    func package(_ path: AbsolutePath) -> PackageDependencyNode? {
         return packageNodes[path]
     }
 
     /// Adds a parsed Package graph node to the cache.
     ///
     /// - Parameter package: Node to be added to the cache.
-    func add(package: PackageNode) {
+    func add(package: PackageDependencyNode) {
         packageNodes[package.path] = package
     }
 
@@ -93,6 +96,7 @@ class GraphLoaderCache: GraphLoaderCaching {
 
     func add(project: Project) {
         projects[project.path] = project
+        packages[project.path] = project.packages.map({ PackageNode(package: $0, path: project.path) })
     }
 
     func add(precompiledNode: PrecompiledNode) {

--- a/Sources/TuistGenerator/Graph/PackageNode.swift
+++ b/Sources/TuistGenerator/Graph/PackageNode.swift
@@ -2,36 +2,32 @@ import Basic
 import Foundation
 import TuistCore
 
-class PackageNode: GraphNode {
-    let packageType: Dependency.PackageType
+class PackageDependencyNode: GraphNode {
+    let product: String
+    init(product: String, path: AbsolutePath) {
+        self.product = product
+        super.init(path: path, name: product)
+    }
+    
+}
 
-    init(packageType: Dependency.PackageType, path: AbsolutePath) {
-        self.packageType = packageType
+class PackageNode: GraphNode {
+    
+    let package: Package
+
+    init(package: Package, path: AbsolutePath) {
+        self.package = package
+        
         let name: String
-        switch packageType {
-        case let .local(path: _, productName: productName):
-            name = productName
-        case let .remote(url: _, productName: productName, versionRequirement: _):
-            name = productName
+        
+        switch package {
+        case let .local(path: path):
+            name = path.pathString
+        case let .remote(url: url, requirement: _):
+            name = url
         }
+        
         super.init(path: path, name: name)
     }
 
-    /// Reads the Package node. If it it exists in the cache, it returns it from the cache.
-    /// Otherwise, it initializes it, stores it in the cache, and then returns it.
-    ///
-    /// - Parameters:
-    ///   - path: Path to the directory that contains the Podfile.
-    ///   - cache: Cache instance where the nodes are cached.
-    /// - Returns: The initialized instance of the Package node.
-    static func read(
-        packageType: Dependency.PackageType,
-        path: AbsolutePath,
-        cache: GraphLoaderCaching
-    ) -> PackageNode {
-        if let cached = cache.package(path) { return cached }
-        let node = PackageNode(packageType: packageType, path: path)
-        cache.add(package: node)
-        return node
-    }
 }

--- a/Sources/TuistGenerator/Graph/TargetNode.swift
+++ b/Sources/TuistGenerator/Graph/TargetNode.swift
@@ -135,8 +135,11 @@ class TargetNode: GraphNode {
             return try SDKNode(name: name, platform: platform, status: status)
         case let .cocoapods(podsPath):
             return CocoaPodsNode.read(path: path.appending(podsPath), cache: cache)
-        case let .package(packageType):
-            return PackageNode(packageType: packageType, path: path)
+        case let .package(product):
+            return PackageDependencyNode(
+                product: product,
+                path: path
+            )
         }
     }
 }

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -74,7 +74,7 @@ class GraphLinter: GraphLinting {
                 issues.append(contentsOf: lintDependency(from: targetNode,
                                                          to: toTargetNode,
                                                          linkedStaticProducts: &linkedStaticProducts))
-            } else if let toPackageNode = toNode as? PackageNode {
+            } else if let toPackageNode = toNode as? PackageDependencyNode {
                 issues.append(contentsOf: lintPackageDependency(from: targetNode,
                                                                 to: toPackageNode,
                                                                 linkedStaticProducts: &linkedStaticProducts))
@@ -89,7 +89,7 @@ class GraphLinter: GraphLinting {
 
     /// Package dependencies are also static products, so we need to perform the same check as for them
     private func lintPackageDependency(from: TargetNode,
-                                       to: PackageNode,
+                                       to: PackageDependencyNode,
                                        linkedStaticProducts: inout Set<StaticDepedencyWarning>) -> [LintingIssue] {
         guard from.target.canLinkStaticProducts() else {
             return []

--- a/Sources/TuistGenerator/Models/Dependency.swift
+++ b/Sources/TuistGenerator/Models/Dependency.swift
@@ -8,12 +8,24 @@ public enum SDKStatus {
 }
 
 public enum Dependency: Equatable {
-    public enum PackageType: Equatable {
-        case remote(url: String, productName: String, versionRequirement: VersionRequirement)
-        case local(path: RelativePath, productName: String)
-    }
+    case target(name: String)
+    case project(target: String, path: RelativePath)
+    case framework(path: RelativePath)
+    case library(path: RelativePath, publicHeaders: RelativePath, swiftModuleMap: RelativePath?)
+    case package(product: String)
+    case sdk(name: String, status: SDKStatus)
+    case cocoapods(path: RelativePath)
+}
 
-    public enum VersionRequirement: Equatable {
+public enum Package: Equatable {
+    case remote(url: String, requirement: Requirement)
+    case local(path: RelativePath)
+}
+
+extension Package {
+    
+    public enum Requirement: Equatable {
+        
         case upToNextMajor(String)
         case upToNextMinor(String)
         case range(from: String, to: String)
@@ -38,12 +50,5 @@ public enum Dependency: Equatable {
             }
         }
     }
-
-    case target(name: String)
-    case project(target: String, path: RelativePath)
-    case framework(path: RelativePath)
-    case library(path: RelativePath, publicHeaders: RelativePath, swiftModuleMap: RelativePath?)
-    case package(PackageType)
-    case sdk(name: String, status: SDKStatus)
-    case cocoapods(path: RelativePath)
+    
 }

--- a/Sources/TuistGenerator/Models/Project.swift
+++ b/Sources/TuistGenerator/Models/Project.swift
@@ -16,6 +16,9 @@ public class Project: Equatable, CustomStringConvertible {
 
     /// Project targets.
     public let targets: [Target]
+    
+    /// Project swift packages.
+    public let packages: [Package]
 
     /// Project schemes
     public let schemes: [Scheme]
@@ -47,12 +50,14 @@ public class Project: Equatable, CustomStringConvertible {
                 settings: Settings,
                 filesGroup: ProjectGroup,
                 targets: [Target],
+                packages: [Package],
                 schemes: [Scheme],
                 additionalFiles: [FileElement] = []) {
         self.path = path
         self.name = name
         self.fileName = fileName ?? name
         self.targets = targets
+        self.packages = packages
         self.schemes = schemes
         self.settings = settings
         self.filesGroup = filesGroup

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -260,12 +260,17 @@ extension TuistGenerator.Project {
             TuistGenerator.FileElement.from(manifest: $0,
                                             path: path)
         }
+        
+        let packages = manifest.packages.map { package in
+            TuistGenerator.Package.from(manifest: package)
+        }
 
         return Project(path: path,
                        name: name,
                        settings: settings ?? .default,
                        filesGroup: .group(name: "Project"),
                        targets: targets,
+                       packages: packages,
                        schemes: schemes,
                        additionalFiles: additionalFiles)
     }
@@ -277,6 +282,7 @@ extension TuistGenerator.Project {
                        settings: settings,
                        filesGroup: filesGroup,
                        targets: targets + [target],
+                       packages: packages,
                        schemes: schemes,
                        additionalFiles: additionalFiles)
     }
@@ -288,6 +294,7 @@ extension TuistGenerator.Project {
                        settings: settings,
                        filesGroup: filesGroup,
                        targets: targets,
+                       packages: packages,
                        schemes: schemes,
                        additionalFiles: additionalFiles)
     }
@@ -521,8 +528,19 @@ extension TuistGenerator.Headers {
     }
 }
 
-extension TuistGenerator.Dependency.VersionRequirement {
-    static func from(manifest: ProjectDescription.TargetDependency.VersionRequirement) -> TuistGenerator.Dependency.VersionRequirement {
+extension TuistGenerator.Package {
+    static func from(manifest: ProjectDescription.Package) -> TuistGenerator.Package {
+        switch manifest {
+        case let .local(path: local):
+            return .local(path: RelativePath(local))
+        case let .remote(url: url, requirement: version):
+            return .remote(url: url, requirement: .from(manifest: version))
+        }
+    }
+}
+
+extension TuistGenerator.Package.Requirement {
+    static func from(manifest: ProjectDescription.Package.Requirement) -> TuistGenerator.Package.Requirement {
         switch manifest {
         case let .branch(branch):
             return .branch(branch)
@@ -553,15 +571,8 @@ extension TuistGenerator.Dependency {
             return .library(path: RelativePath(libraryPath),
                             publicHeaders: RelativePath(publicHeaders),
                             swiftModuleMap: swiftModuleMap.map { RelativePath($0) })
-        case let .package(packageType):
-            switch packageType {
-            case let .local(path: packagePath, productName: productName):
-                return .package(.local(path: RelativePath(packagePath), productName: productName))
-            case let .remote(url: url,
-                             productName: productName,
-                             versionRequirement: versionRules):
-                return .package(.remote(url: url, productName: productName, versionRequirement: .from(manifest: versionRules)))
-            }
+        case let .package(product):
+            return .package(product: product)
 
         case let .sdk(name, status):
             return .sdk(name: name,

--- a/Tests/ProjectDescriptionTests/PackageTests.swift
+++ b/Tests/ProjectDescriptionTests/PackageTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+import ProjectDescription
+import TuistCoreTesting
+
+class PackageTests: XCTestCase {
+    
+    func test_package_remotePackages_codable() throws {
+        // Given
+        let subject = Package.package(url: "https://github.com/Swinject/Swinject",
+                                               .upToNextMajor(from: "2.6.2"))
+
+        // Then
+        XCTAssertCodable(subject)
+    }
+
+    func test_package_localPackages_codable() throws {
+        // Given
+        let subject = Package.package(path: "foo/bar")
+
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
+}

--- a/Tests/ProjectDescriptionTests/TargetDependencyTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetDependencyTests.swift
@@ -57,21 +57,12 @@ final class TargetDependencyTests: XCTestCase {
         XCTAssertCodable(subject)
     }
 
-    func test_package_remotePackages_codable() throws {
+    func test_package_codable() throws {
         // Given
-        let subject = TargetDependency.package(url: "https://github.com/Swinject/Swinject",
-                                               productName: "Swinject",
-                                               .upToNextMajor(from: "2.6.2"))
+        let subject = TargetDependency.package(product: "foo")
 
         // Then
         XCTAssertCodable(subject)
     }
-
-    func test_package_localPackages_codable() throws {
-        // Given
-        let subject = TargetDependency.package(path: "foo/bar", productName: "FooBar")
-
-        // Then
-        XCTAssertCodable(subject)
-    }
+    
 }

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -589,49 +589,18 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         XCTAssertEqual(sdkElement?.name, sdk.path.basename)
     }
 
-    func test_generateDependencies_localSwiftPackage() throws {
-        // Given
-        let pbxproj = PBXProj()
-        let target = Target.empty(name: "TargetA")
-        let project = Project.empty(path: "/a/project",
-                                    targets: [target])
-        let groups = ProjectGroups.generate(project: .test(),
-                                            pbxproj: pbxproj,
-                                            sourceRootPath: project.path)
-
-        let package = PackageNode(packageType: .local(path: RelativePath("packages/A"),
-                                                      productName: "A"),
-                                  path: "/a/project/packages/A")
-        let graph = createGraph(project: project, target: target, dependencies: [package])
-
-        // When
-        try subject.generateProjectFiles(project: project,
-                                         graph: graph,
-                                         groups: groups,
-                                         pbxproj: pbxproj,
-                                         sourceRootPath: project.path)
-
-        // Then
-        let projectGroup = groups.main.group(named: "Project")
-        XCTAssertEqual(projectGroup?.flattenedChildren, [
-            "packages/A",
-        ])
-    }
-
     func test_generateDependencies_remoteSwiftPackage_doNotGenerateElements() throws {
         // Given
         let pbxproj = PBXProj()
         let target = Target.empty(name: "TargetA")
         let project = Project.empty(path: "/a/project",
-                                    targets: [target])
+                                    targets: [target],
+                                    packages: [ .remote(url: "url", requirement: .branch("master")) ])
         let groups = ProjectGroups.generate(project: .test(),
                                             pbxproj: pbxproj,
                                             sourceRootPath: project.path)
 
-        let package = PackageNode(packageType: .remote(url: "url",
-                                                       productName: "A",
-                                                       versionRequirement: .branch("master")),
-                                  path: "/packages/url")
+        let package = PackageDependencyNode(product: "A", path: "/packages/url")
 
         let graph = createGraph(project: project, target: target, dependencies: [package])
 

--- a/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
@@ -27,6 +27,7 @@ final class ProjectGroupsTests: XCTestCase {
                               .test(filesGroup: .group(name: "Target")),
                               .test(),
                           ],
+                          packages: [ ],
                           schemes: [])
         pbxproj = PBXProj()
     }

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceGeneratorTests.swift
@@ -130,12 +130,15 @@ final class WorkspaceGeneratorTests: TuistUnitTestCase {
         // Given
         let temporaryPath = try self.temporaryPath()
         let target = anyTarget(dependencies: [
-            .package(.remote(url: "http://some.remote/repo.git", productName: "Example", versionRequirement: .exact("branch"))),
+            .package(product: "Example"),
         ])
         let project = Project.test(path: temporaryPath,
                                    name: "Test",
                                    settings: .default,
-                                   targets: [target])
+                                   targets: [target],
+                                   packages: [
+                                       .remote(url: "http://some.remote/repo.git", requirement: .exact("branch")),
+                                   ])
         let graph = Graph.create(project: project,
                                  dependencies: [(target, [])])
 
@@ -164,12 +167,15 @@ final class WorkspaceGeneratorTests: TuistUnitTestCase {
         // Given
         let temporaryPath = try self.temporaryPath()
         let target = anyTarget(dependencies: [
-            .package(.remote(url: "http://some.remote/repo.git", productName: "Example", versionRequirement: .exact("branch"))),
+            .package(product: "Example"),
         ])
         let project = Project.test(path: temporaryPath,
                                    name: "Test",
                                    settings: .default,
-                                   targets: [target])
+                                   targets: [target],
+                                   packages: [
+                                     .remote(url: "http://some.remote/repo.git", requirement: .exact("branch"))
+                                   ])
         let graph = Graph.create(project: project,
                                  dependencies: [(target, [])])
 

--- a/Tests/TuistGeneratorTests/Graph/GraphTests.swift
+++ b/Tests/TuistGeneratorTests/Graph/GraphTests.swift
@@ -566,10 +566,13 @@ final class GraphTests: TuistUnitTestCase {
     func test_packageDepedencies_fromTargetDependency() throws {
         // Given
         let target = Target.test(name: "Test", product: .app, dependencies: [
-            .package(.remote(url: "url", productName: "testA", versionRequirement: .branch("master"))),
-            .package(.local(path: RelativePath(""), productName: "testB")),
+            .package(product: "A"),
+            .package(product: "B"),
         ])
-        let project = Project.test(path: "/path")
+        let project = Project.test(path: "/path", packages: [
+            .remote(url: "testA", requirement: .branch("master")),
+            .local(path: RelativePath("testB")),
+        ])
 
         let graph = Graph.create(project: project,
                                  dependencies: [

--- a/Tests/TuistGeneratorTests/Graph/Mocks/MockGraphLoaderCache.swift
+++ b/Tests/TuistGeneratorTests/Graph/Mocks/MockGraphLoaderCache.swift
@@ -21,15 +21,16 @@ final class MockGraphLoaderCache: GraphLoaderCaching {
     var cocoapodsNodes: [AbsolutePath: CocoaPodsNode] = [:]
     var cocoapodsStub: [AbsolutePath: CocoaPodsNode] = [:]
     var addCococaPodsArgs: [CocoaPodsNode] = []
-    var packageNodes: [AbsolutePath: PackageNode] = [:]
-    var packagesStub: [AbsolutePath: PackageNode] = [:]
-    var addPackageArgs: [PackageNode] = []
+    var packageNodes: [AbsolutePath: PackageDependencyNode] = [:]
+    var packagesStub: [AbsolutePath: PackageDependencyNode] = [:]
+    var addPackageArgs: [PackageDependencyNode] = []
+    var packages: [AbsolutePath: [PackageNode]] = [:]
 
-    func package(_ path: AbsolutePath) -> PackageNode? {
+    func package(_ path: AbsolutePath) -> PackageDependencyNode? {
         return packagesStub[path]
     }
 
-    func add(package: PackageNode) {
+    func add(package: PackageDependencyNode) {
         addPackageArgs.append(package)
     }
 

--- a/Tests/TuistGeneratorTests/Graph/PackageNodeTests.swift
+++ b/Tests/TuistGeneratorTests/Graph/PackageNodeTests.swift
@@ -8,7 +8,7 @@ final class PackageNodeTests: XCTestCase {
     func test_remotePackage_name() {
         // Given
         let path = AbsolutePath("/")
-        let subject = PackageNode(packageType: .remote(url: "url", productName: "RemotePackage", versionRequirement: .branch("master")), path: path)
+        let subject = PackageNode(package: .remote(url: "RemotePackage", requirement: .branch("master")), path: path)
 
         // When
         let got = subject.name
@@ -20,7 +20,7 @@ final class PackageNodeTests: XCTestCase {
     func test_localPackage_name() {
         // Given
         let path = AbsolutePath("/")
-        let subject = PackageNode(packageType: .local(path: RelativePath(""), productName: "LocalPackage"), path: path)
+        let subject = PackageNode(package: .local(path: RelativePath("LocalPackage")), path: path)
 
         // When
         let got = subject.name
@@ -32,8 +32,8 @@ final class PackageNodeTests: XCTestCase {
     func test_remotePackage_isEqual_returnsTrue_when_thePathsAreTheSame() {
         // Given
         let path = AbsolutePath("/")
-        let lhs = PackageNode(packageType: .remote(url: "url", productName: "RemotePackage", versionRequirement: .branch("master")), path: path)
-        let rhs = PackageNode(packageType: .remote(url: "url", productName: "RemotePackage", versionRequirement: .branch("master")), path: path)
+        let lhs = PackageNode(package: .remote(url: "url", requirement: .branch("master")), path: path)
+        let rhs = PackageNode(package: .remote(url: "url", requirement: .branch("master")), path: path)
 
         // Then
         XCTAssertEqual(lhs, rhs)
@@ -42,8 +42,8 @@ final class PackageNodeTests: XCTestCase {
     func test_localPackage_isEqual_returnsTrue_when_thePathsAreTheSame() {
         // Given
         let path = AbsolutePath("/")
-        let lhs = PackageNode(packageType: .local(path: RelativePath(""), productName: "LocalPackage"), path: path)
-        let rhs = PackageNode(packageType: .local(path: RelativePath(""), productName: "LocalPackage"), path: path)
+        let lhs = PackageNode(package: .local(path: RelativePath("")), path: path)
+        let rhs = PackageNode(package: .local(path: RelativePath("")), path: path)
 
         // Then
         XCTAssertEqual(lhs, rhs)
@@ -51,8 +51,8 @@ final class PackageNodeTests: XCTestCase {
 
     func test_remotePackage_isEqual_returnsFalse_when_thePathsAreTheSame() {
         // Given
-        let lhs = PackageNode(packageType: .remote(url: "url", productName: "RemotePackage", versionRequirement: .branch("master")), path: AbsolutePath("/"))
-        let rhs = PackageNode(packageType: .remote(url: "url", productName: "RemotePackage", versionRequirement: .branch("master")), path: AbsolutePath("/other"))
+        let lhs = PackageNode(package: .remote(url: "url", requirement: .branch("master")), path: AbsolutePath("/"))
+        let rhs = PackageNode(package: .remote(url: "url", requirement: .branch("master")), path: AbsolutePath("/other"))
 
         // Then
         XCTAssertNotEqual(lhs, rhs)
@@ -60,8 +60,8 @@ final class PackageNodeTests: XCTestCase {
 
     func test_localPackage_isEqual_returnsFalse_when_thePathsAreTheSame() {
         // Given
-        let lhs = PackageNode(packageType: .local(path: RelativePath(""), productName: "LocalPackage"), path: AbsolutePath("/"))
-        let rhs = PackageNode(packageType: .local(path: RelativePath(""), productName: "LocalPackage"), path: AbsolutePath("/other"))
+        let lhs = PackageNode(package: .local(path: RelativePath("")), path: AbsolutePath("/"))
+        let rhs = PackageNode(package: .local(path: RelativePath("")), path: AbsolutePath("/other"))
 
         // Then
         XCTAssertNotEqual(lhs, rhs)

--- a/Tests/TuistGeneratorTests/Graph/TestData/Graph+TestData.swift
+++ b/Tests/TuistGeneratorTests/Graph/TestData/Graph+TestData.swift
@@ -85,14 +85,14 @@ extension Graph {
             node.dependencies.append(contentsOf: sdkDependencies.compactMap {
                 try? SDKNode(name: $0.name, platform: platform, status: $0.status)
             })
-            let packageDependencies: [Dependency.PackageType] = $0.target.dependencies.compactMap {
+            let packageDependencies: [String] = $0.target.dependencies.compactMap {
                 if case let .package(packageType) = $0 {
                     return packageType
                 }
                 return nil
             }
             node.dependencies.append(contentsOf: packageDependencies.map {
-                PackageNode(packageType: $0, path: node.path)
+                PackageDependencyNode(product: $0, path: node.path)
             })
         }
 

--- a/Tests/TuistGeneratorTests/Models/TestData/Project+TestData.swift
+++ b/Tests/TuistGeneratorTests/Models/TestData/Project+TestData.swift
@@ -9,6 +9,7 @@ extension Project {
                      settings: Settings = Settings.test(),
                      filesGroup: ProjectGroup = .group(name: "Project"),
                      targets: [Target] = [Target.test()],
+                     packages: [Package] = [],
                      schemes: [Scheme] = [],
                      additionalFiles: [FileElement] = []) -> Project {
         return Project(path: path,
@@ -17,6 +18,7 @@ extension Project {
                        settings: settings,
                        filesGroup: filesGroup,
                        targets: targets,
+                       packages: packages,
                        schemes: schemes,
                        additionalFiles: additionalFiles)
     }
@@ -26,6 +28,7 @@ extension Project {
                       settings: Settings = .default,
                       filesGroup: ProjectGroup = .group(name: "Project"),
                       targets: [Target] = [],
+                      packages: [Package] = [],
                       schemes: [Scheme] = [],
                       additionalFiles: [FileElement] = []) -> Project {
         return Project(path: path,
@@ -33,6 +36,7 @@ extension Project {
                        settings: settings,
                        filesGroup: filesGroup,
                        targets: targets,
+                       packages: packages,
                        schemes: schemes,
                        additionalFiles: additionalFiles)
     }

--- a/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -331,12 +331,13 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         return Workspace(name: "Workspace", projects: try projects.map { try pathTo($0) })
     }
 
-    private func createProject(path: AbsolutePath, settings: Settings, targets: [Target], schemes: [Scheme]) -> Project {
+    private func createProject(path: AbsolutePath, settings: Settings, targets: [Target], packages: [Package] = [ ], schemes: [Scheme]) -> Project {
         return Project(path: path,
                        name: "App",
                        settings: settings,
                        filesGroup: .group(name: "Project"),
                        targets: targets,
+                       packages: packages,
                        schemes: schemes)
     }
 

--- a/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
@@ -99,12 +99,13 @@ final class StableXcodeProjIntegrationTests: TuistUnitTestCase {
         return Workspace(name: "Workspace", projects: try projects.map { try pathTo($0) })
     }
 
-    private func createProject(path: AbsolutePath, settings: Settings, targets: [Target], schemes: [Scheme]) -> Project {
+    private func createProject(path: AbsolutePath, settings: Settings, targets: [Target], packages: [Package] = [ ], schemes: [Scheme]) -> Project {
         return Project(path: path,
                        name: "App",
                        settings: settings,
                        filesGroup: .group(name: "Project"),
                        targets: targets,
+                       packages: packages,
                        schemes: schemes,
                        additionalFiles: createAdditionalFiles())
     }

--- a/Tests/TuistKitIntegrationTests/Commands/DumpCommandIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Commands/DumpCommandIntegrationTests.swift
@@ -44,7 +44,7 @@ final class DumpCommandTests: TuistTestCase {
                          encoding: .utf8)
         let result = try parser.parse([DumpCommand.command, "-p", tmpDir.path.pathString])
         try subject.run(with: result)
-        let expected = "{\n  \"additionalFiles\": [\n\n  ],\n  \"name\": \"tuist\",\n  \"schemes\": [\n\n  ],\n  \"targets\": [\n\n  ]\n}\n"
+        let expected = "{\n  \"additionalFiles\": [\n\n  ],\n  \"name\": \"tuist\",\n  \"packages\": [\n\n  ],\n  \"schemes\": [\n\n  ],\n  \"targets\": [\n\n  ]\n}\n"
 
         XCTAssertPrinterOutputContains(expected)
     }

--- a/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
+++ b/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
@@ -366,41 +366,19 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
 
     func test_dependency_when_localPackage() {
         // Given
-        let dependency = TargetDependency.package(path: "package", productName: "library")
+        let dependency = TargetDependency.package(product: "library")
 
         // When
         let got = TuistGenerator.Dependency.from(manifest: dependency)
 
         // Then
         guard
-            case let .package(packageType) = got,
-            case let .local(path: path, productName: productName) = packageType
+            case let .package(product) = got
         else {
-            XCTFail("Dependency should be local package")
+            XCTFail("Dependency should be package")
             return
         }
-        XCTAssertEqual(path, RelativePath("package"))
-        XCTAssertEqual(productName, "library")
-    }
-
-    func test_depedency_when_remotePackage() throws {
-        // Given
-        let dependency = TargetDependency.package(url: "url", productName: "library", .branch("master"))
-
-        // When
-        let got = TuistGenerator.Dependency.from(manifest: dependency)
-
-        // Then
-        guard
-            case let .package(packageType) = got,
-            case let .remote(url: url, productName: productName, versionRequirement: versionRequirement) = packageType
-        else {
-            XCTFail("Dependency should be remote package")
-            return
-        }
-        XCTAssertEqual(url, "url")
-        XCTAssertEqual(productName, "library")
-        XCTAssertEqual(versionRequirement, .branch("master"))
+        XCTAssertEqual(product, "library")
     }
 
     func test_headers() throws {

--- a/fixtures/ios_app_with_local_swift_package/Frameworks/FrameworkA/Project.swift
+++ b/fixtures/ios_app_with_local_swift_package/Frameworks/FrameworkA/Project.swift
@@ -2,6 +2,9 @@ import ProjectDescription
 
 let project = Project(
     name: "FrameworkA",
+    packages: [
+        .package(path: "../../Packages/PackageA")
+    ],
     targets: [
         Target(name: "FrameworkA",
                platform: .iOS,
@@ -10,7 +13,7 @@ let project = Project(
                infoPlist: "Config/FrameworkA-Info.plist",
                sources: "Sources/**",
                dependencies: [
-                   .package(path: "../../Packages/PackageA", productName: "LibraryA"),
+                   .package(product: "LibraryA"),
         ]),
     ]
 )

--- a/fixtures/ios_app_with_local_swift_package/Project.swift
+++ b/fixtures/ios_app_with_local_swift_package/Project.swift
@@ -1,6 +1,9 @@
 import ProjectDescription
 
 let project = Project(name: "App",
+                      packages: [
+                        .package(path: "Packages/PackageA")
+                      ],
                       targets: [
                         Target(name: "App",
                                platform: .iOS,
@@ -14,8 +17,8 @@ let project = Project(name: "App",
                                ],
                                dependencies: [
                                     .project(target: "FrameworkA", path: "Frameworks/FrameworkA"),
-                                    .package(path: "Packages/PackageA", productName: "LibraryA"),
-                                    .package(path: "Packages/PackageA", productName: "LibraryB"),
+                                    .package(product: "LibraryA"),
+                                    .package(product: "LibraryB"),
                                 ]),
                         Target(name: "AppTests",
                                platform: .iOS,

--- a/fixtures/ios_app_with_remote_swift_package/.package.resolved
+++ b/fixtures/ios_app_with_remote_swift_package/.package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "RxSwift",
+        "repositoryURL": "https://github.com/ReactiveX/RxSwift",
+        "state": {
+          "branch": null,
+          "revision": "b3e888b4972d9bc76495dd74d30a8c7fad4b9395",
+          "version": "5.0.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/fixtures/ios_app_with_remote_swift_package/Project.swift
+++ b/fixtures/ios_app_with_remote_swift_package/Project.swift
@@ -1,6 +1,9 @@
 import ProjectDescription
 
 let project = Project(name: "App",
+                      packages: [
+                        .package(url: "https://github.com/ReactiveX/RxSwift", .upToNextMajor(from: "5.0.0")),
+                      ],
                       targets: [
                         Target(name: "App",
                                platform: .iOS,
@@ -13,7 +16,8 @@ let project = Project(name: "App",
                                        // "Resources/**"
                                ],
                                dependencies: [
-                                    .package(url: "https://github.com/ReactiveX/RxSwift", productName: "RxSwift", .upToNextMajor(from: "5.0.0")),
+                                    .package(product: "RxSwift"),
+                                    .package(product: "RxBlocking")
                                 ]),
                         Target(name: "AppTests",
                                platform: .iOS,

--- a/fixtures/ios_app_with_remote_swift_package/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_remote_swift_package/Sources/AppDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 import RxSwift
+import RxBlocking
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -11,7 +12,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
     ) -> Bool {
         // To make sure RxSwift is available
-        let observable = Observable.just("Test")
+        let observable = RxSwift.Observable.just("Test")
+        
+        let result = RxBlocking.MaterializedSequenceResult.completed(elements: [1, 2])
         
         window = UIWindow(frame: UIScreen.main.bounds)
         let viewController = UIViewController()


### PR DESCRIPTION
### Short description 📝

With the previous API it was difficult to define multiple dependencies to a swift package resulting in manifests looking like the following:

```swift
Target(
    dependencies: [
        .target(name: "..."),
        .package(url: "https://github.com/Quick/Quick", productName: "Quick", from: "2.2.0"),
        .package(url: "https://github.com/Quick/Nimble", productName: "Nimble", from: "8.0.4"),
        .package(url: "https://github.com/ReactiveX/RxSwift", productName: "RxTest", from: "5.0.1"),
        .package(url: "https://github.com/ReactiveX/RxSwift", productName: "RxBlocking", from: "5.0.1"),
    ]
)
```

Thanks for raising this `André Patrício` (Slack).

### Solution 📦

Taking influence from SwiftPM who split the package depdendencies from the target dependencies I have been able to define the following API:

```swift
import ProjectDescription

let project = Project(
    name: "App",
    packages: [
        .package(url: "https://github.com/Quick/Quick", .upToNextMajor(from: "2.2.0")),
        .package(url: "https://github.com/Quick/Nimble", .upToNextMajor(from: "8.0.4")),
        .package(url: "https://github.com/ReactiveX/RxSwift", .upToNextMajor(from: "5.0.1")),
    ],
    targets: [
        Target(
            name: "App",
            platform: .iOS,
            product: .app,
            bundleId: "io.tuist.App",
            infoPlist: "Support/Info.plist",
            sources: ["Sources/**"],
            dependencies: [
                .package(product: "Quick"),
                .package(product: "Nimble"),
                .package(product: "RxSwift"),
                .package(product: "RxBlocking")
        ])
])
```

The implementation has only changed to support the new API and at the core of it there is no change. 
