### PR TITLE
Cache the helpers module

### DIFF
--- a/Sources/TuistKit/Generator/GraphManifestLoader.swift
+++ b/Sources/TuistKit/Generator/GraphManifestLoader.swift
@@ -185,12 +185,12 @@ class GraphManifestLoader: GraphManifestLoading {
         ]
 
         // Helpers
-        let projectDesciptionHelpersModule = try projectDescriptionHelpersBuilder.build(at: path, projectDescriptionPath: projectDescriptionPath)
-        if let projectDesciptionHelpersModule = projectDesciptionHelpersModule {
+        let projectDesciptionHelpersModulePath = try projectDescriptionHelpersBuilder.build(at: path, projectDescriptionPath: projectDescriptionPath)
+        if let projectDesciptionHelpersModulePath = projectDesciptionHelpersModulePath {
             arguments.append(contentsOf: [
-                "-I", projectDesciptionHelpersModule.path.parentDirectory.pathString,
-                "-L", projectDesciptionHelpersModule.path.parentDirectory.pathString,
-                "-F", projectDesciptionHelpersModule.path.parentDirectory.pathString,
+                "-I", projectDesciptionHelpersModulePath.parentDirectory.pathString,
+                "-L", projectDesciptionHelpersModulePath.parentDirectory.pathString,
+                "-F", projectDesciptionHelpersModulePath.parentDirectory.pathString,
                 "-lProjectDescriptionHelpers",
             ])
         }
@@ -202,8 +202,6 @@ class GraphManifestLoader: GraphManifestLoading {
         guard let jsonString = result, let data = jsonString.data(using: .utf8) else {
             throw GraphManifestLoaderError.unexpectedOutput(path)
         }
-
-        try projectDesciptionHelpersModule?.cleanup()
 
         return data
     }

--- a/Sources/TuistKit/Generator/ProjectDescriptionHelpersBuilder.swift
+++ b/Sources/TuistKit/Generator/ProjectDescriptionHelpersBuilder.swift
@@ -17,10 +17,17 @@ final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding 
     /// Instance to locate the root directory of the project.
     let rootDirectoryLocator: RootDirectoryLocating
 
+    /// Path to the cache directory.
+    let cacheDirectory: AbsolutePath
+
     /// Initializes the builder with its attributes.
-    /// - Parameter rootDirectoryLocator: Instance to locate the root directory of the project.
-    init(rootDirectoryLocator: RootDirectoryLocating = RootDirectoryLocator()) {
+    /// - Parameters:
+    ///   - rootDirectoryLocator: Instance to locate the root directory of the project.
+    ///   - cacheDirectory: Path to the cache directory.
+    init(rootDirectoryLocator: RootDirectoryLocating = RootDirectoryLocator(),
+         cacheDirectory: AbsolutePath = Environment.shared.projectDescriptionHelpersCacheDirectory) {
         self.rootDirectoryLocator = rootDirectoryLocator
+        self.cacheDirectory = cacheDirectory
     }
 
     func build(at: AbsolutePath, projectDescriptionPath: AbsolutePath) throws -> AbsolutePath? {
@@ -29,8 +36,7 @@ final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding 
         let prefixHash = self.prefixHash(helpersDirectory: helpersDirectory)
 
         // Get paths
-        let cachePath = Environment.shared.projectDescriptionHelpersCacheDirectory
-        let helpersCachePath = cachePath.appending(component: prefixHash)
+        let helpersCachePath = cacheDirectory.appending(component: prefixHash)
         let helpersModuleCachePath = helpersCachePath.appending(component: hash)
         let dylibName = "libProjectDescriptionHelpers.dylib"
 

--- a/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
+++ b/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
@@ -1,4 +1,5 @@
 import Basic
+import CommonCrypto
 import Darwin
 import Foundation
 
@@ -54,6 +55,49 @@ extension AbsolutePath {
             }
         }
         return ancestorPath
+    }
+
+    /// Returns the hash of the file the path points to.
+    public func sha256() -> Data? {
+        do {
+            let bufferSize = 1024 * 1024
+            // Open file for reading:
+            let file = try FileHandle(forReadingFrom: url)
+            defer {
+                file.closeFile()
+            }
+
+            // Create and initialize SHA256 context:
+            var context = CC_SHA256_CTX()
+            CC_SHA256_Init(&context)
+
+            // Read up to `bufferSize` bytes, until EOF is reached, and update SHA256 context:
+            while autoreleasepool(invoking: {
+                // Read up to `bufferSize` bytes
+                let data = file.readData(ofLength: bufferSize)
+                if data.count > 0 {
+                    data.withUnsafeBytes {
+                        _ = CC_SHA256_Update(&context, $0, numericCast(data.count))
+                    }
+                    // Continue
+                    return true
+                } else {
+                    // End of file
+                    return false
+                }
+            }) {}
+
+            // Compute the SHA256 digest:
+            var digest = Data(count: Int(CC_SHA256_DIGEST_LENGTH))
+            digest.withUnsafeMutableBytes {
+                _ = CC_SHA256_Final($0, &context)
+            }
+
+            return digest
+        } catch {
+            print(error)
+            return nil
+        }
     }
 }
 

--- a/Sources/TuistSupport/Utils/Environment.swift
+++ b/Sources/TuistSupport/Utils/Environment.swift
@@ -16,6 +16,12 @@ public protocol Environmenting: AnyObject {
 
     /// Returns true if the output of Tuist should be coloured.
     var shouldOutputBeColoured: Bool { get }
+
+    /// Returns the cache directory
+    var cacheDirectory: AbsolutePath { get }
+
+    /// Returns the directory where the project description helper modules are cached.
+    var projectDescriptionHelpersCacheDirectory: AbsolutePath { get }
 }
 
 /// Local environment controller.
