### PR TITLE
Document some best practices around dependencies and the file structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Added
+
+- Best practices page to the documentation https://github.com/tuist/tuist/pull/843 by @pepibumur.
+
 ## 1.1.0
 
 ### Changed

--- a/website/markdown/docs/usage/best-practices.mdx
+++ b/website/markdown/docs/usage/best-practices.mdx
@@ -1,7 +1,7 @@
 ---
 name: Best practices
 order: 9
-exceprt: Xcode being weakly opinionated in regards to the project structure might result in complex and hard to manage project. To prevent that, this document describes best practices that users of Tuist can follow to have projects that are optimal and easy to reason about.
+excerpt: Xcode being weakly opinionated in regards to the project structure might result in complex and hard to manage project. To prevent that, this document describes best practices that users of Tuist can follow to have projects that are optimal and easy to reason about.
 ---
 
 # Best practices

--- a/website/markdown/docs/usage/best-practices.mdx
+++ b/website/markdown/docs/usage/best-practices.mdx
@@ -1,0 +1,32 @@
+---
+name: Best practices
+order: 9
+exceprt: Xcode being weakly opinionated in regards to the project structure might result in complex and hard to manage project. To prevent that, this document describes best practices that users of Tuist can follow to have projects that are optimal and easy to reason about.
+---
+
+# Best practices
+
+Although Tuist defaults to some conventions on the projects that are initialized with Tuist, its API doesn't enforce them purposedly to ease the adoption of the tool. Very often, Xcode projects end up being complex because Xcode is weakly opinionated about the project structure. As long as the build system is able to process build settings and phases and output valid, it's all good.
+
+**Complex and non-conventional projects** are undesirable because they are hard to reason about and might lead to compilation errors. The result of that is that only a few people in the team can make well-informed decisions to scale up the project. In other words, your team ends up with a high [bus factor](https://en.wikipedia.org/wiki/Bus_factor).
+
+The good news is that Tuist is an excellent tool to **codify conventions**: _how files are structured in frameworks, how frameworks should be named,
+how resources should be bundled._ Although they are not necessary to benefit from Tuist, we encourage spending some time defining them for your project and codifying them in your project manifests.
+
+This document contains a list of recommendations for conventions that we'd follow to **ease scaling up** your projects.
+
+## Dependencies
+
+- **Explicit definition:** Dependencies can be defined implicitly through build settings. Xcode is smart enough to detect them and determine the order in which targets should be built. Although implicitness might work fine in small projects, as they get larger, it might turn into a source of issues and slowness. Default to explicit definition of dependencies using the [dependencies API](/docs/usage/dependencies/) that Tuist provides. Tuist has handy built-in features such as [tuist graph](/docs/usage/graph/) or detection of circular dependencies that rely on dependencies being explicitly defined.
+
+## File structure
+
+- **Keep it simple:** Although the API for defining a list of files is very flexible, we discourage having a complex file structure because they increase the project generation time and make it hard for developers to spot at glance what belongs to what. A complex file structure is a structure where files of different nature are placed alongside and require the usage of glob patterns and excluded files that are expensive to resolve.
+
+```swift
+// Recommended
+let target = Target(name: "MyFramework", sources: ["MyFramework/Sources"])
+
+// Discouraged
+let target = Target(name: "MyFramework", sources: ["MyFramework/**/*.swift"])
+```


### PR DESCRIPTION
### Context 📝
Although Tuist defaults to some conventions for the projects generated with `tuist init`, we give developers the flexibility to design the structure of their projects and codify them into the manifests and helpers.

Being weakly opinionated eases the adoption of the tool because they just need to map the definition from the `.xcodeproj` domain to Tuist's domain.

### What 📦
I'm adding  a new page to the documentation, `Best practices`, where we include some recommendations for best practices on how to structure the projects. As stated in the page, it's not necessary to follow them in order to benefit from Tuist but we encourage doing so.