### PR TITLE
Enable Dependabot automerges

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,7 +10,7 @@ update_configs:
     automerged_updates:
       - match:
           dependency_type: 'development'
-          update_type: 'minor'
+          update_type: 'semver:minor'
       - match:
           dependency_type: 'production'
           update_type: 'semver:minor'
@@ -24,7 +24,7 @@ update_configs:
     automerged_updates:
       - match:
           dependency_type: 'development'
-          update_type: 'minor'
+          update_type: 'semver:minor'
       - match:
           dependency_type: 'production'
           update_type: 'semver:minor'

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,6 +7,13 @@ update_configs:
       - 'tuist/core'
     default_labels:
       - 'dependencies'
+    automerged_updates:
+      - match:
+          dependency_type: 'development'
+          update_type: 'minor'
+      - match:
+          dependency_type: 'production'
+          update_type: 'semver:minor'
   - package_manager: 'javascript'
     directory: '/website'
     update_schedule: 'weekly'
@@ -14,3 +21,10 @@ update_configs:
       - 'tuist/core'
     default_labels:
       - 'dependencies'
+    automerged_updates:
+      - match:
+          dependency_type: 'development'
+          update_type: 'minor'
+      - match:
+          dependency_type: 'production'
+          update_type: 'semver:minor'


### PR DESCRIPTION
### Short description 📝
Being able to automate updating the dependencies of the Gatsby website and the Ruby tooling by leveraging Dependabot is amazing. However, the PR needs to be manually merged, which is a manual process that could be automated too. Luckily, Dependabot has a feature for that that I'm just enabling on this PR.

Since we have a CI workflow that builds the website and runs the CLI tasks developed in Ruby, it should be safe to automate the merges if CI is green.