### PR TITLE
Configure all workflows to run on every push

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -1,30 +1,6 @@
 name: Tuist
 
-on:
-  push:
-    paths:
-      - Sources/**/*
-      - Tests/**/*
-      - Gemfile*
-      - Rakefile
-      - Package.swift
-      - Package.resolved
-      - script/**/*
-      - fixtures/**/*
-      - features/**/*
-      - .github/workflows/tuist.yml
-  pull_request:
-    paths:
-      - Sources/**/*
-      - Tests/**/*
-      - Gemfile*
-      - Rakefile
-      - Package.swift
-      - Package.resolved
-      - script/**/*
-      - fixtures/**/*
-      - features/**/*
-      - .github/workflows/tuist.yml
+on: ['push', 'pull_request']
 
 jobs:
   unit_tests:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,12 +1,6 @@
 name: Website
 
-on:
-  push:
-    paths:
-      - website/**/*
-  pull_request:
-    paths:
-      - website/**/*
+on: ['push', 'pull_request']
 
 jobs:
   build:


### PR DESCRIPTION
### Short description 📝
To prevent some merges from breaking the CI workflows, I'm setting them up to run on every push and pull request. Since they run in parallel and are fairly fast, it's ok to run all of them in every push.