### PR TITLE
Adds codeCoverageTargets to TestAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - **Breaking** Allow specifying a deployment target within project manifests https://github.com/tuist/tuist/pull/541 by @mollyIV
 - Add support for sticker pack extension & app extension products https://github.com/tuist/tuist/pull/489 by @Rag0n
 - Utility to locate the root directory of a project https://github.com/tuist/tuist/pull/622/checks?check_run_id=284958709 by @pepibumur.
+- Adds `codeCoverageTargets` to `TestAction` to make XCode gather coverage info only for that targets https://github.com/tuist/tuist/pull/619/checks?check_run_id=282561179 by @abbasmousavi
 
 ### Changed
 

--- a/Sources/ProjectDescription/Scheme.swift
+++ b/Sources/ProjectDescription/Scheme.swift
@@ -72,6 +72,7 @@ public struct TestAction: Equatable, Codable {
     public let arguments: Arguments?
     public let configurationName: String
     public let coverage: Bool
+    public let codeCoverageTargets: [String]
     public let preActions: [ExecutionAction]
     public let postActions: [ExecutionAction]
 
@@ -79,6 +80,7 @@ public struct TestAction: Equatable, Codable {
                 arguments: Arguments? = nil,
                 configurationName: String,
                 coverage: Bool = false,
+                codeCoverageTargets: [String] = [],
                 preActions: [ExecutionAction] = [],
                 postActions: [ExecutionAction] = []) {
         self.targets = targets
@@ -87,18 +89,21 @@ public struct TestAction: Equatable, Codable {
         self.coverage = coverage
         self.preActions = preActions
         self.postActions = postActions
+        self.codeCoverageTargets = codeCoverageTargets
     }
 
     public init(targets: [String],
                 arguments: Arguments? = nil,
                 config: PresetBuildConfiguration = .debug,
                 coverage: Bool = false,
+                codeCoverageTargets: [String] = [],
                 preActions: [ExecutionAction] = [],
                 postActions: [ExecutionAction] = []) {
         self.init(targets: targets,
                   arguments: arguments,
                   configurationName: config.name,
                   coverage: coverage,
+                  codeCoverageTargets: codeCoverageTargets,
                   preActions: preActions,
                   postActions: postActions)
     }

--- a/Sources/TuistGenerator/Generator/SchemesGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemesGenerator.swift
@@ -161,6 +161,18 @@ final class SchemesGenerator: SchemesGenerating {
         var testables: [XCScheme.TestableReference] = []
         var preActions: [XCScheme.ExecutionAction] = []
         var postActions: [XCScheme.ExecutionAction] = []
+        var codeCoverageTargets: [XCScheme.BuildableReference] = []
+        
+        testAction.codeCoverageTargets.forEach { name in
+            
+            guard let target = project.targets.first(where: { $0.name == name }) else { return }
+            guard let pbxTarget = generatedProject.targets[name] else { return }
+
+            let reference = self.targetBuildableReference(target: target,
+                                                          pbxTarget: pbxTarget,
+                                                          projectName: generatedProject.name)
+            codeCoverageTargets.append(reference)
+        }
 
         testAction.targets.forEach { name in
             guard let target = project.targets.first(where: { $0.name == name }), target.product.testsBundle else { return }
@@ -189,6 +201,7 @@ final class SchemesGenerator: SchemesGenerating {
             args = XCScheme.CommandLineArguments(arguments: commandlineArgruments(arguments.launch))
             environments = environmentVariables(arguments.environment)
         }
+        let onlyGenerateCoverageForSpecifiedTargets = codeCoverageTargets.count > 0 ? true : nil
 
         let shouldUseLaunchSchemeArgsEnv: Bool = args == nil && environments == nil
 
@@ -199,6 +212,8 @@ final class SchemesGenerator: SchemesGenerating {
                                    postActions: postActions,
                                    shouldUseLaunchSchemeArgsEnv: shouldUseLaunchSchemeArgsEnv,
                                    codeCoverageEnabled: testAction.coverage,
+                                   codeCoverageTargets: codeCoverageTargets,
+                                   onlyGenerateCoverageForSpecifiedTargets: onlyGenerateCoverageForSpecifiedTargets,
                                    commandlineArguments: args,
                                    environmentVariables: environments)
     }

--- a/Sources/TuistGenerator/Generator/SchemesGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemesGenerator.swift
@@ -145,6 +145,31 @@ final class SchemesGenerator: SchemesGenerating {
                                    macroExpansion: nil,
                                    testables: testables)
     }
+    
+    /// Generates the array of BuildableReference for targets that the
+    /// coverage report should be generated for them.
+    ///
+    /// - Parameters:
+    ///   - testAction: test actions.
+    ///   - project: Project manifest.
+    ///   - generatedProject: Generated Xcode project.
+    /// - Returns: Array of buildable references.
+    private func testCoverageTargetReferences(testAction: TestAction, project: Project, generatedProject: GeneratedProject) -> [XCScheme.BuildableReference] {
+        
+        var codeCoverageTargets: [XCScheme.BuildableReference] = []
+        testAction.codeCoverageTargets.forEach { name in
+            
+            guard let target = project.targets.first(where: { $0.name == name }) else { return }
+            guard let pbxTarget = generatedProject.targets[name] else { return }
+
+            let reference = self.targetBuildableReference(target: target,
+                                                          pbxTarget: pbxTarget,
+                                                          projectName: generatedProject.name)
+            codeCoverageTargets.append(reference)
+        }
+        
+        return codeCoverageTargets
+    }
 
     /// Generates the scheme test action.
     ///
@@ -161,18 +186,6 @@ final class SchemesGenerator: SchemesGenerating {
         var testables: [XCScheme.TestableReference] = []
         var preActions: [XCScheme.ExecutionAction] = []
         var postActions: [XCScheme.ExecutionAction] = []
-        var codeCoverageTargets: [XCScheme.BuildableReference] = []
-        
-        testAction.codeCoverageTargets.forEach { name in
-            
-            guard let target = project.targets.first(where: { $0.name == name }) else { return }
-            guard let pbxTarget = generatedProject.targets[name] else { return }
-
-            let reference = self.targetBuildableReference(target: target,
-                                                          pbxTarget: pbxTarget,
-                                                          projectName: generatedProject.name)
-            codeCoverageTargets.append(reference)
-        }
 
         testAction.targets.forEach { name in
             guard let target = project.targets.first(where: { $0.name == name }), target.product.testsBundle else { return }
@@ -201,6 +214,9 @@ final class SchemesGenerator: SchemesGenerating {
             args = XCScheme.CommandLineArguments(arguments: commandlineArgruments(arguments.launch))
             environments = environmentVariables(arguments.environment)
         }
+        
+        let codeCoverageTargets = self.testCoverageTargetReferences(testAction: testAction, project: project, generatedProject: generatedProject)
+        
         let onlyGenerateCoverageForSpecifiedTargets = codeCoverageTargets.count > 0 ? true : nil
 
         let shouldUseLaunchSchemeArgsEnv: Bool = args == nil && environments == nil

--- a/Sources/TuistGenerator/Models/Scheme.swift
+++ b/Sources/TuistGenerator/Models/Scheme.swift
@@ -114,6 +114,7 @@ public class TestAction: Equatable {
     public let arguments: Arguments?
     public let configurationName: String
     public let coverage: Bool
+    public let codeCoverageTargets: [String]
     public let preActions: [ExecutionAction]
     public let postActions: [ExecutionAction]
 
@@ -123,6 +124,7 @@ public class TestAction: Equatable {
                 arguments: Arguments? = nil,
                 configurationName: String,
                 coverage: Bool = false,
+                codeCoverageTargets: [String] = [],
                 preActions: [ExecutionAction] = [],
                 postActions: [ExecutionAction] = []) {
         self.targets = targets
@@ -131,6 +133,7 @@ public class TestAction: Equatable {
         self.coverage = coverage
         self.preActions = preActions
         self.postActions = postActions
+        self.codeCoverageTargets = codeCoverageTargets
     }
 
     // MARK: - Equatable
@@ -140,6 +143,7 @@ public class TestAction: Equatable {
             lhs.arguments == rhs.arguments &&
             lhs.configurationName == rhs.configurationName &&
             lhs.coverage == rhs.coverage &&
+            lhs.codeCoverageTargets == rhs.codeCoverageTargets &&
             lhs.preActions == rhs.preActions &&
             lhs.postActions == rhs.postActions
     }

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -634,6 +634,7 @@ extension TuistGenerator.TestAction {
         let arguments = manifest.arguments.map { TuistGenerator.Arguments.from(manifest: $0) }
         let configurationName = manifest.configurationName
         let coverage = manifest.coverage
+        let codeCoverageTargets = manifest.codeCoverageTargets
         let preActions = manifest.preActions.map { TuistGenerator.ExecutionAction.from(manifest: $0) }
         let postActions = manifest.postActions.map { TuistGenerator.ExecutionAction.from(manifest: $0) }
 
@@ -641,6 +642,7 @@ extension TuistGenerator.TestAction {
                           arguments: arguments,
                           configurationName: configurationName,
                           coverage: coverage,
+                          codeCoverageTargets: codeCoverageTargets,
                           preActions: preActions,
                           postActions: postActions)
     }

--- a/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
@@ -155,6 +155,30 @@ final class SchemeGeneratorTests: XCTestCase {
         XCTAssertEqual(postBuildableReference?.blueprintName, "AppTests")
         XCTAssertEqual(postBuildableReference?.buildableIdentifier, "primary")
     }
+    
+    func test_schemeTestAction_with_codeCoverageTargets() {
+        
+        let target = Target.test(name: "App", product: .app)
+        let testTarget = Target.test(name: "AppTests", product: .unitTests)
+
+        let testAction = TestAction.test(targets: ["AppTests"], coverage: true, codeCoverageTargets: ["App"])
+        let buildAction = BuildAction.test(targets: ["App"])
+
+        let scheme = Scheme.test(name: "AppTests", shared: true, buildAction: buildAction, testAction: testAction)
+        let project = Project.test(targets: [target,testTarget])
+
+        let pbxTarget = PBXNativeTarget(name: "App", productType: .application)
+        let pbxTestTarget = PBXNativeTarget(name: "AppTests", productType: .unitTestBundle)
+        let generatedProject = GeneratedProject.test(targets: ["AppTests": pbxTestTarget, "App": pbxTarget])
+
+        let got = subject.schemeTestAction(scheme: scheme, project: project, generatedProject: generatedProject)
+
+        let codeCoverageTargetsBuildableReference = got?.codeCoverageTargets
+        
+        XCTAssertEqual(got?.onlyGenerateCoverageForSpecifiedTargets, true)
+        XCTAssertEqual(codeCoverageTargetsBuildableReference?.count, 1)
+        XCTAssertEqual(codeCoverageTargetsBuildableReference?.first?.buildableName, "App.app")
+    }
 
     func test_schemeBuildAction() {
         let target = Target.test(name: "App", product: .app)

--- a/Tests/TuistGeneratorTests/Models/TestData/Scheme+TestData.swift
+++ b/Tests/TuistGeneratorTests/Models/TestData/Scheme+TestData.swift
@@ -25,12 +25,14 @@ extension TestAction {
                      arguments: Arguments? = Arguments.test(),
                      configurationName: String = BuildConfiguration.debug.name,
                      coverage: Bool = false,
+                     codeCoverageTargets: [String] = [],
                      preActions: [ExecutionAction] = [],
                      postActions: [ExecutionAction] = []) -> TestAction {
         return TestAction(targets: targets,
                           arguments: arguments,
                           configurationName: configurationName,
                           coverage: coverage,
+                          codeCoverageTargets: codeCoverageTargets,
                           preActions: preActions,
                           postActions: postActions)
     }

--- a/docs/usage/2-projectswift.mdx
+++ b/docs/usage/2-projectswift.mdx
@@ -798,6 +798,14 @@ Alternatively, when leveraging custom configurations, the configuration name can
       default: 'false',
     },
     {
+      name: 'codeCoverageTargets',
+      description:
+        'A list of targets you want to gather the test coverage data for them, which are defined in the project.',
+      type: '[String]',
+      optional: true,
+      default: '[]',
+    },
+    {
       name: 'Pre-actions',
       description:
         'A list of actions that are executed before starting the tests-run process.',


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/618

### Short description 📝

Adds codeCoverageTargets to TestAction

### Solution 📦

This property is already implemented in XcodeProj. We only need to assign values to related properties.

### Implementation 👩‍💻👨‍💻

It adds `codeCoverageTargets` property to the `TestAction` model in manifest and uses it to populate `codeCoverageTargets` and `onlyGenerateCoverageForSpecifiedTargets` in `XCScheme.TestAction`
