### PR TITLE
Remove symbols from test input/output file lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- Prevent `Multiple commands produce XXXXX` error produced by multiple test targets using “Embed Precompiled Frameworks” script https://github.com/tuist/tuist/pull/1118 by @paulsamuels
+
 ## 1.5.2
 
 ### Fixed

--- a/Package.resolved
+++ b/Package.resolved
@@ -47,15 +47,6 @@
         }
       },
       {
-        "package": "PathKit",
-        "repositoryURL": "https://github.com/kylef/PathKit.git",
-        "state": {
-          "branch": null,
-          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
-          "version": "1.0.0"
-        }
-      },
-      {
         "package": "RxSwift",
         "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
         "state": {

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -89,6 +89,7 @@ final class LinkGenerator: LinkGenerating {
                                        linkableModules: linkableModules)
 
         try generateEmbedPhase(dependencies: embeddableFrameworks,
+                               target: target,
                                pbxTarget: pbxTarget,
                                pbxproj: pbxproj,
                                fileElements: fileElements,
@@ -152,6 +153,7 @@ final class LinkGenerator: LinkGenerating {
     }
 
     func generateEmbedPhase(dependencies: [GraphDependencyReference],
+                            target: Target,
                             pbxTarget: PBXTarget,
                             pbxproj: PBXProj,
                             fileElements: ProjectFileElements,
@@ -201,7 +203,10 @@ final class LinkGenerator: LinkGenerating {
         if frameworkReferences.isEmpty {
             precompiledEmbedPhase.shellScript = "echo \"Skipping, nothing to be embedded.\""
         } else {
-            let script = try embedScriptGenerator.script(sourceRootPath: sourceRootPath, frameworkReferences: frameworkReferences)
+            let script = try embedScriptGenerator.script(sourceRootPath: sourceRootPath,
+                                                         frameworkReferences: frameworkReferences,
+                                                         includeSymbolsInFileLists: !target.product.testsBundle)
+
             precompiledEmbedPhase.shellScript = script.script
             precompiledEmbedPhase.inputPaths = script.inputPaths.map(\.pathString)
             precompiledEmbedPhase.outputPaths = script.outputPaths

--- a/Tests/TuistGeneratorTests/Utils/EmbedScriptGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/EmbedScriptGeneratorTests.swift
@@ -20,7 +20,7 @@ final class EmbedScriptGeneratorTests: TuistUnitTestCase {
         subject = nil
     }
 
-    func test_script() throws {
+    func test_script_when_includingSymbolsInFileLists() throws {
         // Given
         let path = AbsolutePath("/frameworks/tuist.framework")
         let dsymPath = AbsolutePath("/frameworks/tuist.dSYM")
@@ -30,7 +30,7 @@ final class EmbedScriptGeneratorTests: TuistUnitTestCase {
                                                                dsymPath: dsymPath,
                                                                bcsymbolmapPaths: [bcsymbolPath])
         // When
-        let got = try subject.script(sourceRootPath: framework.precompiledPath!.parentDirectory, frameworkReferences: [framework])
+        let got = try subject.script(sourceRootPath: framework.precompiledPath!.parentDirectory, frameworkReferences: [framework], includeSymbolsInFileLists: true)
 
         // Then
         XCTAssertEqual(got.inputPaths, [
@@ -41,6 +41,31 @@ final class EmbedScriptGeneratorTests: TuistUnitTestCase {
         XCTAssertEqual(got.outputPaths, [
             "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/\(path.basename)",
             "${DWARF_DSYM_FOLDER_PATH}/tuist.dSYM", "${BUILT_PRODUCTS_DIR}/\(bcsymbolPath.basename)",
+        ])
+
+        XCTAssertTrue(got.script.contains("install_framework \"\(path.basename)\""))
+        XCTAssertTrue(got.script.contains("install_dsym \"\(dsymPath.basename)\""))
+        XCTAssertTrue(got.script.contains("install_bcsymbolmap \"\(bcsymbolPath.basename)\""))
+    }
+
+    func test_script_when_not_includingSymbolsInFileLists() throws {
+        // Given
+        let path = AbsolutePath("/frameworks/tuist.framework")
+        let dsymPath = AbsolutePath("/frameworks/tuist.dSYM")
+        let bcsymbolPath = AbsolutePath("/frameworks/tuist.bcsymbolmap")
+        let framework = GraphDependencyReference.testFramework(path: path,
+                                                               binaryPath: path.appending(component: "tuist"),
+                                                               dsymPath: dsymPath,
+                                                               bcsymbolmapPaths: [bcsymbolPath])
+        // When
+        let got = try subject.script(sourceRootPath: framework.precompiledPath!.parentDirectory, frameworkReferences: [framework], includeSymbolsInFileLists: false)
+
+        // Then
+        XCTAssertEqual(got.inputPaths, [
+            RelativePath(path.basename),
+        ])
+        XCTAssertEqual(got.outputPaths, [
+            "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/\(path.basename)",
         ])
 
         XCTAssertTrue(got.script.contains("install_framework \"\(path.basename)\""))

--- a/Tests/TuistGeneratorTests/Utils/Mocks/MockEmbedScriptGenerator.swift
+++ b/Tests/TuistGeneratorTests/Utils/Mocks/MockEmbedScriptGenerator.swift
@@ -6,12 +6,13 @@ import TuistCore
 @testable import TuistSupportTesting
 
 final class MockEmbedScriptGenerator: EmbedScriptGenerating {
-    var scriptArgs: [(AbsolutePath, [GraphDependencyReference])] = []
+    var scriptArgs: [(AbsolutePath, [GraphDependencyReference], Bool)] = []
     var scriptStub: Result<EmbedScript, Error>?
 
     func script(sourceRootPath: AbsolutePath,
-                frameworkReferences: [GraphDependencyReference]) throws -> EmbedScript {
-        scriptArgs.append((sourceRootPath, frameworkReferences))
+                frameworkReferences: [GraphDependencyReference],
+                includeSymbolsInFileLists: Bool) throws -> EmbedScript {
+        scriptArgs.append((sourceRootPath, frameworkReferences, includeSymbolsInFileLists))
         if let scriptStub = scriptStub {
             switch scriptStub {
             case let .failure(error): throw error

--- a/features/generate-4.feature
+++ b/features/generate-4.feature
@@ -30,7 +30,7 @@ Scenario: The project is an iOS application with Carthage frameworks (ios_app_wi
     And I have a working directory
     Then I copy the fixture ios_app_with_carthage_frameworks into the working directory
     Then tuist generates the project
-    Then I should be able to build for iOS the scheme App
+    Then I should be able to build for iOS the scheme AllTargets
     Then the product 'App.app' with destination 'Debug-iphoneos' contains the framework 'RxSwift' without architecture 'armv7'
     Then the product 'App.app' with destination 'Debug-iphoneos' contains the framework 'RxSwift' with architecture 'arm64'
     Then the product 'App.app' with destination 'Debug-iphoneos' does not contain headers

--- a/fixtures/ios_app_with_carthage_frameworks/Core/CoreFile.swift
+++ b/fixtures/ios_app_with_carthage_frameworks/Core/CoreFile.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public class CoreFile {
+    public init() {}
+
+    public func hello() -> String {
+        return "CoreFile.hello()"
+    }
+}

--- a/fixtures/ios_app_with_carthage_frameworks/CoreTests/CoreTests.swift
+++ b/fixtures/ios_app_with_carthage_frameworks/CoreTests/CoreTests.swift
@@ -1,0 +1,14 @@
+import Foundation
+import XCTest
+
+@testable import Core
+
+final class CoreTests: XCTestCase {
+    
+    func testHello() {
+        let sut = CoreFile()
+        
+        XCTAssertEqual("CoreTests.hello()", sut.hello())
+    }
+    
+}

--- a/fixtures/ios_app_with_carthage_frameworks/Project.swift
+++ b/fixtures/ios_app_with_carthage_frameworks/Project.swift
@@ -2,14 +2,51 @@ import ProjectDescription
 
 let project = Project(name: "App",
                       targets: [
-                          Target(name: "App",
-                                 platform: .iOS,
-                                 product: .app,
-                                 bundleId: "io.tuist.App",
-                                 infoPlist: .extendingDefault(with: [:]),
-                                 sources: "Sources/**",
-                                 resources: "Sources/Main.storyboard",
-                                 dependencies: [
-                                    .framework(path: "Carthage/Build/iOS/RxSwift.framework")
-                          ])
+                        Target(name: "App",
+                               platform: .iOS,
+                               product: .app,
+                               bundleId: "io.tuist.App",
+                               infoPlist: .default,
+                               sources: "Sources/**",
+                               resources: "Sources/Main.storyboard",
+                               dependencies: [
+                                .target(name: "Core"),
+                                .framework(path: "Carthage/Build/iOS/RxSwift.framework")
+                        ]),
+                        Target(name: "AppTests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               bundleId: "io.tuist.AppTests",
+                               infoPlist: .default,
+                               sources: "Tests/**",
+                               dependencies: [
+                                .target(name: "App"),
+                        ]),
+                        Target(name: "Core",
+                               platform: .iOS,
+                               product: .framework,
+                               bundleId: "io.tuist.Core",
+                               infoPlist: .default,
+                               sources: "Core/**",
+                               dependencies: [
+                                .framework(path: "Carthage/Build/iOS/RxSwift.framework"),
+                        ]),
+                        Target(name: "CoreTests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               bundleId: "io.tuist.CoreTests",
+                               infoPlist: .default,
+                               sources: "CoreTests/**",
+                               dependencies: [
+                                .target(name: "Core")
+                        ])
+    ], schemes: [
+        Scheme(name: "AllTargets",
+               shared: true,
+               buildAction: BuildAction(targets: [
+                "App",
+                "AppTests",
+                "Core",
+                "CoreTests"
+               ]))
 ])

--- a/fixtures/ios_app_with_carthage_frameworks/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_carthage_frameworks/Sources/AppDelegate.swift
@@ -8,4 +8,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidFinishLaunching(_: UIApplication) {
         let observable = Observable<String>.just("hello world")
     }
+    
+    public func hello() -> String {
+        return "AppDelegate.hello()"
+    }
 }

--- a/fixtures/ios_app_with_carthage_frameworks/Tests/AppTests.swift
+++ b/fixtures/ios_app_with_carthage_frameworks/Tests/AppTests.swift
@@ -1,0 +1,13 @@
+import Foundation
+import XCTest
+
+@testable import App
+
+final class AppTests: XCTestCase {
+    
+    func testHello() {
+        let sut = AppDelegate()
+        
+        XCTAssertEqual("AppDelegate.hello()", sut.hello())
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/919

### Short description 📝

When a project has a scheme that runs multiple test targets that rely on
the `Embed Precompiled Frameworks` script then the new build system
fails because there are multiple commands that produce the same target
file.

### Solution 📦

> The solution was discussed on the linked ticket

### Implementation 👩‍💻👨‍💻

This commit prevents adding symbol files to the input/output file lists
for test targets to prevent this error from occuring.
