### PR TITLE
Remove changelog check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,12 +45,3 @@ jobs:
         uses: norio-nomura/action-swiftlint@3c67ce2e382be797d968883944140ffa0113f737
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  changelog:
-    name: Changelog
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Changelog Reminder
-        uses: peterjgrainger/action-changelog-reminder@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Short description 📝

Sadly the change log GitHub check doesn't appear to be working for PRs from forks. (https://github.com/peterjgrainger/action-changelog-reminder/issues/28)

### Solution 📦

While an alternative is investigated we can disable this to avoid discouraging new contributions

### Test Plan 🛠

- Verify this PR (from a fork repo) doesn't fail the change log check
