### PR TITLE
Graph cache mapper

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -130,7 +130,7 @@ let package = Package(
         ),
         .testTarget(
             name: "TuistCacheTests",
-            dependencies: ["TuistCache", "TuistSupportTesting", "TuistCoreTesting", "RxBlocking"]
+            dependencies: ["TuistCache", "TuistSupportTesting", "TuistCoreTesting", "RxBlocking", "TuistCacheTesting"]
         ),
         .target(
             name: "TuistCacheTesting",

--- a/Sources/TuistCache/Cache/CacheGraphMapper.swift
+++ b/Sources/TuistCache/Cache/CacheGraphMapper.swift
@@ -1,0 +1,111 @@
+import Basic
+import Foundation
+import RxSwift
+import TuistCore
+import TuistSupport
+
+/// It defines the interface to mutate a graph using information from the cache.
+protocol CacheGraphMapping {
+    /// Given a graph an a dictionary whose keys are targets of the graph, and the values are paths
+    /// to the .xcframeworks in the cache, it mutates the graph to link the enry nodes against the .xcframeworks instead.
+    /// - Parameters:
+    ///   - graph: Dependency graph.
+    ///   - xcframeworks: Dictionary that maps targets with the paths to their cached .xcframeworks.
+    func map(graph: Graph, xcframeworks: [TargetNode: AbsolutePath]) throws -> Graph
+}
+
+class CacheGraphMapper: CacheGraphMapping {
+    struct VisitedXCFramework {
+        let path: AbsolutePath?
+    }
+
+    // MARK: - Attributes
+
+    /// Utility to parse an .xcframework from the filesystem and load it into memory.
+    private let xcframeworkLoader: XCFrameworkNodeLoading
+
+    /// Initializes the graph mapper with its attributes.
+    /// - Parameter xcframeworkLoader: Utility to parse an .xcframework from the filesystem and load it into memory.
+    init(xcframeworkLoader: XCFrameworkNodeLoading = XCFrameworkNodeLoader()) {
+        self.xcframeworkLoader = xcframeworkLoader
+    }
+
+    // MARK: - CacheGraphMapping
+
+    public func map(graph: Graph, xcframeworks: [TargetNode: AbsolutePath]) throws -> Graph {
+        var visitedXCFrameworkPaths: [TargetNode: VisitedXCFramework?] = [:]
+        var loadedXCFrameworks: [AbsolutePath: XCFrameworkNode] = [:]
+
+        func mapDependencies(_ dependencies: [GraphNode]) throws -> [GraphNode] {
+            var newDependencies: [GraphNode] = []
+            try dependencies.forEach { dependency in
+                // If the dependency is not a target node we keep it.
+                guard let targetDependency = dependency as? TargetNode else {
+                    newDependencies.append(dependency)
+                    return
+                }
+                // If the target cannot be replace with its associated .xcframework we return
+                guard let xcframeworkPath = xcframeworkPath(target: targetDependency,
+                                                            xcframeworks: xcframeworks,
+                                                            visitedXCFrameworkPaths: &visitedXCFrameworkPaths) else {
+                    newDependencies.append(dependency)
+                    return
+                }
+
+                // We load the xcframework
+                let xcframework = try self.loadXCFramework(path: xcframeworkPath, loadedXCFrameworks: &loadedXCFrameworks)
+                try mapDependencies(targetDependency.dependencies).forEach { dependency in
+                    if let frameworkDependency = dependency as? FrameworkNode {
+                        xcframework.add(dependency: XCFrameworkNode.Dependency.framework(frameworkDependency))
+                    } else if let xcframeworkDependency = dependency as? XCFrameworkNode {
+                        xcframework.add(dependency: XCFrameworkNode.Dependency.xcframework(xcframeworkDependency))
+                    } else {
+                        // Static dependencies fall into this case.
+                        // Those are now part of the precompiled xcframework and therefore we don't have to link against them.
+                    }
+                }
+                newDependencies.append(xcframework)
+            }
+            return newDependencies
+        }
+
+        func visit(node: GraphNode) throws {
+            guard let targetNode = node as? TargetNode else { return }
+            targetNode.dependencies = try mapDependencies(targetNode.dependencies)
+        }
+
+        try graph.entryNodes.forEach(visit)
+
+        return graph
+    }
+
+    fileprivate func loadXCFramework(path: AbsolutePath, loadedXCFrameworks: inout [AbsolutePath: XCFrameworkNode]) throws -> XCFrameworkNode {
+        if let cachedXCFramework = loadedXCFrameworks[path] { return cachedXCFramework }
+        let xcframework = try xcframeworkLoader.load(path: path)
+        loadedXCFrameworks[path] = xcframework
+        return xcframework
+    }
+
+    fileprivate func xcframeworkPath(target: TargetNode,
+                                     xcframeworks: [TargetNode: AbsolutePath],
+                                     visitedXCFrameworkPaths: inout [TargetNode: VisitedXCFramework?]) -> AbsolutePath? {
+        // Already visited
+        if let visited = visitedXCFrameworkPaths[target] { return visited?.path }
+
+        // The target doesn't have a cached xcframework
+        if xcframeworks[target] == nil {
+            visitedXCFrameworkPaths[target] = VisitedXCFramework(path: nil)
+            return nil
+        }
+        // The target can be replaced
+        else if let path = xcframeworks[target],
+            target.targetDependencies.allSatisfy({ xcframeworkPath(target: $0, xcframeworks: xcframeworks,
+                                                                   visitedXCFrameworkPaths: &visitedXCFrameworkPaths) != nil }) {
+            visitedXCFrameworkPaths[target] = VisitedXCFramework(path: path)
+            return path
+        } else {
+            visitedXCFrameworkPaths[target] = VisitedXCFramework(path: nil)
+            return nil
+        }
+    }
+}

--- a/Sources/TuistCache/Generator/GeneratorCacheMapper.swift
+++ b/Sources/TuistCache/Generator/GeneratorCacheMapper.swift
@@ -1,0 +1,97 @@
+import Basic
+import Foundation
+import RxSwift
+import TuistCore
+import TuistSupport
+
+/// It defines the interface to map a graph and swap those targets
+/// that have an associated .xcframework in the cache. Note that transitive
+/// dependencies should be cacheable too.
+public protocol GeneratorCacheMapping {
+    /// Given a graph, it modifies it to replace some of the nodes with their associated from the cache.
+    /// Note that cache might be remote so we model the asynchrony by returning an observable instead.
+    /// - Parameter graph: Graph.
+    /// - Returns: A single to obtain the mutated graph.
+    func map(graph: Graph) -> Single<Graph>
+}
+
+public class GeneratorCacheMapper: GeneratorCacheMapping {
+    // MARK: - Attributes
+
+    /// Cache.
+    private let cache: CacheStoraging
+
+    /// Graph content hasher.
+    private let graphContentHasher: GraphContentHashing
+
+    /// Cache graph mapper.
+    private let cacheGraphMapper: CacheGraphMapping
+
+    /// Dispatch queue.
+    private let queue: DispatchQueue
+
+    // MARK: - Init
+
+    public convenience init() {
+        self.init(cache: Cache(),
+                  graphContentHasher: GraphContentHasher())
+    }
+
+    init(cache: CacheStoraging,
+         graphContentHasher: GraphContentHashing,
+         cacheGraphMapper: CacheGraphMapping = CacheGraphMapper(),
+         queue: DispatchQueue = GeneratorCacheMapper.dispatchQueue()) {
+        self.cache = cache
+        self.graphContentHasher = graphContentHasher
+        self.queue = queue
+        self.cacheGraphMapper = cacheGraphMapper
+    }
+
+    // MARK: - CacheGraphMapping
+
+    public func map(graph: Graph) -> Single<Graph> {
+        hashes(graph: graph).flatMap { self.map(graph: graph, hashes: $0) }
+    }
+
+    // MARK: - Fileprivate
+
+    fileprivate static func dispatchQueue() -> DispatchQueue {
+        let qos: DispatchQoS = .userInitiated
+        return DispatchQueue(label: "io.tuist.generator-cache-mapper.\(qos)", qos: qos, attributes: [], target: nil)
+    }
+
+    fileprivate func hashes(graph: Graph) -> Single<[TargetNode: String]> {
+        Single.create { (observer) -> Disposable in
+            do {
+                let hashes = try self.graphContentHasher.contentHashes(for: graph)
+                observer(.success(hashes))
+            } catch {
+                observer(.error(error))
+            }
+            return Disposables.create {}
+        }
+        .subscribeOn(ConcurrentDispatchQueueScheduler(queue: queue))
+    }
+
+    fileprivate func map(graph: Graph, hashes: [TargetNode: String]) -> Single<Graph> {
+        fetch(hashes: hashes).map { xcframeworkPaths in
+            try self.cacheGraphMapper.map(graph: graph, xcframeworks: xcframeworkPaths)
+        }
+    }
+
+    fileprivate func fetch(hashes: [TargetNode: String]) -> Single<[TargetNode: AbsolutePath]> {
+        Single.zip(hashes.map { target, hash in
+            self.cache.exists(hash: hash)
+                .flatMap { (exists) -> Single<(target: TargetNode, path: AbsolutePath?)> in
+                    guard exists else { return Single.just((target: target, path: nil)) }
+                    return self.cache.fetch(hash: hash).map { (target: target, path: $0) }
+                }
+        })
+            .map { result in
+                result.reduce(into: [TargetNode: AbsolutePath]()) { acc, next in
+                    guard let path = next.path else { return }
+                    acc[next.target] = path
+                }
+            }
+    }
+}

--- a/Sources/TuistCacheTesting/Cache/Mocks/MockCacheStorage.swift
+++ b/Sources/TuistCacheTesting/Cache/Mocks/MockCacheStorage.swift
@@ -17,10 +17,14 @@ public final class MockCacheStorage: CacheStoraging {
         }
     }
 
