### PR TITLE
Add support for watchOS apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - `HTTPClient` utility class to `TuistEnvKit` https://github.com/tuist/tuist/pull/508 by @pepibumur.
 - **Breaking** Allow specifying a deployment target within project manifests https://github.com/tuist/tuist/pull/541 by @mollyIV
 - Add support for sticker pack extension & app extension products https://github.com/tuist/tuist/pull/489 by @Rag0n
+- Add support for watchOS apps https://github.com/tuist/tuist/pull/623 by @kwridan
 
 ### Changed
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
           "branch": "master",
-          "revision": "0a778ca0c51025ffec95de881e59eb35c92f9944",
+          "revision": "f12b35be7243c09f17c9de1f71c21abf133b9da6",
           "version": null
         }
       },
@@ -51,7 +51,7 @@
         "repositoryURL": "https://github.com/tuist/XcodeProj",
         "state": {
           "branch": "master",
-          "revision": "4b285748321bd4bbdb0ae274dd9a22d454ef1a69",
+          "revision": "e051bb1637ccfd51d98d1b056186319c9c75f1e4",
           "version": null
         }
       }

--- a/Sources/ProjectDescription/Product.swift
+++ b/Sources/ProjectDescription/Product.swift
@@ -15,9 +15,9 @@ public enum Product: String, Codable, Equatable {
     // Not supported yet
     case appExtension = "app_extension"
 //    case watchApp
-//    case watch2App
+    case watch2App
 //    case watchExtension
-//    case watch2Extension
+    case watch2Extension
 //    case tvExtension
 //    case messagesApplication
 //    case messagesExtension

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -300,8 +300,8 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
                                       pbxTarget: PBXTarget,
                                       fileElements: ProjectFileElements,
                                       pbxproj: PBXProj) throws {
-        let targetNode = graph.targetDependencies(path: path, name: target.name)
-        let watchApps = targetNode.filter { $0.target.product == .watch2App }
+        let targetDependencies = graph.targetDependencies(path: path, name: target.name)
+        let watchApps = targetDependencies.filter { $0.target.product == .watch2App }
         guard !watchApps.isEmpty else { return }
 
         let embedWatchAppBuildPhase = PBXCopyFilesBuildPhase(dstPath: "$(CONTENTS_FOLDER_PATH)/Watch",

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -153,14 +153,14 @@ final class ConfigGenerator: ConfigGenerating {
                                      target: Target,
                                      graph: Graphing,
                                      sourceRootPath: AbsolutePath) {
-        settings.merge(generalTargetDerrivedSettings(target: target, sourceRootPath: sourceRootPath)) { $1 }
-        settings.merge(testBundleTargetDerrivedSettings(target: target, graph: graph, sourceRootPath: sourceRootPath)) { $1 }
-        settings.merge(deploymentTargetDerrivedSettings(target: target)) { $1 }
-        settings.merge(watchTargetDerrivedSettings(target: target, graph: graph, sourceRootPath: sourceRootPath)) { $1 }
+        settings.merge(generalTargetDerivedSettings(target: target, sourceRootPath: sourceRootPath)) { $1 }
+        settings.merge(testBundleTargetDerivedSettings(target: target, graph: graph, sourceRootPath: sourceRootPath)) { $1 }
+        settings.merge(deploymentTargetDerivedSettings(target: target)) { $1 }
+        settings.merge(watchTargetDerivedSettings(target: target, graph: graph, sourceRootPath: sourceRootPath)) { $1 }
     }
 
-    private func generalTargetDerrivedSettings(target: Target,
-                                               sourceRootPath: AbsolutePath) -> [String: SettingValue] {
+    private func generalTargetDerivedSettings(target: Target,
+                                              sourceRootPath: AbsolutePath) -> [String: SettingValue] {
         var settings: [String: SettingValue] = [:]
         settings["PRODUCT_BUNDLE_IDENTIFIER"] = .string(target.bundleId)
 
@@ -189,9 +189,9 @@ final class ConfigGenerator: ConfigGenerating {
         return settings
     }
 
-    private func testBundleTargetDerrivedSettings(target: Target,
-                                                  graph: Graphing,
-                                                  sourceRootPath: AbsolutePath) -> [String: SettingValue] {
+    private func testBundleTargetDerivedSettings(target: Target,
+                                                 graph: Graphing,
+                                                 sourceRootPath: AbsolutePath) -> [String: SettingValue] {
         guard target.product.testsBundle else {
             return [:]
         }
@@ -215,7 +215,7 @@ final class ConfigGenerator: ConfigGenerating {
         return settings
     }
 
-    private func deploymentTargetDerrivedSettings(target: Target) -> [String: SettingValue] {
+    private func deploymentTargetDerivedSettings(target: Target) -> [String: SettingValue] {
         guard let deploymentTarget = target.deploymentTarget else {
             return [:]
         }
@@ -242,9 +242,9 @@ final class ConfigGenerator: ConfigGenerating {
         return settings
     }
 
-    private func watchTargetDerrivedSettings(target: Target,
-                                             graph: Graphing,
-                                             sourceRootPath: AbsolutePath) -> [String: SettingValue] {
+    private func watchTargetDerivedSettings(target: Target,
+                                            graph: Graphing,
+                                            sourceRootPath: AbsolutePath) -> [String: SettingValue] {
         guard target.product == .watch2App else {
             return [:]
         }

--- a/Sources/TuistGenerator/Generator/InfoPlistContentProvider.swift
+++ b/Sources/TuistGenerator/Generator/InfoPlistContentProvider.swift
@@ -85,6 +85,8 @@ final class InfoPlistContentProvider: InfoPlistContentProviding {
             packageType = "BNDL"
         case .staticFramework, .framework:
             packageType = "FMWK"
+        case .watch2App, .watch2Extension:
+            packageType = "$(PRODUCT_BUNDLE_PACKAGE_TYPE)"
         case .appExtension, .stickerPackExtension:
             packageType = "XPC!"
         }

--- a/Sources/TuistGenerator/Graph/Graph.swift
+++ b/Sources/TuistGenerator/Graph/Graph.swift
@@ -306,6 +306,7 @@ class Graph: Graphing {
             .app,
             .unitTests,
             .uiTests,
+            .watch2Extension,
         ]
 
         if validProducts.contains(targetNode.target.product) == false {
@@ -370,7 +371,7 @@ class Graph: Graphing {
         }
 
         let validProducts: [Product] = [
-            .appExtension, .stickerPackExtension,
+            .appExtension, .stickerPackExtension, .watch2Extension,
         ]
 
         return targetNode.targetDependencies

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -460,6 +460,11 @@ class GraphLinter: GraphLinting {
             LintableTarget(platform: .watchOS, product: .staticLibrary),
             LintableTarget(platform: .watchOS, product: .staticFramework),
         ],
+        LintableTarget(platform: .watchOS, product: .staticFramework): [
+            LintableTarget(platform: .watchOS, product: .staticLibrary),
+            LintableTarget(platform: .watchOS, product: .staticFramework),
+            LintableTarget(platform: .watchOS, product: .framework),
+        ],
         LintableTarget(platform: .watchOS, product: .dynamicLibrary): [
             LintableTarget(platform: .watchOS, product: .dynamicLibrary),
         ],

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -251,7 +251,7 @@ class GraphLinter: GraphLinting {
             LintableTarget(platform: .iOS, product: .appExtension),
             //            LintableTarget(platform: .iOS, product: .messagesExtension),
             LintableTarget(platform: .iOS, product: .stickerPackExtension),
-//            LintableTarget(platform: .watchOS, product: .watch2App),
+            LintableTarget(platform: .watchOS, product: .watch2App),
 //            LintableTarget(platform: .watchOS, product: .watchApp),
         ],
         LintableTarget(platform: .iOS, product: .staticLibrary): [
@@ -386,7 +386,7 @@ class GraphLinter: GraphLinting {
             LintableTarget(platform: .tvOS, product: .framework),
             LintableTarget(platform: .iOS, product: .staticFramework),
         ],
-//        LintableTarget(platform: .tvOS, product: .tvExtension): [
+        //        LintableTarget(platform: .tvOS, product: .tvExtension): [
 //            LintableTarget(platform: .tvOS, product: .staticLibrary),
 //            LintableTarget(platform: .tvOS, product: .dynamicLibrary),
 //            LintableTarget(platform: .tvOS, product: .framework),
@@ -398,30 +398,31 @@ class GraphLinter: GraphLinting {
 //            LintableTarget(platform: .watchOS, product: .framework),
 //            LintableTarget(platform: .watchOS, product: .watchExtension),
 //        ],
-//        LintableTarget(platform: .watchOS, product: .watch2App): [
-//            LintableTarget(platform: .watchOS, product: .staticLibrary),
-//            LintableTarget(platform: .watchOS, product: .dynamicLibrary),
-//            LintableTarget(platform: .watchOS, product: .framework),
-//            LintableTarget(platform: .watchOS, product: .watch2Extension),
-//        ],
-//        LintableTarget(platform: .watchOS, product: .staticLibrary): [
-//            LintableTarget(platform: .watchOS, product: .staticLibrary),
-//        ],
-//        LintableTarget(platform: .watchOS, product: .dynamicLibrary): [
-//            LintableTarget(platform: .watchOS, product: .dynamicLibrary),
-//        ],
-//        LintableTarget(platform: .watchOS, product: .framework): [
-//            LintableTarget(platform: .watchOS, product: .framework),
-//        ],
-//        LintableTarget(platform: .watchOS, product: .watchExtension): [
-//            LintableTarget(platform: .watchOS, product: .staticLibrary),
-//            LintableTarget(platform: .watchOS, product: .dynamicLibrary),
-//            LintableTarget(platform: .watchOS, product: .framework),
-//        ],
-//        LintableTarget(platform: .watchOS, product: .watch2Extension): [
+        LintableTarget(platform: .watchOS, product: .watch2App): [
+            LintableTarget(platform: .watchOS, product: .watch2Extension),
+        ],
+        LintableTarget(platform: .watchOS, product: .staticLibrary): [
+            LintableTarget(platform: .watchOS, product: .staticLibrary),
+            LintableTarget(platform: .watchOS, product: .staticFramework),
+        ],
+        LintableTarget(platform: .watchOS, product: .dynamicLibrary): [
+            LintableTarget(platform: .watchOS, product: .dynamicLibrary),
+        ],
+        LintableTarget(platform: .watchOS, product: .framework): [
+            LintableTarget(platform: .watchOS, product: .staticLibrary),
+            LintableTarget(platform: .watchOS, product: .framework),
+            LintableTarget(platform: .watchOS, product: .staticFramework),
+        ],
+        //        LintableTarget(platform: .watchOS, product: .watchExtension): [
 //            LintableTarget(platform: .watchOS, product: .staticLibrary),
 //            LintableTarget(platform: .watchOS, product: .dynamicLibrary),
 //            LintableTarget(platform: .watchOS, product: .framework),
 //        ],
+        LintableTarget(platform: .watchOS, product: .watch2Extension): [
+            LintableTarget(platform: .watchOS, product: .staticLibrary),
+            LintableTarget(platform: .watchOS, product: .dynamicLibrary),
+            LintableTarget(platform: .watchOS, product: .framework),
+            LintableTarget(platform: .watchOS, product: .staticFramework),
+        ],
     ]
 }

--- a/Sources/TuistGenerator/Linter/ProjectLinter.swift
+++ b/Sources/TuistGenerator/Linter/ProjectLinter.swift
@@ -11,13 +11,13 @@ class ProjectLinter: ProjectLinting {
 
     let targetLinter: TargetLinting
     let settingsLinter: SettingsLinting
-    let schemeLinter: SchemeLinter
+    let schemeLinter: SchemeLinting
 
     // MARK: - Init
 
     init(targetLinter: TargetLinting = TargetLinter(),
          settingsLinter: SettingsLinting = SettingsLinter(),
-         schemeLinter: SchemeLinter = SchemeLinter()) {
+         schemeLinter: SchemeLinting = SchemeLinter()) {
         self.targetLinter = targetLinter
         self.settingsLinter = settingsLinter
         self.schemeLinter = schemeLinter
@@ -30,6 +30,7 @@ class ProjectLinter: ProjectLinting {
         issues.append(contentsOf: lintTargets(project: project))
         issues.append(contentsOf: settingsLinter.lint(project: project))
         issues.append(contentsOf: schemeLinter.lint(project: project))
+        issues.append(contentsOf: lintWatchTargetBundleIdentifiers(project: project))
         return issues
     }
 
@@ -54,5 +55,13 @@ class ProjectLinter: ProjectLinting {
             issues.append(issue)
         }
         return issues
+    }
+
+    private func lintWatchTargetBundleIdentifiers(project: Project) -> [LintingIssue] {
+        let applications = project.targets.filter { $0.product == .app }
+        let watchApps = project.targets.filter { $0.product == .watch2App }
+        let watchExtensions = project.targets.filter { $0.product == .watch2Extension }
+
+        return []
     }
 }

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -24,6 +24,7 @@ class TargetLinter: TargetLinting {
     func lint(target: Target) -> [LintingIssue] {
         var issues: [LintingIssue] = []
         issues.append(contentsOf: lintProductName(target: target))
+        issues.append(contentsOf: lintValidPlatformProductCombinations(target: target))
         issues.append(contentsOf: lintBundleIdentifier(target: target))
         issues.append(contentsOf: lintHasSourceFiles(target: target))
         issues.append(contentsOf: lintCopiedFiles(target: target))
@@ -150,6 +151,22 @@ class TargetLinter: TargetLinting {
 
         let osVersionRegex = "\\b[0-9]+\\.[0-9]+(?:\\.[0-9]+)?\\b"
         if !deploymentTarget.version.matches(pattern: osVersionRegex) { return [issue] }
+        return []
+    }
+
+    private func lintValidPlatformProductCombinations(target: Target) -> [LintingIssue] {
+        let invalidProductsForPlatforms: [Platform: [Product]] = [
+            .iOS: [.watch2App, .watch2Extension],
+        ]
+
+        if let invalidProducts = invalidProductsForPlatforms[target.platform],
+            invalidProducts.contains(target.product) {
+            return [
+                LintingIssue(reason: "'\(target.name)' for platform '\(target.platform)' can't have a product type '\(target.product)'",
+                             severity: .error),
+            ]
+        }
+
         return []
     }
 }

--- a/Sources/TuistGenerator/Models/Platform.swift
+++ b/Sources/TuistGenerator/Models/Platform.swift
@@ -4,12 +4,14 @@ public enum Platform: String {
     case iOS = "ios"
     case macOS = "macos"
     case tvOS = "tvos"
+    case watchOS = "watchos"
 
     public var caseValue: String {
         switch self {
         case .iOS: return "iOS"
         case .macOS: return "macOS"
         case .tvOS: return "tvOS"
+        case .watchOS: return "watchOS"
         }
     }
 }
@@ -23,6 +25,8 @@ extension Platform {
             return "iphoneos"
         case .tvOS:
             return "appletvos"
+        case .watchOS:
+            return "watchos"
         }
     }
 
@@ -34,6 +38,8 @@ extension Platform {
             return "iphonesimulator iphoneos"
         case .macOS:
             return "macosx"
+        case .watchOS:
+            return "watchsimulator watchos"
         }
     }
 
@@ -46,6 +52,8 @@ extension Platform {
             return "Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
         case .tvOS:
             return "Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk"
+        case .watchOS:
+            return "Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk"
         }
     }
 }

--- a/Sources/TuistGenerator/Models/Product.swift
+++ b/Sources/TuistGenerator/Models/Product.swift
@@ -12,9 +12,9 @@ public enum Product: String, CustomStringConvertible, CaseIterable, Encodable {
     case bundle
     case appExtension = "app_extension"
 //    case watchApp = "watch_app"
-//    case watch2App = "watch_2_app"
+    case watch2App = "watch_2_app"
 //    case watchExtension = "watch_extension"
-//    case watch2Extension = "watch_2_extension"
+    case watch2Extension = "watch_2_extension"
 //    case tvExtension = "tv_extension"
 //    case messagesApplication = "messages_application"
 //    case messagesExtension = "messages_extension"
@@ -42,12 +42,12 @@ public enum Product: String, CustomStringConvertible, CaseIterable, Encodable {
             return "appExtension"
 //        case .watchApp:
 //            return "watchApp"
-//        case .watch2App:
-//            return "watch2App"
+        case .watch2App:
+            return "watch2App"
 //        case .watchExtension:
 //            return "watchExtension"
-//        case .watch2Extension:
-//            return "watch2Extension"
+        case .watch2Extension:
+            return "watch2Extension"
 //        case .tvExtension:
 //            return "tvExtension"
 //        case .messagesApplication:
@@ -81,12 +81,12 @@ public enum Product: String, CustomStringConvertible, CaseIterable, Encodable {
             return "app extension"
 //        case .watchApp:
 //            return "watch application"
-//        case .watch2App:
-//            return "watch 2 application"
+        case .watch2App:
+            return "watch 2 application"
 //        case .watchExtension:
 //            return "watch extension"
-//        case .watch2Extension:
-//            return "watch 2 extension"
+        case .watch2Extension:
+            return "watch 2 extension"
 //        case .tvExtension:
 //            return "tv extension"
 //        case .messagesApplication:
@@ -174,12 +174,12 @@ extension Product {
             return .appExtension
 //        case .watchApp:
 //            return .watchApp
-//        case .watch2App:
-//            return .watch2App
+        case .watch2App:
+            return .watch2App
 //        case .watchExtension:
 //            return .watchExtension
-//        case .watch2Extension:
-//            return .watch2Extension
+        case .watch2Extension:
+            return .watch2Extension
 //        case .tvExtension:
 //            return .tvExtension
 //        case .messagesApplication:

--- a/Sources/TuistGenerator/Models/Target.swift
+++ b/Sources/TuistGenerator/Models/Target.swift
@@ -78,7 +78,14 @@ public class Target: Equatable, Hashable {
 
     /// Target can link staitc products (e.g. an app can link a staticLibrary)
     func canLinkStaticProducts() -> Bool {
-        return [.framework, .app, .unitTests, .uiTests].contains(product)
+        return [
+            .framework,
+            .app,
+            .unitTests,
+            .uiTests,
+            .appExtension,
+            .watch2Extension,
+        ].contains(product)
     }
 
     /// Returns the product name including the extension.
@@ -93,7 +100,7 @@ public class Target: Equatable, Hashable {
 
     var supportsSources: Bool {
         switch (platform, product) {
-        case (.iOS, .bundle), (.iOS, .stickerPackExtension):
+        case (.iOS, .bundle), (.iOS, .stickerPackExtension), (.watchOS, .watch2App):
             return false
         default:
             return true

--- a/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
+++ b/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
@@ -33,13 +33,13 @@ public final class DefaultSettingsProvider: DefaultSettingsProviding {
         "GCC_C_LANGUAGE_STANDARD",
         "GCC_NO_COMMON_BLOCKS",
         "PRODUCT_NAME",
+        "VALIDATE_PRODUCT",
     ]
 
     private static let essentialTargetSettings: Set<String> = [
         "SDKROOT",
         "CODE_SIGN_IDENTITY",
         "LD_RUNPATH_SEARCH_PATHS",
-        "VALIDATE_PRODUCT",
         "SWIFT_OPTIMIZATION_LEVEL",
         "SWIFT_ACTIVE_COMPILATION_CONDITIONS",
         "CURRENT_PROJECT_VERSION",

--- a/Sources/TuistGenerator/Utils/SettingsHelper.swift
+++ b/Sources/TuistGenerator/Utils/SettingsHelper.swift
@@ -21,13 +21,13 @@ final class SettingsHelper {
         case .iOS: return .iOS
         case .macOS: return .macOS
         case .tvOS: return .tvOS
-            // case .watchOS: return .watchOS
+        case .watchOS: return .watchOS
         }
     }
 
     func settingsProviderProduct(_ target: Target) -> BuildSettingsProvider.Product? {
         switch target.product {
-        case .app:
+        case .app, .watch2App:
             return .application
         case .dynamicLibrary:
             return .dynamicLibrary
@@ -35,6 +35,10 @@ final class SettingsHelper {
             return .staticLibrary
         case .framework, .staticFramework:
             return .framework
+        case .appExtension:
+            return .appExtension
+        case .watch2Extension:
+            return .watchExtension
         default:
             return nil
         }

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -1,16 +1,13 @@
 import Basic
 import Foundation
 import ProjectDescription
-import TuistSupport
 import TuistGenerator
+import TuistSupport
 
 enum GeneratorModelLoaderError: Error, Equatable, FatalError {
-    case featureNotYetSupported(String)
     case missingFile(AbsolutePath)
     var type: ErrorType {
         switch self {
-        case .featureNotYetSupported:
-            return .abort
         case .missingFile:
             return .abort
         }
@@ -18,8 +15,6 @@ enum GeneratorModelLoaderError: Error, Equatable, FatalError {
 
     var description: String {
         switch self {
-        case let .featureNotYetSupported(details):
-            return "\(details) is not yet supported"
         case let .missingFile(path):
             return "Couldn't find file at path '\(path.pathString)'"
         }
@@ -707,6 +702,10 @@ extension TuistGenerator.Product {
             return .appExtension
         case .stickerPackExtension:
             return .stickerPackExtension
+        case .watch2App:
+            return .watch2App
+        case .watch2Extension:
+            return .watch2Extension
         }
     }
 }
@@ -721,7 +720,7 @@ extension TuistGenerator.Platform {
         case .tvOS:
             return .tvOS
         case .watchOS:
-            throw GeneratorModelLoaderError.featureNotYetSupported("watchOS platform")
+            return .watchOS
         }
     }
 }

--- a/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
@@ -128,4 +128,22 @@ public extension XCTestCase {
     func XCTEmpty<S>(_ array: [S], file: StaticString = #file, line: UInt = #line) {
         XCTAssertTrue(array.isEmpty, "Expected array to be empty but it's not. It contains the following elements: \(array)", file: file, line: line)
     }
+
+    // `XCTUnwrap` is unavailable when building using SwiftPM
+    //
+    // - related: https://bugs.swift.org/browse/SR-11501
+
+    enum XCTUnwrapError: Error {
+        case nilValueDetected
+    }
+
+    func XCTUnwrap<T>(_ element: T?, file: StaticString = #file, line: UInt = #line) throws -> T {
+        guard let element = element else {
+            XCTFail("expected non-nil value of type \"\(type(of: T.self))\"",
+                    file: file,
+                    line: line)
+            throw XCTUnwrapError.nilValueDetected
+        }
+        return element
+    }
 }

--- a/Tests/TuistGeneratorTests/Graph/GraphTests.swift
+++ b/Tests/TuistGeneratorTests/Graph/GraphTests.swift
@@ -3,9 +3,9 @@ import Foundation
 import TuistSupport
 import XCTest
 
+@testable import TuistGenerator
 @testable import TuistSupport
 @testable import TuistSupportTesting
-@testable import TuistGenerator
 
 final class GraphErrorTests: XCTestCase {
     func test_description_when_unsupportedFileExtension() {
@@ -356,6 +356,53 @@ final class GraphTests: TuistUnitTestCase {
                        [SDKPathAndStatus(name: "ThingOne.framework", status: .optional)])
     }
 
+    func test_linkableDependencies_when_watchExtension() throws {
+        // Given
+        let frameworkA = Target.test(name: "FrameworkA", product: .framework)
+        let frameworkB = Target.test(name: "FrameworkB", product: .framework)
+        let watchExtension = Target.test(name: "WatchExtension", product: .watch2Extension)
+        let project = Project.test(targets: [watchExtension, frameworkA, frameworkB])
+
+        let graph = Graph.create(project: project,
+                                 dependencies: [
+                                     (target: watchExtension, dependencies: [frameworkA]),
+                                     (target: frameworkA, dependencies: [frameworkB]),
+                                     (target: frameworkB, dependencies: []),
+                                 ])
+
+        // When
+        let result = try graph.linkableDependencies(path: project.path, name: watchExtension.name)
+
+        // Then
+        XCTAssertEqual(result, [
+            .product(target: "FrameworkA", productName: "FrameworkA.framework"),
+        ])
+    }
+
+    func test_linkableDependencies_when_watchExtension_staticDependency() throws {
+        // Given
+        let frameworkA = Target.test(name: "FrameworkA", product: .staticFramework)
+        let frameworkB = Target.test(name: "FrameworkB", product: .framework)
+        let watchExtension = Target.test(name: "WatchExtension", product: .watch2Extension)
+        let project = Project.test(targets: [watchExtension, frameworkA, frameworkB])
+
+        let graph = Graph.create(project: project,
+                                 dependencies: [
+                                     (target: watchExtension, dependencies: [frameworkA]),
+                                     (target: frameworkA, dependencies: [frameworkB]),
+                                     (target: frameworkB, dependencies: []),
+                                 ])
+
+        // When
+        let result = try graph.linkableDependencies(path: project.path, name: watchExtension.name)
+
+        // Then
+        XCTAssertEqual(result, [
+            .product(target: "FrameworkA", productName: "FrameworkA.framework"),
+            .product(target: "FrameworkB", productName: "FrameworkB.framework"),
+        ])
+    }
+
     func test_librariesPublicHeaders() throws {
         let target = Target.test(name: "Main")
         let publicHeadersPath = AbsolutePath("/test/public/")
@@ -490,6 +537,30 @@ final class GraphTests: TuistUnitTestCase {
 
         // Then
         XCTAssertTrue(result.isEmpty)
+    }
+
+    func test_embeddableFrameworks_when_watchExtension() throws {
+        // Given
+        let frameworkA = Target.test(name: "FrameworkA", product: .framework)
+        let frameworkB = Target.test(name: "FrameworkB", product: .framework)
+        let watchExtension = Target.test(name: "WatchExtension", product: .watch2Extension)
+        let project = Project.test(targets: [watchExtension, frameworkA, frameworkB])
+
+        let graph = Graph.create(project: project,
+                                 dependencies: [
+                                     (target: watchExtension, dependencies: [frameworkA]),
+                                     (target: frameworkA, dependencies: [frameworkB]),
+                                     (target: frameworkB, dependencies: []),
+                                 ])
+
+        // When
+        let result = try graph.embeddableFrameworks(path: project.path, name: watchExtension.name)
+
+        // Then
+        XCTAssertEqual(result, [
+            .product(target: "FrameworkA", productName: "FrameworkA.framework"),
+            .product(target: "FrameworkB", productName: "FrameworkB.framework"),
+        ])
     }
 
     func test_embeddableFrameworks_ordered() throws {

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -3,8 +3,8 @@ import Foundation
 import SPMUtility
 import TuistSupport
 import XCTest
-@testable import TuistSupportTesting
 @testable import TuistGenerator
+@testable import TuistSupportTesting
 
 final class GraphLinterTests: TuistUnitTestCase {
     var subject: GraphLinter!
@@ -349,6 +349,40 @@ final class GraphLinterTests: TuistUnitTestCase {
                                      (target: macStaticFramework, dependencies: [iosStaticFramework, iosStaticLibrary]),
                                      (target: iosStaticFramework, dependencies: []),
                                      (target: iosStaticLibrary, dependencies: []),
+                                 ])
+
+        // When
+        let result = subject.lint(graph: graph)
+
+        // Then
+        XCTAssertFalse(result.isEmpty)
+    }
+
+    func test_lint_watch_canDependOnWatchExtension() throws {
+        // Given
+        let watchExtension = Target.empty(name: "WatckExtension", platform: .watchOS, product: .watch2Extension)
+        let watchApp = Target.empty(name: "WatchApp", platform: .watchOS, product: .watch2App)
+        let graph = Graph.create(project: .empty(),
+                                 dependencies: [
+                                     (target: watchApp, dependencies: [watchExtension]),
+                                     (target: watchExtension, dependencies: []),
+                                 ])
+
+        // When
+        let result = subject.lint(graph: graph)
+
+        // Then
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func test_lint_watch_canOnlyDependOnWatchExtension() throws {
+        // Given
+        let invalidDependency = Target.empty(name: "Framework", platform: .watchOS, product: .framework)
+        let watchApp = Target.empty(name: "WatchApp", platform: .watchOS, product: .watch2App)
+        let graph = Graph.create(project: .empty(),
+                                 dependencies: [
+                                     (target: watchApp, dependencies: [invalidDependency]),
+                                     (target: invalidDependency, dependencies: []),
                                  ])
 
         // When

--- a/Tests/TuistGeneratorTests/Linter/Mocks/MockProjectLinter.swift
+++ b/Tests/TuistGeneratorTests/Linter/Mocks/MockProjectLinter.swift
@@ -1,0 +1,9 @@
+import Foundation
+import TuistSupport
+@testable import TuistGenerator
+
+class MockProjectLinter: ProjectLinting {
+    func lint(_: Project) -> [LintingIssue] {
+        return []
+    }
+}

--- a/Tests/TuistGeneratorTests/Linter/Mocks/MockSchemeLinter.swift
+++ b/Tests/TuistGeneratorTests/Linter/Mocks/MockSchemeLinter.swift
@@ -1,0 +1,9 @@
+import Foundation
+import TuistSupport
+@testable import TuistGenerator
+
+class MockSchemeLinter: SchemeLinting {
+    func lint(project _: Project) -> [LintingIssue] {
+        return []
+    }
+}

--- a/Tests/TuistGeneratorTests/Linter/Mocks/MockSettingsLinter.swift
+++ b/Tests/TuistGeneratorTests/Linter/Mocks/MockSettingsLinter.swift
@@ -1,0 +1,13 @@
+import Foundation
+import TuistSupport
+@testable import TuistGenerator
+
+class MockSettingsLinter: SettingsLinting {
+    func lint(project _: Project) -> [LintingIssue] {
+        return []
+    }
+
+    func lint(target _: Target) -> [LintingIssue] {
+        return []
+    }
+}

--- a/Tests/TuistGeneratorTests/Linter/Mocks/MockTargetLinter.swift
+++ b/Tests/TuistGeneratorTests/Linter/Mocks/MockTargetLinter.swift
@@ -1,0 +1,9 @@
+import Foundation
+import TuistSupport
+@testable import TuistGenerator
+
+class MockTargetLinter: TargetLinting {
+    func lint(target _: Target) -> [LintingIssue] {
+        return []
+    }
+}

--- a/Tests/TuistGeneratorTests/Linter/ProjectLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/ProjectLinterTests.swift
@@ -5,11 +5,20 @@ import XCTest
 @testable import TuistGenerator
 
 final class ProjectLinterTests: XCTestCase {
+    var targetLinter: MockTargetLinter!
+    var schemeLinter: MockSchemeLinter!
+    var settingsLinter: MockSettingsLinter!
+
     var subject: ProjectLinter!
 
     override func setUp() {
         super.setUp()
-        subject = ProjectLinter()
+        targetLinter = MockTargetLinter()
+        schemeLinter = MockSchemeLinter()
+        settingsLinter = MockSettingsLinter()
+        subject = ProjectLinter(targetLinter: targetLinter,
+                                settingsLinter: settingsLinter,
+                                schemeLinter: schemeLinter)
     }
 
     func test_validate_when_there_are_duplicated_targets() throws {
@@ -17,5 +26,19 @@ final class ProjectLinterTests: XCTestCase {
         let project = Project.test(targets: [target, target])
         let got = subject.lint(project)
         XCTAssertTrue(got.contains(LintingIssue(reason: "Targets A from project at \(project.path.pathString) have duplicates.", severity: .error)))
+    }
+
+    func test_lint_valid_watchTargetBundleIdentifiers() throws {
+        // Given
+        let app = Target.test(name: "App", product: .app, bundleId: "app")
+        let watchApp = Target.test(name: "WatchApp", product: .watch2App, bundleId: "app.watchapp")
+        let watchExtension = Target.test(name: "WatchExtension", product: .watch2Extension, bundleId: "app.watchapp.watchextension")
+        let project = Project.test(targets: [app, watchApp, watchExtension])
+
+        // When
+        let got = subject.lint(project)
+
+        // Then
+        XCTAssertTrue(got.isEmpty)
     }
 }

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -180,4 +180,23 @@ final class TargetLinterTests: TuistUnitTestCase {
             XCTAssertTrue(got.contains(LintingIssue(reason: "The version of deployment target is incorrect", severity: .error)))
         }
     }
+
+    func test_lint_invalidProductPlatformCombinations() throws {
+        // Given
+        let invalidTargets: [Target] = [
+            .empty(name: "WatchApp_for_iOS", platform: .iOS, product: .watch2App),
+            .empty(name: "Watch2Extension_for_iOS", platform: .iOS, product: .watch2Extension),
+        ]
+
+        // When
+        let got = invalidTargets.flatMap { subject.lint(target: $0) }
+
+        // Then
+        let expectedIssues: [LintingIssue] = [
+            LintingIssue(reason: "'WatchApp_for_iOS' for platform 'iOS' can't have a product type 'watch 2 application'", severity: .error),
+            LintingIssue(reason: "'Watch2Extension_for_iOS' for platform 'iOS' can't have a product type 'watch 2 extension'",
+                         severity: .error),
+        ]
+        XCTAssertTrue(expectedIssues.allSatisfy { got.contains($0) })
+    }
 }

--- a/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -45,6 +45,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         "GCC_NO_COMMON_BLOCKS": "YES",
         "ENABLE_NS_ASSERTIONS": "NO",
         "CLANG_CXX_LANGUAGE_STANDARD": "gnu++14",
+        "VALIDATE_PRODUCT": "YES",
     ]
 
     private let appTargetEssentialDebugSettings: [String: SettingValue] = [
@@ -63,7 +64,6 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         "SWIFT_COMPILATION_MODE": "wholemodule",
         "SDKROOT": "iphoneos",
         "CODE_SIGN_IDENTITY": "iPhone Developer",
-        "VALIDATE_PRODUCT": "YES",
         "SWIFT_OPTIMIZATION_LEVEL": "-Owholemodule",
     ]
 
@@ -98,7 +98,6 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         "SDKROOT": "iphoneos",
         "TARGETED_DEVICE_FAMILY": "1,2",
         "PRODUCT_NAME": "$(TARGET_NAME:c99extidentifier)",
-        "VALIDATE_PRODUCT": "YES",
         "VERSION_INFO_PREFIX": "",
         "CODE_SIGN_IDENTITY": "",
         "SKIP_INSTALL": "YES",
@@ -222,7 +221,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
 
         // Then
         XCTAssertSettings(got, containsAll: projectEssentialReleaseSettings)
-        XCTAssertEqual(got.count, 43)
+        XCTAssertEqual(got.count, 44)
     }
 
     func testProjectSettings_whenNoneDebug() throws {
@@ -288,7 +287,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
 
         // Then
         XCTAssertSettings(got, containsAll: appTargetEssentialReleaseSettings)
-        XCTAssertEqual(got.count, 8)
+        XCTAssertEqual(got.count, 7)
     }
 
     func testTargetSettings_whenRecommendedDebug_Framework() throws {
@@ -322,7 +321,7 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
 
         // Then
         XCTAssertSettings(got, containsAll: frameworkTargetEssentialReleaseSettings)
-        XCTAssertEqual(got.count, 17)
+        XCTAssertEqual(got.count, 16)
     }
 
     func testTargetSettings_whenNoneDebug_Framework() throws {
@@ -424,7 +423,13 @@ private extension XCTestCase {
                            containsAll second: [String: SettingValue],
                            file: StaticString = #file,
                            line: UInt = #line) {
-        let filteredFirst = first.filter { second.keys.contains($0.key) }
-        XCTAssertEqual(filteredFirst, second, file: file, line: line)
+        for (key, expectedValue) in second {
+            let result = first[key]
+            XCTAssertEqual(result,
+                           expectedValue,
+                           "\(key):\(result) does not match expected \(key): \(expectedValue)",
+                           file: file,
+                           line: line)
+        }
     }
 }

--- a/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
+++ b/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
@@ -1,11 +1,11 @@
 import Basic
 import Foundation
-import TuistSupport
 import TuistGenerator
+import TuistSupport
 import XCTest
 @testable import ProjectDescription
-@testable import TuistSupportTesting
 @testable import TuistKit
+@testable import TuistSupportTesting
 
 class GeneratorModelLoaderTest: TuistUnitTestCase {
     typealias WorkspaceManifest = ProjectDescription.Workspace
@@ -577,18 +577,11 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
         assert(scheme: model, matches: manifest)
     }
 
-    func test_platform_watchOSNotSupported() {
-        XCTAssertThrowsSpecific(try TuistGenerator.Platform.from(manifest: .watchOS),
-                                GeneratorModelLoaderError.featureNotYetSupported("watchOS platform"))
-    }
-
     func test_generatorModelLoaderError_type() {
-        XCTAssertEqual(GeneratorModelLoaderError.featureNotYetSupported("").type, .abort)
         XCTAssertEqual(GeneratorModelLoaderError.missingFile("/missing/path").type, .abort)
     }
 
     func test_generatorModelLoaderError_description() {
-        XCTAssertEqual(GeneratorModelLoaderError.featureNotYetSupported("abc").description, "abc is not yet supported")
         XCTAssertEqual(GeneratorModelLoaderError.missingFile("/missing/path").description, "Couldn't find file at path '/missing/path'")
     }
 

--- a/docs/usage/2-projectswift.mdx
+++ b/docs/usage/2-projectswift.mdx
@@ -435,6 +435,10 @@ The platform type represents the platform a target is built for. It can be any o
       case: '.tvOS',
       description: 'A tvOS platform.',
     },
+    {
+      case: '.watchOS',
+      description: 'A watchOS platform.',
+    },
   ]}
 />
 
@@ -485,6 +489,14 @@ The type of build product this target will output. It can be any of the followin
     {
       case: '.stickerPackExtension',
       description: 'A sticker pack extension.',
+    },
+    {
+      case: '.watch2App',
+      description: 'A Watch application. (watchOS platform only)',
+    },
+    {
+      case: '.watch2Extension',
+      description: 'A Watch application extension. (watchOS platform only)',
     },
   ]}
 />

--- a/features/generate.feature
+++ b/features/generate.feature
@@ -227,3 +227,12 @@ Scenario: The project is an iOS application with extensions (ios_app_with_extens
     Then I should be able to build for iOS the scheme App
     Then the product 'App.app' with destination 'Debug-iphoneos' contains extension 'StickersPackExtension'
     Then the product 'App.app' with destination 'Debug-iphoneos' contains extension 'NotificationServiceExtension' 
+
+Scenario: The project is an iOS application with watch app (ios_app_with_watchapp2)
+    Given that tuist is available
+    And I have a working directory
+    Then I copy the fixture ios_app_with_watchapp2 into the working directory
+    Then tuist generates the project
+    Then I should be able to build for watchOS the scheme App
+    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'Watch/WatchApp.app'
+    Then the product 'WatchApp.app' with destination 'Debug-watchos' contains extension 'WatchAppExtension' 

--- a/fixtures/ios_app_with_watchapp2/Project.swift
+++ b/fixtures/ios_app_with_watchapp2/Project.swift
@@ -1,0 +1,39 @@
+import ProjectDescription
+
+let project = Project(name: "App",
+                      targets: [
+                        Target(name: "App",
+                               platform: .iOS,
+                               product: .app,
+                               bundleId: "io.tuist.App",
+                               infoPlist: "Support/App-Info.plist",
+                               sources: ["Sources/**"],
+                               resources: [
+                                       /* Path to resouces can be defined here */
+                                       // "Resources/**"
+                               ],
+                               dependencies: [
+                                    /* Target dependencies can be defined here */
+                                    // .framework(path: "Frameworks/MyFramework.framework")
+                                    .target(name: "WatchApp")
+                                ]),
+                        Target(name: "WatchApp",
+                               platform: .watchOS,
+                               product: .watch2App,
+                               bundleId: "io.tuist.App.watchkitapp",
+                               infoPlist: "Support/WatchApp-Info.plist",
+                               resources: "WatchApp/**",
+                               dependencies: [
+                                    .target(name: "WatchAppExtension")
+                               ]),
+                      Target(name: "WatchAppExtension",
+                               platform: .watchOS,
+                               product: .watch2Extension,
+                               bundleId: "io.tuist.App.watchkitapp.watchkitextension",
+                               infoPlist: "Support/WatchAppExtension-Info.plist",
+                               sources: ["WatchAppExtension/**"],
+                               resources: ["WatchAppExtension/**/*.xcassets"],
+                               dependencies: [
+                                    
+                               ])
+                      ])

--- a/fixtures/ios_app_with_watchapp2/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_watchapp2/Sources/AppDelegate.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
+    ) -> Bool {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        let viewController = UIViewController()
+        viewController.view.backgroundColor = .white
+        window?.rootViewController = viewController
+        window?.makeKeyAndVisible()
+        return true
+    }
+
+}

--- a/fixtures/ios_app_with_watchapp2/Support/App-Info.plist
+++ b/fixtures/ios_app_with_watchapp2/Support/App-Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_watchapp2/Support/WatchApp-Info.plist
+++ b/fixtures/ios_app_with_watchapp2/Support/WatchApp-Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>WatchApp</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>WKCompanionAppBundleIdentifier</key>
+	<string>io.tuist.App</string>
+	<key>WKWatchKitApp</key>
+	<true/>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_watchapp2/Support/WatchAppExtension-Info.plist
+++ b/fixtures/ios_app_with_watchapp2/Support/WatchAppExtension-Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>WatchApp Extension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>WKAppBundleIdentifier</key>
+			<string>io.tuist.App.watchkitapp</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.watchkit</string>
+	</dict>
+	<key>WKExtensionDelegateClassName</key>
+	<string>$(PRODUCT_MODULE_NAME).ExtensionDelegate</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_watchapp2/WatchApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/fixtures/ios_app_with_watchapp2/WatchApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,81 @@
+{
+  "images" : [
+    {
+      "size" : "24x24",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "notificationCenter",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "27.5x27.5",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "notificationCenter",
+      "subtype" : "42mm"
+    },
+    {
+      "size" : "29x29",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "2x"
+    },
+    {
+      "size" : "29x29",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "3x"
+    },
+    {
+      "size" : "40x40",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "appLauncher",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "44x44",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "appLauncher",
+      "subtype" : "40mm"
+    },
+    {
+      "size" : "50x50",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "appLauncher",
+      "subtype" : "44mm"
+    },
+    {
+      "size" : "86x86",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "quickLook",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "98x98",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "quickLook",
+      "subtype" : "42mm"
+    },
+    {
+      "size" : "108x108",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "quickLook",
+      "subtype" : "44mm"
+    },
+    {
+      "idiom" : "watch-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/fixtures/ios_app_with_watchapp2/WatchApp/Assets.xcassets/Contents.json
+++ b/fixtures/ios_app_with_watchapp2/WatchApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/fixtures/ios_app_with_watchapp2/WatchApp/Base.lproj/Interface.storyboard
+++ b/fixtures/ios_app_with_watchapp2/WatchApp/Base.lproj/Interface.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="15400" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="AgC-eL-Hgc">
+    <device id="watch38"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="15400"/>
+    </dependencies>
+    <scenes>
+        <!--Interface Controller-->
+        <scene sceneID="aou-V4-d1y">
+            <objects>
+                <controller id="AgC-eL-Hgc" customClass="InterfaceController" customModule="WatchApp" customModuleProvider="target">
+                    <items>
+                        <group width="1" alignment="left" id="0z5-lt-vg9">
+                            <items>
+                                <label alignment="left" text="Hello World" id="bWh-a9-duM"/>
+                            </items>
+                        </group>
+                        <activity alignment="left" id="YbW-9z-b71"/>
+                    </items>
+                </controller>
+            </objects>
+            <point key="canvasLocation" x="159" y="117"/>
+        </scene>
+    </scenes>
+</document>

--- a/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Complication.complicationset/Circular.imageset/Contents.json
+++ b/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Complication.complicationset/Circular.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Complication.complicationset/Contents.json
+++ b/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Complication.complicationset/Contents.json
@@ -1,0 +1,48 @@
+{
+  "assets" : [
+    {
+      "idiom" : "watch",
+      "filename" : "Circular.imageset",
+      "role" : "circular"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Extra Large.imageset",
+      "role" : "extra-large"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Graphic Bezel.imageset",
+      "role" : "graphic-bezel"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Graphic Circular.imageset",
+      "role" : "graphic-circular"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Graphic Corner.imageset",
+      "role" : "graphic-corner"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Graphic Large Rectangular.imageset",
+      "role" : "graphic-large-rectangular"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Modular.imageset",
+      "role" : "modular"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Utilitarian.imageset",
+      "role" : "utilitarian"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Complication.complicationset/Extra Large.imageset/Contents.json
+++ b/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Complication.complicationset/Extra Large.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Complication.complicationset/Graphic Bezel.imageset/Contents.json
+++ b/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Complication.complicationset/Graphic Bezel.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Complication.complicationset/Graphic Circular.imageset/Contents.json
+++ b/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Complication.complicationset/Graphic Circular.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Complication.complicationset/Graphic Corner.imageset/Contents.json
+++ b/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Complication.complicationset/Graphic Corner.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Complication.complicationset/Graphic Large Rectangular.imageset/Contents.json
+++ b/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Complication.complicationset/Graphic Large Rectangular.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Complication.complicationset/Modular.imageset/Contents.json
+++ b/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Complication.complicationset/Modular.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Complication.complicationset/Utilitarian.imageset/Contents.json
+++ b/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Complication.complicationset/Utilitarian.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Contents.json
+++ b/fixtures/ios_app_with_watchapp2/WatchAppExtension/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/fixtures/ios_app_with_watchapp2/WatchAppExtension/ExtensionDelegate.swift
+++ b/fixtures/ios_app_with_watchapp2/WatchAppExtension/ExtensionDelegate.swift
@@ -1,0 +1,48 @@
+import WatchKit
+
+class ExtensionDelegate: NSObject, WKExtensionDelegate {
+
+    func applicationDidFinishLaunching() {
+        // Perform any final initialization of your application.
+    }
+
+    func applicationDidBecomeActive() {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillResignActive() {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, etc.
+    }
+
+    func handle(_ backgroundTasks: Set<WKRefreshBackgroundTask>) {
+        // Sent when the system needs to launch the application in the background to process tasks. Tasks arrive in a set, so loop through and process each one.
+        for task in backgroundTasks {
+            // Use a switch statement to check the task type
+            switch task {
+            case let backgroundTask as WKApplicationRefreshBackgroundTask:
+                // Be sure to complete the background task once you’re done.
+                backgroundTask.setTaskCompletedWithSnapshot(false)
+            case let snapshotTask as WKSnapshotRefreshBackgroundTask:
+                // Snapshot tasks have a unique completion call, make sure to set your expiration date
+                snapshotTask.setTaskCompleted(restoredDefaultState: true, estimatedSnapshotExpiration: Date.distantFuture, userInfo: nil)
+            case let connectivityTask as WKWatchConnectivityRefreshBackgroundTask:
+                // Be sure to complete the connectivity task once you’re done.
+                connectivityTask.setTaskCompletedWithSnapshot(false)
+            case let urlSessionTask as WKURLSessionRefreshBackgroundTask:
+                // Be sure to complete the URL session task once you’re done.
+                urlSessionTask.setTaskCompletedWithSnapshot(false)
+            case let relevantShortcutTask as WKRelevantShortcutRefreshBackgroundTask:
+                // Be sure to complete the relevant-shortcut task once you're done.
+                relevantShortcutTask.setTaskCompletedWithSnapshot(false)
+            case let intentDidRunTask as WKIntentDidRunRefreshBackgroundTask:
+                // Be sure to complete the intent-did-run task once you're done.
+                intentDidRunTask.setTaskCompletedWithSnapshot(false)
+            default:
+                // make sure to complete unhandled task types
+                task.setTaskCompletedWithSnapshot(false)
+            }
+        }
+    }
+
+}

--- a/fixtures/ios_app_with_watchapp2/WatchAppExtension/InterfaceController.swift
+++ b/fixtures/ios_app_with_watchapp2/WatchAppExtension/InterfaceController.swift
@@ -1,0 +1,22 @@
+import WatchKit
+import Foundation
+
+class InterfaceController: WKInterfaceController {
+
+    override func awake(withContext context: Any?) {
+        super.awake(withContext: context)
+        
+        // Configure interface objects here.
+    }
+    
+    override func willActivate() {
+        // This method is called when watch view controller is about to be visible to user
+        super.willActivate()
+    }
+    
+    override func didDeactivate() {
+        // This method is called when watch view controller is no longer visible
+        super.didDeactivate()
+    }
+
+}


### PR DESCRIPTION
### Short description 📝

Adds support for watchOS apps.

### Solution 📦

Add support for watchOS / watchOS Extension products as well as appropriate dependency rules.

### Implementation 👩‍💻👨‍💻

- [x] Add product types
- [x] Add fixture & acceptance test
- [x] Update graph / link rules
- [x] Add embed watch build phase
- [x] Add watch build settings
- [x] Update changelog

### Test Plan 🛠

- Run `tuist generate` within `fixtures/ios_app_with_watchapp2`
- Verify the generated project contains a Watch App & Watch App Extension
- Compare against a manually created project with a Watch App

### Notes

For follow up PRs:

- [ ] Update schemes to include a runnable watch apps (requires using `RemoteRunnable` launch actions)
- [ ] Add support for watch app containers (aka standalone watch apps)