### PR TITLE
Allow http proxy variables from shell environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Changed
 
 - Update XcodeProj to 7.8.0 https://github.com/tuist/tuist/pull/create?base=tuist%3Amaster&head=tuist%3Atarget-attributes by @pepibumur.
-
-### Changed
-
 - Path sorting speed gains https://github.com/tuist/tuist/pull/980 by @adamkhazi
+- Added support for HTTP_PROXY settings from shell environment. https://github.com/tuist/tuist/pull/1015 by @aegzorz
 
 ## 1.2.0
 

--- a/Sources/TuistSupport/System/System.swift
+++ b/Sources/TuistSupport/System/System.swift
@@ -198,6 +198,8 @@ public final class System: Systeming {
         "GEM_PATH", "RUBY_ENGINE", "GEM_ROOT", "GEM_HOME", "RUBY_ROOT", "RUBY_VERSION",
         // Xcode
         "DEVELOPER_DIR",
+        // Proxy
+        "HTTP_PROXY", "HTTPS_PROXY", "FTP_PROXY", "ALL_PROXY",
     ]
 
     /// Environment filtering out the variables that are not defined in 'acceptedEnvironmentVariables'.

--- a/Sources/TuistSupport/System/System.swift
+++ b/Sources/TuistSupport/System/System.swift
@@ -199,7 +199,7 @@ public final class System: Systeming {
         // Xcode
         "DEVELOPER_DIR",
         // Proxy
-        "HTTP_PROXY", "HTTPS_PROXY", "FTP_PROXY", "ALL_PROXY",
+        "HTTP_PROXY", "HTTPS_PROXY", "FTP_PROXY", "ALL_PROXY", "NO_PROXY",
     ]
 
     /// Environment filtering out the variables that are not defined in 'acceptedEnvironmentVariables'.


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1014

### Short description 📝

> Describe here the purpose of your PR.

Allow subset of environment variables to be passed on to CLI programs when running `tuist up`

### Solution 📦

> Describe the solution you came up with and the reasons that led you to that solution. If you thought about other solutions don't forget about mentioning them.

Appending `HTTP_PROXY` etc to `System.acceptedEnvironmentVariables`

### Implementation 👩‍💻👨‍💻

> Detail in a checklist the steps that you took to implement the PR.

- [x] Added more values to `System.acceptedEnvironmentVariables `
- [x] Ran `swift test` to verify that the tests still pass.
