### PR TITLE
Fix test target build settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Fix false positive cycle detection https://github.com/tuist/tuist/pull/546 by @kwridan
+- Fix test target build settings https://github.com/tuist/tuist/pull/661 by @kwridan
 
 ## 0.18.1
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/tuist/XcodeProj",
         "state": {
           "branch": null,
-          "revision": "0bea96dacbc7031893646be56c19e7a5e2c2881d",
-          "version": "7.4.0"
+          "revision": "23f7e12a7e0db29b4f16052692d99f9fbe41fa15",
+          "version": "7.5.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
                  targets: ["TuistGenerator"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tuist/XcodeProj", .upToNextMajor(from: "7.4.0")),
+        .package(url: "https://github.com/tuist/XcodeProj", .upToNextMajor(from: "7.5.0")),
         .package(url: "https://github.com/apple/swift-package-manager", .upToNextMajor(from: "0.5.0")),
     ],
     targets: [

--- a/Sources/TuistGenerator/Utils/SettingsHelper.swift
+++ b/Sources/TuistGenerator/Utils/SettingsHelper.swift
@@ -39,6 +39,10 @@ final class SettingsHelper {
             return .appExtension
         case .watch2Extension:
             return .watchExtension
+        case .unitTests:
+            return .unitTests
+        case .uiTests:
+            return .uiTests
         default:
             return nil
         }

--- a/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -104,6 +104,15 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
         "DYLIB_CURRENT_VERSION": "1",
     ]
 
+    private let testTargetEssentialDebugSettings: [String: SettingValue] = [
+        "SDKROOT": "iphoneos",
+        "LD_RUNPATH_SEARCH_PATHS": ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"],
+        "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+        "CODE_SIGN_IDENTITY": "iPhone Developer",
+        "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+        "TARGETED_DEVICE_FAMILY": "1,2",
+    ]
+
     override func setUp() {
         super.setUp()
         subject = DefaultSettingsProvider()
@@ -354,6 +363,70 @@ final class DefaultSettingsProvider_iOSTests: XCTestCase {
 
         // Then
         XCTAssertEqual(got.count, 0)
+    }
+
+    func testTargetSettings_whenRecommendedDebug_UnitTests() throws {
+        // Given
+        let buildConfiguration: BuildConfiguration = .debug
+        let settings = Settings(base: [:],
+                                configurations: [buildConfiguration: nil],
+                                defaultSettings: .recommended)
+        let target = Target.test(product: .unitTests, settings: settings)
+
+        // When
+        let got = try subject.targetSettings(target: target,
+                                             buildConfiguration: buildConfiguration)
+
+        // Then
+        XCTAssertSettings(got, containsAll: testTargetEssentialDebugSettings)
+    }
+
+    func testTargetSettings_whenRecommendedDebug_UITests() throws {
+        // Given
+        let buildConfiguration: BuildConfiguration = .debug
+        let settings = Settings(base: [:],
+                                configurations: [buildConfiguration: nil],
+                                defaultSettings: .recommended)
+        let target = Target.test(product: .uiTests, settings: settings)
+
+        // When
+        let got = try subject.targetSettings(target: target,
+                                             buildConfiguration: buildConfiguration)
+
+        // Then
+        XCTAssertSettings(got, containsAll: testTargetEssentialDebugSettings)
+    }
+
+    func testTargetSettings_whenEssentialDebug_UnitTests() throws {
+        // Given
+        let buildConfiguration: BuildConfiguration = .debug
+        let settings = Settings(base: [:],
+                                configurations: [buildConfiguration: nil],
+                                defaultSettings: .essential)
+        let target = Target.test(product: .unitTests, settings: settings)
+
+        // When
+        let got = try subject.targetSettings(target: target,
+                                             buildConfiguration: buildConfiguration)
+
+        // Then
+        XCTAssertEqual(got, testTargetEssentialDebugSettings)
+    }
+
+    func testTargetSettings_whenEssentialDebug_UITests() throws {
+        // Given
+        let buildConfiguration: BuildConfiguration = .debug
+        let settings = Settings(base: [:],
+                                configurations: [buildConfiguration: nil],
+                                defaultSettings: .essential)
+        let target = Target.test(product: .uiTests, settings: settings)
+
+        // When
+        let got = try subject.targetSettings(target: target,
+                                             buildConfiguration: buildConfiguration)
+
+        // Then
+        XCTAssertEqual(got, testTargetEssentialDebugSettings)
     }
 }
 


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/660

### Short description 📝

The `LD_RUNPATH_SEARCH_PATHS` was no longer getting set on test targets.

### Solution 📦

Ensure the `LD_RUNPATH_SEARCH_PATHS` build setting is set for test targets

### Implementation 👩‍💻👨‍💻

- [x] Update to XcodeProj 7.5.0 (contains built settings fix)
- [x] Update settings provider to propagate unit / ui test target types
- [x] Update tests to validate unit test target settings
- [x] Update changelog

### Test Plan 🛠

- Generate `fixtures/ios_app_with_tests`
- Verify the generated project's test target contains a valid `LD_RUNPATH_SEARCH_PATHS` build setting