### PR TITLE
Enable Pull Request Checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,7 +1,21 @@
 # https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idname
 name: Checks
 
-on: [push]
+on:
+  push:
+    branches:    
+      - master
+    paths:
+      - Sources/**/*
+      - Tests/**/*
+      - fixtures/**/*
+      - .github/workflows/checks.yml
+  pull_request:
+    paths:
+      - Sources/**/*
+      - Tests/**/*
+      - fixtures/**/*
+      - .github/workflows/checks.yml
 
 jobs:
   swiftformat:

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -1,6 +1,20 @@
 name: Tuist
 
-on: ['push']
+on:
+  push:
+    branches:    
+      - master
+    paths:
+      - Sources/**/*
+      - Tests/**/*
+      - fixtures/**/*
+      - .github/workflows/tuist.yml
+  pull_request:
+    paths:
+      - Sources/**/*
+      - Tests/**/*
+      - fixtures/**/*
+      - .github/workflows/tuist.yml
 
 jobs:
   unit_tests:
@@ -50,6 +64,7 @@ jobs:
       - name: Run tests
         run: bundle exec rake features
   upload:
+    if: github.ref == 'refs/heads/master'
     name: Upload
     runs-on: macOS-latest
     steps:

--- a/Sources/TuistGenerator/Generator/ProjectGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGenerator.swift
@@ -35,6 +35,7 @@ protocol ProjectGenerating: AnyObject {
                   xcodeprojPath: AbsolutePath?) throws -> GeneratedProject
 }
 
+// swiftlint:disable type_body_length
 final class ProjectGenerator: ProjectGenerating {
     // MARK: - Attributes
 

--- a/Tests/TuistEnvKitTests/Updater/EnvUpdaterTests.swift
+++ b/Tests/TuistEnvKitTests/Updater/EnvUpdaterTests.swift
@@ -25,6 +25,7 @@ final class EnvUpdaterTests: TuistUnitTestCase {
     func test_update() throws {
         // Given
         let temporaryPath = try self.temporaryPath()
+        fileHandler.stubInTemporaryDirectory = temporaryPath
         let downloadURL = URL(string: "https://file.download.com/tuistenv.zip")!
         let release = Release.test(assets: [Release.Asset(downloadURL: downloadURL, name: "tuistenv.zip")])
         githubClient.releasesStub = { [release] }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1002

### Short description 📝

GitHub Actions weren't running on pull requests sent from other forks, this sadly allowed master to regress in a recent PR that landed. #1006 

### Solution 📦

Re-enable actions on pull requests, however to address the concerns in https://github.com/tuist/tuist/pull/980 we can condition the checks to also run on master only when pushing to the same fork.

### Implementation 👩‍💻👨‍💻

- [x] Fix for a recently regressed unit test due to missing PR checks
- [x] Re-enable pull request actions
- [x] To avoid duplicate jobs the on push action only triggers the checks when the branch is master

### Test Plan 🛠

- Verify github actions are run on this PR
