### PR TITLE
Cache command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Make scheme generation methods more generic by @adamkhazi @kwridan.
 - `SimulatorController` with method to fetch the runtimes https://github.com/tuist/tuist/pull/746 by @pepibumur.
 - Add RxSwift as a dependency of `TuistKit` https://github.com/tuist/tuist/pull/760 by @pepibumur.
+- Add cache command https://github.com/tuist/tuist/pull/762 by @pepibumur.
 
 ### Fixed
 

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         .package(url: "https://github.com/tuist/XcodeProj", .upToNextMajor(from: "7.5.0")),
         .package(url: "https://github.com/apple/swift-package-manager", .upToNextMajor(from: "0.5.0")),
         .package(url: "https://github.com/IBM-Swift/BlueSignals", .upToNextMajor(from: "1.0.21")),
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.1"))
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.1")),
     ],
     targets: [
         .target(

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -464,9 +464,9 @@ extension Graph {
 
     // swiftlint:disable:next line_length
     func frameworkUsesDynamicLinking(frameworkMetadataProvider: FrameworkMetadataProviding = FrameworkMetadataProvider()) -> (_ frameworkNode: PrecompiledNode) -> Bool { { frameworkNode in
-            let isDynamicLink = try? frameworkMetadataProvider.linking(precompiled: frameworkNode) == .dynamic
-            return isDynamicLink ?? false
-        }
+        let isDynamicLink = try? frameworkMetadataProvider.linking(precompiled: frameworkNode) == .dynamic
+        return isDynamicLink ?? false
+    }
     }
 }
 

--- a/Sources/TuistKit/Commands/CacheCommand.swift
+++ b/Sources/TuistKit/Commands/CacheCommand.swift
@@ -1,0 +1,52 @@
+import Basic
+import Foundation
+import SPMUtility
+import TuistSupport
+
+/// Command to cache frameworks as .xcframeworks and speed up your and others' build times.
+class CacheCommand: NSObject, Command {
+    // MARK: - Attributes
+
+    /// Name of the command.
+    static let command = "cache"
+
+    /// Description of the command.
+    static let overview = "Cache frameworks as .xcframeworks to speed up build times in generated projects"
+
+    /// Path to the project directory.
+    let pathArgument: OptionArgument<String>
+
+    // MARK: - Init
+    
+    /// Initializes the command with the CLI parser.
+    ///
+    /// - Parameter parser: CLI parser where the command should register itself.
+    public required init(parser: ArgumentParser) {
+        let subParser = parser.add(subparser: CacheCommand.command, overview: CacheCommand.overview)
+        self.pathArgument = subParser.add(option: "--path",
+                                          shortName: "-p",
+                                          kind: String.self,
+                                          usage: "The path to the directory that contains the project whose frameworks will be cached.",
+                                          completion: .filename)
+    }
+
+    /// Runs the command using the result from parsing the command line arguments.
+    ///
+    /// - Throws: An error if the the configuration of the environment fails.
+    func run(with arguments: ArgumentParser.Result) throws {
+        let twitterHandle = "@\(Constants.twitterHandle)"
+        Printer.shared.print("This feature is being worked on. Follow us on Twitter \(.bold(.raw(twitterHandle))) or join our Slack channel to stay up to date: \(.bold(.raw(Constants.joinSlackURL)))")
+    }
+
+    /// Parses the arguments and returns the path to the directory where
+    /// the up command should be ran.
+    ///
+    /// - Parameter arguments: Result from parsing the command line arguments.
+    /// - Returns: Path to be used for the up command.
+    private func path(arguments: ArgumentParser.Result) -> AbsolutePath {
+        guard let path = arguments.get(pathArgument) else {
+            return FileHandler.shared.currentPath
+        }
+        return AbsolutePath(path, relativeTo: FileHandler.shared.currentPath)
+    }
+}

--- a/Sources/TuistKit/Commands/CacheCommand.swift
+++ b/Sources/TuistKit/Commands/CacheCommand.swift
@@ -17,23 +17,23 @@ class CacheCommand: NSObject, Command {
     let pathArgument: OptionArgument<String>
 
     // MARK: - Init
-    
+
     /// Initializes the command with the CLI parser.
     ///
     /// - Parameter parser: CLI parser where the command should register itself.
     public required init(parser: ArgumentParser) {
         let subParser = parser.add(subparser: CacheCommand.command, overview: CacheCommand.overview)
-        self.pathArgument = subParser.add(option: "--path",
-                                          shortName: "-p",
-                                          kind: String.self,
-                                          usage: "The path to the directory that contains the project whose frameworks will be cached.",
-                                          completion: .filename)
+        pathArgument = subParser.add(option: "--path",
+                                     shortName: "-p",
+                                     kind: String.self,
+                                     usage: "The path to the directory that contains the project whose frameworks will be cached.",
+                                     completion: .filename)
     }
 
     /// Runs the command using the result from parsing the command line arguments.
     ///
     /// - Throws: An error if the the configuration of the environment fails.
-    func run(with arguments: ArgumentParser.Result) throws {
+    func run(with _: ArgumentParser.Result) throws {
         let twitterHandle = "@\(Constants.twitterHandle)"
         Printer.shared.print("This feature is being worked on. Follow us on Twitter \(.bold(.raw(twitterHandle))) or join our Slack channel to stay up to date: \(.bold(.raw(Constants.joinSlackURL)))")
     }

--- a/Sources/TuistKit/Commands/CommandRegistry.swift
+++ b/Sources/TuistKit/Commands/CommandRegistry.swift
@@ -27,6 +27,7 @@ public final class CommandRegistry {
         register(command: UpCommand.self)
         register(command: GraphCommand.self)
         register(command: EditCommand.self)
+        register(command: CacheCommand.self)
         register(rawCommand: BuildCommand.self)
     }
 

--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -13,7 +13,7 @@ public struct Constants {
     public static let helpersDirectoryName: String = "ProjectDescriptionHelpers"
     public static let twitterHandle: String = "tuistio"
     public static let joinSlackURL: String = "https://slack.tuist.io/"
-    
+
     public struct EnvironmentVariables {
         public static let colouredOutput = "TUIST_COLOURED_OUTPUT"
     }

--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -11,7 +11,9 @@ public struct Constants {
     public static let trueValues: [String] = ["1", "true", "TRUE", "yes", "YES"]
     public static let tuistDirectoryName: String = "Tuist"
     public static let helpersDirectoryName: String = "ProjectDescriptionHelpers"
-
+    public static let twitterHandle: String = "tuistio"
+    public static let joinSlackURL: String = "https://slack.tuist.io/"
+    
     public struct EnvironmentVariables {
         public static let colouredOutput = "TUIST_COLOURED_OUTPUT"
     }

--- a/Tests/TuistKitTests/Commands/CacheCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/CacheCommandTests.swift
@@ -1,0 +1,33 @@
+import Basic
+import Foundation
+import SPMUtility
+import TuistSupport
+import XCTest
+
+@testable import TuistKit
+@testable import TuistSupportTesting
+
+final class CacheCommandTests: TuistUnitTestCase {
+    var subject: CacheCommand!
+    var parser: ArgumentParser!
+
+    override func setUp() {
+        super.setUp()
+        parser = ArgumentParser.test()
+        subject = CacheCommand(parser: parser)
+    }
+
+    override func tearDown() {
+        parser = nil
+        subject = nil
+        super.tearDown()
+    }
+
+    func test_name() {
+        XCTAssertEqual(CacheCommand.command, "cache")
+    }
+
+    func test_overview() {
+        XCTAssertEqual(CacheCommand.overview, "Cache frameworks as .xcframeworks to speed up build times in generated projects")
+    }
+}


### PR DESCRIPTION
### Short description 📝
This PR adds a new command, `tuist cache`, that developers can run from CI to cache frameworks using Tuist's galaxy.

### Solution 📦
The command just outputs that we are working on the feature and tell users to join our Slack channel. We'll add the implementation in a follow-up PR.