### PR TITLE
Extend the printer to support interpolation of formatted content

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,7 +1,7 @@
 # https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idname
 name: Checks
 
-on: push
+on: [push, pull_request]
 
 jobs:
   swiftlint:

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -13,6 +13,18 @@ on:
       - fixtures/**/*
       - features/**/*
       - .github/workflows/tuist.yml
+  pull_request:
+    paths:
+      - Sources/**/*
+      - Tests/**/*
+      - Gemfile*
+      - Rakefile
+      - Package.swift
+      - Package.resolved
+      - script/**/*
+      - fixtures/**/*
+      - features/**/*
+      - .github/workflows/tuist.yml
 
 jobs:
   unit_tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fix warnings in the project, refactor SHA256 diegest code https://github.com/tuist/tuist/pull/704 by @rowwingman.
 - Define `ArchiveAction` on `Scheme` https://github.com/tuist/tuist/pull/697 by @grsouza.
 - `tuist edit` command https://github.com/tuist/tuist/pull/703 by @pepibumur.
+- Support interpolating formatted strings in the printer https://github.com/tuist/tuist/pull/726 by @pepibumur.
 
 ## 0.19.0
 

--- a/Sources/TuistCore/Models/LintingIssue.swift
+++ b/Sources/TuistCore/Models/LintingIssue.swift
@@ -51,12 +51,12 @@ public extension Array where Element == LintingIssue {
 
         if !warningIssues.isEmpty {
             let message = warningIssues.map { "- \($0.description)" }.joined(separator: "\n")
-            Printer.shared.print(warning: message)
+            Printer.shared.print(warning: "\(message)")
         }
 
         if !errorIssues.isEmpty {
             let message = errorIssues.map { "- \($0.description)" }.joined(separator: "\n")
-            Printer.shared.print(errorMessage: message)
+            Printer.shared.print(errorMessage: "\(message)")
 
             throw LintingError()
         }

--- a/Sources/TuistEnvKit/Commands/LocalCommand.swift
+++ b/Sources/TuistEnvKit/Commands/LocalCommand.swift
@@ -49,7 +49,7 @@ class LocalCommand: Command {
         Printer.shared.print(section: "The following versions are available in the local environment:")
         let versions = versionController.semverVersions()
         let output = versions.sorted().reversed().map { "- \($0)" }.joined(separator: "\n")
-        Printer.shared.print(output)
+        Printer.shared.print("\(output)")
     }
 
     private func createVersionFile(version: String) throws {

--- a/Sources/TuistEnvKit/Commands/VersionCommand.swift
+++ b/Sources/TuistEnvKit/Commands/VersionCommand.swift
@@ -18,6 +18,6 @@ class VersionCommand: NSObject, Command {
     // MARK: - Command
 
     func run(with _: ArgumentParser.Result) {
-        Printer.shared.print(Constants.version)
+        Printer.shared.print("\(Constants.version)")
     }
 }

--- a/Sources/TuistKit/Commands/DumpCommand.swift
+++ b/Sources/TuistKit/Commands/DumpCommand.swift
@@ -43,6 +43,6 @@ class DumpCommand: NSObject, Command {
         }
         let project = try manifestLoader.loadProject(at: path)
         let json: JSON = try project.toJSON()
-        Printer.shared.print(json.toString(prettyPrint: true))
+        Printer.shared.print("\(json.toString(prettyPrint: true))")
     }
 }

--- a/Sources/TuistKit/Commands/EditCommand.swift
+++ b/Sources/TuistKit/Commands/EditCommand.swift
@@ -51,7 +51,7 @@ class EditCommand: NSObject, Command {
                 try! FileHandler.shared.delete(EditCommand.temporaryDirectory.path)
                 exit(0)
             }
