### PR TITLE
Add related test targets as testables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
-- Support ignoring specific source file pattern when adding them to the target https://github.com/tuist/tuist/pull/811 by @vytis
+- Support ignoring specific source file pattern when adding them to the target https://github.com/tuist/tuist/pull/811 by @vytis.
+- Made targets testable if there is a corresponding test target https://github.com/tuist/tuist/pull/818 by @vytis.
 
 ### Added
 

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -58,6 +58,12 @@ public protocol Graphing: AnyObject, Encodable {
     ///   - name: Name of the target.
     func targetDependencies(path: AbsolutePath, name: String) -> [TargetNode]
 
+    /// Returns all test targets directly dependent on the given target
+    /// - Parameters:
+    ///   - path: Path to the directory where the project that defines the target is located.
+    ///   - name: Name of the target.
+    func testTargetsDependingOn(path: AbsolutePath, name: String) -> [TargetNode]
+
     /// Returns all non-transitive target static dependencies for the given target.
     /// - Parameters:
     ///   - path: Path to the directory where the project that defines the target is located.
@@ -238,6 +244,15 @@ public class Graph: Graphing {
 
         return targetNode.targetDependencies
             .filter { $0.path == path }
+    }
+
+    public func testTargetsDependingOn(path: AbsolutePath, name: String) -> [TargetNode] {
+        guard let targetNode = findTargetNode(path: path, name: name) else {
+            return []
+        }
+        return targets(at: path)
+        .filter { $0.target.product.testsBundle }
+        .filter { $0.targetDependencies.contains(targetNode) }
     }
 
     public func staticDependencies(path: AbsolutePath, name: String) -> [GraphDependencyReference] {

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -41,6 +41,11 @@ public protocol Graphing: AnyObject, Encodable {
     /// Returns all the targets that are part of the graph.
     var targets: [TargetNode] { get }
 
+    /// Returns all target nodes at a given path (i.e. all target nodes in a project)
+    /// - Parameters:
+    ///   - path: Path to the directory where the project is located
+    func targets(at path: AbsolutePath) -> [TargetNode]
+
     /// Returns the target with the given name and at the given directory.
     /// - Parameters:
     ///   - path: Path to the directory where the project that defines the target is located.
@@ -213,6 +218,13 @@ public class Graph: Graphing {
 
     public var targets: [TargetNode] {
         cache.targetNodes.flatMap { $0.value.values }
+    }
+
+    public func targets(at path: AbsolutePath) -> [TargetNode] {
+        guard let nodes = cache.targetNodes[path] else {
+            return []
+        }
+        return Array(nodes.values)
     }
 
     public func target(path: AbsolutePath, name: String) -> TargetNode? {

--- a/Sources/TuistGenerator/Generator/SchemesGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemesGenerator.swift
@@ -126,15 +126,10 @@ final class SchemesGenerator: SchemesGenerating {
         
         if target.product.testsBundle {
             testTargets = [TestableTarget(target: targetReference)]
-        } else if let targetNode = graph.findTargetNode(path: project.path, name: target.name) {
-            // Find all test targets that depend on this target
-            testTargets = graph.targets(at: project.path)
-                .filter { $0.target.product.testsBundle }
-                .filter { $0.targetDependencies.contains(targetNode) }
+        } else {
+            testTargets = graph.testTargetsDependingOn(path: project.path, name: target.name)
                 .map { TargetReference.project(path: $0.project.path, target: $0.target.name) }
                 .map { TestableTarget(target: $0) }
-        } else {
-            testTargets = []
         }
         
         return Scheme(name: target.name,

--- a/Sources/TuistGenerator/Generator/SchemesGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemesGenerator.swift
@@ -119,7 +119,7 @@ final class SchemesGenerator: SchemesGenerating {
         if fileHandler.exists(sharedPath) { try fileHandler.delete(sharedPath) }
     }
     
-    private func createDefaultScheme(target: Target, project: Project, buildConfiguration: String, graph: Graphing) -> Scheme {
+    func createDefaultScheme(target: Target, project: Project, buildConfiguration: String, graph: Graphing) -> Scheme {
         let targetReference = TargetReference.project(path: project.path, target: target.name)
         
         let testTargets: [TestableTarget]


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/569

### Short description 📝

It should be possible to run tests if target has any test targets.

### Solution 📦

This PR finds all related test targets to the test scheme. It was already done for test targets themselves, but the functionality was extended to include all other targets.

### Implementation 👩‍💻👨‍💻

- [x] Added implementation
- [x] Added tests

### Test Plan 🛠

Run with `app_with_framework_and_tests` fixture and check that in generated schemes:

#### Previous behaviour didn't break
1. `AppTests` scheme has `AppTests` as a testable target.
1. `FrameworkTests` scheme has `FrameworkTests` as a testable target.

#### New behaviour works as expected
1. `App` scheme has `AppTests` as a testable target.
1. `Framework` scheme has `FrameworkTests` as a testable target.
