### PR TITLE
Avoid running GitHub Actions twice

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,7 +1,7 @@
 # https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idname
 name: Checks
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   swiftformat:

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -1,6 +1,6 @@
 name: Tuist
 
-on: ['push', 'pull_request']
+on: ['push']
 
 jobs:
   unit_tests:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,6 +1,6 @@
 name: Website
 
-on: ['push', 'pull_request']
+on: ['push']
 
 jobs:
   build:


### PR DESCRIPTION
### Short description 📝

It seems we are running GitHub Actions on both `push` and  `pull_request` events. This effectively means we run the same checks twice.

### Solution 📦

Trigger action only on `push` event.