-            Printer.shared.print(success: "Opening Xcode to edit the project. Press CTRL + C once you are done editing")
+            Printer.shared.print(success: "Opening Xcode to edit the project. Press \(.keystroke("CTRL + C")) once you are done editing")
             try opener.open(path: xcodeprojPath, wait: true)
         } else {
             Printer.shared.print(success: "Xcode project generated at \(xcodeprojPath.pathString)")

--- a/Sources/TuistKit/Commands/VersionCommand.swift
+++ b/Sources/TuistKit/Commands/VersionCommand.swift
@@ -18,6 +18,6 @@ class VersionCommand: NSObject, Command {
     // MARK: - Command
 
     func run(with _: ArgumentParser.Result) {
-        Printer.shared.print(Constants.version)
+        Printer.shared.print("\(Constants.version)")
     }
 }

--- a/Sources/TuistSupport/Errors/ErrorHandler.swift
+++ b/Sources/TuistSupport/Errors/ErrorHandler.swift
@@ -41,13 +41,13 @@ public final class ErrorHandler: ErrorHandling {
     public func fatal(error: FatalError) {
         let isSilent = error.type == .abortSilent || error.type == .bugSilent
         if !error.description.isEmpty, !isSilent {
-            Printer.shared.print(errorMessage: error.description)
+            Printer.shared.print(errorMessage: "\(error.description)")
         } else if isSilent {
             let message = """
             An unexpected error happened. We've opened an issue to fix it as soon as possible.
             We are sorry for any inconveniences it might have caused.
             """
-            Printer.shared.print(errorMessage: message)
+            Printer.shared.print(errorMessage: "\(message)")
         }
         exiter(1)
     }

--- a/Sources/TuistSupport/Utils/Deprecator.swift
+++ b/Sources/TuistSupport/Utils/Deprecator.swift
@@ -20,7 +20,6 @@ public final class Deprecator: Deprecating {
     ///   - deprecation: Feature that will be deprecated.
     ///   - suggestion: Suggestions for the user to migrate.
     public func notify(deprecation: String, suggestion: String) {
-        let message = "\(deprecation) will be deprecated in the next major release. Use \(suggestion) instead."
-        Printer.shared.print(deprecation: message)
+        Printer.shared.print(deprecation: "\(.raw(deprecation)) will be deprecated in the next major release. Use \(suggestion) instead.")
     }
 }

--- a/Sources/TuistSupportTesting/Utils/MockPrinter.swift
+++ b/Sources/TuistSupportTesting/Utils/MockPrinter.swift
@@ -7,23 +7,23 @@ public final class MockPrinter: Printing {
     var standardOutput: String = ""
     var standardError: String = ""
 
-    public func print(_ text: String) {
+    public func print(_ text: PrintableString) {
         standardOutput.append("\(text)\n")
     }
 
-    public func print(section: String) {
+    public func print(section: PrintableString) {
         standardOutput.append("\(section)\n")
     }
 
-    public func print(warning: String) {
+    public func print(warning: PrintableString) {
         standardOutput.append("\(warning)\n")
     }
 
-    public func print(deprecation: String) {
+    public func print(deprecation: PrintableString) {
         standardOutput.append("\(deprecation)\n")
     }
 
-    public func print(errorMessage: String) {
+    public func print(errorMessage: PrintableString) {
         standardError.append("\(errorMessage)\n")
     }
 
@@ -31,11 +31,11 @@ public final class MockPrinter: Printing {
         standardError.append("\(error.localizedDescription)\n")
     }
 
-    public func print(success: String) {
+    public func print(success: PrintableString) {
         standardOutput.append("\(success)\n")
     }
 
-    public func print(subsection: String) {
+    public func print(subsection: PrintableString) {
         standardOutput.append("\(subsection)\n")
     }
 

--- a/Tests/TuistIntegrationTests/Generator/Mocks/MockPrinter.swift
+++ b/Tests/TuistIntegrationTests/Generator/Mocks/MockPrinter.swift
@@ -3,19 +3,19 @@ import Foundation
 import TuistSupport
 
 class MockPrinter: Printing {
-    func print(_: String) {}
+    func print(_: PrintableString) {}
 
-    func print(section _: String) {}
+    func print(section _: PrintableString) {}
 
-    func print(subsection _: String) {}
+    func print(subsection _: PrintableString) {}
 
-    func print(warning _: String) {}
+    func print(warning _: PrintableString) {}
 
     func print(error _: Error) {}
 
-    func print(success _: String) {}
+    func print(success _: PrintableString) {}
 
-    func print(errorMessage _: String) {}
+    func print(errorMessage _: PrintableString) {}
 
-    func print(deprecation _: String) {}
+    func print(deprecation _: PrintableString) {}
 }

--- a/Tests/TuistSupportTests/Utils/PrinterTests.swift
+++ b/Tests/TuistSupportTests/Utils/PrinterTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import XCTest
+
+@testable import TuistSupport
+@testable import TuistSupportTesting
+
+final class PrintableStringTests: TuistUnitTestCase {
+    func test_raw_description_when_colored_output() {
+        environment.shouldOutputBeColoured = true
+        let value = PrintableString.Token.raw("test")
+        XCTAssertEqual(value.description, "test")
+    }
+
+    func test_raw_description_when_not_colored_output() {
+        environment.shouldOutputBeColoured = false
+        let value = PrintableString.Token.raw("test")
+        XCTAssertEqual(value.description, "test")
+    }
+
+    func test_command_description_when_colored_output() {
+        environment.shouldOutputBeColoured = true
+        let value = PrintableString.Token.command("test")
+        XCTAssertEqual(value.description, "test".cyan())
+    }
+
+    func test_command_description_when_not_colored_output() {
+        environment.shouldOutputBeColoured = false
+        let value = PrintableString.Token.command("test")
+        XCTAssertEqual(value.description, "test")
+    }
+
+    func test_keystroke_description_when_colored_output() {
+        environment.shouldOutputBeColoured = true
+        let value = PrintableString.Token.keystroke("test")
+        XCTAssertEqual(value.description, "test".cyan())
+    }
+
+    func test_keystroke_description_when_not_colored_output() {
+        environment.shouldOutputBeColoured = false
+        let value = PrintableString.Token.keystroke("test")
+        XCTAssertEqual(value.description, "test")
+    }
+
+    func test_bold_description_when_colored_output() {
+        environment.shouldOutputBeColoured = true
+        let value = PrintableString.Token.bold("test")
+        XCTAssertEqual(value.description, "test".bold())
+    }
+
+    func test_bold_description_when_not_colored_output() {
+        environment.shouldOutputBeColoured = false
+        let value = PrintableString.Token.bold("test")
+        XCTAssertEqual(value.description, "test")
+    }
+
+    func test_error_description_when_colored_output() {
+        environment.shouldOutputBeColoured = true
+        let value = PrintableString.Token.error("test")
+        XCTAssertEqual(value.description, "test".red())
+    }
+
+    func test_error_description_when_not_colored_output() {
+        environment.shouldOutputBeColoured = false
+        let value = PrintableString.Token.error("test")
+        XCTAssertEqual(value.description, "test")
+    }
+
+    func test_success_description_when_colored_output() {
+        environment.shouldOutputBeColoured = true
+        let value = PrintableString.Token.success("test")
+        XCTAssertEqual(value.description, "test".green())
+    }
+
+    func test_success_description_when_not_colored_output() {
+        environment.shouldOutputBeColoured = false
+        let value = PrintableString.Token.success("test")
+        XCTAssertEqual(value.description, "test")
+    }
+
+    func test_warning_description_when_colored_output() {
+        environment.shouldOutputBeColoured = true
+        let value = PrintableString.Token.warning("test")
+        XCTAssertEqual(value.description, "test".yellow())
+    }
+
+    func test_warning_description_when_not_colored_output() {
+        environment.shouldOutputBeColoured = false
+        let value = PrintableString.Token.warning("test")
+        XCTAssertEqual(value.description, "test")
+    }
+
+    func test_info_description_when_colored_output() {
+        environment.shouldOutputBeColoured = true
+        let value = PrintableString.Token.info("test")
+        XCTAssertEqual(value.description, "test".lightBlue())
+    }
+
+    func test_info_description_when_not_colored_output() {
+        environment.shouldOutputBeColoured = false
+        let value = PrintableString.Token.info("test")
+        XCTAssertEqual(value.description, "test")
+    }
+}

--- a/docs/contribution/tuist.mdx
+++ b/docs/contribution/tuist.mdx
@@ -64,6 +64,21 @@ The project is organized in several targets that are defined in the `Package.swi
 <Message info title="Package.swift" description="The Package.swift file declares the structure of our project (a Swift package) and the Swift Package Manager uses it to generate the Xcode project and provide us with a set of commands to interact with it, like 'swift build'"/>
 <Message info title="Tests" description="The targets have an associated target that contains the tests. They are named with the same name suffixed with 'Tests'"/>
 
+## Utilities
+
+All generic utilities live in the `TuistSupport` framework. This section documents some of the utilities and how to use them.
+
+### Printer
+
+When printing output for the user, this is the utility that should be used over the global `print` method. The utility provides formatting that varies depending on the terminal the process is run from, and determines whether the standard output or error should be used based on the type of content being output.
+
+The methods from the public interface take a `PrintableString` as an input. Printable strings support interpolating formatted strings. For instance, if we want to tell users they need to run a command, we can do the following:
+
+```swift
+Printer.shared.print("Please run the folling command to setup the environment: \(.command("tuist up"))")
+```
+
+
 ## Testing
 
 Tuist employs a diverse suite tests that help ensure it works as intended and prevents regressions as it continues to grow and evolve.

--- a/features/generate.feature
+++ b/features/generate.feature
@@ -8,7 +8,6 @@ Feature: Generate a new project using Tuist
     Then I should be able to build for iOS the scheme App
     Then I should be able to test for iOS the scheme AppTests
     Then I should be able to test for iOS the scheme AppUITests
-    Then I should be able to build for macOS the scheme App_Manifest
 
   Scenario: The project is an iOS application with frameworks and tests (ios_app_with_frameworks)
     Given that tuist is available
@@ -21,9 +20,6 @@ Feature: Generate a new project using Tuist
     Then I should be able to build for iOS the scheme Framework2-iOS
     Then I should be able to build for macOS the scheme Framework2-macOS
     Then I should be able to test for iOS the scheme Framework2Tests
-    Then I should be able to build for macOS the scheme MainApp_Manifest
-    Then I should be able to build for macOS the scheme Framework1_Manifest
-    Then I should be able to build for macOS the scheme Framework2_Manifest
     Then I should be able to build for iOS the scheme Framework1
     Then the product 'Framework1.framework' with destination 'Debug-iphoneos' contains the Info.plist key 'Test'
 
@@ -37,8 +33,6 @@ Feature: Generate a new project using Tuist
     Then I should be able to build for iOS the scheme Framework1-iOS
     Then I should be able to build for macOS the scheme Framework1-macOS
     Then I should be able to test for iOS the scheme Framework1Tests
-    Then I should be able to build for macOS the scheme MainApp_Manifest
-    Then I should be able to build for macOS the scheme Framework1_Manifest
 
   Scenario: The project is a directory without valid manifest file (invalid_workspace_manifest_name)
     Given that tuist is available
@@ -86,9 +80,7 @@ Feature: Generate a new project using Tuist
     Then I should be able to build for iOS the scheme App
     Then I should be able to test for iOS the scheme AppTests
     Then I should be able to build for macOS the scheme MacFramework
-    Then I should be able to build for macOS the scheme Project_Manifest
     Then I should be able to build for iOS the scheme StaticFramework
-    Then I should be able to build for macOS the scheme StaticFramework_Manifest
     Then I should be able to test for iOS the scheme StaticFrameworkTests
     Then I should be able to build for tvOS the scheme TVFramework
 


### PR DESCRIPTION
### Short description 📝
Change the interface of the `Printer` utility to support the interpolation of formatted components:

```swift
Printer.shared.print("Please run the command: \(.command("tuist generate"))")
```