### PR TITLE
Generate ProjectDescription.swiftinterface

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -81,14 +81,22 @@ def package
   print_section("Building tuist")
   FileUtils.mkdir_p("build")
   system("swift", "build", "--product", "tuist", "--configuration", "release")
-  system("swift", "build", "--product", "ProjectDescription", "--configuration", "release", "-Xswiftc", "-enable-library-evolution")
+  system(
+    "swift", "build",
+    "--product", "ProjectDescription",
+    "--configuration", "release",
+    "-Xswiftc", "-enable-library-evolution",
+    "-Xswiftc", "-emit-module-interface",
+    "-Xswiftc", "-emit-module-interface-path",
+    "-Xswiftc", ".build/release/ProjectDescription.swiftinterface"
+  )
   system("swift", "build", "--product", "tuistenv", "--configuration", "release")
 
   Dir.chdir(".build/release") do
     system(
       "zip", "-q", "-r", "--symlinks",
       "tuist.zip", "tuist",
-      "ProjectDescription.swiftmodule", "ProjectDescription.swiftdoc", "libProjectDescription.dylib"
+      "ProjectDescription.swiftmodule", "ProjectDescription.swiftdoc", "libProjectDescription.dylib", "ProjectDescription.swiftinterface"
     )
     system("zip", "-q", "-r", "--symlinks", "tuistenv.zip", "tuistenv")
   end

--- a/Sources/TuistEnvKit/Installer/BuildCopier.swift
+++ b/Sources/TuistEnvKit/Installer/BuildCopier.swift
@@ -15,6 +15,7 @@ class BuildCopier: BuildCopying {
         // Project description
         "ProjectDescription.swiftmodule",
         "ProjectDescription.swiftdoc",
+        "ProjectDescription.swiftinterface",
         "libProjectDescription.dylib",
     ]
 

--- a/Sources/TuistEnvKit/Installer/Installer.swift
+++ b/Sources/TuistEnvKit/Installer/Installer.swift
@@ -180,11 +180,15 @@ final class Installer: Installing {
                                   "--product", "tuist",
                                   "--package-path", temporaryDirectory.path.pathString,
                                   "--configuration", "release")
+
             try System.shared.run(swiftPath, "build",
                                   "--product", "ProjectDescription",
                                   "--package-path", temporaryDirectory.path.pathString,
                                   "--configuration", "release",
-                                  "-Xswiftc", "-enable-library-evolution")
+                                  "-Xswiftc", "-enable-library-evolution",
+                                  "-Xswiftc", "-emit-module-interface",
+                                  "-Xswiftc", "-emit-module-interface-path",
+                                  "-Xswiftc", temporaryDirectory.path.appending(RelativePath(".build/release/ProjectDescription.swiftinterface")).pathString)
 
             if FileHandler.shared.exists(installationDirectory) {
                 try FileHandler.shared.delete(installationDirectory)

--- a/Tests/TuistEnvKitTests/Installer/BuildCopierTests.swift
+++ b/Tests/TuistEnvKitTests/Installer/BuildCopierTests.swift
@@ -19,6 +19,7 @@ final class BuildCopierTests: XCTestCase {
             "tuist",
             "ProjectDescription.swiftmodule",
             "ProjectDescription.swiftdoc",
+            "ProjectDescription.swiftinterface",
             "libProjectDescription.dylib",
         ])
     }

--- a/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
+++ b/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
@@ -181,7 +181,10 @@ final class InstallerTests: TuistUnitTestCase {
                               "--product", "ProjectDescription",
                               "--package-path", temporaryDirectory.path.pathString,
                               "--configuration", "release",
-                              "-Xswiftc", "-enable-library-evolution")
+                              "-Xswiftc", "-enable-library-evolution",
+                              "-Xswiftc", "-emit-module-interface",
+                              "-Xswiftc", "-emit-module-interface-path",
+                              "-Xswiftc", temporaryDirectory.path.appending(RelativePath(".build/release/ProjectDescription.swiftinterface")).pathString)
 
         try subject.install(version: version, temporaryDirectory: temporaryDirectory)
 
@@ -223,7 +226,10 @@ final class InstallerTests: TuistUnitTestCase {
                               "--product", "ProjectDescription",
                               "--package-path", temporaryDirectory.path.pathString,
                               "--configuration", "release",
-                              "-Xswiftc", "-enable-library-evolution")
+                              "-Xswiftc", "-enable-library-evolution",
+                              "-Xswiftc", "-emit-module-interface",
+                              "-Xswiftc", "-emit-module-interface-path",
+                              "-Xswiftc", temporaryDirectory.path.appending(RelativePath(".build/release/ProjectDescription.swiftinterface")).pathString)
 
         try subject.install(version: version, temporaryDirectory: temporaryDirectory, force: true)
 


### PR DESCRIPTION
### Short description 📝
Even after passing the flag `-enable-library-evolution`, the `ProjectDescription.swiftinterface` file was not getting generated. As @kwridan pointed out, we need to explicitly pass the `-emit-module-interface` and `-emit-module-interface-path` arguments when compiling the `ProjectDescription` framework.

### Solution 📦

Extend the logic that builds Tuist to generate that file and include it with the rest of the files when packaging everything together.
