### PR TITLE
Enable the library evolution for the ProjectDescription framework

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,4 @@ AllCops:
     - Sources/**/*
     - Tests/**/*
     - galaxy/node_modules/**/*
+    - .github/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Add support for sticker pack extension & app extension products https://github.com/tuist/tuist/pull/489 by @Rag0n
 - Utility to locate the root directory of a project https://github.com/tuist/tuist/pull/622/checks?check_run_id=284958709 by @pepibumur.
 - Adds `codeCoverageTargets` to `TestAction` to make XCode gather coverage info only for that targets https://github.com/tuist/tuist/pull/619/checks?check_run_id=282561179 by @abbasmousavi
+- Enable the library evololution for the ProjectDescription framework https://github.com/tuist/tuist/pull/625 by @pepibumur.
 
 ### Changed
 

--- a/Rakefile
+++ b/Rakefile
@@ -81,7 +81,7 @@ def package
   print_section("Building tuist")
   FileUtils.mkdir_p("build")
   system("swift", "build", "--product", "tuist", "--configuration", "release")
-  system("swift", "build", "--product", "ProjectDescription", "--configuration", "release")
+  system("swift", "build", "--product", "ProjectDescription", "--configuration", "release", "-Xswiftc", "-enable-library-evolution")
   system("swift", "build", "--product", "tuistenv", "--configuration", "release")
 
   Dir.chdir(".build/release") do

--- a/Sources/TuistEnvKit/Installer/Installer.swift
+++ b/Sources/TuistEnvKit/Installer/Installer.swift
@@ -183,7 +183,8 @@ final class Installer: Installing {
             try System.shared.run(swiftPath, "build",
                                   "--product", "ProjectDescription",
                                   "--package-path", temporaryDirectory.path.pathString,
-                                  "--configuration", "release")
+                                  "--configuration", "release",
+                                  "-Xswiftc", "-enable-library-evolution")
 
             if FileHandler.shared.exists(installationDirectory) {
                 try FileHandler.shared.delete(installationDirectory)

--- a/Sources/TuistGenerator/Generator/SchemesGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemesGenerator.swift
@@ -145,7 +145,7 @@ final class SchemesGenerator: SchemesGenerating {
                                    macroExpansion: nil,
                                    testables: testables)
     }
-    
+
     /// Generates the array of BuildableReference for targets that the
     /// coverage report should be generated for them.
     ///
@@ -155,10 +155,9 @@ final class SchemesGenerator: SchemesGenerating {
     ///   - generatedProject: Generated Xcode project.
     /// - Returns: Array of buildable references.
     private func testCoverageTargetReferences(testAction: TestAction, project: Project, generatedProject: GeneratedProject) -> [XCScheme.BuildableReference] {
-        
         var codeCoverageTargets: [XCScheme.BuildableReference] = []
         testAction.codeCoverageTargets.forEach { name in
-            
+
             guard let target = project.targets.first(where: { $0.name == name }) else { return }
             guard let pbxTarget = generatedProject.targets[name] else { return }
 
@@ -167,7 +166,7 @@ final class SchemesGenerator: SchemesGenerating {
                                                           projectName: generatedProject.name)
             codeCoverageTargets.append(reference)
         }
-        
+
         return codeCoverageTargets
     }
 
@@ -214,9 +213,9 @@ final class SchemesGenerator: SchemesGenerating {
             args = XCScheme.CommandLineArguments(arguments: commandlineArgruments(arguments.launch))
             environments = environmentVariables(arguments.environment)
         }
-        
-        let codeCoverageTargets = self.testCoverageTargetReferences(testAction: testAction, project: project, generatedProject: generatedProject)
-        
+
+        let codeCoverageTargets = testCoverageTargetReferences(testAction: testAction, project: project, generatedProject: generatedProject)
+
         let onlyGenerateCoverageForSpecifiedTargets = codeCoverageTargets.count > 0 ? true : nil
 
         let shouldUseLaunchSchemeArgsEnv: Bool = args == nil && environments == nil

--- a/Sources/TuistGenerator/Linter/SchemeLinter.swift
+++ b/Sources/TuistGenerator/Linter/SchemeLinter.swift
@@ -41,7 +41,7 @@ private extension SchemeLinter {
                 )
             }
         }
