### PR TITLE
Add dependabot configuration

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,30 @@
+version: 1
+update_configs:
+  - package_manager: 'ruby:bundler'
+    directory: '/'
+    update_schedule: 'weekly'
+    default_reviewers:
+      - 'tuist/core'
+    default_labels:
+      - 'dependencies'
+  - package_manager: 'javascript'
+    directory: '/docs'
+    update_schedule: 'weekly'
+    default_reviewers:
+      - 'tuist/core'
+    default_labels:
+      - 'dependencies'
+  - package_manager: 'javascript'
+    directory: '/website'
+    update_schedule: 'weekly'
+    default_reviewers:
+      - 'tuist/core'
+    default_labels:
+      - 'dependencies'
+  - package_manager: 'ruby:bundler'
+    directory: '/galaxy'
+    update_schedule: 'weekly'
+    default_reviewers:
+      - 'tuist/core'
+    default_labels:
+      - 'dependencies'


### PR DESCRIPTION
### Short description 📝
Dependabot is a great tool to keep up with dependency updates, but it can be a bit noisy when it's not configured properly.

### Solution 📦
This PR adds a configuration file to configure Dependabot to run weekly instead of live. Moreover, it sets `tuist/core` as a default reviewer.