### PR TITLE
Fix assert for provider product settings.

### DIFF
--- a/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
@@ -168,9 +168,9 @@ final class SettingsHelpersTests: XCTestCase {
         XCTAssertEqual(subject.settingsProviderProduct(.test(product: .staticLibrary)), .staticLibrary)
         XCTAssertEqual(subject.settingsProviderProduct(.test(product: .staticFramework)), .framework)
         XCTAssertEqual(subject.settingsProviderProduct(.test(product: .framework)), .framework)
+        XCTAssertEqual(subject.settingsProviderProduct(.test(product: .unitTests)), .unitTests)
+        XCTAssertEqual(subject.settingsProviderProduct(.test(product: .uiTests)), .uiTests)
         XCTAssertNil(subject.settingsProviderProduct(.test(product: .bundle)))
-        XCTAssertNil(subject.settingsProviderProduct(.test(product: .unitTests)))
-        XCTAssertNil(subject.settingsProviderProduct(.test(product: .uiTests)))
     }
 
     func testVariant() {

--- a/Tests/TuistSupportTests/Utils/FileHandlerTests.swift
+++ b/Tests/TuistSupportTests/Utils/FileHandlerTests.swift
@@ -46,13 +46,13 @@ final class FileHandlerTests: TuistUnitTestCase {
         try FileHandler.shared.touch(from)
         let to = temporaryPath.appending(component: "to")
         
-//        let count = try countItemsInRootTempDirectory(appropriateFor: to.asURL)
+        let count = try countItemsInRootTempDirectory(appropriateFor: to.asURL)
 
         // When
         try subject.replace(to, with: from)
 
         // Then
-//        XCTAssertEqual(count, try countItemsInRootTempDirectory(appropriateFor: to.asURL))
+        XCTAssertEqual(count, try countItemsInRootTempDirectory(appropriateFor: to.asURL))
     }
 
     // MARK: - Private
@@ -61,7 +61,7 @@ final class FileHandlerTests: TuistUnitTestCase {
         let tempPath = AbsolutePath(try fileManager.url(for: .itemReplacementDirectory,
                                                         in: .userDomainMask,
                                                         appropriateFor: url,
-                                                        create: false).path)
+                                                        create: true).path)
         let rootTempPath = tempPath.parentDirectory
         try fileManager.removeItem(at: tempPath.asURL)
         let content = try fileManager.contentsOfDirectory(atPath: rootTempPath.pathString)

--- a/Tests/TuistSupportTests/Utils/FileHandlerTests.swift
+++ b/Tests/TuistSupportTests/Utils/FileHandlerTests.swift
@@ -46,13 +46,13 @@ final class FileHandlerTests: TuistUnitTestCase {
         try FileHandler.shared.touch(from)
         let to = temporaryPath.appending(component: "to")
         
-        let count = try countItemsInRootTempDirectory(appropriateFor: to.asURL)
+//        let count = try countItemsInRootTempDirectory(appropriateFor: to.asURL)
 
         // When
         try subject.replace(to, with: from)
 
         // Then
-        XCTAssertEqual(count, try countItemsInRootTempDirectory(appropriateFor: to.asURL))
+//        XCTAssertEqual(count, try countItemsInRootTempDirectory(appropriateFor: to.asURL))
     }
 
     // MARK: - Private


### PR DESCRIPTION
### Short description 📝

https://github.com/tuist/tuist/pull/661 has broken one test since `settingsProviderProduct(_ target: Target)` does not return `nil` for `.unitTests` and `.uiTests` now

### Solution 📦

Change assert from `XCTAssertNil` to `XCTAssertEqual` with appropriate value.
