### PR TITLE
Add CacheStoraging protocol and a local cache implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Add RxSwift as a dependency of `TuistKit` https://github.com/tuist/tuist/pull/760 by @pepibumur.
 - Add cache command https://github.com/tuist/tuist/pull/762 by @pepibumur.
 - Utility to build xcframeworks https://github.com/tuist/tuist/pull/759 by @pepibumur.
+- Add `CacheStoraging` protocol and a implementation for a local cache https://github.com/tuist/tuist/pull/763 by @pepibumur.
 
 ### Fixed
 

--- a/Sources/TuistKit/Cache/Cache.swift
+++ b/Sources/TuistKit/Cache/Cache.swift
@@ -45,7 +45,7 @@ final class Cache: CacheStoraging {
             }!
     }
 
-    func store(hash: String, path: AbsolutePath) -> Completable {
-        Completable.zip(storages.map { $0.store(hash: hash, path: path) })
+    func store(hash: String, xcframeworkPath: AbsolutePath) -> Completable {
+        Completable.zip(storages.map { $0.store(hash: hash, xcframeworkPath: xcframeworkPath) })
     }
 }

--- a/Sources/TuistKit/Cache/Cache.swift
+++ b/Sources/TuistKit/Cache/Cache.swift
@@ -1,0 +1,51 @@
+import Basic
+import Foundation
+import RxSwift
+
+final class Cache: CacheStoraging {
+    // MARK: - Attributes
+
+    /// Storages where the targest will be cached.
+    private let storages: [CacheStoraging]
+
+    // MARK: - Init
+
+    /// Initializes the cache with its attributes.
+    /// - Parameter storages: Storages where the targest will be cached.
+    init(storages: [CacheStoraging] = [CacheLocalStorage()]) {
+        self.storages = storages
+    }
+
+    // MARK: - CacheStoraging
+
+    func exists(hash: String) -> Single<Bool> {
+        /// It calls exists sequentially until one of the storages returns true.
+        storages.map { $0.exists(hash: hash) }.reduce(Single.just(false)) { (result, next) -> Single<Bool> in
+            result.flatMap { exists in
+                if exists {
+                    return Single.just(exists)
+                } else {
+                    return next
+                }
+            }.catchError { (_) -> Single<Bool> in
+                next
+            }
+        }
+    }
+
+    func fetch(hash: String) -> Single<AbsolutePath> {
+        storages
+            .map { $0.fetch(hash: hash) }
+            .reduce(nil) { (result, next) -> Single<AbsolutePath> in
+                if let result = result {
+                    return result.catchError { _ in next }
+                } else {
+                    return next
+                }
+            }!
+    }
+
+    func store(hash: String, path: AbsolutePath) -> Completable {
+        Completable.zip(storages.map { $0.store(hash: hash, path: path) })
+    }
+}

--- a/Sources/TuistKit/Cache/CacheLocalStorage.swift
+++ b/Sources/TuistKit/Cache/CacheLocalStorage.swift
@@ -1,0 +1,93 @@
+import Basic
+import Foundation
+import RxSwift
+import TuistSupport
+
+enum CacheLocalStorageError: FatalError {
+    case fileNotFound(hash: String)
+
+    var type: ErrorType {
+        switch self {
+        case .fileNotFound: return .abort
+        }
+    }
+
+    var description: String {
+        switch self {
+        case let .fileNotFound(hash):
+            return "File with hash \(hash) not found in the local cache"
+        }
+    }
+}
+
+final class CacheLocalStorage: CacheStoraging {
+    // MARK: - Attributes
+
+    private let cacheDirectory: AbsolutePath
+
+    // MARK: - Init
+
+    init(cacheDirectory: AbsolutePath = Environment.shared.xcframeworksCacheDirectory) {
+        self.cacheDirectory = cacheDirectory
+    }
+
+    // MARK: - CacheStoraging
+
+    func exists(hash: String) -> Single<Bool> {
+        Single.create { (completed) -> Disposable in
+            completed(.success(FileHandler.shared.glob(self.cacheDirectory, glob: "\(hash)/*").count != 0))
+            return Disposables.create()
+        }
+    }
+
+    func fetch(hash: String) -> Single<AbsolutePath> {
+        Single.create { (completed) -> Disposable in
+            if let path = FileHandler.shared.glob(self.cacheDirectory, glob: "\(hash)/*").first {
+                completed(.success(path))
+            } else {
+                completed(.error(CacheLocalStorageError.fileNotFound(hash: hash)))
+            }
+            return Disposables.create()
+        }
+    }
+
+    func store(hash: String, path: AbsolutePath) -> Completable {
+        let copy = Completable.create { (completed) -> Disposable in
+            let hashFolder = self.cacheDirectory.appending(component: hash)
+            let destinationPath = hashFolder.appending(component: path.basename)
+
+            do {
+                if !FileHandler.shared.exists(hashFolder) {
+                    try FileHandler.shared.createFolder(hashFolder)
+                }
+
+                try FileHandler.shared.copy(from: path, to: destinationPath)
+
+            } catch {
+                completed(.error(error))
+                return Disposables.create()
+            }
+            completed(.completed)
+            return Disposables.create()
+        }
+
+        return createCacheDirectory().concat(copy)
+    }
+
+    // MARK: - Fileprivate
+
+    fileprivate func createCacheDirectory() -> Completable {
+        Completable.create { (completed) -> Disposable in
+            do {
+                if !FileHandler.shared.exists(self.cacheDirectory) {
+                    try FileHandler.shared.createFolder(self.cacheDirectory)
+                }
+            } catch {
+                completed(.error(error))
+                return Disposables.create()
+            }
+            completed(.completed)
+            return Disposables.create()
+        }
+    }
+}

