### PR TITLE
Add Testable instead of Target in TestAction

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -25,6 +25,7 @@ on:
       - fixtures/**/*
       - features/**/*
       - .github/workflows/tuist.yml
+    types: [edited, dismissed]
 
 jobs:
   unit_tests:
@@ -45,6 +46,8 @@ jobs:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v1
+        with: 
+           github_token: ${{ secrets.GITHUB_TOKEN }} 
       - name: Select Xcode 11.1
         run: sudo xcode-select -switch /Applications/Xcode_11.1.app
       - name: Build Tuist for release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Define `ArchiveAction` on `Scheme` https://github.com/tuist/tuist/pull/697 by @grsouza.
 - `tuist edit` command https://github.com/tuist/tuist/pull/703 by @pepibumur.
 - Support interpolating formatted strings in the printer https://github.com/tuist/tuist/pull/726 by @pepibumur.
+- Replace `Sheme.testAction.targets` type from `String` to `TestableTarget` is a description of target that adds to the `TestAction`, you can specify execution tests parallelizable, random execution order or skip tests https://github.com/tuist/tuist/pull/722 by @rowwingman.
 
 ## 0.19.0
 

--- a/Sources/ProjectDescription/Scheme.swift
+++ b/Sources/ProjectDescription/Scheme.swift
@@ -71,7 +71,7 @@ public struct BuildAction: Equatable, Codable {
 // MARK: - TestAction
 
 public struct TestAction: Equatable, Codable {
-    public let targets: [String]
+    public let targets: [TestableTarget]
     public let arguments: Arguments?
     public let configurationName: String
     public let coverage: Bool
@@ -79,7 +79,7 @@ public struct TestAction: Equatable, Codable {
     public let preActions: [ExecutionAction]
     public let postActions: [ExecutionAction]
 
-    public init(targets: [String],
+    public init(targets: [TestableTarget] = [],
                 arguments: Arguments? = nil,
                 configurationName: String,
                 coverage: Bool = false,
@@ -95,7 +95,7 @@ public struct TestAction: Equatable, Codable {
         self.codeCoverageTargets = codeCoverageTargets
     }
 
-    public init(targets: [String],
+    public init(targets: [TestableTarget],
                 arguments: Arguments? = nil,
                 config: PresetBuildConfiguration = .debug,
                 coverage: Bool = false,
@@ -109,6 +109,24 @@ public struct TestAction: Equatable, Codable {
                   codeCoverageTargets: codeCoverageTargets,
                   preActions: preActions,
                   postActions: postActions)
+    }
+}
+
+public struct TestableTarget: Equatable, Hashable, Codable, ExpressibleByStringLiteral {
+    public let target: String
+    public let isSkipped: Bool
+    public let isParallelizable: Bool
+    public let isRandomExecutionOrdering: Bool
+
+    public init(target: String, skipped: Bool = false, parallelizable: Bool = false, randomExecutionOrdering: Bool = false) {
+        self.target = target
+        self.isSkipped = skipped
+        self.isParallelizable = parallelizable
+        self.isRandomExecutionOrdering = randomExecutionOrdering
+    }
+
+    public init(stringLiteral value: String) {
+        self.init(target: value)
     }
 }
 

--- a/Sources/TuistCore/Models/Scheme.swift
+++ b/Sources/TuistCore/Models/Scheme.swift
@@ -114,7 +114,7 @@ public class BuildAction: Equatable {
 public class TestAction: Equatable {
     // MARK: - Attributes
 
-    public let targets: [String]
+    public let targets: [TestableTarget]
     public let arguments: Arguments?
     public let configurationName: String
     public let coverage: Bool
@@ -124,7 +124,7 @@ public class TestAction: Equatable {
 
     // MARK: - Init
 
-    public init(targets: [String] = [],
+    public init(targets: [TestableTarget] = [],
                 arguments: Arguments? = nil,
                 configurationName: String,
                 coverage: Bool = false,
@@ -150,6 +150,24 @@ public class TestAction: Equatable {
             lhs.codeCoverageTargets == rhs.codeCoverageTargets &&
             lhs.preActions == rhs.preActions &&
             lhs.postActions == rhs.postActions
+    }
+}
+
+public struct TestableTarget: Equatable, Hashable, ExpressibleByStringLiteral {
+    public let target: String
+    public let isSkipped: Bool
+    public let isParallelizable: Bool
+    public let isRandomExecutionOrdering: Bool
+
+    public init(target: String, skipped: Bool = false, parallelizable: Bool = false, randomExecutionOrdering: Bool = false) {
+        self.target = target
+        self.isSkipped = skipped
+        self.isParallelizable = parallelizable
+        self.isRandomExecutionOrdering = randomExecutionOrdering
+    }
+
+    public init(stringLiteral value: String) {
+        self.init(target: value)
     }
 }
 

--- a/Sources/TuistCoreTesting/Models/Scheme+TestData.swift
+++ b/Sources/TuistCoreTesting/Models/Scheme+TestData.swift
@@ -28,7 +28,7 @@ public extension TestAction {
                      codeCoverageTargets: [String] = [],
                      preActions: [ExecutionAction] = [],
                      postActions: [ExecutionAction] = []) -> TestAction {
-        return TestAction(targets: targets,
+        return TestAction(targets: targets.map { TestableTarget(target: $0) },
                           arguments: arguments,
                           configurationName: configurationName,
                           coverage: coverage,

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -596,7 +596,7 @@ extension TuistCore.BuildAction {
 
 extension TuistCore.TestAction {
     static func from(manifest: ProjectDescription.TestAction) -> TuistCore.TestAction {
-        let targets = manifest.targets
+        let targets = manifest.targets.map { TuistCore.TestableTarget.from(manifest: $0) }
         let arguments = manifest.arguments.map { TuistCore.Arguments.from(manifest: $0) }
         let configurationName = manifest.configurationName
         let coverage = manifest.coverage
@@ -611,6 +611,15 @@ extension TuistCore.TestAction {
                           codeCoverageTargets: codeCoverageTargets,
                           preActions: preActions,
                           postActions: postActions)
+    }
+}
+
+extension TuistCore.TestableTarget {
+    static func from(manifest: ProjectDescription.TestableTarget) -> TuistCore.TestableTarget {
+        return TestableTarget(target: manifest.target,
+                              skipped: manifest.isSkipped,
+                              parallelizable: manifest.isParallelizable,
+                              randomExecutionOrdering: manifest.isRandomExecutionOrdering)
     }
 }
 

--- a/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
+++ b/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
@@ -819,7 +819,8 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
                 matches manifest: ProjectDescription.TestAction,
                 file: StaticString = #file,
                 line: UInt = #line) {
-        XCTAssertEqual(testAction.targets, manifest.targets, file: file, line: line)
+        let targets = manifest.targets.map { TestableTarget.from(manifest: $0) }
+        XCTAssertEqual(testAction.targets, targets, file: file, line: line)
         XCTAssertTrue(testAction.configurationName == manifest.configurationName, file: file, line: line)
         XCTAssertEqual(testAction.coverage, manifest.coverage, file: file, line: line)
         optionalAssert(testAction.arguments, manifest.arguments) {

--- a/Tests/TuistKitTests/Generator/TestData/ProjectDescription+TestData.swift
+++ b/Tests/TuistKitTests/Generator/TestData/ProjectDescription+TestData.swift
@@ -100,7 +100,7 @@ extension BuildAction {
 }
 
 extension TestAction {
-    static func test(targets: [String] = [],
+    static func test(targets: [TestableTarget] = [],
                      arguments: Arguments? = nil,
                      config: PresetBuildConfiguration = .debug,
                      coverage: Bool = true) -> TestAction {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/707

### Short description 📝

`Sheme.TestAction` replace targets with `testableTargets`. New type contains target name, and tests information how to execute target's tests.

### Solution 📦

Provide broking change by replacing `TestAction.targets` with `TestAction.testableTargets`

### Implementation 👩‍💻👨‍💻

Provide new struct that describes tests info for target, `TestableTarget`.
