### PR TITLE
Fix static products false positive lint warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
+- Fix static products false positive lint warning by https://github.com/tuist/tuist/pull/981 @kwridan.
+
 ### Changed
 
 ## 1.2.0

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -11,25 +11,15 @@ protocol GraphLinting: AnyObject {
 class GraphLinter: GraphLinting {
     // MARK: - Attributes
 
-    let projectLinter: ProjectLinting
+    private let projectLinter: ProjectLinting
+    private let staticProductsLinter: StaticProductsGraphLinting
 
     // MARK: - Init
 
-    init(projectLinter: ProjectLinting = ProjectLinter()) {
+    init(projectLinter: ProjectLinting = ProjectLinter(),
+         staticProductsLinter: StaticProductsGraphLinting = StaticProductsGraphLinter()) {
         self.projectLinter = projectLinter
-    }
-
-    struct StaticDepedencyWarning: Hashable {
-        let fromTargetNode: TargetNode
-        let toTargetNode: GraphNode
-
-        func hash(into hasher: inout Hasher) {
-            hasher.combine(toTargetNode)
-        }
-
-        static func == (lhs: StaticDepedencyWarning, rhs: StaticDepedencyWarning) -> Bool {
-            lhs.toTargetNode == rhs.toTargetNode
-        }
+        self.staticProductsLinter = staticProductsLinter
     }
 
     // MARK: - GraphLinting
@@ -48,13 +38,12 @@ class GraphLinter: GraphLinting {
     func lintDependencies(graph: Graphing) -> [LintingIssue] {
         var issues: [LintingIssue] = []
         var evaluatedNodes: [GraphNode] = []
-        var linkedStaticProducts = Set<StaticDepedencyWarning>()
         graph.entryNodes.forEach {
             issues.append(contentsOf: lintGraphNode(node: $0,
-                                                    evaluatedNodes: &evaluatedNodes,
-                                                    linkedStaticProducts: &linkedStaticProducts))
+                                                    evaluatedNodes: &evaluatedNodes))
         }
 
+        issues.append(contentsOf: staticProductsLinter.lint(graph: graph))
         issues.append(contentsOf: lintCarthageDependencies(graph: graph))
         issues.append(contentsOf: lintCocoaPodsDependencies(graph: graph))
         issues.append(contentsOf: lintPackageDependencies(graph: graph))
@@ -63,8 +52,7 @@ class GraphLinter: GraphLinting {
     }
 
     private func lintGraphNode(node: GraphNode,
-                               evaluatedNodes: inout [GraphNode],
-                               linkedStaticProducts: inout Set<StaticDepedencyWarning>) -> [LintingIssue] {
+                               evaluatedNodes: inout [GraphNode]) -> [LintingIssue] {
         var issues: [LintingIssue] = []
         defer { evaluatedNodes.append(node) }
 
@@ -74,43 +62,17 @@ class GraphLinter: GraphLinting {
         targetNode.dependencies.forEach { toNode in
             if let toTargetNode = toNode as? TargetNode {
                 issues.append(contentsOf: lintDependency(from: targetNode,
-                                                         to: toTargetNode,
-                                                         linkedStaticProducts: &linkedStaticProducts))
-            } else if let toPackageNode = toNode as? PackageProductNode {
-                issues.append(contentsOf: lintPackageDependency(from: targetNode,
-                                                                to: toPackageNode,
-                                                                linkedStaticProducts: &linkedStaticProducts))
+                                                         to: toTargetNode))
             }
             issues.append(contentsOf: lintGraphNode(node: toNode,
-                                                    evaluatedNodes: &evaluatedNodes,
-                                                    linkedStaticProducts: &linkedStaticProducts))
+                                                    evaluatedNodes: &evaluatedNodes))
         }
 
         return issues
     }
 
