### PR TITLE
Add simulator controller with method to fetch the available runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Replace `Sheme.testAction.targets` type from `String` to `TestableTarget` is a description of target that adds to the `TestAction`, you can specify execution tests parallelizable, random execution order or skip tests https://github.com/tuist/tuist/pull/728 by @rowwingman.
 - Galaxy manifest model https://github.com/tuist/tuist/pull/729 by @pepibumur.
 - Make scheme generation methods more generic https://github.com/tuist/tuist/pull/730  by @adamkhazi @kwridan.
-
+- Make scheme generation methods more generic by @adamkhazi @kwridan.
+- `SimulatorController` with method to fetch the runtimes https://github.com/tuist/tuist/pull/746 by @pepibumur.
 
 ## 0.19.0
 

--- a/Sources/ProjectDescription/Scheme.swift
+++ b/Sources/ProjectDescription/Scheme.swift
@@ -120,9 +120,9 @@ public struct TestableTarget: Equatable, Hashable, Codable, ExpressibleByStringL
 
     public init(target: String, skipped: Bool = false, parallelizable: Bool = false, randomExecutionOrdering: Bool = false) {
         self.target = target
-        self.isSkipped = skipped
-        self.isParallelizable = parallelizable
-        self.isRandomExecutionOrdering = randomExecutionOrdering
+        isSkipped = skipped
+        isParallelizable = parallelizable
+        isRandomExecutionOrdering = randomExecutionOrdering
     }
 
     public init(stringLiteral value: String) {

--- a/Sources/TuistCore/Models/Platform.swift
+++ b/Sources/TuistCore/Models/Platform.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum Platform: String {
+public enum Platform: String, CaseIterable {
     case iOS = "ios"
     case macOS = "macos"
     case tvOS = "tvos"

--- a/Sources/TuistCore/Models/Scheme.swift
+++ b/Sources/TuistCore/Models/Scheme.swift
@@ -175,9 +175,9 @@ public struct TestableTarget: Equatable {
 
     public init(target: TargetReference, skipped: Bool = false, parallelizable: Bool = false, randomExecutionOrdering: Bool = false) {
         self.target = target
-        self.isSkipped = skipped
-        self.isParallelizable = parallelizable
-        self.isRandomExecutionOrdering = randomExecutionOrdering
+        isSkipped = skipped
+        isParallelizable = parallelizable
+        isRandomExecutionOrdering = randomExecutionOrdering
     }
 }
 

--- a/Sources/TuistKit/Simulators/SimulatorRuntime.swift
+++ b/Sources/TuistKit/Simulators/SimulatorRuntime.swift
@@ -1,19 +1,19 @@
-import Foundation
 import Basic
+import Foundation
 import TuistCore
 import TuistSupport
 
 enum SimulatorRuntimeError: FatalError {
     /// Thrown when the platform cant't be recognized from the runtime name.
     case unsupportedPlatform(String)
-    
+
     var description: String {
         switch self {
-        case .unsupportedPlatform(let runtime):
+        case let .unsupportedPlatform(runtime):
             return "Couldn't recognize the platform from runtime \(runtime)"
         }
     }
-    
+
     var type: ErrorType {
         switch self {
         case .unsupportedPlatform: return .bug
@@ -23,22 +23,21 @@ enum SimulatorRuntimeError: FatalError {
 
 /// Enum that represents all different runtimes that are available for simulators.
 struct SimulatorRuntime: CustomStringConvertible, Decodable {
-  
     /// Simulator platform.
     let platform: Platform
-  
+
     /// Runtime version.
     let version: SimulatorRuntimeVersion
-    
+
     /// Bundle path.
     let bundlePath: AbsolutePath
-    
+
     /// Whether the runtime is available or not.
     let isAvailable: Bool
- 
+
     /// Runtime identifier.
     let identifier: String
-    
+
     /// Runtime buidl version.
     let buildVersion: String
 
@@ -46,7 +45,7 @@ struct SimulatorRuntime: CustomStringConvertible, Decodable {
     var description: String {
         return "\(platform.caseValue) \(version) runtime"
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case version
         case bundlePath
@@ -55,27 +54,26 @@ struct SimulatorRuntime: CustomStringConvertible, Decodable {
         case identifier
         case buildVersion = "buildversion"
     }
-    
+
     // MARK: - Constructors
-    
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.version = try container.decode(SimulatorRuntimeVersion.self, forKey: .version)
-        self.bundlePath = try container.decode(AbsolutePath.self, forKey: .bundlePath)
-        self.isAvailable = try container.decode(Bool.self, forKey: .isAvailable)
-        self.identifier = try container.decode(String.self, forKey: .identifier)
-        self.buildVersion = try container.decode(String.self, forKey: .buildVersion)
+        version = try container.decode(SimulatorRuntimeVersion.self, forKey: .version)
+        bundlePath = try container.decode(AbsolutePath.self, forKey: .bundlePath)
+        isAvailable = try container.decode(Bool.self, forKey: .isAvailable)
+        identifier = try container.decode(String.self, forKey: .identifier)
+        buildVersion = try container.decode(String.self, forKey: .buildVersion)
         let name = try container.decode(String.self, forKey: .name)
-        self.platform = try SimulatorRuntime.platformFrom(name: name)
+        platform = try SimulatorRuntime.platformFrom(name: name)
     }
-    
+
     // MARK: - Fileprivate
-    
+
     fileprivate static func platformFrom(name: String) throws -> Platform {
         if let platform = Platform.allCases.first(where: { name.contains($0.caseValue) }) {
             return platform
         }
         throw SimulatorRuntimeError.unsupportedPlatform(name)
     }
-    
 }

--- a/Sources/TuistKit/Simulators/SimulatorRuntime.swift
+++ b/Sources/TuistKit/Simulators/SimulatorRuntime.swift
@@ -1,27 +1,81 @@
 import Foundation
+import Basic
+import TuistCore
+import TuistSupport
 
-/// Enum that represents all different runtimes that are available for simulators.
-enum SimulatorRuntime: CustomStringConvertible {
-    /// iOS runtime
-    case iOS(SimulatorRuntimeVersion)
-    
-    /// watchOS runtime
-    case watchOS(SimulatorRuntimeVersion)
-    
-    /// tvOS runtime
-    case tvOS(SimulatorRuntimeVersion)
-    
-    // MARK: - CustomStringConvertible
+enum SimulatorRuntimeError: FatalError {
+    /// Thrown when the platform cant't be recognized from the runtime name.
+    case unsupportedPlatform(String)
     
     var description: String {
         switch self {
-        case .iOS(let version):
-            return "iOS \(version) runtime"
-        case .tvOS(let version):
-            return "tvOS \(version) runtime"
-        case .watchOS(let version):
-            return "watchOS \(version) runtime"
+        case .unsupportedPlatform(let runtime):
+            return "Couldn't recognize the platform from runtime \(runtime)"
         }
+    }
+    
+    var type: ErrorType {
+        switch self {
+        case .unsupportedPlatform: return .bug
+        }
+    }
+}
+
+/// Enum that represents all different runtimes that are available for simulators.
+struct SimulatorRuntime: CustomStringConvertible, Decodable {
+  
+    /// Simulator platform.
+    let platform: Platform
+  
+    /// Runtime version.
+    let version: SimulatorRuntimeVersion
+    
+    /// Bundle path.
+    let bundlePath: AbsolutePath
+    
+    /// Whether the runtime is available or not.
+    let isAvailable: Bool
+ 
+    /// Runtime identifier.
+    let identifier: String
+    
+    /// Runtime buidl version.
+    let buildVersion: String
+
+    /// Runtime description.
+    var description: String {
+        return "\(platform.caseValue) \(version) runtime"
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case version
+        case bundlePath
+        case isAvailable
+        case name
+        case identifier
+        case buildVersion = "buildversion"
+    }
+    
+    // MARK: - Constructors
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.version = try container.decode(SimulatorRuntimeVersion.self, forKey: .version)
+        self.bundlePath = try container.decode(AbsolutePath.self, forKey: .bundlePath)
+        self.isAvailable = try container.decode(Bool.self, forKey: .isAvailable)
+        self.identifier = try container.decode(String.self, forKey: .identifier)
+        self.buildVersion = try container.decode(String.self, forKey: .buildVersion)
+        let name = try container.decode(String.self, forKey: .name)
+        self.platform = try SimulatorRuntime.platformFrom(name: name)
+    }
+    
+    // MARK: - Fileprivate
+    
+    fileprivate static func platformFrom(name: String) throws -> Platform {
+        if let platform = Platform.allCases.first(where: { name.contains($0.caseValue) }) {
+            return platform
+        }
+        throw SimulatorRuntimeError.unsupportedPlatform(name)
     }
     
 }

--- a/Sources/TuistKit/Simulators/SimulatorRuntime.swift
+++ b/Sources/TuistKit/Simulators/SimulatorRuntime.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Enum that represents all different runtimes that are available for simulators.
+enum SimulatorRuntime: CustomStringConvertible {
+    /// iOS runtime
+    case iOS(SimulatorRuntimeVersion)
+    
+    /// watchOS runtime
+    case watchOS(SimulatorRuntimeVersion)
+    
+    /// tvOS runtime
+    case tvOS(SimulatorRuntimeVersion)
+    
+    // MARK: - CustomStringConvertible
+    
+    var description: String {
+        switch self {
+        case .iOS(let version):
+            return "iOS \(version) runtime"
+        case .tvOS(let version):
+            return "tvOS \(version) runtime"
+        case .watchOS(let version):
+            return "watchOS \(version) runtime"
+        }
+    }
+    
+}

--- a/Sources/TuistKit/Simulators/SimulatorRuntimeVersion.swift
+++ b/Sources/TuistKit/Simulators/SimulatorRuntimeVersion.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct SimulatorRuntimeVersion: CustomStringConvertible, Equatable, ExpressibleByStringLiteral, Comparable {
+struct SimulatorRuntimeVersion: CustomStringConvertible, Equatable, ExpressibleByStringLiteral, Comparable, Decodable {
     
     // MARK: - Attributes
     
@@ -14,6 +14,11 @@ struct SimulatorRuntimeVersion: CustomStringConvertible, Equatable, ExpressibleB
         self.major = major
         self.minor = minor
         self.patch = patch
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.init(stringLiteral: try container.decode(String.self))
     }
     
     // MARK: - Internal

--- a/Sources/TuistKit/Simulators/SimulatorRuntimeVersion.swift
+++ b/Sources/TuistKit/Simulators/SimulatorRuntimeVersion.swift
@@ -1,38 +1,37 @@
 import Foundation
 
 struct SimulatorRuntimeVersion: CustomStringConvertible, Equatable, ExpressibleByStringLiteral, Comparable, Decodable {
-    
     // MARK: - Attributes
-    
+
     let major: Int
     let minor: Int?
     let patch: Int?
-    
+
     // MARK: - Constructors
-    
+
     init(major: Int, minor: Int? = nil, patch: Int? = nil) {
         self.major = major
         self.minor = minor
         self.patch = patch
     }
-    
+
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         self.init(stringLiteral: try container.decode(String.self))
     }
-    
+
     // MARK: - Internal
-    
+
     func flattened() -> SimulatorRuntimeVersion {
-        return SimulatorRuntimeVersion(major: self.major,
-                                       minor: self.minor ?? 0,
-                                       patch: self.patch ?? 0)
+        return SimulatorRuntimeVersion(major: major,
+                                       minor: minor ?? 0,
+                                       patch: patch ?? 0)
     }
-    
+
     // MARK: - CustomStringConvertible
-    
+
     var description: String {
-        var version = "\(self.major)"
+        var version = "\(major)"
         if let minor = minor {
             version.append(".\(minor)")
         } else {
@@ -45,21 +44,21 @@ struct SimulatorRuntimeVersion: CustomStringConvertible, Equatable, ExpressibleB
         }
         return version
     }
-    
+
     // MARK: - Equatable
-    
-    static func ==(lhs: SimulatorRuntimeVersion, rhs: SimulatorRuntimeVersion) -> Bool {
+
+    static func == (lhs: SimulatorRuntimeVersion, rhs: SimulatorRuntimeVersion) -> Bool {
         return lhs.major == rhs.major &&
             lhs.minor == rhs.minor &&
             lhs.patch == rhs.patch
     }
-    
+
     // MARK: - Comparable
-    
+
     static func < (lhs: SimulatorRuntimeVersion, rhs: SimulatorRuntimeVersion) -> Bool {
         let lhs = lhs.flattened()
         let rhs = rhs.flattened()
-        
+
         if lhs.major < rhs.major {
             return true
         } else if lhs.major == rhs.major {
@@ -74,19 +73,19 @@ struct SimulatorRuntimeVersion: CustomStringConvertible, Equatable, ExpressibleB
             return false
         }
     }
-    
+
     // MARK: - ExpressibleByStringLiteral
-    
+
     init(stringLiteral value: String) {
         let components = value.split(separator: ".")
-        
+
         // Major
         if let major = Int(String(components.first!)) {
             self.major = major
         } else {
             fatalError("Invalid major component. It should be an integer")
         }
-        
+
         // Minor
         if components.count >= 2 {
             if let minor = Int(components[1]) {
@@ -95,9 +94,9 @@ struct SimulatorRuntimeVersion: CustomStringConvertible, Equatable, ExpressibleB
                 fatalError("Invalid minor component. It should be an integer")
             }
         } else {
-            self.minor = nil
+            minor = nil
         }
-        
+
         // Patch
         if components.count >= 3 {
             if let patch = Int(components[2]) {
@@ -106,8 +105,7 @@ struct SimulatorRuntimeVersion: CustomStringConvertible, Equatable, ExpressibleB
                 fatalError("Invalid patch component. It should be an integer")
             }
         } else {
-            self.patch = nil
+            patch = nil
         }
     }
-    
 }

--- a/Sources/TuistKit/Simulators/SimulatorRuntimeVersion.swift
+++ b/Sources/TuistKit/Simulators/SimulatorRuntimeVersion.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+struct SimulatorRuntimeVersion: CustomStringConvertible, Equatable, ExpressibleByStringLiteral, Comparable {
+    
+    // MARK: - Attributes
+    
+    let major: Int
+    let minor: Int?
+    let patch: Int?
+    
+    // MARK: - Constructors
+    
+    init(major: Int, minor: Int? = nil, patch: Int? = nil) {
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+    }
+    
+    // MARK: - Internal
+    
+    func flattened() -> SimulatorRuntimeVersion {
+        return SimulatorRuntimeVersion(major: self.major,
+                                       minor: self.minor ?? 0,
+                                       patch: self.patch ?? 0)
+    }
+    
+    // MARK: - CustomStringConvertible
+    
+    var description: String {
+        var version = "\(self.major)"
+        if let minor = minor {
+            version.append(".\(minor)")
+        } else {
+            return version
+        }
+        if let patch = patch {
+            version.append(".\(patch)")
+        } else {
+            return version
+        }
+        return version
+    }
+    
+    // MARK: - Equatable
+    
+    static func ==(lhs: SimulatorRuntimeVersion, rhs: SimulatorRuntimeVersion) -> Bool {
+        return lhs.major == rhs.major &&
+            lhs.minor == rhs.minor &&
+            lhs.patch == rhs.patch
+    }
+    
+    // MARK: - Comparable
+    
+    static func < (lhs: SimulatorRuntimeVersion, rhs: SimulatorRuntimeVersion) -> Bool {
+        let lhs = lhs.flattened()
+        let rhs = rhs.flattened()
+        
+        if lhs.major < rhs.major {
+            return true
+        } else if lhs.major == rhs.major {
+            if lhs.minor! < rhs.minor! {
+                return true
+            } else if lhs.minor! == rhs.minor! {
+                return lhs.patch! < rhs.patch!
+            } else {
+                return false
+            }
+        } else {
+            return false
+        }
+    }
+    
+    // MARK: - ExpressibleByStringLiteral
+    
+    init(stringLiteral value: String) {
+        let components = value.split(separator: ".")
+        
+        // Major
+        if let major = Int(String(components.first!)) {
+            self.major = major
+        } else {
+            fatalError("Invalid major component. It should be an integer")
+        }
+        
+        // Minor
+        if components.count >= 2 {
+            if let minor = Int(components[1]) {
+                self.minor = minor
+            } else {
+                fatalError("Invalid minor component. It should be an integer")
+            }
+        } else {
+            self.minor = nil
+        }
+        
+        // Patch
+        if components.count >= 3 {
+            if let patch = Int(components[2]) {
+                self.patch = patch
+            } else {
+                fatalError("Invalid patch component. It should be an integer")
+            }
+        } else {
+            self.patch = nil
+        }
+    }
+    
+}

--- a/Sources/TuistKit/Simulators/SimulatorsController.swift
+++ b/Sources/TuistKit/Simulators/SimulatorsController.swift
@@ -1,0 +1,92 @@
+import Foundation
+import TuistSupport
+import TuistCore
+
+enum SimulatorControllerError: FatalError {
+    
+    /// Thrown when the simctl output can't be turned into a Data object.
+    case nilDataFromOutput(arguments: [String])
+    
+    /// Thrown when the output from simctl can't be JSON-decoded
+    case jsonDecoding(arguments: [String], error: Error)
+    
+    /// Thrown when the output is not a expected dictionary.
+    case notADictionary(arguments: [String])
+
+    /// Thrown when a key is missing from the decoded object.
+    case missingKey(String, arguments: [String])
+    
+    var type: ErrorType {
+        switch self {
+        case .nilDataFromOutput: return .bug
+        case .jsonDecoding: return .bug
+        case .notADictionary: return .bug
+        case .missingKey: return .bug
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .nilDataFromOutput(let arguments):
+            return "Couldn't turn the output from 'simctl \(arguments.joined(separator: " "))' into data"
+        case .jsonDecoding(let arguments, let error):
+            return "Could not JSON-decode the output returned by 'simctl \(arguments.joined(separator: " "))': \(error)"
+        case .notADictionary(let arguments):
+            return "The output from 'simctl \(arguments.joined(separator: " "))' is not a dictionary"
+        case .missingKey(let key, let arguments):
+            return "The output from 'simctl \(arguments.joined(separator: " "))' does not have the key \(key) or has an invalid format"
+        }
+    }
+}
+
+protocol SimulatorsControlling {
+    
+    /// Returns the list of runtimes available in the system.
+    /// - Returns: A list of simulator runtimes.
+    func runtimes() throws -> [SimulatorRuntime]
+}
+
+final class SimulatorsController: SimulatorsControlling {
+    
+    /// JSON decoder instance.
+    fileprivate let jsonDecoder: JSONDecoder = JSONDecoder()
+    
+    // MARK: - Internal
+    
+    func runtimes() throws -> [SimulatorRuntime] {
+        let arguments = ["list", "runtimes", "-j"]
+        let dictionary = try self.captureSimctlJSON(arguments)
+        guard let runtimes = dictionary["runtimes"] as? [Any] else {
+            throw SimulatorControllerError.missingKey("runtimes", arguments: arguments)
+        }
+        let data = try JSONSerialization.data(withJSONObject: runtimes, options: [])
+        return try jsonDecoder.decode([SimulatorRuntime].self, from: data)
+    }
+    
+    // MARK: - Fileprivate
+    
+    fileprivate func captureSimctlJSON(_ arguments: [String]) throws -> [String: Any] {
+        let output = try captureSimctl(arguments)
+        
+        guard let data = output.data(using: .utf8) else {
+            throw SimulatorControllerError.nilDataFromOutput(arguments: arguments)
+        }
+        
+        var json: Any!
+        do {
+            json = try JSONSerialization.jsonObject(with: data, options: [])
+        } catch {
+            throw SimulatorControllerError.jsonDecoding(arguments: arguments, error: error)
+        }
+        guard let dictionary = json as? [String: Any] else {
+            throw SimulatorControllerError.notADictionary(arguments: arguments)
+        }
+        return dictionary
+    }
+    
+    fileprivate func captureSimctl(_ arguments: [String]) throws -> String {
+        var arguments = arguments
+        arguments.insert(contentsOf: ["xcrun", "simctl"], at: 0)
+        return try System.shared.capture(arguments)
+    }
+}

--- a/Sources/TuistKit/Simulators/SimulatorsController.swift
+++ b/Sources/TuistKit/Simulators/SimulatorsController.swift
@@ -1,21 +1,20 @@
 import Foundation
-import TuistSupport
 import TuistCore
+import TuistSupport
 
 enum SimulatorControllerError: FatalError {
-    
     /// Thrown when the simctl output can't be turned into a Data object.
     case nilDataFromOutput(arguments: [String])
-    
+
     /// Thrown when the output from simctl can't be JSON-decoded
     case jsonDecoding(arguments: [String], error: Error)
-    
+
     /// Thrown when the output is not a expected dictionary.
     case notADictionary(arguments: [String])
 
     /// Thrown when a key is missing from the decoded object.
     case missingKey(String, arguments: [String])
-    
+
     var type: ErrorType {
         switch self {
         case .nilDataFromOutput: return .bug
@@ -24,54 +23,52 @@ enum SimulatorControllerError: FatalError {
         case .missingKey: return .bug
         }
     }
-    
+
     var description: String {
         switch self {
-        case .nilDataFromOutput(let arguments):
+        case let .nilDataFromOutput(arguments):
             return "Couldn't turn the output from 'simctl \(arguments.joined(separator: " "))' into data"
-        case .jsonDecoding(let arguments, let error):
+        case let .jsonDecoding(arguments, error):
             return "Could not JSON-decode the output returned by 'simctl \(arguments.joined(separator: " "))': \(error)"
-        case .notADictionary(let arguments):
+        case let .notADictionary(arguments):
             return "The output from 'simctl \(arguments.joined(separator: " "))' is not a dictionary"
-        case .missingKey(let key, let arguments):
+        case let .missingKey(key, arguments):
             return "The output from 'simctl \(arguments.joined(separator: " "))' does not have the key \(key) or has an invalid format"
         }
     }
 }
 
 protocol SimulatorsControlling {
-    
     /// Returns the list of runtimes available in the system.
     /// - Returns: A list of simulator runtimes.
     func runtimes() throws -> [SimulatorRuntime]
 }
 
 final class SimulatorsController: SimulatorsControlling {
-    
     /// JSON decoder instance.
     fileprivate let jsonDecoder: JSONDecoder = JSONDecoder()
-    
+
     // MARK: - Internal
-    
+
     func runtimes() throws -> [SimulatorRuntime] {
         let arguments = ["list", "runtimes", "-j"]
-        let dictionary = try self.captureSimctlJSON(arguments)
+        let dictionary = try captureSimctlJSON(arguments)
         guard let runtimes = dictionary["runtimes"] as? [Any] else {
             throw SimulatorControllerError.missingKey("runtimes", arguments: arguments)
         }
         let data = try JSONSerialization.data(withJSONObject: runtimes, options: [])
         return try jsonDecoder.decode([SimulatorRuntime].self, from: data)
     }
-    
+
     // MARK: - Fileprivate
-    
+
     fileprivate func captureSimctlJSON(_ arguments: [String]) throws -> [String: Any] {
         let output = try captureSimctl(arguments)
-        
+
         guard let data = output.data(using: .utf8) else {
             throw SimulatorControllerError.nilDataFromOutput(arguments: arguments)
         }
-        
+
         var json: Any!
         do {
             json = try JSONSerialization.jsonObject(with: data, options: [])
@@ -83,7 +80,7 @@ final class SimulatorsController: SimulatorsControlling {
         }
         return dictionary
     }
-    
+
     fileprivate func captureSimctl(_ arguments: [String]) throws -> String {
         var arguments = arguments
         arguments.insert(contentsOf: ["xcrun", "simctl"], at: 0)

--- a/Tests/TuistKitIntegrationTests/Simulators/SimulatorsControllerIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Simulators/SimulatorsControllerIntegrationTests.swift
@@ -1,0 +1,31 @@
+import Basic
+import Foundation
+import SPMUtility
+import TuistSupport
+import XCTest
+
+@testable import TuistKit
+@testable import TuistSupportTesting
+
+final class SimulatorsControllerIntegrationTests: TuistTestCase {
+    var subject: SimulatorsController!
+
+    override func setUp() {
+        super.setUp()
+        subject = SimulatorsController()
+    }
+
+    override func tearDown() {
+        subject = nil
+        super.tearDown()
+    }
+
+    
+    func test_runtimes_parses_simctl_output_and_returns_a_list_of_runtimes() throws {
+        // Given
+        let runtimes = try subject.runtimes()
+        
+        // Then
+        XCTAssertNotEqual(runtimes.count, 0)
+    }
+}

--- a/Tests/TuistKitIntegrationTests/Simulators/SimulatorsControllerIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Simulators/SimulatorsControllerIntegrationTests.swift
@@ -20,11 +20,10 @@ final class SimulatorsControllerIntegrationTests: TuistTestCase {
         super.tearDown()
     }
 
-    
     func test_runtimes_parses_simctl_output_and_returns_a_list_of_runtimes() throws {
         // Given
         let runtimes = try subject.runtimes()
-        
+
         // Then
         XCTAssertNotEqual(runtimes.count, 0)
     }

--- a/Tests/TuistKitTests/Simulators/SimulatorRuntimeTests.swift
+++ b/Tests/TuistKitTests/Simulators/SimulatorRuntimeTests.swift
@@ -5,27 +5,26 @@ import XCTest
 @testable import TuistSupportTesting
 
 final class SimulatorRuntimeTests: TuistUnitTestCase {
-    
 //    func test_description_when_ios() {
 //        // Given
 //        let subject = SimulatorRuntime.iOS("11.2")
-//        
+//
 //        // Then
 //        XCTAssertEqual(subject.description, "iOS 11.2 runtime")
 //    }
-//    
+//
 //    func test_description_when_tvos() {
 //        // Given
 //        let subject = SimulatorRuntime.tvOS("11.0")
-//        
+//
 //        // Then
 //        XCTAssertEqual(subject.description, "tvOS 11.0 runtime")
 //    }
-//    
+//
 //    func test_description_when_watchOS() {
 //        // Given
 //        let subject = SimulatorRuntime.watchOS("11.0")
-//        
+//
 //        // Then
 //        XCTAssertEqual(subject.description, "watchOS 11.0 runtime")
 //    }

--- a/Tests/TuistKitTests/Simulators/SimulatorRuntimeTests.swift
+++ b/Tests/TuistKitTests/Simulators/SimulatorRuntimeTests.swift
@@ -1,8 +1,32 @@
-//
-//  SimulatorRuntimeTests.swift
-//  TuistKitTests
-//
-//  Created by Pedro Piñera Buendía on 02.12.19.
-//
-
 import Foundation
+import XCTest
+
+@testable import TuistKit
+@testable import TuistSupportTesting
+
+final class SimulatorRuntimeTests: TuistUnitTestCase {
+    
+//    func test_description_when_ios() {
+//        // Given
+//        let subject = SimulatorRuntime.iOS("11.2")
+//        
+//        // Then
+//        XCTAssertEqual(subject.description, "iOS 11.2 runtime")
+//    }
+//    
+//    func test_description_when_tvos() {
+//        // Given
+//        let subject = SimulatorRuntime.tvOS("11.0")
+//        
+//        // Then
+//        XCTAssertEqual(subject.description, "tvOS 11.0 runtime")
+//    }
+//    
+//    func test_description_when_watchOS() {
+//        // Given
+//        let subject = SimulatorRuntime.watchOS("11.0")
+//        
+//        // Then
+//        XCTAssertEqual(subject.description, "watchOS 11.0 runtime")
+//    }
+}

--- a/Tests/TuistKitTests/Simulators/SimulatorRuntimeTests.swift
+++ b/Tests/TuistKitTests/Simulators/SimulatorRuntimeTests.swift
@@ -1,0 +1,8 @@
+//
+//  SimulatorRuntimeTests.swift
+//  TuistKitTests
+//
+//  Created by Pedro Piñera Buendía on 02.12.19.
+//
+
+import Foundation

--- a/Tests/TuistKitTests/Simulators/SimulatorRuntimeVersionTests.swift
+++ b/Tests/TuistKitTests/Simulators/SimulatorRuntimeVersionTests.swift
@@ -8,65 +8,65 @@ final class SimulatorRuntimeVersionTests: TuistUnitTestCase {
     func test_description_when_only_major() {
         // Given
         let version = SimulatorRuntimeVersion(major: 2)
-        
+
         // Then
         XCTAssertEqual(version.description, "2")
     }
-    
+
     func test_description_when_major_and_minor() {
         // Given
         let version = SimulatorRuntimeVersion(major: 2, minor: 3)
-        
+
         // Then
         XCTAssertEqual(version.description, "2.3")
     }
-    
+
     func test_description_when_major_minor_and_patch() {
         // Given
         let version = SimulatorRuntimeVersion(major: 2, minor: 3, patch: 4)
-        
+
         // Then
         XCTAssertEqual(version.description, "2.3.4")
     }
-    
+
     func test_equal_when_they_are_equal() {
         // Given
         let first = SimulatorRuntimeVersion(major: 3, minor: 2, patch: 1)
         let second = SimulatorRuntimeVersion(major: 3, minor: 2, patch: 1)
-        
+
         // Then
         XCTAssertEqual(first, second)
     }
-    
+
     func test_equal_when_they_are_not_equal() {
         // Given
         let first = SimulatorRuntimeVersion(major: 3, minor: 2, patch: 1)
         let second = SimulatorRuntimeVersion(major: 3, minor: 3, patch: 1)
-        
+
         // Then
         XCTAssertNotEqual(first, second)
     }
-    
+
     func test_expressible_by_string_literal() {
         // Given
         let first: SimulatorRuntimeVersion = "3.2.1"
         let second = SimulatorRuntimeVersion(major: 3, minor: 2, patch: 1)
-        
+
         // Then
         XCTAssertEqual(first, second)
     }
-    
+
     func test_flattened() {
         // Given
         let version: SimulatorRuntimeVersion = "3"
-        
+
         // Then
         XCTAssertNil(version.minor)
         XCTAssertNil(version.patch)
         XCTAssertEqual(version.flattened().minor, 0)
         XCTAssertEqual(version.flattened().patch, 0)
     }
-    
+
     func test_comparable() {
         XCTAssertTrue(SimulatorRuntimeVersion(major: 3, minor: 2, patch: 1) < SimulatorRuntimeVersion(major: 3, minor: 2, patch: 2))
         XCTAssertTrue(SimulatorRuntimeVersion(major: 3, minor: 2, patch: 1) <= SimulatorRuntimeVersion(major: 3, minor: 2, patch: 2))
@@ -76,4 +76,3 @@ final class SimulatorRuntimeVersionTests: TuistUnitTestCase {
         XCTAssertFalse(SimulatorRuntimeVersion(major: 4, minor: 2, patch: 1) < SimulatorRuntimeVersion(major: 4, minor: 1, patch: 2))
     }
 }
-

--- a/Tests/TuistKitTests/Simulators/SimulatorRuntimeVersionTests.swift
+++ b/Tests/TuistKitTests/Simulators/SimulatorRuntimeVersionTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import XCTest
+
+@testable import TuistKit
+@testable import TuistSupportTesting
+
+final class SimulatorRuntimeVersionTests: TuistUnitTestCase {
+    func test_description_when_only_major() {
+        // Given
+        let version = SimulatorRuntimeVersion(major: 2)
+        
+        // Then
+        XCTAssertEqual(version.description, "2")
+    }
+    
+    func test_description_when_major_and_minor() {
+        // Given
+        let version = SimulatorRuntimeVersion(major: 2, minor: 3)
+        
+        // Then
+        XCTAssertEqual(version.description, "2.3")
+    }
+    
+    func test_description_when_major_minor_and_patch() {
+        // Given
+        let version = SimulatorRuntimeVersion(major: 2, minor: 3, patch: 4)
+        
+        // Then
+        XCTAssertEqual(version.description, "2.3.4")
+    }
+    
+    func test_equal_when_they_are_equal() {
+        // Given
+        let first = SimulatorRuntimeVersion(major: 3, minor: 2, patch: 1)
+        let second = SimulatorRuntimeVersion(major: 3, minor: 2, patch: 1)
+        
+        // Then
+        XCTAssertEqual(first, second)
+    }
+    
+    func test_equal_when_they_are_not_equal() {
+        // Given
+        let first = SimulatorRuntimeVersion(major: 3, minor: 2, patch: 1)
+        let second = SimulatorRuntimeVersion(major: 3, minor: 3, patch: 1)
+        
+        // Then
+        XCTAssertNotEqual(first, second)
+    }
+    
+    func test_expressible_by_string_literal() {
+        // Given
+        let first: SimulatorRuntimeVersion = "3.2.1"
+        let second = SimulatorRuntimeVersion(major: 3, minor: 2, patch: 1)
+        
+        // Then
+        XCTAssertEqual(first, second)
+    }
+    
+    func test_flattened() {
+        // Given
+        let version: SimulatorRuntimeVersion = "3"
+        
+        // Then
+        XCTAssertNil(version.minor)
+        XCTAssertNil(version.patch)
+        XCTAssertEqual(version.flattened().minor, 0)
+        XCTAssertEqual(version.flattened().patch, 0)
+    }
+    
+    func test_comparable() {
+        XCTAssertTrue(SimulatorRuntimeVersion(major: 3, minor: 2, patch: 1) < SimulatorRuntimeVersion(major: 3, minor: 2, patch: 2))
+        XCTAssertTrue(SimulatorRuntimeVersion(major: 3, minor: 2, patch: 1) <= SimulatorRuntimeVersion(major: 3, minor: 2, patch: 2))
+        XCTAssertTrue(SimulatorRuntimeVersion(major: 3, minor: 2, patch: 1) <= SimulatorRuntimeVersion(major: 3, minor: 2, patch: 1))
+        XCTAssertTrue(SimulatorRuntimeVersion(major: 4, minor: 2, patch: 1) > SimulatorRuntimeVersion(major: 3, minor: 2, patch: 2))
+        XCTAssertTrue(SimulatorRuntimeVersion(major: 4, minor: 2, patch: 1) > SimulatorRuntimeVersion(major: 4, minor: 1, patch: 2))
+        XCTAssertFalse(SimulatorRuntimeVersion(major: 4, minor: 2, patch: 1) < SimulatorRuntimeVersion(major: 4, minor: 1, patch: 2))
+    }
+}
+


### PR DESCRIPTION
### Context 📝
To build cacheable xcframeworks, we'll need to build the frameworks for both, device and simulator. For the later we need to pass a `-destination` argument targeting the device we are building the framework for.

### Description 📦
I'm adding a new utility to `TuistKit`, `SimulatorController`, that wraps the `simctl` command. The only method implemented for now is a method that fetches the runtimes that are available.
