### PR TITLE
Link documentation to glob patterns

### DIFF
--- a/docs/usage/2-projectswift.mdx
+++ b/docs/usage/2-projectswift.mdx
@@ -300,7 +300,7 @@ It represents a list of source files that are part of a target:
     {
       name: 'Globs',
       description:
-        'Path to the source files. They represented by a glob pattern and the compiler flags.',
+        'Path to the source files. They are represented by a [glob pattern](https://facelessuser.github.io/wcmatch/glob/) and the compiler flags.',
       type: '[SourceFileGlob]',
       typeLink: '#source-file-glob',
       optional: false,


### PR DESCRIPTION
### Short description 📝

Extend documentation by adding a link to glob patterns.

TBH I've not run the documentation locally to check that the markdown is correct, any steps to do that?