-        
+
         if let testAction = scheme.testAction {
             if !buildConfigurationNames.contains(testAction.configurationName) {
                 issues.append(
@@ -58,12 +58,11 @@ private extension SchemeLinter {
         let reason = "The build configuration '\(buildConfigurationName)' specified in \(actionDescription) isn't defined in the project."
         return LintingIssue(reason: reason, severity: .error)
     }
-    
+
     func lintCodeCoverageTargets(schemes: [Scheme], targets: [Target]) -> [LintingIssue] {
-        
-        let targetNames = targets.map{$0.name}
+        let targetNames = targets.map { $0.name }
         var issues: [LintingIssue] = []
-        
+
         for scheme in schemes {
             for target in scheme.testAction?.codeCoverageTargets ?? [] {
                 if !targetNames.contains(target) {
@@ -71,13 +70,12 @@ private extension SchemeLinter {
                 }
             }
         }
-        
+
         return issues
     }
-    
+
     func missingCodeCoverageTargetIssue(missingTargetName: String, schemaName: String) -> LintingIssue {
         let reason = "The target '\(missingTargetName)' specified in \(schemaName) code coverage targets list isn't defined in the project."
         return LintingIssue(reason: reason, severity: .error)
     }
-
 }

--- a/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
+++ b/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
@@ -181,7 +181,7 @@ final class InstallerTests: TuistUnitTestCase {
                               "--product", "ProjectDescription",
                               "--package-path", temporaryDirectory.path.pathString,
                               "--configuration", "release",
-                              "-Xswiftc", "-enable-library-evolution"")
+                              "-Xswiftc", "-enable-library-evolution")
 
         try subject.install(version: version, temporaryDirectory: temporaryDirectory)
 

--- a/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
+++ b/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
@@ -180,7 +180,8 @@ final class InstallerTests: TuistUnitTestCase {
         system.succeedCommand("/path/to/swift", "build",
                               "--product", "ProjectDescription",
                               "--package-path", temporaryDirectory.path.pathString,
-                              "--configuration", "release")
+                              "--configuration", "release",
+                              "-Xswiftc", "-enable-library-evolution"")
 
         try subject.install(version: version, temporaryDirectory: temporaryDirectory)
 
@@ -221,7 +222,8 @@ final class InstallerTests: TuistUnitTestCase {
         system.succeedCommand("/path/to/swift", "build",
                               "--product", "ProjectDescription",
                               "--package-path", temporaryDirectory.path.pathString,
-                              "--configuration", "release")
+                              "--configuration", "release",
+                              "-Xswiftc", "-enable-library-evolution")
 
         try subject.install(version: version, temporaryDirectory: temporaryDirectory, force: true)
 

--- a/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
@@ -155,9 +155,8 @@ final class SchemeGeneratorTests: XCTestCase {
         XCTAssertEqual(postBuildableReference?.blueprintName, "AppTests")
         XCTAssertEqual(postBuildableReference?.buildableIdentifier, "primary")
     }
-    
+
     func test_schemeTestAction_with_codeCoverageTargets() {
-        
         let target = Target.test(name: "App", product: .app)
         let testTarget = Target.test(name: "AppTests", product: .unitTests)
 
@@ -165,7 +164,7 @@ final class SchemeGeneratorTests: XCTestCase {
         let buildAction = BuildAction.test(targets: ["App"])
 
         let scheme = Scheme.test(name: "AppTests", shared: true, buildAction: buildAction, testAction: testAction)
-        let project = Project.test(targets: [target,testTarget])
+        let project = Project.test(targets: [target, testTarget])
 
         let pbxTarget = PBXNativeTarget(name: "App", productType: .application)
         let pbxTestTarget = PBXNativeTarget(name: "AppTests", productType: .unitTestBundle)
@@ -174,7 +173,7 @@ final class SchemeGeneratorTests: XCTestCase {
         let got = subject.schemeTestAction(scheme: scheme, project: project, generatedProject: generatedProject)
 
         let codeCoverageTargetsBuildableReference = got?.codeCoverageTargets
-        
+
         XCTAssertEqual(got?.onlyGenerateCoverageForSpecifiedTargets, true)
         XCTAssertEqual(codeCoverageTargetsBuildableReference?.count, 1)
         XCTAssertEqual(codeCoverageTargetsBuildableReference?.first?.buildableName, "App.app")

--- a/Tests/TuistGeneratorTests/Linter/SchemeLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/SchemeLinterTests.swift
@@ -12,6 +12,11 @@ class SchemeLinterTests: XCTestCase {
         subject = SchemeLinter()
     }
 
+    override func tearDown() {
+        subject = nil
+        super.tearDown()
+    }
+
     func test_lint_missingConfigurations() {
         // Given
         let settings = Settings(configurations: [
@@ -26,10 +31,9 @@ class SchemeLinterTests: XCTestCase {
         let got = subject.lint(project: project)
 
         // Then
-        XCTAssertEqual(got.map { $0.severity }, [.error, .error])
-        XCTAssertEqual(got.map { $0.reason }, [
-            "The build configuration 'CustomDebug' specified in the scheme's run action isn't defined in the project.",
-            "The build configuration 'Alpha' specified in the scheme's test action isn't defined in the project.",
-        ])
+        XCTAssertEqual(got.first?.severity, .error)
+        XCTAssertEqual(got.last?.severity, .error)
+        XCTAssertEqual(got.first?.reason, "The build configuration 'CustomDebug' specified in the scheme's run action isn't defined in the project.")
+        XCTAssertEqual(got.last?.reason, "The build configuration 'Alpha' specified in the scheme's test action isn't defined in the project.")
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/624

### Short description 📝
The ABI-Stability that Swift 5.1 provides is disabled by default when binaries are compiled. As [described in this proposal](https://github.com/apple/swift-evolution/blob/master/proposals/0260-library-evolution.md), to compile a binary with ABI-Stability we need to pass the `-enable-library-evolution` argument to the compiler.

That should mitigate the issue [developers run into](https://github.com/tuist/tuist/issues/624) when they try to use Tuist with Xcode versions newer than the one that was used to compile the `ProjectDescription` framework.

### Solution 📦
- [x] Update the Rake task to pass that argument to the compiler.