### PR TITLE
Ensure custom search path settings are included in generated projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Make scheme generation methods more generic by @adamkhazi @kwridan.
 - `SimulatorController` with method to fetch the runtimes https://github.com/tuist/tuist/pull/746 by @pepibumur.
 
+### Fixed
+
+- Ensure custom search path settings are included in generated projects https://github.com/tuist/tuist/pull/751 by @kwridan
+
 ## 0.19.0
 
 ### Added

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -244,15 +244,13 @@ final class LinkGenerator: LinkGenerating {
             return
         }
         let value = SettingValue
-            .array(paths
+            .array(["$(inherited)"] + paths
                 .map { $0.relative(to: sourceRootPath).pathString }
                 .map { "$(SRCROOT)/\($0)" })
         let newSetting = [name: value]
-        let inheritedSetting = [name: SettingValue.string("$(inherited)")]
         let helper = SettingsHelper()
         try configurationList.buildConfigurations.forEach { configuration in
             try helper.extend(buildSettings: &configuration.buildSettings, with: newSetting)
-            try helper.extend(buildSettings: &configuration.buildSettings, with: inheritedSetting)
         }
     }
 

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -244,7 +244,7 @@ final class LinkGenerator: LinkGenerating {
             return
         }
         let value = SettingValue
-            .array(["$(inherited)"] + paths
+            .array(["$(inherited)"] + paths.sorted()
                 .map { $0.relative(to: sourceRootPath).pathString }
                 .map { "$(SRCROOT)/\($0)" })
         let newSetting = [name: value]

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -144,6 +144,31 @@ final class LinkGeneratorErrorTests: XCTestCase {
         XCTAssertEqual(config.buildSettings["HEADER_SEARCH_PATHS"] as? [String], expected)
     }
 
+    func test_setupHeadersSearchPaths_extendCustomSettings() throws {
+        // Given
+        let searchPaths = [
+            AbsolutePath("/path/to/libraries"),
+            AbsolutePath("/path/to/other/libraries"),
+        ]
+        let sourceRootPath = AbsolutePath("/path")
+        let xcodeprojElements = createXcodeprojElements()
+        xcodeprojElements.config.buildSettings["HEADER_SEARCH_PATHS"] = "my/custom/path"
+
+        // When
+        try subject.setupHeadersSearchPath(searchPaths,
+                                           pbxTarget: xcodeprojElements.pbxTarget,
+                                           sourceRootPath: sourceRootPath)
+
+        // Then
+        let config = xcodeprojElements.config
+        XCTAssertEqual(config.buildSettings["HEADER_SEARCH_PATHS"] as? [String], [
+            "$(inherited)",
+            "$(SRCROOT)/to/libraries",
+            "$(SRCROOT)/to/other/libraries",
+            "my/custom/path",
+        ])
+    }
+
     func test_setupHeadersSearchPath_throws_whenTheConfigurationListIsMissing() throws {
         let headersFolders = [AbsolutePath("/headers")]
         let pbxproj = PBXProj()

--- a/fixtures/ios_app_with_static_libraries/Modules/A/Project.swift
+++ b/fixtures/ios_app_with_static_libraries/Modules/A/Project.swift
@@ -13,7 +13,7 @@ let project = Project(name: "A",
                                      .library(path: "../C/prebuilt/C/libC.a",
                                              publicHeaders: "../C/prebuilt/C",
                                              swiftModuleMap: "../C/prebuilt/C/C.swiftmodule")
-                          ]),
+                          ], settings: Settings(base: ["HEADER_SEARCH_PATHS": "$(SRCROOT)/CustomHeaders"])),
                           Target(name: "ATests",
                                  platform: .iOS,
                                  product: .unitTests,


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/750

### Short description 📝

Specifying a custom `HEADER_SEARCH_PATHS` or `FRAMEWORK_SEARCH_PATHS` build setting in manifest is ignored in the event a project has a static library dependency.

### Solution 📦

- The previous logic was setting the `$(inherited)` and the derived search paths seperately
- This caused the derrived search paths to replace any existing custom settings
- To solve this, we can set the derived search paths and the `$(inherited)` setting as one setting
- This allows the extend helper method to extend existing settings

### Implementation 👩‍💻👨‍💻

- [x] Update `LinkGenerator`
- [x] Add unit tests
- [x] Update fixture
- [x] Update changelog

### Test Plan 🛠

- Run `tuist generate` within `fixtures/ios_app_with_static_libraries`
- Inspect the generated workspace, Module A should have a `$(SRCROOT/CustomHeader` header search path
