### PR TITLE
Hashing frameworks based on source files

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -20,6 +20,15 @@
         }
       },
       {
+        "package": "Checksum",
+        "repositoryURL": "https://github.com/rnine/Checksum.git",
+        "state": {
+          "branch": null,
+          "revision": "9dde3d1d898a5074608a1420791ef0a80c2399f2",
+          "version": "1.0.2"
+        }
+      },
+      {
         "package": "PathKit",
         "repositoryURL": "https://github.com/kylef/PathKit",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "tuist",
+    platforms: [.macOS(.v10_11)],
     products: [
         .executable(name: "tuist", targets: ["tuist"]),
         .executable(name: "tuistenv", targets: ["tuistenv"]),
@@ -30,6 +31,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-package-manager", .upToNextMajor(from: "0.5.0")),
         .package(url: "https://github.com/IBM-Swift/BlueSignals", .upToNextMajor(from: "1.0.21")),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.1")),
+        .package(url: "https://github.com/rnine/Checksum.git", .upToNextMajor(from: "1.0.2")),
     ],
     targets: [
         .target(
@@ -50,15 +52,15 @@ let package = Package(
         ),
         .target(
             name: "TuistKit",
-            dependencies: ["XcodeProj", "SPMUtility", "TuistSupport", "TuistGenerator", "ProjectDescription", "Signals", "RxSwift"]
+            dependencies: ["XcodeProj", "SPMUtility", "TuistSupport", "TuistGenerator", "ProjectDescription", "Signals", "RxSwift", "Checksum"]
         ),
         .testTarget(
             name: "TuistKitTests",
-            dependencies: ["TuistKit", "TuistSupportTesting", "ProjectDescription", "RxBlocking"]
+            dependencies: ["TuistKit", "TuistSupportTesting", "ProjectDescription", "RxBlocking", "Checksum"]
         ),
         .testTarget(
             name: "TuistKitIntegrationTests",
-            dependencies: ["TuistKit", "TuistSupportTesting", "ProjectDescription", "RxBlocking"]
+            dependencies: ["TuistKit", "TuistSupportTesting", "ProjectDescription", "RxBlocking", "Checksum"]
         ),
         .target(
             name: "tuist",

--- a/Sources/TuistKit/ContentHashing/ContentHashingError.swift
+++ b/Sources/TuistKit/ContentHashing/ContentHashingError.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Basic
+import TuistCore
+import TuistSupport
+
+enum ContentHashingError: FatalError, Equatable {
+    case fileNotFound(AbsolutePath)
+    case checksumFileFailed(AbsolutePath)
+    case checksumStringFailed(String)
+
+    var type: ErrorType {
+        .abort
+    }
+
+    var description: String {
+        switch self {
+        case let .fileNotFound(path):
+            return "Couldn't find file at path \(path.pathString)."
+        case let .checksumFileFailed(path):
+            return "Couldn't calculate checksum for file at path \(path.pathString)."
+        case let .checksumStringFailed(string):
+            return "Couldn't calculate checksum for string \(string)."
+        }
+    }
+
+    static func == (lhs: ContentHashingError, rhs: ContentHashingError) -> Bool {
+        switch (lhs, rhs) {
+        case let (.fileNotFound(lhsPath), .fileNotFound(rhsPath)):
+            return lhsPath == rhsPath
+        case let (.checksumFileFailed(lhsPath), .checksumFileFailed(rhsPath)):
+            return lhsPath == rhsPath
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/TuistKit/ContentHashing/ContentHashingError.swift
+++ b/Sources/TuistKit/ContentHashing/ContentHashingError.swift
@@ -5,8 +5,8 @@ import TuistSupport
 
 enum ContentHashingError: FatalError, Equatable {
     case fileNotFound(AbsolutePath)
-    case checksumFileFailed(AbsolutePath)
-    case checksumStringFailed(String)
+    case fileHashingFailed(AbsolutePath)
+    case stringHashingFailed(String)
 
     var type: ErrorType {
         .abort
@@ -15,11 +15,11 @@ enum ContentHashingError: FatalError, Equatable {
     var description: String {
         switch self {
         case let .fileNotFound(path):
-            return "Couldn't find file at path \(path.pathString)."
-        case let .checksumFileFailed(path):
-            return "Couldn't calculate checksum for file at path \(path.pathString)."
-        case let .checksumStringFailed(string):
-            return "Couldn't calculate checksum for string \(string)."
+            return "Couldn't find file at path \(path.pathString) while hashing the target for caching."
+        case let .fileHashingFailed(path):
+            return "Couldn't calculate hash of file at path \(path.pathString) for caching."
+        case let .stringHashingFailed(string):
+            return "Couldn't calculate hash of string \(string) for caching."
         }
     }
 
@@ -27,8 +27,10 @@ enum ContentHashingError: FatalError, Equatable {
         switch (lhs, rhs) {
         case let (.fileNotFound(lhsPath), .fileNotFound(rhsPath)):
             return lhsPath == rhsPath
-        case let (.checksumFileFailed(lhsPath), .checksumFileFailed(rhsPath)):
+        case let (.fileHashingFailed(lhsPath), .fileHashingFailed(rhsPath)):
             return lhsPath == rhsPath
+        case let (.stringHashingFailed(lhsPath), .stringHashingFailed(rhsPath)):
+                return lhsPath == rhsPath
         default:
             return false
         }

--- a/Sources/TuistKit/ContentHashing/GraphContentHasher.swift
+++ b/Sources/TuistKit/ContentHashing/GraphContentHasher.swift
@@ -29,7 +29,7 @@ public final class GraphContentHasher: GraphContentHashing {
     private func hashSources(of targetNode: TargetNode) throws -> String {
         let hashes = try targetNode.target.sources.map(md5)
         guard let joinedHash = hashes.joined().checksum(algorithm: .md5) else {
-            throw ContentHashingError.checksumStringFailed(hashes.joined())
+            throw ContentHashingError.stringHashingFailed(hashes.joined())
         }
         return joinedHash
     }
@@ -39,7 +39,7 @@ public final class GraphContentHasher: GraphContentHashing {
             throw ContentHashingError.fileNotFound(source.path)
         }
         guard let checksum = sourceData.checksum(algorithm: .md5) else {
-            throw ContentHashingError.checksumFileFailed(source.path)
+            throw ContentHashingError.fileHashingFailed(source.path)
         }
         return checksum
     }

--- a/Sources/TuistKit/ContentHashing/GraphContentHasher.swift
+++ b/Sources/TuistKit/ContentHashing/GraphContentHasher.swift
@@ -2,10 +2,9 @@ import Foundation
 import TuistCore
 import Checksum
 import TuistSupport
-import TuistCore
 
 public protocol GraphContentHashing {
-    func contentHashes(for graph: Graphing) throws -> Dictionary<TargetNode, String>
+    func contentHashes(for graph: Graphing) throws -> [TargetNode: String]
 }
 
 public final class GraphContentHasher: GraphContentHashing {
@@ -15,7 +14,7 @@ public final class GraphContentHasher: GraphContentHashing {
         self.fileHandler = fileHandler
     }
     
-    public func contentHashes(for graph: Graphing) throws -> Dictionary<TargetNode, String> {
+    public func contentHashes(for graph: Graphing) throws -> [TargetNode: String] {
         let hashableTargets = graph.targets.filter { $0.target.product == .framework }
         let hashes = try hashableTargets.map { try makeContentHash(of: $0) }
         return Dictionary(uniqueKeysWithValues: zip(hashableTargets, hashes))
@@ -49,7 +48,7 @@ public final class GraphContentHasher: GraphContentHashing {
         return joinedHash
     }
     
-    private func md5(of source: Target.SourceFile) throws -> String{
+    private func md5(of source: Target.SourceFile) throws -> String {
         guard let sourceData = try? fileHandler.readFile(source.path) else {
             throw ContentHashingError.fileNotFound(source.path)
         }

--- a/Sources/TuistKit/ContentHashing/GraphContentHasher.swift
+++ b/Sources/TuistKit/ContentHashing/GraphContentHasher.swift
@@ -1,20 +1,46 @@
 import Foundation
 import TuistCore
+import Checksum
+import TuistSupport
+import TuistCore
 
 public protocol GraphContentHashing {
-    func contentHashes(for graph: Graphing) -> [TargetNode: String]
+    func contentHashes(for graph: Graphing) throws -> Dictionary<TargetNode, String>
 }
 
 public final class GraphContentHasher: GraphContentHashing {
-    public init() {}
-
-    public func contentHashes(for graph: Graphing) -> [TargetNode: String] {
+    private let fileHandler: FileHandling
+    
+    public init(fileHandler: FileHandling = FileHandler.shared) {
+        self.fileHandler = fileHandler
+    }
+    
+    public func contentHashes(for graph: Graphing) throws -> Dictionary<TargetNode, String> {
         let hashableTargets = graph.targets.filter { $0.target.product == .framework }
-        let hashes = hashableTargets.map { makeContentHash(of: $0) }
+        let hashes = try hashableTargets.map { try makeContentHash(of: $0) }
         return Dictionary(uniqueKeysWithValues: zip(hashableTargets, hashes))
     }
-
-    private func makeContentHash(of _: TargetNode) -> String {
-        "" // TODO: will be implemented in subsequent PR
+    
+    private func makeContentHash(of targetNode: TargetNode) throws -> String {
+        return try hashSources(of: targetNode)
+        //TODO: extend function to consider build settings, compiler flags, dependencies, and a lot more
+    }
+    
+    private func hashSources(of targetNode: TargetNode) throws -> String {
+        let hashes = try targetNode.target.sources.map(md5)
+        guard let joinedHash = hashes.joined().checksum(algorithm: .md5) else {
+            throw ContentHashingError.checksumStringFailed(hashes.joined())
+        }
+        return joinedHash
+    }
+    
+    private func md5(of source: Target.SourceFile) throws -> String{
+        guard let sourceData = try? fileHandler.readFile(source.path) else {
+            throw ContentHashingError.fileNotFound(source.path)
+        }
+        guard let checksum = sourceData.checksum(algorithm: .md5) else {
+            throw ContentHashingError.checksumFileFailed(source.path)
+        }
+        return checksum
     }
 }

--- a/Sources/TuistKit/ContentHashing/GraphContentHasher.swift
+++ b/Sources/TuistKit/ContentHashing/GraphContentHasher.swift
@@ -22,14 +22,29 @@ public final class GraphContentHasher: GraphContentHashing {
     }
     
     private func makeContentHash(of targetNode: TargetNode) throws -> String {
-        return try hashSources(of: targetNode)
         //TODO: extend function to consider build settings, compiler flags, dependencies, and a lot more
+        let sourcesHash = try hashSources(of: targetNode)
+        let productHash = try hash(string: targetNode.target.productName)
+        let platformHash = try hash(string: targetNode.target.platform.rawValue)
+        return try hash(strings: [sourcesHash, productHash, platformHash])
     }
     
     private func hashSources(of targetNode: TargetNode) throws -> String {
-        let hashes = try targetNode.target.sources.map(md5)
-        guard let joinedHash = hashes.joined().checksum(algorithm: .md5) else {
-            throw ContentHashingError.stringHashingFailed(hashes.joined())
+        let hashes = try targetNode.target.sources.sorted(by: { $0.path < $1.path }).map(md5)
+        let joinedHash = try hash(strings: hashes)
+        return joinedHash
+    }
+    
+    private func hash(string: String) throws -> String {
+        guard let hash = string.checksum(algorithm: .md5) else {
+            throw ContentHashingError.stringHashingFailed(string)
+        }
+        return hash
+    }
+    
+    private func hash(strings: [String]) throws -> String {
+        guard let joinedHash = strings.joined().checksum(algorithm: .md5) else {
+            throw ContentHashingError.stringHashingFailed(strings.joined())
         }
         return joinedHash
     }
@@ -38,9 +53,9 @@ public final class GraphContentHasher: GraphContentHashing {
         guard let sourceData = try? fileHandler.readFile(source.path) else {
             throw ContentHashingError.fileNotFound(source.path)
         }
-        guard let checksum = sourceData.checksum(algorithm: .md5) else {
+        guard let hash = sourceData.checksum(algorithm: .md5) else {
             throw ContentHashingError.fileHashingFailed(source.path)
         }
-        return checksum
+        return hash
     }
 }

--- a/Sources/TuistSupport/Utils/FileHandler.swift
+++ b/Sources/TuistSupport/Utils/FileHandler.swift
@@ -59,6 +59,13 @@ public protocol FileHandling: AnyObject {
     /// - Throws: An error if from doesn't exist or to does.
     func copy(from: AbsolutePath, to: AbsolutePath) throws
 
+    /// Reads a file at the given path and returns its data.
+    ///
+    /// - Parameter at: Path to the text file.
+    /// - Returns: The content of the file.
+    /// - Throws: An error if the file doesn't exist
+    func readFile(_ at: AbsolutePath) throws -> Data
+    
     /// Reads a text file at the given path and returns it.
     ///
     /// - Parameter at: Path to the text file.
@@ -157,6 +164,10 @@ public class FileHandler: FileHandling {
         try fileManager.moveItem(atPath: from.pathString, toPath: to.pathString)
     }
 
+    public func readFile(_ at: AbsolutePath) throws -> Data {
+        return try Data(contentsOf: at.url)
+    }
+    
     public func readTextFile(_ at: AbsolutePath) throws -> String {
         let data = try Data(contentsOf: at.url)
         if let content = String(data: data, encoding: .utf8) {

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
@@ -278,6 +278,7 @@ class WorkspaceStructureGeneratorTests: XCTestCase {
     }
 
     fileprivate class InMemoryFileHandler: FileHandling {
+        
         private enum Node {
             case file
             case folder
@@ -299,6 +300,10 @@ class WorkspaceStructureGeneratorTests: XCTestCase {
 
         func readTextFile(_: AbsolutePath) throws -> String {
             ""
+        }
+        
+        func readFile(_ at: AbsolutePath) throws -> Data {
+            return Data()
         }
 
         func inTemporaryDirectory(_: (AbsolutePath) throws -> Void) throws {}

--- a/Tests/TuistKitIntegrationTests/ContentHashing/ContentHashingIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/ContentHashing/ContentHashingIntegrationTests.swift
@@ -1,0 +1,96 @@
+import Basic
+import Foundation
+import TuistSupport
+import XCTest
+import TuistCore
+import TuistCoreTesting
+
+@testable import TuistKit
+@testable import TuistSupportTesting
+
+final class ContentHashingIntegrationTests: TuistTestCase {
+    var subject: GraphContentHasher!
+    
+    override func setUp() {
+        super.setUp()
+        subject = GraphContentHasher()
+    }
+
+    override func tearDown() {
+        subject = nil
+        super.tearDown()
+    }
+
+    func test_contentHashes_frameworksWithSameSources() throws {
+        let cache = GraphLoaderCache()
+        let graph = Graph.test(cache: cache)
+        
+        let temporaryDirectoryPath = try self.temporaryPath()
+        let source1 = try createTemporaryFile(on: temporaryDirectoryPath, name: "1", content: "1")
+        let source2 = try createTemporaryFile(on: temporaryDirectoryPath, name: "2", content: "2")
+        let framework1 = makeFramework(named: "f1", withSources: [source1, source2])
+        let framework2 = makeFramework(named: "f2", withSources: [source1, source2])
+        cache.add(targetNode: framework1)
+        cache.add(targetNode: framework2)
+        
+        let contentHashes = try subject.contentHashes(for: graph)
+        
+        XCTAssertNotNil(contentHashes[framework1])
+        XCTAssertNotNil(contentHashes[framework2])
+        XCTAssertEqual(contentHashes[framework1], contentHashes[framework2])
+    }
+    
+    func test_contentHashes_frameworksWithDifferentSources() throws {
+        let cache = GraphLoaderCache()
+        let graph = Graph.test(cache: cache)
+        
+        let temporaryDirectoryPath = try self.temporaryPath()
+        let source1 = try createTemporaryFile(on: temporaryDirectoryPath, name: "1", content: "1")
+        let source2 = try createTemporaryFile(on: temporaryDirectoryPath, name: "2", content: "2")
+        let source3 = try createTemporaryFile(on: temporaryDirectoryPath, name: "3", content: "3")
+        let source4 = try createTemporaryFile(on: temporaryDirectoryPath, name: "4", content: "4")
+        let framework1 = makeFramework(named: "f1", withSources: [source1, source2])
+        let framework2 = makeFramework(named: "f2", withSources: [source3, source4])
+        cache.add(targetNode: framework1)
+        cache.add(targetNode: framework2)
+        
+        let contentHashes = try subject.contentHashes(for: graph)
+        
+        XCTAssertNotNil(contentHashes[framework1])
+        XCTAssertNotNil(contentHashes[framework2])
+        XCTAssertNotEqual(contentHashes[framework1], contentHashes[framework2])
+    }
+    
+    func test_contentHashes_hashIsConsistent() throws {
+        let cache = GraphLoaderCache()
+        let graph = Graph.test(cache: cache)
+        
+        let temporaryDirectoryPath = try self.temporaryPath()
+        let source1 = try createTemporaryFile(on: temporaryDirectoryPath, name: "1", content: "1")
+        let source2 = try createTemporaryFile(on: temporaryDirectoryPath, name: "2", content: "2")
+        let source3 = try createTemporaryFile(on: temporaryDirectoryPath, name: "3", content: "3")
+        let source4 = try createTemporaryFile(on: temporaryDirectoryPath, name: "4", content: "4")
+        let framework1 = makeFramework(named: "f1", withSources: [source1, source2])
+        let framework2 = makeFramework(named: "f2", withSources: [source3, source4])
+        cache.add(targetNode: framework1)
+        cache.add(targetNode: framework2)
+        
+        let contentHashes = try subject.contentHashes(for: graph)
+        
+        XCTAssertEqual(contentHashes[framework1], "302cbafc0dfbc97f30d576a6f394dad3")
+        XCTAssertEqual(contentHashes[framework2], "284914d9fc3eba381602a8adc626fbfd")
+    }
+    
+    // MARK: - Private helpers
+    
+    private func createTemporaryFile(on temporaryDirectoryPath: AbsolutePath, name: String, content: String) throws -> Target.SourceFile {
+        let filePath = temporaryDirectoryPath.appending(component: name)
+        try FileHandler.shared.touch(filePath)
+        try FileHandler.shared.write(content, path: filePath, atomically: true)
+        return Target.SourceFile(path: filePath, compilerFlags: nil)
+    }
+    
+    private func makeFramework(named: String, withSources sources: [Target.SourceFile]) -> TargetNode {
+        return TargetNode.test(project: .test(path: AbsolutePath("/test/\(named)")), target: .test(product: .framework, sources: sources))
+    }
+}

--- a/Tests/TuistKitTests/ContentHashing/GraphContentHasherTests.swift
+++ b/Tests/TuistKitTests/ContentHashing/GraphContentHasherTests.swift
@@ -18,13 +18,13 @@ final class GraphContentHasherTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_contentHashes_emptyGraph() {
+    func test_contentHashes_emptyGraph() throws {
         let graph = Graph.test()
-        let hashes = sut.contentHashes(for: graph)
+        let hashes = try sut.contentHashes(for: graph)
         XCTAssertEqual(hashes, Dictionary())
     }
 
-    func test_contentHashes_returnsOnlyFrameworks() {
+    func test_contentHashes_returnsOnlyFrameworks() throws {
         // Given
         let cache = GraphLoaderCache()
         let graph = Graph.test(cache: cache)
@@ -41,7 +41,7 @@ final class GraphContentHasherTests: XCTestCase {
         let expectedCachableTargets = [frameworkTarget, secondFrameworkTarget]
 
         // When
-        let hashes = sut.contentHashes(for: graph)
+        let hashes = try sut.contentHashes(for: graph)
         let hashedTargets: [TargetNode] = hashes.keys.sorted { left, right -> Bool in
             left.project.path.pathString < right.project.path.pathString
         }


### PR DESCRIPTION
# Short description 📝

Implement content hashing of a frameworks, based on the `md5` of their source files, `platform` and `productName`

### Implementation 👩‍💻👨‍💻

- Add [Checksum](https://github.com/rnine/Checksum) dependency via SPM. For now I don't think it makes sense to implement MD5 ourself. We have to test the perfs and decide if we should replace this part with running `md5file` via bash
- Extend `FileHandler` with a function that reads a file from a Path and returns `Data`
- Calculate the hash by making the `md5` of each file, and then doing the MD5 again of the concatenated string of the sources, together with the `productName` and `platform`
