### PR TITLE
TestAction.targets testable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - `tuist edit` command https://github.com/tuist/tuist/pull/703 by @pepibumur.
 - Support interpolating formatted strings in the printer https://github.com/tuist/tuist/pull/726 by @pepibumur.
 - Support for paths relative to root https://github.com/tuist/tuist/pull/727 by @pepibumur.
+- Replace `Sheme.testAction.targets` type from `String` to `TestableTarget` is a description of target that adds to the `TestAction`, you can specify execution tests parallelizable, random execution order or skip tests https://github.com/tuist/tuist/pull/728 by @rowwingman.
 
 ## 0.19.0
 

--- a/Sources/ProjectDescription/Scheme.swift
+++ b/Sources/ProjectDescription/Scheme.swift
@@ -71,7 +71,7 @@ public struct BuildAction: Equatable, Codable {
 // MARK: - TestAction
 
 public struct TestAction: Equatable, Codable {
-    public let targets: [String]
+    public let targets: [TestableTarget]
     public let arguments: Arguments?
     public let configurationName: String
     public let coverage: Bool
@@ -79,7 +79,7 @@ public struct TestAction: Equatable, Codable {
     public let preActions: [ExecutionAction]
     public let postActions: [ExecutionAction]
 
-    public init(targets: [String],
+    public init(targets: [TestableTarget] = [],
                 arguments: Arguments? = nil,
                 configurationName: String,
                 coverage: Bool = false,
@@ -95,7 +95,7 @@ public struct TestAction: Equatable, Codable {
         self.codeCoverageTargets = codeCoverageTargets
     }
 
-    public init(targets: [String],
+    public init(targets: [TestableTarget],
                 arguments: Arguments? = nil,
                 config: PresetBuildConfiguration = .debug,
                 coverage: Bool = false,
@@ -109,6 +109,24 @@ public struct TestAction: Equatable, Codable {
                   codeCoverageTargets: codeCoverageTargets,
                   preActions: preActions,
                   postActions: postActions)
+    }
+}
+
+public struct TestableTarget: Equatable, Hashable, Codable, ExpressibleByStringLiteral {
+    public let target: String
+    public let isSkipped: Bool
+    public let isParallelizable: Bool
+    public let isRandomExecutionOrdering: Bool
+
+    public init(target: String, skipped: Bool = false, parallelizable: Bool = false, randomExecutionOrdering: Bool = false) {
+        self.target = target
+        self.isSkipped = skipped
+        self.isParallelizable = parallelizable
+        self.isRandomExecutionOrdering = randomExecutionOrdering
+    }
+
+    public init(stringLiteral value: String) {
+        self.init(target: value)
     }
 }
 

--- a/Sources/TuistCore/Models/Scheme.swift
+++ b/Sources/TuistCore/Models/Scheme.swift
@@ -114,7 +114,7 @@ public class BuildAction: Equatable {
 public class TestAction: Equatable {
     // MARK: - Attributes
 
-    public let targets: [String]
+    public let targets: [TestableTarget]
     public let arguments: Arguments?
     public let configurationName: String
     public let coverage: Bool
@@ -124,7 +124,7 @@ public class TestAction: Equatable {
 
     // MARK: - Init
 
-    public init(targets: [String] = [],
+    public init(targets: [TestableTarget] = [],
                 arguments: Arguments? = nil,
                 configurationName: String,
                 coverage: Bool = false,
@@ -150,6 +150,20 @@ public class TestAction: Equatable {
             lhs.codeCoverageTargets == rhs.codeCoverageTargets &&
             lhs.preActions == rhs.preActions &&
             lhs.postActions == rhs.postActions
+    }
+}
+
+public struct TestableTarget: Equatable, Hashable {
+    public let target: String
+    public let isSkipped: Bool
+    public let isParallelizable: Bool
+    public let isRandomExecutionOrdering: Bool
+
+    public init(target: String, skipped: Bool = false, parallelizable: Bool = false, randomExecutionOrdering: Bool = false) {
+        self.target = target
+        self.isSkipped = skipped
+        self.isParallelizable = parallelizable
+        self.isRandomExecutionOrdering = randomExecutionOrdering
     }
 }
 

--- a/Sources/TuistCoreTesting/Models/Scheme+TestData.swift
+++ b/Sources/TuistCoreTesting/Models/Scheme+TestData.swift
@@ -21,7 +21,7 @@ public extension RunAction {
 }
 
 public extension TestAction {
-    static func test(targets: [String] = ["AppTests"],
+    static func test(targets: [TestableTarget] = [TestableTarget(target: "AppTests")],
                      arguments: Arguments? = Arguments.test(),
                      configurationName: String = BuildConfiguration.debug.name,
                      coverage: Bool = false,

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -597,7 +597,7 @@ extension TuistCore.BuildAction {
 
 extension TuistCore.TestAction {
     static func from(manifest: ProjectDescription.TestAction) -> TuistCore.TestAction {
-        let targets = manifest.targets
+        let targets = manifest.targets.map { TuistCore.TestableTarget.from(manifest: $0) }
         let arguments = manifest.arguments.map { TuistCore.Arguments.from(manifest: $0) }
         let configurationName = manifest.configurationName
         let coverage = manifest.coverage
@@ -612,6 +612,15 @@ extension TuistCore.TestAction {
                           codeCoverageTargets: codeCoverageTargets,
                           preActions: preActions,
                           postActions: postActions)
+    }
+}
+
+extension TuistCore.TestableTarget {
+    static func from(manifest: ProjectDescription.TestableTarget) -> TuistCore.TestableTarget {
+        return TestableTarget(target: manifest.target,
+                              skipped: manifest.isSkipped,
+                              parallelizable: manifest.isParallelizable,
+                              randomExecutionOrdering: manifest.isRandomExecutionOrdering)
     }
 }
 

--- a/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
+++ b/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
@@ -819,7 +819,8 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
                 matches manifest: ProjectDescription.TestAction,
                 file: StaticString = #file,
                 line: UInt = #line) {
-        XCTAssertEqual(testAction.targets, manifest.targets, file: file, line: line)
+        let targets = manifest.targets.map { TestableTarget.from(manifest: $0) }
+        XCTAssertEqual(testAction.targets, targets, file: file, line: line)
         XCTAssertTrue(testAction.configurationName == manifest.configurationName, file: file, line: line)
         XCTAssertEqual(testAction.coverage, manifest.coverage, file: file, line: line)
         optionalAssert(testAction.arguments, manifest.arguments) {

--- a/Tests/TuistKitTests/Generator/TestData/ProjectDescription+TestData.swift
+++ b/Tests/TuistKitTests/Generator/TestData/ProjectDescription+TestData.swift
@@ -100,7 +100,7 @@ extension BuildAction {
 }
 
 extension TestAction {
-    static func test(targets: [String] = [],
+    static func test(targets: [TestableTarget] = [],
                      arguments: Arguments? = nil,
                      config: PresetBuildConfiguration = .debug,
                      coverage: Bool = true) -> TestAction {

--- a/docs/usage/projectswift.mdx
+++ b/docs/usage/projectswift.mdx
@@ -787,10 +787,11 @@ Alternatively, when leveraging custom configurations, the configuration name can
     {
       name: 'Targets',
       description:
-        'A list of targets to test, which are defined in the project.',
-      type: '[String]',
+        'A list of testable targets, that are targets which are defined in the project with testable information.',
+      type: '[TestableTarget]',
+      typeLink: '#testableTarget',
       optional: false,
-      default: '',
+      default: '[]',
     },
     {
       name: 'Arguments',
@@ -887,6 +888,39 @@ Scheme run scripts can be defined with the following attributes:
       type: 'String',
       optional: true,
       default: 'nil',
+    },
+  ]}
+/>
+
+### TestableTarget
+
+Testable target descibe target and tests information.
+
+<PropertiesTable
+  properties={[
+    {
+      name: 'Skipped',
+      description:
+        'Skip test target from TestAction.',
+      type: 'Bool',
+      optional: true,
+      default: 'false',
+    },
+    {
+      name: 'Parallelizable',
+      description:
+        'Execute tests in parallel.',
+      type: 'Bool',
+      optional: true,
+      default: 'false',
+    },
+    {
+      name: 'RandomExecutionOrdering',
+      description:
+        'Execute tests in random order.',
+      type: 'Bool',
+      optional: true,
+      default: 'false',
     },
   ]}
 />


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/707

### Short description 📝

`Sheme.TestAction` replace targets with `testableTargets`. New type contains target name, and tests information how to execute target's tests.

### Solution 📦

Provide broking change by replacing `TestAction.targets` with `TestAction.testableTargets`

### Implementation 👩‍💻👨‍💻

Provide new struct that describes tests info for target, `TestableTarget`.
