### PR TITLE
Add defaultConfigurationName to generated projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Ensure custom search path settings are included in generated projects https://github.com/tuist/tuist/pull/751 by @kwridan
 - Remove duplicate HEADER_SEARCH_PATHS https://github.com/tuist/tuist/pull/787 by @kwridan
 - Fix unstable scheme generation https://github.com/tuist/tuist/pull/790 by @marciniwanicki
+- Add defaultConfigurationName to generated projects https://github.com/tuist/tuist/pull/793 by @kwridan
 
 ## 0.19.0
 

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -39,6 +39,7 @@ final class ConfigGenerator: ConfigGenerating {
                                fileElements: ProjectFileElements) throws -> XCConfigurationList {
         /// Configuration list
         let defaultConfiguration = project.settings.defaultReleaseBuildConfiguration()
+            ?? project.settings.defaultDebugBuildConfiguration()
         let configurationList = XCConfigurationList(buildConfigurations: [],
                                                     defaultConfigurationName: defaultConfiguration?.name)
         pbxproj.add(object: configurationList)
@@ -63,6 +64,7 @@ final class ConfigGenerator: ConfigGenerating {
                               graph: Graphing,
                               sourceRootPath: AbsolutePath) throws {
         let defaultConfiguration = projectSettings.defaultReleaseBuildConfiguration()
+            ?? projectSettings.defaultDebugBuildConfiguration()
         let configurationList = XCConfigurationList(buildConfigurations: [],
                                                     defaultConfigurationName: defaultConfiguration?.name)
         pbxproj.add(object: configurationList)

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -38,7 +38,9 @@ final class ConfigGenerator: ConfigGenerating {
                                pbxproj: PBXProj,
                                fileElements: ProjectFileElements) throws -> XCConfigurationList {
         /// Configuration list
-        let configurationList = XCConfigurationList(buildConfigurations: [])
+        let defaultConfiguration = project.settings.defaultReleaseBuildConfiguration()
+        let configurationList = XCConfigurationList(buildConfigurations: [],
+                                                    defaultConfigurationName: defaultConfiguration?.name)
         pbxproj.add(object: configurationList)
 
         try project.settings.configurations.sortedByBuildConfigurationName().forEach {
@@ -60,7 +62,9 @@ final class ConfigGenerator: ConfigGenerating {
                               fileElements: ProjectFileElements,
                               graph: Graphing,
                               sourceRootPath: AbsolutePath) throws {
-        let configurationList = XCConfigurationList(buildConfigurations: [])
+        let defaultConfiguration = projectSettings.defaultReleaseBuildConfiguration()
+        let configurationList = XCConfigurationList(buildConfigurations: [],
+                                                    defaultConfigurationName: defaultConfiguration?.name)
         pbxproj.add(object: configurationList)
         pbxTarget.buildConfigurationList = configurationList
 

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -216,6 +216,49 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         assert(config: releaseConfig, contains: expectedSettings)
     }
 
+    func test_generateProjectConfig_defaultConfigurationName() throws {
+        // Given
+        let settings = Settings(configurations: [
+            .debug("CustomDebug"): nil,
+            .debug("AnotherDebug"): nil,
+            .release("CustomRelease"): nil,
+        ])
+        let project = Project.test(settings: settings)
+
+        // When
+        let result = try subject.generateProjectConfig(project: project,
+                                                       pbxproj: pbxproj,
+                                                       fileElements: ProjectFileElements())
+
+        // Then
+        XCTAssertEqual(result.defaultConfigurationName, "CustomRelease")
+    }
+
+    func test_generateTargetConfig_defaultConfigurationName() throws {
+        // Given
+        let projectSettings = Settings(configurations: [
+            .debug("CustomDebug"): nil,
+            .debug("AnotherDebug"): nil,
+            .release("CustomRelease"): nil,
+        ])
+        let target = Target.test()
+
+        // When
+        try subject.generateTargetConfig(target,
+                                         pbxTarget: pbxTarget,
+                                         pbxproj: pbxproj,
+                                         projectSettings: projectSettings,
+                                         fileElements: ProjectFileElements(),
+                                         graph: Graph.test(),
+                                         sourceRootPath: AbsolutePath("/project"))
+
+        // Then
+        let result = pbxTarget.buildConfigurationList
+        XCTAssertEqual(result?.defaultConfigurationName, "CustomRelease")
+    }
+
+    // MARK: - Helpers
+
     private func generateProjectConfig(config _: BuildConfiguration) throws {
         let dir = try TemporaryDirectory(removeTreeOnDeinit: true)
         let xcconfigsDir = dir.path.appending(component: "xcconfigs")
@@ -300,8 +343,6 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
                                              graph: graph,
                                              sourceRootPath: dir.path)
     }
-
-    // MARK: - Helpers
 
     func assert(config: XCBuildConfiguration?,
                 contains settings: [String: String],

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -234,6 +234,23 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         XCTAssertEqual(result.defaultConfigurationName, "CustomRelease")
     }
 
+    func test_generateProjectConfig_defaultConfigurationName_whenNoReleaseConfiguration() throws {
+        // Given
+        let settings = Settings(configurations: [
+            .debug("CustomDebug"): nil,
+            .debug("AnotherDebug"): nil,
+        ])
+        let project = Project.test(settings: settings)
+
+        // When
+        let result = try subject.generateProjectConfig(project: project,
+                                                       pbxproj: pbxproj,
+                                                       fileElements: ProjectFileElements())
+
+        // Then
+        XCTAssertEqual(result.defaultConfigurationName, "AnotherDebug")
+    }
+
     func test_generateTargetConfig_defaultConfigurationName() throws {
         // Given
         let projectSettings = Settings(configurations: [
@@ -255,6 +272,28 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         // Then
         let result = pbxTarget.buildConfigurationList
         XCTAssertEqual(result?.defaultConfigurationName, "CustomRelease")
+    }
+
+    func test_generateTargetConfig_defaultConfigurationName_whenNoReleaseConfiguration() throws {
+        // Given
+        let projectSettings = Settings(configurations: [
+            .debug("CustomDebug"): nil,
+            .debug("AnotherDebug"): nil,
+        ])
+        let target = Target.test()
+
+        // When
+        try subject.generateTargetConfig(target,
+                                         pbxTarget: pbxTarget,
+                                         pbxproj: pbxproj,
+                                         projectSettings: projectSettings,
+                                         fileElements: ProjectFileElements(),
+                                         graph: Graph.test(),
+                                         sourceRootPath: AbsolutePath("/project"))
+
+        // Then
+        let result = pbxTarget.buildConfigurationList
+        XCTAssertEqual(result?.defaultConfigurationName, "AnotherDebug")
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
Part of: https://github.com/tuist/tuist/issues/659

### Short description 📝

Generated projects were missing the `defaultConfigurationName` attribute. This led to Xcode sometimes modifying the generated project to fix this whenever a modification is made

### Solution 📦

To resolve this, we can set the project's default release configuration as the defaultConfigurationName

### Implementation 👩‍💻👨‍💻

- [x] Update `ConfigGenerator`
- [x] Update changelog

### Test Plan 🛠

- Run `tuist generate` within `fixtures/ios_app_with_multi_configs`
- Verify the generated projects include `defaultConfigurationName` attribute in the generated pbxproj file
- Verify it's set to Release
