### PR TITLE
Cachable targets

### DIFF
--- a/Sources/TuistCore/Graph/ContentHashing/ContentHashing.swift
+++ b/Sources/TuistCore/Graph/ContentHashing/ContentHashing.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public protocol ContentHashable {
+    /// The hash that uniquely identifies the content of the node. Returns nil if the node can't be hashed
+    var contentHash: Int? { get }
+}

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -94,7 +94,10 @@ public protocol Graphing: AnyObject, Encodable {
 
     /// Returns all the targets that are part of the graph.
     var targets: [TargetNode] { get }
-
+    
+    ///Returns all the cachable targets that are part of the graph.
+    var cachableTargets: [TargetNode] { get }
+    
     func packages(path: AbsolutePath, name: String) throws -> [PackageNode]
     func linkableDependencies(path: AbsolutePath, name: String) throws -> [DependencyReference]
     func librariesPublicHeadersFolders(path: AbsolutePath, name: String) -> [AbsolutePath]
@@ -185,6 +188,10 @@ public class Graph: Graphing {
     /// Returns all the targets that are part of the graph.
     public var targets: [TargetNode] {
         return cache.targetNodes.flatMap { $0.value.values }
+    
+    ///Returns all the cachable targets that are part of the graph.
+    public var cachableTargets: [TargetNode] {
+        targets.filter{ $0.contentHash != nil }
     }
 
     public func target(path: AbsolutePath, name: String) -> TargetNode? {

--- a/Sources/TuistCore/Graph/TargetNode.swift
+++ b/Sources/TuistCore/Graph/TargetNode.swift
@@ -138,4 +138,9 @@ public class TargetNode: GraphNode {
             )
         }
     }
+    
+    public override var description: String {
+        return "\(project.name) at \(project.path) with dependencies: \(dependencies)"
+    }
+}
 }

--- a/Sources/TuistCore/Graph/TargetNode.swift
+++ b/Sources/TuistCore/Graph/TargetNode.swift
@@ -143,4 +143,11 @@ public class TargetNode: GraphNode {
         return "\(project.name) at \(project.path) with dependencies: \(dependencies)"
     }
 }
+
+extension TargetNode: ContentHashable {
+    /// The hash that uniquely identifies the content of the node. Returns nil if the node can't be hashed
+    public var contentHash: Int? {
+        guard target.product == .framework else { return nil }
+        return -1 // TODO: The calculation of the hash will be implemented in a subsequent PR
+    }
 }

--- a/Sources/TuistCore/Models/Target.swift
+++ b/Sources/TuistCore/Models/Target.swift
@@ -2,7 +2,7 @@ import Basic
 import Foundation
 import TuistSupport
 
