### PR TITLE
Fix logo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="assets/tuist.png" width="200" align="center"/>
+<img src="website/static/tuist.png" width="200" align="center"/>
 
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 [![codecov](https://codecov.io/gh/tuist/tuist/branch/master/graph/badge.svg)](https://codecov.io/gh/tuist/tuist)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<img src="website/static/tuist.png" width="200" align="center"/>
+<p align="center">
+    <img src="website/static/tuist.png" width="200" />
+</p>
 
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 [![codecov](https://codecov.io/gh/tuist/tuist/branch/master/graph/badge.svg)](https://codecov.io/gh/tuist/tuist)


### PR DESCRIPTION
### Short description 📝

Noticed the tuist logo in the README was pointing to the wrong path. Also fixed the center aligning.

### Solution 📦

- Found the tuist logo under `tuist/website/static/tuist.png`
- Center aligned logo by wrapping in a `<p>` as per https://gist.github.com/DavidWells/7d2e0e1bc78f4ac59a123ddf8b74932d reference


| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/316931/71763482-897fa100-2f30-11ea-8660-3c35f7cf7b61.png) | ![image](https://user-images.githubusercontent.com/316931/71763489-900e1880-2f30-11ea-9f9a-c5ccff64bd5f.png) |

