### PR TITLE
Add Galaxy manifest file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ## Next
 
 ### Removed
+
 - **Breaking** Generate manifests target as part of the generated project https://github.com/tuist/tuist/pull/724 by @pepibumur.
 - The installation no longer checks if the Swift version is compatible https://github.com/tuist/tuist/pull/727 by @pepibumur.
 
@@ -18,6 +19,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Support interpolating formatted strings in the printer https://github.com/tuist/tuist/pull/726 by @pepibumur.
 - Support for paths relative to root https://github.com/tuist/tuist/pull/727 by @pepibumur.
 - Replace `Sheme.testAction.targets` type from `String` to `TestableTarget` is a description of target that adds to the `TestAction`, you can specify execution tests parallelizable, random execution order or skip tests https://github.com/tuist/tuist/pull/728 by @rowwingman.
+- Galaxy manifest model https://github.com/tuist/tuist/pull/729 by @pepibumur.
 
 ## 0.19.0
 

--- a/Sources/ProjectDescription/Galaxy.swift
+++ b/Sources/ProjectDescription/Galaxy.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// MARK: - Galaxy
+
+public struct Galaxy: Codable, Equatable {
+    /// The project token to authenticate with the API.
+    public let token: String
+
+    /// Initializes the Galaxy instance with its attributes.
+    /// - Parameter token: The project token to authenticate with the API.
+    public init(token: String) {
+        self.token = token
+        dumpIfNeeded(self)
+    }
+}

--- a/Sources/TuistKit/Generator/GraphManifestLoader.swift
+++ b/Sources/TuistKit/Generator/GraphManifestLoader.swift
@@ -50,26 +50,6 @@ enum GraphManifestLoaderError: FatalError, Equatable {
     }
 }
 