-    var fetchStub: ((String) -> AbsolutePath)?
+    var fetchStub: ((String) throws -> AbsolutePath)?
     public func fetch(hash: String) -> Single<AbsolutePath> {
         if let fetchStub = fetchStub {
-            return Single.just(fetchStub(hash))
+            do {
+                return Single.just(try fetchStub(hash))
+            } catch {
+                return Single.error(error)
+            }
         } else {
             return Single.just(AbsolutePath.root)
         }

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -421,6 +421,14 @@ public class Graph: Encodable {
                 for child in targetNode.dependencies where !visited.contains(child) {
                     stack.push(child)
                 }
+            } else if let xcframeworkNode = node as? XCFrameworkNode {
+                for child in xcframeworkNode.dependencies.map(\.node) where !visited.contains(child) {
+                    stack.push(child)
+                }
+            } else if let frameworkNode = node as? FrameworkNode {
+                for child in frameworkNode.dependencies where !visited.contains(child) {
+                    stack.push(child)
+                }
             }
         }
 

--- a/Sources/TuistCore/NodeLoaders/XCFrameworkNodeLoader.swift
+++ b/Sources/TuistCore/NodeLoaders/XCFrameworkNodeLoader.swift
@@ -28,17 +28,21 @@ public protocol XCFrameworkNodeLoading {
     func load(path: AbsolutePath) throws -> XCFrameworkNode
 }
 
