### PR TITLE
Fix unstable scheme generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Ensure custom search path settings are included in generated projects https://github.com/tuist/tuist/pull/751 by @kwridan
 - Remove duplicate HEADER_SEARCH_PATHS https://github.com/tuist/tuist/pull/787 by @kwridan
+- Fix unstable scheme generation https://github.com/tuist/tuist/pull/790 by @marciniwanicki
 
 ## 0.19.0
 

--- a/Sources/TuistGenerator/Generator/SchemesGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemesGenerator.swift
@@ -572,7 +572,7 @@ final class SchemesGenerator: SchemesGenerating {
     private func commandlineArgruments(_ arguments: [String: Bool]) -> [XCScheme.CommandLineArguments.CommandLineArgument] {
         arguments.map { key, enabled in
             XCScheme.CommandLineArguments.CommandLineArgument(name: key, enabled: enabled)
-        }
+        }.sorted { $0.name < $1.name }
     }
 
     /// Returns the scheme environment variables
@@ -583,7 +583,7 @@ final class SchemesGenerator: SchemesGenerating {
     private func environmentVariables(_ environments: [String: String]) -> [XCScheme.EnvironmentVariable] {
         environments.map { key, value in
             XCScheme.EnvironmentVariable(variable: key, value: value, enabled: true)
-        }
+        }.sorted { $0.variable < $1.variable }
     }
 
     private func defaultDebugBuildConfigurationName(in project: Project) -> String {

--- a/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
@@ -345,14 +345,16 @@ final class SchemesGeneratorTests: XCTestCase {
     func test_schemeLaunchAction() throws {
         // Given
         let projectPath = AbsolutePath("/somepath/Workspace/Projects/Project")
+        let environment = ["env1": "1", "env2": "2", "env3": "3", "env4": "4"]
+        let launch = ["arg1": true, "arg2": true, "arg3": false, "arg4": true]
 
         let buildAction = BuildAction.test(targets: [TargetReference(projectPath: projectPath, name: "App")])
         let runAction = RunAction.test(configurationName: "Release",
                                        executable: TargetReference(projectPath: projectPath, name: "App"),
-                                       arguments: Arguments(environment: ["a": "b"], launch: ["some": true]))
+                                       arguments: Arguments(environment: environment, launch: launch))
         let scheme = Scheme.test(buildAction: buildAction, runAction: runAction)
 
-        let app = Target.test(name: "App", product: .app, environment: ["a": "b"])
+        let app = Target.test(name: "App", product: .app, environment: environment)
 
         let project = Project.test(path: projectPath, targets: [app])
         let graph = Graph.create(dependencies: [(project: project, target: app, dependencies: [])])
@@ -371,7 +373,18 @@ final class SchemesGeneratorTests: XCTestCase {
         let buildableReference = try XCTUnwrap(result.runnable?.buildableReference)
 
         XCTAssertEqual(result.buildConfiguration, "Release")
-        XCTAssertEqual(result.environmentVariables, [XCScheme.EnvironmentVariable(variable: "a", value: "b", enabled: true)])
+        XCTAssertEqual(result.commandlineArguments, XCScheme.CommandLineArguments(arguments: [
+            XCScheme.CommandLineArguments.CommandLineArgument(name: "arg1", enabled: true),
+            XCScheme.CommandLineArguments.CommandLineArgument(name: "arg2", enabled: true),
+            XCScheme.CommandLineArguments.CommandLineArgument(name: "arg3", enabled: false),
+            XCScheme.CommandLineArguments.CommandLineArgument(name: "arg4", enabled: true),
+        ]))
+        XCTAssertEqual(result.environmentVariables, [
+            XCScheme.EnvironmentVariable(variable: "env1", value: "1", enabled: true),
+            XCScheme.EnvironmentVariable(variable: "env2", value: "2", enabled: true),
+            XCScheme.EnvironmentVariable(variable: "env3", value: "3", enabled: true),
+            XCScheme.EnvironmentVariable(variable: "env4", value: "4", enabled: true),
+        ])
         XCTAssertEqual(buildableReference.referencedContainer, "container:Projects/Project/Project.xcodeproj")
         XCTAssertEqual(buildableReference.buildableName, "App.app")
         XCTAssertEqual(buildableReference.blueprintName, "App")


### PR DESCRIPTION
### Short description 📝

Running `tuist generate` second time without modifying the project can result in unexpected differences in project `.xcscheme` files.

### Solution 📦

Sort both arguments and environment variables by name during the generation process.

### Implementation 👩‍💻👨‍💻

- [x] Update integration tests to cover schemes generation 
- [x] Sort arguments and environment variables
- [x] Update CHANGELOG
