### PR TITLE
Added glob pattern to exclude files from target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+- Support ignoring specific source file pattern when adding them to the target https://github.com/tuist/tuist/pull/811 by @vytis
+
 ## 1.0.1
 
 ### Fixed

--- a/Sources/ProjectDescription/SourceFilesList.swift
+++ b/Sources/ProjectDescription/SourceFilesList.swift
@@ -5,6 +5,9 @@ public struct SourceFileGlob: ExpressibleByStringLiteral, Codable, Equatable {
     /// Relative glob pattern.
     public let glob: Path
 
+    /// Relative glob pattern for excluded files
+    public let excluding: Path?
+
     /// Compiler flags.
     public let compilerFlags: String?
 
@@ -13,8 +16,9 @@ public struct SourceFileGlob: ExpressibleByStringLiteral, Codable, Equatable {
     /// - Parameters:
     ///   - glob: Relative glob pattern.
     ///   - compilerFlags: Compiler flags.
-    public init(_ glob: Path, compilerFlags: String? = nil) {
+    public init(_ glob: Path, excluding: Path? = nil, compilerFlags: String? = nil) {
         self.glob = glob
+        self.excluding = excluding
         self.compilerFlags = compilerFlags
     }
 

--- a/Sources/TuistKit/Generator/GeneratorModelLoader.swift
+++ b/Sources/TuistKit/Generator/GeneratorModelLoader.swift
@@ -296,7 +296,9 @@ extension TuistCore.Target {
 
         let settings = try manifest.settings.map { try TuistCore.Settings.from(manifest: $0, path: path, generatorPaths: generatorPaths) }
         let sources = try TuistCore.Target.sources(projectPath: path, sources: manifest.sources?.globs.map {
-            (glob: try generatorPaths.resolve(path: $0.glob).pathString, compilerFlags: $0.compilerFlags)
+            let glob = try generatorPaths.resolve(path: $0.glob).pathString
+            let excluding = try $0.excluding.map { try generatorPaths.resolve(path: $0).pathString }
+            return (glob: glob, excluding: excluding, compilerFlags: $0.compilerFlags)
         } ?? [])
 
         let resourceFilter = { (path: AbsolutePath) -> Bool in

--- a/Tests/TuistCoreTests/Models/TargetTests.swift
+++ b/Tests/TuistCoreTests/Models/TargetTests.swift
@@ -61,8 +61,8 @@ final class TargetTests: TuistUnitTestCase {
         // When
         let sources = try Target.sources(projectPath: temporaryPath,
                                          sources: [
-                                             (glob: temporaryPath.appending(RelativePath("sources/**")).pathString, compilerFlags: nil),
-                                             (glob: temporaryPath.appending(RelativePath("sources/**")).pathString, compilerFlags: nil),
+                                             (glob: temporaryPath.appending(RelativePath("sources/**")).pathString, excluding: nil, compilerFlags: nil),
+                                             (glob: temporaryPath.appending(RelativePath("sources/**")).pathString, excluding: nil, compilerFlags: nil),
                                          ])
 
         // Then
@@ -74,6 +74,34 @@ final class TargetTests: TuistUnitTestCase {
             "sources/c.mm",
             "sources/d.c",
             "sources/e.cpp",
+        ]))
+    }
+
+    func test_sources_excluding() throws {
+        // Given
+        let temporaryPath = try self.temporaryPath()
+        try createFiles([
+            "sources/a.swift",
+            "sources/b.swift",
+            "sources/aTests.swift",
+            "sources/bTests.swift",
+            "sources/kTests.kt",
+        ])
+
+        // When
+        let sources = try Target.sources(projectPath: temporaryPath,
+                                         sources: [(
+                                                glob: temporaryPath.appending(RelativePath("sources/**")).pathString,
+                                                excluding: temporaryPath.appending(RelativePath("sources/**/*Tests.swift")).pathString,
+                                                compilerFlags: nil
+                                            )])
+
+        // Then
+        let relativeSources = sources.map { $0.path.relative(to: temporaryPath).pathString }
+
+        XCTAssertEqual(Set(relativeSources), Set([
+            "sources/a.swift",
+            "sources/b.swift"
         ]))
     }
 

--- a/website/markdown/docs/usage/projectswift.mdx
+++ b/website/markdown/docs/usage/projectswift.mdx
@@ -332,6 +332,14 @@ It represents a glob pattern that refers to source files and the compiler flags 
       default: '',
     },
     {
+      name: 'Excluding',
+      description: 'Glob pattern for source files that will be excluded.',
+      type: 'Path',
+      typeLink: '#path',
+      optional: true,
+      default: 'nil',
+    },
+    {
       name: 'Compiler flags',
       description:
         'The compiler flags to be set to the source files in the sources build phase.',


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/808

### Short description 📝

Adding a way to specify which files should be ignored by a target.

### Solution 📦

Added `excluding` glob to `SourceFileGlob` that is later used when resolving which files are included in the target.

### Implementation 👩‍💻👨‍💻

- [x] Added `excluding` variable
- [x] Making sure to not include ignored files in the target source file list
- [x] Added a simple test
- [x] Updated documentation
