### PR TITLE
Add Google Analytics to the website

### DIFF
--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -27,6 +27,12 @@ module.exports = {
     `gatsby-transformer-yaml`,
     `gatsby-plugin-react-helmet`,
     {
+      resolve: `gatsby-plugin-google-analytics`,
+      options: {
+        trackingId: "UA-125584790-1",
+      },
+    },
+    {
       resolve: `gatsby-source-filesystem`,
       name: 'data',
       options: {

--- a/website/package.json
+++ b/website/package.json
@@ -26,6 +26,7 @@
     "gatsby-image": "^2.2.44",
     "gatsby-plugin-favicon": "3.1.6",
     "gatsby-plugin-feed": "^2.3.28",
+    "gatsby-plugin-google-analytics": "^2.1.38",
     "gatsby-plugin-manifest": "2.2.48",
     "gatsby-plugin-mdx": "^1.0.83",
     "gatsby-plugin-meta-redirect": "^1.1.1",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -6817,6 +6817,13 @@ gatsby-plugin-feed@^2.3.28:
     lodash.merge "^4.6.2"
     rss "^1.2.2"
 
+gatsby-plugin-google-analytics@^2.1.38:
+  version "2.1.38"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.1.38.tgz#37907b2000abf19dcba06da31ccca99abf3fbbc2"
+  integrity sha512-Ce5E1qoD1jQkDcQIm4qPmu0L66ujqwHua0Vy+UC4rUw2GdIn5dunpBklgYaDFF2DG1gDyMwJ4v+XElLaltXcDQ==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+
 gatsby-plugin-manifest@2.2.48:
   version "2.2.48"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.2.48.tgz#a082addd697a9d7c27ce51f1c08690b8215c8283"


### PR DESCRIPTION
### Short description 📝

This PR adds Google Analytics to the website. As we continue adding more content to the website and growing our user base, understanding how the users use the tool and the documentation is useful to know where we should put our efforts. Since we don't have that information at the moment, our decisions are based on assumptions and feedback that we get on Slack. With analytics in place, we'll be able to quantify and validate our assumptions with numbers.