### PR TITLE
Document what is cloud and how to authenticate users and projects

### DIFF
--- a/website/markdown/docs/cloud/cloud.mdx
+++ b/website/markdown/docs/cloud/cloud.mdx
@@ -35,6 +35,6 @@ and defines the contract with the server-side component through an HTTP [REST AP
 That gives the teams and projects the flexibility to choose the implementation that they'd like to use,
 and also decide if they'd like to host it internally.
 
-More information about the contract can be found on [this page](/cloud/contract/).
+More information about the contract can be found on [this page](/docs/cloud/contract/).
 
 

--- a/website/markdown/docs/cloud/cloud.mdx
+++ b/website/markdown/docs/cloud/cloud.mdx
@@ -1,0 +1,40 @@
+---
+name: Cloud
+excerpt: 'Learn more about what cloud features are, why the are important for scaling up projects, and why they need a server-side component that holds state across project generations, builds, and team mebers.'
+---
+
+# Cloud
+
+## Context
+
+Easing the maintenance of large and modular Xcode projects is **not the only challenge** teams run into when scaling up projects.
+Other challenges that they face are keeping the build and test times slow, both locally and on CI *(i.e. faster feedback)*,
+and ensuring that the projects and the derived artifacts *(e.g. app bundles)* meet some quality standards. 
+For instance,
+in most Xcode projects,
+when developers open pull/merge requests,
+they don't have a way to know if they are negatively impacting the quality of the project:
+*build times are under a reasonable value, or
+the size of the apps is acceptable.*
+
+Tuist can leverage the generation of Xcode projects to help teams with those challenges.
+However,
+**it needs a server side component** that holds a state across project generations, builds, and all the team members.
+The subset of features that require that server side component are referred to as **cloud**.
+
+<Message 
+    info 
+    title="Work in progress" 
+    description={`We are currently working on the implementation of the first two cloud features: *caching and insights*. If you'd like to stay up to date with the progress that we are making, we suggest following us on [Twitter](https://twitter.com/tuistio).`}/>
+
+
+## Server-agnostic
+
+Tuist provides the client-side logic for those features,
+and defines the contract with the server-side component through an HTTP [REST API](https://en.wikipedia.org/wiki/Representational_state_transfer).
+That gives the teams and projects the flexibility to choose the implementation that they'd like to use,
+and also decide if they'd like to host it internally.
+
+More information about the contract can be found on [this page](/cloud/contract/).
+
+

--- a/website/markdown/docs/cloud/contract.mdx
+++ b/website/markdown/docs/cloud/contract.mdx
@@ -1,0 +1,68 @@
+---
+name: Contract
+excerpt: ''
+---
+
+# Contract
+
+In order for Tuist's cloud features to interact with HTTP servers,
+the exposed API needs to conform with the contract described in this page. 
+
+<Message
+    info
+    title="Base URL"
+    description={`In all the examples below, we are assuming that the project is pointing to a server with URL https://cloud.tuist.io`}/>
+
+## Authentication
+
+### User authentication
+
+When using Tuist's cloud features from a local environments,
+users will need to authenticate with the API.
+If the authentication is successful,
+a token will be generated and stored safely in the user's environment.
+The generated token must be unique to the user and valid across all the projects the user has access to.
+
+The authentication flow:
+
+1. When the user runs `tuist cloud auth`, Tuist sends the user to `https://cloud.tuist.io/auth`.
+2. The user authenticates on the server.
+3. When the authentication finishes, the server redirects the user to `http://localhost:4455/auth`.
+
+The URL that triggers the call to localhost should include the any of the following attributes:
+
+- **token:** The generated token if the authentication was successful.
+- **error:** The error message if the authentication failed.
+
+```bash
+# A successful authentication
+http://localhost:4455/auth?token=xyz
+
+# An errored authentication
+# Notice that the error argument has been escaped.
+http://localhost:4455/auth?error=Couldn%27t%20find%20the%20current%20user
+```
+
+<Message
+    info
+    title="Authenticating users"
+    description={`How the server decides to authenticate the user is up to the server. However, we recommend authenticating using the version control provider *(e.g. GitHub)*. That'll allow tying the project to a repository and leverage the API to know whether the user has access to the repository and therefore the project.`}/>
+
+### Continuous integration (CI) authentication
+
+On CI,
+projects will authenticate using a secret token that is associated to the project.
+The variable should be present in the environment with the name `TUIST_CLOUD_TOKEN`.
+For security reasons,
+we recommend defining that variable as a secret variables.
+
+### Authentication header
+
+Tuist will authenticate HTTP requests by including an `Authorization` header:
+
+```bash
+curl -v -H "Authorization: token TOKEN" https://cloud.tuist.io/api/...
+```
+
+Depending on the endpoint, the token will represent a project or a user.
+Each of the endpoints documented in the following sections will indicate what type of token is expected.

--- a/website/markdown/docs/components/message.jsx
+++ b/website/markdown/docs/components/message.jsx
@@ -11,7 +11,14 @@ const Message = ({ title, description }) => {
       <div sx={{ fontWeight: 'heading', fontSize: 2 }}>
         <span>{title}</span>
       </div>
-      <ReactMarkdown source={description} />
+      <ReactMarkdown source={description} sx={{
+        "a:-webkit-any-link": {
+          color: "primary",
+          ":hover,:focus,:visited": {
+            color: "secondary",
+          },
+        },
+      }} />
     </ThemeUIMessage>
   )
 }

--- a/website/markdown/docs/links.mdx
+++ b/website/markdown/docs/links.mdx
@@ -11,6 +11,11 @@
 
 <br></br>
 
+- [Cloud](/docs/cloud/cloud/)
+  - [Contract](/docs/cloud/contract/)
+
+<br></br>
+
 - [Architectures](/docs/architectures/microfeatures/)
   - [µFeatures](/docs/architectures/microfeatures/)
 

--- a/website/src/gatsby-plugin-theme-ui/index.js
+++ b/website/src/gatsby-plugin-theme-ui/index.js
@@ -120,7 +120,7 @@ const styles = {
   },
   a: {
     color: "primary",
-    ":hover,:focus": {
+    ":hover,:focus,:visited": {
       color: "secondary",
     },
   },
@@ -131,6 +131,7 @@ const styles = {
   h2: {
     my: 4,
     variant: "text.heading",
+    fontSize: 4,
   },
   h3: {
     my: 4,


### PR DESCRIPTION
### Short description 📝
This PR adds an new section to the documentation, cloud, and 2 pages, "what is cloud" and "contract". The former explains what we refer to as cloud, and why we are implementing those features to be server-agnostic. The latter documents the contract between the client (Tuist) and the server-side component (HTTP server). 

Since this is a WIP work, I added a message indicating that this is not ready to be used yet. 