### PR TITLE
Fix hosted unit test dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Fix false positive cycle detection https://github.com/tuist/tuist/pull/546 by @kwridan
 - Fix test target build settings https://github.com/tuist/tuist/pull/661 by @kwridan
+- Fix hosted unit test dependencies https://github.com/tuist/tuist/pull/664/ by @kwridan
 
 ## 0.18.1
 

--- a/Tests/TuistGeneratorTests/Graph/GraphTests.swift
+++ b/Tests/TuistGeneratorTests/Graph/GraphTests.swift
@@ -403,6 +403,52 @@ final class GraphTests: TuistUnitTestCase {
         ])
     }
 
+    func test_linkableDependencies_whenHostedTestTarget_withCommonStaticProducts() throws {
+        // Given
+        let staticFramework = Target.test(name: "StaticFramework",
+                                          product: .staticFramework)
+
+        let app = Target.test(name: "App", product: .app)
+        let tests = Target.test(name: "AppTests", product: .unitTests)
+        let projectA = Project.test(path: "/path/a")
+
+        let graph = Graph.create(project: projectA,
+                                 dependencies: [
+                                     (target: app, dependencies: [staticFramework]),
+                                     (target: staticFramework, dependencies: []),
+                                     (target: tests, dependencies: [app, staticFramework]),
+                                 ])
+
+        // When
+        let result = try graph.linkableDependencies(path: projectA.path, name: tests.name)
+
+        // Then
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func test_linkableDependencies_whenHostedTestTarget() throws {
+        // Given
+        let framework = Target.test(name: "Framework",
+                                    product: .framework)
+
+        let app = Target.test(name: "App", product: .app)
+        let tests = Target.test(name: "AppTests", product: .unitTests)
+        let projectA = Project.test(path: "/path/a")
+
+        let graph = Graph.create(project: projectA,
+                                 dependencies: [
+                                     (target: app, dependencies: [framework]),
+                                     (target: framework, dependencies: []),
+                                     (target: tests, dependencies: [app]),
+                                 ])
+
+        // When
+        let result = try graph.linkableDependencies(path: projectA.path, name: tests.name)
+
+        // Then
+        XCTAssertTrue(result.isEmpty)
+    }
+
     func test_librariesPublicHeaders() throws {
         let target = Target.test(name: "Main")
         let publicHeadersPath = AbsolutePath("/test/public/")
@@ -586,6 +632,56 @@ final class GraphTests: TuistUnitTestCase {
         // Then
         let expected = dependencyNames.sorted().map { DependencyReference.product(target: $0, productName: "\($0).framework") }
         XCTAssertEqual(got, expected)
+    }
+
+    func test_embeddableDependencies_whenHostedTestTarget() throws {
+        // Given
+        let framework = Target.test(name: "Framework",
+                                    product: .framework)
+
+        let app = Target.test(name: "App", product: .app)
+        let tests = Target.test(name: "AppTests", product: .unitTests)
+        let projectA = Project.test(path: "/path/a")
+
+        let graph = Graph.create(project: projectA,
+                                 dependencies: [
+                                     (target: app, dependencies: [framework]),
+                                     (target: framework, dependencies: []),
+                                     (target: tests, dependencies: [app]),
+                                 ])
+
+        // When
+        let result = try graph.embeddableFrameworks(path: projectA.path, name: tests.name)
+
+        // Then
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func test_embeddableDependencies_whenHostedTestTarget_transitiveDepndencies() throws {
+        // Given
+        let framework = Target.test(name: "Framework",
+                                    product: .framework)
+
+        let staticFramework = Target.test(name: "StaticFramework",
+                                          product: .framework)
+
+        let app = Target.test(name: "App", product: .app)
+        let tests = Target.test(name: "AppTests", product: .unitTests)
+        let projectA = Project.test(path: "/path/a")
+
+        let graph = Graph.create(project: projectA,
+                                 dependencies: [
+                                     (target: app, dependencies: [staticFramework]),
+                                     (target: framework, dependencies: []),
+                                     (target: staticFramework, dependencies: [framework]),
+                                     (target: tests, dependencies: [app, staticFramework]),
+                                 ])
+
+        // When
+        let result = try graph.embeddableFrameworks(path: projectA.path, name: tests.name)
+
+        // Then
+        XCTAssertTrue(result.isEmpty)
     }
 
     func test_librariesSearchPaths() throws {

--- a/fixtures/ios_app_with_static_frameworks/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks/Project.swift
@@ -20,6 +20,7 @@ let project = Project(name: "App",
                                  infoPlist: "Tests.plist",
                                  sources: "Tests/**",
                                  dependencies: [
+                                     .project(target: "A", path: "Modules/A"),
                                      .target(name: "App"),
                           ]),
 ])


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/658

### Short description 📝

Unit test targets that were hosted in an application were including redundant (transitive) dependencies.  This in some cases caused duplicate symbols errors during runtime when the dependencies were static products

### Solution 📦

- Hosted unit test targets should no longer link static products already linked by the host application
- Hosted unit test targets should no longer embed frameworks already embed by the host application

### Implementation 👩‍💻👨‍💻

- [x] Update fixture
- [x] Update Graph `linkableDepndencies` method
- [x] Update Graph `embeddableDependencies` method
- [x] Update `GraphTests`
- [x] Update change log

### Test Plan 🛠

- Run `tuist generate` within `fixtures/ios_app_with_static_frameworks`
- Verify the unit test target doesn't link any products
- Run `tuist generate` within `fixtures/ios_app_with_frameworks`
- Verify the unit test target doesn't transitively link/embed its host application's dependencies
