### PR TITLE
Add a utility to locate the root directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - `HTTPClient` utility class to `TuistEnvKit` https://github.com/tuist/tuist/pull/508 by @pepibumur.
 - **Breaking** Allow specifying a deployment target within project manifests https://github.com/tuist/tuist/pull/541 by @mollyIV
 - Add support for sticker pack extension & app extension products https://github.com/tuist/tuist/pull/489 by @Rag0n
+- Utility to locate the root directory of a project https://github.com/tuist/tuist/pull/622/checks?check_run_id=284958709 by @pepibumur.
 
 ### Changed
 

--- a/Sources/TuistKit/Commands/FocusCommand.swift
+++ b/Sources/TuistKit/Commands/FocusCommand.swift
@@ -1,8 +1,8 @@
 import Basic
 import Foundation
 import SPMUtility
-import TuistSupport
 import TuistGenerator
+import TuistSupport
 
 /// The focus command generates the Xcode workspace and launches it on Xcode.
 class FocusCommand: NSObject, Command {

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -1,8 +1,8 @@
 import Basic
 import Foundation
 import SPMUtility
-import TuistSupport
 import TuistGenerator
+import TuistSupport
 
 class GenerateCommand: NSObject, Command {
     // MARK: - Static

--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -1,8 +1,8 @@
 import Basic
 import Foundation
 import SPMUtility
-import TuistSupport
 import TuistGenerator
+import TuistSupport
 
 /// Command that generates and exports a dot graph from the workspace or project in the current directory.
 class GraphCommand: NSObject, Command {

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -1,8 +1,8 @@
 import Basic
 import Foundation
 import SPMUtility
-import TuistSupport
 import TuistGenerator
+import TuistSupport
 
 private typealias Platform = TuistGenerator.Platform
 private typealias Product = TuistGenerator.Product

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -1,8 +1,8 @@
 import Basic
 import Foundation
 import ProjectDescription
-import TuistSupport
 import TuistGenerator
+import TuistSupport
 
 enum GeneratorModelLoaderError: Error, Equatable, FatalError {
     case featureNotYetSupported(String)

--- a/Sources/TuistKit/Generator/ManifestTargetGenerator.swift
+++ b/Sources/TuistKit/Generator/ManifestTargetGenerator.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistSupport
 import TuistGenerator
+import TuistSupport
 
 protocol ManifestTargetGenerating {
     func generateManifestTarget(for project: String, at path: AbsolutePath) throws -> Target

--- a/Sources/TuistKit/Models/Up/UpCarthage.swift
+++ b/Sources/TuistKit/Models/Up/UpCarthage.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistSupport
 import TuistGenerator
+import TuistSupport
 
 /// Up that updates outdated Carthage dependencies.
 class UpCarthage: Up, GraphInitiatable {

--- a/Sources/TuistKit/Playgrounds/PlaygroundGenerator.swift
+++ b/Sources/TuistKit/Playgrounds/PlaygroundGenerator.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistSupport
 import TuistGenerator
+import TuistSupport
 
 enum PlaygroundGenerationError: FatalError, Equatable {
     case alreadyExisting(AbsolutePath)

--- a/Sources/TuistKit/Utils/Carthage.swift
+++ b/Sources/TuistKit/Utils/Carthage.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistSupport
 import TuistGenerator
+import TuistSupport
 
 /// Model that represents the content of the file that Carthage
 /// generates for each resolved dependency.

--- a/Sources/TuistKit/Utils/GraphPrinter.swift
+++ b/Sources/TuistKit/Utils/GraphPrinter.swift
@@ -1,6 +1,6 @@
 import Foundation
-import TuistSupport
 import TuistGenerator
+import TuistSupport
 
 protocol GraphPrinting {
     /// Outputs the graph to the standard output.

--- a/Sources/TuistKit/Utils/InfoPlistProvisioner.swift
+++ b/Sources/TuistKit/Utils/InfoPlistProvisioner.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistSupport
 import TuistGenerator
+import TuistSupport
 
 protocol InfoPlistProvisioning: AnyObject {
     func generate(path: AbsolutePath, platform: Platform, product: Product) throws

--- a/Sources/TuistKit/Utils/RootDirectoryLocator.swift
+++ b/Sources/TuistKit/Utils/RootDirectoryLocator.swift
@@ -19,13 +19,13 @@ final class RootDirectoryLocator: RootDirectoryLocating {
     /// git repository is defined if no Tuist/ directory is found.
     /// - Parameter path: Path for which we'll look the root directory.
     func locate(from path: AbsolutePath) -> AbsolutePath? {
-        if let cachedDirectory = self.cache[path] {
+        if let cachedDirectory = cached(path: path) {
             return cachedDirectory
-        } else if let tuistDirectory = FileHandler.shared.locateDirectoryTraversingParents(from: path, Constants.tuistFolderName) {
+        } else if let tuistDirectory = FileHandler.shared.locateDirectory(Constants.tuistFolderName, traversingFrom: path) {
             let rootDirectory = tuistDirectory.parentDirectory
             cache(rootDirectory: rootDirectory, for: path)
             return rootDirectory
-        } else if let gitDirectory = FileHandler.shared.locateDirectoryTraversingParents(from: path, ".git") {
+        } else if let gitDirectory = FileHandler.shared.locateDirectory(".git", traversingFrom: path) {
             let rootDirectory = gitDirectory.parentDirectory
             cache(rootDirectory: rootDirectory, for: path)
             return rootDirectory
@@ -35,6 +35,10 @@ final class RootDirectoryLocator: RootDirectoryLocating {
     }
 
     // MARK: - Fileprivate
+
+    fileprivate func cached(path: AbsolutePath) -> AbsolutePath? {
+        if let cached = self.cache[path] { return cached } else if !path.parentDirectory.isRoot { return cached(path: path.parentDirectory) } else { return nil }
+    }
 
     /// This method caches the root directory of path, and all its parents up to the root directory.
     /// - Parameters:

--- a/Sources/TuistKit/Utils/RootDirectoryLocator.swift
+++ b/Sources/TuistKit/Utils/RootDirectoryLocator.swift
@@ -1,0 +1,51 @@
+import Basic
+import Foundation
+import TuistSupport
+
+protocol RootDirectoryLocating {
+    /// Given a path, it finds the root directory by traversing up the hierarchy.
+    /// The root directory is considered the directory that contains a Tuist/ directory or the directory where the
+    /// git repository is defined if no Tuist/ directory is found.
+    /// - Parameter path: Path for which we'll look the root directory.
+    func locate(from path: AbsolutePath) -> AbsolutePath?
+}
+
+final class RootDirectoryLocator: RootDirectoryLocating {
+    /// This cache avoids having to traverse the directories hierarchy every time the locate method is called.
+    fileprivate var cache: [AbsolutePath: AbsolutePath] = [:]
+
+    /// Given a path, it finds the root directory by traversing up the hierarchy.
+    /// The root directory is considered the directory that contains a Tuist/ directory or the directory where the
+    /// git repository is defined if no Tuist/ directory is found.
+    /// - Parameter path: Path for which we'll look the root directory.
+    func locate(from path: AbsolutePath) -> AbsolutePath? {
+        if let cachedDirectory = self.cache[path] {
+            return cachedDirectory
+        } else if let tuistDirectory = FileHandler.shared.locateDirectoryTraversingParents(from: path, Constants.tuistFolderName) {
+            let rootDirectory = tuistDirectory.parentDirectory
+            cache(rootDirectory: rootDirectory, for: path)
+            return rootDirectory
+        } else if let gitDirectory = FileHandler.shared.locateDirectoryTraversingParents(from: path, ".git") {
+            let rootDirectory = gitDirectory.parentDirectory
+            cache(rootDirectory: rootDirectory, for: path)
+            return rootDirectory
+        } else {
+            return nil
+        }
+    }
+
+    // MARK: - Fileprivate
+
+    /// This method caches the root directory of path, and all its parents up to the root directory.
+    /// - Parameters:
+    ///   - rootDirectory: Path to the root directory.
+    ///   - path: Path for which we are caching the root directory.
+    fileprivate func cache(rootDirectory: AbsolutePath, for path: AbsolutePath) {
+        if path != rootDirectory {
+            cache[path] = rootDirectory
+            cache(rootDirectory: rootDirectory, for: path.parentDirectory)
+        } else if path == rootDirectory {
+            cache[path] = rootDirectory
+        }
+    }
+}

--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public class Constants {
+public struct Constants {
     public static let versionFileName = ".tuist-version"
     public static let binFolderName = ".tuist-bin"
     public static let binName = "tuist"
@@ -9,12 +9,13 @@ public class Constants {
     public static let swiftVersion: String = "5.0"
     public static let bundleName: String = "tuist.zip"
     public static let trueValues: [String] = ["1", "true", "TRUE", "yes", "YES"]
+    public static let tuistFolderName: String = "Tuist"
 
-    public class EnvironmentVariables {
+    public struct EnvironmentVariables {
         public static let colouredOutput = "TUIST_COLOURED_OUTPUT"
     }
 
-    public class GoogleCloud {
+    public struct GoogleCloud {
         public static let relasesBucketURL = "https://storage.googleapis.com/tuist-releases/"
     }
 }

--- a/Sources/TuistSupport/Utils/FileHandler.swift
+++ b/Sources/TuistSupport/Utils/FileHandler.swift
@@ -85,10 +85,9 @@ public protocol FileHandling: AnyObject {
     /// It traverses up the directories hierarchy appending the given path and returning the
     /// resulting path if it exists.
     /// - Parameters:
-    ///   - from: Path to traverse the hierarchy from.
     ///   - path: Relative path to append to each path in the hierarchy.
-    /// - Returns: Any found path.
-    func locateDirectoryTraversingParents(from: AbsolutePath, _ path: String) -> AbsolutePath?
+    ///   - from: Path to traverse the hierarchy from.
+    func locateDirectory(_ path: String, traversingFrom from: AbsolutePath) -> AbsolutePath?
 
     func glob(_ path: AbsolutePath, glob: String) -> [AbsolutePath]
     func linkFile(atPath: AbsolutePath, toPath: AbsolutePath) throws
@@ -170,12 +169,12 @@ public class FileHandler: FileHandling {
         } catch {}
     }
 
-    public func locateDirectoryTraversingParents(from: AbsolutePath, _ path: String) -> AbsolutePath? {
+    public func locateDirectory(_ path: String, traversingFrom from: AbsolutePath) -> AbsolutePath? {
         let extendedPath = from.appending(RelativePath(path))
         if exists(extendedPath) {
             return extendedPath
-        } else if from != AbsolutePath("/") {
-            return locateDirectoryTraversingParents(from: from.parentDirectory, path)
+        } else if !from.isRoot {
+            return locateDirectory(path, traversingFrom: from.parentDirectory)
         } else {
             return nil
         }

--- a/Tests/TuistEnvKitTests/Commands/BundleCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/BundleCommandTests.swift
@@ -2,9 +2,9 @@ import Basic
 import Foundation
 import XCTest
 @testable import SPMUtility
+@testable import TuistEnvKit
 @testable import TuistSupport
 @testable import TuistSupportTesting
-@testable import TuistEnvKit
 
 final class BundleCommandErrorTests: XCTestCase {
     func test_type() {

--- a/Tests/TuistEnvKitTests/Commands/CommandRegistryTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/CommandRegistryTests.swift
@@ -1,8 +1,8 @@
 import Foundation
 import TuistSupport
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistEnvKit
+@testable import TuistSupportTesting
 
 final class CommandRegistryTests: XCTestCase {
     var subject: CommandRegistry!

--- a/Tests/TuistEnvKitTests/Commands/CommandRunnerTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/CommandRunnerTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import SPMUtility
 import TuistSupport
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistEnvKit
+@testable import TuistSupportTesting
 
 final class CommandRunnerErrorTests: XCTestCase {
     func test_type() {

--- a/Tests/TuistEnvKitTests/Commands/InstallCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/InstallCommandTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import TuistSupport
 import XCTest
 @testable import SPMUtility
-@testable import TuistSupportTesting
 @testable import TuistEnvKit
+@testable import TuistSupportTesting
 
 final class InstallCommandTests: TuistUnitTestCase {
     var parser: ArgumentParser!

--- a/Tests/TuistEnvKitTests/Commands/LocalCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/LocalCommandTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import TuistSupport
 import XCTest
 @testable import SPMUtility
-@testable import TuistSupportTesting
 @testable import TuistEnvKit
+@testable import TuistSupportTesting
 
 final class LocalCommandTests: TuistUnitTestCase {
     var argumentParser: ArgumentParser!

--- a/Tests/TuistEnvKitTests/Commands/UninstallCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/UninstallCommandTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import TuistSupport
 import XCTest
 @testable import SPMUtility
-@testable import TuistSupportTesting
 @testable import TuistEnvKit
+@testable import TuistSupportTesting
 
 final class UninstallCommandTests: TuistUnitTestCase {
     var parser: ArgumentParser!

--- a/Tests/TuistEnvKitTests/Commands/UpdateCommandTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/UpdateCommandTests.swift
@@ -3,8 +3,8 @@ import TuistSupport
 import XCTest
 
 @testable import SPMUtility
-@testable import TuistSupportTesting
 @testable import TuistEnvKit
+@testable import TuistSupportTesting
 
 final class UpdateCommandTests: TuistUnitTestCase {
     var parser: ArgumentParser!

--- a/Tests/TuistEnvKitTests/HTTP/HTTPClientTests.swift
+++ b/Tests/TuistEnvKitTests/HTTP/HTTPClientTests.swift
@@ -2,8 +2,8 @@ import Foundation
 import TuistSupport
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistEnvKit
+@testable import TuistSupportTesting
 
 final class HTTPClientErrorTests: XCTestCase {
     func test_type() {

--- a/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
+++ b/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import SPMUtility
 import TuistSupport
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistEnvKit
+@testable import TuistSupportTesting
 
 final class InstallerTests: TuistUnitTestCase {
     var buildCopier: MockBuildCopier!

--- a/Tests/TuistEnvKitTests/Settings/SettingsControllerTests.swift
+++ b/Tests/TuistEnvKitTests/Settings/SettingsControllerTests.swift
@@ -1,8 +1,8 @@
 import Basic
 import Foundation
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistEnvKit
+@testable import TuistSupportTesting
 
 final class SettingsControllerTests: TuistUnitTestCase {
     var subject: SettingsController!

--- a/Tests/TuistEnvKitTests/Updater/EnvUpdaterTests.swift
+++ b/Tests/TuistEnvKitTests/Updater/EnvUpdaterTests.swift
@@ -1,8 +1,8 @@
 import Foundation
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistEnvKit
+@testable import TuistSupportTesting
 
 final class EnvUpdaterTests: TuistUnitTestCase {
     var githubClient: MockGitHubClient!

--- a/Tests/TuistEnvKitTests/Updater/UpdaterTests.swift
+++ b/Tests/TuistEnvKitTests/Updater/UpdaterTests.swift
@@ -2,8 +2,8 @@ import Foundation
 import TuistSupport
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistEnvKit
+@testable import TuistSupportTesting
 
 final class UpdaterTests: TuistUnitTestCase {
     var githubClient: MockGitHubClient!

--- a/Tests/TuistEnvKitTests/Versions/VersionsControllerTests.swift
+++ b/Tests/TuistEnvKitTests/Versions/VersionsControllerTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import SPMUtility
 import TuistSupport
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistEnvKit
+@testable import TuistSupportTesting
 
 final class InstalledVersionTests: XCTestCase {
     func test_description() {

--- a/Tests/TuistGeneratorIntegrationTests/Utils/EmbedScriptGeneratorIntegrationTests.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Utils/EmbedScriptGeneratorIntegrationTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import TuistSupport
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class EmbedScriptGeneratorIntegrationTests: TuistTestCase {
     var subject: EmbedScriptGenerator!

--- a/Tests/TuistGeneratorIntegrationTests/Utils/FrameworkMetadataProviderIntegrationTests.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Utils/FrameworkMetadataProviderIntegrationTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import TuistSupport
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class FrameworkMetadataProviderIntegrationTests: TuistTestCase {
     var subject: FrameworkMetadataProvider!

--- a/Tests/TuistGeneratorIntegrationTests/Utils/PrecompiledMetadataProviderIntegrationTests.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Utils/PrecompiledMetadataProviderIntegrationTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import TuistSupport
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class PrecompiledMetadataProviderIntegrationTests: TuistTestCase {
     var subject: PrecompiledMetadataProvider!

--- a/Tests/TuistGeneratorTests/DotGraph/GraphToDotGraphMapperTests.swift
+++ b/Tests/TuistGeneratorTests/DotGraph/GraphToDotGraphMapperTests.swift
@@ -2,8 +2,8 @@ import Basic
 import Foundation
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class GraphToDotGraphMapperTests: XCTestCase {
     var subject: GraphToDotGraphMapper!

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import TuistSupport
 import XcodeProj
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class ConfigGeneratorTests: TuistUnitTestCase {
     var pbxproj: PBXProj!

--- a/Tests/TuistGeneratorTests/Generator/DerivedFileGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/DerivedFileGeneratorTests.swift
@@ -4,8 +4,8 @@ import TuistSupport
 import XcodeProj
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class DerivedFileGeneratorTests: TuistUnitTestCase {
     var infoPlistContentProvider: MockInfoPlistContentProvider!

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -2,8 +2,8 @@ import Basic
 import Foundation
 import XcodeProj
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class ProjectFileElementsTests: TuistUnitTestCase {
     typealias GroupFileElement = ProjectFileElements.GroupFileElement

--- a/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
@@ -5,8 +5,8 @@ import TuistSupport
 import XcodeProj
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class ProjectGeneratorTests: TuistUnitTestCase {
     var subject: ProjectGenerator!

--- a/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import PathKit
 import XcodeProj
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class ProjectGroupsTests: XCTestCase {
     var subject: ProjectGroups!

--- a/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
@@ -4,8 +4,8 @@ import TuistSupport
 import XcodeProj
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class SchemeGeneratorTests: XCTestCase {
     var subject: SchemesGenerator!

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceGeneratorTests.swift
@@ -4,8 +4,8 @@ import TuistSupport
 import XcodeProj
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class WorkspaceGeneratorTests: TuistUnitTestCase {
     var subject: WorkspaceGenerator!

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
@@ -1,8 +1,8 @@
 import Basic
 import TuistSupport
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 class WorkspaceStructureGeneratorTests: XCTestCase {
     fileprivate var fileHandler: InMemoryFileHandler!
@@ -333,6 +333,10 @@ class WorkspaceStructureGeneratorTests: XCTestCase {
             let parent = path.parentDirectory
             try createFolder(parent)
             cache[path] = .file
+        }
+
+        func locateDirectoryTraversingParents(from _: AbsolutePath, _: String) -> AbsolutePath? {
+            return nil
         }
 
         func ls(_: AbsolutePath) throws -> [AbsolutePath] {

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
@@ -335,7 +335,7 @@ class WorkspaceStructureGeneratorTests: XCTestCase {
             cache[path] = .file
         }
 
-        func locateDirectoryTraversingParents(from _: AbsolutePath, _: String) -> AbsolutePath? {
+        func locateDirectory(_: String, traversingFrom _: AbsolutePath) -> AbsolutePath? {
             return nil
         }
 

--- a/Tests/TuistGeneratorTests/GeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/GeneratorTests.swift
@@ -1,7 +1,7 @@
 import Basic
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 class GeneratorTests: XCTestCase {
     var workspaceGenerator: MockWorkspaceGenerator!

--- a/Tests/TuistGeneratorTests/Graph/FrameworkNodeTests.swift
+++ b/Tests/TuistGeneratorTests/Graph/FrameworkNodeTests.swift
@@ -2,9 +2,9 @@ import Basic
 import Foundation
 import XCTest
 
+@testable import TuistGenerator
 @testable import TuistSupport
 @testable import TuistSupportTesting
-@testable import TuistGenerator
 
 final class FrameworkNodeTests: TuistUnitTestCase {
     var subject: FrameworkNode!

--- a/Tests/TuistGeneratorTests/Graph/GraphTests.swift
+++ b/Tests/TuistGeneratorTests/Graph/GraphTests.swift
@@ -3,9 +3,9 @@ import Foundation
 import TuistSupport
 import XCTest
 
+@testable import TuistGenerator
 @testable import TuistSupport
 @testable import TuistSupportTesting
-@testable import TuistGenerator
 
 final class GraphErrorTests: XCTestCase {
     func test_description_when_unsupportedFileExtension() {

--- a/Tests/TuistGeneratorTests/Graph/LibraryNodeTests.swift
+++ b/Tests/TuistGeneratorTests/Graph/LibraryNodeTests.swift
@@ -2,9 +2,9 @@ import Basic
 import Foundation
 import XCTest
 
+@testable import TuistGenerator
 @testable import TuistSupport
 @testable import TuistSupportTesting
-@testable import TuistGenerator
 
 final class LibraryNodeTests: TuistUnitTestCase {
     var subject: LibraryNode!

--- a/Tests/TuistGeneratorTests/Linter/EnvironmentLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/EnvironmentLinterTests.swift
@@ -2,8 +2,8 @@ import Foundation
 import TuistSupport
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class EnvironmentLinterTests: TuistUnitTestCase {
     var subject: EnvironmentLinter!

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import SPMUtility
 import TuistSupport
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class GraphLinterTests: TuistUnitTestCase {
     var subject: GraphLinter!

--- a/Tests/TuistGeneratorTests/Linter/SettingsLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/SettingsLinterTests.swift
@@ -2,8 +2,8 @@ import Basic
 import Foundation
 import TuistSupport
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class SettingsLinterTests: TuistUnitTestCase {
     var subject: SettingsLinter!

--- a/Tests/TuistGeneratorTests/Linter/TargetActionLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetActionLinterTests.swift
@@ -2,8 +2,8 @@ import Basic
 import Foundation
 import TuistSupport
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class TargetActionLinterTests: TuistUnitTestCase {
     var subject: TargetActionLinter!

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -2,8 +2,8 @@ import Basic
 import Foundation
 import TuistSupport
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class TargetLinterTests: TuistUnitTestCase {
     var subject: TargetLinter!

--- a/Tests/TuistGeneratorTests/Models/HeadersTests.swift
+++ b/Tests/TuistGeneratorTests/Models/HeadersTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import SPMUtility
 import TuistSupport
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class HeadersTests: XCTestCase {}

--- a/Tests/TuistGeneratorTests/Models/InfoPlistTests.swift
+++ b/Tests/TuistGeneratorTests/Models/InfoPlistTests.swift
@@ -1,8 +1,8 @@
 import Basic
 import Foundation
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class InfoPlistTests: XCTestCase {
     func test_equal_when_file() {

--- a/Tests/TuistGeneratorTests/Models/TargetTests.swift
+++ b/Tests/TuistGeneratorTests/Models/TargetTests.swift
@@ -1,8 +1,8 @@
 import Basic
 import Foundation
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class TargetTests: TuistUnitTestCase {
     func test_validSourceExtensions() {

--- a/Tests/TuistGeneratorTests/Utils/CocoaPodsInteractorTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/CocoaPodsInteractorTests.swift
@@ -2,8 +2,8 @@ import Foundation
 import TuistSupport
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class CocoaPodsInteractorErrorTests: XCTestCase {
     func test_type() {

--- a/Tests/TuistGeneratorTests/Utils/Mocks/MockEmbedScriptGenerator.swift
+++ b/Tests/TuistGeneratorTests/Utils/Mocks/MockEmbedScriptGenerator.swift
@@ -1,8 +1,8 @@
 import Basic
 import Foundation
 
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class MockEmbedScriptGenerator: EmbedScriptGenerating {
     var scriptArgs: [(AbsolutePath, [AbsolutePath])] = []

--- a/Tests/TuistGeneratorTests/Utils/PrecompiledMetadataProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/PrecompiledMetadataProviderTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import TuistSupport
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class BinaryArchitectureTests: TuistTestCase {
     func test_rawValue() {

--- a/Tests/TuistGeneratorTests/Utils/ProjectFilesSortenerTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/ProjectFilesSortenerTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import TuistSupport
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class ProjectFilesSortenerTests: TuistUnitTestCase {
     var subject: ProjectFilesSortener!

--- a/Tests/TuistIntegrationTests/Generator/Mocks/MockGeneratorModelLoader.swift
+++ b/Tests/TuistIntegrationTests/Generator/Mocks/MockGeneratorModelLoader.swift
@@ -1,6 +1,6 @@
 import Basic
-import TuistSupport
 import TuistGenerator
+import TuistSupport
 
 class MockGeneratorModelLoader: GeneratorModelLoading {
     private var projects = [String: (AbsolutePath) throws -> Project]()

--- a/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -1,9 +1,9 @@
 import Basic
 import XcodeProj
 import XCTest
+@testable import TuistGenerator
 @testable import TuistSupport
 @testable import TuistSupportTesting
-@testable import TuistGenerator
 
 final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
     override func setUp() {

--- a/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
@@ -1,9 +1,9 @@
 import Basic
 import XcodeProj
 import XCTest
+@testable import TuistGenerator
 @testable import TuistSupport
 @testable import TuistSupportTesting
-@testable import TuistGenerator
 
 final class StableXcodeProjIntegrationTests: TuistUnitTestCase {
     override func setUp() {

--- a/Tests/TuistKitIntegrationTests/Commands/DumpCommandIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Commands/DumpCommandIntegrationTests.swift
@@ -4,8 +4,8 @@ import SPMUtility
 import TuistSupport
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistKit
+@testable import TuistSupportTesting
 
 final class DumpCommandTests: TuistTestCase {
     var errorHandler: MockErrorHandler!

--- a/Tests/TuistKitIntegrationTests/Generator/GraphManifestLoaderIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Generator/GraphManifestLoaderIntegrationTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import TuistSupport
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistKit
+@testable import TuistSupportTesting
 
 final class GraphManifestLoaderTests: TuistTestCase {
     var subject: GraphManifestLoader!

--- a/Tests/TuistKitIntegrationTests/Utils/RootDirectoryLocatorIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Utils/RootDirectoryLocatorIntegrationTests.swift
@@ -1,0 +1,57 @@
+import Basic
+import Foundation
+import TuistSupport
+import XCTest
+
+@testable import TuistKit
+@testable import TuistSupportTesting
+
+final class RootDirectoryLocatorIntegrationTests: TuistTestCase {
+    var subject: RootDirectoryLocator!
+
+    override func setUp() {
+        super.setUp()
+        subject = RootDirectoryLocator()
+    }
+
+    override func tearDown() {
+        subject = nil
+        super.tearDown()
+    }
+
+    func test_locale_when_a_tuist_and_git_directory_exists() throws {
+        // Given
+        let temporaryDirectory = try temporaryPath()
+        try createFolders(["this/is/a/very/nested/directory", "this/is/Tuist/", "this/.git"])
+
+        // When
+        let got = subject.locate(from: temporaryDirectory.appending(RelativePath("this/is/a/very/nested/directory")))
+
+        // Then
+        XCTAssertEqual(got, temporaryDirectory.appending(RelativePath("this/is")))
+    }
+
+    func test_locale_when_a_tuist_directory_exists() throws {
+        // Given
+        let temporaryDirectory = try temporaryPath()
+        try createFolders(["this/is/a/very/nested/directory", "this/is/Tuist/"])
+
+        // When
+        let got = subject.locate(from: temporaryDirectory.appending(RelativePath("this/is/a/very/nested/directory")))
+
+        // Then
+        XCTAssertEqual(got, temporaryDirectory.appending(RelativePath("this/is")))
+    }
+
+    func test_locale_when_a_git_directory_exists() throws {
+        // Given
+        let temporaryDirectory = try temporaryPath()
+        try createFolders(["this/is/a/very/nested/directory", "this/.git"])
+
+        // When
+        let got = subject.locate(from: temporaryDirectory.appending(RelativePath("this/is/a/very/nested/directory")))
+
+        // Then
+        XCTAssertEqual(got, temporaryDirectory.appending(RelativePath("this")))
+    }
+}

--- a/Tests/TuistKitTests/Commands/CreateIssueCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/CreateIssueCommandTests.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SPMUtility
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistKit
+@testable import TuistSupportTesting
 
 final class CreateIssueCommandTests: TuistUnitTestCase {
     var subject: CreateIssueCommand!

--- a/Tests/TuistKitTests/Commands/DumpCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/DumpCommandTests.swift
@@ -4,8 +4,8 @@ import SPMUtility
 import TuistSupport
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistKit
+@testable import TuistSupportTesting
 
 final class DumpCommandTests: TuistUnitTestCase {
     var errorHandler: MockErrorHandler!

--- a/Tests/TuistKitTests/Commands/FocusCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/FocusCommandTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import SPMUtility
 import XcodeProj
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistKit
+@testable import TuistSupportTesting
 
 final class FocusCommandTests: TuistUnitTestCase {
     var subject: FocusCommand!

--- a/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
@@ -4,8 +4,8 @@ import SPMUtility
 import TuistSupport
 import XcodeProj
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistKit
+@testable import TuistSupportTesting
 
 final class GenerateCommandTests: TuistUnitTestCase {
     var subject: GenerateCommand!

--- a/Tests/TuistKitTests/Commands/GraphCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/GraphCommandTests.swift
@@ -4,8 +4,8 @@ import SPMUtility
 import TuistSupport
 import XcodeProj
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistKit
+@testable import TuistSupportTesting
 
 final class GraphCommandTests: TuistUnitTestCase {
     var subject: GraphCommand!

--- a/Tests/TuistKitTests/Commands/InitCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/InitCommandTests.swift
@@ -4,8 +4,8 @@ import TuistSupport
 import XCTest
 
 @testable import SPMUtility
-@testable import TuistSupportTesting
 @testable import TuistKit
+@testable import TuistSupportTesting
 
 final class InitCommandErrorTests: XCTestCase {
     func test_description() {

--- a/Tests/TuistKitTests/Commands/UpCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/UpCommandTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import SPMUtility
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistKit
+@testable import TuistSupportTesting
 
 final class UpCommandTests: TuistUnitTestCase {
     var subject: UpCommand!

--- a/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
+++ b/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
@@ -1,11 +1,11 @@
 import Basic
 import Foundation
-import TuistSupport
 import TuistGenerator
+import TuistSupport
 import XCTest
 @testable import ProjectDescription
-@testable import TuistSupportTesting
 @testable import TuistKit
+@testable import TuistSupportTesting
 
 class GeneratorModelLoaderTest: TuistUnitTestCase {
     typealias WorkspaceManifest = ProjectDescription.Workspace

--- a/Tests/TuistKitTests/Generator/GraphManifestLoaderTests.swift
+++ b/Tests/TuistKitTests/Generator/GraphManifestLoaderTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import TuistSupport
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistKit
+@testable import TuistSupportTesting
 
 final class GraphManifestLoaderErrorTests: TuistUnitTestCase {
     func test_description() {

--- a/Tests/TuistKitTests/Generator/ManifestTargetGeneratorTests.swift
+++ b/Tests/TuistKitTests/Generator/ManifestTargetGeneratorTests.swift
@@ -1,7 +1,7 @@
 import Basic
 import Foundation
-import TuistSupport
 import TuistGenerator
+import TuistSupport
 import XCTest
 @testable import TuistKit
 

--- a/Tests/TuistKitTests/Models/Up/UpCarthageTests.swift
+++ b/Tests/TuistKitTests/Models/Up/UpCarthageTests.swift
@@ -1,10 +1,10 @@
 import Basic
 import Foundation
-import TuistSupport
 import TuistGenerator
+import TuistSupport
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistKit
+@testable import TuistSupportTesting
 
 final class UpCarthageTests: TuistUnitTestCase {
     var platforms: [Platform]!

--- a/Tests/TuistKitTests/Models/Up/UpHomebrewTapTests.swift
+++ b/Tests/TuistKitTests/Models/Up/UpHomebrewTapTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import TuistSupport
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistKit
+@testable import TuistSupportTesting
 
 final class UpHomebrewTapTests: TuistUnitTestCase {
     var upHomebrew: MockUp!

--- a/Tests/TuistKitTests/Models/Up/UpHomebrewTests.swift
+++ b/Tests/TuistKitTests/Models/Up/UpHomebrewTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import TuistSupport
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistKit
+@testable import TuistSupportTesting
 
 final class UpHomebrewTests: TuistUnitTestCase {
     func test_isMet_when_homebrew_is_missing() throws {

--- a/Tests/TuistKitTests/Models/Up/UpTests.swift
+++ b/Tests/TuistKitTests/Models/Up/UpTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import TuistSupport
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistKit
+@testable import TuistSupportTesting
 
 final class UpTests: TuistUnitTestCase {
     func test_with_when_custom() throws {

--- a/Tests/TuistKitTests/Playgrounds/PlaygroundGeneratorTests.swift
+++ b/Tests/TuistKitTests/Playgrounds/PlaygroundGeneratorTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import TuistSupport
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistKit
+@testable import TuistSupportTesting
 
 final class PlaygroundGenerationErrorTests: XCTestCase {
     func test_description() {

--- a/Tests/TuistKitTests/Setup/SetupLoaderTests.swift
+++ b/Tests/TuistKitTests/Setup/SetupLoaderTests.swift
@@ -1,8 +1,8 @@
 import Basic
 import XCTest
+@testable import TuistKit
 @testable import TuistSupport
 @testable import TuistSupportTesting
-@testable import TuistKit
 
 final class SetupLoaderTests: TuistUnitTestCase {
     var subject: SetupLoader!

--- a/Tests/TuistKitTests/Utils/CarthageTests.swift
+++ b/Tests/TuistKitTests/Utils/CarthageTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import TuistSupport
 import XCTest
 
-@testable import TuistSupportTesting
 @testable import TuistKit
+@testable import TuistSupportTesting
 
 final class CarthageTests: TuistUnitTestCase {
     var subject: Carthage!


### PR DESCRIPTION
### Short description 📝
This PR adds a utility that given a directory, it traverses up the directories hierarchy to find the root of the project. It's considered the root of the project a directory that contains a `Tuist/` directory, or where the git repository is defined.

The `Tuist/` directory will contain the project description helpers, and in the future, some other global files that are accessible by any project.

> Note: There are so many changes in the imports because I ran swiftformat.
