### PR TITLE
Support relative paths from current file and the manifest's directory

### DIFF
--- a/Sources/ProjectDescription/CoreDataModel.swift
+++ b/Sources/ProjectDescription/CoreDataModel.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Core Data model.
 public class CoreDataModel: Codable {
     /// Relative path to the model.
-    public let path: String
+    public let path: Path
 
     /// Current version (with or without extension)
     public let currentVersion: String
@@ -18,7 +18,7 @@ public class CoreDataModel: Codable {
     /// - Parameters:
     ///   - path: relative path to the Core Data model.
     ///   - currentVersion: current version name (with or without the extension).
-    public init(_ path: String,
+    public init(_ path: Path,
                 currentVersion: String) {
         self.path = path
         self.currentVersion = currentVersion

--- a/Sources/ProjectDescription/Dump.swift
+++ b/Sources/ProjectDescription/Dump.swift
@@ -2,7 +2,7 @@ import Foundation
 
 func dumpIfNeeded<E: Encodable>(_ entity: E) {
     if CommandLine.argc > 0 {
-        if CommandLine.arguments.contains("--dump") {
+        if CommandLine.arguments.contains("--tuist-dump") {
             let encoder = JSONEncoder()
             // swiftlint:disable:next force_try
             let data = try! encoder.encode(entity)

--- a/Sources/ProjectDescription/FileElement.swift
+++ b/Sources/ProjectDescription/FileElement.swift
@@ -9,11 +9,11 @@ import Foundation
 ///       `"some/pattern/**"` is the equivalent of `FileElement.glob(pattern: "some/pattern/**")`
 public enum FileElement: Codable {
     /// A glob pattern of files to include
-    case glob(pattern: String)
+    case glob(pattern: Path)
 
     /// Relative path to a directory to include
     /// as a folder reference
-    case folderReference(path: String)
+    case folderReference(path: Path)
 
     private enum TypeName: String, Codable {
         case glob
@@ -41,10 +41,10 @@ public enum FileElement: Codable {
         switch type {
         case .glob:
             let pattern = try container.decode(String.self, forKey: .pattern)
-            self = .glob(pattern: pattern)
+            self = .glob(pattern: Path(pattern))
         case .folderReference:
             let path = try container.decode(String.self, forKey: .path)
-            self = .folderReference(path: path)
+            self = .folderReference(path: Path(path))
         }
     }
 
@@ -62,7 +62,7 @@ public enum FileElement: Codable {
 
 extension FileElement: ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
-        self = .glob(pattern: value)
+        self = .glob(pattern: Path(value))
     }
 }
 
@@ -78,6 +78,6 @@ extension Array: ExpressibleByStringLiteral where Element == FileElement {
     public typealias StringLiteralType = String
 
     public init(stringLiteral value: String) {
-        self = [.glob(pattern: value)]
+        self = [.glob(pattern: Path(value))]
     }
 }

--- a/Sources/ProjectDescription/FileList.swift
+++ b/Sources/ProjectDescription/FileList.swift
@@ -2,24 +2,24 @@ import Foundation
 
 public final class FileList: Codable {
     /// List glob patterns.
-    public let globs: [String]
+    public let globs: [Path]
 
     /// Initializes the files list with the glob patterns.
     ///
     /// - Parameter globs: Glob patterns.
-    public init(globs: [String]) {
+    public init(globs: [Path]) {
         self.globs = globs
     }
 }
 
 extension FileList: ExpressibleByStringLiteral {
     public convenience init(stringLiteral value: String) {
-        self.init(globs: [value])
+        self.init(globs: [Path(value)])
     }
 }
 
 extension FileList: ExpressibleByArrayLiteral {
     public convenience init(arrayLiteral elements: String...) {
-        self.init(globs: elements)
+        self.init(globs: elements.map { Path($0) })
     }
 }

--- a/Sources/ProjectDescription/Package.swift
+++ b/Sources/ProjectDescription/Package.swift
@@ -6,7 +6,7 @@
 ///     - local: A relative path to the package.
 public enum Package: Equatable, Codable {
     case remote(url: String, requirement: Requirement)
-    case local(path: String)
+    case local(path: Path)
 
     private enum Kind: String, Codable {
         case remote
@@ -31,7 +31,7 @@ public enum Package: Equatable, Codable {
             self = .remote(url: url, requirement: requirement)
         case .local:
             let path = try container.decode(String.self, forKey: .path)
-            self = .local(path: path)
+            self = .local(path: Path(path))
         }
     }
 
@@ -223,7 +223,7 @@ extension Package {
     public static func package(
         path: String
     ) -> Package {
-        return .local(path: path)
+        return .local(path: Path(path))
     }
 }
 

--- a/Sources/ProjectDescription/Path.swift
+++ b/Sources/ProjectDescription/Path.swift
@@ -1,0 +1,596 @@
+// PathKit - Effortless path operations
+// https://github.com/kylef/PathKit
+import Darwin
+
+let system_glob = Darwin.glob
+import Foundation
+
+/// Represents a filesystem path.
+public struct Path {
+    /// The character used by the OS to separate two path elements
+    static let separator = "/"
+
+    /// The underlying string representation
+    internal var path: String
+
+    internal static var fileManager = FileManager.default
+
+    // MARK: Init
+
+    public init() {
+        path = ""
+    }
+
+    /// Create a Path from a given String
+    public init(_ path: String) {
+        self.path = path
+    }
+
+    /// Create a Path by joining multiple path components together
+    public init<S: Collection>(components: S) where S.Iterator.Element == String {
+        if components.isEmpty {
+            path = "."
+        } else if components.first == Path.separator, components.count > 1 {
+            let p = components.joined(separator: Path.separator)
+            path = String(p[p.index(after: p.startIndex)...])
+        } else {
+            path = components.joined(separator: Path.separator)
+        }
+    }
+}
+
+// MARK: StringLiteralConvertible
+
+extension Path: ExpressibleByStringLiteral {
+    public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
+    public typealias UnicodeScalarLiteralType = StringLiteralType
+
+    public init(extendedGraphemeClusterLiteral path: StringLiteralType) {
+        self.init(stringLiteral: path)
+    }
+
+    public init(unicodeScalarLiteral path: StringLiteralType) {
+        self.init(stringLiteral: path)
+    }
+
+    public init(stringLiteral value: StringLiteralType) {
+        path = value
+    }
+}
+
+// MARK: CustomStringConvertible
+
+extension Path: CustomStringConvertible {
+    public var description: String {
+        return path
+    }
+}
+
+// MARK: Conversion
+
+extension Path {
+    public var string: String {
+        return path
+    }
+
+    public var url: URL {
+        return URL(fileURLWithPath: path)
+    }
+}
+
+// MARK: Hashable
+
+extension Path: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(path.hashValue)
+    }
+}
+
+// MARK: Path Info
+
+extension Path {
+    /// Test whether a path is absolute.
+    ///
+    /// - Returns: `true` iff the path begins with a slash
+    ///
+    public var isAbsolute: Bool {
+        return path.hasPrefix(Path.separator)
+    }
+
+    /// Test whether a path is relative.
+    ///
+    /// - Returns: `true` iff a path is relative (not absolute)
+    ///
+    public var isRelative: Bool {
+        return !isAbsolute
+    }
+
+    /// Concatenates relative paths to the current directory and derives the normalized path
+    ///
+    /// - Returns: the absolute path in the actual filesystem
+    ///
+    public func absolute() -> Path {
+        if isAbsolute {
+            return normalize()
+        }
+
+        let expandedPath = Path(NSString(string: path).expandingTildeInPath)
+        if expandedPath.isAbsolute {
+            return expandedPath.normalize()
+        }
+
+        return (Path.current + self).normalize()
+    }
+
+    /// Normalizes the path, this cleans up redundant ".." and ".", double slashes
+    /// and resolves "~".
+    ///
+    /// - Returns: a new path made by removing extraneous path components from the underlying String
+    ///   representation.
+    ///
+    public func normalize() -> Path {
+        return Path(NSString(string: path).standardizingPath)
+    }
+}
+
+// MARK: Path Components
+
+extension Path {
+    /// The last path component
+    ///
+    /// - Returns: the last path component
+    ///
+    public var lastComponent: String {
+        return NSString(string: path).lastPathComponent
+    }
+
+    /// The last path component without file extension
+    ///
+    /// - Note: This returns "." for ".." on Linux, and ".." on Apple platforms.
+    ///
+    /// - Returns: the last path component without file extension
+    ///
+    public var lastComponentWithoutExtension: String {
+        return NSString(string: lastComponent).deletingPathExtension
+    }
+
+    /// Splits the string representation on the directory separator.
+    /// Absolute paths remain the leading slash as first component.
+    ///
+    /// - Returns: all path components
+    ///
+    public var components: [String] {
+        return NSString(string: path).pathComponents
+    }
+
+    /// The file extension behind the last dot of the last component.
+    ///
+    /// - Returns: the file extension
+    ///
+    public var `extension`: String? {
+        let pathExtension = NSString(string: path).pathExtension
+        if pathExtension.isEmpty {
+            return nil
+        }
+
+        return pathExtension
+    }
+}
+
+// MARK: File Info
+
+extension Path {
+    /// Test whether a file or directory exists at a specified path
+    ///
+    /// - Returns: `false` iff the path doesn't exist on disk or its existence could not be
+    ///   determined
+    ///
+    public var exists: Bool {
+        return Path.fileManager.fileExists(atPath: path)
+    }
+
+    /// Test whether a path is a directory.
+    ///
+    /// - Returns: `true` if the path is a directory or a symbolic link that points to a directory;
+    ///   `false` if the path is not a directory or the path doesn't exist on disk or its existence
+    ///   could not be determined
+    ///
+    public var isDirectory: Bool {
+        var directory = ObjCBool(false)
+        guard Path.fileManager.fileExists(atPath: normalize().path, isDirectory: &directory) else {
+            return false
+        }
+        return directory.boolValue
+    }
+
+    /// Test whether a path is a regular file.
+    ///
+    /// - Returns: `true` if the path is neither a directory nor a symbolic link that points to a
+    ///   directory; `false` if the path is a directory or a symbolic link that points to a
+    ///   directory or the path doesn't exist on disk or its existence
+    ///   could not be determined
+    ///
+    public var isFile: Bool {
+        var directory = ObjCBool(false)
+        guard Path.fileManager.fileExists(atPath: normalize().path, isDirectory: &directory) else {
+            return false
+        }
+        return !directory.boolValue
+    }
+
+    /// Test whether a path is a symbolic link.
+    ///
+    /// - Returns: `true` if the path is a symbolic link; `false` if the path doesn't exist on disk
+    ///   or its existence could not be determined
+    ///
+    public var isSymlink: Bool {
+        do {
+            _ = try Path.fileManager.destinationOfSymbolicLink(atPath: path)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// Test whether a path is readable
+    ///
+    /// - Returns: `true` if the current process has read privileges for the file at path;
+    ///   otherwise `false` if the process does not have read privileges or the existence of the
+    ///   file could not be determined.
+    ///
+    public var isReadable: Bool {
+        return Path.fileManager.isReadableFile(atPath: path)
+    }
+
+    /// Test whether a path is writeable
+    ///
+    /// - Returns: `true` if the current process has write privileges for the file at path;
+    ///   otherwise `false` if the process does not have write privileges or the existence of the
+    ///   file could not be determined.
+    ///
+    public var isWritable: Bool {
+        return Path.fileManager.isWritableFile(atPath: path)
+    }
+
+    /// Test whether a path is executable
+    ///
+    /// - Returns: `true` if the current process has execute privileges for the file at path;
+    ///   otherwise `false` if the process does not have execute privileges or the existence of the
+    ///   file could not be determined.
+    ///
+    public var isExecutable: Bool {
+        return Path.fileManager.isExecutableFile(atPath: path)
+    }
+
+    /// Test whether a path is deletable
+    ///
+    /// - Returns: `true` if the current process has delete privileges for the file at path;
+    ///   otherwise `false` if the process does not have delete privileges or the existence of the
+    ///   file could not be determined.
+    ///
+    public var isDeletable: Bool {
+        return Path.fileManager.isDeletableFile(atPath: path)
+    }
+}
+
+// MARK: File Manipulation
+
+extension Path {
+    /// Create the directory.
+    ///
+    /// - Note: This method fails if any of the intermediate parent directories does not exist.
+    ///   This method also fails if any of the intermediate path elements corresponds to a file and
+    ///   not a directory.
+    ///
+    public func mkdir() throws {
+        try Path.fileManager.createDirectory(atPath: path, withIntermediateDirectories: false, attributes: nil)
+    }
+
+    /// Create the directory and any intermediate parent directories that do not exist.
+    ///
+    /// - Note: This method fails if any of the intermediate path elements corresponds to a file and
+    ///   not a directory.
+    ///
+    public func mkpath() throws {
+        try Path.fileManager.createDirectory(atPath: path, withIntermediateDirectories: true, attributes: nil)
+    }
+
+    /// Delete the file or directory.
+    ///
+    /// - Note: If the path specifies a directory, the contents of that directory are recursively
+    ///   removed.
+    ///
+    public func delete() throws {
+        try Path.fileManager.removeItem(atPath: path)
+    }
+
+    /// Move the file or directory to a new location synchronously.
+    ///
+    /// - Parameter destination: The new path. This path must include the name of the file or
+    ///   directory in its new location.
+    ///
+    public func move(_ destination: Path) throws {
+        try Path.fileManager.moveItem(atPath: path, toPath: destination.path)
+    }
+
+    /// Copy the file or directory to a new location synchronously.
+    ///
+    /// - Parameter destination: The new path. This path must include the name of the file or
+    ///   directory in its new location.
+    ///
+    public func copy(_ destination: Path) throws {
+        try Path.fileManager.copyItem(atPath: path, toPath: destination.path)
+    }
+
+    /// Creates a hard link at a new destination.
+    ///
+    /// - Parameter destination: The location where the link will be created.
+    ///
+    public func link(_ destination: Path) throws {
+        try Path.fileManager.linkItem(atPath: path, toPath: destination.path)
+    }
+
+    /// Creates a symbolic link at a new destination.
+    ///
+    /// - Parameter destintation: The location where the link will be created.
+    ///
+    public func symlink(_ destination: Path) throws {
+        try Path.fileManager.createSymbolicLink(atPath: path, withDestinationPath: destination.path)
+    }
+}
+
+// MARK: Current Directory
+
+extension Path {
+    /// The current working directory of the process
+    ///
+    /// - Returns: the current working directory of the process
+    ///
+    public static var current: Path {
+        get {
+            return self.init(Path.fileManager.currentDirectoryPath)
+        }
+        set {
+            _ = Path.fileManager.changeCurrentDirectoryPath(newValue.description)
+        }
+    }
+}
+
+// MARK: Traversing
+
+extension Path {
+    /// Get the parent directory
+    ///
+    /// - Returns: the normalized path of the parent directory
+    ///
+    public func parent() -> Path {
+        return self + ".."
+    }
+
+    /// Performs a shallow enumeration in a directory
+    ///
+    /// - Returns: paths to all files, directories and symbolic links contained in the directory
+    ///
+    public func children() throws -> [Path] {
+        return try Path.fileManager.contentsOfDirectory(atPath: path).map {
+            self + Path($0)
+        }
+    }
+
+    /// Performs a deep enumeration in a directory
+    ///
+    /// - Returns: paths to all files, directories and symbolic links contained in the directory or
+    ///   any subdirectory.
+    ///
+    public func recursiveChildren() throws -> [Path] {
+        return try Path.fileManager.subpathsOfDirectory(atPath: path).map {
+            self + Path($0)
+        }
+    }
+}
+
+// MARK: Globbing
+
+extension Path {
+    public static func glob(_ pattern: String) -> [Path] {
+        var gt = glob_t()
+        let cPattern = strdup(pattern)
+        defer {
+            globfree(&gt)
+            free(cPattern)
+        }
+
+        let flags = GLOB_TILDE | GLOB_BRACE | GLOB_MARK
+        if system_glob(cPattern, flags, nil, &gt) == 0 {
+            let matchc = gt.gl_matchc
+
+            return (0 ..< Int(matchc)).compactMap { index in
+                if let path = String(validatingUTF8: gt.gl_pathv[index]!) {
+                    return Path(path)
+                }
+
+                return nil
+            }
+        }
+
+        // GLOB_NOMATCH
+        return []
+    }
+
+    public func glob(_ pattern: String) -> [Path] {
+        return Path.glob((self + pattern).description)
+    }
+}
+
+// MARK: SequenceType
+
+extension Path: Sequence {
+    public struct DirectoryEnumerationOptions: OptionSet {
+        public let rawValue: UInt
+        public init(rawValue: UInt) {
+            self.rawValue = rawValue
+        }
+
+        public static var skipsSubdirectoryDescendants = DirectoryEnumerationOptions(rawValue: FileManager.DirectoryEnumerationOptions.skipsSubdirectoryDescendants.rawValue)
+        public static var skipsPackageDescendants = DirectoryEnumerationOptions(rawValue: FileManager.DirectoryEnumerationOptions.skipsPackageDescendants.rawValue)
+        public static var skipsHiddenFiles = DirectoryEnumerationOptions(rawValue: FileManager.DirectoryEnumerationOptions.skipsHiddenFiles.rawValue)
+    }
+
+    /// Represents a path sequence with specific enumeration options
+    public struct PathSequence: Sequence {
+        private var path: Path
+        private var options: DirectoryEnumerationOptions
+        init(path: Path, options: DirectoryEnumerationOptions) {
+            self.path = path
+            self.options = options
+        }
+
+        public func makeIterator() -> DirectoryEnumerator {
+            return DirectoryEnumerator(path: path, options: options)
+        }
+    }
+
+    /// Enumerates the contents of a directory, returning the paths of all files and directories
+    /// contained within that directory. These paths are relative to the directory.
+    public struct DirectoryEnumerator: IteratorProtocol {
+        public typealias Element = Path
+
+        let path: Path
+        let directoryEnumerator: FileManager.DirectoryEnumerator?
+
+        init(path: Path, options mask: DirectoryEnumerationOptions = []) {
+            let options = FileManager.DirectoryEnumerationOptions(rawValue: mask.rawValue)
+            self.path = path
+            directoryEnumerator = Path.fileManager.enumerator(at: path.url, includingPropertiesForKeys: nil, options: options)
+        }
+
+        public func next() -> Path? {
+            let next = directoryEnumerator?.nextObject()
+
+            if let next = next as? URL {
+                return Path(next.path)
+            }
+            return nil
+        }
+
+        /// Skip recursion into the most recently obtained subdirectory.
+        public func skipDescendants() {
+            directoryEnumerator?.skipDescendants()
+        }
+    }
+
+    /// Perform a deep enumeration of a directory.
+    ///
+    /// - Returns: a directory enumerator that can be used to perform a deep enumeration of the
+    ///   directory.
+    ///
+    public func makeIterator() -> DirectoryEnumerator {
+        return DirectoryEnumerator(path: self)
+    }
+
+    /// Perform a deep enumeration of a directory.
+    ///
+    /// - Parameter options: FileManager directory enumerator options.
+    ///
+    /// - Returns: a path sequence that can be used to perform a deep enumeration of the
+    ///   directory.
+    ///
+    public func iterateChildren(options: DirectoryEnumerationOptions = []) -> PathSequence {
+        return PathSequence(path: self, options: options)
+    }
+}
+
+// MARK: Equatable
+
+extension Path: Equatable {}
+
+/// Determines if two paths are identical
+///
+/// - Note: The comparison is string-based. Be aware that two different paths (foo.txt and
+///   ./foo.txt) can refer to the same file.
+///
+public func == (lhs: Path, rhs: Path) -> Bool {
+    return lhs.path == rhs.path
+}
+
+// MARK: Pattern Matching
+
+/// Implements pattern-matching for paths.
+///
+/// - Returns: `true` iff one of the following conditions is true:
+///     - the paths are equal (based on `Path`'s `Equatable` implementation)
+///     - the paths can be normalized to equal Paths.
+///
+public func ~= (lhs: Path, rhs: Path) -> Bool {
+    return lhs == rhs
+        || lhs.normalize() == rhs.normalize()
+}
+
+// MARK: Comparable
+
+extension Path: Comparable {}
+
+/// Defines a strict total order over Paths based on their underlying string representation.
+public func < (lhs: Path, rhs: Path) -> Bool {
+    return lhs.path < rhs.path
+}
+
+// MARK: Operators
+
+/// Appends a Path fragment to another Path to produce a new Path
+public func + (lhs: Path, rhs: Path) -> Path {
+    return lhs.path + rhs.path
+}
+
+/// Appends a String fragment to another Path to produce a new Path
+public func + (lhs: Path, rhs: String) -> Path {
+    return lhs.path + rhs
+}
+
+/// Appends a String fragment to another String to produce a new Path
+internal func + (lhs: String, rhs: String) -> Path {
+    if rhs.hasPrefix(Path.separator) {
+        // Absolute paths replace relative paths
+        return Path(rhs)
+    } else {
+        var lSlice = NSString(string: lhs).pathComponents.fullSlice
+        var rSlice = NSString(string: rhs).pathComponents.fullSlice
+
+        // Get rid of trailing "/" at the left side
+        if lSlice.count > 1, lSlice.last == Path.separator {
+            lSlice.removeLast()
+        }
+
+        // Advance after the first relevant "."
+        lSlice = lSlice.filter { $0 != "." }.fullSlice
+        rSlice = rSlice.filter { $0 != "." }.fullSlice
+
+        // Eats up trailing components of the left and leading ".." of the right side
+        while lSlice.last != "..", !lSlice.isEmpty, rSlice.first == ".." {
+            if lSlice.count > 1 || lSlice.first != Path.separator {
+                // A leading "/" is never popped
+                lSlice.removeLast()
+            }
+            if !rSlice.isEmpty {
+                rSlice.removeFirst()
+            }
+
+            switch (lSlice.isEmpty, rSlice.isEmpty) {
+            case (true, _):
+                break
+            case (_, true):
+                break
+            default:
+                continue
+            }
+        }
+
+        return Path(components: lSlice + rSlice)
+    }
+}
+
+extension Array {
+    var fullSlice: ArraySlice<Element> {
+        return self[self.indices.suffix(from: 0)]
+    }
+}

--- a/Sources/ProjectDescription/Path.swift
+++ b/Sources/ProjectDescription/Path.swift
@@ -60,6 +60,18 @@ extension Path: ExpressibleByStringLiteral {
     public init(stringLiteral value: StringLiteralType) {
         path = value
     }
+    
+    
+    /// Returns the path
+    public static var manifestDirectory: Path {
+        Path(CommandLine.arguments[CommandLine.arguments.firstIndex(of: "--tuist-manifest-dir")! + 1])
+    }
+    
+    /// Returns the directory of the file that is calling this method.
+    public static func currentFileDirectory(file: StaticString = #file, line: UInt = #line) -> Path {
+        let file = file.withUTF8Buffer { String(decoding: $0, as: UTF8.self) }
+        return Path(file).parent()
+    }
 }
 
 // MARK: CustomStringConvertible

--- a/Sources/ProjectDescription/Path.swift
+++ b/Sources/ProjectDescription/Path.swift
@@ -39,6 +39,10 @@ public struct Path {
     }
 }
 
+// MARK: - Codable
+
+extension Path: Codable {}
+
 // MARK: StringLiteralConvertible
 
 extension Path: ExpressibleByStringLiteral {

--- a/Sources/ProjectDescription/SourceFilesList.swift
+++ b/Sources/ProjectDescription/SourceFilesList.swift
@@ -3,7 +3,7 @@
 /// A model to refer to source files that supports passing compiler flags.
 public final class SourceFileGlob: ExpressibleByStringLiteral, Codable {
     /// Relative glob pattern.
-    public let glob: String
+    public let glob: Path
 
     /// Compiler flags.
     public let compilerFlags: String?
@@ -13,13 +13,13 @@ public final class SourceFileGlob: ExpressibleByStringLiteral, Codable {
     /// - Parameters:
     ///   - glob: Relative glob pattern.
     ///   - compilerFlags: Compiler flags.
-    public init(_ glob: String, compilerFlags: String? = nil) {
+    public init(_ glob: Path, compilerFlags: String? = nil) {
         self.glob = glob
         self.compilerFlags = compilerFlags
     }
 
     public convenience init(stringLiteral value: String) {
-        self.init(value)
+        self.init(Path(value))
     }
 }
 

--- a/Sources/ProjectDescription/SourceFilesList.swift
+++ b/Sources/ProjectDescription/SourceFilesList.swift
@@ -44,6 +44,12 @@ public final class SourceFilesList: Codable {
     public init(globs: [String]) {
         self.globs = globs.map(SourceFileGlob.init)
     }
+    
+    /// Initializes a sources list with a list of paths.
+    /// - Parameter paths: Source paths.
+    public static func paths(_ paths: [Path]) -> SourceFilesList  {
+        return SourceFilesList.init(globs: paths.map({ SourceFileGlob($0) }))
+    }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()

--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -27,7 +27,7 @@ public class Target: Codable {
     public let infoPlist: InfoPlist
 
     /// Relative path to the entitlements file.
-    public let entitlements: String?
+    public let entitlements: Path?
 
     /// Target settings.
     public let settings: Settings?
@@ -99,7 +99,7 @@ public class Target: Codable {
                 sources: SourceFilesList? = nil,
                 resources: [FileElement]? = nil,
                 headers: Headers? = nil,
-                entitlements: String? = nil,
+                entitlements: Path? = nil,
                 actions: [TargetAction] = [],
                 dependencies: [TargetDependency] = [],
                 settings: Settings? = nil,

--- a/Sources/ProjectDescription/TargetAction.swift
+++ b/Sources/ProjectDescription/TargetAction.swift
@@ -17,7 +17,7 @@ public struct TargetAction: Codable {
     public let tool: String?
 
     /// Path to the script to execute.
-    public let path: String?
+    public let path: Path?
 
     /// Target action order.
     public let order: Order
@@ -26,16 +26,16 @@ public struct TargetAction: Codable {
     public let arguments: [String]
 
     /// List of input file paths
-    public let inputPaths: [String]
+    public let inputPaths: [Path]
 
     /// List of input filelist paths
-    public let inputFileListPaths: [String]
+    public let inputFileListPaths: [Path]
 
     /// List of output file paths
-    public let outputPaths: [String]
+    public let outputPaths: [Path]
 
     /// List of output filelist paths
-    public let outputFileListPaths: [String]
+    public let outputFileListPaths: [Path]
 
     public enum CodingKeys: String, CodingKey {
         case name
@@ -63,13 +63,13 @@ public struct TargetAction: Codable {
     ///   - outputFileListPaths: List of output filelist paths.
     init(name: String,
          tool: String?,
-         path: String?,
+         path: Path?,
          order: Order,
          arguments: [String],
-         inputPaths: [String] = [],
-         inputFileListPaths: [String] = [],
-         outputPaths: [String] = [],
-         outputFileListPaths: [String] = []) {
+         inputPaths: [Path] = [],
+         inputFileListPaths: [Path] = [],
+         outputPaths: [Path] = [],
+         outputFileListPaths: [Path] = []) {
         self.name = name
         self.path = path
         self.tool = tool
@@ -95,10 +95,10 @@ public struct TargetAction: Codable {
     public static func pre(tool: String,
                            arguments: String...,
                            name: String,
-                           inputPaths: [String] = [],
-                           inputFileListPaths: [String] = [],
-                           outputPaths: [String] = [],
-                           outputFileListPaths: [String] = []) -> TargetAction {
+                           inputPaths: [Path] = [],
+                           inputFileListPaths: [Path] = [],
+                           outputPaths: [Path] = [],
+                           outputFileListPaths: [Path] = []) -> TargetAction {
         return TargetAction(name: name,
                             tool: tool,
                             path: nil,
@@ -124,10 +124,10 @@ public struct TargetAction: Codable {
     public static func pre(tool: String,
                            arguments: [String],
                            name: String,
-                           inputPaths: [String] = [],
-                           inputFileListPaths: [String] = [],
-                           outputPaths: [String] = [],
-                           outputFileListPaths: [String] = []) -> TargetAction {
+                           inputPaths: [Path] = [],
+                           inputFileListPaths: [Path] = [],
+                           outputPaths: [Path] = [],
+                           outputFileListPaths: [Path] = []) -> TargetAction {
         return TargetAction(name: name,
                             tool: tool,
                             path: nil,
@@ -150,13 +150,13 @@ public struct TargetAction: Codable {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     /// - Returns: Target action.
-    public static func pre(path: String,
+    public static func pre(path: Path,
                            arguments: String...,
                            name: String,
-                           inputPaths: [String] = [],
-                           inputFileListPaths: [String] = [],
-                           outputPaths: [String] = [],
-                           outputFileListPaths: [String] = []) -> TargetAction {
+                           inputPaths: [Path] = [],
+                           inputFileListPaths: [Path] = [],
+                           outputPaths: [Path] = [],
+                           outputFileListPaths: [Path] = []) -> TargetAction {
         return TargetAction(name: name,
                             tool: nil,
                             path: path,
@@ -179,13 +179,13 @@ public struct TargetAction: Codable {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     /// - Returns: Target action.
-    public static func pre(path: String,
+    public static func pre(path: Path,
                            arguments: [String],
                            name: String,
-                           inputPaths: [String] = [],
-                           inputFileListPaths: [String] = [],
-                           outputPaths: [String] = [],
-                           outputFileListPaths: [String] = []) -> TargetAction {
+                           inputPaths: [Path] = [],
+                           inputFileListPaths: [Path] = [],
+                           outputPaths: [Path] = [],
+                           outputFileListPaths: [Path] = []) -> TargetAction {
         return TargetAction(name: name,
                             tool: nil,
                             path: path,
@@ -211,10 +211,10 @@ public struct TargetAction: Codable {
     public static func post(tool: String,
                             arguments: String...,
                             name: String,
-                            inputPaths: [String] = [],
-                            inputFileListPaths: [String] = [],
-                            outputPaths: [String] = [],
-                            outputFileListPaths: [String] = []) -> TargetAction {
+                            inputPaths: [Path] = [],
+                            inputFileListPaths: [Path] = [],
+                            outputPaths: [Path] = [],
+                            outputFileListPaths: [Path] = []) -> TargetAction {
         return TargetAction(name: name,
                             tool: tool,
                             path: nil,
@@ -240,10 +240,10 @@ public struct TargetAction: Codable {
     public static func post(tool: String,
                             arguments: [String],
                             name: String,
-                            inputPaths: [String] = [],
-                            inputFileListPaths: [String] = [],
-                            outputPaths: [String] = [],
-                            outputFileListPaths: [String] = []) -> TargetAction {
+                            inputPaths: [Path] = [],
+                            inputFileListPaths: [Path] = [],
+                            outputPaths: [Path] = [],
+                            outputFileListPaths: [Path] = []) -> TargetAction {
         return TargetAction(name: name,
                             tool: tool,
                             path: nil,
@@ -266,13 +266,13 @@ public struct TargetAction: Codable {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     /// - Returns: Target action.
-    public static func post(path: String,
+    public static func post(path: Path,
                             arguments: String...,
                             name: String,
-                            inputPaths: [String] = [],
-                            inputFileListPaths: [String] = [],
-                            outputPaths: [String] = [],
-                            outputFileListPaths: [String] = []) -> TargetAction {
+                            inputPaths: [Path] = [],
+                            inputFileListPaths: [Path] = [],
+                            outputPaths: [Path] = [],
+                            outputFileListPaths: [Path] = []) -> TargetAction {
         return TargetAction(name: name,
                             tool: nil,
                             path: path,
@@ -295,13 +295,13 @@ public struct TargetAction: Codable {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     /// - Returns: Target action.
-    public static func post(path: String,
+    public static func post(path: Path,
                             arguments: [String],
                             name: String,
-                            inputPaths: [String] = [],
-                            inputFileListPaths: [String] = [],
-                            outputPaths: [String] = [],
-                            outputFileListPaths: [String] = []) -> TargetAction {
+                            inputPaths: [Path] = [],
+                            inputFileListPaths: [Path] = [],
+                            outputPaths: [Path] = [],
+                            outputFileListPaths: [Path] = []) -> TargetAction {
         return TargetAction(name: name,
                             tool: nil,
                             path: path,
@@ -320,12 +320,12 @@ public struct TargetAction: Codable {
         name = try container.decode(String.self, forKey: .name)
         order = try container.decode(Order.self, forKey: .order)
         arguments = try container.decode([String].self, forKey: .arguments)
-        inputPaths = try container.decodeIfPresent([String].self, forKey: .inputPaths) ?? []
-        inputFileListPaths = try container.decodeIfPresent([String].self, forKey: .inputFileListPaths) ?? []
-        outputPaths = try container.decodeIfPresent([String].self, forKey: .outputPaths) ?? []
-        outputFileListPaths = try container.decodeIfPresent([String].self, forKey: .outputFileListPaths) ?? []
+        inputPaths = try container.decodeIfPresent([String].self, forKey: .inputPaths)?.map { Path($0) } ?? []
+        inputFileListPaths = try container.decodeIfPresent([String].self, forKey: .inputFileListPaths)?.map { Path($0) } ?? []
+        outputPaths = try container.decodeIfPresent([String].self, forKey: .outputPaths)?.map { Path($0) } ?? []
+        outputFileListPaths = try container.decodeIfPresent([String].self, forKey: .outputFileListPaths)?.map { Path($0) } ?? []
         if let path = try container.decodeIfPresent(String.self, forKey: .path) {
-            self.path = path
+            self.path = Path(path)
             tool = nil
         } else {
             path = nil

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -95,10 +95,10 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
         try actions.forEach { action in
             let buildPhase = try PBXShellScriptBuildPhase(files: [],
                                                           name: action.name,
-                                                          inputPaths: action.inputPaths,
-                                                          outputPaths: action.outputPaths,
-                                                          inputFileListPaths: action.inputFileListPaths,
-                                                          outputFileListPaths: action.outputFileListPaths,
+                                                          inputPaths: action.inputPaths.map { $0.relative(to: sourceRootPath).pathString },
+                                                          outputPaths: action.outputPaths.map { $0.relative(to: sourceRootPath).pathString },
+                                                          inputFileListPaths: action.inputFileListPaths.map { $0.relative(to: sourceRootPath).pathString },
+                                                          outputFileListPaths: action.outputFileListPaths.map { $0.relative(to: sourceRootPath).pathString },
                                                           shellPath: "/bin/sh",
                                                           shellScript: action.shellScript(sourceRootPath: sourceRootPath))
             pbxproj.add(object: buildPhase)

--- a/Sources/TuistGenerator/Models/Dependency.swift
+++ b/Sources/TuistGenerator/Models/Dependency.swift
@@ -19,7 +19,7 @@ public enum Dependency: Equatable {
 
 public enum Package: Equatable {
     case remote(url: String, requirement: Requirement)
-    case local(path: RelativePath)
+    case local(path: AbsolutePath)
 }
 
 extension Package {

--- a/Sources/TuistGenerator/Models/Target.swift
+++ b/Sources/TuistGenerator/Models/Target.swift
@@ -103,7 +103,7 @@ public class Target: Equatable, Hashable {
     public static func sources(projectPath: AbsolutePath, sources: [(glob: String, compilerFlags: String?)]) throws -> [Target.SourceFile] {
         var sourceFiles: [AbsolutePath: Target.SourceFile] = [:]
         sources.forEach { source in
-            projectPath.glob(source.glob).filter { path in
+            AbsolutePath("/").glob(String(source.glob.dropFirst())).filter { path in
                 if let `extension` = path.extension, Target.validSourceExtensions.contains(`extension`) {
                     return true
                 }

--- a/Sources/TuistGenerator/Models/TargetAction.swift
+++ b/Sources/TuistGenerator/Models/TargetAction.swift
@@ -29,16 +29,16 @@ public struct TargetAction {
     public let arguments: [String]
 
     /// List of input file paths
-    public let inputPaths: [String]
+    public let inputPaths: [AbsolutePath]
 
     /// List of input filelist paths
-    public let inputFileListPaths: [String]
+    public let inputFileListPaths: [AbsolutePath]
 
     /// List of output file paths
-    public let outputPaths: [String]
+    public let outputPaths: [AbsolutePath]
 
     /// List of output filelist paths
-    public let outputFileListPaths: [String]
+    public let outputFileListPaths: [AbsolutePath]
 
     /// Initializes a new target action with its attributes.
     ///
@@ -57,10 +57,10 @@ public struct TargetAction {
                 tool: String? = nil,
                 path: AbsolutePath? = nil,
                 arguments: [String] = [],
-                inputPaths: [String] = [],
-                inputFileListPaths: [String] = [],
-                outputPaths: [String] = [],
-                outputFileListPaths: [String] = []) {
+                inputPaths: [AbsolutePath] = [],
+                inputFileListPaths: [AbsolutePath] = [],
+                outputPaths: [AbsolutePath] = [],
+                outputFileListPaths: [AbsolutePath] = []) {
         self.name = name
         self.order = order
         self.tool = tool

--- a/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
+++ b/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
@@ -224,6 +224,7 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
         }
         """
     }
+
     // swiftlint:enable function_body_length
     // swiftlint:enable line_length
 }

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -318,7 +318,7 @@ extension TuistGenerator.Target {
 
         let settings = manifest.settings.map { TuistGenerator.Settings.from(manifest: $0, path: path) }
         let sources = try TuistGenerator.Target.sources(projectPath: path, sources: manifest.sources?.globs.map {
-            (glob: $0.glob.string, compilerFlags: $0.compilerFlags)
+            (glob: AbsolutePath.init($0.glob.string, relativeTo: path).pathString, compilerFlags: $0.compilerFlags)
         } ?? [])
 
         let resourceFilter = { (path: AbsolutePath) -> Bool in

--- a/Sources/TuistKit/Generator/GraphManifestLoader.swift
+++ b/Sources/TuistKit/Generator/GraphManifestLoader.swift
@@ -177,10 +177,12 @@ class GraphManifestLoader: GraphManifestLoading {
             "-lProjectDescription",
         ]
         arguments.append(path.pathString)
-        arguments.append("--dump")
+        arguments.append("--tuist-dump")
+        arguments.append("--tuist-manifest-dir")
+        arguments.append(path.parentDirectory.pathString)
 
-        guard let jsonString = try System.shared.capture(arguments).spm_chuzzle(),
-            let data = jsonString.data(using: .utf8) else {
+        let result = try System.shared.capture(arguments).spm_chuzzle()
+        guard let jsonString = result, let data = jsonString.data(using: .utf8) else {
             throw GraphManifestLoaderError.unexpectedOutput(path)
         }
 

--- a/fixtures/ios_app_with_tests/Project.swift
+++ b/fixtures/ios_app_with_tests/Project.swift
@@ -7,7 +7,7 @@ let project = Project(name: "App",
                                  product: .app,
                                  bundleId: "io.tuist.App",
                                  infoPlist: "Info.plist",
-                                 sources: "Sources/**",
+                                 sources: .paths([Path.currentFileDirectory() + "Sources/**"]),
                                  dependencies: [
                                      /* Target dependencies can be defined here */
                                      /* .framework(path: "framework") */


### PR DESCRIPTION
### Short description 📝
As it was commented [on this PR](https://github.com/tuist/tuist/pull/542), one of the challenges of reusing code across manifests is how to define paths that are relative to the file being compiled. 

This PR provides a solution for that by introducing a new model, `Path` that users can use to declare paths. The model provides 2 getters, `Path.manifestDirectory`, & `Path.currentFileDirectory` to return the previously mentioned directories.

When Tuist loads the manifest by compiling it, it passes an extra argument, `--tuist-manifest-dir`, that the `.manifestDirectory` getter users to return the manifest directory. We might introduce a new getter on [this PR](https://github.com/tuist/tuist/pull/542) to return the path to the root directory, typically where the `.git` directory exists alongside the `TuistConfig.swift` file and `Tuist` directory.