### PR TITLE
Support paths relative to the root directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Removed
 - **Breaking** Generate manifests target as part of the generated project https://github.com/tuist/tuist/pull/724 by @pepibumur.
+- The installation no longer checks if the Swift version is compatible https://github.com/tuist/tuist/pull/727 by @pepibumur.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Define `ArchiveAction` on `Scheme` https://github.com/tuist/tuist/pull/697 by @grsouza.
 - `tuist edit` command https://github.com/tuist/tuist/pull/703 by @pepibumur.
 - Support interpolating formatted strings in the printer https://github.com/tuist/tuist/pull/726 by @pepibumur.
+- Support for paths relative to root https://github.com/tuist/tuist/pull/727 by @pepibumur.
 
 ## 0.19.0
 

--- a/Sources/ProjectDescription/Path.swift
+++ b/Sources/ProjectDescription/Path.swift
@@ -36,6 +36,10 @@ public struct Path: Codable, ExpressibleByStringLiteral, Equatable {
     // MARK: - ExpressibleByStringLiteral
 
     public init(stringLiteral: String) {
-        self.init(stringLiteral, type: .relativeToManifest)
+        if stringLiteral.starts(with: "//") {
+            self.init(stringLiteral.replacingOccurrences(of: "//", with: ""), type: .relativeToRoot)
+        } else {
+            self.init(stringLiteral, type: .relativeToManifest)
+        }
     }
 }

