### PR TITLE
Add missing Package dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
         ),
         .target(
             name: "tuist",
-            dependencies: ["TuistKit"]
+            dependencies: ["TuistKit", "ProjectDescription"]
         ),
         .target(
             name: "TuistEnvKit",
@@ -116,7 +116,7 @@ let package = Package(
         ),
         .target(
             name: "TuistCache",
-            dependencies: ["XcodeProj", "SPMUtility", "TuistCore", "TuistSupport"]
+            dependencies: ["XcodeProj", "SPMUtility", "TuistCore", "TuistSupport", "Checksum", "RxSwift"]
         ),
         .testTarget(
             name: "TuistCacheTests",
@@ -140,7 +140,7 @@ let package = Package(
         ),
         .target(
             name: "TuistLoader",
-            dependencies: ["XcodeProj", "SPMUtility", "TuistCore", "TuistSupport"]
+            dependencies: ["XcodeProj", "SPMUtility", "TuistCore", "TuistSupport", "ProjectDescription"]
         ),
         .target(
             name: "TuistLoaderTesting",
@@ -152,7 +152,7 @@ let package = Package(
         ),
         .testTarget(
             name: "TuistLoaderIntegrationTests",
-            dependencies: ["TuistLoader", "TuistSupportTesting"]
+            dependencies: ["TuistLoader", "TuistSupportTesting", "ProjectDescription"]
         ),
         .testTarget(
             name: "TuistIntegrationTests",


### PR DESCRIPTION
- Building Tuist when opening it Natively in Xcode (double clicking the Package.swift) yields a few buidl errors
- This is due to missing explicit dependencies between targets

Test Plan:

- Open the Package.swift to launch it in Xcode

_Note: even with this fix it doesn't seem the ProjectDescription framework/dylib is being built correctly in this mode, the current workaround is to continue to use `swift package generate-xcodeproj`_
