### PR TITLE
Update SchemeLinter.swift to lint BuildAction

### DIFF
--- a/Sources/TuistGenerator/Linter/SchemeLinter.swift
+++ b/Sources/TuistGenerator/Linter/SchemeLinter.swift
@@ -44,11 +44,11 @@ private extension SchemeLinter {
             }
         }
 
-        if let testAction = scheme.testAction {
-            if !buildConfigurationNames.contains(testAction.configurationName) {
+        if let buildAction = scheme.buildAction {
+            if !buildConfigurationNames.contains(buildAction.configurationName) {
                 issues.append(
-                    missingBuildConfigurationIssue(buildConfigurationName: testAction.configurationName,
-                                                   actionDescription: "the scheme's test action")
+                    missingBuildConfigurationIssue(buildConfigurationName: buildAction.configurationName,
+                                                   actionDescription: "the scheme's build action")
                 )
             }
         }

--- a/Sources/TuistGenerator/Linter/SchemeLinter.swift
+++ b/Sources/TuistGenerator/Linter/SchemeLinter.swift
@@ -44,15 +44,6 @@ private extension SchemeLinter {
             }
         }
 
-        if let buildAction = scheme.buildAction {
-            if !buildConfigurationNames.contains(buildAction.configurationName) {
-                issues.append(
-                    missingBuildConfigurationIssue(buildConfigurationName: buildAction.configurationName,
-                                                   actionDescription: "the scheme's build action")
-                )
-            }
-        }
-
         return issues
     }
 


### PR DESCRIPTION
Adds missing linting of a scheme's `BuildAction`

### Short description 📝

> The `SchemeLinter`'s  `lintScheme(scheme:, buildConfigurations:)` method contained duplicated validation of `testAction` instead of `buildAction`. This PR replaces the duplicate with the correct action.