### PR TITLE
Add source to sdk target dependency

### DIFF
--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -68,6 +68,9 @@ public enum TargetDependency: Codable, Equatable {
 
     case xcFramework(path: Path)
 
+    /// Dependency on XCTest.
+    case xctest
+
     /// Dependency on system library or framework
     ///
     /// - Parameters:
@@ -97,6 +100,8 @@ public enum TargetDependency: Codable, Equatable {
             return "cocoapods"
         case .xcFramework:
             return "xcframework"
+        case .xctest:
+            return "xctest"
         }
     }
 }
@@ -164,6 +169,9 @@ extension TargetDependency {
         case "cocoapods":
             self = .cocoapods(path: try container.decode(Path.self, forKey: .path))
 
+        case "xctest":
+            self = .xctest
+
         default:
             throw CodingError.unknownType(type)
         }
@@ -195,6 +203,8 @@ extension TargetDependency {
             try container.encode(path, forKey: .path)
         case let .xcFramework(path):
             try container.encode(path, forKey: .path)
+        case .xctest:
+            break
         }
     }
 }

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -182,7 +182,7 @@ public class Graph: Encodable {
         if targetNode.target.canLinkStaticProducts() {
             let transitiveSystemLibraries = transitiveStaticTargetNodes(for: targetNode).flatMap {
                 $0.sdkDependencies.map {
-                    GraphDependencyReference.sdk(path: $0.path, status: $0.status)
+                    GraphDependencyReference.sdk(path: $0.path, status: $0.status, source: $0.source)
                 }
             }
 
@@ -190,7 +190,7 @@ public class Graph: Encodable {
         }
 
         let directSystemLibrariesAndFrameworks = targetNode.sdkDependencies.map {
-            GraphDependencyReference.sdk(path: $0.path, status: $0.status)
+            GraphDependencyReference.sdk(path: $0.path, status: $0.status, source: $0.source)
         }
 
         references = references.union(directSystemLibrariesAndFrameworks)

--- a/Sources/TuistCore/Graph/GraphDependencyReference.swift
+++ b/Sources/TuistCore/Graph/GraphDependencyReference.swift
@@ -26,7 +26,7 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
         product: Product
     )
     case product(target: String, productName: String)
-    case sdk(path: AbsolutePath, status: SDKStatus)
+    case sdk(path: AbsolutePath, status: SDKStatus, source: SDKSource)
 
     init(precompiledNode: PrecompiledNode) {
         if let frameworkNode = precompiledNode as? FrameworkNode {
@@ -65,9 +65,10 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
         case let .product(target, productName):
             hasher.combine(target)
             hasher.combine(productName)
-        case let .sdk(path, status):
+        case let .sdk(path, status, source):
             hasher.combine(path)
             hasher.combine(status)
+            hasher.combine(source)
         }
     }
 
@@ -99,7 +100,7 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
                 return lhsProductName < rhsProductName
             }
             return lhsTarget < rhsTarget
-        case let (.sdk(lhsPath, _), .sdk(rhsPath, _)):
+        case let (.sdk(lhsPath, _, _), .sdk(rhsPath, _, _)):
             return lhsPath < rhsPath
         case (.sdk, .framework):
             return true

--- a/Sources/TuistCore/Graph/GraphLoader.swift
+++ b/Sources/TuistCore/Graph/GraphLoader.swift
@@ -220,7 +220,7 @@ public class GraphLoader: GraphLoading {
 
         // System SDK
         case let .sdk(name, status):
-            return try SDKNode(name: name, platform: platform, status: status)
+            return try SDKNode(name: name, platform: platform, status: status, source: .developer)
 
         // CocoaPods
         case let .cocoapods(podsPath):
@@ -229,6 +229,10 @@ public class GraphLoader: GraphLoading {
         // Swift Package
         case let .package(product):
             return PackageProductNode(product: product, path: path)
+
+        // XCTest
+        case .xctest:
+            return try SDKNode(name: SDKNode.xctestFrameworkName, platform: platform, status: .required, source: .system)
         }
     }
 