--- a/Sources/TuistKit/Cache/CacheLocalStorage.swift
+++ b/Sources/TuistKit/Cache/CacheLocalStorage.swift
@@ -15,7 +15,7 @@ enum CacheLocalStorageError: FatalError, Equatable {
     var description: String {
         switch self {
         case let .xcframeworkNotFound(hash):
-            return ".xcframework with hash '\(hash)' not found in the local cache"
+            return "xcframework with hash '\(hash)' not found in the local cache"
         }
     }
 }

--- a/Sources/TuistKit/Cache/CacheStoraging.swift
+++ b/Sources/TuistKit/Cache/CacheStoraging.swift
@@ -1,0 +1,19 @@
+import Basic
+import Foundation
+import RxSwift
+
+protocol CacheStoraging {
+    /// Returns if the target with the given hash exists in the cache.
+    /// - Parameter hash: Target's hash.
+    /// - Returns: An observable that returns a boolean indicating whether the target is cached.
+    func exists(hash: String) -> Single<Bool>
+
+    /// For the target with the given hash, it fetches it from the cache and returns a path
+    /// pointint to the .xcframework that represents it.
+    ///
+    /// - Parameter hash: Target's hash.
+    /// - Returns: An observable that returns a boolean indicating whether the target is cached.
+    func fetch(hash: String) -> Single<AbsolutePath>
+
+    func store(hash: String, path: AbsolutePath) -> Completable
+}

--- a/Sources/TuistKit/Cache/CacheStoraging.swift
+++ b/Sources/TuistKit/Cache/CacheStoraging.swift
@@ -15,5 +15,9 @@ protocol CacheStoraging {
     /// - Returns: An observable that returns a boolean indicating whether the target is cached.
     func fetch(hash: String) -> Single<AbsolutePath>
 
-    func store(hash: String, path: AbsolutePath) -> Completable
+    /// It stores the xcframework at the given path in the cache.
+    /// - Parameters:
+    ///   - hash: Hash of the target the xcframework belongs to.
+    ///   - xcframeworkPath: Path to the .xcframework.
+    func store(hash: String, xcframeworkPath: AbsolutePath) -> Completable
 }

