### PR TITLE
Add RxSwift as a dependency of TuistKit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Make scheme generation methods more generic https://github.com/tuist/tuist/pull/730 by @adamkhazi @kwridan.
 - Make scheme generation methods more generic by @adamkhazi @kwridan.
 - `SimulatorController` with method to fetch the runtimes https://github.com/tuist/tuist/pull/746 by @pepibumur.
+- Add RxSwift as a dependency of `TuistKit` https://github.com/tuist/tuist/pull/760 by @pepibumur.
 
 ### Fixed
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -29,6 +29,15 @@
         }
       },
       {
+        "package": "RxSwift",
+        "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "b3e888b4972d9bc76495dd74d30a8c7fad4b9395",
+          "version": "5.0.1"
+        }
+      },
+      {
         "package": "Spectre",
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,7 @@ let package = Package(
         .package(url: "https://github.com/tuist/XcodeProj", .upToNextMajor(from: "7.5.0")),
         .package(url: "https://github.com/apple/swift-package-manager", .upToNextMajor(from: "0.5.0")),
         .package(url: "https://github.com/IBM-Swift/BlueSignals", .upToNextMajor(from: "1.0.21")),
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.1"))
     ],
     targets: [
         .target(
@@ -49,15 +50,15 @@ let package = Package(
         ),
         .target(
             name: "TuistKit",
-            dependencies: ["XcodeProj", "SPMUtility", "TuistSupport", "TuistGenerator", "ProjectDescription", "Signals"]
+            dependencies: ["XcodeProj", "SPMUtility", "TuistSupport", "TuistGenerator", "ProjectDescription", "Signals", "RxSwift"]
         ),
         .testTarget(
             name: "TuistKitTests",
-            dependencies: ["TuistKit", "TuistSupportTesting", "ProjectDescription"]
+            dependencies: ["TuistKit", "TuistSupportTesting", "ProjectDescription", "RxBlocking"]
         ),
         .testTarget(
             name: "TuistKitIntegrationTests",
-            dependencies: ["TuistKit", "TuistSupportTesting", "ProjectDescription"]
+            dependencies: ["TuistKit", "TuistSupportTesting", "ProjectDescription", "RxBlocking"]
         ),
         .target(
             name: "tuist",


### PR DESCRIPTION
### Short description 📝
With the introduction of caching, we'll need to perform operations in parallel, for example pulling the frameworks from the cache. Modelling them with a reactive interface makes the asynchronous logic easier to reason about.

## What
I'm introducing RxSwift as a dependency of `TuistKit`. 

**Why not Combine?** Combine is only available from macOS 10.15.x and there might be users using `tuist` with lower versions of macOS. Since the usage of RxSwift will be scoped to just the asynchronous operations required for caching, should be easy to replace with Combine once we drop the support for macOS 10.14.x