### PR TITLE
Change Object Version Behaviour to Mimic Xcode 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Changed
 
 - Introduce `Systems.shared`, `TuistTestCase`, and `TuistUnitTestCase` https://github.com/tuist/tuist/pull/519 by @pepibumur.
+- Change generated object version behaviour to mimic Xcode 11 by @adamkhazi
 
 ### Fixed
 

--- a/Sources/TuistGenerator/Generator/ProjectGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGenerator.swift
@@ -91,7 +91,7 @@ final class ProjectGenerator: ProjectGenerating {
 
         let workspaceData = XCWorkspaceData(children: [])
         let workspace = XCWorkspace(data: workspaceData)
-        let projectConstants = try determineProjectConstants()
+        let projectConstants = try determineProjectConstants(graph: graph)
         let pbxproj = PBXProj(objectVersion: projectConstants.objectVersion,
                               archiveVersion: projectConstants.archiveVersion,
                               classes: [:])
@@ -252,10 +252,8 @@ final class ProjectGenerator: ProjectGenerating {
                                                    generatedProject: generatedProject)
     }
 
-    private func determineProjectConstants() throws -> ProjectConstants {
-        let version = try XcodeController.shared.selectedVersion()
-
-        if version.major >= 11 {
+    private func determineProjectConstants(graph: Graphing) throws -> ProjectConstants {
+        if !graph.packages.isEmpty {
             return .xcode11
         } else {
             return .xcode10

--- a/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
@@ -168,6 +168,39 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
         XCTAssertEqual(got.path.components.last, "SomeAwesomeName.xcodeproj")
         XCTAssertEqual(project.name, "Project")
     }
+    
+    func test_objectVersion_when_xcode11_and_spm() throws {
+        xcodeController.selectedVersionStub = .success(Version(11, 0, 0))
+
+        // Given
+        let temporaryPath = try self.temporaryPath()
+        let project = Project.test(path: temporaryPath,
+                                   name: "Project",
+                                   fileName: "SomeAwesomeName",
+                                   targets: [.test(dependencies: [.package(.remote(url: "A",
+                                                                                   productName: "A",
+                                                                                   versionRequirement: .exact("0.1")))])])
+        
+        let target = Target.test()
+        let cache = GraphLoaderCache()
+        let packageNode = PackageNode(packageType: .remote(url: "A",
+                                                           productName: "A",
+                                                           versionRequirement: .exact("0.1")),
+                                                           path: temporaryPath)
+        cache.add(package: packageNode)
+        let graph = Graph.test(entryPath: temporaryPath,
+                               cache: cache,
+                               entryNodes: [TargetNode(project: project,
+                                                       target: target,
+                                                       dependencies: [packageNode])])
+
+        // When
+        let got = try subject.generate(project: project, graph: graph)
+
+        // Then
+        XCTAssertEqual(got.pbxproj.objectVersion, 52)
+        XCTAssertEqual(got.pbxproj.archiveVersion, Xcode.LastKnown.archiveVersion)
+    }
 
     func test_objectVersion_when_xcode11() throws {
         xcodeController.selectedVersionStub = .success(Version(11, 0, 0))
@@ -184,7 +217,7 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
         let got = try subject.generate(project: project, graph: graph)
 
         // Then
-        XCTAssertEqual(got.pbxproj.objectVersion, 52)
+        XCTAssertEqual(got.pbxproj.objectVersion, 50)
         XCTAssertEqual(got.pbxproj.archiveVersion, Xcode.LastKnown.archiveVersion)
     }
 

--- a/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
@@ -168,7 +168,7 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
         XCTAssertEqual(got.path.components.last, "SomeAwesomeName.xcodeproj")
         XCTAssertEqual(project.name, "Project")
     }
-    
+
     func test_objectVersion_when_xcode11_and_spm() throws {
         xcodeController.selectedVersionStub = .success(Version(11, 0, 0))
 
@@ -180,13 +180,13 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
                                    targets: [.test(dependencies: [.package(.remote(url: "A",
                                                                                    productName: "A",
                                                                                    versionRequirement: .exact("0.1")))])])
-        
+
         let target = Target.test()
         let cache = GraphLoaderCache()
         let packageNode = PackageNode(packageType: .remote(url: "A",
                                                            productName: "A",
                                                            versionRequirement: .exact("0.1")),
-                                                           path: temporaryPath)
+                                      path: temporaryPath)
         cache.add(package: packageNode)
         let graph = Graph.test(entryPath: temporaryPath,
                                cache: cache,


### PR DESCRIPTION
### Short description 📝

Use `objectVersion = 52` only when Swift Package Manager dependencies exist in the project. This is mimicking Xcode 11 behaviour. If a new Xcode project is created with Xcode 11 without SPM dependencies then use `objectVersion = 50` by default.

### Solution 📦

Check `graph.packages` for SPM dependencies and alter `ObjectVersion` accordingly.

### Implementation 👩‍💻👨‍💻

- [X] Check `graph.packages` for SPM dependencies
- [X] Write test
