### PR TITLE
Add a plugin to fail CI if there are broken links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 - Best practices page to the documentation https://github.com/tuist/tuist/pull/843 by @pepibumur.
+- Fail CI if there are broken links on the website https://github.com/tuist/tuist/pull/917 by @pepibumur.
 
 ### Fixed
 

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -197,6 +197,7 @@ module.exports = {
               yMargin: 24,
             },
           },
+          'gatsby-remark-check-links',
         ],
       },
     },

--- a/website/markdown/docs/contribution/testing-strategy.mdx
+++ b/website/markdown/docs/contribution/testing-strategy.mdx
@@ -10,9 +10,9 @@ Tuist employs a diverse suite tests that help ensure it works as intended and pr
 
 ### Acceptance Tests
 
-Acceptance tests run the built `tuist` command line against a wide range of [fixtures](/https://github.com/tuist/tuist/tree/master/fixtures) and verify its output and results. They are the slowest to run however provide the most coverage. The idea is to **test a few complete scenarios for each major feature**.
+Acceptance tests run the built `tuist` command line against a wide range of [fixtures](https://github.com/tuist/tuist/tree/master/fixtures) and verify its output and results. They are the slowest to run however provide the most coverage. The idea is to **test a few complete scenarios for each major feature**.
 
-Those are written in [Cucumber](https://cucumber.io/docs) and Ruby and can be found in [features](/https://github.com/tuist/tuist/tree/master/features). Those are run when calling `bundle exec rake features`. To run only a test, we can set the `FEATURE` environment variable:
+Those are written in [Cucumber](https://cucumber.io/docs) and Ruby and can be found in [features](https://github.com/tuist/tuist/tree/master/features). Those are run when calling `bundle exec rake features`. To run only a test, we can set the `FEATURE` environment variable:
 
 ```bash
 # 32 is the line where the definition of the test starts

--- a/website/markdown/docs/usage/projectswift.mdx
+++ b/website/markdown/docs/usage/projectswift.mdx
@@ -135,7 +135,7 @@ For local:
 .package(path: "MyLibrary")
 ```
 
-Targets can then depend on products from these Swift Packages. See [Dependencies](../dependencies)
+Targets can then depend on products from these Swift Packages. See [Dependencies](/docs/usage/dependencies/)
 
 <Message
   info

--- a/website/markdown/posts/2018-07-28-introducing-tuist/post.md
+++ b/website/markdown/posts/2018-07-28-introducing-tuist/post.md
@@ -113,7 +113,7 @@ You can check out [the project issues](https://github.com/tuist/tuist/issues) th
 
 ## 📱 Start using it
 
-Would you like to give Tuist a try? You can check out the [Getting started](/guides/1-getting-started) guide that explains how to install the tool and how to bootstrap your first project.
+Would you like to give Tuist a try? You can check out the [Getting started](/docs/usage/getting-started/) guide that explains how to install the tool and how to bootstrap your first project.
 
 ## 📒 Resources
 

--- a/website/package.json
+++ b/website/package.json
@@ -34,6 +34,7 @@
     "gatsby-plugin-sitemap": "^2.2.26",
     "gatsby-plugin-theme-ui": "^0.2.53",
     "gatsby-redirect-from": "^0.2.1",
+    "gatsby-remark-check-links": "^2.1.0",
     "gatsby-remark-images": "^3.1.42",
     "gatsby-remark-smartypants": "^2.1.20",
     "gatsby-remark-social-cards": "https://github.com/pepibumur/gatsby-remark-social-cards.git#0.5.2",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -6636,6 +6636,13 @@ gatsby-redirect-from@^0.2.1:
   resolved "https://registry.yarnpkg.com/gatsby-redirect-from/-/gatsby-redirect-from-0.2.1.tgz#d5041f8730348d4652f1a8a752bca1cf7e86bc75"
   integrity sha512-GLDM1hwOaeh95QFibTMuZORxXUrDXbSX+JOGjLDldDNC2KD8uILO0MNnwqf2UOXytD+5eTHaJAGLNiUjvWOKaw==
 
+gatsby-remark-check-links@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-check-links/-/gatsby-remark-check-links-2.1.0.tgz#8e8a2b1b82ac6c516fcc2074e8f806e2c0d53571"
+  integrity sha512-TbhT8oVlAgJfxe0WUQWDOb0kLkMUYo1N4AfFstejClPWO4OjRlznt3IMW3weQkwuweiovF5cxVpQcFrkCGVFBw==
+  dependencies:
+    unist-util-visit "^1.4.1"
+
 gatsby-remark-images@^3.1.42:
   version "3.1.42"
   resolved "https://registry.yarnpkg.com/gatsby-remark-images/-/gatsby-remark-images-3.1.42.tgz#93a6e191c6af7fafad3966616ea66b4bd5280082"


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/916

### Short description 📝
Adds a plugin to the Gatsby website that fails the build process of the website if there are broken links. CI will fail if that's the case alerting the developer about something to be addressed.