### PR TITLE
ProjectDescription.Settings provide none case for default settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+- Add `ProjectDescription.Settings.defaultSettings` none case that don't override any `Project` or `Target` settings. https://github.com/tuist/tuist/pull/698 by @rowwingman
+
 ## 0.19.0
 
 ### Added

--- a/Sources/ProjectDescription/Settings.swift
+++ b/Sources/ProjectDescription/Settings.swift
@@ -140,6 +140,7 @@ public extension CustomConfiguration {
 public enum DefaultSettings: String, Codable {
     case recommended
     case essential
+    case none
 }
 
 // MARK: - Settings

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -413,6 +413,8 @@ extension TuistCore.DefaultSettings {
             return .recommended
         case .essential:
             return .essential
+        case .none:
+            return .none
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/670

### Short description 📝

Add missing default settings none case. The case is mentioned in the documentation https://docs.tuist.io/usage-projectswift#defaultsettings