### PR TITLE
Don't generate target build settings when default settings are ".none"

### DIFF
--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -154,6 +154,7 @@ final class ConfigGenerator: ConfigGenerating {
                                      target: Target,
                                      graph: Graphing,
                                      sourceRootPath: AbsolutePath) {
+        guard target.settings?.defaultSettings != DefaultSettings.none else { return }
         settings.merge(generalTargetDerivedSettings(target: target, sourceRootPath: sourceRootPath)) { $1 }
         settings.merge(testBundleTargetDerivedSettings(target: target, graph: graph, sourceRootPath: sourceRootPath)) { $1 }
         settings.merge(deploymentTargetDerivedSettings(target: target)) { $1 }

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -215,6 +215,30 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         assert(config: debugConfig, contains: expectedSettings)
         assert(config: releaseConfig, contains: expectedSettings)
     }
+    
+    func test_generateTargetWithNoSettings() throws {
+        // Given
+        let target = Target.test(settings: Settings(base: [:], configurations: [:], defaultSettings: .none))
+        
+        // When
+        try subject.generateTargetConfig(target,
+                                         pbxTarget: pbxTarget,
+                                         pbxproj: pbxproj,
+                                         projectSettings: Settings(base: [:], configurations: [:], defaultSettings: .none),
+                                         fileElements: ProjectFileElements(),
+                                         graph: Graph.test(),
+                                         sourceRootPath: AbsolutePath("/project"))
+        
+        // Then
+        let configurationList = pbxTarget.buildConfigurationList
+        let debugConfig = configurationList?.configuration(name: "Debug")
+        let releaseConfig = configurationList?.configuration(name: "Release")
+        
+        XCTAssertEqual(debugConfig?.buildSettings.count, 0)
+        XCTAssertEqual(releaseConfig?.buildSettings.count, 0)
+    }
+
+    // MARK: - Helpers
 
     private func generateProjectConfig(config _: BuildConfiguration) throws {
         let dir = try TemporaryDirectory(removeTreeOnDeinit: true)
@@ -300,8 +324,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
                                              graph: graph,
                                              sourceRootPath: dir.path)
     }
-
-    // MARK: - Helpers
+ 
 
     func assert(config: XCBuildConfiguration?,
                 contains settings: [String: String],


### PR DESCRIPTION
Pair with @RomainBoulay 

### Short description 📝

In our projects, we don't want have build settings in `pbxproj` files, as we prefer to keep them only in `xcconfig` files.
Even though the `defaultSettings` where set to `.none`, Tuist was generating some "essential" build settings. The scope of the PR is to update the code to not generate any settings when `defaultSettings == .none`


### Solution 📦

Don't merge the default settings when `Settings.defaultSettings == .none`