-final class XCFrameworkNodeLoader: XCFrameworkNodeLoading {
+public final class XCFrameworkNodeLoader: XCFrameworkNodeLoading {
     /// xcframework metadata provider.
     fileprivate let xcframeworkMetadataProvider: XCFrameworkMetadataProviding
 
+    public convenience init() {
+        self.init(xcframeworkMetadataProvider: XCFrameworkMetadataProvider())
+    }
+
     /// Initializes the loader with its attributes.
     /// - Parameter xcframeworkMetadataProvider: xcframework metadata provider.
-    init(xcframeworkMetadataProvider: XCFrameworkMetadataProviding = XCFrameworkMetadataProvider()) {
+    init(xcframeworkMetadataProvider: XCFrameworkMetadataProviding) {
         self.xcframeworkMetadataProvider = xcframeworkMetadataProvider
     }
 
-    func load(path: AbsolutePath) throws -> XCFrameworkNode {
+    public func load(path: AbsolutePath) throws -> XCFrameworkNode {
         guard FileHandler.shared.exists(path) else {
             throw XCFrameworkNodeLoaderError.xcframeworkNotFound(path)
         }

--- a/Sources/TuistCoreTesting/Graph/XCFrameworkNode+TestData.swift
+++ b/Sources/TuistCoreTesting/Graph/XCFrameworkNode+TestData.swift
@@ -8,7 +8,7 @@ public extension XCFrameworkNode {
                      infoPlist: XCFrameworkInfoPlist = .test(),
                      primaryBinaryPath: AbsolutePath = "/MyFramework/MyFramework.xcframework/binary",
                      linking: BinaryLinking = .dynamic,
-                     dependencies: [XCFrameworkNode] = []) -> XCFrameworkNode {
+                     dependencies: [XCFrameworkNode.Dependency] = []) -> XCFrameworkNode {
         XCFrameworkNode(path: path,
                         infoPlist: infoPlist,
                         primaryBinaryPath: primaryBinaryPath,

--- a/Sources/TuistKit/Commands/FocusCommand.swift
+++ b/Sources/TuistKit/Commands/FocusCommand.swift
@@ -1,6 +1,9 @@
 import Basic
 import Foundation
+import RxBlocking
+import RxSwift
 import SPMUtility
+import TuistCache
 import TuistGenerator
 import TuistLoader
 import TuistSupport
@@ -29,8 +32,10 @@ class FocusCommand: NSObject, Command {
     ///
     /// - Parameter parser: Argument parser that parses the CLI arguments.
     required convenience init(parser: ArgumentParser) {
+        let generatorCacheMapper = GeneratorCacheMapper()
+        let graphMapper = AnyProjectGeneratorGraphMapper(mapper: { try generatorCacheMapper.map(graph: $0).toBlocking().single() })
         self.init(parser: parser,
-                  generator: ProjectGenerator(),
+                  generator: ProjectGenerator(graphMapper: graphMapper),
                   opener: Opener())
     }
 

--- a/Sources/TuistSupportTesting/Errors/TestError.swift
+++ b/Sources/TuistSupportTesting/Errors/TestError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct TestError: Error, CustomStringConvertible {
+public struct TestError: Error, CustomStringConvertible, Equatable {
     public var description: String
 
     public init(_ description: String) {

--- a/Tests/TuistCacheTests/Cache/CacheGraphMapperTests.swift
+++ b/Tests/TuistCacheTests/Cache/CacheGraphMapperTests.swift
@@ -1,0 +1,206 @@
+import Foundation
+import TuistCore
+import XCTest
+
+@testable import TuistCache
+@testable import TuistCoreTesting
+@testable import TuistSupportTesting
+
+// To generate the ASCII graphs: http://asciiflow.com/
+// Alternative: https://dot-to-ascii.ggerganov.com/
+final class CacheGraphMapperTests: TuistUnitTestCase {
+    var xcframeworkLoader: MockXCFrameworkNodeLoader!
+    var subject: CacheGraphMapper!
+
+    override func setUp() {
+        xcframeworkLoader = MockXCFrameworkNodeLoader()
+        subject = CacheGraphMapper(xcframeworkLoader: xcframeworkLoader)
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        xcframeworkLoader = nil
+        subject = nil
+    }
+
+    // First scenario
+    //       +---->B (Cached Framework)+
+    //       |                         |
+    //    App|                         +------>D (Cached Framework)
+    //       |                         |
+    //       +---->C (Cached Framework)+
+    func test_map_when_first_scenario() throws {
+        let path = try temporaryPath()
+
+        // Given nodes
+        let dFramework = TargetNode.test(target: Target.test(name: "D", platform: .iOS, product: .framework))
+        let bFramework = TargetNode.test(target: Target.test(name: "B", platform: .iOS, product: .framework), dependencies: [dFramework])
+        let cFramework = TargetNode.test(target: Target.test(name: "C", platform: .iOS, product: .framework), dependencies: [dFramework])
+        let appTarget = TargetNode.test(target: Target.test(name: "App", platform: .iOS, product: .app), dependencies: [bFramework, cFramework])
+        let graph = Graph.test(entryNodes: [appTarget])
+
+        // Given xcframeworks
+        let dXCFrameworkPath = path.appending(component: "D.xcframework")
+        let dXCFramework = XCFrameworkNode.test(path: dXCFrameworkPath)
+        let bXCFrameworkPath = path.appending(component: "B.xcframework")
+        let bXCFramework = XCFrameworkNode.test(path: bXCFrameworkPath)
+        let cXCFrameworkPath = path.appending(component: "C.xcframework")
+        let cXCFramework = XCFrameworkNode.test(path: cXCFrameworkPath)
+        let xcframeworks = [
+            dFramework: dXCFrameworkPath,
+            bFramework: bXCFrameworkPath,
+            cFramework: cXCFrameworkPath,
+        ]
+
+        xcframeworkLoader.loadStub = { path in
+            if path == dXCFrameworkPath { return dXCFramework }
+            else if path == bXCFrameworkPath { return bXCFramework }
+            else if path == cXCFrameworkPath { return cXCFramework }
+            else { fatalError("Unexpected load call") }
+        }
+
+        // When
+        let got = try subject.map(graph: graph, xcframeworks: xcframeworks)
+
+        // Then
+        let app = try XCTUnwrap(got.entryNodes.first as? TargetNode)
+        let b = try XCTUnwrap(app.dependencies.compactMap { $0 as? XCFrameworkNode }.first(where: { $0.path == bXCFrameworkPath }))
+        let c = try XCTUnwrap(app.dependencies.compactMap { $0 as? XCFrameworkNode }.first(where: { $0.path == cXCFrameworkPath }))
+        XCTAssertTrue(b.dependencies.contains(where: { $0.path == dXCFrameworkPath }))
+        XCTAssertTrue(c.dependencies.contains(where: { $0.path == dXCFrameworkPath }))
+    }
+
+    // Second scenario
+    //       +---->B (Cached Framework)+
+    //       |                         |
+    //    App|                         +------>D Precompiled .framework
+    //       |                         |
+    //       +---->C (Cached Framework)+
+    func test_map_when_second_scenario() throws {
+        let path = try temporaryPath()
+
+        // Given nodes
+        let dFrameworkPath = path.appending(component: "D.framework")
+        let dFramework = FrameworkNode.test(path: dFrameworkPath)
+        let bFramework = TargetNode.test(target: Target.test(name: "B", platform: .iOS, product: .framework), dependencies: [dFramework])
+        let cFramework = TargetNode.test(target: Target.test(name: "C", platform: .iOS, product: .framework), dependencies: [dFramework])
+        let appTarget = TargetNode.test(target: Target.test(name: "App", platform: .iOS, product: .app), dependencies: [bFramework, cFramework])
+        let graph = Graph.test(entryNodes: [appTarget])
+
+        // Given xcframeworks
+        let bXCFrameworkPath = path.appending(component: "B.xcframework")
+        let bXCFramework = XCFrameworkNode.test(path: bXCFrameworkPath)
+        let cXCFrameworkPath = path.appending(component: "C.xcframework")
+        let cXCFramework = XCFrameworkNode.test(path: cXCFrameworkPath)
+        let xcframeworks = [
+            bFramework: bXCFrameworkPath,
+            cFramework: cXCFrameworkPath,
+        ]
+
+        xcframeworkLoader.loadStub = { path in
+            if path == bXCFrameworkPath { return bXCFramework }
+            else if path == cXCFrameworkPath { return cXCFramework }
+            else { fatalError("Unexpected load call") }
+        }
+
+        // When
+        let got = try subject.map(graph: graph, xcframeworks: xcframeworks)
+
+        // Then
+        let app = try XCTUnwrap(got.entryNodes.first as? TargetNode)
+        let b = try XCTUnwrap(app.dependencies.compactMap { $0 as? XCFrameworkNode }.first(where: { $0.path == bXCFrameworkPath }))
+        let c = try XCTUnwrap(app.dependencies.compactMap { $0 as? XCFrameworkNode }.first(where: { $0.path == cXCFrameworkPath }))
+        XCTAssertTrue(b.dependencies.contains(where: { $0.path == dFrameworkPath }))
+        XCTAssertTrue(c.dependencies.contains(where: { $0.path == dFrameworkPath }))
+    }
+
+    // Third scenario
+    //       +---->B (Cached Framework)+
+    //       |                         |
+    //    App|                         +------>D Precompiled .framework
+    //       |                         |
+    //       +---->C (Cached Framework)+------>E Precompiled .xcframework
+    func test_map_when_third_scenario() throws {
+        let path = try temporaryPath()
+
+        // Given nodes
+        let eXCFrameworkPath = path.appending(component: "E.xcframework")
+        let eXCFramework = XCFrameworkNode.test(path: eXCFrameworkPath)
+        let dFrameworkPath = path.appending(component: "D.framework")
+        let dFramework = FrameworkNode.test(path: dFrameworkPath)
+        let bFramework = TargetNode.test(target: Target.test(name: "B", platform: .iOS, product: .framework), dependencies: [dFramework])
+        let cFramework = TargetNode.test(target: Target.test(name: "C", platform: .iOS, product: .framework), dependencies: [dFramework, eXCFramework])
+        let appTarget = TargetNode.test(target: Target.test(name: "App", platform: .iOS, product: .app), dependencies: [bFramework, cFramework])
+        let graph = Graph.test(entryNodes: [appTarget])
+
+        // Given xcframeworks
+        let bXCFrameworkPath = path.appending(component: "B.xcframework")
+        let bXCFramework = XCFrameworkNode.test(path: bXCFrameworkPath)
+        let cXCFrameworkPath = path.appending(component: "C.xcframework")
+        let cXCFramework = XCFrameworkNode.test(path: cXCFrameworkPath)
+        let xcframeworks = [
+            bFramework: bXCFrameworkPath,
+            cFramework: cXCFrameworkPath,
+        ]
+
+        xcframeworkLoader.loadStub = { path in
+            if path == bXCFrameworkPath { return bXCFramework }
+            else if path == cXCFrameworkPath { return cXCFramework }
+            else { fatalError("Unexpected load call") }
+        }
+
+        // When
+        let got = try subject.map(graph: graph, xcframeworks: xcframeworks)
+
+        // Then
+        let app = try XCTUnwrap(got.entryNodes.first as? TargetNode)
+        let b = try XCTUnwrap(app.dependencies.compactMap { $0 as? XCFrameworkNode }.first(where: { $0.path == bXCFrameworkPath }))
+        let c = try XCTUnwrap(app.dependencies.compactMap { $0 as? XCFrameworkNode }.first(where: { $0.path == cXCFrameworkPath }))
+        XCTAssertTrue(b.dependencies.contains(where: { $0.path == dFrameworkPath }))
+        XCTAssertTrue(c.dependencies.contains(where: { $0.path == dFrameworkPath }))
+        XCTAssertTrue(c.dependencies.contains(where: { $0.path == eXCFrameworkPath }))
+    }
+
+    // Fourth scenario
+    //       +---->B (Framework)+------>D Precompiled .framework
+    //       |
+    //    App|
+    //       |
+    //       +---->C (Cached Framework)+------>E Precompiled .xcframework
+    func test_map_when_fourth_scenario() throws {
+        let path = try temporaryPath()
+
+        // Given nodes
+        let eXCFrameworkPath = path.appending(component: "E.xcframework")
+        let eXCFramework = XCFrameworkNode.test(path: eXCFrameworkPath)
+        let dFrameworkPath = path.appending(component: "D.framework")
+        let dFramework = FrameworkNode.test(path: dFrameworkPath)
+        let bFramework = TargetNode.test(target: Target.test(name: "B", platform: .iOS, product: .framework), dependencies: [dFramework])
+        let cFramework = TargetNode.test(target: Target.test(name: "C", platform: .iOS, product: .framework), dependencies: [eXCFramework])
+        let appTarget = TargetNode.test(target: Target.test(name: "App", platform: .iOS, product: .app), dependencies: [bFramework, cFramework])
+        let graph = Graph.test(entryNodes: [appTarget])
+
+        // Given xcframeworks
+        let cXCFrameworkPath = path.appending(component: "C.xcframework")
+        let cXCFramework = XCFrameworkNode.test(path: cXCFrameworkPath)
+        let xcframeworks = [
+            cFramework: cXCFrameworkPath,
+        ]
+
+        xcframeworkLoader.loadStub = { path in
+            if path == cXCFrameworkPath { return cXCFramework }
+            else { fatalError("Unexpected load call") }
+        }
+
+        // When
+        let got = try subject.map(graph: graph, xcframeworks: xcframeworks)
+
+        // Then
+        let app = try XCTUnwrap(got.entryNodes.first as? TargetNode)
+        let b = try XCTUnwrap(app.dependencies.compactMap { $0 as? TargetNode }.first(where: { $0.name == "B" }))
+        let c = try XCTUnwrap(app.dependencies.compactMap { $0 as? XCFrameworkNode }.first(where: { $0.path == cXCFrameworkPath }))
+        XCTAssertTrue(b.dependencies.contains(where: { $0.path == dFrameworkPath }))
+        XCTAssertTrue(c.dependencies.contains(where: { $0.path == eXCFrameworkPath }))
+    }
+}

--- a/Tests/TuistCacheTests/Cache/Mocks/MockCacheGraphMapper.swift
+++ b/Tests/TuistCacheTests/Cache/Mocks/MockCacheGraphMapper.swift
@@ -1,0 +1,24 @@
+import Basic
+import Foundation
+import TuistCore
+import XCTest
+
+@testable import TuistCache
+@testable import TuistSupportTesting
+
+final class MockCacheGraphMapper: CacheGraphMapping {
+    var mapArgs: [(graph: Graph, xcframeworks: [TargetNode: AbsolutePath])] = []
+    var mapStub: Result<Graph, Error>?
+
+    func map(graph: Graph, xcframeworks: [TargetNode: AbsolutePath]) throws -> Graph {
+        mapArgs.append((graph: graph, xcframeworks: xcframeworks))
+        if let mapStub = mapStub {
+            switch mapStub {
+            case let .failure(error): throw error
+            case let .success(graph): return graph
+            }
+        } else {
+            throw TestError("call to map that has not been stubbed")
+        }
+    }
+}

--- a/Tests/TuistCacheTests/Generator/GeneratorCacheMapperTests.swift
+++ b/Tests/TuistCacheTests/Generator/GeneratorCacheMapperTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import RxBlocking
+import RxSwift
+import TuistCore
+import XCTest
+
+@testable import TuistCache
+@testable import TuistCacheTesting
+@testable import TuistCoreTesting
+@testable import TuistSupportTesting
+
+final class GeneratorCacheMapperTests: TuistUnitTestCase {
+    var cache: MockCacheStorage!
+    var graphContentHasher: MockGraphContentHasher!
+    var cacheGraphMapper: MockCacheGraphMapper!
+    var subject: GeneratorCacheMapper!
+
+    override func setUp() {
+        cache = MockCacheStorage()
+        graphContentHasher = MockGraphContentHasher()
+        cacheGraphMapper = MockCacheGraphMapper()
+        subject = GeneratorCacheMapper(cache: cache,
+                                       graphContentHasher: graphContentHasher,
+                                       cacheGraphMapper: cacheGraphMapper,
+                                       queue: DispatchQueue.main)
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        cache = nil
+        graphContentHasher = nil
+        cacheGraphMapper = nil
+        subject = nil
+    }
+
+    func test_map_when_all_xcframeworks_are_fetched_successfully() throws {
+        let path = try temporaryPath()
+
+        // Given
+        let cFramework = Target.test(name: "C", platform: .iOS, product: .framework)
+        let cNode = TargetNode.test(target: cFramework, dependencies: [])
+        let cXCFrameworkPath = path.appending(component: "C.xcframework")
+        let cHash = "C"
+
+        let bFramework = Target.test(name: "B", platform: .iOS, product: .framework)
+        let bNode = TargetNode.test(target: bFramework, dependencies: [cNode])
+        let bHash = "B"
+        let bXCFrameworkPath = path.appending(component: "B.xcframework")
+
+        let app = Target.test(name: "App", platform: .iOS, product: .app)
+        let appNode = TargetNode.test(target: app, dependencies: [bNode])
+        let appHash = "App"
+
+        let inputGraph = Graph.test(name: "output", entryNodes: [appNode])
+        let outputGraph = Graph.test(name: "output")
+
+        let contentHashes = [
+            cNode: cHash,
+            bNode: bHash,
+            appNode: appHash,
+        ]
+        graphContentHasher.contentHashesStub = contentHashes
+
+        cache.existsStub = { hash in
+            if hash == bHash { return true }
+            if hash == cHash { return true }
+            return false
+        }
+
+        cache.fetchStub = { hash in
+            if hash == bHash { return bXCFrameworkPath }
+            if hash == cHash { return cXCFrameworkPath }
+            else { fatalError("unexpected call to fetch") }
+        }
+        cacheGraphMapper.mapStub = .success(outputGraph)
+
+        // When
+        let got = try subject.map(graph: inputGraph).toBlocking().single()
+
+        // Then
+        XCTAssertEqual(got.name, outputGraph.name)
+    }
+
+    func test_map_when_one_of_the_xcframeworks_fails_cannot_be_fetched() throws {
+        let path = try temporaryPath()
+
+        // Given
+        let cFramework = Target.test(name: "C", platform: .iOS, product: .framework)
+        let cNode = TargetNode.test(target: cFramework, dependencies: [])
+        let cXCFrameworkPath = path.appending(component: "C.xcframework")
+        let cHash = "C"
+
+        let bFramework = Target.test(name: "B", platform: .iOS, product: .framework)
+        let bNode = TargetNode.test(target: bFramework, dependencies: [cNode])
+        let bHash = "B"
+        let bXCFrameworkPath = path.appending(component: "B.xcframework")
+
+        let app = Target.test(name: "App", platform: .iOS, product: .app)
+        let appNode = TargetNode.test(target: app, dependencies: [bNode])
+        let appHash = "App"
+
+        let inputGraph = Graph.test(name: "output", entryNodes: [appNode])
+        let outputGraph = Graph.test(name: "output")
+
+        let contentHashes = [
+            cNode: cHash,
+            bNode: bHash,
+            appNode: appHash,
+        ]
+        let error = TestError("error downloading C")
+        graphContentHasher.contentHashesStub = contentHashes
+
+        cache.existsStub = { hash in
+            if hash == bHash { return true }
+            if hash == cHash { return true }
+            return false
+        }
+
+        cache.fetchStub = { hash in
+            if hash == bHash { return bXCFrameworkPath }
+            if hash == cHash { throw error }
+            else { fatalError("unexpected call to fetch") }
+        }
+        cacheGraphMapper.mapStub = .success(outputGraph)
+
+        // Then
+        XCTAssertThrowsSpecific(try subject.map(graph: inputGraph).toBlocking().single(), error)
+    }
+}


### PR DESCRIPTION
### Short description 📝
This PR adds a utility that maps the graph replacing the framework targets that exist in the cache with their `.xcframework` equivalent.