--- a/Sources/TuistKit/ContentHashing/GraphContentHasher.swift
+++ b/Sources/TuistKit/ContentHashing/GraphContentHasher.swift
@@ -2,19 +2,19 @@ import Foundation
 import TuistCore
 
 public protocol GraphContentHashing {
-    func contentHashes(for graph: Graphing) -> Dictionary<TargetNode, String>
+    func contentHashes(for graph: Graphing) -> [TargetNode: String]
 }
 
 public final class GraphContentHasher: GraphContentHashing {
     public init() {}
-    
-    public func contentHashes(for graph: Graphing) -> Dictionary<TargetNode, String> {
+
+    public func contentHashes(for graph: Graphing) -> [TargetNode: String] {
         let hashableTargets = graph.targets.filter { $0.target.product == .framework }
         let hashes = hashableTargets.map { makeContentHash(of: $0) }
         return Dictionary(uniqueKeysWithValues: zip(hashableTargets, hashes))
     }
-    
-    private func makeContentHash(of targetNode: TargetNode) -> String {
-        return "" //TODO: will be implemented in subsequent PR
+
+    private func makeContentHash(of _: TargetNode) -> String {
+        "" // TODO: will be implemented in subsequent PR
     }
 }

--- a/Sources/TuistSupport/Utils/Environment.swift
+++ b/Sources/TuistSupport/Utils/Environment.swift
@@ -22,6 +22,9 @@ public protocol Environmenting: AnyObject {
 
     /// Returns the directory where the project description helper modules are cached.
     var projectDescriptionHelpersCacheDirectory: AbsolutePath { get }
+
+    /// Returns the directory where the xcframeworks are cached.
+    var xcframeworksCacheDirectory: AbsolutePath { get }
 }
 
 /// Local environment controller.
@@ -85,6 +88,11 @@ public class Environment: Environmenting {
     /// Returns the directory where all the versions are.
     public var versionsDirectory: AbsolutePath {
         directory.appending(component: "Versions")
+    }
+
+    /// Returns the directory where the xcframeworks are cached.
+    public var xcframeworksCacheDirectory: AbsolutePath {
+        cacheDirectory.appending(component: "xcframeworks")
     }
 
     /// Returns the directory where the project description helper modules are cached.

--- a/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
+++ b/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
@@ -38,6 +38,10 @@ public class MockEnvironment: Environmenting {
         cacheDirectory.appending(component: "ProjectDescriptionHelpers")
     }
 
+    public var xcframeworksCacheDirectory: AbsolutePath {
+        cacheDirectory.appending(component: "xcframeworks")
+    }
+
     func path(version: String) -> AbsolutePath {
         versionsDirectory.appending(component: version)
     }

--- a/Tests/TuistKitIntegrationTests/Cache/CacheLocalStorageIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Cache/CacheLocalStorageIntegrationTests.swift
@@ -1,0 +1,86 @@
+import Basic
+import Foundation
+import RxBlocking
+import SPMUtility
+import TuistCore
+import TuistSupport
+import XCTest
+@testable import TuistCoreTesting
+@testable import TuistKit
+@testable import TuistSupportTesting
+
+final class CacheLocalStorageIntegrationTests: TuistTestCase {
+    var subject: CacheLocalStorage!
+
+    override func setUp() {
+        super.setUp()
+        let cacheDirectory = try! temporaryPath()
+        subject = CacheLocalStorage(cacheDirectory: cacheDirectory)
+    }
+
+    override func tearDown() {
+        subject = nil
+        super.tearDown()
+    }
+
+    func test_exists_when_a_cached_xcframework_exists() throws {
+        // Given
+        let cacheDirectory = try temporaryPath()
+        let hash = "abcde"
+        let hashDirectory = cacheDirectory.appending(component: hash)
+        let xcframeworkPath = hashDirectory.appending(component: "framework.xcframework")
+        try FileHandler.shared.createFolder(hashDirectory)
+        try FileHandler.shared.createFolder(xcframeworkPath)
+
+        // When
+        let got = try subject.exists(hash: hash).toBlocking().first()
+
+        // Then
+        XCTAssertTrue(got == true)
+    }
+
+    func test_exists_when_a_cached_xcframework_does_not_exist() throws {
+        // When
+        let hash = "abcde"
+        let got = try subject.exists(hash: hash).toBlocking().first()
+
+        // Then
+        XCTAssertTrue(got == false)
+    }
+
+    func test_fetch_when_a_cached_xcframework_exists() throws {
+        // Given
+        let cacheDirectory = try temporaryPath()
+        let hash = "abcde"
+        let hashDirectory = cacheDirectory.appending(component: hash)
+        let xcframeworkPath = hashDirectory.appending(component: "framework.xcframework")
+        try FileHandler.shared.createFolder(hashDirectory)
+        try FileHandler.shared.createFolder(xcframeworkPath)
+
+        // When
+        let got = try subject.fetch(hash: hash).toBlocking().first()
+
+        // Then
+        XCTAssertTrue(got == xcframeworkPath)
+    }
+
+    func test_fetch_when_a_cached_xcframework_does_not_exist() throws {
+        let hash = "abcde"
+        XCTAssertThrowsSpecific(try subject.fetch(hash: hash).toBlocking().first(),
+                                CacheLocalStorageError.xcframeworkNotFound(hash: hash))
+    }
+
+    func test_store() throws {
+        // Given
+        let hash = "abcde"
+        let cacheDirectory = try temporaryPath()
+        let xcframeworkPath = cacheDirectory.appending(component: "framework.xcframework")
+        try FileHandler.shared.createFolder(xcframeworkPath)
+
+        // When
+        _ = try subject.store(hash: hash, xcframeworkPath: xcframeworkPath).toBlocking().first()
+
+        // Then
+        XCTAssertTrue(FileHandler.shared.exists(cacheDirectory.appending(RelativePath("\(hash)/framework.xcframework"))))
+    }
+}

--- a/Tests/TuistKitTests/Cache/CacheLocalStorageTests.swift
+++ b/Tests/TuistKitTests/Cache/CacheLocalStorageTests.swift
@@ -1,0 +1,15 @@
+import Foundation
+import XCTest
+
+@testable import TuistKit
+@testable import TuistSupportTesting
+
+final class CacheLocalStorageErrorTests: TuistUnitTestCase {
+    func test_type() {
+        XCTAssertEqual(CacheLocalStorageError.xcframeworkNotFound(hash: "hash").type, .abort)
+    }
+
+    func test_description() {
+        XCTAssertEqual(CacheLocalStorageError.xcframeworkNotFound(hash: "hash").description, "File with hash 'hash' not found in the local cache")
+    }
+}

--- a/Tests/TuistKitTests/Cache/CacheLocalStorageTests.swift
+++ b/Tests/TuistKitTests/Cache/CacheLocalStorageTests.swift
@@ -10,6 +10,6 @@ final class CacheLocalStorageErrorTests: TuistUnitTestCase {
     }
 
     func test_description() {
-        XCTAssertEqual(CacheLocalStorageError.xcframeworkNotFound(hash: "hash").description, "File with hash 'hash' not found in the local cache")
+        XCTAssertEqual(CacheLocalStorageError.xcframeworkNotFound(hash: "hash").description, "xcframework with hash 'hash' not found in the local cache")
     }
 }

--- a/Tests/TuistKitTests/ContentHashing/GraphContentHasherTests.swift
+++ b/Tests/TuistKitTests/ContentHashing/GraphContentHasherTests.swift
@@ -1,22 +1,22 @@
-import Foundation
-import XCTest
-import TuistCoreTesting
-import TuistCore
 import Basic
+import Foundation
+import TuistCore
+import TuistCoreTesting
+import XCTest
 @testable import TuistKit
 
 final class GraphContentHasherTests: XCTestCase {
     private var sut: GraphContentHasher!
-    
+
     override func setUp() {
         super.setUp()
         sut = GraphContentHasher()
-     }
+    }
 
     override func tearDown() {
-         sut = nil
-         super.tearDown()
-     }
+        sut = nil
+        super.tearDown()
+    }
 
     func test_contentHashes_emptyGraph() {
         let graph = Graph.test()
@@ -25,7 +25,7 @@ final class GraphContentHasherTests: XCTestCase {
     }
 
     func test_contentHashes_returnsOnlyFrameworks() {
-        //Given
+        // Given
         let cache = GraphLoaderCache()
         let graph = Graph.test(cache: cache)
         let frameworkTarget = TargetNode.test(project: .test(path: AbsolutePath("/test/1")), target: .test(product: .framework))
@@ -39,13 +39,13 @@ final class GraphContentHasherTests: XCTestCase {
         cache.add(targetNode: dynamicLibraryTarget)
         cache.add(targetNode: staticFrameworkTarget)
         let expectedCachableTargets = [frameworkTarget, secondFrameworkTarget]
-        
+
         // When
         let hashes = sut.contentHashes(for: graph)
-        let hashedTargets: [TargetNode] = hashes.keys.sorted{ left, right -> Bool in
+        let hashedTargets: [TargetNode] = hashes.keys.sorted { left, right -> Bool in
             left.project.path.pathString < right.project.path.pathString
         }
-        
+
         // Then
         XCTAssertEqual(hashedTargets, expectedCachableTargets)
     }


### PR DESCRIPTION
### Short description 📝
This PR defines an interface to store and retrieve xcframework from the cache and a implementation to store them locally.

Once we validate the caching, we'll extend this feature with a remote caching that will interact with Galaxy. Note that the interface has been purposely designed to be reactive to allow running caching operations in parallel asynchronously. 