### PR TITLE
Add metal as valid source extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Add FAQ section by @mollyIV
 - Add benchmarking helper tool https://github.com/tuist/tuist/pull/957 by @kwridan.
+- Add metal as a valid source extension https://github.com/tuist/tuist/pull/1023 by @natanrolnik 
 
 ### Fixed
 

--- a/Sources/TuistCore/Models/Target.swift
+++ b/Sources/TuistCore/Models/Target.swift
@@ -8,7 +8,7 @@ public struct Target: Equatable, Hashable {
 
     // MARK: - Static
 
-    public static let validSourceExtensions: [String] = ["m", "swift", "mm", "cpp", "c", "d", "intentdefinition", "xcmappingmodel"]
+    public static let validSourceExtensions: [String] = ["m", "swift", "mm", "cpp", "c", "d", "intentdefinition", "xcmappingmodel", "metal"]
     public static let validFolderExtensions: [String] = ["framework", "bundle", "app", "xcassets", "appiconset"]
 
     // MARK: - Attributes

--- a/Tests/TuistCoreTests/Models/TargetTests.swift
+++ b/Tests/TuistCoreTests/Models/TargetTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 final class TargetTests: TuistUnitTestCase {
     func test_validSourceExtensions() {
-        XCTAssertEqual(Target.validSourceExtensions, ["m", "swift", "mm", "cpp", "c", "d", "intentdefinition", "xcmappingmodel"])
+        XCTAssertEqual(Target.validSourceExtensions, ["m", "swift", "mm", "cpp", "c", "d", "intentdefinition", "xcmappingmodel", "metal"])
     }
 
     func test_productName_when_staticLibrary() {
@@ -56,6 +56,7 @@ final class TargetTests: TuistUnitTestCase {
             "sources/d.c",
             "sources/e.cpp",
             "sources/k.kt",
+            "sources/n.metal",
         ])
 
         // When
@@ -73,6 +74,7 @@ final class TargetTests: TuistUnitTestCase {
             "sources/c.mm",
             "sources/d.c",
             "sources/e.cpp",
+            "sources/n.metal",
         ]))
     }
 


### PR DESCRIPTION
Files with the `.metal` extension should be valid as well for compiled sources.
This PR adds it to the static `validSourceExtensions` property.