### PR TITLE
Support ability to locate multiple Tuist directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Introduce `Systems.shared`, `TuistTestCase`, and `TuistUnitTestCase` https://github.com/tuist/tuist/pull/519 by @pepibumur.
 - Change generated object version behaviour to mimic Xcode 11 by @adamkhazi
 - **Breaking** Refine API for Swift Packages https://github.com/tuist/tuist/pull/578 by @ollieatkinson
+- Support ability to locate multiple Tuist directories https://github.com/tuist/tuist/pull/630 by @kwridan
 
 ### Fixed
 

--- a/Tests/TuistKitIntegrationTests/Utils/RootDirectoryLocatorIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Utils/RootDirectoryLocatorIntegrationTests.swift
@@ -19,7 +19,7 @@ final class RootDirectoryLocatorIntegrationTests: TuistTestCase {
         super.tearDown()
     }
 
-    func test_locale_when_a_tuist_and_git_directory_exists() throws {
+    func test_locate_when_a_tuist_and_git_directory_exists() throws {
         // Given
         let temporaryDirectory = try temporaryPath()
         try createFolders(["this/is/a/very/nested/directory", "this/is/Tuist/", "this/.git"])
@@ -31,7 +31,7 @@ final class RootDirectoryLocatorIntegrationTests: TuistTestCase {
         XCTAssertEqual(got, temporaryDirectory.appending(RelativePath("this/is")))
     }
 
-    func test_locale_when_a_tuist_directory_exists() throws {
+    func test_locate_when_a_tuist_directory_exists() throws {
         // Given
         let temporaryDirectory = try temporaryPath()
         try createFolders(["this/is/a/very/nested/directory", "this/is/Tuist/"])
@@ -43,7 +43,7 @@ final class RootDirectoryLocatorIntegrationTests: TuistTestCase {
         XCTAssertEqual(got, temporaryDirectory.appending(RelativePath("this/is")))
     }
 
-    func test_locale_when_a_git_directory_exists() throws {
+    func test_locate_when_a_git_directory_exists() throws {
         // Given
         let temporaryDirectory = try temporaryPath()
         try createFolders(["this/is/a/very/nested/directory", "this/.git"])
@@ -53,5 +53,17 @@ final class RootDirectoryLocatorIntegrationTests: TuistTestCase {
 
         // Then
         XCTAssertEqual(got, temporaryDirectory.appending(RelativePath("this")))
+    }
+
+    func test_locate_when_multiple_tuist_directories_exists() throws {
+        // Given
+        let temporaryDirectory = try temporaryPath()
+        try createFolders(["this/is/a/very/nested/Tuist/", "this/is/Tuist/"])
+
+        // When
+        let got = subject.locate(from: temporaryDirectory.appending(RelativePath("this/is/a/very/nested/directory")))
+
+        // Then
+        XCTAssertEqual(got, temporaryDirectory.appending(RelativePath("this/is/a/very/nested")))
     }
 }

--- a/Tests/TuistKitIntegrationTests/Utils/RootDirectoryLocatorIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Utils/RootDirectoryLocatorIntegrationTests.swift
@@ -59,11 +59,20 @@ final class RootDirectoryLocatorIntegrationTests: TuistTestCase {
         // Given
         let temporaryDirectory = try temporaryPath()
         try createFolders(["this/is/a/very/nested/Tuist/", "this/is/Tuist/"])
+        let paths = [
+            "this/is/a/very/directory",
+            "this/is/a/very/nested/directory",
+        ]
 
         // When
-        let got = subject.locate(from: temporaryDirectory.appending(RelativePath("this/is/a/very/nested/directory")))
+        let got = paths.map {
+            subject.locate(from: temporaryDirectory.appending(RelativePath($0)))
+        }
 
         // Then
-        XCTAssertEqual(got, temporaryDirectory.appending(RelativePath("this/is/a/very/nested")))
+        XCTAssertEqual(got, [
+            "this/is",
+            "this/is/a/very/nested",
+        ].map { temporaryDirectory.appending(RelativePath($0)) })
     }
 }


### PR DESCRIPTION
### Short description 📝 

Currently the root locator only support locating one Tuist directory, in a large workspace there could be multiple directories.

Additional context: https://github.com/tuist/tuist/pull/542#issuecomment-540966544

### Solution 📦

Update the logic to consult the file system and the cache when traversing the hierarchy

### Implementation 👩‍💻👨‍💻

- [x] Update implementation & tests
- [x] Update changelog

### Test Plan 🛠

- Verify unit tests continue to pass