### PR TITLE
WIP: Signing

### DIFF
--- a/Tests/TuistLoaderTests/Models/GeneratorPathsTests.swift
+++ b/Tests/TuistLoaderTests/Models/GeneratorPathsTests.swift
@@ -39,7 +39,8 @@ class GeneratorPathsTests: TuistUnitTestCase {
         path = try! temporaryPath()
         rootDirectoryLocator = MockRootDirectoryLocator()
         rootDirectoryLocator.locateStub = path.appending(component: "Root")
-        subject = GeneratorPaths(manifestDirectory: path)
+        subject = GeneratorPaths(manifestDirectory: path,
+                                 rootDirectoryLocator: rootDirectoryLocator)
     }
 
     override func tearDown() {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/246

### Short description 📝

Signing is another domain that we can make easier for developers to interact with. While fastlane is a great tool, we believe that we can improve upon it as tuist has a deep understanding of the Xcode project and can make the integration more seamless.

Here is a basic implementation plan that expands on how @pepibumur envisioned this feature (more [here](https://github.com/tuist/tuist/issues/246))

# Implementation plan:

## 1. Encrypt/decrypt

Simply encrypt/decrypt keys of all files in `Tuist/Signing` directory with `master.key` in `Tuist/Signing`

Current implementation leverages `swift-crypto` and AES specifically as a safe method for symmetric communication.

`master.key` should be placed in `.gitignore` and it is on the user's side to manage it (company's password manager, etc.) This is a place that we can improve upon in further iterations and can make it more frictionless - for now it will hopefully do.

User should be also able to encrypt/decrypt with a command. We should group `signing` commands under a common keyword in order not to cause information overload as there is a lot of commands already. Probably something along the lines of `tuist signing encrypt` and `tuist signing decrypt`

## 2. Generate project

When user uses our approach, there are several things that need to happen when generating a project:
    - decipher all keys in `Tuist/Signing`
    - add all provisioning profiles (files with `.mobileprovision` extension) to `~/Library/MobileDevice/Provisioning\ Profiles` where they are stored
    - save all certificates to keychain (I have not looked into this much, hopefully standard Apple's keychain API will suffice)
    - configure generated Xcode project with the proper build settings (development team, provisioning profile)
    
In order to achieve the last step we need to derive for each configuration the files for `CODE_SIGN_IDENTITY` and provisioning profile. As @pepibumur has outlined [here](https://github.com/tuist/tuist/issues/951#issue-557366151), I'd follow the convention:
    - for provisioning profiles: `{Target}.{Configuration}.mobileprovisiong`
    - for certs: `{Configuration}.p12`

Unfortunately, this means that you can not have different certs based on targets *and* configuration. But I think we can expand on that later if such a need arises. Also note that tuist will find certs and profiles automatically in `Tuist/Signing` directory, so there are no extra steps needed if you want to use tuist-provided signing. You can also always fallback to a manual signing.

## 3. Linting

We can also check if the signing configuration is valid - that is certs can be expired, does the profile match the certificate, etc.

## 4. Next steps

Ideally, we should also be able to generate the certificates using iTunes Connect API, but that can be done later.

## Testing strategy

To test our implementation we will need some provisioning profiles and certificates. For now I have used my own, but it is not ideal. Unfortunately, creating a Tuist Apple developer account does not seem feasible, too, as Apple has a lot of requirements for enterprise accounts. This is an open problem and would appreciate any suggestions of what's the proper solution (as @ollie has mentioned, fastlane uses personal certificates, too, so we will probably have to go down that road, too, but it is worth having a discussion about what rules we want to impose on ourselves)


### Implementation 👩‍💻👨‍💻

- [x] Encrypt command
- [x] Decrypt command
- [ ] master.key generation
- [ ] Decrypting all needed keys upon project generation
- [ ] Saving new keys to their appropriate locations
- [ ] Edit build settings with certificates and profiles during generation
- [ ] tuist signing [vendor](https://github.com/tuist/tuist/pull/1127#pullrequestreview-378997368)
- [ ] Lint signing setup
- [ ] Tests
- [ ] Add documentation
