### PR TITLE
Fix clickable elements too close together

### DIFF
--- a/website/src/components/header.jsx
+++ b/website/src/components/header.jsx
@@ -78,7 +78,11 @@ export default () => {
                 }}
               >
                 <Link
-                  sx={{ ...linkStyle, ...(isDocs ? hoverStyle : {}) }}
+                  sx={{
+                    ...linkStyle,
+                    ...(isDocs ? hoverStyle : {}),
+                    my: [2, 0, 0],
+                  }}
                   to={firstDocumentationPagePath}
                 >
                   DOCS
@@ -87,6 +91,7 @@ export default () => {
                   sx={{
                     ...linkStyle,
                     ...(isBlog ? hoverStyle : {}),
+                    my: [2, 0, 0],
                     ml: [0, 0, 4],
                   }}
                   to="/blog"
@@ -98,6 +103,7 @@ export default () => {
                   sx={{
                     ...linkStyle,
                     ...(isFaq ? hoverStyle : {}),
+                    my: [2, 0, 0],
                     ml: [0, 0, 4],
                   }}
                   to="/faq"
@@ -108,6 +114,7 @@ export default () => {
                 <a
                   sx={{
                     ...linkStyle,
+                    my: [2, 0, 0],
                     ml: [0, 0, 4],
                     display: 'flex',
                     flexDirection: 'row',
@@ -121,12 +128,13 @@ export default () => {
                   <FontAwesomeIcon
                     sx={{ ml: 2, mt: -1 }}
                     icon={faGithub}
-                    size="s"
+                    size="sm"
                   />
                 </a>
                 <a
                   sx={{
                     ...linkStyle,
+                    my: [2, 0, 0],
                     ml: [0, 0, 4],
                     display: 'flex',
                     flexDirection: 'row',
@@ -140,7 +148,7 @@ export default () => {
                   <FontAwesomeIcon
                     sx={{ ml: 2, mt: -1 }}
                     icon={faSlack}
-                    size="s"
+                    size="sm"
                   />
                 </a>
               </div>

--- a/website/src/templates/documentation.jsx
+++ b/website/src/templates/documentation.jsx
@@ -27,39 +27,46 @@ const DocumentationPage = ({
       >
         <aside
           sx={{
+            flex: [1, 'none'],
             px: 3,
             bg: 'gray6',
             mt: 2,
+            width: ['none', 200],
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: ['center', 'flex-start'],
           }}
         >
-          <div sx={{ width: '200px' }}>
-            {documentationCategories.map((category, categoryIndex) => {
-              return (
-                <div key={categoryIndex}>
-                  <Styled.h3>{category.name}</Styled.h3>
-                  {files
-                    .filter(file =>
-                      file.relativeDirectory.endsWith(category.folderName)
-                    )
-                    .map((file, fileIndex) => {
-                      const current =
-                        file.childMdx.fields.slug === mdx.fields.slug
-                      return (
-                        <Link
-                          key={fileIndex}
-                          to={file.childMdx.fields.slug}
-                          sx={{ color: current ? 'primary' : 'gray2' }}
+          {documentationCategories.map((category, categoryIndex) => {
+            return (
+              <div key={categoryIndex}>
+                <Styled.h3 sx={{ textAlign: ['center', 'left'], mt: 4 }}>
+                  {category.name}
+                </Styled.h3>
+                {files
+                  .filter(file =>
+                    file.relativeDirectory.endsWith(category.folderName)
+                  )
+                  .map((file, fileIndex) => {
+                    const current =
+                      file.childMdx.fields.slug === mdx.fields.slug
+                    return (
+                      <Link
+                        key={`${categoryIndex}-${fileIndex}`}
+                        to={file.childMdx.fields.slug}
+                        sx={{ color: current ? 'primary' : 'gray2' }}
+                      >
+                        <Styled.h4
+                          sx={{ textAlign: ['center', 'left'], mt: 3 }}
                         >
-                          <Styled.h4 key={fileIndex}>
-                            {file.childMdx.frontmatter.name}
-                          </Styled.h4>
-                        </Link>
-                      )
-                    })}
-                </div>
-              )
-            })}
-          </div>
+                          {file.childMdx.frontmatter.name}
+                        </Styled.h4>
+                      </Link>
+                    )
+                  })}
+              </div>
+            )
+          })}
         </aside>
         <div
           sx={{


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY

### Short description 📝

The Google web console scrapped the documentation website and reported the following issues because the items in the header and the aside list are too close to each other.

<img width="759" alt="image" src="https://user-images.githubusercontent.com/663605/71666236-6605fc00-2d60-11ea-95e4-c31e7677f0aa.png">

### Solution
Add a bit of margin when the website is open on a mobile device