--- a/Sources/TuistCore/Graph/Nodes/SDKNode.swift
+++ b/Sources/TuistCore/Graph/Nodes/SDKNode.swift
@@ -28,8 +28,8 @@ public class SDKNode: GraphNode {
             sdkRootPath = AbsolutePath(xcodeDeveloperSdkRootPath,
                                        relativeTo: AbsolutePath("/"))
             path = sdkRootPath
-                    .appending(RelativePath("Frameworks"))
-                    .appending(component: name)
+                .appending(RelativePath("Frameworks"))
+                .appending(component: name)
         } else {
             sdkRootPath = AbsolutePath(platform.xcodeSdkRootPath,
                                        relativeTo: AbsolutePath("/"))

--- a/Sources/TuistCore/Graph/Nodes/SDKNode.swift
+++ b/Sources/TuistCore/Graph/Nodes/SDKNode.swift
@@ -2,32 +2,53 @@ import Foundation
 import TSCBasic
 import TuistSupport
 
+public enum SDKSource {
+    case developer // Platforms/iPhoneOS.platform/Developer/Library
+    case system // Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library
+
+    /// Returns the framewok search path that should be used in Xcode to locate the SDK.
+    public var frameworkSearchPath: String {
+        switch self {
+        case .developer:
+            return "$(DEVELOPER_FRAMEWORKS_DIR)"
+        case .system:
+            return "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+        }
+    }
+}
+
 public class SDKNode: GraphNode {
+    static let xctestFrameworkName = "XCTest.framework"
+
     public let status: SDKStatus
     public let type: Type
+    public let source: SDKSource
 
     public init(name: String,
                 platform: Platform,
-                status: SDKStatus) throws {
+                status: SDKStatus,
+                source: SDKSource) throws {
         let sdk = AbsolutePath("/\(name)")
         // TODO: Validate using a linter
-        guard let sdkExtension = sdk.extension,
-            let type = Type(rawValue: sdkExtension) else {
+        guard let sdkExtension = sdk.extension, let type = Type(rawValue: sdkExtension) else {
             throw Error.unsupported(sdk: name)
         }
-
         self.status = status
         self.type = type
+        self.source = source
+        let path = try SDKNode.path(name: name, platform: platform, source: source, type: type)
+        super.init(path: path, name: String(name.split(separator: ".").first!))
+    }
 
-        let path: AbsolutePath
+    static func path(name: String, platform: Platform, source _: SDKSource, type: Type) throws -> AbsolutePath {
         let sdkRootPath: AbsolutePath
-        if name == "XCTest.framework" {
+        if name == SDKNode.xctestFrameworkName {
             guard let xcodeDeveloperSdkRootPath = platform.xcodeDeveloperSdkRootPath else {
                 throw Error.unsupported(sdk: name)
             }
             sdkRootPath = AbsolutePath(xcodeDeveloperSdkRootPath,
                                        relativeTo: AbsolutePath("/"))
-            path = sdkRootPath
+            return sdkRootPath
                 .appending(RelativePath("Frameworks"))
                 .appending(component: name)
         } else {
@@ -35,17 +56,15 @@ public class SDKNode: GraphNode {
                                        relativeTo: AbsolutePath("/"))
             switch type {
             case .framework:
-                path = sdkRootPath
+                return sdkRootPath
                     .appending(RelativePath("System/Library/Frameworks"))
                     .appending(component: name)
             case .library:
-                path = sdkRootPath
+                return sdkRootPath
                     .appending(RelativePath("usr/lib"))
                     .appending(component: name)
             }
         }
-
-        super.init(path: path, name: String(name.split(separator: ".").first!))
     }
 
     public enum `Type`: String, CaseIterable {

--- a/Sources/TuistCore/Models/Dependency.swift
+++ b/Sources/TuistCore/Models/Dependency.swift
@@ -15,4 +15,5 @@ public enum Dependency: Equatable, Hashable {
     case package(product: String)
     case sdk(name: String, status: SDKStatus)
     case cocoapods(path: AbsolutePath)
+    case xctest
 }

--- a/Sources/TuistCore/Models/Platform.swift
+++ b/Sources/TuistCore/Models/Platform.swift
@@ -98,4 +98,14 @@ extension Platform {
             return "Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk"
         }
     }
+
+    public var xcodeDeveloperSdkRootPath: String? {
+        switch self {
+        case .iOS:
+            return "Platforms/iPhoneOS.platform/Developer/Library"
+        case .macOS:
+            return "Platforms/MacOSX.platform/Developer/Library"
+        default: return nil
+        }
+    }
 }

--- a/Sources/TuistCoreTesting/Graph/Graph+TestData.swift
+++ b/Sources/TuistCoreTesting/Graph/Graph+TestData.swift
@@ -115,7 +115,7 @@ public extension Graph {
                 return nil
             }
             node.dependencies.append(contentsOf: sdkDependencies.compactMap {
-                try? SDKNode(name: $0.name, platform: platform, status: $0.status)
+                try? SDKNode(name: $0.name, platform: platform, status: $0.status, source: .developer)
             })
             let packageDependencies: [String] = $0.target.dependencies.compactMap {
                 if case let .package(packageType) = $0 {

--- a/Sources/TuistCoreTesting/Graph/GraphDependencyReference+TestData.swift
+++ b/Sources/TuistCoreTesting/Graph/GraphDependencyReference+TestData.swift
@@ -47,9 +47,12 @@ public extension GraphDependencyReference {
                                          product: product)
     }
 
-    static func testSDK(path: AbsolutePath = "/path/CoreData.framework", status: SDKStatus = .required) -> GraphDependencyReference {
+    static func testSDK(path: AbsolutePath = "/path/CoreData.framework",
+                        status: SDKStatus = .required,
+                        source: SDKSource = .developer) -> GraphDependencyReference {
         GraphDependencyReference.sdk(path: path,
-                                     status: status)
+                                     status: status,
+                                     source: source)
     }
 
     static func testProduct(target: String = "Target", productName: String = "Target.framework") -> GraphDependencyReference {

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -196,7 +196,7 @@ class ProjectFileElements {
                 try generatePrecompiled(path)
             case let .library(path, _, _, _, _):
                 try generatePrecompiled(path)
-            case let .sdk(sdkNodePath, _):
+            case let .sdk(sdkNodePath, _, _):
                 generateSDKFileElement(sdkNodePath: sdkNodePath,
                                        toGroup: groups.frameworks,
                                        pbxproj: pbxproj)

--- a/Sources/TuistLoader/Models+ManifestMappers/Dependency+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Dependency+ManifestMapper.swift
@@ -30,6 +30,8 @@ extension TuistCore.Dependency {
             return .cocoapods(path: try generatorPaths.resolve(path: path))
         case let .xcFramework(path):
             return .xcFramework(path: try generatorPaths.resolve(path: path))
+        case .xctest:
+            return .xctest
         }
     }
 }

--- a/Tests/TuistCoreTests/Graph/GraphDependencyReferenceTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphDependencyReferenceTests.swift
@@ -13,8 +13,8 @@ final class GraphDependencyReferenceTests: TuistUnitTestCase {
         let subject = makeReferences().sorted()
 
         XCTAssertEqual(subject, [
-            .sdk(path: "/A.framework", status: .required),
-            .sdk(path: "/B.framework", status: .optional),
+            .sdk(path: "/A.framework", status: .required, source: .developer),
+            .sdk(path: "/B.framework", status: .optional, source: .developer),
             .product(target: "A", productName: "A.framework"),
             .product(target: "B", productName: "B.framework"),
             .testLibrary(path: "/libraries/A.library"),
@@ -48,8 +48,8 @@ final class GraphDependencyReferenceTests: TuistUnitTestCase {
             .testLibrary(path: "/libraries/B.library"),
             .product(target: "A", productName: "A.framework"),
             .product(target: "B", productName: "B.framework"),
-            .sdk(path: "/A.framework", status: .required),
-            .sdk(path: "/B.framework", status: .optional),
+            .sdk(path: "/A.framework", status: .required, source: .developer),
+            .sdk(path: "/B.framework", status: .optional, source: .developer),
         ]
     }
 }

--- a/Tests/TuistCoreTests/Graph/GraphTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTests.swift
@@ -1007,7 +1007,7 @@ final class GraphTests: TuistUnitTestCase {
 
     private func sdkDependency(from dependency: GraphDependencyReference) -> SDKPathAndStatus? {
         switch dependency {
-        case let .sdk(path, status):
+        case let .sdk(path, status, _):
             return SDKPathAndStatus(name: path.basename, status: status)
         default:
             return nil

--- a/Tests/TuistCoreTests/Graph/Nodes/SDKNodeTests.swift
+++ b/Tests/TuistCoreTests/Graph/Nodes/SDKNodeTests.swift
@@ -45,6 +45,30 @@ final class SDKNodeTests: XCTestCase {
         ])
     }
 
+    func test_xctest_sdk_framework_path() throws {
+        // Given
+        let libraries: [(name: String, platform: Platform)] = [
+            ("XCTest.framework", .iOS),
+            ("XCTest.framework", .macOS),
+        ]
+
+        // When
+        let nodes = try libraries.map { try SDKNode(name: $0.name, platform: $0.platform, status: .required) }
+
+        // Then
+        XCTAssertEqual(nodes.map(\.path), [
+            "/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework",
+            "/Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework",
+        ])
+    }
+
+    func test_xctest_sdk_framework_unsupported_platforms_path() throws {
+        XCTAssertThrowsSpecific(try SDKNode(name: "XCTest.framework", platform: .tvOS, status: .required),
+                                SDKNode.Error.unsupported(sdk: "XCTest.framework"))
+        XCTAssertThrowsSpecific(try SDKNode(name: "XCTest.framework", platform: .watchOS, status: .required),
+                                SDKNode.Error.unsupported(sdk: "XCTest.framework"))
+    }
+
     func test_sdk_library_paths() throws {
         // Given
         let libraries: [(name: String, platform: Platform)] = [

--- a/Tests/TuistCoreTests/Graph/Nodes/SDKNodeTests.swift
+++ b/Tests/TuistCoreTests/Graph/Nodes/SDKNodeTests.swift
@@ -6,6 +6,11 @@ import TuistSupportTesting
 @testable import TuistCore
 
 final class SDKNodeTests: XCTestCase {
+    func test_frameworkSearchPath() throws {
+        XCTAssertEqual(SDKSource.developer.frameworkSearchPath, "$(DEVELOPER_FRAMEWORKS_DIR)")
+        XCTAssertEqual(SDKSource.system.frameworkSearchPath, "$(PLATFORM_DIR)/Developer/Library/Frameworks")
+    }
+
     func test_sdk_supportedTypes() throws {
         // Given
         let libraries = [
@@ -14,11 +19,11 @@ final class SDKNodeTests: XCTestCase {
         ]
 
         // When / Then
-        XCTAssertNoThrow(try libraries.map { try SDKNode(name: $0, platform: .macOS, status: .required) })
+        XCTAssertNoThrow(try libraries.map { try SDKNode(name: $0, platform: .macOS, status: .required, source: .developer) })
     }
 
     func test_sdk_usupportedTypes() throws {
-        XCTAssertThrowsSpecific(try SDKNode(name: "FooBar", platform: .tvOS, status: .required),
+        XCTAssertThrowsSpecific(try SDKNode(name: "FooBar", platform: .tvOS, status: .required, source: .developer),
                                 SDKNode.Error.unsupported(sdk: "FooBar"))
     }
 
@@ -35,7 +40,7 @@ final class SDKNodeTests: XCTestCase {
         ]
 
         // When
-        let nodes = try libraries.map { try SDKNode(name: $0.name, platform: $0.platform, status: .required) }
+        let nodes = try libraries.map { try SDKNode(name: $0.name, platform: $0.platform, status: .required, source: .developer) }
 
         // Then
         XCTAssertEqual(nodes.map(\.path), [
@@ -53,7 +58,7 @@ final class SDKNodeTests: XCTestCase {
         ]
 
         // When
-        let nodes = try libraries.map { try SDKNode(name: $0.name, platform: $0.platform, status: .required) }
+        let nodes = try libraries.map { try SDKNode(name: $0.name, platform: $0.platform, status: .required, source: .developer) }
 
         // Then
         XCTAssertEqual(nodes.map(\.path), [
@@ -63,9 +68,9 @@ final class SDKNodeTests: XCTestCase {
     }
 
     func test_xctest_sdk_framework_unsupported_platforms_path() throws {
-        XCTAssertThrowsSpecific(try SDKNode(name: "XCTest.framework", platform: .tvOS, status: .required),
+        XCTAssertThrowsSpecific(try SDKNode(name: "XCTest.framework", platform: .tvOS, status: .required, source: .developer),
                                 SDKNode.Error.unsupported(sdk: "XCTest.framework"))
-        XCTAssertThrowsSpecific(try SDKNode(name: "XCTest.framework", platform: .watchOS, status: .required),
+        XCTAssertThrowsSpecific(try SDKNode(name: "XCTest.framework", platform: .watchOS, status: .required, source: .developer),
                                 SDKNode.Error.unsupported(sdk: "XCTest.framework"))
     }
 
@@ -78,7 +83,7 @@ final class SDKNodeTests: XCTestCase {
         ]
 
         // When
-        let nodes = try libraries.map { try SDKNode(name: $0.name, platform: $0.platform, status: .required) }
+        let nodes = try libraries.map { try SDKNode(name: $0.name, platform: $0.platform, status: .required, source: .developer) }
 
         // Then
         XCTAssertEqual(nodes.map(\.path), [
@@ -92,7 +97,8 @@ final class SDKNodeTests: XCTestCase {
         // Given
         let subject = try SDKNode(name: "CoreData.framework",
                                   platform: .iOS,
-                                  status: .required)
+                                  status: .required,
+                                  source: .developer)
 
         // When
         let got = subject.name

--- a/Tests/TuistGeneratorTests/DotGraph/GraphToDotGraphMapperTests.swift
+++ b/Tests/TuistGeneratorTests/DotGraph/GraphToDotGraphMapperTests.swift
@@ -18,7 +18,7 @@ final class GraphToDotGraphMapperTests: XCTestCase {
         let project = Project.test()
         let framework = FrameworkNode.test(path: AbsolutePath("/XcodeProj.framework"))
         let library = LibraryNode.test(path: AbsolutePath("/RxSwift.a"))
-        let sdk = try SDKNode(name: "CoreData.framework", platform: .iOS, status: .required)
+        let sdk = try SDKNode(name: "CoreData.framework", platform: .iOS, status: .required, source: .developer)
 
         let core = TargetNode.test(target: Target.test(name: "Core"), dependencies: [
             framework, library, sdk,

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -5,6 +5,15 @@ import TuistCoreTesting
 import XcodeProj
 import XCTest
 @testable import TuistGenerator
+@testable import TuistSupportTesting
+
+final class LinkGeneratorPathTests: TuistUnitTestCase {
+    func test_xcodeValue() {
+        let path = AbsolutePath("/my-path")
+        XCTAssertEqual(LinkGeneratorPath.absolutePath(path).xcodeValue(sourceRootPath: .root), "$(SRCROOT)/my-path")
+        XCTAssertEqual(LinkGeneratorPath.string("$(DEVELOPER_FRAMEWORKS_DIR)").xcodeValue(sourceRootPath: .root), "$(DEVELOPER_FRAMEWORKS_DIR)")
+    }
+}
 
 final class LinkGeneratorErrorTests: XCTestCase {
     var embedScriptGenerator: MockEmbedScriptGenerator!
@@ -207,6 +216,7 @@ final class LinkGeneratorErrorTests: XCTestCase {
         // Then
         let config = xcodeprojElements.config
         XCTAssertEqual(config.buildSettings["FRAMEWORK_SEARCH_PATHS"] as? [String], [
+            "$(DEVELOPER_FRAMEWORKS_DIR)",
             "$(inherited)",
             "$(SRCROOT)/Dependencies/Frameworks",
             "$(SRCROOT)/Dependencies/Libraries",
@@ -436,8 +446,8 @@ final class LinkGeneratorErrorTests: XCTestCase {
     func test_generateLinkingPhase_sdkNodes() throws {
         // Given
         let dependencies: [GraphDependencyReference] = [
-            .sdk(path: "/Strong/Foo.framework", status: .required),
-            .sdk(path: "/Weak/Bar.framework", status: .optional),
+            .sdk(path: "/Strong/Foo.framework", status: .required, source: .developer),
+            .sdk(path: "/Weak/Bar.framework", status: .optional, source: .developer),
         ]
         let pbxproj = PBXProj()
         let pbxTarget = PBXNativeTarget(name: "Test")

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -609,8 +609,9 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
 
         let sdk = try SDKNode(name: "ARKit.framework",
                               platform: .iOS,
-                              status: .required)
-        let sdkDependency = GraphDependencyReference.sdk(path: sdk.path, status: sdk.status)
+                              status: .required,
+                              source: .developer)
+        let sdkDependency = GraphDependencyReference.sdk(path: sdk.path, status: sdk.status, source: .developer)
 
         // When
         try subject.generate(dependencyReferences: [sdkDependency],

--- a/fixtures/ios_app_with_sdk/Derived/InfoPlists/MyTestFramework.plist
+++ b/fixtures/ios_app_with_sdk/Derived/InfoPlists/MyTestFramework.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_sdk/MyTestFramework/MyTestHelper.swift
+++ b/fixtures/ios_app_with_sdk/MyTestFramework/MyTestHelper.swift
@@ -1,0 +1,11 @@
+import XCTest
+
+public class MyTestHelper {
+    public init() {
+
+    }
+
+    public func customAssert(_ value: Bool, file: StaticString = #file, line: Int = #line) {
+        XCTAssertTrue(value, file: file, line: line)
+    }
+}

--- a/fixtures/ios_app_with_sdk/MyTestFramework/MyTestHelper.swift
+++ b/fixtures/ios_app_with_sdk/MyTestFramework/MyTestHelper.swift
@@ -6,6 +6,5 @@ public class MyTestHelper {
     }
 
     public func customAssert(_ value: Bool, file: StaticString = #file, line: Int = #line) {
-        XCTAssertTrue(value, file: file, line: line)
     }
 }

--- a/fixtures/ios_app_with_sdk/Project.swift
+++ b/fixtures/ios_app_with_sdk/Project.swift
@@ -22,7 +22,7 @@ let project = Project(name: "Project",
                                  infoPlist: .default,
                                  sources: "MyTestFramework/**",
                                  dependencies: [
-                                     .sdk(name: "XCTest.framework")
+                                     .xctest
                           ]),
                           Target(name: "AppTests",
                                  platform: .iOS,

--- a/fixtures/ios_app_with_sdk/Project.swift
+++ b/fixtures/ios_app_with_sdk/Project.swift
@@ -15,6 +15,15 @@ let project = Project(name: "Project",
                                      .sdk(name: "MobileCoreServices.framework", status: .required),
                                      .project(target: "StaticFramework", path: "Modules/StaticFramework")
                           ]),
+                          Target(name: "MyTestFramework",
+                                 platform: .iOS,
+                                 product: .framework,
+                                 bundleId: "io.tuist.MyTestFramework",
+                                 infoPlist: .default,
+                                 sources: "MyTestFramework/**",
+                                 dependencies: [
+                                     .sdk(name: "XCTest.framework")
+                          ]),
                           Target(name: "AppTests",
                                  platform: .iOS,
                                  product: .unitTests,
@@ -23,6 +32,7 @@ let project = Project(name: "Project",
                                  sources: "Tests/**",
                                  dependencies: [
                                      .target(name: "App"),
+                                     .target(name: "MyTestFramework")
                           ]),
                           Target(name: "MacFramework",
                                  platform: .macOS,

--- a/fixtures/ios_app_with_sdk/Tests/AppTests.swift
+++ b/fixtures/ios_app_with_sdk/Tests/AppTests.swift
@@ -1,6 +1,12 @@
 import Foundation
 import XCTest
+import MyTestFramework
 
 @testable import App
 
-final class AppTests: XCTestCase {}
+final class AppTests: XCTestCase {
+    private let helper = MyTestHelper()
+    func test_foo() {
+        helper.customAssert(true)
+    }
+}

--- a/website/markdown/docs/usage/dependencies.mdx
+++ b/website/markdown/docs/usage/dependencies.mdx
@@ -86,6 +86,16 @@ It defines a dependency with a pre-compiled library. It allows specifying the pa
 
 It defines a dependency on a system library (`.tbd`) or framework (`.framework`) and optionally if it is `required` or `optional` (i.e. gets weakly linked).
 
+## XCTest dependencies
+
+It's used to indicate a dependency with the system's `XCTest` framework. Unlike SDK dependencies, `XCTest.framework` is located under the directory `$(PLATFORM_DIR)/Developer/Library/Frameworks` and requires Tuist to expose that path through the `FRAMEWORK_SEARCH_PATH` build setting.
+
+You can read more about the different locations of frameworks on [this issue](https://github.com/tuist/tuist/issues/837).
+
+```swift
+.xctest
+```
+
 ## SPM dependencies
 
 Targets can add Swift package products as dependencies:


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/837

### Short description 📝

This change adds source for sdk target's dependency. Xcode provide system sdk and developer sdk for unit tests, for example.

### Solution 📦

Add source parameter to SDK target dependency.