--- a/Sources/ProjectDescription/Path.swift
+++ b/Sources/ProjectDescription/Path.swift
@@ -2,6 +2,7 @@ public struct Path: Codable, ExpressibleByStringLiteral, Equatable {
     public enum PathType: String, Codable {
         case relativeToCurrentFile
         case relativeToManifest
+        case relativeToRoot
     }
 
     public let type: PathType
@@ -26,6 +27,10 @@ public struct Path: Codable, ExpressibleByStringLiteral, Equatable {
 
     public static func relativeToManifest(_ pathString: String) -> Path {
         return Path(pathString, type: .relativeToManifest)
+    }
+
+    public static func relativeToRoot(_ pathString: String) -> Path {
+        return Path(pathString, type: .relativeToRoot)
     }
 
     // MARK: - ExpressibleByStringLiteral

--- a/Sources/ProjectDescription/Path.swift
+++ b/Sources/ProjectDescription/Path.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public struct Path: Codable, ExpressibleByStringLiteral, Equatable {
     public enum PathType: String, Codable {
         case relativeToCurrentFile
@@ -13,9 +15,9 @@ public struct Path: Codable, ExpressibleByStringLiteral, Equatable {
         self.init(path, type: .relativeToManifest)
     }
 
-    private init(_ pathString: String,
-                 type: PathType,
-                 callerPath: String? = nil) {
+    init(_ pathString: String,
+         type: PathType,
+         callerPath: String? = nil) {
         self.type = type
         self.pathString = pathString
         self.callerPath = callerPath

--- a/Sources/TuistEnvKit/Installer/Installer.swift
+++ b/Sources/TuistEnvKit/Installer/Installer.swift
@@ -83,8 +83,6 @@ final class Installer: Installing {
             return
         }
 
-        try verifySwiftVersion(version: version)
-
         var bundleURL: URL?
         do {
             bundleURL = try self.bundleURL(version: version)
@@ -97,29 +95,6 @@ final class Installer: Installing {
         } else {
             try installFromSource(version: version,
                                   temporaryDirectory: temporaryDirectory)
-        }
-    }
-
-    func verifySwiftVersion(version: String) throws {
-        guard let localVersionString = try System.shared.swiftVersion() else { return }
-        Printer.shared.print("Verifying the Swift version is compatible with your version \(localVersionString)")
-        var remoteVersionString: String!
-        do {
-            remoteVersionString = try githubClient.getContent(ref: version, path: ".swift-version").spm_chomp()
-        } catch is GitHubClientError {
-            Printer.shared.print(warning: "Couldn't get the Swift version needed for \(version). Continuing...")
-        }
-
-        let localVersion = SwiftVersion(localVersionString)
-        let remoteVersion = SwiftVersion(remoteVersionString)
-        let versionFive = SwiftVersion("5")
-
-        if localVersion >= versionFive, remoteVersion >= versionFive {
-            return
-        } else if localVersion == remoteVersion {
-            return
-        } else {
-            throw InstallerError.incompatibleSwiftVersion(local: localVersionString, expected: remoteVersionString)
         }
     }
 

--- a/Sources/TuistKit/Generator/GeneratorPaths.swift
+++ b/Sources/TuistKit/Generator/GeneratorPaths.swift
@@ -3,7 +3,7 @@ import Foundation
 import ProjectDescription
 import TuistSupport
 
-enum GeneratorPathsError: FatalError {
+enum GeneratorPathsError: FatalError, Equatable {
     /// Thrown when the root directory can't be located.
     case rootDirectoryNotFound(AbsolutePath)
 
@@ -42,8 +42,8 @@ struct GeneratorPaths {
         case .relativeToManifest:
             return AbsolutePath(path.pathString, relativeTo: manifestDirectory)
         case .relativeToRoot:
-            guard let rootPath = RootDirectoryLocator.shared.locate(from: AbsolutePath(path.pathString)) else {
-                throw GeneratorPathsError.rootDirectoryNotFound(AbsolutePath(path.pathString))
+            guard let rootPath = RootDirectoryLocator.shared.locate(from: AbsolutePath(manifestDirectory.pathString)) else {
+                throw GeneratorPathsError.rootDirectoryNotFound(AbsolutePath(manifestDirectory.pathString))
             }
             return AbsolutePath(path.pathString, relativeTo: rootPath)
         }

--- a/Sources/TuistKit/Generator/GeneratorPaths.swift
+++ b/Sources/TuistKit/Generator/GeneratorPaths.swift
@@ -1,6 +1,25 @@
 import Basic
 import Foundation
 import ProjectDescription
+import TuistSupport
+
+enum GeneratorPathsError: FatalError {
+    /// Thrown when the root directory can't be located.
+    case rootDirectoryNotFound(AbsolutePath)
+
+    var type: ErrorType {
+        switch self {
+        case .rootDirectoryNotFound: return .abort
+        }
+    }
+
+    var description: String {
+        switch self {
+        case let .rootDirectoryNotFound(path):
+            return "Couldn't locate the root directory from path \(path.pathString). The root directory is the closest directory that contains a Tuist or a .git directory."
+        }
+    }
+}
 
 /// This model includes paths the manifest path can be relative to.
 struct GeneratorPaths {
@@ -15,13 +34,18 @@ struct GeneratorPaths {
 
     /// Given a project description path, it returns the absolute path of the given path.
     /// - Parameter path: Absolute path.
-    func resolve(path: Path) -> AbsolutePath {
+    func resolve(path: Path) throws -> AbsolutePath {
         switch path.type {
         case .relativeToCurrentFile:
             let callerAbsolutePath = AbsolutePath(path.callerPath!).removingLastComponent()
             return AbsolutePath(path.pathString, relativeTo: callerAbsolutePath)
         case .relativeToManifest:
             return AbsolutePath(path.pathString, relativeTo: manifestDirectory)
+        case .relativeToRoot:
+            guard let rootPath = RootDirectoryLocator.shared.locate(from: AbsolutePath(path.pathString)) else {
+                throw GeneratorPathsError.rootDirectoryNotFound(AbsolutePath(path.pathString))
+            }
+            return AbsolutePath(path.pathString, relativeTo: rootPath)
         }
     }
 }

--- a/Sources/TuistKit/Utils/HelpersDirectoryLocator.swift
+++ b/Sources/TuistKit/Utils/HelpersDirectoryLocator.swift
@@ -14,7 +14,7 @@ final class HelpersDirectoryLocator: HelpersDirectoryLocating {
 
     /// Initializes the locator with its dependencies.
     /// - Parameter rootDirectoryLocator: Instance to locate the root directory of the project.
-    init(rootDirectoryLocator: RootDirectoryLocating = RootDirectoryLocator()) {
+    init(rootDirectoryLocator: RootDirectoryLocating = RootDirectoryLocator.shared) {
         self.rootDirectoryLocator = rootDirectoryLocator
     }
 

--- a/Sources/TuistKit/Utils/RootDirectoryLocator.swift
+++ b/Sources/TuistKit/Utils/RootDirectoryLocator.swift
@@ -15,6 +15,12 @@ final class RootDirectoryLocator: RootDirectoryLocating {
     /// This cache avoids having to traverse the directories hierarchy every time the locate method is called.
     fileprivate var cache: [AbsolutePath: AbsolutePath] = [:]
 
+    /// Shared instance
+    static var shared = RootDirectoryLocator()
+
+    /// Constructor
+    internal init() {}
+
     /// Given a path, it finds the root directory by traversing up the hierarchy.
     /// The root directory is considered the directory that contains a Tuist/ directory or the directory where the
     /// git repository is defined if no Tuist/ directory is found.

--- a/Sources/TuistKit/Utils/RootDirectoryLocator.swift
+++ b/Sources/TuistKit/Utils/RootDirectoryLocator.swift
@@ -16,7 +16,7 @@ final class RootDirectoryLocator: RootDirectoryLocating {
     fileprivate var cache: [AbsolutePath: AbsolutePath] = [:]
 
     /// Shared instance
-    static var shared = RootDirectoryLocator()
+    static var shared: RootDirectoryLocating = RootDirectoryLocator()
 
     /// Constructor
     internal init() {}

--- a/Tests/ProjectDescriptionTests/PathTests.swift
+++ b/Tests/ProjectDescriptionTests/PathTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import TuistSupportTesting
+import XCTest
+
+@testable import ProjectDescription
+@testable import TuistSupportTesting
+
+final class PathTests: TuistUnitTestCase {
+    func test_codable_when_relativeToCurrentFile() {
+        XCTAssertCodable(Path.relativeToCurrentFile("file.swift"))
+    }
+
+    func test_codable_when_relativeToManifest() {
+        XCTAssertCodable(Path.relativeToManifest("file.swift"))
+    }
+
+    func test_codable_when_relativeToRoot() {
+        XCTAssertCodable(Path.relativeToRoot("file.swift"))
+    }
+
+    func test_init_when_the_path_is_prefixed_with_two_slashes() {
+        let path: Path = "//file.swift"
+        XCTAssertEqual(path, Path.relativeToRoot("file.swift"))
+    }
+
+    func test_init_when_the_path_is_not_prefixed() {
+        let path: Path = "file.swift"
+        XCTAssertEqual(path, Path.relativeToManifest("file.swift"))
+    }
+}

--- a/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
+++ b/Tests/TuistEnvKitTests/Installer/InstallerTests.swift
@@ -33,24 +33,6 @@ final class InstallerTests: TuistUnitTestCase {
         subject = nil
     }
 
-    func test_install_when_invalid_swift_version() throws {
-        let version = "3.2.1"
-        let temporaryDirectory = try TemporaryDirectory(removeTreeOnDeinit: true)
-        system.swiftVersionStub = { "4.2.1" }
-        githubClient.getContentStub = { ref, path in
-            if ref == version, path == ".swift-version" {
-                return "5.0.0"
-            } else {
-                throw NSError.test()
-            }
-        }
-
-        let expectedError = InstallerError.incompatibleSwiftVersion(local: "4.2.1", expected: "5.0.0")
-        XCTAssertThrowsSpecific(try subject.install(version: version,
-                                                    temporaryDirectory: temporaryDirectory), expectedError)
-        XCTAssertPrinterOutputContains("Verifying the Swift version is compatible with your version 4.2.1")
-    }
-
     func test_install_when_bundled_release() throws {
         let version = "3.2.1"
         let temporaryPath = try self.temporaryPath()
@@ -84,7 +66,6 @@ final class InstallerTests: TuistUnitTestCase {
                             temporaryDirectory: temporaryDirectory)
 
         XCTAssertPrinterOutputContains("""
-        Verifying the Swift version is compatible with your version 5.0.0
         Downloading version from \(downloadURL.absoluteString)
         Installing...
         Version \(version) installed
@@ -189,7 +170,6 @@ final class InstallerTests: TuistUnitTestCase {
         try subject.install(version: version, temporaryDirectory: temporaryDirectory)
 
         XCTAssertPrinterOutputContains("""
-        Verifying the Swift version is compatible with your version 5.0.0
         The release \(version) is not bundled
         Pulling source code
         Building using Swift (it might take a while)

--- a/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
+++ b/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
@@ -72,8 +72,8 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(model.targets.count, 2)
-        assert(target: model.targets[0], matches: targetA, at: temporaryPath, generatorPaths: generatorPaths)
-        assert(target: model.targets[1], matches: targetB, at: temporaryPath, generatorPaths: generatorPaths)
+        try assert(target: model.targets[0], matches: targetA, at: temporaryPath, generatorPaths: generatorPaths)
+        try assert(target: model.targets[1], matches: targetB, at: temporaryPath, generatorPaths: generatorPaths)
     }
 
     func test_loadProject_withManifestTargetOptionDisabled() throws {
@@ -339,7 +339,7 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
         let manifest = SettingsManifest(base: ["base": .string("base")], debug: debug, release: release)
 
         // When
-        let model = TuistCore.Settings.from(manifest: manifest, path: temporaryPath, generatorPaths: generatorPaths)
+        let model = try TuistCore.Settings.from(manifest: manifest, path: temporaryPath, generatorPaths: generatorPaths)
 
         // Then
         assert(settings: model, matches: manifest, at: temporaryPath, generatorPaths: generatorPaths)
@@ -351,7 +351,7 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
         let generatorPaths = GeneratorPaths(manifestDirectory: AbsolutePath("/"))
 
         // When
-        let got = TuistCore.Dependency.from(manifest: dependency, generatorPaths: generatorPaths)
+        let got = try TuistCore.Dependency.from(manifest: dependency, generatorPaths: generatorPaths)
 
         // Then
         guard case let .cocoapods(path) = got else {
@@ -361,13 +361,13 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
         XCTAssertEqual(path, AbsolutePath("/path/to/project"))
     }
 
-    func test_dependency_when_localPackage() {
+    func test_dependency_when_localPackage() throws {
         // Given
         let dependency = TargetDependency.package(product: "library")
         let generatorPaths = GeneratorPaths(manifestDirectory: AbsolutePath("/"))
 
         // When
-        let got = TuistCore.Dependency.from(manifest: dependency, generatorPaths: generatorPaths)
+        let got = try TuistCore.Dependency.from(manifest: dependency, generatorPaths: generatorPaths)
 
         // Then
         guard
@@ -405,7 +405,7 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
                                        project: "Sources/project/**")
 
         // When
-        let model = TuistCore.Headers.from(manifest: manifest, path: temporaryPath, generatorPaths: generatorPaths)
+        let model = try TuistCore.Headers.from(manifest: manifest, path: temporaryPath, generatorPaths: generatorPaths)
 
         // Then
         XCTAssertEqual(model.public, [
@@ -450,7 +450,7 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
                                        project: ["Sources/project/E/*.h", "Sources/project/F/*.h"])
 
         // When
-        let model = TuistCore.Headers.from(manifest: manifest, path: temporaryPath, generatorPaths: generatorPaths)
+        let model = try TuistCore.Headers.from(manifest: manifest, path: temporaryPath, generatorPaths: generatorPaths)
 
         // Then
         XCTAssertEqual(model.public, [
@@ -487,7 +487,7 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
                                        project: ["Sources/project/C/*.h", "Sources/project/D/*.h"])
 
         // When
-        let model = TuistCore.Headers.from(manifest: manifest, path: temporaryPath, generatorPaths: generatorPaths)
+        let model = try TuistCore.Headers.from(manifest: manifest, path: temporaryPath, generatorPaths: generatorPaths)
 
         // Then
         XCTAssertEqual(model.public, [
@@ -512,7 +512,7 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
         let model = try TuistCore.CoreDataModel.from(manifest: manifest, path: temporaryPath, generatorPaths: generatorPaths)
 
         // Then
-        XCTAssertTrue(coreDataModel(model, matches: manifest, at: temporaryPath, generatorPaths: generatorPaths))
+        XCTAssertTrue(try coreDataModel(model, matches: manifest, at: temporaryPath, generatorPaths: generatorPaths))
     }
 
     func test_targetActions() throws {
@@ -525,7 +525,7 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
                                                             order: .pre,
                                                             arguments: ["arg1", "arg2"])
         // When
-        let model = TuistCore.TargetAction.from(manifest: manifest, path: temporaryPath, generatorPaths: generatorPaths)
+        let model = try TuistCore.TargetAction.from(manifest: manifest, path: temporaryPath, generatorPaths: generatorPaths)
 
         // Then
         XCTAssertEqual(model.name, "MyScript")
@@ -591,10 +591,10 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
         let manifest = ProjectDescription.FileElement.glob(pattern: "Documentation")
 
         // When
-        let model = TuistCore.FileElement.from(manifest: manifest,
-                                               path: temporaryPath,
-                                               generatorPaths: generatorPaths,
-                                               includeFiles: { !FileHandler.shared.isFolder($0) })
+        let model = try TuistCore.FileElement.from(manifest: manifest,
+                                                   path: temporaryPath,
+                                                   generatorPaths: generatorPaths,
+                                                   includeFiles: { !FileHandler.shared.isFolder($0) })
 
         // Then
         let documentationPath = temporaryPath.appending(component: "Documentation").pathString
@@ -609,7 +609,7 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
         let manifest = ProjectDescription.FileElement.glob(pattern: "Documentation/**")
 
         // When
-        let model = TuistCore.FileElement.from(manifest: manifest, path: temporaryPath, generatorPaths: generatorPaths)
+        let model = try TuistCore.FileElement.from(manifest: manifest, path: temporaryPath, generatorPaths: generatorPaths)
 
         // Then
         let documentationPath = temporaryPath.appending(RelativePath("Documentation/**"))
@@ -628,7 +628,7 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
         let manifest = ProjectDescription.FileElement.folderReference(path: "README.md")
 
         // When
-        let model = TuistCore.FileElement.from(manifest: manifest, path: temporaryPath, generatorPaths: generatorPaths)
+        let model = try TuistCore.FileElement.from(manifest: manifest, path: temporaryPath, generatorPaths: generatorPaths)
 
         // Then
         XCTAssertPrinterOutputContains("README.md is not a directory - folder reference paths need to point to directories")
@@ -642,7 +642,7 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
         let manifest = ProjectDescription.FileElement.folderReference(path: "Documentation")
 
         // When
-        let model = TuistCore.FileElement.from(manifest: manifest, path: temporaryPath, generatorPaths: generatorPaths)
+        let model = try TuistCore.FileElement.from(manifest: manifest, path: temporaryPath, generatorPaths: generatorPaths)
 
         // Then
         XCTAssertPrinterOutputContains("Documentation does not exist")
@@ -725,15 +725,15 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
                 at path: AbsolutePath,
                 generatorPaths: GeneratorPaths,
                 file: StaticString = #file,
-                line: UInt = #line) {
+                line: UInt = #line) throws {
         XCTAssertEqual(target.name, manifest.name, file: file, line: line)
         XCTAssertEqual(target.bundleId, manifest.bundleId, file: file, line: line)
         XCTAssertTrue(target.platform == manifest.platform, file: file, line: line)
         XCTAssertTrue(target.product == manifest.product, file: file, line: line)
-        XCTAssertEqual(target.infoPlist?.path, generatorPaths.resolve(path: manifest.infoPlist.path!), file: file, line: line)
-        XCTAssertEqual(target.entitlements, manifest.entitlements.map { generatorPaths.resolve(path: $0) }, file: file, line: line)
+        XCTAssertEqual(target.infoPlist?.path, try generatorPaths.resolve(path: manifest.infoPlist.path!), file: file, line: line)
+        XCTAssertEqual(target.entitlements, try manifest.entitlements.map { try generatorPaths.resolve(path: $0) }, file: file, line: line)
         XCTAssertEqual(target.environment, manifest.environment, file: file, line: line)
-        assert(coreDataModels: target.coreDataModels, matches: manifest.coreDataModels, at: path, generatorPaths: generatorPaths, file: file, line: line)
+        try assert(coreDataModels: target.coreDataModels, matches: manifest.coreDataModels, at: path, generatorPaths: generatorPaths, file: file, line: line)
         optionalAssert(target.settings, manifest.settings, file: file, line: line) {
             assert(settings: $0, matches: $1, at: path, generatorPaths: generatorPaths, file: file, line: line)
         }
@@ -765,7 +765,7 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
                        manifest.configuration?.settings.count,
                        file: file, line: line)
         XCTAssertEqual(configuration.1?.xcconfig,
-                       manifest.configuration?.xcconfig.map { generatorPaths.resolve(path: $0) },
+                       try manifest.configuration?.xcconfig.map { try generatorPaths.resolve(path: $0) },
                        file: file, line: line)
     }
 
@@ -774,9 +774,9 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
                 at path: AbsolutePath,
                 generatorPaths: GeneratorPaths,
                 file: StaticString = #file,
-                line: UInt = #line) {
+                line: UInt = #line) throws {
         XCTAssertEqual(coreDataModels.count, manifests.count, file: file, line: line)
-        XCTAssertTrue(coreDataModels.elementsEqual(manifests, by: { coreDataModel($0, matches: $1, at: path, generatorPaths: generatorPaths) }),
+        XCTAssertTrue(try coreDataModels.elementsEqual(manifests, by: { try coreDataModel($0, matches: $1, at: path, generatorPaths: generatorPaths) }),
                       file: file,
                       line: line)
     }
@@ -784,8 +784,8 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
     func coreDataModel(_ coreDataModel: TuistCore.CoreDataModel,
                        matches manifest: ProjectDescription.CoreDataModel,
                        at _: AbsolutePath,
-                       generatorPaths: GeneratorPaths) -> Bool {
-        return coreDataModel.path == generatorPaths.resolve(path: manifest.path)
+                       generatorPaths: GeneratorPaths) throws -> Bool {
+        return coreDataModel.path == (try generatorPaths.resolve(path: manifest.path))
             && coreDataModel.currentVersion == manifest.currentVersion
     }
 

--- a/Tests/TuistKitTests/Generator/GeneratorPathsTests.swift
+++ b/Tests/TuistKitTests/Generator/GeneratorPathsTests.swift
@@ -1,0 +1,93 @@
+import Basic
+import TuistCore
+import TuistSupport
+import XCTest
+
+@testable import ProjectDescription
+@testable import TuistKit
+@testable import TuistSupportTesting
+
+class GeneratorPathsErrorTests: TuistUnitTestCase {
+    func test_type_when_rootDirectoryNotFound() {
+        // Given
+        let path = AbsolutePath("/")
+        let error = GeneratorPathsError.rootDirectoryNotFound(path)
+
+        // Then
+        XCTAssertEqual(error.type, .abort)
+    }
+
+    func test_description_when_rootDirectoryNotFound() {
+        // Given
+        let path = AbsolutePath("/")
+        let error = GeneratorPathsError.rootDirectoryNotFound(path)
+
+        // Then
+        XCTAssertEqual(error.description, "Couldn't locate the root directory from path \(path.pathString). The root directory is the closest directory that contains a Tuist or a .git directory.")
+    }
+}
+
+class GeneratorPathsTests: TuistUnitTestCase {
+    var subject: GeneratorPaths!
+    var path: AbsolutePath!
+    var rootDirectoryLocator: MockRootDirectoryLocator!
+
+    override func setUp() {
+        super.setUp()
+        path = try! temporaryPath()
+        rootDirectoryLocator = MockRootDirectoryLocator()
+        rootDirectoryLocator.locateStub = path.appending(component: "Root")
+        RootDirectoryLocator.shared = rootDirectoryLocator
+        subject = GeneratorPaths(manifestDirectory: path)
+    }
+
+    override func tearDown() {
+        rootDirectoryLocator = nil
+        path = nil
+        super.tearDown()
+    }
+
+    func test_resolve_when_relative_to_current_file() throws {
+        // Given
+        let filePath = Path("file.swift",
+                            type: .relativeToCurrentFile,
+                            callerPath: path.pathString)
+
+        // When
+        let got = try subject.resolve(path: filePath)
+
+        // Then
+        XCTAssertEqual(got, path.removingLastComponent().appending(component: "file.swift"))
+    }
+
+    func test_resolve_when_relative_to_manifest() throws {
+        // Given
+        let filePath = Path.relativeToManifest("file.swift")
+
+        // When
+        let got = try subject.resolve(path: filePath)
+
+        // Then
+        XCTAssertEqual(got, path.appending(component: "file.swift"))
+    }
+
+    func test_resolve_when_relative_to_root_directory() throws {
+        // Given
+        let filePath = Path.relativeToRoot("file.swift")
+
+        // When
+        let got = try subject.resolve(path: filePath)
+
+        // Then
+        XCTAssertEqual(got, path.appending(component: "Root").appending(component: "file.swift"))
+    }
+
+    func test_resolve_throws_when_the_root_directory_cant_be_found() throws {
+        // Given
+        let filePath = Path.relativeToRoot("file.swift")
+        rootDirectoryLocator.locateStub = nil
+
+        // When
+        XCTAssertThrowsSpecific(try subject.resolve(path: filePath), GeneratorPathsError.rootDirectoryNotFound(path))
+    }
+}

--- a/Tests/TuistKitTests/Utils/Mocks/MockRootDirectoryLocator.swift
+++ b/Tests/TuistKitTests/Utils/Mocks/MockRootDirectoryLocator.swift
@@ -1,0 +1,13 @@
+import Basic
+import Foundation
+@testable import TuistKit
+
+final class MockRootDirectoryLocator: RootDirectoryLocating {
+    var locateArgs: [AbsolutePath] = []
+    var locateStub: AbsolutePath?
+
+    func locate(from path: AbsolutePath) -> AbsolutePath? {
+        locateArgs.append(path)
+        return locateStub
+    }
+}

--- a/docs/usage/projectswift.mdx
+++ b/docs/usage/projectswift.mdx
@@ -1274,6 +1274,11 @@ A path represents a path to a file, directory, or a group of files represented b
       case: '.relativeToManifest(String)',
       description:
         'Initialize a path that is relative to the directory that contains the manifest file being loaded, for example the directory that contains the Project.swift file.',
+    },
+    {
+      case: '.relativeToRoot(String)',
+      description:
+        'Initialize a path that is relative to the closest directory that contains a Tuist or a .git directory.',
     }
   ]}
 />

--- a/docs/usage/projectswift.mdx
+++ b/docs/usage/projectswift.mdx
@@ -1285,6 +1285,6 @@ A path represents a path to a file, directory, or a group of files represented b
 
 <Message
   info
-  title="ExpressibleByStringLiteral and ExpressibleByArrayLiteral"
-  description="The path can be initialized with a plain string. It's equivalent to using .relativeToManifest."
+  title="ExpressibleByStringLiteral"
+  description="The path can be initialized with a plain string. It's equivalent to using `.relativeToManifest.` except when the path starts with `//`, in which case the path is considered relative to the root directory."
 />

--- a/fixtures/ios_app_with_helpers/Projects/App/Project.swift
+++ b/fixtures/ios_app_with_helpers/Projects/App/Project.swift
@@ -2,5 +2,5 @@ import ProjectDescription
 import ProjectDescriptionHelpers
 
 let project = Project.app(name: "App", platform: .iOS, dependencies: [
-    .project(target: "AppKit", path: .relativeToManifest("../AppKit"))
+    .project(target: "AppKit", path: "//Projects/AppKit")
 ])

--- a/fixtures/ios_app_with_helpers/Projects/AppKit/Project.swift
+++ b/fixtures/ios_app_with_helpers/Projects/AppKit/Project.swift
@@ -2,5 +2,5 @@ import ProjectDescription
 import ProjectDescriptionHelpers
 
 let project = Project.framework(name: "AppKit", platform: .iOS, dependencies: [
-    .project(target: "AppSupport", path: .relativeToManifest("../AppSupport"))
+    .project(target: "AppSupport", path: "//Projects/AppSupport")
 ])


### PR DESCRIPTION
# Short description 📝
This PR adds support for defining paths relative to the root directory. The paths can be initialized with `.relativeToRoot("file.swift")` or just prefixing the string with two slashes: `//file.swift`.

### Implementation 👩‍💻👨‍💻
- [x] Add the new case to `Path`.
- [x] Extend `GeneratorPaths`.
- [x] Add unit & acceptance tests.