-    /// Package dependencies are also static products, so we need to perform the same check as for them
-    private func lintPackageDependency(from: TargetNode,
-                                       to: PackageProductNode,
-                                       linkedStaticProducts: inout Set<StaticDepedencyWarning>) -> [LintingIssue] {
-        guard from.target.canLinkStaticProducts() else {
-            return []
-        }
-        let warning = StaticDepedencyWarning(fromTargetNode: from,
-                                             toTargetNode: to)
-        let (inserted, oldMember) = linkedStaticProducts.insert(warning)
-        guard inserted == false else {
-            return []
-        }
-
-        let reason = "Package \(to.name) has been linked against \(oldMember.fromTargetNode.target.name) and \(from.target.name), it is a static product so may introduce unwanted side effects."
-        let issue = LintingIssue(reason: reason, severity: .warning)
-        return [issue]
-    }
-
     private func lintDependency(from: TargetNode,
-                                to: TargetNode,
-                                linkedStaticProducts: inout Set<StaticDepedencyWarning>) -> [LintingIssue] {
+                                to: TargetNode) -> [LintingIssue] {
         var issues: [LintingIssue] = []
 
         let fromTarget = LintableTarget(platform: from.target.platform,
@@ -131,29 +93,7 @@ class GraphLinter: GraphLinting {
             issues.append(issue)
         }
 
-        issues.append(contentsOf: lintStaticDependencies(from: from,
-                                                         to: to,
-                                                         linkedStaticProducts: &linkedStaticProducts))
-
         return issues
-    }
-
-    private func lintStaticDependencies(from: TargetNode,
-                                        to: TargetNode,
-                                        linkedStaticProducts: inout Set<StaticDepedencyWarning>) -> [LintingIssue] {
-        guard to.target.product.isStatic, from.target.canLinkStaticProducts() else {
-            return []
-        }
-        let warning = StaticDepedencyWarning(fromTargetNode: from,
-                                             toTargetNode: to)
-        let (inserted, oldMember) = linkedStaticProducts.insert(warning)
-        guard inserted == false else {
-            return []
-        }
-
-        let reason = "Target \(to.target.name) has been linked against \(oldMember.fromTargetNode.target.name) and \(from.target.name), it is a static product so may introduce unwanted side effects."
-        let issue = LintingIssue(reason: reason, severity: .warning)
-        return [issue]
     }
 
     private func lintMismatchingConfigurations(graph: Graphing) -> [LintingIssue] {

--- a/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -1,0 +1,166 @@
+import Basic
+import Foundation
+import TuistCore
+
+protocol StaticProductsGraphLinting {
+    func lint(graph: Graphing) -> [LintingIssue]
+}
+
+class StaticProductsGraphLinter: StaticProductsGraphLinting {
+    func lint(graph: Graphing) -> [LintingIssue] {
+        let nodes = graph.entryNodes
+        return warnings(in: nodes)
+            .sorted()
+            .map(lintIssue)
+    }
+
+    private func warnings(in nodes: [GraphNode]) -> Set<StaticDependencyWarning> {
+        var warnings = Set<StaticDependencyWarning>()
+        let cache = Cache()
+        nodes.forEach { node in
+            // Skip already evaluated nodes
+            guard cache.results(for: node) == nil else {
+                return
+            }
+            let results = buildStaticProductsMap(visiting: node,
+                                                 cache: cache)
+            warnings.formUnion(results.linked.flatMap(staticDependencyWarning))
+        }
+        return warnings
+    }
+
+    private func staticDependencyWarning(staticProduct: GraphNode, linkedBy: Set<TargetNode>) -> [StaticDependencyWarning] {
+        // Common dependencies between test bundles and their host apps are automatically omitted
+        // during generation - as such those shouldn't be flagged
+        //
+        // reference: https://github.com/tuist/tuist/pull/664
+        let apps: Set<GraphNode> = linkedBy.filter { $0.target.product == .app }
+        let hostedTestBundles = linkedBy
+            .filter { $0.target.product.testsBundle }
+            .filter { $0.dependencies.contains(where: { apps.contains($0) }) }
+
+        let links = linkedBy.subtracting(hostedTestBundles)
+
+        guard links.count > 1 else {
+            return []
+        }
+
+        let sortedLinks = links.sorted(by: { $0.name < $1.name })
+        return [
+            .init(staticProduct: staticProduct,
+                  linkingNodes: sortedLinks),
+        ]
+    }
+
+    private func buildStaticProductsMap(visiting node: GraphNode,
+                                        cache: Cache) -> StaticProducts {
+        if let cachedResult = cache.results(for: node) {
+            return cachedResult
+        }
+
+        // Collect dependency results traversing the graph (dfs)
+        var results = dependencies(for: node).reduce(StaticProducts()) { results, node in
+            buildStaticProductsMap(visiting: node, cache: cache).merged(with: results)
+        }
+
+        // Static node case
+        if nodeIsStaticProduct(node) {
+            results.unlinked.insert(node)
+            cache.cache(results: results, for: node)
+            return results
+        }
+
+        // Linking node case
+        guard let linkingNode = node as? TargetNode,
+            linkingNode.target.canLinkStaticProducts() else {
+            return results
+        }
+
+        while let staticProduct = results.unlinked.popFirst() {
+            results.linked[staticProduct, default: Set()].insert(linkingNode)
+        }
+
+        cache.cache(results: results,
+                    for: node)
+
+        return results
+    }
+
+    private func dependencies(for node: GraphNode) -> [GraphNode] {
+        (node as? TargetNode)?.dependencies ?? []
+    }
+
+    private func nodeIsStaticProduct(_ node: GraphNode) -> Bool {
+        switch node {
+        case is PackageProductNode:
+            // Swift package products are currently assumed to be static
+            return true
+        case is LibraryNode:
+            return true
+        case let targetNode as TargetNode where targetNode.target.product.isStatic:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func lintIssue(from warning: StaticDependencyWarning) -> LintingIssue {
+        let staticProduct = nodeDescription(warning.staticProduct)
+        let names = warning.linkingNodes.map(\.name)
+        return LintingIssue(reason: "\(staticProduct) has been linked against \(names), it is a static product so may introduce unwanted side effects.",
+                            severity: .warning)
+    }
+
+    private func nodeDescription(_ node: GraphNode) -> String {
+        switch node {
+        case is PackageProductNode:
+            return "Package \"\(node.name)\""
+        case is LibraryNode:
+            return "Library \"\(node.name)\""
+        case is TargetNode:
+            return "Target \"\(node.name)\""
+        default:
+            return node.name
+        }
+    }
+}
+
+// MARK: - Helper Types
+
+extension StaticProductsGraphLinter {
+    private struct StaticDependencyWarning: Hashable, Comparable, CustomStringConvertible {
+        var staticProduct: GraphNode
+        var linkingNodes: [TargetNode]
+
+        var description: String {
+            "\(staticProduct.name) > \(linkingNodes.map(\.name))"
+        }
+
+        static func < (lhs: StaticProductsGraphLinter.StaticDependencyWarning, rhs: StaticProductsGraphLinter.StaticDependencyWarning) -> Bool {
+            lhs.description < rhs.description
+        }
+    }
+
+    private struct StaticProducts {
+        var unlinked: Set<GraphNode> = Set()
+        var linked: [GraphNode: Set<TargetNode>] = [:]
+
+        func merged(with other: StaticProducts) -> StaticProducts {
+            StaticProducts(unlinked: unlinked.union(other.unlinked),
+                           linked: linked.merging(other.linked, uniquingKeysWith: { $0.union($1) }))
+        }
+    }
+
+    private class Cache {
+        private var cachedResults: [GraphNode: StaticProducts] = [:]
+
+        func results(for node: GraphNode) -> StaticProducts? {
+            cachedResults[node]
+        }
+
+        func cache(results: StaticProducts,
+                   for node: GraphNode) {
+            cachedResults[node] = results
+        }
+    }
+}

--- a/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -52,6 +52,24 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
         ]
     }
 
+    ///
+    /// Builds a static products map to enable performing some validation/lint checks.
+    ///
+    /// The map consists of all linked static products as follows:
+    /// `StaticProducts.linked`:
+    /// - MyStaticFrameworkA > [MyDynamicFrameworkA, MyTestsTarget]
+    /// - MyStaticFrameworkB > [MyDynamicFrameworkA, MyTestsTarget]
+    ///
+    /// The map is constructed by traversing the graph from the given node using
+    /// a depth first approach reaching to the leaf nodes. Once there, working
+    /// backwards all nodes are evaluated as follows:
+    ///
+    /// There are two "buckets", `StaticProducts.unlinked` and `StaticProducts.linked`
+    ///
+    /// - In the event a node is a static product it adds itself to the unlinked bucket
+    /// - In the event a node is a node capable of linking static products, it removes all the nodes
+    ///   from the unlinked bucket and places them in the linked bucket in format of _staticNode > [linkingNode]_.
+    ///
     private func buildStaticProductsMap(visiting node: GraphNode,
                                         cache: Cache) -> StaticProducts {
         if let cachedResult = cache.results(for: node) {
@@ -142,7 +160,13 @@ extension StaticProductsGraphLinter {
     }
 
     private struct StaticProducts {
+        // Unlinked static products
         var unlinked: Set<GraphNode> = Set()
+
+        // Map of Static product to nodes that link it
+        // e.g.
+        //    - MyStaticFrameworkA > [MyDynamicFrameworkA, MyTestsTarget]
+        //    - MyStaticFrameworkB > [MyDynamicFrameworkA, MyTestsTarget]
         var linked: [GraphNode: Set<TargetNode>] = [:]
 
         func merged(with other: StaticProducts) -> StaticProducts {

--- a/Tests/TuistGeneratorTests/Linter/Mocks/MockStaticProductsGraphLinter.swift
+++ b/Tests/TuistGeneratorTests/Linter/Mocks/MockStaticProductsGraphLinter.swift
@@ -3,7 +3,8 @@ import TuistCore
 @testable import TuistGenerator
 
 class MockStaticProductsGraphLinter: StaticProductsGraphLinting {
-    func lint(graph _: Graphing) -> [LintingIssue] {
-        []
+    var lintStub: ((Graphing) -> [LintingIssue])?
+    func lint(graph: Graphing) -> [LintingIssue] {
+        lintStub?(graph) ?? []
     }
 }

--- a/Tests/TuistGeneratorTests/Linter/Mocks/MockStaticProductsGraphLinter.swift
+++ b/Tests/TuistGeneratorTests/Linter/Mocks/MockStaticProductsGraphLinter.swift
@@ -1,0 +1,9 @@
+import Foundation
+import TuistCore
+@testable import TuistGenerator
+
+class MockStaticProductsGraphLinter: StaticProductsGraphLinting {
+    func lint(graph _: Graphing) -> [LintingIssue] {
+        []
+    }
+}

--- a/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
@@ -1,0 +1,393 @@
+import Basic
+import Foundation
+import XCTest
+
+@testable import TuistCore
+@testable import TuistGenerator
+@testable import TuistSupportTesting
+
+class StaticProductsGraphLinterTests: XCTestCase {
+    var subject: StaticProductsGraphLinter!
+
+    override func setUp() {
+        subject = StaticProductsGraphLinter()
+    }
+
+    func test_lint_whenPackageDependencyLinkedTwice() throws {
+        // Given
+        let app = Target.test(name: "App")
+        let framework = Target.test(name: "Framework", product: .framework)
+        let project = Project.test(path: "/tmp/app", name: "AppProject", targets: [app])
+
+        let package = PackageProductNode(product: "PackageLibrary", path: "/tmp/packageLibrary")
+        let frameworkNode = TargetNode(project: project, target: framework, dependencies: [package])
+        let appNode = TargetNode(project: project, target: app, dependencies: [package, frameworkNode])
+
+        let cache = GraphLoaderCache()
+        cache.add(project: project)
+        cache.add(targetNode: appNode)
+        cache.add(targetNode: frameworkNode)
+
+        let graph = Graph.test(cache: cache, entryNodes: [appNode, frameworkNode, package])
+
+        // When
+        let results = subject.lint(graph: graph)
+
+        // Then
+        XCTAssertEqual(results, [
+            warning(product: "PackageLibrary", type: "Package", linkedBy: ["App", "Framework"]),
+        ])
+    }
+
+    func test_lint_whenPrecompiledStaticLibraryLinkedTwice() throws {
+        // Given
+        let app = Target.test(name: "App")
+        let framework = Target.test(name: "Framework", product: .framework)
+        let project = Project.test(targets: [app, framework])
+
+        let libraryNode = LibraryNode(path: "/path/to/library", publicHeaders: "/path/to/library/include")
+        let frameworkNode = TargetNode(project: project, target: framework, dependencies: [libraryNode])
+        let appNode = TargetNode(project: project, target: app, dependencies: [libraryNode, frameworkNode])
+
+        let cache = GraphLoaderCache()
+        cache.add(project: project)
+        cache.add(targetNode: appNode)
+        cache.add(targetNode: frameworkNode)
+        cache.add(precompiledNode: libraryNode)
+
+        let graph = Graph.test(cache: cache, entryNodes: [appNode, frameworkNode, libraryNode])
+
+        // When
+        let results = subject.lint(graph: graph)
+
+        // Then
+        XCTAssertEqual(results, [
+            warning(product: "library", type: "Library", linkedBy: ["App", "Framework"]),
+        ])
+    }
+
+    func test_lint_whenStaticProductLinkedTwice_1() throws {
+        // Given
+        let app = Target.test(name: "App")
+        let staticFramework = Target.test(name: "StaticFramework", product: .staticFramework)
+        let framework = Target.test(name: "Framework", product: .framework)
+
+        let graph = Graph.create(project: .test(),
+                                 dependencies: [
+                                     (target: app, dependencies: [staticFramework, framework]),
+                                     (target: framework, dependencies: [staticFramework]),
+                                     (target: staticFramework, dependencies: []),
+                                 ])
+
+        // When
+        let results = subject.lint(graph: graph)
+
+        // Then
+        XCTAssertEqual(results, [
+            warning(product: "StaticFramework", linkedBy: ["App", "Framework"]),
+        ])
+    }
+
+    func test_lint_whenStaticProductLinkedTwice_transitiveStaticFrameworks() throws {
+        // Given
+        let app = Target.test(name: "App")
+        let staticFrameworkA = Target.test(name: "StaticFrameworkA", product: .staticFramework)
+        let staticFrameworkB = Target.test(name: "StaticFrameworkB", product: .staticFramework)
+        let staticFrameworkC = Target.test(name: "StaticFrameworkC", product: .staticFramework)
+        let frameworkA = Target.test(name: "FrameworkA", product: .framework)
+        let frameworkB = Target.test(name: "FrameworkB", product: .framework)
+        let frameworkC = Target.test(name: "FrameworkC", product: .framework)
+
+        let graph = Graph.create(project: Project.test(),
+                                 entryNodes: [frameworkB, app],
+                                 dependencies: [
+                                     (target: app, dependencies: [staticFrameworkC, frameworkA]),
+                                     (target: frameworkA, dependencies: [frameworkB]),
+                                     (target: frameworkB, dependencies: [frameworkC]),
+                                     (target: frameworkC, dependencies: [staticFrameworkA]),
+                                     (target: staticFrameworkA, dependencies: [staticFrameworkB]),
+                                     (target: staticFrameworkB, dependencies: [staticFrameworkC]),
+                                     (target: staticFrameworkC, dependencies: []),
+                                 ])
+
+        // When
+        let results = subject.lint(graph: graph)
+
+        // Then
+        XCTAssertEqual(results, [
+            warning(product: "StaticFrameworkC", linkedBy: ["App", "FrameworkC"]),
+        ])
+    }
+
+    func test_lint_whenStaticProductLinkedTwice_transitiveFrameworks() throws {
+        // Given
+        let app = Target.test(name: "App")
+        let staticFrameworkA = Target.test(name: "StaticFrameworkA", product: .staticFramework)
+        let staticFrameworkB = Target.test(name: "StaticFrameworkB", product: .staticFramework)
+        let staticFrameworkC = Target.test(name: "StaticFrameworkC", product: .staticFramework)
+        let frameworkA = Target.test(name: "FrameworkA", product: .framework)
+        let frameworkB = Target.test(name: "FrameworkB", product: .framework)
+        let frameworkC = Target.test(name: "FrameworkC", product: .framework)
+
+        let graph = Graph.create(project: Project.test(),
+                                 entryNodes: [frameworkB, frameworkC, app],
+                                 dependencies: [
+                                     (target: app, dependencies: [staticFrameworkC, frameworkA]),
+                                     (target: frameworkA, dependencies: [frameworkB, frameworkC]),
+                                     (target: frameworkB, dependencies: [frameworkC]),
+                                     (target: frameworkC, dependencies: [staticFrameworkA]),
+                                     (target: staticFrameworkA, dependencies: [staticFrameworkB]),
+                                     (target: staticFrameworkB, dependencies: [staticFrameworkC]),
+                                     (target: staticFrameworkC, dependencies: []),
+                                 ])
+
+        // When
+        let results = subject.lint(graph: graph)
+
+        // Then
+        XCTAssertEqual(results, [
+            warning(product: "StaticFrameworkC", linkedBy: ["App", "FrameworkC"]),
+        ])
+    }
+
+    func test_lint_whenStaticProductLinkedTwice_transitiveFrameworks_2() throws {
+        // Given
+        let app = Target.test(name: "App")
+        let staticFrameworkA = Target.test(name: "StaticFrameworkA", product: .staticFramework)
+        let frameworkA = Target.test(name: "FrameworkA", product: .framework)
+        let frameworkB = Target.test(name: "FrameworkB", product: .framework)
+        let frameworkC = Target.test(name: "FrameworkC", product: .framework)
+        let frameworkD = Target.test(name: "FrameworkD", product: .framework)
+
+        let graph = Graph.create(project: Project.test(),
+                                 entryNodes: [app, frameworkD],
+                                 dependencies: [
+                                     (target: app, dependencies: [frameworkA, staticFrameworkA]),
+                                     (target: frameworkA, dependencies: [frameworkB, frameworkC]),
+                                     (target: frameworkB, dependencies: [frameworkC]),
+                                     (target: frameworkC, dependencies: [staticFrameworkA]),
+                                     (target: staticFrameworkA, dependencies: []),
+
+                                     (target: frameworkD, dependencies: [frameworkC, staticFrameworkA]),
+                                 ])
+
+        // When
+        let results = subject.lint(graph: graph)
+
+        // Then
+        XCTAssertEqual(results, [
+            warning(product: "StaticFrameworkA", linkedBy: ["App", "FrameworkC"]),
+            warning(product: "StaticFrameworkA", linkedBy: ["FrameworkC", "FrameworkD"]),
+        ])
+    }
+
+    func test_lint_whenNoStaticProductsLinkedTwice_1() throws {
+        // Given
+        let app = Target.test(name: "App")
+        let staticFramework = Target.test(name: "StaticFramework", product: .staticFramework)
+        let framework = Target.test(name: "Framework", product: .framework)
+
+        let graph = Graph.create(project: Project.test(),
+                                 entryNodes: [framework, app],
+                                 dependencies: [
+                                     (target: app, dependencies: [staticFramework, framework]),
+                                     (target: framework, dependencies: [staticFramework]),
+                                     (target: staticFramework, dependencies: []),
+                                 ])
+
+        // When
+        let results = subject.lint(graph: graph)
+
+        // Then
+        XCTAssertFalse(results.isEmpty)
+    }
+
+    func test_lint_whenNoStaticProductsLinkedTwice_2() throws {
+        // Given
+        let app = Target.test(name: "App")
+        let staticFrameworkA = Target.test(name: "StaticFrameworkA", product: .staticFramework)
+        let staticFrameworkB = Target.test(name: "StaticFrameworkB", product: .staticFramework)
+        let staticFrameworkC = Target.test(name: "StaticFrameworkC", product: .staticFramework)
+        let frameworkA = Target.test(name: "FrameworkA", product: .framework)
+        let frameworkB = Target.test(name: "FrameworkB", product: .framework)
+        let frameworkC = Target.test(name: "FrameworkC", product: .framework)
+
+        let graph = Graph.create(project: Project.test(),
+                                 entryNodes: [frameworkB, app],
+                                 dependencies: [
+                                     (target: app, dependencies: [staticFrameworkB, staticFrameworkA, frameworkA]),
+                                     (target: frameworkA, dependencies: [frameworkB]),
+                                     (target: frameworkB, dependencies: [frameworkC]),
+                                     (target: frameworkC, dependencies: []),
+                                     (target: staticFrameworkA, dependencies: [staticFrameworkB]),
+                                     (target: staticFrameworkB, dependencies: [staticFrameworkC]),
+                                     (target: staticFrameworkC, dependencies: []),
+                                 ])
+
+        // When
+        let results = subject.lint(graph: graph)
+
+        // Then
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func test_lint_whenNoStaticProductLinkedTwice_testTargets() throws {
+        // Given
+        let app = Target.test(name: "App")
+        let staticFramework = Target.test(name: "StaticFramework", product: .staticFramework)
+        let frameworkTests = Target.test(name: "FrameworkTests", product: .unitTests)
+
+        let graph = Graph.create(project: .test(),
+                                 dependencies: [
+                                     (target: app, dependencies: [staticFramework]),
+                                     (target: staticFramework, dependencies: []),
+                                     (target: frameworkTests, dependencies: [staticFramework]),
+                                 ])
+
+        // When
+        let results = subject.lint(graph: graph)
+
+        // Then
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func test_lint_whenStaticProductLinkedTwice_testTargets() throws {
+        // Given
+        let app = Target.test(name: "App")
+        let framework = Target.test(name: "Framework", product: .framework)
+        let staticFramework = Target.test(name: "StaticFramework", product: .staticFramework)
+        let frameworkTests = Target.test(name: "FrameworkTests", product: .unitTests)
+
+        let graph = Graph.create(project: .test(),
+                                 dependencies: [
+                                     (target: app, dependencies: []),
+                                     (target: framework, dependencies: [staticFramework]),
+                                     (target: staticFramework, dependencies: []),
+
+                                     (target: frameworkTests, dependencies: [framework, staticFramework]),
+                                 ])
+
+        // When
+        let results = subject.lint(graph: graph)
+
+        // Then
+        XCTAssertEqual(results, [
+            warning(product: "StaticFramework", linkedBy: ["Framework", "FrameworkTests"]),
+        ])
+    }
+
+    func test_lint_whenNoStaticProductLinkedTwice_hostedTestTargets_1() throws {
+        // Given
+        let app = Target.test(name: "App")
+        let appTestsTarget = Target.test(name: "AppTests", product: .unitTests)
+        let staticFramework = Target.test(name: "StaticFramework", product: .staticFramework)
+
+        let graph = Graph.create(project: Project.test(),
+                                 entryNodes: [appTestsTarget],
+                                 dependencies: [
+                                     (target: app, dependencies: [staticFramework]),
+                                     (target: appTestsTarget, dependencies: [staticFramework, app]),
+                                     (target: staticFramework, dependencies: []),
+                                 ])
+
+        // When
+        let results = subject.lint(graph: graph)
+
+        // Then
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func test_lint_whenNoStaticProductLinkedTwice_hostedTestTargets_2() throws {
+        // Given
+        let app = Target.test(name: "App")
+        let appTests = Target.test(name: "AppTests", product: .unitTests)
+        let appUITests = Target.test(name: "AppUITests", product: .uiTests)
+
+        let frameworkA = Target.test(name: "FrameworkA", product: .framework)
+        let frameworkB = Target.test(name: "FrameworkB", product: .framework)
+        let frameworkC = Target.test(name: "FrameworkC", product: .framework)
+        let frameworkTests = Target.test(name: "FrameworkTests", product: .unitTests)
+
+        let staticFrameworkA = Target.test(name: "StaticFrameworkA", product: .staticFramework)
+        let staticFrameworkB = Target.test(name: "StaticFrameworkB", product: .staticFramework)
+        let staticFrameworkC = Target.test(name: "StaticFrameworkC", product: .staticFramework)
+        let staticFrameworkATests = Target.test(name: "StaticFrameworkATests", product: .unitTests)
+        let staticFrameworkBTests = Target.test(name: "StaticFrameworkBTests", product: .unitTests)
+        let staticFrameworkCTests = Target.test(name: "StaticFrameworkCTests", product: .unitTests)
+
+        let graph = Graph.create(project: Project.test(),
+                                 dependencies: [
+                                     (target: app, dependencies: [frameworkA]),
+                                     (target: appTests, dependencies: [app]),
+                                     (target: appUITests, dependencies: [app]),
+
+                                     (target: frameworkA, dependencies: [frameworkB, staticFrameworkA]),
+                                     (target: frameworkB, dependencies: [frameworkC]),
+                                     (target: frameworkC, dependencies: [staticFrameworkC]),
+                                     (target: frameworkTests, dependencies: [frameworkA]),
+
+                                     (target: staticFrameworkA, dependencies: [staticFrameworkB]),
+                                     (target: staticFrameworkB, dependencies: []),
+                                     (target: staticFrameworkC, dependencies: []),
+
+                                     (target: staticFrameworkATests, dependencies: [staticFrameworkA]),
+                                     (target: staticFrameworkBTests, dependencies: [staticFrameworkB, frameworkB]),
+                                     (target: staticFrameworkCTests, dependencies: [staticFrameworkC, staticFrameworkB]),
+                                 ])
+
+        // When
+        let results = subject.lint(graph: graph)
+
+        // Then
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func test_lint_whenStaticProductLinkedTwice_hostedTestTargets_1() throws {
+        // Given
+        let app = Target.test(name: "App")
+        let appTests = Target.test(name: "AppTests", product: .unitTests)
+        let appUITests = Target.test(name: "AppUITests", product: .uiTests)
+
+        let frameworkA = Target.test(name: "FrameworkA", product: .framework)
+        let frameworkB = Target.test(name: "FrameworkB", product: .framework)
+        let frameworkC = Target.test(name: "FrameworkC", product: .framework)
+        let frameworkTests = Target.test(name: "FrameworkTests", product: .unitTests)
+
+        let staticFrameworkA = Target.test(name: "StaticFrameworkA", product: .staticFramework)
+        let staticFrameworkB = Target.test(name: "StaticFrameworkB", product: .staticFramework)
+        let staticFrameworkC = Target.test(name: "StaticFrameworkC", product: .staticFramework)
+
+        let graph = Graph.create(project: Project.test(),
+                                 dependencies: [
+                                     (target: app, dependencies: [frameworkA]),
+                                     (target: appTests, dependencies: [app, staticFrameworkA]),
+                                     (target: appUITests, dependencies: [app]),
+
+                                     (target: frameworkA, dependencies: [frameworkB, staticFrameworkA]),
+                                     (target: frameworkB, dependencies: [frameworkC]),
+                                     (target: frameworkC, dependencies: [staticFrameworkC]),
+                                     (target: frameworkTests, dependencies: [frameworkA]),
+
+                                     (target: staticFrameworkA, dependencies: [staticFrameworkB]),
+                                     (target: staticFrameworkB, dependencies: []),
+                                     (target: staticFrameworkC, dependencies: []),
+                                 ])
+
+        // When
+        let results = subject.lint(graph: graph)
+
+        // Then
+        XCTAssertEqual(results, [
+            warning(product: "StaticFrameworkA", linkedBy: ["AppTests", "FrameworkA"]),
+            warning(product: "StaticFrameworkB", linkedBy: ["AppTests", "FrameworkA"]),
+        ])
+    }
+
+    // MARK: - Helpers
+
+    private func warning(product node: String, type: String = "Target", linkedBy: [String]) -> LintingIssue {
+        let reason = "\(type) \"\(node)\" has been linked against \(linkedBy), it is a static product so may introduce unwanted side effects."
+        return LintingIssue(reason: reason,
+                            severity: .warning)
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/973

### Short description 📝

- In the event a static product was linked more than once in a graph a warning was raised
- The `GraphLinter` had a step to check for this scenario during its graph traversal
- The previous method could accidentally flag false positives in the event multiple test targets depended on the same static product
- Additionally, depending on the order the entry nodes of a graph were evaluated there were scenarios which the check wouldn't catch real issues due to skipping evaluated nodes

### Solution 📦

- Add a dedicated `StaticProductsGraphLinter` component
- Evaluate each graph entry node separately to avoid flagging products linked multiple times when traversing from different entry nodes
- Cache the results for each node to flag issues regardless of the order nodes are visited for evaluation

### Implementation 👩‍💻👨‍💻

- [x] Create a dedicated linter `StaticProductsGraphLinter`
- [x] Update test to include more cases (multiple test targets, hosted test targets etc...)
- [x] Update change log

### Test Plan 🛠

- run `tuist generate` within `fixtures/ios_app_with_static_frameworks`
- verify no warnings are displayed
- manually modify the fixture to introduce an error

e.g.

```swift
// Modules/D/Project.swift
import ProjectDescription

let project = Project(name: "D",
                      targets: [
                          Target(name: "D",
                                 platform: .iOS,
                                 product: .framework,
                                 bundleId: "io.tuist.D",
                                 infoPlist: "Info.plist",
                                 sources: "Sources/**",
                                 dependencies: [
                                       .project(target: "B", path: "../B") // <-- B is transitively linked by App
                          ])
])

```

- Run `tuist generate` and verify a warning is displayed:

```
Warning: - Target "B" has been linked against ["App", "D"], it is a static product so may introduce unwanted side effects.
```
