### PR TITLE
Fix inconsistant ordering of bcsymbolmap paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fix static products false positive lint warning by https://github.com/tuist/tuist/pull/981 @kwridan.
 - TargetAction path without ./ prefix https://github.com/tuist/tuist/pull/997 by @fortmarek
 - Preserve xcuserdata when re-generating projects https://github.com/tuist/tuist/pull/1006 by @kwridan
+- Stable sort order for bcsymbolmap paths by @paulsamuels
 
 ### Changed
 

--- a/Sources/TuistCore/Utils/FrameworkMetadataProvider.swift
+++ b/Sources/TuistCore/Utils/FrameworkMetadataProvider.swift
@@ -49,6 +49,7 @@ public final class FrameworkMetadataProvider: PrecompiledMetadataProvider, Frame
         return uuids
             .map { frameworkPath.parentDirectory.appending(component: "\($0).bcsymbolmap") }
             .filter { FileHandler.shared.exists($0) }
+            .sorted()
     }
 
     public func bcsymbolmapPaths(framework: FrameworkNode) throws -> [AbsolutePath] {


### PR DESCRIPTION
### Short description 📝

The bcsymbolmap paths are retrieved by calling dwarfdump and collecting
the UUIDs into a Set. The use of Set results in an indeterminate sort
order, which can result in the frameworks script changing between runs
of generate.

### Solution 📦

This commit sorts the paths to give them a stable order.