### PR TITLE
Extend URLSessionScheduler to expose a publisher

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -29,6 +29,15 @@
         }
       },
       {
+        "package": "OpenCombine",
+        "repositoryURL": "https://github.com/broadwaylamb/OpenCombine.git",
+        "state": {
+          "branch": null,
+          "revision": "1496bab2724bf6f794cba8ac4d97d2a5013eeba7",
+          "version": "0.8.0"
+        }
+      },
+      {
         "package": "PathKit",
         "repositoryURL": "https://github.com/kylef/PathKit",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,7 @@ let package = Package(
         .package(url: "https://github.com/IBM-Swift/BlueSignals", .upToNextMajor(from: "1.0.21")),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.1")),
         .package(url: "https://github.com/rnine/Checksum.git", .upToNextMajor(from: "1.0.2")),
+        .package(url: "https://github.com/broadwaylamb/OpenCombine.git", .upToNextMajor(from: "0.8.0")),
     ],
     targets: [
         .target(
@@ -68,7 +69,7 @@ let package = Package(
         ),
         .target(
             name: "TuistEnvKit",
-            dependencies: ["SPMUtility", "TuistSupport"]
+            dependencies: ["SPMUtility", "TuistSupport", "OpenCombine", "OpenCombineFoundation"]
         ),
         .testTarget(
             name: "TuistEnvKitTests",
@@ -88,7 +89,7 @@ let package = Package(
         ),
         .target(
             name: "TuistSupport",
-            dependencies: ["SPMUtility", "RxSwift", "RxRelay"]
+            dependencies: ["SPMUtility", "RxSwift", "RxRelay", "OpenCombine", "OpenCombineDispatch"]
         ),
         .target(
             name: "TuistSupportTesting",

--- a/Sources/TuistCore/Models/Target.swift
+++ b/Sources/TuistCore/Models/Target.swift
@@ -117,7 +117,7 @@ public struct Target: Equatable, Hashable {
             // Paths that should be excluded from sources
             let excluded = source.excluding
                 .map { AbsolutePath($0) }
-                .map { (excludePath) in AbsolutePath(excludePath.dirname).glob(excludePath.basename) }
+                .map { excludePath in AbsolutePath(excludePath.dirname).glob(excludePath.basename) }
                 ?? []
 
             Set(base.glob(sourcePath.basename))

--- a/Sources/TuistEnvKit/GitHub/URLSessionScheduler.swift
+++ b/Sources/TuistEnvKit/GitHub/URLSessionScheduler.swift
@@ -1,4 +1,6 @@
 import Foundation
+import OpenCombine
+import OpenCombineFoundation
 
 protocol URLSessionScheduling: AnyObject {
     /// Schedules an URLSession request and returns the result synchronously.
@@ -6,6 +8,10 @@ protocol URLSessionScheduling: AnyObject {
     /// - Parameter request: request to be executed.
     /// - Returns: request's response.
     func schedule(request: URLRequest) -> (error: Error?, data: Data?)
+
+    /// Returns a publisher that sends the given request. The publisher forwards the response data and error to the subscribers.
+    /// - Parameter request: The request to be sent.
+    func publisher(request: URLRequest) -> OpenCombine.AnyPublisher<(data: Data, response: URLResponse), URLError>
 }
 
 final class URLSessionScheduler: URLSessionScheduling {
@@ -32,10 +38,6 @@ final class URLSessionScheduler: URLSessionScheduling {
         self.requestTimeout = requestTimeout
     }
 
-    /// Schedules an URLSession request and returns the result synchronously.
-    ///
-    /// - Parameter request: request to be executed.
-    /// - Returns: request's response.
     func schedule(request: URLRequest) -> (error: Error?, data: Data?) {
         var data: Data?
         var error: Error?
@@ -47,5 +49,9 @@ final class URLSessionScheduler: URLSessionScheduling {
         }.resume()
         _ = semaphore.wait(timeout: .now() + 3)
         return (error: error, data: data)
+    }
+
+    func publisher(request: URLRequest) -> OpenCombine.AnyPublisher<(data: Data, response: URLResponse), URLError> {
+        return URLSession.OCombine.DataTaskPublisher(request: request, session: session).eraseToAnyPublisher()
     }
 }

--- a/Sources/TuistEnvKit/GitHub/URLSessionScheduler.swift
+++ b/Sources/TuistEnvKit/GitHub/URLSessionScheduler.swift
@@ -52,6 +52,6 @@ final class URLSessionScheduler: URLSessionScheduling {
     }
 
     func publisher(request: URLRequest) -> OpenCombine.AnyPublisher<(data: Data, response: URLResponse), URLError> {
-        return URLSession.OCombine.DataTaskPublisher(request: request, session: session).eraseToAnyPublisher()
+        URLSession.OCombine.DataTaskPublisher(request: request, session: session).eraseToAnyPublisher()
     }
 }

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -76,11 +76,11 @@ final class ConfigGenerator: ConfigGenerating {
         let buildConfigurations = Set(projectBuildConfigurations).union(targetBuildConfigurations)
         let configurationsTuples: [(BuildConfiguration, Configuration?)] = buildConfigurations
             .map { buildConfiguration in
-            if let configuration = target.settings?.configurations[buildConfiguration] {
-                return (buildConfiguration, configuration)
+                if let configuration = target.settings?.configurations[buildConfiguration] {
+                    return (buildConfiguration, configuration)
+                }
+                return (buildConfiguration, nil)
             }
-            return (buildConfiguration, nil)
-        }
         let configurations = Dictionary(uniqueKeysWithValues: configurationsTuples)
         let nonEmptyConfigurations = !configurations.isEmpty ? configurations : Settings.default.configurations
         let orderedConfigurations = nonEmptyConfigurations.sortedByBuildConfigurationName()

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -76,11 +76,11 @@ final class ConfigGenerator: ConfigGenerating {
         let buildConfigurations = Set(projectBuildConfigurations).union(targetBuildConfigurations)
         let configurationsTuples: [(BuildConfiguration, Configuration?)] = buildConfigurations
             .map { buildConfiguration in
-                if let configuration = target.settings?.configurations[buildConfiguration] {
-                    return (buildConfiguration, configuration)
-                }
-                return (buildConfiguration, nil)
+            if let configuration = target.settings?.configurations[buildConfiguration] {
+                return (buildConfiguration, configuration)
             }
+            return (buildConfiguration, nil)
+        }
         let configurations = Dictionary(uniqueKeysWithValues: configurationsTuples)
         let nonEmptyConfigurations = !configurations.isEmpty ? configurations : Settings.default.configurations
         let orderedConfigurations = nonEmptyConfigurations.sortedByBuildConfigurationName()

--- a/Sources/TuistSupport/Combine/Publisher+Blocking.swift
+++ b/Sources/TuistSupport/Combine/Publisher+Blocking.swift
@@ -1,0 +1,29 @@
+import Foundation
+import OpenCombine
+
+public extension OpenCombine.Publisher {
+    /// Waits for the publisher to complete and then returns the values or the error.
+    /// This method blocks the thread from which it's called from so it should be used cautiously.
+    func wait() throws -> [Output] {
+        var output: [Self.Output] = []
+        var error: Self.Failure?
+
+        let semaphore = DispatchSemaphore(value: 0)
+        _ = handleEvents(receiveOutput: { _output in
+            output.append(_output)
+        }, receiveCompletion: { completion in
+            if case let .failure(_error) = completion {
+                error = _error
+            }
+            semaphore.signal()
+        }, receiveCancel: {
+            semaphore.signal()
+        })
+        semaphore.wait()
+
+        if let error = error {
+            throw error
+        }
+        return output
+    }
+}

--- a/Sources/TuistSupport/Combine/Publisher+Blocking.swift
+++ b/Sources/TuistSupport/Combine/Publisher+Blocking.swift
@@ -9,11 +9,11 @@ public extension OpenCombine.Publisher {
         var error: Self.Failure?
 
         let semaphore = DispatchSemaphore(value: 0)
-        _ = handleEvents(receiveOutput: { _output in
-            output.append(_output)
+        _ = handleEvents(receiveOutput: { receivedOutput in
+            output.append(receivedOutput)
         }, receiveCompletion: { completion in
-            if case let .failure(_error) = completion {
-                error = _error
+            if case let .failure(receivedError) = completion {
+                error = receivedError
             }
             semaphore.signal()
         }, receiveCancel: {

--- a/Tests/TuistCoreTests/Models/TargetTests.swift
+++ b/Tests/TuistCoreTests/Models/TargetTests.swift
@@ -87,15 +87,15 @@ final class TargetTests: TuistUnitTestCase {
             "sources/bTests.swift",
             "sources/kTests.kt",
             "sources/c/c.swift",
-            "sources/c/cTests.swift"
+            "sources/c/cTests.swift",
         ])
 
         // When
         let sources = try Target.sources(projectPath: temporaryPath,
                                          sources: [(
                                              glob: temporaryPath.appending(RelativePath("sources/**")).pathString,
-                                                   excluding: temporaryPath.appending(RelativePath("sources/**/*Tests.swift")).pathString,
-                                                   compilerFlags: nil
+                                             excluding: temporaryPath.appending(RelativePath("sources/**/*Tests.swift")).pathString,
+                                             compilerFlags: nil
                                          )])
 
         // Then
@@ -104,7 +104,7 @@ final class TargetTests: TuistUnitTestCase {
         XCTAssertEqual(Set(relativeSources), Set([
             "sources/a.swift",
             "sources/b.swift",
-            "sources/c/c.swift"
+            "sources/c/c.swift",
         ]))
     }
 

--- a/Tests/TuistCoreTests/Models/TargetTests.swift
+++ b/Tests/TuistCoreTests/Models/TargetTests.swift
@@ -94,8 +94,8 @@ final class TargetTests: TuistUnitTestCase {
         let sources = try Target.sources(projectPath: temporaryPath,
                                          sources: [(
                                              glob: temporaryPath.appending(RelativePath("sources/**")).pathString,
-                                             excluding: temporaryPath.appending(RelativePath("sources/**/*Tests.swift")).pathString,
-                                             compilerFlags: nil
+                                                   excluding: temporaryPath.appending(RelativePath("sources/**/*Tests.swift")).pathString,
+                                                   compilerFlags: nil
                                          )])
 
         // Then

--- a/Tests/TuistEnvKitTests/GitHub/GitHubClientTests .swift
+++ b/Tests/TuistEnvKitTests/GitHub/GitHubClientTests .swift
@@ -23,35 +23,24 @@ final class GitHubClientTests: XCTestCase {
     }
 
     func test_execute_when_returns_an_error() throws {
-        let error = NSError(domain: "test", code: 1, userInfo: nil)
         let request = URLRequest(url: URL(string: "http://test")!)
-        sessionScheduler.scheduleStub = { _request in
-            if _request == request {
-                return (error, nil)
-            } else {
-                return (nil, nil)
-            }
-        }
+        sessionScheduler.stub(request: request, error: URLError(.badServerResponse))
+
         XCTAssertThrowsError(try subject.execute(request: request))
     }
 
     func test_execute_when_returns_no_data() {
         let request = URLRequest(url: URL(string: "http://test")!)
-        sessionScheduler.scheduleStub = { _ in (nil, nil) }
+
         XCTAssertThrowsError(try subject.execute(request: request))
     }
 
     func test_execute_when_returns_data_without_errors() throws {
         let request = URLRequest(url: URL(string: "http://test")!)
-        sessionScheduler.scheduleStub = { _request in
-            if _request == request {
-                let json: [String: Any] = ["test": "test"]
-                let data = try! JSONSerialization.data(withJSONObject: json, options: [])
-                return (nil, data)
-            } else {
-                return (nil, nil)
-            }
-        }
+        let json: [String: Any] = ["test": "test"]
+        let data = try! JSONSerialization.data(withJSONObject: json, options: [])
+        sessionScheduler.stub(request: request, data: data)
+
         let gotData = try subject.execute(request: request)
         let got = try JSONSerialization.jsonObject(with: gotData, options: []) as? [String: String]
         XCTAssertEqual(got?["test"], "test")

--- a/Tests/TuistEnvKitTests/GitHub/Mocks/MockURLSessionScheduler.swift
+++ b/Tests/TuistEnvKitTests/GitHub/Mocks/MockURLSessionScheduler.swift
@@ -1,10 +1,41 @@
 import Foundation
+import OpenCombine
 @testable import TuistEnvKit
 
 final class MockURLSessionScheduler: URLSessionScheduling {
-    var scheduleStub: ((URLRequest) -> (Error?, Data?))?
+    private var stubs: [URLRequest: (error: URLError?, data: Data?)] = [:]
+
+    func stub(request: URLRequest, error: URLError?) {
+        stubs[request] = (error: error, data: nil)
+    }
+
+    func stub(request: URLRequest, data: Data?) {
+        stubs[request] = (error: nil, data: data)
+    }
 
     func schedule(request: URLRequest) -> (error: Error?, data: Data?) {
-        return scheduleStub?(request) ?? (error: nil, data: nil)
+        guard let stub = self.stubs[request] else {
+            return (error: nil, data: nil)
+        }
+        return stub
+    }
+
+    func publisher(request: URLRequest) -> OpenCombine.AnyPublisher<(data: Data, response: URLResponse), URLError> {
+        guard let stub = self.stubs[request] else {
+            return OpenCombine.Fail<(data: Data, response: URLResponse), URLError>(error: URLError(.badServerResponse))
+                .eraseToAnyPublisher()
+        }
+        if let data = stub.data {
+            let response = URLResponse()
+            return OpenCombine.Just<(data: Data, response: URLResponse)>.init((data: data, response: response))
+                .setFailureType(to: URLError.self)
+                .eraseToAnyPublisher()
+        } else if let error = stub.error {
+            return OpenCombine.Fail<(data: Data, response: URLResponse), URLError>(error: error)
+                .eraseToAnyPublisher()
+        } else {
+            return OpenCombine.Fail<(data: Data, response: URLResponse), URLError>(error: URLError(.badServerResponse))
+                .eraseToAnyPublisher()
+        }
     }
 }

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -431,6 +431,6 @@ final class BuildPhaseGeneratorTests: XCTestCase {
     }
 
     private func createFileElements(for headers: Headers) -> ProjectFileElements {
-        return createFileElements(for: headers.public + headers.private + headers.project)
+        createFileElements(for: headers.public + headers.private + headers.project)
     }
 }

--- a/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
@@ -65,11 +65,11 @@ final class StableXcodeProjIntegrationTests: TuistUnitTestCase {
     }
 
     private func findSharedSchemes(in workspace: XCWorkspace) throws -> [XCScheme] {
-        return try findSchemes(in: workspace, relativePath: RelativePath("xcshareddata"))
+        try findSchemes(in: workspace, relativePath: RelativePath("xcshareddata"))
     }
 
     private func findUserSchemes(in workspace: XCWorkspace) throws -> [XCScheme] {
-        return try findSchemes(in: workspace, relativePath: RelativePath("xcuserdata"))
+        try findSchemes(in: workspace, relativePath: RelativePath("xcuserdata"))
     }
 
     private func findSchemes(in workspace: XCWorkspace, relativePath: RelativePath) throws -> [XCScheme] {


### PR DESCRIPTION
### Short description 📝
This PR extends the interface of `URLSessionScheduler` to provide an API using Combine subscribers. Notice that I'm introducing a dependency with [OpenCombine](https://github.com/broadwaylamb/OpenCombine) for that. The reason why I'm doing that instead of using just Combine is because Combine is only compatible with macOS > 10.15. 

Moreover, notice that this means another dependency on a reactive framework. I'm aware of that and the idea is to get rid of RxSwift in favour of Combine, which more and more people will get familiar with. I'll open a follow-up PR getting rid of it and using Combine instead.

The idea is to use this new reactive interface from the installer logic to pull the binaries from Google Cloud Storage instead of GitHub releases.