### PR TITLE
Fix: Project.swift example from "Getting Started" does not compile

### DIFF
--- a/website/markdown/docs/usage/getting-started.mdx
+++ b/website/markdown/docs/usage/getting-started.mdx
@@ -73,6 +73,7 @@ let project = Project(name: "MyApp",
                                dependencies: [
                                     .target(name: "MyApp")
                                ])
+                      ])
 ```
 
 Since we are defining an Xcode project, most of the properties might be familiar to you. There are some that are available which are not used from the manifest that you've got generated. You can [check out](https://tuist.github.io/tuist/index.html) the project reference to see all the public models that are available in the `ProjectDescription` framework.


### PR DESCRIPTION
### Short description 📝

Example `Project.swift` in "Getting started" section of the website doesn't compile because of missing brackets.

### Solution 📦

Add the brackets 😎 