### PR TITLE
Adds `language` and `region` to `TestAction` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
-- Adds a possibility to set Options > Application Language and Application Region for a `TestAction` on a scheme by @paciej00
+
+### Added
+
+- Adds a possibility to set Options > Application Language and Application Region for a `TestAction` on a scheme [#1055](https://github.com/tuist/tuist/pull/1055) by [@paciej00](https://github.com/paciej00)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
+- Adds a possibility to set Options > Application Language and Application Region for a `TestAction` on a scheme by @paciej00
 
 ### Changed
 

--- a/Sources/ProjectDescription/TestAction.swift
+++ b/Sources/ProjectDescription/TestAction.swift
@@ -25,7 +25,7 @@ public struct TestAction: Equatable, Codable {
 
     /// Language
     public let language: String?
-    
+
     /// Region
     public let region: String?
 
@@ -42,6 +42,8 @@ public struct TestAction: Equatable, Codable {
     ///   - preActions: ist of actions to be executed before running the tests.
     ///   - postActions: List of actions to be executed after running the tests.
     ///   - diagnosticsOptions: Diagnostics options.
+    ///   - language: Language (e.g. "pl")
+    ///   - region: Region (e.g. "PL")
     public init(targets: [TestableTarget] = [],
                 arguments: Arguments? = nil,
                 configurationName: String,
@@ -74,6 +76,8 @@ public struct TestAction: Equatable, Codable {
     ///   - preActions: ist of actions to be executed before running the tests.
     ///   - postActions: List of actions to be executed after running the tests.
     ///   - diagnosticsOptions: Diagnostics options.
+    ///   - language: Language (e.g. "pl")
+    ///   - region: Region (e.g. "PL")
     public init(targets: [TestableTarget],
                 arguments: Arguments? = nil,
                 config: PresetBuildConfiguration = .debug,

--- a/Sources/ProjectDescription/TestAction.swift
+++ b/Sources/ProjectDescription/TestAction.swift
@@ -23,6 +23,12 @@ public struct TestAction: Equatable, Codable {
     /// List of actions to be executed after running the tests.
     public let postActions: [ExecutionAction]
 
+    /// Language
+    public let language: String?
+    
+    /// Region
+    public let region: String?
+
     /// Diagnostics options.
     public let diagnosticsOptions: [SchemeDiagnosticsOption]
 
@@ -43,7 +49,9 @@ public struct TestAction: Equatable, Codable {
                 codeCoverageTargets: [TargetReference] = [],
                 preActions: [ExecutionAction] = [],
                 postActions: [ExecutionAction] = [],
-                diagnosticsOptions: [SchemeDiagnosticsOption] = []) {
+                diagnosticsOptions: [SchemeDiagnosticsOption] = [],
+                language: String? = nil,
+                region: String? = nil) {
         self.targets = targets
         self.arguments = arguments
         self.configurationName = configurationName
@@ -52,6 +60,8 @@ public struct TestAction: Equatable, Codable {
         self.postActions = postActions
         self.codeCoverageTargets = codeCoverageTargets
         self.diagnosticsOptions = diagnosticsOptions
+        self.language = language
+        self.region = region
     }
 
     /// Initializes a new instance of a test action
@@ -71,7 +81,9 @@ public struct TestAction: Equatable, Codable {
                 codeCoverageTargets: [TargetReference] = [],
                 preActions: [ExecutionAction] = [],
                 postActions: [ExecutionAction] = [],
-                diagnosticsOptions: [SchemeDiagnosticsOption] = []) {
+                diagnosticsOptions: [SchemeDiagnosticsOption] = [],
+                language: String? = nil,
+                region: String? = nil) {
         self.init(targets: targets,
                   arguments: arguments,
                   configurationName: config.name,
@@ -79,6 +91,8 @@ public struct TestAction: Equatable, Codable {
                   codeCoverageTargets: codeCoverageTargets,
                   preActions: preActions,
                   postActions: postActions,
-                  diagnosticsOptions: diagnosticsOptions)
+                  diagnosticsOptions: diagnosticsOptions,
+                  language: language,
+                  region: region)
     }
 }

--- a/Sources/TuistCore/Models/TestAction.swift
+++ b/Sources/TuistCore/Models/TestAction.swift
@@ -12,7 +12,9 @@ public struct TestAction: Equatable {
     public let preActions: [ExecutionAction]
     public let postActions: [ExecutionAction]
     public let diagnosticsOptions: Set<SchemeDiagnosticsOption>
-
+    public let language: String?
+    public let region: String?
+    
     // MARK: - Init
 
     public init(targets: [TestableTarget],
@@ -22,7 +24,9 @@ public struct TestAction: Equatable {
                 codeCoverageTargets: [TargetReference],
                 preActions: [ExecutionAction],
                 postActions: [ExecutionAction],
-                diagnosticsOptions: Set<SchemeDiagnosticsOption>) {
+                diagnosticsOptions: Set<SchemeDiagnosticsOption>,
+                language: String? = nil,
+                region: String? = nil) {
         self.targets = targets
         self.arguments = arguments
         self.configurationName = configurationName
@@ -31,5 +35,7 @@ public struct TestAction: Equatable {
         self.postActions = postActions
         self.codeCoverageTargets = codeCoverageTargets
         self.diagnosticsOptions = diagnosticsOptions
+        self.language = language
+        self.region = region
     }
 }

--- a/Sources/TuistCore/Models/TestAction.swift
+++ b/Sources/TuistCore/Models/TestAction.swift
@@ -14,7 +14,7 @@ public struct TestAction: Equatable {
     public let diagnosticsOptions: Set<SchemeDiagnosticsOption>
     public let language: String?
     public let region: String?
-    
+
     // MARK: - Init
 
     public init(targets: [TestableTarget],

--- a/Sources/TuistCoreTesting/Models/TestAction+TestData.swift
+++ b/Sources/TuistCoreTesting/Models/TestAction+TestData.swift
@@ -10,7 +10,9 @@ public extension TestAction {
                      codeCoverageTargets: [TargetReference] = [],
                      preActions: [ExecutionAction] = [],
                      postActions: [ExecutionAction] = [],
-                     diagnosticsOptions: Set<SchemeDiagnosticsOption> = Set()) -> TestAction {
+                     diagnosticsOptions: Set<SchemeDiagnosticsOption> = Set(),
+                     language: String? = nil,
+                     region: String? = nil) -> TestAction {
         TestAction(targets: targets,
                    arguments: arguments,
                    configurationName: configurationName,
@@ -18,6 +20,8 @@ public extension TestAction {
                    codeCoverageTargets: codeCoverageTargets,
                    preActions: preActions,
                    postActions: postActions,
-                   diagnosticsOptions: diagnosticsOptions)
+                   diagnosticsOptions: diagnosticsOptions,
+                   language: language,
+                   region: region)
     }
 }

--- a/Sources/TuistGenerator/Generator/SchemesGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemesGenerator.swift
@@ -244,7 +244,6 @@ final class SchemesGenerator: SchemesGenerating {
                                                                graph: graph,
                                                                rootPath: rootPath,
                                                                generatedProjects: generatedProjects) else { return }
-
             let testable = XCScheme.TestableReference(skipped: testableTarget.isSkipped,
                                                       parallelizable: testableTarget.isParallelizable,
                                                       randomExecutionOrdering: testableTarget.isRandomExecutionOrdering,
@@ -282,7 +281,7 @@ final class SchemesGenerator: SchemesGenerating {
         let shouldUseLaunchSchemeArgsEnv: Bool = args == nil && environments == nil
         let language = testAction.language
         let region = testAction.region
-        
+
         return XCScheme.TestAction(buildConfiguration: testAction.configurationName,
                                    macroExpansion: nil,
                                    testables: testables,

--- a/Sources/TuistGenerator/Generator/SchemesGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemesGenerator.swift
@@ -280,7 +280,9 @@ final class SchemesGenerator: SchemesGenerating {
 
         let disableMainThreadChecker = !testAction.diagnosticsOptions.contains(.mainThreadChecker)
         let shouldUseLaunchSchemeArgsEnv: Bool = args == nil && environments == nil
-
+        let language = testAction.language
+        let region = testAction.region
+        
         return XCScheme.TestAction(buildConfiguration: testAction.configurationName,
                                    macroExpansion: nil,
                                    testables: testables,
@@ -292,7 +294,9 @@ final class SchemesGenerator: SchemesGenerating {
                                    onlyGenerateCoverageForSpecifiedTargets: onlyGenerateCoverageForSpecifiedTargets,
                                    disableMainThreadChecker: disableMainThreadChecker,
                                    commandlineArguments: args,
-                                   environmentVariables: environments)
+                                   environmentVariables: environments,
+                                   language: language,
+                                   region: region)
     }
 
     /// Generates the scheme launch action.

--- a/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
@@ -25,7 +25,7 @@ extension TuistCore.TestAction {
 
         let language: String? = manifest.language
         let region: String? = manifest.region
-        
+
         return TestAction(targets: targets,
                           arguments: arguments,
                           configurationName: configurationName,

--- a/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
@@ -23,6 +23,9 @@ extension TuistCore.TestAction {
                                                                                             generatorPaths: generatorPaths) }
         let diagnosticsOptions = Set(manifest.diagnosticsOptions.map { TuistCore.SchemeDiagnosticsOption.from(manifest: $0) })
 
+        let language: String? = manifest.language
+        let region: String? = manifest.region
+        
         return TestAction(targets: targets,
                           arguments: arguments,
                           configurationName: configurationName,
@@ -30,6 +33,8 @@ extension TuistCore.TestAction {
                           codeCoverageTargets: codeCoverageTargets,
                           preActions: preActions,
                           postActions: postActions,
-                          diagnosticsOptions: diagnosticsOptions)
+                          diagnosticsOptions: diagnosticsOptions,
+                          language: language,
+                          region: region)
     }
 }

--- a/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
@@ -366,7 +366,7 @@ final class SchemesGeneratorTests: XCTestCase {
 
         let preAction = ExecutionAction(title: "Pre Action", scriptText: "echo Pre Actions", target: TargetReference(projectPath: projectPath, name: "AppTests"))
         let postAction = ExecutionAction(title: "Post Action", scriptText: "echo Post Actions", target: TargetReference(projectPath: projectPath, name: "AppTests"))
-        let testAction = TestAction.test(targets: [TestableTarget(target: TargetReference(projectPath: projectPath, name: "AppTests"))], preActions: [preAction], postActions: [postAction])
+        let testAction = TestAction.test(targets: [TestableTarget(target: TargetReference(projectPath: projectPath, name: "AppTests"))], preActions: [preAction], postActions: [postAction], language: "es", region: "ES")
 
         let scheme = Scheme.test(name: "AppTests", shared: true, testAction: testAction)
         let project = Project.test(path: projectPath, targets: [testTarget])
@@ -380,6 +380,9 @@ final class SchemesGeneratorTests: XCTestCase {
         // Then
         // Pre Action
         let result = try XCTUnwrap(got)
+        XCTAssertEqual(result.language, "es")
+        XCTAssertEqual(result.region, "ES")
+
         XCTAssertEqual(result.preActions.first?.title, "Pre Action")
         XCTAssertEqual(result.preActions.first?.scriptText, "echo Pre Actions")
 

--- a/website/markdown/docs/usage/projectswift.mdx
+++ b/website/markdown/docs/usage/projectswift.mdx
@@ -915,6 +915,20 @@ Alternatively, when leveraging custom configurations, the configuration name can
       optional: true,
       default: '[]',
     },
+    {
+      name: 'Language',
+      description: 'Language used to run the tests',
+      type: 'String?',
+      optional: true,
+      default: 'nil',
+    },
+    {
+      name: 'Region',
+      description: 'Region used to run the tests',
+      type: 'String?',
+      optional: true,
+      default: 'nil',
+    },
   ]}
 />
 


### PR DESCRIPTION
### Short description 📝

> Adds a possibility to set Options > Application Language and Application Region for a `TestAction` on a scheme:

```
<TestAction
      buildConfiguration = "Debug"
      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
      shouldUseLaunchSchemeArgsEnv = "YES"
      language = "pl"
      region = "PL">
```

### Solution 📦

> Extends `ProjectDescription.TestAction` and `TuistCore.TestAction` by adding `language` and `region` strings. The strings are then used by `SchemesGenerator` to create an `XCScheme.TestAction` from `XcodeProj` library and written to a workspace (no changes to the proces were made).
