### PR TITLE
Update the documentation to suggest using the "--skip-extra-files" argument

### DIFF
--- a/website/markdown/docs/contribution/getting-started.mdx
+++ b/website/markdown/docs/contribution/getting-started.mdx
@@ -42,7 +42,7 @@ With it you'll also get familiar with the most used elements from the Foundation
 To start working on the project, we can follow the steps below:
 
 - Clone the repository by running: `git clone git@github.com:tuist/tuist.git`
-- Generate Xcode project with `swift package generate-xcodeproj`.
+- Generate Xcode project with `swift package generate-xcodeproj --skip-extra-files`.
 - Open `tuist.xcodeproj` using Xcode.
 
 <Message


### PR DESCRIPTION
### Short description 📝

I updated the documentation to suggest using the `--skip-extra-files` argument when generating the Xcode project. Otherwise SPM adds all the files of the repository and Xcode is not able to index the project properly.
