### PR TITLE
Add a tool that checks whether Tuist is running on CI

### DIFF
--- a/Sources/TuistSupport/Utils/CIChecker.swift
+++ b/Sources/TuistSupport/Utils/CIChecker.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public protocol CIChecking: AnyObject {
+    /// Returns true when the environment in which the tuist process is running is a CI environment.
+    func isCI() -> Bool
+}
+
+public final class CIChecker: CIChecking {
+    static let variables = [
+        // GitHub: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables
+        "GITHUB_RUN_ID",
+        // CircleCI: https://circleci.com/docs/2.0/env-vars/
+        // Bitrise: https://devcenter.bitrise.io/builds/available-environment-variables/
+        // Buildkite: https://buildkite.com/docs/pipelines/environment-variables
+        // Travis: https://docs.travis-ci.com/user/environment-variables/
+        "CI",
+        // Jenkins: https://wiki.jenkins.io/display/JENKINS/Building+a+software+project
+        "BUILD_NUMBER",
+    ]
+
+    // MARK: - CIChecking
+
+    public func isCI() -> Bool {
+        isCI(environment: ProcessInfo.processInfo.environment)
+    }
+
+    // MARK: - Internal
+
+    func isCI(environment: [String: String]) -> Bool {
+        environment.first(where: {
+            CIChecker.variables.contains($0.key) && Constants.trueValues.contains($0.value)
+        }) != nil
+    }
+}

--- a/Sources/TuistSupportTesting/Utils/MockCIChecker.swift
+++ b/Sources/TuistSupportTesting/Utils/MockCIChecker.swift
@@ -1,0 +1,10 @@
+import Foundation
+import TuistSupport
+
+public final class MockCIChecker: CIChecking {
+    var isCIStub: Bool = false
+
+    public func isCI() -> Bool {
+        isCIStub
+    }
+}

--- a/Tests/TuistSupportTests/Utils/CICheckerTests.swift
+++ b/Tests/TuistSupportTests/Utils/CICheckerTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import XCTest
+@testable import TuistSupport
+
+final class CICheckerTests: XCTestCase {
+    var subject: CIChecker!
+
+    override func setUp() {
+        super.setUp()
+        subject = CIChecker()
+    }
+
+    override func tearDown() {
+        subject = nil
+        super.tearDown()
+    }
+
+    func testIsCI_when_isCI() {
+        // Given
+        let env = ["CI": "1"]
+
+        // When
+        let got = subject.isCI(environment: env)
+
+        // Then
+        XCTAssertTrue(got)
+    }
+
+    func testIsCI_when_isNotCI() {
+        // Given
+        let env: [String: String] = [:]
+
+        // When
+        let got = subject.isCI(environment: env)
+
+        // Then
+        XCTAssertFalse(got)
+    }
+}


### PR DESCRIPTION
Related https://github.com/tuist/tuist/issues/977

### Short description 📝
There are commands like `tuist cache` that are intended to be used on CI. This PR adds a tool to check whether the Tuist process is running on a CI environment.