### PR TITLE
Add a utility to build xcframeworks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: GitHub Action for SwiftLint
-        uses: pepibumur/action-swiftlint@0d4afd006bb24e4525b5afcefd4ab5e2537193ac
+        uses: norio-nomura/action-swiftlint@3c67ce2e382be797d968883944140ffa0113f737
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   changelog:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - `SimulatorController` with method to fetch the runtimes https://github.com/tuist/tuist/pull/746 by @pepibumur.
 - Add RxSwift as a dependency of `TuistKit` https://github.com/tuist/tuist/pull/760 by @pepibumur.
 - Add cache command https://github.com/tuist/tuist/pull/762 by @pepibumur.
+- Utility to build xcframeworks https://github.com/tuist/tuist/pull/759 by @pepibumur.
 
 ### Fixed
 

--- a/Sources/TuistCore/Models/Platform.swift
+++ b/Sources/TuistCore/Models/Platform.swift
@@ -30,6 +30,48 @@ extension Platform {
         }
     }
 
+    /// Returns whether the platform has simulators.
+    public var hasSimulators: Bool {
+        switch self {
+        case .macOS: return false
+        default: return true
+        }
+    }
+
+    /// It returns the destination that should be used to
+    /// compile a product for this platform's simulator.
+    public var xcodeSimulatorDestination: String? {
+        switch self {
+        case .macOS: return nil
+        default: return "\(caseValue) Simulator"
+        }
+    }
+
+    /// Returns the SDK of the platform's simulator
+    /// If the platform doesn't have simulators, like macOS, it returns nil.
+    public var xcodeSimulatorSDK: String? {
+        switch self {
+        case .tvOS: return "appletvsimulator"
+        case .iOS: return "iphonesimulator"
+        case .watchOS: return "watchsimulator"
+        case .macOS: return nil
+        }
+    }
+
+    /// Returns the SDK to build for the platform's device.
+    public var xcodeDeviceSDK: String {
+        switch self {
+        case .tvOS:
+            return "appletvos"
+        case .iOS:
+            return "iphoneos"
+        case .macOS:
+            return "macosx"
+        case .watchOS:
+            return "watchos"
+        }
+    }
+
     public var xcodeSupportedPlatforms: String {
         switch self {
         case .tvOS:

--- a/Sources/TuistKit/Cache/XCFrameworkBuilder.swift
+++ b/Sources/TuistKit/Cache/XCFrameworkBuilder.swift
@@ -1,0 +1,175 @@
+import Basic
+import Foundation
+import TuistCore
+import TuistSupport
+
+enum XCFrameworkBuilderError: FatalError {
+    case nonFrameworkTarget(String)
+
+    /// Error type.
+    var type: ErrorType {
+        switch self {
+        case .nonFrameworkTarget: return .abort
+        }
+    }
+
+    /// Error description.
+    var description: String {
+        switch self {
+        case let .nonFrameworkTarget(name):
+            return "Can't generate an .xcframework from the target '\(name)' because it's not a framework target"
+        }
+    }
+}
+
+protocol XCFrameworkBuilding {
+    /// It builds an xcframework for the given target.
+    /// The target must have framework as product.
+    ///
+    /// - Parameters:
+    ///   - workspacePath: Path to the generated .xcworkspace that contains the given target.
+    ///   - target: Target whose .xcframework will be generated.
+    /// - Returns: Path to the compiled .xcframework.
+    func build(workspacePath: AbsolutePath, target: Target) throws -> AbsolutePath
+
+    /// It builds an xcframework for the given target.
+    /// The target must have framework as product.
+    ///
+    /// - Parameters:
+    ///   - projectPath: Path to the generated .xcodeproj that contains the given target.
+    ///   - target: Target whose .xcframework will be generated.
+    /// - Returns: Path to the compiled .xcframework.
+    func build(projectPath: AbsolutePath, target: Target) throws -> AbsolutePath
+}
+
+final class XCFrameworkBuilder: XCFrameworkBuilding {
+    // MARK: - Attributes
+
+    /// When true the builder outputs the output from xcodebuild.
+    private let printOutput: Bool
+
+    // MARK: - Init
+
+    /// Initializes the builder.
+    /// - Parameter printOutput: When true the builder outputs the output from xcodebuild.
+    init(printOutput: Bool = true) {
+        self.printOutput = printOutput
+    }
+
+    // MARK: - XCFrameworkBuilding
+
+    func build(workspacePath: AbsolutePath, target: Target) throws -> AbsolutePath {
+        try build(arguments: ["-workspace", workspacePath.pathString], target: target)
+    }
+
+    func build(projectPath: AbsolutePath, target: Target) throws -> AbsolutePath {
+        try build(arguments: ["-project", projectPath.pathString], target: target)
+    }
+
+    // MARK: - Fileprivate
+
+    fileprivate func build(arguments: [String], target: Target) throws -> AbsolutePath {
+        if target.product != .framework {
+            throw XCFrameworkBuilderError.nonFrameworkTarget(target.name)
+        }
+
+        // Create temporary directories
+        let outputDirectory = try TemporaryDirectory(removeTreeOnDeinit: false)
+        let derivedDataPath = try TemporaryDirectory(removeTreeOnDeinit: true)
+
+        Printer.shared.print(section: "Building .xcframework for \(target.productName)")
+
+        // Build for the device
+        let deviceArchivePath = derivedDataPath.path.appending(component: "device.xcarchive")
+        var deviceArguments = xcodebuildCommand(scheme: target.name,
+                                                destination: deviceDestination(platform: target.platform),
+                                                sdk: target.platform.xcodeDeviceSDK,
+                                                derivedDataPath: derivedDataPath.path)
+        deviceArguments.append(contentsOf: ["-archivePath", deviceArchivePath.pathString])
+        deviceArguments.append(contentsOf: arguments)
+        Printer.shared.print(subsection: "Building \(target.productName) for device")
+        try runCommand(deviceArguments)
+
+        // Build for the simulator
+        var simulatorArchivePath: AbsolutePath?
+        if target.platform.hasSimulators {
+            simulatorArchivePath = derivedDataPath.path.appending(component: "simulator.xcarchive")
+            var simulatorArguments = xcodebuildCommand(scheme: target.name,
+                                                       destination: target.platform.xcodeSimulatorDestination!,
+                                                       sdk: target.platform.xcodeSimulatorSDK!,
+                                                       derivedDataPath: derivedDataPath.path)
+            simulatorArguments.append(contentsOf: ["-archivePath", simulatorArchivePath!.pathString])
+            simulatorArguments.append(contentsOf: arguments)
+            Printer.shared.print(subsection: "Building \(target.productName) for simulator")
+            try runCommand(simulatorArguments)
+        }
+
+        // Build the xcframework
+        Printer.shared.print(subsection: "Exporting xcframework for \(target.productName)")
+        let xcframeworkPath = outputDirectory.path.appending(component: "\(target.productName).xcframework")
+        let xcframeworkArguments = xcodebuildXcframeworkCommand(deviceArchivePath: deviceArchivePath,
+                                                                simulatorArchivePath: simulatorArchivePath,
+                                                                productName: target.productName,
+                                                                xcframeworkPath: xcframeworkPath)
+        try runCommand(xcframeworkArguments)
+
+        return xcframeworkPath
+    }
+
+    /// Runs the given command.
+    /// - Parameter arguments: Command arguments.
+    fileprivate func runCommand(_ arguments: [String]) throws {
+        if printOutput {
+            try System.shared.runAndPrint(arguments)
+        } else {
+            try System.shared.run(arguments)
+        }
+    }
+
+    /// Returns the arguments that should be passed to xcodebuild to compile for a device on the given platform.
+    /// - Parameter platform: Platform we are compiling for.
+    fileprivate func deviceDestination(platform: Platform) -> String {
+        switch platform {
+        case .macOS: return "osx"
+        default: return "generic/platform=\(platform.caseValue)"
+        }
+    }
+
+    /// Returns the xcodebuild command to generate the .xcframework from the device
+    /// and the simulator frameworks.
+    ///
+    /// - Parameters:
+    ///   - deviceArchivePath: Path to the archive that contains the framework for the device.
+    ///   - simulatorArchivePath: Path to the archive that contains the framework for the simulator.
+    ///   - productName: Name of the product.
+    ///   - xcframeworkPath: Path where the .xcframework should be exported to (e.g. /path/to/MyFeature.xcframework).
+    fileprivate func xcodebuildXcframeworkCommand(deviceArchivePath: AbsolutePath,
+                                                  simulatorArchivePath: AbsolutePath?,
+                                                  productName: String,
+                                                  xcframeworkPath: AbsolutePath) -> [String] {
+        var command = ["xcrun", "xcodebuild", "-create-xcframework"]
+        command.append(contentsOf: ["-framework", deviceArchivePath.appending(RelativePath("Products/Library/Frameworks/\(productName).framework")).pathString])
+        if let simulatorArchivePath = simulatorArchivePath {
+            command.append(contentsOf: ["-framework", simulatorArchivePath.appending(RelativePath("Products/Library/Frameworks/\(productName).framework")).pathString])
+        }
+        command.append(contentsOf: ["-output", xcframeworkPath.pathString])
+        return command
+    }
+
+    /// It returns the xcodebuild command to archive the .framework.
+    /// - Parameters:
+    ///   - scheme: Name of the scheme that archives the framework.
+    ///   - destination: Compilation destination.
+    ///   - sdk: Compilation SDK.
+    ///   - derivedDataPath: Derived data directory.
+    fileprivate func xcodebuildCommand(scheme: String, destination: String, sdk: String, derivedDataPath: AbsolutePath) -> [String] {
+        var command = ["xcrun", "xcodebuild", "clean", "archive"]
+        command.append(contentsOf: ["-scheme", scheme.spm_shellEscaped()])
+        command.append(contentsOf: ["-sdk", sdk])
+        command.append(contentsOf: ["-destination='\(destination)'"])
+        command.append(contentsOf: ["-derivedDataPath", derivedDataPath.pathString])
+        // Without the BUILD_LIBRARY_FOR_DISTRIBUTION argument xcodebuild doesn't generate the .swiftinterface file
+        command.append(contentsOf: ["SKIP_INSTALL=NO", "BUILD_LIBRARY_FOR_DISTRIBUTION=YES"])
+        return command
+    }
+}

--- a/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
+++ b/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
@@ -102,4 +102,12 @@ public class TuistTestCase: XCTestCase {
         """
         XCTAssertTrue(printer.standardErrorMatches(with: expected), message, file: file, line: line)
     }
+
+    public func temporaryFixture(_ pathString: String) throws -> AbsolutePath {
+        let path = RelativePath(pathString)
+        let fixturePath = self.fixturePath(path: path)
+        let destinationPath = (try temporaryPath()).appending(component: path.basename)
+        try FileHandler.shared.copy(from: fixturePath, to: destinationPath)
+        return destinationPath
+    }
 }

--- a/Tests/Fixtures/Frameworks/.gitignore
+++ b/Tests/Fixtures/Frameworks/.gitignore
@@ -1,0 +1,1 @@
+!Frameworks.xcodeproj

--- a/Tests/Fixtures/Frameworks/Frameworks.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/Frameworks/Frameworks.xcodeproj/project.pbxproj
@@ -1,0 +1,739 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		B9023E07239BCDA200666BE6 /* iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = B9023E05239BCDA200666BE6 /* iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9023E0E239BCDBE00666BE6 /* iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9023E0D239BCDBE00666BE6 /* iOS.swift */; };
+		B9023E18239BCDE900666BE6 /* watchOS.h in Headers */ = {isa = PBXBuildFile; fileRef = B9023E16239BCDE900666BE6 /* watchOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9023E1D239BCDF500666BE6 /* watchOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9023E1C239BCDF500666BE6 /* watchOS.swift */; };
+		B9023E27239BCE1000666BE6 /* tvOS.h in Headers */ = {isa = PBXBuildFile; fileRef = B9023E25239BCE1000666BE6 /* tvOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9023E2C239BCE1800666BE6 /* tvOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9023E2B239BCE1800666BE6 /* tvOS.swift */; };
+		B9023E36239BCE2D00666BE6 /* macOS.h in Headers */ = {isa = PBXBuildFile; fileRef = B9023E34239BCE2D00666BE6 /* macOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9023E3B239BCE3300666BE6 /* macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9023E3A239BCE3300666BE6 /* macOS.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		B9023E02239BCDA200666BE6 /* iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B9023E05239BCDA200666BE6 /* iOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iOS.h; sourceTree = "<group>"; };
+		B9023E06239BCDA200666BE6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B9023E0D239BCDBE00666BE6 /* iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOS.swift; sourceTree = "<group>"; };
+		B9023E14239BCDE900666BE6 /* watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B9023E16239BCDE900666BE6 /* watchOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = watchOS.h; sourceTree = "<group>"; };
+		B9023E17239BCDE900666BE6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B9023E1C239BCDF500666BE6 /* watchOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = watchOS.swift; sourceTree = "<group>"; };
+		B9023E23239BCE1000666BE6 /* tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B9023E25239BCE1000666BE6 /* tvOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = tvOS.h; sourceTree = "<group>"; };
+		B9023E26239BCE1000666BE6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B9023E2B239BCE1800666BE6 /* tvOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = tvOS.swift; sourceTree = "<group>"; };
+		B9023E32239BCE2D00666BE6 /* macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B9023E34239BCE2D00666BE6 /* macOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = macOS.h; sourceTree = "<group>"; };
+		B9023E35239BCE2D00666BE6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B9023E3A239BCE3300666BE6 /* macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOS.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B9023DFF239BCDA200666BE6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B9023E11239BCDE900666BE6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B9023E20239BCE1000666BE6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B9023E2F239BCE2D00666BE6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		B9023DF8239BCDA200666BE6 = {
+			isa = PBXGroup;
+			children = (
+				B9023E04239BCDA200666BE6 /* iOS */,
+				B9023E15239BCDE900666BE6 /* watchOS */,
+				B9023E24239BCE1000666BE6 /* tvOS */,
+				B9023E33239BCE2D00666BE6 /* macOS */,
+				B9023E03239BCDA200666BE6 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		B9023E03239BCDA200666BE6 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B9023E02239BCDA200666BE6 /* iOS.framework */,
+				B9023E14239BCDE900666BE6 /* watchOS.framework */,
+				B9023E23239BCE1000666BE6 /* tvOS.framework */,
+				B9023E32239BCE2D00666BE6 /* macOS.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B9023E04239BCDA200666BE6 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				B9023E05239BCDA200666BE6 /* iOS.h */,
+				B9023E06239BCDA200666BE6 /* Info.plist */,
+				B9023E0D239BCDBE00666BE6 /* iOS.swift */,
+			);
+			path = iOS;
+			sourceTree = "<group>";
+		};
+		B9023E15239BCDE900666BE6 /* watchOS */ = {
+			isa = PBXGroup;
+			children = (
+				B9023E16239BCDE900666BE6 /* watchOS.h */,
+				B9023E17239BCDE900666BE6 /* Info.plist */,
+				B9023E1C239BCDF500666BE6 /* watchOS.swift */,
+			);
+			path = watchOS;
+			sourceTree = "<group>";
+		};
+		B9023E24239BCE1000666BE6 /* tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				B9023E25239BCE1000666BE6 /* tvOS.h */,
+				B9023E26239BCE1000666BE6 /* Info.plist */,
+				B9023E2B239BCE1800666BE6 /* tvOS.swift */,
+			);
+			path = tvOS;
+			sourceTree = "<group>";
+		};
+		B9023E33239BCE2D00666BE6 /* macOS */ = {
+			isa = PBXGroup;
+			children = (
+				B9023E34239BCE2D00666BE6 /* macOS.h */,
+				B9023E35239BCE2D00666BE6 /* Info.plist */,
+				B9023E3A239BCE3300666BE6 /* macOS.swift */,
+			);
+			path = macOS;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		B9023DFD239BCDA200666BE6 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B9023E07239BCDA200666BE6 /* iOS.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B9023E0F239BCDE900666BE6 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B9023E18239BCDE900666BE6 /* watchOS.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B9023E1E239BCE1000666BE6 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B9023E27239BCE1000666BE6 /* tvOS.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B9023E2D239BCE2D00666BE6 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B9023E36239BCE2D00666BE6 /* macOS.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		B9023E01239BCDA200666BE6 /* iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B9023E0A239BCDA200666BE6 /* Build configuration list for PBXNativeTarget "iOS" */;
+			buildPhases = (
+				B9023DFD239BCDA200666BE6 /* Headers */,
+				B9023DFE239BCDA200666BE6 /* Sources */,
+				B9023DFF239BCDA200666BE6 /* Frameworks */,
+				B9023E00239BCDA200666BE6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = iOS;
+			productName = iOS;
+			productReference = B9023E02239BCDA200666BE6 /* iOS.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		B9023E13239BCDE900666BE6 /* watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B9023E19239BCDE900666BE6 /* Build configuration list for PBXNativeTarget "watchOS" */;
+			buildPhases = (
+				B9023E0F239BCDE900666BE6 /* Headers */,
+				B9023E10239BCDE900666BE6 /* Sources */,
+				B9023E11239BCDE900666BE6 /* Frameworks */,
+				B9023E12239BCDE900666BE6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = watchOS;
+			productName = watchOS;
+			productReference = B9023E14239BCDE900666BE6 /* watchOS.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		B9023E22239BCE1000666BE6 /* tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B9023E28239BCE1000666BE6 /* Build configuration list for PBXNativeTarget "tvOS" */;
+			buildPhases = (
+				B9023E1E239BCE1000666BE6 /* Headers */,
+				B9023E1F239BCE1000666BE6 /* Sources */,
+				B9023E20239BCE1000666BE6 /* Frameworks */,
+				B9023E21239BCE1000666BE6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = tvOS;
+			productName = tvOS;
+			productReference = B9023E23239BCE1000666BE6 /* tvOS.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		B9023E31239BCE2D00666BE6 /* macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B9023E37239BCE2D00666BE6 /* Build configuration list for PBXNativeTarget "macOS" */;
+			buildPhases = (
+				B9023E2D239BCE2D00666BE6 /* Headers */,
+				B9023E2E239BCE2D00666BE6 /* Sources */,
+				B9023E2F239BCE2D00666BE6 /* Frameworks */,
+				B9023E30239BCE2D00666BE6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = macOS;
+			productName = macOS;
+			productReference = B9023E32239BCE2D00666BE6 /* macOS.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		B9023DF9239BCDA200666BE6 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1120;
+				ORGANIZATIONNAME = Tuist;
+				TargetAttributes = {
+					B9023E01239BCDA200666BE6 = {
+						CreatedOnToolsVersion = 11.2.1;
+						LastSwiftMigration = 1120;
+					};
+					B9023E13239BCDE900666BE6 = {
+						CreatedOnToolsVersion = 11.2.1;
+						LastSwiftMigration = 1120;
+					};
+					B9023E22239BCE1000666BE6 = {
+						CreatedOnToolsVersion = 11.2.1;
+						LastSwiftMigration = 1120;
+					};
+					B9023E31239BCE2D00666BE6 = {
+						CreatedOnToolsVersion = 11.2.1;
+						LastSwiftMigration = 1120;
+					};
+				};
+			};
+			buildConfigurationList = B9023DFC239BCDA200666BE6 /* Build configuration list for PBXProject "Frameworks" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = B9023DF8239BCDA200666BE6;
+			productRefGroup = B9023E03239BCDA200666BE6 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				B9023E01239BCDA200666BE6 /* iOS */,
+				B9023E13239BCDE900666BE6 /* watchOS */,
+				B9023E22239BCE1000666BE6 /* tvOS */,
+				B9023E31239BCE2D00666BE6 /* macOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		B9023E00239BCDA200666BE6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B9023E12239BCDE900666BE6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B9023E21239BCE1000666BE6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B9023E30239BCE2D00666BE6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		B9023DFE239BCDA200666BE6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B9023E0E239BCDBE00666BE6 /* iOS.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B9023E10239BCDE900666BE6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B9023E1D239BCDF500666BE6 /* watchOS.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B9023E1F239BCE1000666BE6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B9023E2C239BCE1800666BE6 /* tvOS.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B9023E2E239BCE2D00666BE6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B9023E3B239BCE3300666BE6 /* macOS.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		B9023E08239BCDA200666BE6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		B9023E09239BCDA200666BE6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		B9023E0B239BCDA200666BE6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = iOS/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.tuist.iOS;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		B9023E0C239BCDA200666BE6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = iOS/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.tuist.iOS;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		B9023E1A239BCDE900666BE6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = watchOS/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.tuist.watchOS;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 6.1;
+			};
+			name = Debug;
+		};
+		B9023E1B239BCDE900666BE6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = watchOS/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.tuist.watchOS;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 6.1;
+			};
+			name = Release;
+		};
+		B9023E29239BCE1000666BE6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = tvOS/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.tuist.tvOS;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 13.2;
+			};
+			name = Debug;
+		};
+		B9023E2A239BCE1000666BE6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = tvOS/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.tuist.tvOS;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 13.2;
+			};
+			name = Release;
+		};
+		B9023E38239BCE2D00666BE6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = macOS/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				PRODUCT_BUNDLE_IDENTIFIER = io.tuist.macOS;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		B9023E39239BCE2D00666BE6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = macOS/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				PRODUCT_BUNDLE_IDENTIFIER = io.tuist.macOS;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		B9023DFC239BCDA200666BE6 /* Build configuration list for PBXProject "Frameworks" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B9023E08239BCDA200666BE6 /* Debug */,
+				B9023E09239BCDA200666BE6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B9023E0A239BCDA200666BE6 /* Build configuration list for PBXNativeTarget "iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B9023E0B239BCDA200666BE6 /* Debug */,
+				B9023E0C239BCDA200666BE6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B9023E19239BCDE900666BE6 /* Build configuration list for PBXNativeTarget "watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B9023E1A239BCDE900666BE6 /* Debug */,
+				B9023E1B239BCDE900666BE6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B9023E28239BCE1000666BE6 /* Build configuration list for PBXNativeTarget "tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B9023E29239BCE1000666BE6 /* Debug */,
+				B9023E2A239BCE1000666BE6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B9023E37239BCE2D00666BE6 /* Build configuration list for PBXNativeTarget "macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B9023E38239BCE2D00666BE6 /* Debug */,
+				B9023E39239BCE2D00666BE6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = B9023DF9239BCDA200666BE6 /* Project object */;
+}

--- a/Tests/Fixtures/Frameworks/Frameworks.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Tests/Fixtures/Frameworks/Frameworks.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:iOS.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Tests/Fixtures/Frameworks/Frameworks.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Tests/Fixtures/Frameworks/Frameworks.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Tests/Fixtures/Frameworks/Frameworks.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
+++ b/Tests/Fixtures/Frameworks/Frameworks.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1120"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B9023E01239BCDA200666BE6"
+               BuildableName = "iOS.framework"
+               BlueprintName = "iOS"
+               ReferencedContainer = "container:Frameworks.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B9023E01239BCDA200666BE6"
+            BuildableName = "iOS.framework"
+            BlueprintName = "iOS"
+            ReferencedContainer = "container:Frameworks.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/Fixtures/Frameworks/Frameworks.xcodeproj/xcshareddata/xcschemes/macOS.xcscheme
+++ b/Tests/Fixtures/Frameworks/Frameworks.xcodeproj/xcshareddata/xcschemes/macOS.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1120"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B9023E31239BCE2D00666BE6"
+               BuildableName = "macOS.framework"
+               BlueprintName = "macOS"
+               ReferencedContainer = "container:Frameworks.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B9023E31239BCE2D00666BE6"
+            BuildableName = "macOS.framework"
+            BlueprintName = "macOS"
+            ReferencedContainer = "container:Frameworks.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/Fixtures/Frameworks/Frameworks.xcodeproj/xcshareddata/xcschemes/tvOS.xcscheme
+++ b/Tests/Fixtures/Frameworks/Frameworks.xcodeproj/xcshareddata/xcschemes/tvOS.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1120"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B9023E22239BCE1000666BE6"
+               BuildableName = "tvOS.framework"
+               BlueprintName = "tvOS"
+               ReferencedContainer = "container:Frameworks.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B9023E22239BCE1000666BE6"
+            BuildableName = "tvOS.framework"
+            BlueprintName = "tvOS"
+            ReferencedContainer = "container:Frameworks.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/Fixtures/Frameworks/Frameworks.xcodeproj/xcshareddata/xcschemes/watchOS.xcscheme
+++ b/Tests/Fixtures/Frameworks/Frameworks.xcodeproj/xcshareddata/xcschemes/watchOS.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1120"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B9023E13239BCDE900666BE6"
+               BuildableName = "watchOS.framework"
+               BlueprintName = "watchOS"
+               ReferencedContainer = "container:Frameworks.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B9023E13239BCDE900666BE6"
+            BuildableName = "watchOS.framework"
+            BlueprintName = "watchOS"
+            ReferencedContainer = "container:Frameworks.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/Fixtures/Frameworks/iOS/Info.plist
+++ b/Tests/Fixtures/Frameworks/iOS/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/Tests/Fixtures/Frameworks/iOS/iOS.h
+++ b/Tests/Fixtures/Frameworks/iOS/iOS.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+//! Project version number for iOS.
+FOUNDATION_EXPORT double iOSVersionNumber;
+
+//! Project version string for iOS.
+FOUNDATION_EXPORT const unsigned char iOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <iOS/PublicHeader.h>
+
+

--- a/Tests/Fixtures/Frameworks/iOS/iOS.swift
+++ b/Tests/Fixtures/Frameworks/iOS/iOS.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public final class iOS {
+    public init() {}
+}

--- a/Tests/Fixtures/Frameworks/macOS/Info.plist
+++ b/Tests/Fixtures/Frameworks/macOS/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2019 Tuist. All rights reserved.</string>
+</dict>
+</plist>

--- a/Tests/Fixtures/Frameworks/macOS/macOS.h
+++ b/Tests/Fixtures/Frameworks/macOS/macOS.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+//! Project version number for macOS.
+FOUNDATION_EXPORT double macOSVersionNumber;
+
+//! Project version string for macOS.
+FOUNDATION_EXPORT const unsigned char macOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <macOS/PublicHeader.h>
+
+

--- a/Tests/Fixtures/Frameworks/macOS/macOS.swift
+++ b/Tests/Fixtures/Frameworks/macOS/macOS.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public final class watchOS {
+    public init() {}
+}

--- a/Tests/Fixtures/Frameworks/tvOS/Info.plist
+++ b/Tests/Fixtures/Frameworks/tvOS/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/Tests/Fixtures/Frameworks/tvOS/tvOS.h
+++ b/Tests/Fixtures/Frameworks/tvOS/tvOS.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+//! Project version number for tvOS.
+FOUNDATION_EXPORT double tvOSVersionNumber;
+
+//! Project version string for tvOS.
+FOUNDATION_EXPORT const unsigned char tvOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <tvOS/PublicHeader.h>
+
+

--- a/Tests/Fixtures/Frameworks/tvOS/tvOS.swift
+++ b/Tests/Fixtures/Frameworks/tvOS/tvOS.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public final class tvOS {
+    public init() {}
+}

--- a/Tests/Fixtures/Frameworks/watchOS/Info.plist
+++ b/Tests/Fixtures/Frameworks/watchOS/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/Tests/Fixtures/Frameworks/watchOS/watchOS.h
+++ b/Tests/Fixtures/Frameworks/watchOS/watchOS.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+//! Project version number for watchOS.
+FOUNDATION_EXPORT double watchOSVersionNumber;
+
+//! Project version string for watchOS.
+FOUNDATION_EXPORT const unsigned char watchOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <watchOS/PublicHeader.h>
+
+

--- a/Tests/Fixtures/Frameworks/watchOS/watchOS.swift
+++ b/Tests/Fixtures/Frameworks/watchOS/watchOS.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public final class watchOS {
+    public init() {}
+}

--- a/Tests/TuistCoreIntegrationTests/Utils/FrameworkMetadataProviderIntegrationTests.swift
+++ b/Tests/TuistCoreIntegrationTests/Utils/FrameworkMetadataProviderIntegrationTests.swift
@@ -21,7 +21,7 @@ final class FrameworkMetadataProviderIntegrationTests: TuistTestCase {
 
     func test_bcsymbolmapPaths() throws {
         // Given
-        let carthagePath = temporaryFixture("Carthage/")
+        let carthagePath = try temporaryFixture("Carthage/")
         let frameworkPath = FileHandler.shared.glob(carthagePath, glob: "*.framework").first!
         let framework = FrameworkNode(path: frameworkPath)
 
@@ -37,7 +37,7 @@ final class FrameworkMetadataProviderIntegrationTests: TuistTestCase {
 
     func test_dsymPath() throws {
         // Given
-        let carthagePath = temporaryFixture("Carthage/")
+        let carthagePath = try temporaryFixture("Carthage/")
         let frameworkPath = FileHandler.shared.glob(carthagePath, glob: "*.framework").first!
         let framework = FrameworkNode(path: frameworkPath)
 
@@ -46,13 +46,5 @@ final class FrameworkMetadataProviderIntegrationTests: TuistTestCase {
 
         // Then
         XCTAssertTrue(got == carthagePath.appending(component: "\(frameworkPath.basename).dSYM"))
-    }
-
-    fileprivate func temporaryFixture(_ pathString: String) -> AbsolutePath {
-        let path = RelativePath(pathString)
-        let fixturePath = self.fixturePath(path: path)
-        let destinationPath = (try! temporaryPath()).appending(component: path.basename)
-        try! FileHandler.shared.copy(from: fixturePath, to: destinationPath)
-        return destinationPath
     }
 }

--- a/Tests/TuistCoreIntegrationTests/Utils/PrecompiledMetadataProviderIntegrationTests.swift
+++ b/Tests/TuistCoreIntegrationTests/Utils/PrecompiledMetadataProviderIntegrationTests.swift
@@ -21,7 +21,7 @@ final class PrecompiledMetadataProviderIntegrationTests: TuistTestCase {
 
     func test_architectures() throws {
         // Given
-        let frameworkPath = temporaryFixture("xpm.framework")
+        let frameworkPath = try temporaryFixture("xpm.framework")
         let framework = FrameworkNode(path: frameworkPath)
 
         // When
@@ -33,7 +33,7 @@ final class PrecompiledMetadataProviderIntegrationTests: TuistTestCase {
 
     func test_uuids() throws {
         // Given
-        let frameworkPath = temporaryFixture("xpm.framework")
+        let frameworkPath = try temporaryFixture("xpm.framework")
         let framework = FrameworkNode(path: frameworkPath)
 
         // When
@@ -45,13 +45,5 @@ final class PrecompiledMetadataProviderIntegrationTests: TuistTestCase {
             UUID(uuidString: "510FD121-B669-3524-A748-2DDF357A051C"),
         ])
         XCTAssertEqual(got, expected)
-    }
-
-    fileprivate func temporaryFixture(_ pathString: String) -> AbsolutePath {
-        let path = RelativePath(pathString)
-        let fixturePath = self.fixturePath(path: path)
-        let destinationPath = (try! temporaryPath()).appending(component: path.basename)
-        try! FileHandler.shared.copy(from: fixturePath, to: destinationPath)
-        return destinationPath
     }
 }

--- a/Tests/TuistCoreTests/Models/PlatformTests.swift
+++ b/Tests/TuistCoreTests/Models/PlatformTests.swift
@@ -15,6 +15,27 @@ final class PlatformTests: XCTestCase {
         XCTAssertEqual(Platform.tvOS.xcodeSupportedPlatforms, "appletvsimulator appletvos")
     }
 
+    func test_xcodeSimulatorSDK() {
+        XCTAssertEqual(Platform.tvOS.xcodeSimulatorSDK, "appletvsimulator")
+        XCTAssertEqual(Platform.iOS.xcodeSimulatorSDK, "iphonesimulator")
+        XCTAssertEqual(Platform.watchOS.xcodeSimulatorSDK, "watchsimulator")
+        XCTAssertNil(Platform.macOS.xcodeSimulatorSDK)
+    }
+
+    func test_xcodeDeviceSDK() {
+        XCTAssertEqual(Platform.tvOS.xcodeDeviceSDK, "appletvos")
+        XCTAssertEqual(Platform.iOS.xcodeDeviceSDK, "iphoneos")
+        XCTAssertEqual(Platform.watchOS.xcodeDeviceSDK, "watchos")
+        XCTAssertEqual(Platform.macOS.xcodeDeviceSDK, "macosx")
+    }
+
+    func test_hasSimulators() {
+        XCTAssertFalse(Platform.macOS.hasSimulators)
+        XCTAssertTrue(Platform.tvOS.hasSimulators)
+        XCTAssertTrue(Platform.watchOS.hasSimulators)
+        XCTAssertTrue(Platform.tvOS.hasSimulators)
+    }
+
     func test_xcodeSdkRootPath() {
         // Given
         let platforms: [Platform] = [

--- a/Tests/TuistGeneratorIntegrationTests/Utils/EmbedScriptGeneratorIntegrationTests.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Utils/EmbedScriptGeneratorIntegrationTests.swift
@@ -22,7 +22,7 @@ final class EmbedScriptGeneratorIntegrationTests: TuistTestCase {
 
     func test_script() throws {
         // Given
-        let carthagePath = temporaryFixture("Carthage/")
+        let carthagePath = try temporaryFixture("Carthage/")
         let frameworkPath = FileHandler.shared.glob(carthagePath, glob: "*.framework").first!
         let framework = FrameworkNode(path: frameworkPath)
 
@@ -44,13 +44,5 @@ final class EmbedScriptGeneratorIntegrationTests: TuistTestCase {
         XCTAssertTrue(got.script.contains("install_dsym \"RxBlocking.framework.dSYM\""))
         XCTAssertTrue(got.script.contains("install_bcsymbolmap \"2510FE01-4D40-3956-BB71-857D3B2D9E73.bcsymbolmap\""))
         XCTAssertTrue(got.script.contains("install_bcsymbolmap \"773847A9-0D05-35AF-9865-94A9A670080B.bcsymbolmap\""))
-    }
-
-    fileprivate func temporaryFixture(_ pathString: String) -> AbsolutePath {
-        let path = RelativePath(pathString)
-        let fixturePath = self.fixturePath(path: path)
-        let destinationPath = (try! temporaryPath()).appending(component: path.basename)
-        try! FileHandler.shared.copy(from: fixturePath, to: destinationPath)
-        return destinationPath
     }
 }

--- a/Tests/TuistKitIntegrationTests/Cache/XCFrameworkBuilderIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Cache/XCFrameworkBuilderIntegrationTests.swift
@@ -15,7 +15,7 @@ final class XCFrameworkBuilderIntegrationTests: TuistTestCase {
     override func setUp() {
         super.setUp()
         plistDecoder = PropertyListDecoder()
-        subject = XCFrameworkBuilder(printOutput: false)
+        subject = XCFrameworkBuilder(printOutput: true)
     }
 
     override func tearDown() {

--- a/Tests/TuistKitIntegrationTests/Cache/XCFrameworkBuilderIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Cache/XCFrameworkBuilderIntegrationTests.swift
@@ -15,7 +15,7 @@ final class XCFrameworkBuilderIntegrationTests: TuistTestCase {
     override func setUp() {
         super.setUp()
         plistDecoder = PropertyListDecoder()
-        subject = XCFrameworkBuilder(printOutput: true)
+        subject = XCFrameworkBuilder(printOutput: false)
     }
 
     override func tearDown() {

--- a/Tests/TuistKitIntegrationTests/Cache/XCFrameworkBuilderIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Cache/XCFrameworkBuilderIntegrationTests.swift
@@ -1,0 +1,149 @@
+import Basic
+import Foundation
+import SPMUtility
+import TuistCore
+import TuistSupport
+import XCTest
+@testable import TuistCoreTesting
+@testable import TuistKit
+@testable import TuistSupportTesting
+
+final class XCFrameworkBuilderIntegrationTests: TuistTestCase {
+    var subject: XCFrameworkBuilder!
+    var plistDecoder: PropertyListDecoder!
+
+    override func setUp() {
+        super.setUp()
+        plistDecoder = PropertyListDecoder()
+        subject = XCFrameworkBuilder(printOutput: false)
+    }
+
+    override func tearDown() {
+        subject = nil
+        plistDecoder = nil
+        super.tearDown()
+    }
+
+    func test_build_when_iOS_framework() throws {
+        // Given
+        let frameworksPath = try temporaryFixture("Frameworks")
+        let projectPath = frameworksPath.appending(component: "Frameworks.xcodeproj")
+        let target = Target.test(name: "iOS", platform: .iOS, product: .framework, productName: "iOS")
+
+        // When
+        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target)
+        let infoPlist = try self.infoPlist(xcframeworkPath: xcframeworkPath)
+
+        // Then
+        XCTAssertTrue(FileHandler.shared.exists(xcframeworkPath))
+        XCTAssertNotNil(infoPlist.availableLibraries.first(where: { $0.supportedArchitectures.contains("arm64") }))
+        XCTAssertNotNil(infoPlist.availableLibraries.first(where: { $0.supportedArchitectures.contains("x86_64") }))
+        XCTAssertTrue(infoPlist.availableLibraries.allSatisfy { $0.supportedPlatform == "ios" })
+        XCTAssertPrinterOutputContains("""
+        Building .xcframework for iOS
+        Building iOS for device
+        Building iOS for simulator
+        Exporting xcframework for iOS
+        """)
+        try FileHandler.shared.delete(xcframeworkPath)
+    }
+
+    func test_build_when_macOS_framework() throws {
+        // Given
+        let frameworksPath = try temporaryFixture("Frameworks")
+        let projectPath = frameworksPath.appending(component: "Frameworks.xcodeproj")
+        let target = Target.test(name: "macOS", platform: .macOS, product: .framework, productName: "macOS")
+
+        // When
+        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target)
+        let infoPlist = try self.infoPlist(xcframeworkPath: xcframeworkPath)
+
+        // Then
+        XCTAssertTrue(FileHandler.shared.exists(xcframeworkPath))
+        XCTAssertNotNil(infoPlist.availableLibraries.first(where: { $0.supportedArchitectures.contains("x86_64") }))
+        XCTAssertTrue(infoPlist.availableLibraries.allSatisfy { $0.supportedPlatform == "macos" })
+        XCTAssertPrinterOutputContains("""
+        Building .xcframework for macOS
+        Building macOS for device
+        Exporting xcframework for macOS
+        """)
+        try FileHandler.shared.delete(xcframeworkPath)
+    }
+
+    func test_build_when_tvOS_framework() throws {
+        // Given
+        let frameworksPath = try temporaryFixture("Frameworks")
+        let projectPath = frameworksPath.appending(component: "Frameworks.xcodeproj")
+        let target = Target.test(name: "tvOS", platform: .tvOS, product: .framework, productName: "tvOS")
+
+        // When
+        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target)
+        let infoPlist = try self.infoPlist(xcframeworkPath: xcframeworkPath)
+
+        // Then
+        XCTAssertTrue(FileHandler.shared.exists(xcframeworkPath))
+        XCTAssertNotNil(infoPlist.availableLibraries.first(where: { $0.supportedArchitectures.contains("x86_64") }))
+        XCTAssertNotNil(infoPlist.availableLibraries.first(where: { $0.supportedArchitectures.contains("arm64") }))
+        XCTAssertTrue(infoPlist.availableLibraries.allSatisfy { $0.supportedPlatform == "tvos" })
+        XCTAssertPrinterOutputContains("""
+        Building .xcframework for tvOS
+        Building tvOS for device
+        Building tvOS for simulator
+        Exporting xcframework for tvOS
+        """)
+        try FileHandler.shared.delete(xcframeworkPath)
+    }
+
+    func test_build_when_watchOS_framework() throws {
+        // Given
+        let frameworksPath = try temporaryFixture("Frameworks")
+        let projectPath = frameworksPath.appending(component: "Frameworks.xcodeproj")
+        let target = Target.test(name: "watchOS", platform: .watchOS, product: .framework, productName: "watchOS")
+
+        // When
+        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target)
+        let infoPlist = try self.infoPlist(xcframeworkPath: xcframeworkPath)
+
+        // Then
+        XCTAssertTrue(FileHandler.shared.exists(xcframeworkPath))
+        XCTAssertNotNil(infoPlist.availableLibraries.first(where: { $0.supportedArchitectures.contains("i386") }))
+        XCTAssertNotNil(infoPlist.availableLibraries.first(where: { $0.supportedArchitectures.contains("armv7k") }))
+        XCTAssertNotNil(infoPlist.availableLibraries.first(where: { $0.supportedArchitectures.contains("arm64_32") }))
+        XCTAssertTrue(infoPlist.availableLibraries.allSatisfy { $0.supportedPlatform == "watchos" })
+        XCTAssertPrinterOutputContains("""
+        Building .xcframework for watchOS
+        Building watchOS for device
+        Building watchOS for simulator
+        Exporting xcframework for watchOS
+        """)
+        try FileHandler.shared.delete(xcframeworkPath)
+    }
+
+    fileprivate func infoPlist(xcframeworkPath: AbsolutePath) throws -> XCFrameworkInfoPlist {
+        let infoPlistPath = xcframeworkPath.appending(component: "Info.plist")
+        let data = try Data(contentsOf: infoPlistPath.url)
+        return try plistDecoder.decode(XCFrameworkInfoPlist.self, from: data)
+    }
+}
+
+private struct XCFrameworkInfoPlist: Decodable {
+    let availableLibraries: [Library]
+
+    enum CodingKeys: String, CodingKey {
+        case availableLibraries = "AvailableLibraries"
+    }
+
+    fileprivate struct Library: Decodable {
+        let identifier: String
+        let path: String
+        let supportedArchitectures: [String]
+        let supportedPlatform: String
+
+        enum CodingKeys: String, CodingKey {
+            case identifier = "LibraryIdentifier"
+            case path = "LibraryPath"
+            case supportedArchitectures = "SupportedArchitectures"
+            case supportedPlatform = "SupportedPlatform"
+        }
+    }
+}


### PR DESCRIPTION
### Short description 📝
In order to cache the frameworks, we need to build `.xcframeworks` first that contain both the device and simulator's architectures.

### Solution 📦
This PR adds a new utility, `XCFrameworkBuilder`, that given a project or workspace, and the target representation it generates an `.xcframework` in a temporary directory and returns its path.

### Testing strategy ✅ 
I've decided to use an integration test instead and runs assertions on the generated .xcframework. That way if future versions of `xcodebuild` break the integration of this utility with the command the tests will fail and we'll  catch it. 