-public class Target: Equatable, Hashable {
+public class Target: Equatable, Hashable, CustomStringConvertible {
     public typealias SourceFile = (path: AbsolutePath, compilerFlags: String?)
 
     // MARK: - Static
@@ -160,6 +160,10 @@ public class Target: Equatable, Hashable {
         hasher.combine(productName)
         hasher.combine(entitlements)
         hasher.combine(environment)
+    }
+    
+    public var description: String {
+        return name
     }
 }
 

--- a/Tests/TuistCoreTests/Graph/GraphTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTests.swift
@@ -911,7 +911,39 @@ final class GraphTests: TuistUnitTestCase {
         // Then
         XCTAssertEncodableEqualToJson(graph, expected)
     }
+    
+    func test_cachableTargets_noTargets() {
+        //Given
+        let graph = Graph.test()
+        
+        // Then
+        XCTAssertEqual(graph.cachableTargets, [])
+     }
+    
+    func test_cachableTargets_targetNodes() {
+        //Given
+        let cache = GraphLoaderCache()
+        let graph = Graph.test(cache: cache)
+        let frameworkTarget = TargetNode.test(project: .test(path: AbsolutePath("/test/1")), target: .test(product: .framework))
+        let secondFrameworkTarget = TargetNode.test(project: .test(path: AbsolutePath("/test/2")), target: .test(product: .framework))
+        let appTarget = TargetNode.test(project: .test(path: AbsolutePath("/test/3")), target: .test(product: .app))
+        let dynamicLibraryTarget = TargetNode.test(project: .test(path: AbsolutePath("/test/4")), target: .test(product: .dynamicLibrary))
+        let staticFrameworkTarget = TargetNode.test(project: .test(path: AbsolutePath("/test/5")), target: .test(product: .staticFramework))
+        cache.add(targetNode: frameworkTarget)
+        cache.add(targetNode: secondFrameworkTarget)
+        cache.add(targetNode: appTarget)
+        cache.add(targetNode: dynamicLibraryTarget)
+        cache.add(targetNode: staticFrameworkTarget)
 
+        let expectedCachableTargets = [frameworkTarget, secondFrameworkTarget]
+        let cachableTargets = graph.cachableTargets.sorted { left, right -> Bool in
+            left.project.path.pathString < right.project.path.pathString
+        }
+        
+        // Then
+        XCTAssertEqual(cachableTargets, expectedCachableTargets)
+     }
+    
     // MARK: - Helpers
 
     private func sdkDependency(from dependency: DependencyReference) -> SDKPathAndStatus? {

--- a/Tests/TuistCoreTests/Graph/TargetNodeTests.swift
+++ b/Tests/TuistCoreTests/Graph/TargetNodeTests.swift
@@ -20,14 +20,14 @@ final class TargetNodeTests: XCTestCase {
         let d = TargetNode(project: .test(path: AbsolutePath("/d")),
                            target: .test(name: "c"),
                            dependencies: [])
-
+        
         // When / Then
         XCTAssertEqual(c1, c2)
         XCTAssertNotEqual(c2, c3)
         XCTAssertNotEqual(c1, d)
         XCTAssertEqual(d, d)
     }
-
+    
     func test_equality_asGraphNodes() {
         // Given
         let c1: GraphNode = TargetNode(project: .test(path: AbsolutePath("/c")),
@@ -42,13 +42,13 @@ final class TargetNodeTests: XCTestCase {
         let d: GraphNode = TargetNode(project: .test(path: AbsolutePath("/d")),
                                       target: .test(name: "c"),
                                       dependencies: [])
-
+        
         // When / Then
         XCTAssertEqual(c1, c2)
         XCTAssertNotEqual(c2, c3)
         XCTAssertNotEqual(c1, d)
     }
-
+    
     func test_encode() {
         // Given
         let library = LibraryNode.test()
@@ -57,7 +57,7 @@ final class TargetNodeTests: XCTestCase {
         let node = TargetNode(project: .test(path: AbsolutePath("/")),
                               target: .test(name: "Target"),
                               dependencies: [library, framework, cocoapods])
-
+        
         let expected = """
         {
         "type": "source",
@@ -73,8 +73,29 @@ final class TargetNodeTests: XCTestCase {
         "platform" : "\(node.target.platform.rawValue)"
         }
         """
-
+        
         // Then
         XCTAssertEncodableEqualToJson(node, expected)
     }
+    
+    func test_contentHash_targetProductIsFramework_returnsValue() {
+        //Given
+        let frameworkNode = TargetNode(project: .test(),
+                                       target: .test(product: .framework),
+                                       dependencies: [])
+        //Then
+        XCTAssertNotNil(frameworkNode.contentHash)
+    }
+    
+    func test_contentHash_targetProductIsNotFramework_returnsNil() {
+        for product in Product.allCases.filter({ $0 != .framework }) {
+            //Given
+            let frameworkNode = TargetNode(project: .test(),
+                                           target: .test(product: product),
+                                           dependencies: [])
+            //Then
+            XCTAssertNil(frameworkNode.contentHash)
+        }
+    }
+    
 }


### PR DESCRIPTION
### Short description 📝

The goal of the PR is to Identify when a `TargetNode` can be "hashed" and, as a consequence, cached. We assume only `frameworks` can be hashed for now.

### Solution 📦

To avoid a boolean flag, the idea is to return a `contentHash` value when the target is hashable, and `nil` when it's not hashable.
The implementation is not complete, as the calculation of the hash will come into another PR.

### Implementation 👩‍💻👨‍💻

- [X] Make `Target` and `TargetNode` custom string convertible because it helps debugging
- [X] Add an optional `contentHashable` Int on `TargetNode`, and return a value only when the target product is a framework
- [X] Extend `Graph` to return all hashable targets
