### PR TITLE
Docs: Update broken link to "Dependencies"

### DIFF
--- a/website/markdown/docs/usage/projectswift.mdx
+++ b/website/markdown/docs/usage/projectswift.mdx
@@ -135,7 +135,7 @@ For local:
 .package(path: "MyLibrary")
 ```
 
-Targets can then depend on products from these Swift Packages. See [Dependencies](./usage-4-dependencies)
+Targets can then depend on products from these Swift Packages. See [Dependencies](../dependencies)
 
 <Message
   info
@@ -239,7 +239,7 @@ Each target in the list of project targets can be initialized with the following
       name: 'Dependencies',
       description: 'List of target dependencies',
       type: '[TargetDependency]',
-      typeLink: './usage-4-dependencies',
+      typeLink: '../dependencies',
       optional: true,
       default: '[]',
     },


### PR DESCRIPTION
### Short description 📝

A link to "Dependencies" section was broken. It probably was moved at some point and the links were not updated.

### Solution 📦

Update the link.
