### PR TITLE
Lint that duplicate dependencies doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Adds `codeCoverageTargets` to `TestAction` to make XCode gather coverage info only for that targets https://github.com/tuist/tuist/pull/619 by @abbasmousavi
 - Enable the library evololution for the ProjectDescription framework https://github.com/tuist/tuist/pull/625 by @pepibumur.
 - Add support for watchOS apps https://github.com/tuist/tuist/pull/623 by @kwridan
+- Add linting for duplicate dependencies https://github.com/tuist/tuist/pull/629 by @lakpa
 
 ### Changed
 

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -31,6 +31,7 @@ class TargetLinter: TargetLinting {
         issues.append(contentsOf: lintLibraryHasNoResources(target: target))
         issues.append(contentsOf: lintDeploymentTarget(target: target))
         issues.append(contentsOf: settingsLinter.lint(target: target))
+        issues.append(contentsOf: lintDuplicateDependency(target: target))
 
         target.actions.forEach { action in
             issues.append(contentsOf: targetActionLinter.lint(action))
@@ -169,4 +170,14 @@ class TargetLinter: TargetLinting {
 
         return []
     }
+	
+	private func lintDuplicateDependency(target: Target) -> [LintingIssue] {
+		typealias Occurence = Int
+		var seen: [Dependency: Occurence] = [:]
+		target.dependencies.forEach { seen[$0, default: 0] += 1 }
+		let duplicates = seen.enumerated().filter { $0.element.value > 1 }
+		return duplicates.map {
+			.init(reason: "Target has duplicate '\($0.element.key)' dependency specified", severity: .warning)
+		}
+	}
 }

--- a/Sources/TuistGenerator/Models/Dependency.swift
+++ b/Sources/TuistGenerator/Models/Dependency.swift
@@ -7,7 +7,7 @@ public enum SDKStatus {
     case optional
 }
 
-public enum Dependency: Equatable {
+public enum Dependency: Equatable, Hashable {
     case target(name: String)
     case project(target: String, path: AbsolutePath)
     case framework(path: AbsolutePath)

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -199,4 +199,24 @@ final class TargetLinterTests: TuistUnitTestCase {
         ]
         XCTAssertTrue(expectedIssues.allSatisfy { got.contains($0) })
     }
+
+	func test_lint_when_target_has_duplicate_dependencies_specified() {
+		let testDependency: Dependency = .sdk(name: "libc++.tbd", status: .optional)
+
+		// Given
+		let target = Target.test(dependencies: .init(repeating: testDependency, count: 2))
+
+		// When
+		let got = subject.lint(target: target)
+
+		// Then
+		XCTAssertTrue(
+			got.contains(
+				.init(
+					reason: "Target has duplicate '\(testDependency)' dependency specified",
+					severity: .warning
+				)
+			)
+		)
+    }
 }


### PR DESCRIPTION

### Short description 📝

Lints duplicate dependencies and provides appropriate warning

### Solution 📦

Introduced another linter implementation to check duplicate dependencies in **TargetLinter**
