### PR TITLE
Add project editor utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
-- Add `ProjectDescription.Settings.defaultSettings` none case that don't override any `Project` or `Target` settings. https://github.com/tuist/tuist/pull/698 by @rowwingman
+### Added
+
+- Add `ProjectDescription.Settings.defaultSettings` none case that don't override any `Project` or `Target` settings. https://github.com/tuist/tuist/pull/698 by @rowwingman.
+- `ProjectEditor` utility https://github.com/tuist/tuist/pull/702 by @pepibumur.
 
 ## 0.19.0
 

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -141,6 +141,15 @@ public class Graph: Graphing {
 
     // MARK: - Init
 
+    public convenience init(name: String,
+                            entryPath: AbsolutePath,
+                            cache: GraphLoaderCaching) {
+        self.init(name: name,
+                  entryPath: entryPath,
+                  cache: cache,
+                  entryNodes: [])
+    }
+
     init(name: String,
          entryPath: AbsolutePath,
          cache: GraphLoaderCaching,

--- a/Sources/TuistCore/Graph/GraphNode.swift
+++ b/Sources/TuistCore/Graph/GraphNode.swift
@@ -16,7 +16,7 @@ public class GraphNode: Equatable, Hashable, Encodable, CustomStringConvertible 
 
     // MARK: - Init
 
-    init(path: AbsolutePath, name: String) {
+    public init(path: AbsolutePath, name: String) {
         self.path = path
         self.name = name
     }

--- a/Sources/TuistCore/Models/Project.swift
+++ b/Sources/TuistCore/Models/Project.swift
@@ -49,9 +49,9 @@ public class Project: Equatable, CustomStringConvertible {
                 fileName: String? = nil,
                 settings: Settings,
                 filesGroup: ProjectGroup,
-                targets: [Target],
-                packages: [Package],
-                schemes: [Scheme],
+                targets: [Target] = [],
+                packages: [Package] = [],
+                schemes: [Scheme] = [],
                 additionalFiles: [FileElement] = []) {
         self.path = path
         self.name = name

--- a/Sources/TuistGenerator/Generator/Generator.swift
+++ b/Sources/TuistGenerator/Generator/Generator.swift
@@ -14,6 +14,12 @@ public protocol Generating {
     /// - seealso: TuistCore.FatalError
     func generateProject(at path: AbsolutePath) throws -> AbsolutePath
 
+    /// Generates the given project in the same directory where it's defined.
+    /// - Parameters:
+    ///     - project: The project to be generated.
+    ///     - graph: The dependencies graph.
+    func generateProject(_ project: Project, graph: Graphing) throws -> AbsolutePath
+
     /// Generate an Xcode workspace for the project at a given path. All the project's dependencies will also be generated and included.
     ///
     /// - Parameters:
@@ -87,6 +93,13 @@ public class Generator: Generating {
         self.workspaceGenerator = workspaceGenerator
         self.projectGenerator = projectGenerator
         self.environmentLinter = environmentLinter
+    }
+
+    public func generateProject(_ project: Project, graph: Graphing) throws -> AbsolutePath {
+        let generatedProject = try projectGenerator.generate(project: project,
+                                                             graph: graph,
+                                                             sourceRootPath: project.path)
+        return generatedProject.path
     }
 
     public func generateProject(at path: AbsolutePath) throws -> AbsolutePath {

--- a/Sources/TuistKit/Extensions/Generator+TuistKit.swift
+++ b/Sources/TuistKit/Extensions/Generator+TuistKit.swift
@@ -1,0 +1,17 @@
+import Foundation
+import TuistGenerator
+
+extension Generator {
+    /// Initializes a generator instance with all the dependencies that are specific to Tuist.
+    convenience init() {
+        let resourceLocator = ResourceLocator()
+        let manifestLoader = GraphManifestLoader(resourceLocator: resourceLocator)
+        let manifestTargetGenerator = ManifestTargetGenerator(manifestLoader: manifestLoader,
+                                                              resourceLocator: resourceLocator)
+        let manifestLinter = ManifestLinter()
+        let modelLoader = GeneratorModelLoader(manifestLoader: manifestLoader,
+                                               manifestLinter: manifestLinter,
+                                               manifestTargetGenerator: manifestTargetGenerator)
+        self.init(modelLoader: modelLoader)
+    }
+}

--- a/Sources/TuistKit/Generator/GraphManifestLoader.swift
+++ b/Sources/TuistKit/Generator/GraphManifestLoader.swift
@@ -94,6 +94,9 @@ class GraphManifestLoader: GraphManifestLoading {
     /// Instance to compile and return a temporary module that contains the helper files.
     let projectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding
 
+    /// Utility to locate manifest files.
+    let manifestFilesLocator: ManifestFilesLocating
+
     /// A decoder instance for decoding the raw manifest data to their concrete types
     private let decoder: JSONDecoder
 
@@ -104,10 +107,13 @@ class GraphManifestLoader: GraphManifestLoading {
     /// - Parameters:
     ///   - resourceLocator: Resource locator to look up Tuist-related resources.
     ///   - helpersLoader: Instance to compile and return a temporary module that contains the helper files.
+    ///   - manifestFilesLocator: Utility to locate manifest files.
     init(resourceLocator: ResourceLocating = ResourceLocator(),
-         projectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding = ProjectDescriptionHelpersBuilder()) {
+         projectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding = ProjectDescriptionHelpersBuilder(),
+         manifestFilesLocator: ManifestFilesLocating = ManifestFilesLocator()) {
         self.resourceLocator = resourceLocator
         self.projectDescriptionHelpersBuilder = projectDescriptionHelpersBuilder
+        self.manifestFilesLocator = manifestFilesLocator
         decoder = JSONDecoder()
     }
 
@@ -122,9 +128,7 @@ class GraphManifestLoader: GraphManifestLoading {
     }
 
     func manifests(at path: AbsolutePath) -> Set<Manifest> {
-        return .init(Manifest.allCases.filter {
-            FileHandler.shared.exists(path.appending(component: $0.fileName))
-        })
+        return Set(manifestFilesLocator.locate(at: path).map { $0.0 })
     }
 
     /// Loads the TuistConfig.swift in the given directory.

--- a/Sources/TuistKit/Generator/ProjectDescriptionHelpersBuilder.swift
+++ b/Sources/TuistKit/Generator/ProjectDescriptionHelpersBuilder.swift
@@ -18,24 +18,24 @@ final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding 
     /// in the current process for helpers directories (key of the dictionary)
     fileprivate var builtHelpers: [AbsolutePath: AbsolutePath] = [:]
 
-    /// Instance to locate the root directory of the project.
-    let rootDirectoryLocator: RootDirectoryLocating
-
     /// Path to the cache directory.
     let cacheDirectory: AbsolutePath
 
+    /// Instance to locate the helpers directory.
+    let helpersDirectoryLocator: HelpersDirectoryLocating
+
     /// Initializes the builder with its attributes.
     /// - Parameters:
-    ///   - rootDirectoryLocator: Instance to locate the root directory of the project.
     ///   - cacheDirectory: Path to the cache directory.
-    init(rootDirectoryLocator: RootDirectoryLocating = RootDirectoryLocator(),
-         cacheDirectory: AbsolutePath = Environment.shared.projectDescriptionHelpersCacheDirectory) {
-        self.rootDirectoryLocator = rootDirectoryLocator
+    ///   - helpersDirectoryLocating: Instance to locate the helpers directory.
+    init(cacheDirectory: AbsolutePath = Environment.shared.projectDescriptionHelpersCacheDirectory,
+         helpersDirectoryLocator: HelpersDirectoryLocating = HelpersDirectoryLocator()) {
         self.cacheDirectory = cacheDirectory
+        self.helpersDirectoryLocator = helpersDirectoryLocator
     }
 
     func build(at: AbsolutePath, projectDescriptionPath: AbsolutePath) throws -> AbsolutePath? {
-        guard let helpersDirectory = self.helpersDirectory(at: at) else { return nil }
+        guard let helpersDirectory = self.helpersDirectoryLocator.locate(at: at) else { return nil }
         if let cachedPath = builtHelpers[helpersDirectory] { return cachedPath }
 
         let hash = try self.hash(helpersDirectory: helpersDirectory)
@@ -68,17 +68,6 @@ final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding 
     }
 
     // MARK: - Fileprivate
-
-    /// Returns the path to the helpers directory if it exists.
-    /// - Parameter at: Path from which we traverse the hierarchy to obtain the helpers directory.
-    fileprivate func helpersDirectory(at: AbsolutePath) -> AbsolutePath? {
-        guard let rootDirectory = self.rootDirectoryLocator.locate(from: at) else { return nil }
-        let helpersDirectory = rootDirectory
-            .appending(component: Constants.tuistDirectoryName)
-            .appending(component: Constants.helpersDirectoryName)
-        if !FileHandler.shared.exists(helpersDirectory) { return nil }
-        return helpersDirectory
-    }
 
     fileprivate func command(outputDirectory: AbsolutePath,
                              helpersDirectory: AbsolutePath,

--- a/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
@@ -1,0 +1,52 @@
+import Basic
+import Foundation
+import TuistGenerator
+import TuistSupport
+
+protocol ProjectEditing: AnyObject {
+    func edit(at: AbsolutePath, in destinationDirectory: AbsolutePath) throws
+}
+
+final class ProjectEditor: ProjectEditing {
+    /// Project generator.
+    let generator: Generating
+
+    /// Project editor mapper.
+    let projectEditorMapper: ProjectEditorMapping
+
+    /// Utility to locate Tuist's resources.
+    let resourceLocator: ResourceLocating
+
+    /// Utility to locate manifest files.
+    let manifestFilesLocator: ManifestFilesLocating
+
+    /// Utility to locate the helpers directory.
+    let helpersDirectoryLocator: HelpersDirectoryLocating
+
+    init(generator: Generating = Generator(),
+         projectEditorMapper: ProjectEditorMapping = ProjectEditorMapper(),
+         resourceLocator: ResourceLocating = ResourceLocator(),
+         manifestFilesLocator: ManifestFilesLocating = ManifestFilesLocator(),
+         helpersDirectoryLocator: HelpersDirectoryLocating = HelpersDirectoryLocator()) {
+        self.generator = generator
+        self.projectEditorMapper = projectEditorMapper
+        self.resourceLocator = resourceLocator
+        self.manifestFilesLocator = manifestFilesLocator
+        self.helpersDirectoryLocator = helpersDirectoryLocator
+    }
+
+    func edit(at: AbsolutePath, in destinationDirectory: AbsolutePath) throws {
+        let projectDesciptionPath = try resourceLocator.projectDescription()
+        let manifests = manifestFilesLocator.locate(at: at)
+        var helpers: [AbsolutePath] = []
+        if let helpersDirectory = self.helpersDirectoryLocator.locate(at: at) {
+            helpers = FileHandler.shared.glob(helpersDirectory, glob: "**/*.swift")
+        }
+
+        let (project, graph) = projectEditorMapper.map(sourceRootPath: destinationDirectory,
+                                                       manifests: manifests.map { $0.1 },
+                                                       helpers: helpers,
+                                                       projectDescriptionPath: projectDesciptionPath)
+        _ = try generator.generateProject(project, graph: graph)
+    }
+}

--- a/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
@@ -4,6 +4,10 @@ import TuistGenerator
 import TuistSupport
 
 protocol ProjectEditing: AnyObject {
+    /// Generates an Xcode project to edit the Project defined in the given directory.
+    /// - Parameters:
+    ///   - at: Directory whose project will be edited.
+    ///   - destinationDirectory: Directory in which the Xcode project will be generated.
     func edit(at: AbsolutePath, in destinationDirectory: AbsolutePath) throws
 }
 

--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -1,0 +1,86 @@
+import Basic
+import Foundation
+import TuistCore
+import TuistSupport
+
+protocol ProjectEditorMapping: AnyObject {
+    func map(sourceRootPath: AbsolutePath,
+             manifests: [AbsolutePath],
+             helpers: [AbsolutePath],
+             projectDescriptionPath: AbsolutePath) -> (Project, Graph)
+}
+
+final class ProjectEditorMapper: ProjectEditorMapping {
+    func map(sourceRootPath: AbsolutePath,
+             manifests: [AbsolutePath],
+             helpers: [AbsolutePath],
+             projectDescriptionPath: AbsolutePath) -> (Project, Graph) {
+        // Settings
+        let projectSettings = Settings(base: [:],
+                                       configurations: Settings.default.configurations,
+                                       defaultSettings: .recommended)
+
+        let targetSettings = Settings(base: settings(projectDescriptionPath: projectDescriptionPath),
+                                      configurations: Settings.default.configurations,
+                                      defaultSettings: .recommended)
+
+        // Targets
+        let manifestsTarget = Target(name: "Manifests",
+                                     platform: .macOS,
+                                     product: .staticFramework,
+                                     productName: "Manifests",
+                                     bundleId: "io.tuist.manifests.${PRODUCT_NAME:rfc1034identifier}",
+                                     settings: targetSettings,
+                                     sources: manifests.map { (path: $0, compilerFlags: nil) },
+                                     filesGroup: .group(name: "Manifests"),
+                                     dependencies: [.target(name: "ProjectDescriptionHelpers")])
+        var helpersTarget: Target?
+        if !helpers.isEmpty {
+            helpersTarget = Target(name: "ProjectDescriptionHelpers",
+                                   platform: .macOS,
+                                   product: .staticFramework,
+                                   productName: "ProjectDescriptionHelpers",
+                                   bundleId: "io.tuist.manifests.${PRODUCT_NAME:rfc1034identifier}",
+                                   settings: targetSettings,
+                                   sources: helpers.map { (path: $0, compilerFlags: nil) },
+                                   filesGroup: .group(name: "Manifests"))
+        }
+        var targets: [Target] = []
+        targets.append(manifestsTarget)
+        if let helpersTarget = helpersTarget { targets.append(helpersTarget) }
+
+        // Project
+        let project = Project(path: sourceRootPath,
+                              name: "Manifests",
+                              settings: projectSettings,
+                              filesGroup: .group(name: "Manifests"),
+                              targets: targets)
+
+        // Graph
+        let cache = GraphLoaderCache()
+        let graph = Graph(name: "Manifests", entryPath: sourceRootPath, cache: cache)
+        var dependencies: [TargetNode] = []
+
+        if let helpersTarget = helpersTarget {
+            let helpersNode = TargetNode(project: project, target: helpersTarget, dependencies: [])
+            cache.add(targetNode: helpersNode)
+            dependencies.append(helpersNode)
+        }
+        cache.add(targetNode: TargetNode(project: project, target: manifestsTarget, dependencies: dependencies))
+
+        // Project
+        return (project, graph)
+    }
+
+    /// It returns the build settings that should be used in the manifests target.
+    /// - Parameter projectDescriptionPath: Path to the ProjectDescription framework.
+    fileprivate func settings(projectDescriptionPath: AbsolutePath) -> [String: SettingValue] {
+        let frameworkParentDirectory = projectDescriptionPath.parentDirectory
+        var buildSettings = [String: SettingValue]()
+        buildSettings["FRAMEWORK_SEARCH_PATHS"] = .string(frameworkParentDirectory.pathString)
+        buildSettings["LIBRARY_SEARCH_PATHS"] = .string(frameworkParentDirectory.pathString)
+        buildSettings["SWIFT_INCLUDE_PATHS"] = .string(frameworkParentDirectory.pathString)
+        buildSettings["SWIFT_VERSION"] = .string(Constants.swiftVersion)
+        return buildSettings
+    }
+}

--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -25,22 +25,26 @@ final class ProjectEditorMapper: ProjectEditorMapping {
                                       defaultSettings: .recommended)
 
         // Targets
+        var manifestsDependencies: [Dependency] = []
+        if !helpers.isEmpty {
+            manifestsDependencies = [.target(name: "ProjectDescriptionHelpers")]
+        }
         let manifestsTarget = Target(name: "Manifests",
                                      platform: .macOS,
                                      product: .staticFramework,
                                      productName: "Manifests",
-                                     bundleId: "io.tuist.manifests.${PRODUCT_NAME:rfc1034identifier}",
+                                     bundleId: "io.tuist.${PRODUCT_NAME:rfc1034identifier}",
                                      settings: targetSettings,
                                      sources: manifests.map { (path: $0, compilerFlags: nil) },
                                      filesGroup: .group(name: "Manifests"),
-                                     dependencies: [.target(name: "ProjectDescriptionHelpers")])
+                                     dependencies: manifestsDependencies)
         var helpersTarget: Target?
         if !helpers.isEmpty {
             helpersTarget = Target(name: "ProjectDescriptionHelpers",
                                    platform: .macOS,
                                    product: .staticFramework,
                                    productName: "ProjectDescriptionHelpers",
-                                   bundleId: "io.tuist.manifests.${PRODUCT_NAME:rfc1034identifier}",
+                                   bundleId: "io.tuist.${PRODUCT_NAME:rfc1034identifier}",
                                    settings: targetSettings,
                                    sources: helpers.map { (path: $0, compilerFlags: nil) },
                                    filesGroup: .group(name: "Manifests"))

--- a/Sources/TuistKit/Utils/HelpersDirectoryLocator.swift
+++ b/Sources/TuistKit/Utils/HelpersDirectoryLocator.swift
@@ -1,0 +1,31 @@
+import Basic
+import Foundation
+import TuistSupport
+
+protocol HelpersDirectoryLocating {
+    /// Returns the path to the helpers directory if it exists.
+    /// - Parameter at: Path from which we traverse the hierarchy to obtain the helpers directory.
+    func locate(at: AbsolutePath) -> AbsolutePath?
+}
+
+final class HelpersDirectoryLocator: HelpersDirectoryLocating {
+    /// Instance to locate the root directory of the project.
+    let rootDirectoryLocator: RootDirectoryLocating
+
+    /// Initializes the locator with its dependencies.
+    /// - Parameter rootDirectoryLocator: Instance to locate the root directory of the project.
+    init(rootDirectoryLocator: RootDirectoryLocating = RootDirectoryLocator()) {
+        self.rootDirectoryLocator = rootDirectoryLocator
+    }
+
+    // MARK: - HelpersDirectoryLocating
+
+    func locate(at: AbsolutePath) -> AbsolutePath? {
+        guard let rootDirectory = self.rootDirectoryLocator.locate(from: at) else { return nil }
+        let helpersDirectory = rootDirectory
+            .appending(component: Constants.tuistDirectoryName)
+            .appending(component: Constants.helpersDirectoryName)
+        if !FileHandler.shared.exists(helpersDirectory) { return nil }
+        return helpersDirectory
+    }
+}

--- a/Sources/TuistKit/Utils/ManifestFilesLocator.swift
+++ b/Sources/TuistKit/Utils/ManifestFilesLocator.swift
@@ -1,0 +1,20 @@
+import Basic
+import Foundation
+import TuistSupport
+
+protocol ManifestFilesLocating: AnyObject {
+    /// It locates the manifest files that are have a connection with the
+    /// definitions in the current directory.
+    /// - Parameter at: Directory for which the manifest files will be obtained.
+    func locate(at: AbsolutePath) -> [(Manifest, AbsolutePath)]
+}
+
+final class ManifestFilesLocator: ManifestFilesLocating {
+    func locate(at: AbsolutePath) -> [(Manifest, AbsolutePath)] {
+        Manifest.allCases.compactMap { manifest in
+            let path = at.appending(component: manifest.fileName)
+            if FileHandler.shared.exists(path) { return (manifest, path) }
+            return nil
+        }
+    }
+}

--- a/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/GenerateCommandTests.swift
@@ -157,7 +157,7 @@ final class GenerateCommandTests: TuistUnitTestCase {
         manifestLoader.manifestsAtStub = { _ in
             Set([.project])
         }
-        generator.generateProjectStub = { path in
+        generator.generateProjectAtStub = { path in
             generationPath = path
             return path.appending(component: "project.xcodeproj")
         }

--- a/Tests/TuistKitTests/Generator/Mocks/MockGenerator.swift
+++ b/Tests/TuistKitTests/Generator/Mocks/MockGenerator.swift
@@ -1,11 +1,17 @@
 import Basic
 import Foundation
+import TuistCore
 import TuistGenerator
 
 class MockGenerator: Generating {
-    var generateProjectStub: ((AbsolutePath) throws -> AbsolutePath)?
+    var generateProjectAtStub: ((AbsolutePath) throws -> AbsolutePath)?
     func generateProject(at path: AbsolutePath) throws -> AbsolutePath {
-        return try generateProjectStub?(path) ?? AbsolutePath("/test")
+        return try generateProjectAtStub?(path) ?? AbsolutePath("/test")
+    }
+
+    var generateProjectStub: ((Project) throws -> AbsolutePath)?
+    func generateProject(_ project: Project, graph _: Graphing) throws -> AbsolutePath {
+        return try generateProjectStub?(project) ?? AbsolutePath("/test")
     }
 
     var generateProjectWorkspaceStub: ((AbsolutePath, [AbsolutePath]) throws -> AbsolutePath)?

--- a/Tests/TuistKitTests/ProjectEditor/Mocks/MockProjectEditorMapper.swift
+++ b/Tests/TuistKitTests/ProjectEditor/Mocks/MockProjectEditorMapper.swift
@@ -1,0 +1,23 @@
+import Basic
+import Foundation
+import TuistCore
+
+@testable import TuistCoreTesting
+@testable import TuistKit
+
+final class MockProjectEditorMapper: ProjectEditorMapping {
+    var mapStub: (Project, Graph)?
+    var mapArgs: [(sourceRootPath: AbsolutePath, manifests: [AbsolutePath], helpers: [AbsolutePath], projectDescriptionPath: AbsolutePath)] = []
+
+    func map(sourceRootPath: AbsolutePath,
+             manifests: [AbsolutePath],
+             helpers: [AbsolutePath],
+             projectDescriptionPath: AbsolutePath) -> (Project, Graph) {
+        mapArgs.append((sourceRootPath: sourceRootPath,
+                        manifests: manifests,
+                        helpers: helpers,
+                        projectDescriptionPath: projectDescriptionPath))
+        if let mapStub = mapStub { return mapStub }
+        return (Project.test(), Graph.test())
+    }
+}

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
@@ -1,0 +1,98 @@
+import Basic
+import Foundation
+import TuistCore
+import XCTest
+
+@testable import TuistKit
+@testable import TuistSupportTesting
+
+final class ProjectEditorMapperTests: TuistUnitTestCase {
+    var subject: ProjectEditorMapper!
+
+    override func setUp() {
+        super.setUp()
+        subject = ProjectEditorMapper()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        subject = nil
+    }
+
+    func test_edit_when_there_are_helpers() throws {
+        // Given
+        let sourceRootPath = try temporaryPath()
+        let manifestPaths = [sourceRootPath].map { $0.appending(component: "Project.swift") }
+        let helperPaths = [sourceRootPath].map { $0.appending(component: "Project+Template.swift") }
+        let projectDescriptionPath = sourceRootPath.appending(component: "ProjectDescription.framework")
+
+        // When
+        let (project, graph) = subject.map(sourceRootPath: sourceRootPath,
+                                           manifests: manifestPaths,
+                                           helpers: helperPaths,
+                                           projectDescriptionPath: projectDescriptionPath)
+
+        // Then
+        let manifestsTarget = project.targets.first
+        let helpersTarget = project.targets.last
+
+        XCTAssertEqual(project.name, "Manifests")
+        XCTAssertEqual(project.filesGroup, .group(name: "Manifests"))
+
+        XCTAssertEqual(manifestsTarget?.name, "Manifests")
+        XCTAssertEqual(manifestsTarget?.platform, .macOS)
+        XCTAssertEqual(manifestsTarget?.product, .staticFramework)
+        XCTAssertEqual(manifestsTarget?.bundleId, "io.tuist.${PRODUCT_NAME:rfc1034identifier}")
+        XCTAssertEqual(manifestsTarget?.sources.map { $0.path }, manifestPaths)
+        XCTAssertEqual(manifestsTarget?.filesGroup, .group(name: "Manifests"))
+        XCTAssertEqual(manifestsTarget?.dependencies, [.target(name: "ProjectDescriptionHelpers")])
+
+        XCTAssertEqual(helpersTarget?.name, "ProjectDescriptionHelpers")
+        XCTAssertEqual(helpersTarget?.platform, .macOS)
+        XCTAssertEqual(helpersTarget?.product, .staticFramework)
+        XCTAssertEqual(helpersTarget?.bundleId, "io.tuist.${PRODUCT_NAME:rfc1034identifier}")
+        XCTAssertEqual(helpersTarget?.sources.map { $0.path }, helperPaths)
+        XCTAssertEqual(helpersTarget?.filesGroup, .group(name: "Manifests"))
+        XCTAssertEqual(helpersTarget?.dependencies, [])
+
+        let targetNodes = graph.targets.sorted(by: { $0.target.name < $1.target.name })
+        XCTAssertEqual(targetNodes.count, 2)
+        XCTAssertEqual(targetNodes.first?.target, manifestsTarget)
+        XCTAssertEqual(targetNodes.last?.target, helpersTarget)
+        XCTAssertEqual(targetNodes.first?.dependencies, [targetNodes.last!])
+    }
+
+    func test_edit_when_there_are_no_helpers() throws {
+        // Given
+        let sourceRootPath = try temporaryPath()
+        let manifestPaths = [sourceRootPath].map { $0.appending(component: "Project.swift") }
+        let helperPaths: [AbsolutePath] = []
+        let projectDescriptionPath = sourceRootPath.appending(component: "ProjectDescription.framework")
+
+        // When
+        let (project, graph) = subject.map(sourceRootPath: sourceRootPath,
+                                           manifests: manifestPaths,
+                                           helpers: helperPaths,
+                                           projectDescriptionPath: projectDescriptionPath)
+
+        // Then
+        let manifestsTarget = project.targets.first
+        XCTAssertEqual(project.targets.count, 1)
+
+        XCTAssertEqual(project.name, "Manifests")
+        XCTAssertEqual(project.filesGroup, .group(name: "Manifests"))
+
+        XCTAssertEqual(manifestsTarget?.name, "Manifests")
+        XCTAssertEqual(manifestsTarget?.platform, .macOS)
+        XCTAssertEqual(manifestsTarget?.product, .staticFramework)
+        XCTAssertEqual(manifestsTarget?.bundleId, "io.tuist.${PRODUCT_NAME:rfc1034identifier}")
+        XCTAssertEqual(manifestsTarget?.sources.map { $0.path }, manifestPaths)
+        XCTAssertEqual(manifestsTarget?.filesGroup, .group(name: "Manifests"))
+        XCTAssertEqual(manifestsTarget?.dependencies, [])
+
+        let targetNodes = graph.targets.sorted(by: { $0.target.name < $1.target.name })
+        XCTAssertEqual(targetNodes.count, 1)
+        XCTAssertEqual(targetNodes.first?.target, manifestsTarget)
+        XCTAssertEqual(targetNodes.first?.dependencies, [])
+    }
+}

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
@@ -1,6 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
+import TuistSupport
 import XCTest
 
 @testable import TuistKit
@@ -46,6 +47,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(manifestsTarget?.sources.map { $0.path }, manifestPaths)
         XCTAssertEqual(manifestsTarget?.filesGroup, .group(name: "Manifests"))
         XCTAssertEqual(manifestsTarget?.dependencies, [.target(name: "ProjectDescriptionHelpers")])
+        assertRightSettings(manifestsTarget, sourceRootPath: sourceRootPath)
 
         XCTAssertEqual(helpersTarget?.name, "ProjectDescriptionHelpers")
         XCTAssertEqual(helpersTarget?.platform, .macOS)
@@ -54,6 +56,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(helpersTarget?.sources.map { $0.path }, helperPaths)
         XCTAssertEqual(helpersTarget?.filesGroup, .group(name: "Manifests"))
         XCTAssertEqual(helpersTarget?.dependencies, [])
+        assertRightSettings(helpersTarget, sourceRootPath: sourceRootPath)
 
         let targetNodes = graph.targets.sorted(by: { $0.target.name < $1.target.name })
         XCTAssertEqual(targetNodes.count, 2)
@@ -89,10 +92,23 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(manifestsTarget?.sources.map { $0.path }, manifestPaths)
         XCTAssertEqual(manifestsTarget?.filesGroup, .group(name: "Manifests"))
         XCTAssertEqual(manifestsTarget?.dependencies, [])
+        assertRightSettings(manifestsTarget, sourceRootPath: sourceRootPath)
 
         let targetNodes = graph.targets.sorted(by: { $0.target.name < $1.target.name })
         XCTAssertEqual(targetNodes.count, 1)
         XCTAssertEqual(targetNodes.first?.target, manifestsTarget)
         XCTAssertEqual(targetNodes.first?.dependencies, [])
+    }
+
+    fileprivate func assertRightSettings(_ target: Target?, sourceRootPath: AbsolutePath, file _: StaticString = #file, line _: UInt = #line) {
+        XCTAssertEqual(target?.settings?.defaultSettings, .recommended)
+        let base = target?.settings?.base
+
+        XCTAssertEqual(base, [
+            "FRAMEWORK_SEARCH_PATHS": .string(sourceRootPath.pathString),
+            "LIBRARY_SEARCH_PATHS": .string(sourceRootPath.pathString),
+            "SWIFT_INCLUDE_PATHS": .string(sourceRootPath.pathString),
+            "SWIFT_VERSION": .string(Constants.swiftVersion),
+        ])
     }
 }

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
@@ -1,0 +1,23 @@
+import Basic
+import Foundation
+import XCTest
+
+@testable import TuistKit
+
+final class ProjectEditorTests: XCTestCase {
+    var subject: ProjectEditor!
+
+    override func setUp() {
+        super.setUp()
+        subject = ProjectEditor()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        subject = nil
+    }
+
+    func test_edit() throws {
+        // TODO:
+    }
+}

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
@@ -1,23 +1,76 @@
 import Basic
 import Foundation
+import TuistCore
+import TuistSupport
 import XCTest
 
 @testable import TuistKit
+@testable import TuistSupportTesting
 
-final class ProjectEditorTests: XCTestCase {
+final class ProjectEditorTests: TuistUnitTestCase {
+    var generator: MockGenerator!
+    var projectEditorMapper: MockProjectEditorMapper!
+    var resourceLocator: MockResourceLocator!
+    var manifestFilesLocator: MockManifestFilesLocator!
+    var helpersDirectoryLocator: MockHelpersDirectoryLocator!
     var subject: ProjectEditor!
 
     override func setUp() {
         super.setUp()
-        subject = ProjectEditor()
+        generator = MockGenerator()
+        projectEditorMapper = MockProjectEditorMapper()
+        resourceLocator = MockResourceLocator()
+        manifestFilesLocator = MockManifestFilesLocator()
+        helpersDirectoryLocator = MockHelpersDirectoryLocator()
+        subject = ProjectEditor(generator: generator,
+                                projectEditorMapper: projectEditorMapper,
+                                resourceLocator: resourceLocator,
+                                manifestFilesLocator: manifestFilesLocator,
+                                helpersDirectoryLocator: helpersDirectoryLocator)
     }
 
     override func tearDown() {
         super.tearDown()
+        generator = nil
+        projectEditorMapper = nil
+        resourceLocator = nil
+        manifestFilesLocator = nil
+        helpersDirectoryLocator = nil
         subject = nil
     }
 
     func test_edit() throws {
-        // TODO:
+        // Given
+        let directory = try temporaryPath()
+        let projectDescriptionPath = directory.appending(component: "ProjectDescription.framework")
+        let project = Project.test(path: directory, name: "Edit")
+        let graph = Graph.test(name: "Edit")
+        let helpersDirectory = directory.appending(component: "ProjectDDescriptionHelpers")
+        try FileHandler.shared.createFolder(helpersDirectory)
+        let helpers = ["A.swift", "B.swift"].map { helpersDirectory.appending(component: $0) }
+        try helpers.forEach { try FileHandler.shared.touch($0) }
+        let manifests: [(Manifest, AbsolutePath)] = [(.project, directory.appending(component: "Project.swift"))]
+
+        resourceLocator.projectDescriptionStub = { projectDescriptionPath }
+        manifestFilesLocator.locateStub = manifests
+        helpersDirectoryLocator.locateStub = helpersDirectory
+        projectEditorMapper.mapStub = (project, graph)
+        var generatedProject: Project?
+        generator.generateProjectStub = { project in
+            generatedProject = project
+            return directory.appending(component: "Edit.xcodeproj")
+        }
+
+        // When
+        try subject.edit(at: directory, in: directory)
+
+        // Then
+        XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
+        let mapArgs = projectEditorMapper.mapArgs.first
+        XCTAssertEqual(mapArgs?.helpers, helpers)
+        XCTAssertEqual(mapArgs?.sourceRootPath, directory)
+        XCTAssertEqual(mapArgs?.projectDescriptionPath, projectDescriptionPath)
+
+        XCTAssertEqual(generatedProject, project)
     }
 }

--- a/Tests/TuistKitTests/Utils/Mocks/MockHelpersDirectoryLocator.swift
+++ b/Tests/TuistKitTests/Utils/Mocks/MockHelpersDirectoryLocator.swift
@@ -1,0 +1,13 @@
+import Basic
+import Foundation
+@testable import TuistKit
+
+final class MockHelpersDirectoryLocator: HelpersDirectoryLocating {
+    var locateStub: AbsolutePath?
+    var locateArgs: [AbsolutePath] = []
+
+    func locate(at: AbsolutePath) -> AbsolutePath? {
+        locateArgs.append(at)
+        return locateStub
+    }
+}

--- a/Tests/TuistKitTests/Utils/Mocks/MockManifestFilesLocator.swift
+++ b/Tests/TuistKitTests/Utils/Mocks/MockManifestFilesLocator.swift
@@ -1,0 +1,14 @@
+import Basic
+import Foundation
+@testable import TuistKit
+
+final class MockManifestFilesLocator: ManifestFilesLocating {
+    var locateStub: [(Manifest, AbsolutePath)]?
+    var locateArgs: [AbsolutePath] = []
+
+    func locate(at: AbsolutePath) -> [(Manifest, AbsolutePath)] {
+        locateArgs.append(at)
+        if let locateStub = locateStub { return locateStub }
+        return [(.project, at.appending(component: "Project.swift"))]
+    }
+}


### PR DESCRIPTION
Related https://github.com/tuist/tuist/issues/668

### Short description 📝

This PR adds a new utility, `ProjectEditor`, that generates an Xcode project containing a target with the manifests, and another target with the helpers _(if there are any)_. In a follow-up PR I'll add an `EditCommand` that uses this utility to create the project in a temporary directory and delete it once the user is done with the editing.

With this feature in place, I think we should delete the feature that generates the manifest targets in the generated projects. That way generated projects are completely Tuist-agnostic.