### PR TITLE
Support modifying Tuist's directories with environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Add cache command https://github.com/tuist/tuist/pull/762 by @pepibumur.
 - Utility to build xcframeworks https://github.com/tuist/tuist/pull/759 by @pepibumur.
 - Add `CacheStoraging` protocol and a implementation for a local cache https://github.com/tuist/tuist/pull/763 by @pepibumur.
+- Add support for changing the cache and versions directory using environment variables https://github.com/tuist/tuist/pull/765 by @pepibumur.
 
 ### Fixed
 

--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -16,6 +16,8 @@ public struct Constants {
 
     public struct EnvironmentVariables {
         public static let colouredOutput = "TUIST_COLOURED_OUTPUT"
+        public static let versionsDirectory = "TUIST_VERSIONS_DIRECTORY"
+        public static let cacheDirectory = "TUIST_CACHE_DIRECTORY"
     }
 
     public struct GoogleCloud {

--- a/Sources/TuistSupport/Utils/Environment.swift
+++ b/Sources/TuistSupport/Utils/Environment.swift
@@ -11,9 +11,6 @@ public protocol Environmenting: AnyObject {
     /// Returns the path to the settings.
     var settingsPath: AbsolutePath { get }
 
-    /// Returns the directory where all the derived projects are generated.
-    var derivedProjectsDirectory: AbsolutePath { get }
-
     /// Returns true if the output of Tuist should be coloured.
     var shouldOutputBeColoured: Bool { get }
 
@@ -63,7 +60,7 @@ public class Environment: Environmenting {
 
     /// Sets up the local environment.
     private func setup() {
-        [directory, versionsDirectory, derivedProjectsDirectory].forEach {
+        [directory, versionsDirectory, cacheDirectory].forEach {
             if !fileHandler.exists($0) {
                 // swiftlint:disable:next force_try
                 try! fileHandler.createFolder($0)
@@ -87,7 +84,11 @@ public class Environment: Environmenting {
 
     /// Returns the directory where all the versions are.
     public var versionsDirectory: AbsolutePath {
-        directory.appending(component: "Versions")
+        if let envVariable = ProcessInfo.processInfo.environment[Constants.EnvironmentVariables.versionsDirectory] {
+            return AbsolutePath(envVariable)
+        } else {
+            return directory.appending(component: "Versions")
+        }
     }
 
     /// Returns the directory where the xcframeworks are cached.
@@ -102,12 +103,11 @@ public class Environment: Environmenting {
 
     /// Returns the cache directory
     public var cacheDirectory: AbsolutePath {
-        directory.appending(component: "Cache")
-    }
-
-    /// Returns the directory where all the derived projects are generated.
-    public var derivedProjectsDirectory: AbsolutePath {
-        directory.appending(component: "DerivedProjects")
+        if let envVariable = ProcessInfo.processInfo.environment[Constants.EnvironmentVariables.cacheDirectory] {
+            return AbsolutePath(envVariable)
+        } else {
+            return directory.appending(component: "Cache")
+        }
     }
 
     /// Settings path.

--- a/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
+++ b/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
@@ -22,10 +22,6 @@ public class MockEnvironment: Environmenting {
         directory.path.appending(component: "Versions")
     }
 
-    public var derivedProjectsDirectory: AbsolutePath {
-        directory.path.appending(component: "DerivedProjects")
-    }
-
     public var settingsPath: AbsolutePath {
         directory.path.appending(component: "settings.json")
     }


### PR DESCRIPTION
### Short description 📝
Some Tuist's features, like storing Tuist versions, interact with some global directories in the system. That makes it difficult to write deterministic acceptance tests because those directories might already contain some data that might cause the tests to fail.

### Solution 📦
This PR makes the versions and the cache directories customizable through environment variables. Thanks to it we can set those variables from the acceptance tests and prevent Tuist from interacting with a shared space in the environment.