@@ -79,6 +85,16 @@ public class Environment: Environmenting {
     /// Returns the directory where all the versions are.
     public var versionsDirectory: AbsolutePath {
         return directory.appending(component: "Versions")
+    }
+
+    /// Returns the directory where the project description helper modules are cached.
+    public var projectDescriptionHelpersCacheDirectory: AbsolutePath {
+        return cacheDirectory.appending(component: "ProjectDescriptionHelpers")
+    }
+
+    /// Returns the cache directory
+    public var cacheDirectory: AbsolutePath {
+        return directory.appending(component: "Cache")
     }
 
     /// Returns the directory where all the derived projects are generated.

--- a/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
+++ b/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
@@ -30,6 +30,14 @@ public class MockEnvironment: Environmenting {
         return directory.path.appending(component: "settings.json")
     }
 
+    public var cacheDirectory: AbsolutePath {
+        return directory.path.appending(component: "Cache")
+    }
+
+    public var projectDescriptionHelpersCacheDirectory: AbsolutePath {
+        return cacheDirectory.appending(component: "ProjectDescriptionHelpers")
+    }
+
     func path(version: String) -> AbsolutePath {
         return versionsDirectory.appending(component: version)
     }

--- a/Tests/TuistKitIntegrationTests/Utils/ProjectDescriptionHelpersBuilderTests.swift
+++ b/Tests/TuistKitIntegrationTests/Utils/ProjectDescriptionHelpersBuilderTests.swift
@@ -31,14 +31,13 @@ final class ProjectDescriptionHelpersBuilderIntegrationTests: TuistTestCase {
         let projectDescriptionPath = try resourceLocator.projectDescription()
 
         // When
-        _ = try subject.build(at: path, projectDescriptionPath: projectDescriptionPath)
-        let got = try subject.build(at: path, projectDescriptionPath: projectDescriptionPath)
+        let paths = try (0 ..< 3).map { _ in try subject.build(at: path, projectDescriptionPath: projectDescriptionPath) }
 
         // Then
-        XCTAssertNotNil(got)
+        XCTAssertEqual(Set(paths).count, 1)
         XCTAssertNotNil(FileHandler.shared.glob(path, glob: "*/*/ProjectDescriptionHelpers.swiftmodule").first)
         XCTAssertNotNil(FileHandler.shared.glob(path, glob: "*/*/libProjectDescriptionHelpers.dylib").first)
         XCTAssertNotNil(FileHandler.shared.glob(path, glob: "*/*/ProjectDescriptionHelpers.swiftdoc").first)
-        XCTAssertTrue(FileHandler.shared.exists(got!))
+        XCTAssertTrue(FileHandler.shared.exists(paths.first!!))
     }
 }

--- a/Tests/TuistKitIntegrationTests/Utils/ProjectDescriptionHelpersBuilderTests.swift
+++ b/Tests/TuistKitIntegrationTests/Utils/ProjectDescriptionHelpersBuilderTests.swift
@@ -35,7 +35,6 @@ final class ProjectDescriptionHelpersBuilderIntegrationTests: TuistTestCase {
 
         // Then
         XCTAssertNotNil(got)
-        XCTAssertTrue(FileHandler.shared.exists(got!.path))
-        try got!.cleanup()
+        XCTAssertTrue(FileHandler.shared.exists(got!))
     }
 }

--- a/Tests/TuistKitIntegrationTests/Utils/ProjectDescriptionHelpersBuilderTests.swift
+++ b/Tests/TuistKitIntegrationTests/Utils/ProjectDescriptionHelpersBuilderTests.swift
@@ -13,7 +13,6 @@ final class ProjectDescriptionHelpersBuilderIntegrationTests: TuistTestCase {
     override func setUp() {
         super.setUp()
         resourceLocator = ResourceLocator()
-        subject = ProjectDescriptionHelpersBuilder()
     }
 
     override func tearDown() {
@@ -25,16 +24,21 @@ final class ProjectDescriptionHelpersBuilderIntegrationTests: TuistTestCase {
     func test_build_when_the_helpers_is_a_dylib() throws {
         // Given
         let path = try temporaryPath()
+        subject = ProjectDescriptionHelpersBuilder(cacheDirectory: path)
         let helpersPath = path.appending(RelativePath("Tuist/ProjectDescriptionHelpers"))
         try FileHandler.shared.createFolder(helpersPath)
         try FileHandler.shared.write("import Foundation; class Test {}", path: helpersPath.appending(component: "Helper.swift"), atomically: true)
         let projectDescriptionPath = try resourceLocator.projectDescription()
 
         // When
+        _ = try subject.build(at: path, projectDescriptionPath: projectDescriptionPath)
         let got = try subject.build(at: path, projectDescriptionPath: projectDescriptionPath)
 
         // Then
         XCTAssertNotNil(got)
+        XCTAssertNotNil(FileHandler.shared.glob(path, glob: "*/*/ProjectDescriptionHelpers.swiftmodule").first)
+        XCTAssertNotNil(FileHandler.shared.glob(path, glob: "*/*/libProjectDescriptionHelpers.dylib").first)
+        XCTAssertNotNil(FileHandler.shared.glob(path, glob: "*/*/ProjectDescriptionHelpers.swiftdoc").first)
         XCTAssertTrue(FileHandler.shared.exists(got!))
     }
 }


### PR DESCRIPTION
Related https://github.com/tuist/tuist/issues/668

### Short description 📝
This PR adds support for caching the project description helpers modules across runs. If any of the files under the helpers directory changes, the logic deletes the old version of the framework automatically. 

### Solution 📦

Extend the `ProjectDescriptionHelpersBuilder` logic to cache the frameworks in a system directory.