-enum Manifest: CaseIterable {
-    case project
-    case workspace
-    case tuistConfig
-    case setup
-
-    var fileName: String {
-        switch self {
-        case .project:
-            return "Project.swift"
-        case .workspace:
-            return "Workspace.swift"
-        case .tuistConfig:
-            return "TuistConfig.swift"
-        case .setup:
-            return "Setup.swift"
-        }
-    }
-}
-
 protocol GraphManifestLoading {
     /// Loads the TuistConfig.swift in the given directory.
     ///
@@ -77,6 +57,13 @@ protocol GraphManifestLoading {
     /// - Returns: Loaded TuistConfig.swift file.
     /// - Throws: An error if the file has a syntax error.
     func loadTuistConfig(at path: AbsolutePath) throws -> ProjectDescription.TuistConfig
+
+    /// Loads the Galaxy.swift in the given directory.
+    ///
+    /// - Parameter path: Path to the directory that contains the Galaxy.swift file.
+    /// - Returns: Loaded Galaxy.swift file.
+    /// - Throws: An error if the file has a syntax error.
+    func loadGalaxy(at path: AbsolutePath) throws -> ProjectDescription.Galaxy
 
     func loadProject(at path: AbsolutePath) throws -> ProjectDescription.Project
     func loadWorkspace(at path: AbsolutePath) throws -> ProjectDescription.Workspace
@@ -88,26 +75,13 @@ protocol GraphManifestLoading {
 class GraphManifestLoader: GraphManifestLoading {
     // MARK: - Attributes
 
-    /// Resource locator to look up Tuist-related resources.
     let resourceLocator: ResourceLocating
-
-    /// Instance to compile and return a temporary module that contains the helper files.
     let projectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding
-
-    /// Utility to locate manifest files.
     let manifestFilesLocator: ManifestFilesLocating
-
-    /// A decoder instance for decoding the raw manifest data to their concrete types
     private let decoder: JSONDecoder
 
     // MARK: - Init
 
-    /// Initializes the manifest loader with its attributes.
-    ///
-    /// - Parameters:
-    ///   - resourceLocator: Resource locator to look up Tuist-related resources.
-    ///   - helpersLoader: Instance to compile and return a temporary module that contains the helper files.
-    ///   - manifestFilesLocator: Utility to locate manifest files.
     init(resourceLocator: ResourceLocating = ResourceLocator(),
          projectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding = ProjectDescriptionHelpersBuilder(),
          manifestFilesLocator: ManifestFilesLocating = ManifestFilesLocator()) {
@@ -131,13 +105,12 @@ class GraphManifestLoader: GraphManifestLoading {
         return Set(manifestFilesLocator.locate(at: path).map { $0.0 })
     }
 
-    /// Loads the TuistConfig.swift in the given directory.
-    ///
-    /// - Parameter path: Path to the directory that contains the TuistConfig.swift file.
-    /// - Returns: Loaded TuistConfig.swift file.
-    /// - Throws: An error if the file has a syntax error.
     func loadTuistConfig(at path: AbsolutePath) throws -> ProjectDescription.TuistConfig {
         return try loadManifest(.tuistConfig, at: path)
+    }
+
+    func loadGalaxy(at path: AbsolutePath) throws -> ProjectDescription.Galaxy {
+        return try loadManifest(.galaxy, at: path)
     }
 
     func loadProject(at path: AbsolutePath) throws -> ProjectDescription.Project {

--- a/Sources/TuistKit/Models/Galaxy/Galaxy.swift
+++ b/Sources/TuistKit/Models/Galaxy/Galaxy.swift
@@ -1,0 +1,15 @@
+import Basic
+import Foundation
+import TuistSupport
+
+public struct Galaxy: Equatable, Codable {
+    // MARK: - Attributes
+
+    public let token: String
+
+    // MARK: - Init
+
+    public init(token: String) {
+        self.token = token
+    }
+}

--- a/Sources/TuistKit/Models/Manifest.swift
+++ b/Sources/TuistKit/Models/Manifest.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+enum Manifest: CaseIterable {
+    case project
+    case workspace
+    case tuistConfig
+    case setup
+    case galaxy
+
+    var fileName: String {
+        switch self {
+        case .project:
+            return "Project.swift"
+        case .workspace:
+            return "Workspace.swift"
+        case .tuistConfig:
+            return "TuistConfig.swift"
+        case .setup:
+            return "Setup.swift"
+        case .galaxy:
+            return "Galaxy.swift"
+        }
+    }
+}

--- a/Tests/ProjectDescriptionTests/GalaxyTests.swift
+++ b/Tests/ProjectDescriptionTests/GalaxyTests.swift
@@ -1,0 +1,12 @@
+import Foundation
+import TuistSupportTesting
+import XCTest
+
+@testable import ProjectDescription
+
+final class GalaxyTests: XCTestCase {
+    func test_codable() throws {
+        let subject = Galaxy(token: "token")
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/ProjectDescriptionTests/WorkspaceTests.swift
+++ b/Tests/ProjectDescriptionTests/WorkspaceTests.swift
@@ -5,12 +5,12 @@ import XCTest
 @testable import ProjectDescription
 
 final class WorkspaceTests: XCTestCase {
-    func test_toJSON() throws {
+    func test_codable() throws {
         let subject = Workspace(name: "name", projects: ["/path/to/project"])
         XCTAssertCodable(subject)
     }
 
-    func test_toJSON_withAdditionalFiles() throws {
+    func test_codable_withAdditionalFiles() throws {
         let subject = Workspace(name: "name",
                                 projects: ["ProjectA"],
                                 additionalFiles: [

--- a/Tests/TuistKitTests/Generator/GraphManifestLoaderTests.swift
+++ b/Tests/TuistKitTests/Generator/GraphManifestLoaderTests.swift
@@ -20,11 +20,3 @@ final class GraphManifestLoaderErrorTests: TuistUnitTestCase {
         XCTAssertEqual(GraphManifestLoaderError.manifestNotFound(.project, AbsolutePath("/test/")).type, .abort)
     }
 }
-
-final class ManifestTests: TuistUnitTestCase {
-    func test_fileName() {
-        XCTAssertEqual(Manifest.project.fileName, "Project.swift")
-        XCTAssertEqual(Manifest.workspace.fileName, "Workspace.swift")
-        XCTAssertEqual(Manifest.setup.fileName, "Setup.swift")
-    }
-}

--- a/Tests/TuistKitTests/Generator/Mocks/MockManifestLoader.swift
+++ b/Tests/TuistKitTests/Generator/Mocks/MockManifestLoader.swift
@@ -22,6 +22,14 @@ final class MockGraphManifestLoader: GraphManifestLoading {
     var loadTuistConfigCount: UInt = 0
     var loadTuistConfigStub: ((AbsolutePath) throws -> ProjectDescription.TuistConfig)?
 
+    var loadGalaxyCount: UInt = 0
+    var loadGalaxyStub: ((AbsolutePath) throws -> ProjectDescription.Galaxy)?
+
+    func loadGalaxy(at path: AbsolutePath) throws -> ProjectDescription.Galaxy {
+        loadGalaxyCount += 1
+        return try loadGalaxyStub?(path) ?? ProjectDescription.Galaxy.test()
+    }
+
     func loadProject(at path: AbsolutePath) throws -> ProjectDescription.Project {
         return try loadProjectStub?(path) ?? ProjectDescription.Project.test()
     }

--- a/Tests/TuistKitTests/Generator/TestData/ProjectDescription+TestData.swift
+++ b/Tests/TuistKitTests/Generator/TestData/ProjectDescription+TestData.swift
@@ -17,6 +17,12 @@ extension Workspace {
     }
 }
 
+extension Galaxy {
+    static func test(token: String = "xyz") -> Galaxy {
+        return Galaxy(token: token)
+    }
+}
+
 extension Project {
     static func test(name: String = "Project",
                      settings: Settings? = nil,

--- a/Tests/TuistKitTests/Models/ManifestTests.swift
+++ b/Tests/TuistKitTests/Models/ManifestTests.swift
@@ -1,0 +1,15 @@
+import Foundation
+import XCTest
+
+@testable import TuistKit
+@testable import TuistSupportTesting
+
+final class ManifestTests: TuistUnitTestCase {
+    func test_fileName() {
+        XCTAssertEqual(Manifest.project.fileName, "Project.swift")
+        XCTAssertEqual(Manifest.workspace.fileName, "Workspace.swift")
+        XCTAssertEqual(Manifest.tuistConfig.fileName, "TuistConfig.swift")
+        XCTAssertEqual(Manifest.setup.fileName, "Setup.swift")
+        XCTAssertEqual(Manifest.galaxy.fileName, "Galaxy.swift")
+    }
+}

--- a/Tests/TuistKitTests/Models/TestData/Galaxy+TestData.swift
+++ b/Tests/TuistKitTests/Models/TestData/Galaxy+TestData.swift
@@ -1,0 +1,11 @@
+import Basic
+import Foundation
+import TuistSupport
+
+@testable import TuistKit
+
+extension Galaxy {
+    static func test(token: String = "xyz") -> Galaxy {
+        return Galaxy(token: token)
+    }
+}


### PR DESCRIPTION
### Short description 📝
The interaction with Galaxy will require authentication and some other configuration. To configure the integration of the project with Galaxy I'm adding a new type of manifest file, `Galaxy.swift` where developers can configure Galaxy.

For now I'm just adding the model with only one attribute, `token`. In the future I plan to add logic to interact with the service and support caching modules to speed up builds.