### PR TITLE
Change the generation logic to not include the manifest files in the workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - **Breaking** Generate manifests target as part of the generated project https://github.com/tuist/tuist/pull/724 by @pepibumur.
 - The installation no longer checks if the Swift version is compatible https://github.com/tuist/tuist/pull/727 by @pepibumur.
+- Don't include the manifests in the generated workspace https://github.com/tuist/tuist/pull/754 by @pepibumur.
 
 ### Added
 
@@ -20,7 +21,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Support for paths relative to root https://github.com/tuist/tuist/pull/727 by @pepibumur.
 - Replace `Sheme.testAction.targets` type from `String` to `TestableTarget` is a description of target that adds to the `TestAction`, you can specify execution tests parallelizable, random execution order or skip tests https://github.com/tuist/tuist/pull/728 by @rowwingman.
 - Galaxy manifest model https://github.com/tuist/tuist/pull/729 by @pepibumur.
-- Make scheme generation methods more generic https://github.com/tuist/tuist/pull/730  by @adamkhazi @kwridan.
+- Make scheme generation methods more generic https://github.com/tuist/tuist/pull/730 by @adamkhazi @kwridan.
 - Make scheme generation methods more generic by @adamkhazi @kwridan.
 - `SimulatorController` with method to fetch the runtimes https://github.com/tuist/tuist/pull/746 by @pepibumur.
 

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -186,7 +186,7 @@ public class Graph: Graphing {
     public var targets: [TargetNode] {
         return cache.targetNodes.flatMap { $0.value.values }
     }
-    
+
     public func target(path: AbsolutePath, name: String) -> TargetNode? {
         return findTargetNode(path: path, name: name)
     }

--- a/Sources/TuistCore/Models/Scheme.swift
+++ b/Sources/TuistCore/Models/Scheme.swift
@@ -92,7 +92,7 @@ public struct TargetReference: Equatable {
     public static func project(path: AbsolutePath, target: String) -> TargetReference {
         return .init(projectPath: path, name: target)
     }
-    
+
     public init(projectPath: AbsolutePath, name: String) {
         self.projectPath = projectPath
         self.name = name

--- a/Sources/TuistGenerator/Generator/SchemesGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemesGenerator.swift
@@ -27,7 +27,7 @@ final class SchemesGenerator: SchemesGenerating {
 
     /// Default version for generated schemes.
     private static let defaultVersion = "1.3"
-    
+
     /// Generate schemes for a project.
     ///
     /// - Parameters:
@@ -39,7 +39,6 @@ final class SchemesGenerator: SchemesGenerating {
                                 xcprojectPath: AbsolutePath,
                                 generatedProject: GeneratedProject,
                                 graph: Graphing) throws {
-        
         /// Generate custom schemes from manifest
         try project.schemes.forEach { scheme in
             try generateScheme(scheme: scheme,
@@ -48,7 +47,7 @@ final class SchemesGenerator: SchemesGenerating {
                                graph: graph,
                                generatedProjects: [project.path: generatedProject])
         }
-        
+
         /// Generate default schemes for targets in Project that are not defined in Manifest
         let buildConfiguration = defaultDebugBuildConfigurationName(in: project)
         let userDefinedSchemes = Set(project.schemes.map(\.name))
@@ -60,10 +59,9 @@ final class SchemesGenerator: SchemesGenerating {
                                path: project.path,
                                graph: graph,
                                generatedProjects: [project.path: generatedProject])
-
         }
     }
-    
+
     private func createDefaultScheme(target: Target, project: Project, buildConfiguration: String) -> Scheme {
         let targetReference = TargetReference.project(path: project.path, target: target.name)
         let testTargets = target.product.testsBundle ? [TestableTarget(target: targetReference)] : []
@@ -73,7 +71,7 @@ final class SchemesGenerator: SchemesGenerating {
                       testAction: TestAction(targets: testTargets, configurationName: buildConfiguration),
                       runAction: RunAction(configurationName: buildConfiguration, executable: targetReference, arguments: Arguments(environment: target.environment)))
     }
-    
+
     /// Generate schemes for a project or workspace.
     ///
     /// - Parameters:
@@ -89,7 +87,7 @@ final class SchemesGenerator: SchemesGenerating {
                                 generatedProjects: [AbsolutePath: GeneratedProject]) throws {
         let schemeDirectory = try createSchemesDirectory(path: xcPath, shared: scheme.shared)
         let schemePath = schemeDirectory.appending(component: "\(scheme.name).xcscheme")
-        
+
         let generatedBuildAction = try schemeBuildAction(scheme: scheme,
                                                          graph: graph,
                                                          rootPath: path,
@@ -124,10 +122,10 @@ final class SchemesGenerator: SchemesGenerating {
                               profileAction: generatedProfileAction,
                               analyzeAction: generatedAnalyzeAction,
                               archiveAction: generatedArchiveAction)
-                              
+
         try scheme.write(path: schemePath.path, override: true)
     }
-    
+
     /// Generates the scheme build action.
     ///
     /// - Parameters:
@@ -157,11 +155,11 @@ final class SchemesGenerator: SchemesGenerating {
                                                                         generatedProjects: generatedProjects) else { return }
             entries.append(XCScheme.BuildAction.Entry(buildableReference: buildableReference, buildFor: buildFor))
         }
-        
+
         preActions = try buildAction.preActions.map {
             try schemeExecutionAction(action: $0, graph: graph, generatedProjects: generatedProjects, rootPath: rootPath)
         }
-        
+
         postActions = try buildAction.postActions.map {
             try schemeExecutionAction(action: $0, graph: graph, generatedProjects: generatedProjects, rootPath: rootPath)
         }
@@ -172,7 +170,7 @@ final class SchemesGenerator: SchemesGenerating {
                                     parallelizeBuild: true,
                                     buildImplicitDependencies: true)
     }
-    
+
     /// Generates the scheme test action.
     ///
     /// - Parameters:
@@ -186,7 +184,7 @@ final class SchemesGenerator: SchemesGenerating {
                           rootPath: AbsolutePath,
                           generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.TestAction? {
         guard let testAction = scheme.testAction else { return nil }
-        
+
         var testables: [XCScheme.TestableReference] = []
         var preActions: [XCScheme.ExecutionAction] = []
         var postActions: [XCScheme.ExecutionAction] = []
@@ -196,14 +194,14 @@ final class SchemesGenerator: SchemesGenerating {
                                                                graph: graph,
                                                                rootPath: rootPath,
                                                                generatedProjects: generatedProjects) else { return }
-            
+
             let testable = XCScheme.TestableReference(skipped: testableTarget.isSkipped,
                                                       parallelizable: testableTarget.isParallelizable,
                                                       randomExecutionOrdering: testableTarget.isRandomExecutionOrdering,
                                                       buildableReference: reference)
             testables.append(testable)
         }
-        
+
         preActions = try testAction.preActions.map { try schemeExecutionAction(action: $0,
                                                                                graph: graph,
                                                                                generatedProjects: generatedProjects,
@@ -220,7 +218,7 @@ final class SchemesGenerator: SchemesGenerating {
             args = XCScheme.CommandLineArguments(arguments: commandlineArgruments(arguments.launch))
             environments = environmentVariables(arguments.environment)
         }
-        
+
         let codeCoverageTargets = try testAction.codeCoverageTargets.compactMap {
             try testCoverageTargetReferences(target: $0,
                                              graph: graph,
@@ -244,7 +242,7 @@ final class SchemesGenerator: SchemesGenerating {
                                    commandlineArguments: args,
                                    environmentVariables: environments)
     }
-    
+
     /// Generates the scheme launch action.
     ///
     /// - Parameters:
@@ -258,17 +256,17 @@ final class SchemesGenerator: SchemesGenerating {
                             rootPath: AbsolutePath,
                             generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.LaunchAction? {
         guard var target = try defaultTargetReference(scheme: scheme) else { return nil }
-        
+
         if let executable = scheme.runAction?.executable {
             target = executable
         }
-        
+
         guard let targetNode = try graph.target(path: target.projectPath, name: target.name) else { return nil }
         guard let buildableReference = try createBuildableReference(targetReference: target,
                                                                     graph: graph,
                                                                     rootPath: rootPath,
                                                                     generatedProjects: generatedProjects) else { return nil }
-        
+
         var buildableProductRunnable: XCScheme.BuildableProductRunnable?
         var macroExpansion: XCScheme.BuildableReference?
 
@@ -293,7 +291,7 @@ final class SchemesGenerator: SchemesGenerating {
                                      commandlineArguments: commandlineArguments,
                                      environmentVariables: environments)
     }
-    
+
     /// Generates the scheme profile action for a given target.
     ///
     /// - Parameters:
@@ -306,7 +304,6 @@ final class SchemesGenerator: SchemesGenerating {
                              graph: Graphing,
                              rootPath: AbsolutePath,
                              generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.ProfileAction? {
-        
         guard var target = try defaultTargetReference(scheme: scheme) else { return nil }
         if let executable = scheme.runAction?.executable {
             target = executable
@@ -316,22 +313,22 @@ final class SchemesGenerator: SchemesGenerating {
                                                                     graph: graph,
                                                                     rootPath: rootPath,
                                                                     generatedProjects: generatedProjects) else { return nil }
-        
+
         var buildableProductRunnable: XCScheme.BuildableProductRunnable?
         var macroExpansion: XCScheme.BuildableReference?
-        
+
         if targetNode.target.product.runnable {
             buildableProductRunnable = XCScheme.BuildableProductRunnable(buildableReference: buildableReference, runnableDebuggingMode: "0")
         } else {
             macroExpansion = buildableReference
         }
-        
+
         let buildConfiguration = defaultReleaseBuildConfigurationName(in: targetNode.project)
         return XCScheme.ProfileAction(buildableProductRunnable: buildableProductRunnable,
                                       buildConfiguration: buildConfiguration,
                                       macroExpansion: macroExpansion)
     }
-    
+
     /// Returns the scheme analyze action.
     ///
     /// - Parameters:
@@ -342,11 +339,11 @@ final class SchemesGenerator: SchemesGenerating {
     /// - Returns: Scheme analyze action.
     func schemeAnalyzeAction(scheme: Scheme,
                              graph: Graphing,
-                             rootPath: AbsolutePath,
-                             generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.AnalyzeAction? {
+                             rootPath _: AbsolutePath,
+                             generatedProjects _: [AbsolutePath: GeneratedProject]) throws -> XCScheme.AnalyzeAction? {
         guard let target = try defaultTargetReference(scheme: scheme),
             let targetNode = try graph.target(path: target.projectPath, name: target.name) else { return nil }
-        
+
         let buildConfiguration = defaultDebugBuildConfigurationName(in: targetNode.project)
         return XCScheme.AnalyzeAction(buildConfiguration: buildConfiguration)
     }
@@ -363,18 +360,17 @@ final class SchemesGenerator: SchemesGenerating {
                              graph: Graphing,
                              rootPath: AbsolutePath,
                              generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.ArchiveAction? {
-        
         guard let target = try defaultTargetReference(scheme: scheme),
             let targetNode = try graph.target(path: target.projectPath, name: target.name) else { return nil }
 
         guard let archiveAction = scheme.archiveAction else {
             return defaultSchemeArchiveAction(for: targetNode.project)
         }
-        
+
         let preActions = try archiveAction.preActions.map {
             try schemeExecutionAction(action: $0, graph: graph, generatedProjects: generatedProjects, rootPath: rootPath)
         }
-        
+
         let postActions = try archiveAction.postActions.map {
             try schemeExecutionAction(action: $0, graph: graph, generatedProjects: generatedProjects, rootPath: rootPath)
         }
@@ -385,28 +381,27 @@ final class SchemesGenerator: SchemesGenerating {
                                       preActions: preActions,
                                       postActions: postActions)
     }
-    
+
     func schemeExecutionAction(action: ExecutionAction,
                                graph: Graphing,
                                generatedProjects: [AbsolutePath: GeneratedProject],
-                               rootPath: AbsolutePath) throws -> XCScheme.ExecutionAction {
-
+                               rootPath _: AbsolutePath) throws -> XCScheme.ExecutionAction {
         guard let targetReference = action.target,
             let targetNode = try graph.target(path: targetReference.projectPath, name: targetReference.name),
             let generatedProject = generatedProjects[targetReference.projectPath] else {
-                return schemeExecutionAction(action: action)
+            return schemeExecutionAction(action: action)
         }
         return schemeExecutionAction(action: action,
                                      target: targetNode.target,
                                      generatedProject: generatedProject)
     }
-    
+
     private func schemeExecutionAction(action: ExecutionAction) -> XCScheme.ExecutionAction {
         return XCScheme.ExecutionAction(scriptText: action.scriptText,
                                         title: action.title,
                                         environmentBuildable: nil)
     }
-    
+
     /// Returns the scheme pre/post actions.
     ///
     /// - Parameters:
@@ -420,7 +415,7 @@ final class SchemesGenerator: SchemesGenerating {
         /// Return Buildable Reference for Scheme Action
         func schemeBuildableReference(target: Target, generatedProject: GeneratedProject) -> XCScheme.BuildableReference? {
             guard let pbxTarget = generatedProject.targets[target.name] else { return nil }
-            
+
             return targetBuildableReference(target: target,
                                             pbxTarget: pbxTarget,
                                             projectPath: generatedProject.name)
@@ -434,16 +429,16 @@ final class SchemesGenerator: SchemesGenerating {
                                                                      generatedProject: generatedProject)
         return schemeAction
     }
-    
+
     // MARK: - Helpers
-    
+
     private func resolveRelativeProjectPath(targetNode: TargetNode,
                                             generatedProject: GeneratedProject,
                                             rootPath: AbsolutePath) -> RelativePath {
         let xcodeProjectPath = targetNode.path.appending(component: generatedProject.name)
         return xcodeProjectPath.relative(to: rootPath)
     }
-    
+
     /// Creates a target buildable refernece for a target
     ///
     /// - Parameters:
@@ -455,7 +450,6 @@ final class SchemesGenerator: SchemesGenerating {
                                           graph: Graphing,
                                           rootPath: AbsolutePath,
                                           generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.BuildableReference? {
-        
         let projectPath = targetReference.projectPath
         guard let target = try graph.target(path: projectPath, name: targetReference.name) else { return nil }
         guard let generatedProject = generatedProjects[projectPath] else { return nil }
@@ -463,12 +457,12 @@ final class SchemesGenerator: SchemesGenerating {
         let relativeXcodeProjectPath = resolveRelativeProjectPath(targetNode: target,
                                                                   generatedProject: generatedProject,
                                                                   rootPath: rootPath)
-        
+
         return targetBuildableReference(target: target.target,
                                         pbxTarget: pbxTarget,
                                         projectPath: relativeXcodeProjectPath.pathString)
     }
-    
+
     /// Generates the array of BuildableReference for targets that the
     /// coverage report should be generated for them.
     ///
@@ -487,7 +481,7 @@ final class SchemesGenerator: SchemesGenerating {
                                             rootPath: rootPath,
                                             generatedProjects: generatedProjects)
     }
-    
+
     /// Creates the directory where the schemes are stored inside the project.
     /// If the directory exists it does not re-create it.
     ///
@@ -509,7 +503,7 @@ final class SchemesGenerator: SchemesGenerating {
         }
         return schemePath
     }
-    
+
     /// Returns the scheme commandline argument passed on launch
     ///
     /// - Parameters:
@@ -520,7 +514,7 @@ final class SchemesGenerator: SchemesGenerating {
             XCScheme.CommandLineArguments.CommandLineArgument(name: key, enabled: enabled)
         }
     }
-    
+
     /// Returns the scheme environment variables
     ///
     /// - Parameters:
@@ -531,14 +525,14 @@ final class SchemesGenerator: SchemesGenerating {
             XCScheme.EnvironmentVariable(variable: key, value: value, enabled: true)
         }
     }
-    
+
     private func defaultDebugBuildConfigurationName(in project: Project) -> String {
         let debugConfiguration = project.settings.defaultDebugBuildConfiguration()
         let buildConfiguration = debugConfiguration ?? project.settings.configurations.keys.first
 
         return buildConfiguration?.name ?? BuildConfiguration.debug.name
     }
-    
+
     /// Returns the scheme buildable reference for a given target.
     ///
     /// - Parameters:
@@ -564,15 +558,15 @@ final class SchemesGenerator: SchemesGenerating {
         return XCScheme.ArchiveAction(buildConfiguration: buildConfiguration,
                                       revealArchiveInOrganizer: true)
     }
-    
+
     private func defaultReleaseBuildConfigurationName(in project: Project) -> String {
         let releaseConfiguration = project.settings.defaultReleaseBuildConfiguration()
         let buildConfiguration = releaseConfiguration ?? project.settings.configurations.keys.first
 
         return buildConfiguration?.name ?? BuildConfiguration.release.name
     }
-    
-    private func defaultTargetReference(scheme: Scheme) throws  -> TargetReference? {
+
+    private func defaultTargetReference(scheme: Scheme) throws -> TargetReference? {
         return scheme.buildAction?.targets.first
     }
 }

--- a/Sources/TuistKit/Generator/Generator.swift
+++ b/Sources/TuistKit/Generator/Generator.swift
@@ -16,13 +16,10 @@ extension Generating {
     func generateWorkspace(at path: AbsolutePath,
                            manifestLoader: GraphManifestLoading) throws -> AbsolutePath {
         let manifests = manifestLoader.manifests(at: path)
-        let workspaceFiles: [AbsolutePath] = [Manifest.workspace, Manifest.setup]
-            .compactMap { try? manifestLoader.manifestPath(at: path, manifest: $0) }
-
         if manifests.contains(.workspace) {
-            return try generateWorkspace(at: path, workspaceFiles: workspaceFiles)
+            return try generateWorkspace(at: path, workspaceFiles: [])
         } else if manifests.contains(.project) {
-            return try generateProjectWorkspace(at: path, workspaceFiles: workspaceFiles)
+            return try generateProjectWorkspace(at: path, workspaceFiles: [])
         } else {
             throw GraphManifestLoaderError.manifestNotFound(path)
         }

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -607,7 +607,7 @@ extension TuistCore.TestAction {
         let codeCoverageTargets = manifest.codeCoverageTargets.map { TuistCore.TargetReference(projectPath: projectPath, name: $0) }
         let preActions = manifest.preActions.map { TuistCore.ExecutionAction.from(manifest: $0, projectPath: projectPath) }
         let postActions = manifest.postActions.map { TuistCore.ExecutionAction.from(manifest: $0, projectPath: projectPath) }
-        
+
         return TestAction(targets: targets,
                           arguments: arguments,
                           configurationName: configurationName,
@@ -631,7 +631,7 @@ extension TuistCore.RunAction {
     static func from(manifest: ProjectDescription.RunAction, projectPath: AbsolutePath) -> TuistCore.RunAction {
         let configurationName = manifest.configurationName
         let arguments = manifest.arguments.map { TuistCore.Arguments.from(manifest: $0) }
-        
+
         var executableResolved: TuistCore.TargetReference?
         if let executable = manifest.executable {
             executableResolved = TargetReference(projectPath: projectPath, name: executable)

--- a/Tests/TuistGeneratorTests/Generator/Mocks/MockSchemesGenerator.swift
+++ b/Tests/TuistGeneratorTests/Generator/Mocks/MockSchemesGenerator.swift
@@ -1,12 +1,12 @@
-import Foundation
 import Basic
+import Foundation
 import TuistCore
 import TuistCoreTesting
 @testable import TuistGenerator
 
 final class MockSchemesGenerator: SchemesGenerating {
     var generateProjectSchemeArgs: [(project: Project, xcprojectPath: AbsolutePath, generatedProject: GeneratedProject, graph: Graphing)] = []
-    
+
     func generateProjectSchemes(project: Project, xcprojectPath: AbsolutePath, generatedProject: GeneratedProject, graph: Graphing) throws {
         generateProjectSchemeArgs.append((project: project, xcprojectPath: xcprojectPath, generatedProject: generatedProject, graph: graph))
     }

--- a/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
@@ -16,20 +16,20 @@ final class SchemesGeneratorTests: XCTestCase {
         super.setUp()
         subject = SchemesGenerator()
     }
-    
+
     // MARK: - Build Action Tests
 
     func test_schemeBuildAction_whenSingleProject() throws {
         // Given
         let projectPath = AbsolutePath("/somepath/Workspace/Projects/Project")
         let scheme = Scheme.test(buildAction: BuildAction(targets: [TargetReference(projectPath: projectPath, name: "App")]))
-        
+
         let app = Target.test(name: "App", product: .app)
         let targets = [app]
-        
+
         let project = Project.test(path: projectPath)
         let graph = Graph.create(dependencies: [(project: project, target: app, dependencies: [])])
-        
+
         // Then
         let got = try subject.schemeBuildAction(scheme: scheme,
                                                 graph: graph,
@@ -52,46 +52,46 @@ final class SchemesGeneratorTests: XCTestCase {
         XCTAssertEqual(result.parallelizeBuild, true)
         XCTAssertEqual(result.buildImplicitDependencies, true)
     }
-    
+
     func test_schemeBuildAction_whenMultipleProject() throws {
         // Given
         let projectAPath = AbsolutePath("/somepath/Workspace/Projects/ProjectA")
         let projectBPath = AbsolutePath("/somepath/Workspace/Projects/ProjectB")
-        
+
         let buildAction = BuildAction(targets: [
             TargetReference(projectPath: projectAPath, name: "FrameworkA"),
-            TargetReference(projectPath: projectBPath, name: "FrameworkB")
+            TargetReference(projectPath: projectBPath, name: "FrameworkB"),
         ])
         let scheme = Scheme.test(buildAction: buildAction)
-        
+
         let frameworkA = Target.test(name: "FrameworkA", product: .staticFramework)
         let frameworkB = Target.test(name: "FrameworkB", product: .staticFramework)
         let targets = [frameworkA, frameworkB]
-        
+
         let projectA = Project.test(path: projectAPath)
         let projectB = Project.test(path: projectBPath)
         let graph = Graph.create(dependencies: [
             (project: projectA, target: frameworkA, dependencies: []),
-            (project: projectB, target: frameworkB, dependencies: [])
+            (project: projectB, target: frameworkB, dependencies: []),
         ])
-        
+
         // Then
         let got = try subject.schemeBuildAction(scheme: scheme,
                                                 graph: graph,
                                                 rootPath: AbsolutePath("/somepath/Workspace"),
                                                 generatedProjects: [
-                                                                    projectAPath: generatedProject(targets: targets, projectPath: "\(projectAPath)/project.xcodeproj"),
-                                                                    projectBPath: generatedProject(targets: targets, projectPath: "\(projectBPath)/project.xcodeproj")
-                                                                    ])
+                                                    projectAPath: generatedProject(targets: targets, projectPath: "\(projectAPath)/project.xcodeproj"),
+                                                    projectBPath: generatedProject(targets: targets, projectPath: "\(projectBPath)/project.xcodeproj"),
+                                                ])
 
         // When
         let result = try XCTUnwrap(got)
         XCTAssertEqual(result.buildActionEntries.count, 2)
-        
+
         let firstEntry = try XCTUnwrap(result.buildActionEntries[0])
         let firstBuildableReference = firstEntry.buildableReference
         XCTAssertEqual(firstEntry.buildFor, [.analyzing, .archiving, .profiling, .running, .testing])
-        
+
         let secondEntry = try XCTUnwrap(result.buildActionEntries[1])
         let secondBuildableReference = secondEntry.buildableReference
         XCTAssertEqual(secondEntry.buildFor, [.analyzing, .archiving, .profiling, .running, .testing])
@@ -100,7 +100,7 @@ final class SchemesGeneratorTests: XCTestCase {
         XCTAssertEqual(firstBuildableReference.buildableName, "FrameworkA.framework")
         XCTAssertEqual(firstBuildableReference.blueprintName, "FrameworkA")
         XCTAssertEqual(firstBuildableReference.buildableIdentifier, "primary")
-        
+
         XCTAssertEqual(secondBuildableReference.referencedContainer, "container:Projects/ProjectB/project.xcodeproj")
         XCTAssertEqual(secondBuildableReference.buildableName, "FrameworkB.framework")
         XCTAssertEqual(secondBuildableReference.blueprintName, "FrameworkB")
@@ -109,12 +109,12 @@ final class SchemesGeneratorTests: XCTestCase {
         XCTAssertEqual(result.parallelizeBuild, true)
         XCTAssertEqual(result.buildImplicitDependencies, true)
     }
-    
+
     func test_schemeBuildAction_with_executionAction() throws {
         // Given
         let projectPath = AbsolutePath("/somepath/Project")
         let target = Target.test(name: "App", product: .app)
-        
+
         let preAction = ExecutionAction(title: "Pre Action", scriptText: "echo Pre Actions", target: TargetReference(projectPath: projectPath, name: "App"))
         let postAction = ExecutionAction(title: "Post Action", scriptText: "echo Post Actions", target: TargetReference(projectPath: projectPath, name: "App"))
         let buildAction = BuildAction.test(targets: [TargetReference(projectPath: projectPath, name: "Library")], preActions: [preAction], postActions: [postAction])
@@ -122,7 +122,7 @@ final class SchemesGeneratorTests: XCTestCase {
         let scheme = Scheme.test(name: "App", shared: true, buildAction: buildAction)
         let project = Project.test(path: projectPath, targets: [target])
         let graph = Graph.create(dependencies: [
-            (project: project, target: target, dependencies: [])
+            (project: project, target: target, dependencies: []),
         ])
 
         // When
@@ -142,7 +142,7 @@ final class SchemesGeneratorTests: XCTestCase {
         XCTAssertEqual(preBuildableReference?.buildableName, "App.app")
         XCTAssertEqual(preBuildableReference?.blueprintName, "App")
         XCTAssertEqual(preBuildableReference?.buildableIdentifier, "primary")
-        
+
         // Post Action
         XCTAssertEqual(got?.postActions.first?.title, "Post Action")
         XCTAssertEqual(got?.postActions.first?.scriptText, "echo Post Actions")
@@ -153,30 +153,28 @@ final class SchemesGeneratorTests: XCTestCase {
         XCTAssertEqual(postBuildableReference?.buildableName, "App.app")
         XCTAssertEqual(postBuildableReference?.blueprintName, "App")
         XCTAssertEqual(postBuildableReference?.buildableIdentifier, "primary")
-
     }
-    
+
     // MARK: - Test Action Tests
+
     func test_schemeTestAction_when_testsTarget() throws {
         // Given
         let target = Target.test(name: "App", product: .app)
         let testTarget = Target.test(name: "AppTests", product: .unitTests)
         let project = Project.test(targets: [target, testTarget])
-        
+
         let testAction = TestAction.test(targets: [TestableTarget(target: TargetReference(projectPath: project.path, name: "AppTests"))],
                                          arguments: nil)
-        
-        
+
         let scheme = Scheme.test(name: "AppTests", testAction: testAction)
         let generatedProjects = createGeneratedProjects(projects: [project])
-        
+
         let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: []),
                                                 (project: project, target: testTarget, dependencies: [target])])
 
         // When
         let got = try subject.schemeTestAction(scheme: scheme, graph: graph, rootPath: project.path, generatedProjects: generatedProjects)
-        
-        
+
         // Then
         let result = try XCTUnwrap(got)
         XCTAssertEqual(result.buildConfiguration, "Debug")
@@ -205,14 +203,14 @@ final class SchemesGeneratorTests: XCTestCase {
         let buildAction = BuildAction.test(targets: [TargetReference(projectPath: projectPath, name: "App")])
 
         let scheme = Scheme.test(name: "AppTests", shared: true, buildAction: buildAction, testAction: testAction)
-        
+
         let project = Project.test(path: projectPath, targets: [target, testTarget])
         let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: []),
                                                 (project: project, target: testTarget, dependencies: [target])])
-                
+
         // When
         let got = try subject.schemeTestAction(scheme: scheme, graph: graph, rootPath: AbsolutePath("/somepath/Workspace"), generatedProjects: createGeneratedProjects(projects: [project]))
-        
+
         // Then
         let result = try XCTUnwrap(got)
         let codeCoverageTargetsBuildableReference = try XCTUnwrap(result.codeCoverageTargets)
@@ -221,7 +219,7 @@ final class SchemesGeneratorTests: XCTestCase {
         XCTAssertEqual(codeCoverageTargetsBuildableReference.count, 1)
         XCTAssertEqual(codeCoverageTargetsBuildableReference.first?.buildableName, "App.app")
     }
-    
+
     func test_schemeTestAction_when_notTestsTarget() throws {
         // Given
         let scheme = Scheme.test()
@@ -239,7 +237,6 @@ final class SchemesGeneratorTests: XCTestCase {
         XCTAssertNil(result.macroExpansion)
         XCTAssertEqual(result.testables.count, 0)
     }
-
 
     func test_schemeTestAction_with_testable_info() throws {
         // Given
@@ -272,20 +269,19 @@ final class SchemesGeneratorTests: XCTestCase {
         let target = Target.test(name: "App", product: .app)
         let testTarget = Target.test(name: "AppTests", product: .unitTests)
         let project = Project.test(targets: [target, testTarget])
-        
+
         let testAction = TestAction.test(targets: [TestableTarget(target: TargetReference(projectPath: project.path, name: "AppTests"))],
                                          arguments: nil)
-        
-        
+
         let scheme = Scheme.test(name: "AppTests", testAction: testAction)
         let generatedProjects = createGeneratedProjects(projects: [project])
-        
+
         let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: []),
                                                 (project: project, target: testTarget, dependencies: [target])])
-        
+
         // When
         let got = try subject.schemeTestAction(scheme: scheme, graph: graph, rootPath: project.path, generatedProjects: generatedProjects)
-    
+
         // Then
         let result = try XCTUnwrap(got)
         XCTAssertEqual(result.buildConfiguration, "Debug")
@@ -300,7 +296,7 @@ final class SchemesGeneratorTests: XCTestCase {
         XCTAssertEqual(buildableReference.blueprintName, "AppTests")
         XCTAssertEqual(buildableReference.buildableIdentifier, "primary")
     }
-    
+
     func test_schemeTestAction_with_executionAction() throws {
         // Given
         let projectPath = AbsolutePath("/somepath/Project")
@@ -343,7 +339,7 @@ final class SchemesGeneratorTests: XCTestCase {
         XCTAssertEqual(postBuildableReference.blueprintName, "AppTests")
         XCTAssertEqual(postBuildableReference.buildableIdentifier, "primary")
     }
-    
+
     // MARK: - Launch Action Tests
 
     func test_schemeLaunchAction() throws {
@@ -353,23 +349,23 @@ final class SchemesGeneratorTests: XCTestCase {
         let buildAction = BuildAction.test(targets: [TargetReference(projectPath: projectPath, name: "App")])
         let runAction = RunAction.test(configurationName: "Release",
                                        executable: TargetReference(projectPath: projectPath, name: "App"),
-                                       arguments: Arguments(environment:["a": "b"], launch: ["some": true]))
+                                       arguments: Arguments(environment: ["a": "b"], launch: ["some": true]))
         let scheme = Scheme.test(buildAction: buildAction, runAction: runAction)
-        
+
         let app = Target.test(name: "App", product: .app, environment: ["a": "b"])
-        
+
         let project = Project.test(path: projectPath, targets: [app])
         let graph = Graph.create(dependencies: [(project: project, target: app, dependencies: [])])
-        
+
         // When
         let got = try subject.schemeLaunchAction(scheme: scheme,
                                                  graph: graph,
                                                  rootPath: AbsolutePath("/somepath/Workspace"),
                                                  generatedProjects: createGeneratedProjects(projects: [project]))
-        
+
         // Then
         let result = try XCTUnwrap(got)
-        
+
         XCTAssertNil(result.macroExpansion)
 
         let buildableReference = try XCTUnwrap(result.runnable?.buildableReference)
@@ -381,11 +377,11 @@ final class SchemesGeneratorTests: XCTestCase {
         XCTAssertEqual(buildableReference.blueprintName, "App")
         XCTAssertEqual(buildableReference.buildableIdentifier, "primary")
     }
-    
+
     func test_schemeLaunchAction_when_notRunnableTarget() throws {
         // Given
         let projectPath = AbsolutePath("/somepath/Project")
-        
+
         let target = Target.test(name: "Library", platform: .iOS, product: .dynamicLibrary)
 
         let buildAction = BuildAction.test(targets: [TargetReference(projectPath: projectPath, name: "Library")])
@@ -411,23 +407,23 @@ final class SchemesGeneratorTests: XCTestCase {
         XCTAssertEqual(result.macroExpansion?.blueprintName, "Library")
         XCTAssertEqual(result.macroExpansion?.buildableIdentifier, "primary")
     }
-    
+
     // MARK: - Profile Action Tests
 
     func test_schemeProfileAction_when_runnableTarget() throws {
         // Given
         let projectPath = AbsolutePath("/somepath/Project")
         let target = Target.test(name: "App", platform: .iOS, product: .app)
-        
+
         let appTargetReference = TargetReference(projectPath: projectPath, name: "App")
         let buildAction = BuildAction.test(targets: [appTargetReference])
         let testAction = TestAction.test(targets: [TestableTarget(target: appTargetReference)])
         let runAction = RunAction.test(configurationName: "Release", executable: appTargetReference, arguments: nil)
-        
+
         let scheme = Scheme.test(name: "App", buildAction: buildAction, testAction: testAction, runAction: runAction)
         let project = Project.test(path: projectPath, targets: [target])
         let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: [])])
-        
+
         // When
         let got = try subject.schemeProfileAction(scheme: scheme,
                                                   graph: graph,
@@ -457,11 +453,11 @@ final class SchemesGeneratorTests: XCTestCase {
         XCTAssertNil(result.environmentVariables)
         XCTAssertEqual(result.enableTestabilityWhenProfilingTests, true)
     }
-    
+
     func test_schemeProfileAction_when_notRunnableTarget() throws {
         // Given
         let projectPath = AbsolutePath("/somepath/Project")
-        
+
         let target = Target.test(name: "Library", platform: .iOS, product: .dynamicLibrary)
 
         let buildAction = BuildAction.test(targets: [TargetReference(projectPath: projectPath, name: "Library")])
@@ -471,13 +467,12 @@ final class SchemesGeneratorTests: XCTestCase {
         let project = Project.test(path: projectPath, targets: [target])
         let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: [])])
 
-
         // When
         let got = try subject.schemeProfileAction(scheme: scheme,
                                                   graph: graph,
                                                   rootPath: projectPath,
                                                   generatedProjects: createGeneratedProjects(projects: [project]))
-        
+
         // Then
         let result = try XCTUnwrap(got)
         let buildable = result.buildableProductRunnable?.buildableReference
@@ -501,23 +496,23 @@ final class SchemesGeneratorTests: XCTestCase {
         XCTAssertEqual(result.macroExpansion?.blueprintName, "Library")
         XCTAssertEqual(result.macroExpansion?.buildableIdentifier, "primary")
     }
-    
+
     func test_schemeAnalyzeAction() throws {
         // Given
         let projectPath = AbsolutePath("/Project")
         let target = Target.test(name: "App", platform: .iOS, product: .app)
         let buildAction = BuildAction.test(targets: [TargetReference(projectPath: projectPath, name: "App")])
         let scheme = Scheme.test(buildAction: buildAction)
-        
+
         let project = Project.test(path: projectPath, targets: [target])
         let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: [])])
-        
+
         // When
         let got = try subject.schemeAnalyzeAction(scheme: scheme,
                                                   graph: graph,
                                                   rootPath: project.path,
                                                   generatedProjects: createGeneratedProjects(projects: [project]))
-        
+
         // Then
         let result = try XCTUnwrap(got)
         XCTAssertEqual(result.buildConfiguration, "Debug")
@@ -538,7 +533,7 @@ final class SchemesGeneratorTests: XCTestCase {
                                                revealArchiveInOrganizer: true,
                                                customArchiveName: "App [Beta]")
         let scheme = Scheme.test(buildAction: buildAction, archiveAction: archiveAction)
-        
+
         let project = Project.test(path: projectPath, targets: [target])
         let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: [])])
 
@@ -554,14 +549,14 @@ final class SchemesGeneratorTests: XCTestCase {
         XCTAssertEqual(result.customArchiveName, "App [Beta]")
         XCTAssertEqual(result.revealArchiveInOrganizer, true)
     }
-    
+
     private func createGeneratedProjects(projects: [Project]) -> [AbsolutePath: GeneratedProject] {
         return Dictionary(uniqueKeysWithValues: projects.map {
             ($0.path, generatedProject(targets: $0.targets,
                                        projectPath: $0.path.appending(component: "\($0.name).xcodeproj").pathString))
         })
     }
-    
+
     private func generatedProject(targets: [Target], projectPath: String = "/Project.xcodeproj") -> GeneratedProject {
         var pbxTargets: [String: PBXNativeTarget] = [:]
         targets.forEach { pbxTargets[$0.name] = PBXNativeTarget(name: $0.name) }

--- a/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
+++ b/Tests/TuistKitTests/Generator/GeneratorModelLoaderTests.swift
@@ -540,7 +540,7 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
         let manifest = SchemeManifest.test(name: "Scheme",
                                            shared: false)
         let projectPath = AbsolutePath("/somepath/Project")
-        
+
         // When
         let model = TuistCore.Scheme.from(manifest: manifest, projectPath: projectPath)
 
@@ -566,9 +566,9 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
                                            buildAction: buildAction,
                                            testAction: testAction,
                                            runAction: runActions)
-        
+
         let projectPath = AbsolutePath("/somepath/Project")
-        
+
         // When
         let model = TuistCore.Scheme.from(manifest: manifest, projectPath: projectPath)
 
@@ -827,7 +827,6 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
                 path: AbsolutePath,
                 file: StaticString = #file,
                 line: UInt = #line) {
-
         let targets = manifest.targets.map { TestableTarget.from(manifest: $0, projectPath: path) }
         XCTAssertEqual(testAction.targets, targets, file: file, line: line)
         XCTAssertTrue(testAction.configurationName == manifest.configurationName, file: file, line: line)
@@ -843,7 +842,7 @@ class GeneratorModelLoaderTest: TuistUnitTestCase {
                 line: UInt = #line) {
         var runActionExecutable: String?
         if let executable = runAction.executable { runActionExecutable = executable.name }
-            
+
         XCTAssertEqual(runActionExecutable, manifest.executable, file: file, line: line)
         XCTAssertTrue(runAction.configurationName == manifest.configurationName, file: file, line: line)
         optionalAssert(runAction.arguments, manifest.arguments) {


### PR DESCRIPTION
### Short description 📝
With the introduction of the `tuist edit` command, I forgot to clean up the logic that adds the manifests to the workspace.

### Solution 📦
Don't include the manifests in the workspace because that's no longer necessary.

> Note that there are some other changes in this PR derived from running the style formatters and linters.