### PR TITLE
Add support for passing Organization name to project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,14 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
-### Added
+### Fixed
 
-- Allow specifying Project Organization name via new `organizationName` parameter to `Project` initializer or via `Config` new GenerationOption. https://github.com/tuist/tuist/pull/1062 by @c0diq
 - Fix `TargetAction` when `PROJECT_DIR` includes a space https://github.com/tuist/tuist/pull/1037 by @fortmarek
 - Fix code example compilation issues in "Project description helpers" documentation https://github.com/tuist/tuist/pull/1081 by @chojnac
 
 ### Added
 
+- Allow specifying Project Organization name via new `organizationName` parameter to `Project` initializer or via `Config` new GenerationOption. https://github.com/tuist/tuist/pull/1062 by @c0diq
 - `tuist lint` command https://github.com/tuist/tuist/pull/1043 by @pepibumur.
 - Add `--verbose` https://github.com/tuist/tuist/pull/1027 by @ollieatkinson.
 - `TuistInsights` target https://github.com/tuist/tuist/pull/1084 by @pepibumur.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
-### Fixed
+### Added
 
-- Allow specifying Organization name via new `organization` parameter to `Project` initializer. https://github.com/tuist/tuist/pull/1062 by @c0diq
+- Allow specifying Project Organization name via new `organizationName` parameter to `Project` initializer or via `Config` new GenerationOption. https://github.com/tuist/tuist/pull/1062 by @c0diq
 - Fix `TargetAction` when `PROJECT_DIR` includes a space https://github.com/tuist/tuist/pull/1037 by @fortmarek
 - Fix code example compilation issues in "Project description helpers" documentation https://github.com/tuist/tuist/pull/1081 by @chojnac
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
+- Allow specifying Organization name via new `organization` parameter to `Project` initializer. https://github.com/tuist/tuist/pull/1062 by @c0diq
 - Fix `TargetAction` when `PROJECT_DIR` includes a space https://github.com/tuist/tuist/pull/1037 by @fortmarek
 - Fix code example compilation issues in "Project description helpers" documentation https://github.com/tuist/tuist/pull/1081 by @chojnac
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The example below shows how projects are defined with Tuist:
 import ProjectDescription
 
 let project = Project(name: "App",
-                      organization: "tuist",
+                      organizationName: "tuist",
                       targets: [
                         Target(name: "App",
                                platform: .iOS,

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The example below shows how projects are defined with Tuist:
 import ProjectDescription
 
 let project = Project(name: "App",
+                      organization: "tuist",
                       targets: [
                         Target(name: "App",
                                platform: .iOS,

--- a/Sources/ProjectDescription/Config.swift
+++ b/Sources/ProjectDescription/Config.swift
@@ -7,6 +7,7 @@ public struct Config: Codable, Equatable {
     /// Contains options related to the project generation.
     ///
     /// - xcodeProjectName(TemplateString): When passed, Tuist generates the project with the specific name on disk instead of using the project name.
+    /// - organizationName(Strig): When passed, Tuist generates the project with the specific organization name.
     public enum GenerationOptions: Encodable, Decodable, Equatable {
         case xcodeProjectName(TemplateString)
         case organizationName(String)
@@ -26,7 +27,7 @@ public struct Config: Codable, Equatable {
     /// - Parameters:
     ///   - compatibleXcodeVersions: List of Xcode versions the project is compatible with.
     ///   - cloudURL: URL to the server that caching and insights will interact with.
-    ///   - generationOptions: List of Xcode versions that the project supports. An empty list means that
+    ///   - generationOptions: List of options to use when generating the project.
     public init(compatibleXcodeVersions: CompatibleXcodeVersions = .all,
                 cloudURL: String? = nil,
                 generationOptions: [GenerationOptions]) {
@@ -85,7 +86,7 @@ public func == (lhs: TuistConfig.GenerationOptions, rhs: TuistConfig.GenerationO
         return lhs.rawString == rhs.rawString
     case let (.organizationName(lhs), .organizationName(rhs)):
         return lhs == rhs
-    default: 
+    default:
         return false
     }
 }

--- a/Sources/ProjectDescription/Project.swift
+++ b/Sources/ProjectDescription/Project.swift
@@ -4,6 +4,7 @@ import Foundation
 
 public struct Project: Codable, Equatable {
     public let name: String
+    public let organizationName: String?
     public let packages: [Package]
     public let targets: [Target]
     public let schemes: [Scheme]
@@ -11,12 +12,14 @@ public struct Project: Codable, Equatable {
     public let additionalFiles: [FileElement]
 
     public init(name: String,
+                organizationName: String? = nil,
                 packages: [Package] = [],
                 settings: Settings? = nil,
                 targets: [Target] = [],
                 schemes: [Scheme] = [],
                 additionalFiles: [FileElement] = []) {
         self.name = name
+        self.organizationName = organizationName
         self.packages = packages
         self.targets = targets
         self.schemes = schemes

--- a/Sources/TuistCore/Models/Config.swift
+++ b/Sources/TuistCore/Models/Config.swift
@@ -9,6 +9,7 @@ public struct Config: Equatable, Hashable {
     /// - xcodeProjectName: Name used for the Xcode project
     public enum GenerationOption: Hashable, Equatable {
         case xcodeProjectName(String)
+        case organizationName(String)
     }
 
     /// Generation options.

--- a/Sources/TuistCore/Models/Project.swift
+++ b/Sources/TuistCore/Models/Project.swift
@@ -11,6 +11,9 @@ public struct Project: Equatable, CustomStringConvertible {
     /// Project name.
     public let name: String
 
+    /// Organization name.
+    public let organizationName: String?
+
     /// Project file name.
     public let fileName: String
 
@@ -39,6 +42,7 @@ public struct Project: Equatable, CustomStringConvertible {
     /// - Parameters:
     ///   - path: Path to the folder that contains the project manifest.
     ///   - name: Project name.
+    ///   - organizationName: Organization name.
     ///   - settings: The settings to apply at the project level
     ///   - filesGroup: The root group to place project files within
     ///   - targets: The project targets
@@ -46,6 +50,7 @@ public struct Project: Equatable, CustomStringConvertible {
     ///                      *(Those won't be included in any build phases)*
     public init(path: AbsolutePath,
                 name: String,
+                organizationName: String? = nil,
                 fileName: String? = nil,
                 settings: Settings,
                 filesGroup: ProjectGroup,
@@ -55,6 +60,7 @@ public struct Project: Equatable, CustomStringConvertible {
                 additionalFiles: [FileElement] = []) {
         self.path = path
         self.name = name
+        self.organizationName = organizationName
         self.fileName = fileName ?? name
         self.targets = targets
         self.packages = packages

--- a/Sources/TuistCoreTesting/Models/Project+TestData.swift
+++ b/Sources/TuistCoreTesting/Models/Project+TestData.swift
@@ -27,6 +27,7 @@ public extension Project {
 
     static func empty(path: AbsolutePath = AbsolutePath("/test/"),
                       name: String = "Project",
+                      organizationName: String? = nil,
                       settings: Settings = .default,
                       filesGroup: ProjectGroup = .group(name: "Project"),
                       targets: [Target] = [],
@@ -35,6 +36,7 @@ public extension Project {
                       additionalFiles: [FileElement] = []) -> Project {
         Project(path: path,
                 name: name,
+                organizationName: organizationName,
                 settings: settings,
                 filesGroup: filesGroup,
                 targets: targets,

--- a/Sources/TuistCoreTesting/Models/Project+TestData.swift
+++ b/Sources/TuistCoreTesting/Models/Project+TestData.swift
@@ -5,6 +5,7 @@ import Foundation
 public extension Project {
     static func test(path: AbsolutePath = AbsolutePath("/Project"),
                      name: String = "Project",
+                     organizationName: String? = nil,
                      fileName: String? = nil,
                      settings: Settings = Settings.test(),
                      filesGroup: ProjectGroup = .group(name: "Project"),
@@ -14,6 +15,7 @@ public extension Project {
                      additionalFiles: [FileElement] = []) -> Project {
         Project(path: path,
                 name: name,
+                organizationName: organizationName,
                 fileName: fileName,
                 settings: settings,
                 filesGroup: filesGroup,

--- a/Sources/TuistGenerator/Generator/ProjectGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGenerator.swift
@@ -150,7 +150,7 @@ final class ProjectGenerator: ProjectGenerating {
                                     pbxproj: PBXProj) throws -> PBXProject {
         let defaultRegions = ["en", "Base"]
         let knownRegions = Set(defaultRegions + projectFileElements.knownRegions).sorted()
-        let attributes = project.organizationName.map { ["ORGANIZATION": $0] } ?? [:]
+        let attributes = project.organizationName.map { ["ORGANIZATIONNAME": $0] } ?? [:]
         let pbxProject = PBXProject(name: project.name,
                                     buildConfigurationList: configurationList,
                                     compatibilityVersion: Xcode.Default.compatibilityVersion,

--- a/Sources/TuistGenerator/Generator/ProjectGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGenerator.swift
@@ -150,6 +150,7 @@ final class ProjectGenerator: ProjectGenerating {
                                     pbxproj: PBXProj) throws -> PBXProject {
         let defaultRegions = ["en", "Base"]
         let knownRegions = Set(defaultRegions + projectFileElements.knownRegions).sorted()
+        let attributes = project.organizationName.map { ["ORGANIZATION": $0] } ?? [:]
         let pbxProject = PBXProject(name: project.name,
                                     buildConfigurationList: configurationList,
                                     compatibilityVersion: Xcode.Default.compatibilityVersion,
@@ -161,7 +162,8 @@ final class ProjectGenerator: ProjectGenerating {
                                     projectDirPath: "",
                                     projects: [],
                                     projectRoots: [],
-                                    targets: [])
+                                    targets: [],
+                                    attributes: attributes)
         pbxproj.add(object: pbxProject)
         pbxproj.rootObject = pbxProject
         return pbxProject

--- a/Sources/TuistLoader/Loaders/GeneratorModelLoader.swift
+++ b/Sources/TuistLoader/Loaders/GeneratorModelLoader.swift
@@ -84,9 +84,10 @@ public class GeneratorModelLoader: GeneratorModelLoading {
         enrichedModel = enrichedModel.replacing(fileName: xcodeFileName)
 
         // Xcode project organization name
-        let organizationName = organizationNameOverride(from: config)
-        enrichedModel = enrichedModel.replacing(organizationName: organizationName)
-
+        if let organizationName = organizationNameOverride(from: config) {
+            enrichedModel = enrichedModel.replacing(organizationName: organizationName)
+        }
+        
         return enrichedModel
     }
 

--- a/Sources/TuistLoader/Loaders/GeneratorModelLoader.swift
+++ b/Sources/TuistLoader/Loaders/GeneratorModelLoader.swift
@@ -108,7 +108,7 @@ public class GeneratorModelLoader: GeneratorModelLoading {
     }
 
     private func organizationNameOverride(from config: TuistCore.Config) -> String? {
-        return config.generationOptions.compactMap { item -> String? in
+        config.generationOptions.compactMap { item -> String? in
             switch item {
             case let .organizationName(name):
                 return name

--- a/Sources/TuistLoader/Loaders/GeneratorModelLoader.swift
+++ b/Sources/TuistLoader/Loaders/GeneratorModelLoader.swift
@@ -87,7 +87,7 @@ public class GeneratorModelLoader: GeneratorModelLoading {
         if let organizationName = organizationNameOverride(from: config) {
             enrichedModel = enrichedModel.replacing(organizationName: organizationName)
         }
-        
+
         return enrichedModel
     }
 

--- a/Sources/TuistLoader/Loaders/GeneratorModelLoader.swift
+++ b/Sources/TuistLoader/Loaders/GeneratorModelLoader.swift
@@ -83,6 +83,10 @@ public class GeneratorModelLoader: GeneratorModelLoading {
         let xcodeFileName = xcodeFileNameOverride(from: config, for: model)
         enrichedModel = enrichedModel.replacing(fileName: xcodeFileName)
 
+        // Xcode project organization name
+        let organizationName = organizationNameOverride(from: config)
+        enrichedModel = enrichedModel.replacing(organizationName: organizationName)
+
         return enrichedModel
     }
 
@@ -91,6 +95,8 @@ public class GeneratorModelLoader: GeneratorModelLoading {
             switch item {
             case let .xcodeProjectName(projectName):
                 return projectName.description
+            default:
+                return nil
             }
         }.first
 
@@ -99,5 +105,16 @@ public class GeneratorModelLoader: GeneratorModelLoading {
                                                             with: model.name)
 
         return xcodeFileName
+    }
+
+    private func organizationNameOverride(from config: TuistCore.Config) -> String? {
+        return config.generationOptions.compactMap { item -> String? in
+            switch item {
+            case let .organizationName(name):
+                return name
+            default:
+                return nil
+            }
+        }.first
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/Config+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Config+ManifestMapper.swift
@@ -53,6 +53,8 @@ extension TuistCore.Config.GenerationOption {
         switch manifest {
         case let .xcodeProjectName(templateString):
             return .xcodeProjectName(templateString.description)
+        case let .organizationName(name):
+            return .organizationName(name)
         }
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
@@ -30,6 +30,7 @@ extension TuistCore.Project {
     func adding(target: TuistCore.Target) -> TuistCore.Project {
         Project(path: path,
                 name: name,
+                organizationName: organizationName,
                 fileName: fileName,
                 settings: settings,
                 filesGroup: filesGroup,
@@ -42,6 +43,20 @@ extension TuistCore.Project {
     func replacing(fileName: String?) -> TuistCore.Project {
         Project(path: path,
                 name: name,
+                organizationName: organizationName,
+                fileName: fileName,
+                settings: settings,
+                filesGroup: filesGroup,
+                targets: targets,
+                packages: packages,
+                schemes: schemes,
+                additionalFiles: additionalFiles)
+    }
+
+    func replacing(organizationName: String?) -> TuistCore.Project {
+        Project(path: path,
+                name: name,
+                organizationName: organizationName,
                 fileName: fileName,
                 settings: settings,
                 filesGroup: filesGroup,

--- a/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
@@ -12,6 +12,7 @@ extension TuistCore.Project {
     static func from(manifest: ProjectDescription.Project,
                      generatorPaths: GeneratorPaths) throws -> TuistCore.Project {
         let name = manifest.name
+        let organizationName = manifest.organizationName
         let settings = try manifest.settings.map { try TuistCore.Settings.from(manifest: $0, generatorPaths: generatorPaths) }
         let targets = try manifest.targets.map { try TuistCore.Target.from(manifest: $0, generatorPaths: generatorPaths) }
         let schemes = try manifest.schemes.map { try TuistCore.Scheme.from(manifest: $0, generatorPaths: generatorPaths) }
@@ -19,6 +20,7 @@ extension TuistCore.Project {
         let packages = try manifest.packages.map { try TuistCore.Package.from(manifest: $0, generatorPaths: generatorPaths) }
         return Project(path: generatorPaths.manifestDirectory,
                        name: name,
+                       organizationName: organizationName,
                        settings: settings ?? .default,
                        filesGroup: .group(name: "Project"),
                        targets: targets,

--- a/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
+++ b/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
@@ -19,10 +19,12 @@ extension Workspace {
 
 extension Project {
     public static func test(name: String = "Project",
+                            organizationName: String? = nil,
                             settings: Settings? = nil,
                             targets: [Target] = [],
                             additionalFiles: [FileElement] = []) -> Project {
         Project(name: name,
+                organizationName: organizationName,
                 settings: settings,
                 targets: targets,
                 additionalFiles: additionalFiles)

--- a/Tests/ProjectDescriptionTests/ConfigTests.swift
+++ b/Tests/ProjectDescriptionTests/ConfigTests.swift
@@ -5,8 +5,10 @@ import XCTest
 final class ConfigTests: XCTestCase {
     func test_config_toJSON() throws {
         let config = Config(cloudURL: "https://tuist.io",
-                            generationOptions:
-                            [.xcodeProjectName("someprefix-\(.projectName)")])
+                            generationOptions: [
+                                .xcodeProjectName("someprefix-\(.projectName)"),
+                                .organizationName("TestOrg"),
+                            ])
 
         XCTAssertCodable(config)
     }

--- a/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
@@ -216,7 +216,7 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
         let pbxProject = try XCTUnwrap(try got.xcodeProj.pbxproj.rootProject())
         let attributes = try XCTUnwrap(pbxProject.attributes as? [String: String])
         XCTAssertEqual(attributes, [
-            "ORGANIZATION": "tuist",
+            "ORGANIZATIONNAME": "tuist",
         ])
     }
 }

--- a/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
@@ -200,4 +200,23 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
             "en",
         ])
     }
+
+    func test_generate_setsOrganizationName() throws {
+        // Given
+        let path = try temporaryPath()
+        let graph = Graph.test(entryPath: path)
+        let project = Project.test(path: path,
+                                   organizationName: "tuist",
+                                   targets: [])
+
+        // When
+        let got = try subject.generate(project: project, graph: graph)
+
+        // Then
+        let pbxProject = try XCTUnwrap(try got.xcodeProj.pbxproj.rootProject())
+        let attributes = try XCTUnwrap(pbxProject.attributes as? [String: String])
+        XCTAssertEqual(attributes, [
+            "ORGANIZATION": "tuist",
+        ])
+    }
 }

--- a/Tests/TuistKitIntegrationTests/Commands/DumpCommandIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Commands/DumpCommandIntegrationTests.swift
@@ -37,6 +37,7 @@ final class DumpCommandTests: TuistTestCase {
         import ProjectDescription
 
         let project = Project(name: "tuist",
+              organizationName: "tuist",
               settings: nil,
               targets: [])
         """
@@ -45,7 +46,7 @@ final class DumpCommandTests: TuistTestCase {
                          encoding: .utf8)
         let result = try parser.parse([DumpCommand.command, "-p", tmpDir.path.pathString])
         try subject.run(with: result)
-        let expected = "{\n  \"additionalFiles\": [\n\n  ],\n  \"name\": \"tuist\",\n  \"packages\": [\n\n  ],\n  \"schemes\": [\n\n  ],\n  \"targets\": [\n\n  ]\n}\n"
+        let expected = "{\n  \"additionalFiles\": [\n\n  ],\n  \"name\": \"tuist\",\n  \"organizationName\": \"tuist\",\n  \"packages\": [\n\n  ],\n  \"schemes\": [\n\n  ],\n  \"targets\": [\n\n  ]\n}\n"
 
         XCTAssertPrinterOutputContains(expected)
     }

--- a/Tests/TuistLoaderTests/Loaders/GeneratorModelLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/GeneratorModelLoaderTests.swift
@@ -228,6 +228,34 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
                                                 ]),
         ]
         let configs = [
+            temporaryPath: ProjectDescription.TuistConfig.test(generationOptions: []),
+        ]
+        let manifestLoader = createManifestLoader(with: manifests, configs: configs)
+        let subject = GeneratorModelLoader(manifestLoader: manifestLoader,
+                                           manifestLinter: manifestLinter)
+
+        // When
+        let model = try subject.loadProject(at: temporaryPath)
+
+        // Then
+        XCTAssertEqual(model.organizationName, "SomeOrganization")
+    }
+
+    func test_loadProject_withCustomOrganizationNameFromConfig() throws {
+        // Given
+        let temporaryPath = try self.temporaryPath()
+        try createFiles([
+            "TuistConfig.swift",
+        ])
+
+        let manifests = [
+            temporaryPath: ProjectManifest.test(name: "SomeProject",
+                                                organizationName: "SomeOrganization",
+                                                additionalFiles: [
+                                                    .folderReference(path: "Stubs"),
+                                                ]),
+        ]
+        let configs = [
             temporaryPath: ProjectDescription.TuistConfig.test(generationOptions: [.organizationName("tuist")]),
         ]
         let manifestLoader = createManifestLoader(with: manifests, configs: configs)

--- a/Tests/TuistLoaderTests/Loaders/GeneratorModelLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/GeneratorModelLoaderTests.swift
@@ -213,6 +213,34 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
         XCTAssertEqual(model.fileName, "one SomeProject two")
     }
 
+    func test_loadProject_withCustomOrganizationName() throws {
+        // Given
+        let temporaryPath = try self.temporaryPath()
+        try createFiles([
+            "TuistConfig.swift",
+        ])
+
+        let manifests = [
+            temporaryPath: ProjectManifest.test(name: "SomeProject",
+                                                organizationName: "SomeOrganization",
+                                                additionalFiles: [
+                                                    .folderReference(path: "Stubs"),
+                                                ]),
+        ]
+        let configs = [
+            temporaryPath: ProjectDescription.TuistConfig.test(generationOptions: [.organizationName("tuist")]),
+        ]
+        let manifestLoader = createManifestLoader(with: manifests, configs: configs)
+        let subject = GeneratorModelLoader(manifestLoader: manifestLoader,
+                                           manifestLinter: manifestLinter)
+
+        // When
+        let model = try subject.loadProject(at: temporaryPath)
+
+        // Then
+        XCTAssertEqual(model.organizationName, "tuist")
+    }
+
     func test_loadWorkspace() throws {
         // Given
         let temporaryPath = try self.temporaryPath()

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -305,3 +305,11 @@ An iOS app that has a dependency with a dependency with a framework for macOS.
 ## app_with_old_config_name
 
 An iOS app where the configuration is defined following the deprecated naming `TuistConfig`.
+
+## app_with_organization_name_config
+
+An iOS app where the organization name is defined at the `Config` level.
+
+## app_with_organization_name_project
+
+An iOS app where the organization name is defined at the `Project` level.

--- a/fixtures/app_with_organization_name_config/.gitignore
+++ b/fixtures/app_with_organization_name_config/.gitignore
@@ -1,0 +1,63 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two 
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace

--- a/fixtures/app_with_organization_name_config/App/AppDelegate.swift
+++ b/fixtures/app_with_organization_name_config/App/AppDelegate.swift
@@ -1,0 +1,22 @@
+import Framework
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+    var framework: FrameworkClass = FrameworkClass()
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        let viewController = UIViewController()
+        viewController.view.backgroundColor = .white
+        window?.rootViewController = viewController
+        window?.makeKeyAndVisible()
+        return true
+    }
+    
+    func hello() -> String {
+        return "AppDelegate.hello()"
+    }
+    
+}

--- a/fixtures/app_with_organization_name_config/Config.swift
+++ b/fixtures/app_with_organization_name_config/Config.swift
@@ -1,0 +1,7 @@
+import ProjectDescription
+
+let config = TuistConfig(
+  generationOptions: [
+    .organizationName("Tuist")
+  ]
+)

--- a/fixtures/app_with_organization_name_config/Info.plist
+++ b/fixtures/app_with_organization_name_config/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/fixtures/app_with_organization_name_config/Project.swift
+++ b/fixtures/app_with_organization_name_config/Project.swift
@@ -1,0 +1,11 @@
+import ProjectDescription
+
+let project = Project(name: "App",
+                      targets: [
+                          Target(name: "App",
+                                 platform: .iOS,
+                                 product: .app,
+                                 bundleId: "io.tuist.app",
+                                 infoPlist: "Info.plist",
+                                 sources: "App/**")
+])

--- a/fixtures/app_with_organization_name_project/.gitignore
+++ b/fixtures/app_with_organization_name_project/.gitignore
@@ -1,0 +1,63 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two 
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace

--- a/fixtures/app_with_organization_name_project/App/AppDelegate.swift
+++ b/fixtures/app_with_organization_name_project/App/AppDelegate.swift
@@ -1,0 +1,22 @@
+import Framework
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+    var framework: FrameworkClass = FrameworkClass()
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        let viewController = UIViewController()
+        viewController.view.backgroundColor = .white
+        window?.rootViewController = viewController
+        window?.makeKeyAndVisible()
+        return true
+    }
+    
+    func hello() -> String {
+        return "AppDelegate.hello()"
+    }
+    
+}

--- a/fixtures/app_with_organization_name_project/Info.plist
+++ b/fixtures/app_with_organization_name_project/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/fixtures/app_with_organization_name_project/Project.swift
+++ b/fixtures/app_with_organization_name_project/Project.swift
@@ -1,0 +1,12 @@
+import ProjectDescription
+
+let project = Project(name: "App",
+                      organizationName: "Tuist",
+                      targets: [
+                          Target(name: "App",
+                                 platform: .iOS,
+                                 product: .app,
+                                 bundleId: "io.tuist.app",
+                                 infoPlist: "Info.plist",
+                                 sources: "App/**")
+])

--- a/website/markdown/docs/usage/config.mdx
+++ b/website/markdown/docs/usage/config.mdx
@@ -34,7 +34,8 @@ import ProjectDescription
 let config = Config(
   compatibleXcodeVersions: ["10.3"],
   generationOptions: [
-    .xcodeProjectName("SomePrefix-\(.projectName)-SomeSuffix")
+    .xcodeProjectName("SomePrefix-\(.projectName)-SomeSuffix"),
+    .organizationName("Tuist")
   ]
 )
 ```
@@ -95,6 +96,10 @@ Generation options allow customizing the generation of Xcode projects.
     {
       case: '.xcodeProjectName(TemplateString)',
       description: 'Customise the name of the generated .xcodeproj.',
+    },
+    {
+      case: '.organizationName(String)',
+      description: 'Customise the organization name of the generated .xcodeproj.',
     },
   ]}
 />

--- a/website/markdown/docs/usage/getting-started.mdx
+++ b/website/markdown/docs/usage/getting-started.mdx
@@ -49,6 +49,7 @@ The definition file, also known as manifest, has the following structure:
 import ProjectDescription
 
 let project = Project(name: "MyApp",
+                      organizationName: "MyOrg",
                       targets: [
                         Target(name: "MyApp",
                                platform: .iOS,

--- a/website/markdown/docs/usage/projectswift.mdx
+++ b/website/markdown/docs/usage/projectswift.mdx
@@ -15,6 +15,7 @@ Projects are defined in `Project.swift` files, which we refer to as manifest fil
 ```swift
 
 let project = Project(name: "MyProject",
+                      organizationName: "MyOrg",
                       targets: [
                           Target(name: "App",
                                  platform: .iOS,
@@ -64,6 +65,14 @@ A `Project.swift` should initialize a variable of type `Project`. It can take an
         "Name of the project. It's used to determine the name of the generated Xcode project.",
       type: 'String',
       optional: false,
+      default: '',
+    },
+    {
+      name: 'OrganizationName',
+      description:
+        "Name of the organization used by Xcode as copyright when generating new files.",
+      type: 'String',
+      optional: true,
       default: '',
     },
     {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1063

### Short description 📝

New Files created by Xcode use the Organization name set in the project file for copyright notices. The organization was left blank before this PR.

### Solution 📦

It is now possible to optionally pass the organization name to either the `Project` initializer or more generally in `Config`. The latter will override the former if set.

### Implementation 👩‍💻👨‍💻

- [x] Add new `organizationName` argument to Project
- [x] Add new `organizationName` GenerationOptions case to pass to Config
- [x] Use project `organizationName` during pbxproj generation via attributes
- [x] Add Tests
