### PR TITLE
Some documentation tweaks

### DIFF
--- a/website/markdown/docs/usage/dependencies.mdx
+++ b/website/markdown/docs/usage/dependencies.mdx
@@ -1,6 +1,6 @@
 ---
 name: Dependencies
-order: 5
+order: 4
 exceprt: Defining dependencies between modules is a straightforward task in Tuist. This document describes how to use this feature, and all types of dependencies that targets can define.
 ---
 

--- a/website/markdown/docs/usage/getting-started.mdx
+++ b/website/markdown/docs/usage/getting-started.mdx
@@ -95,7 +95,3 @@ tuist generate --project-only
 ```
 
 This will generate an Xcode project for the local project only.
-
-### Editing the Project.swift
-
-Did you realize that there's a target, `MyApp_Manifest`, which contains the manifest file? Thanks to the Swift types system and Xcode, you can edit the manifest file from Xcode and get syntax auto**-**completion, documentation and errors while you are modifying the definition. Isn't it great?

--- a/website/markdown/docs/usage/graph.mdx
+++ b/website/markdown/docs/usage/graph.mdx
@@ -1,10 +1,10 @@
 ---
-name: Dependencies graph
-order: 8
+name: Graph command
+order: 9
 excerpt: For modular projects, having access to the dependencies graph is key to make decisions on the project structure. This document introduces the graph command, that can be used to export graphs of your projects.
 ---
 
-# Graph
+# Generating the dependency graph
 
 When projects grow, it becomes hard to visualize the dependencies between all the targets that are part of the project. Fortunately, Tuist provides a command, `tuist graph`, that loads your project dependencies graph and exports it in a representable format.
 

--- a/website/markdown/docs/usage/managing-versions.mdx
+++ b/website/markdown/docs/usage/managing-versions.mdx
@@ -1,6 +1,6 @@
 ---
 name: Managing versions
-order: 9
+order: 6
 excerpt: Tuist comes with its own version management that is deterministic and ensures that everyone in the team uses the same version of Tuist. This document explains how to use it, and what are the commands available to pin projects or the environment to specific versions of Tuist.
 ---
 

--- a/website/markdown/docs/usage/project-editing.mdx
+++ b/website/markdown/docs/usage/project-editing.mdx
@@ -1,6 +1,6 @@
 ---
-name: Editing your projects
-order: 7
+name: Edit command
+order: 8
 excerpt: This document introduces the edit command that users can use to edit their manifest files using Xcode and therefore taking advantage of inline documentation and syntax autocompletion.
 ---
 

--- a/website/markdown/docs/usage/setup.mdx
+++ b/website/markdown/docs/usage/setup.mdx
@@ -1,6 +1,6 @@
 ---
-name: Set up the environment
-order: 6
+name: Up command
+order: 7
 excerpt: This document describes the Setup manifest file, which developers can use to describe how to set up the environment to be able to work on the project. For example, we could indicate that our project requires Carthage to be installed in the system and 'tuist up' will take care of that.
 ---
 

--- a/website/markdown/docs/usage/tuistconfigswift.mdx
+++ b/website/markdown/docs/usage/tuistconfigswift.mdx
@@ -1,6 +1,6 @@
 ---
 name: Configuration
-order: 4
+order: 5
 excerpt: This page documents how to use the TuistConfig manifest file to configure Tuist's functionalities globally.
 ---
 


### PR DESCRIPTION
### Short description 📝
- Rename the pages that document commands to "xxx command". It makes it easier for users to find where's the documentation for a specific command.
- Change the sidebar order moving the command pages at the bottom, and placing the dependencies documentation before the configuration one.
- Remove a piece from the "getting started" page that says that projects contain a manifest target to edit the manifest files. This is no longer true because that's what we have the "tuist edit" command for.

<img width="234" alt="image" src="https://user-images.githubusercontent.com/663605/71153116-99149f80-2238-11ea-89e0-35a2534c6b6d.png">
