### PR TITLE
Remove the Graphing protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Removed
+
+- `Graphing` protocol https://github.com/tuist/tuist/pull/1128 by @pepibumur
+
 ### Changed
+
 - Optimize `TargetNode`'s set operations https://github.com/tuist/tuist/pull/1095 by @kwridan
 - Optimize `BuildPhaseGenerator`'s method of detecting assets and localized files https://github.com/tuist/tuist/pull/1094 by @kwridan
 - Concurrent project generation https://github.com/tuist/tuist/pull/1096 by @kwridan

--- a/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
@@ -4,7 +4,7 @@ import TuistCore
 import TuistSupport
 
 public protocol GraphContentHashing {
-    func contentHashes(for graph: Graphing) throws -> [TargetNode: String]
+    func contentHashes(for graph: Graph) throws -> [TargetNode: String]
 }
 
 public final class GraphContentHasher: GraphContentHashing {
@@ -14,7 +14,7 @@ public final class GraphContentHasher: GraphContentHashing {
         self.fileHandler = fileHandler
     }
 
-    public func contentHashes(for graph: Graphing) throws -> [TargetNode: String] {
+    public func contentHashes(for graph: Graph) throws -> [TargetNode: String] {
         let hashableTargets = graph.targets.filter { $0.target.product == .framework }
         let hashes = try hashableTargets.map { try makeContentHash(of: $0) }
         return Dictionary(uniqueKeysWithValues: zip(hashableTargets, hashes))

--- a/Sources/TuistCacheTesting/ContentHashing/Mocks/MockGraphContentHasher.swift
+++ b/Sources/TuistCacheTesting/ContentHashing/Mocks/MockGraphContentHasher.swift
@@ -7,7 +7,7 @@ public final class MockGraphContentHasher: GraphContentHashing {
 
     public init() {}
 
-    public func contentHashes(for _: Graphing) throws -> [TargetNode: String] {
+    public func contentHashes(for _: Graph) throws -> [TargetNode: String] {
         contentHashesStub ?? [:]
     }
 }

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -20,145 +20,8 @@ enum GraphError: FatalError {
     }
 }
 
-public protocol Graphing: AnyObject, Encodable {
-    var name: String { get }
-    var entryPath: AbsolutePath { get }
-    var entryNodes: [GraphNode] { get }
-    var projects: [Project] { get }
-
-    /// Returns all the CocoaPods nodes that are part of the graph.
-    var cocoapods: [CocoaPodsNode] { get }
-
-    /// Returns all the SwiftPM package nodes that are part of the graph.
-    var packages: [PackageNode] { get }
-
-    /// Returns all the frameorks that are part of the graph.
-    var frameworks: [FrameworkNode] { get }
-
-    /// Returns all the precompiled nodes that are part of the graph.
-    var precompiled: [PrecompiledNode] { get }
-
-    /// Returns all the targets that are part of the graph.
-    var targets: [TargetNode] { get }
-
-    /// Returns all target nodes at a given path (i.e. all target nodes in a project)
-    /// - Parameters:
-    ///   - path: Path to the directory where the project is located
-    func targets(at path: AbsolutePath) -> [TargetNode]
-
-    /// Returns the target with the given name and at the given directory.
-    /// - Parameters:
-    ///   - path: Path to the directory where the project that defines the target is located.
-    ///   - name: Name of the target.
-    func target(path: AbsolutePath, name: String) throws -> TargetNode?
-
-    /// Returns all the non-transitive target dependencies for the given target.
-    /// - Parameters:
-    ///   - path: Path to the directory where the project that defines the target is located.
-    ///   - name: Name of the target.
-    func targetDependencies(path: AbsolutePath, name: String) -> [TargetNode]
-
-    /// Returns all test targets directly dependent on the given target
-    /// - Parameters:
-    ///   - path: Path to the directory where the project that defines the target is located.
-    ///   - name: Name of the target.
-    func testTargetsDependingOn(path: AbsolutePath, name: String) -> [TargetNode]
-
-    /// Returns all non-transitive target static dependencies for the given target.
-    /// - Parameters:
-    ///   - path: Path to the directory where the project that defines the target is located.
-    ///   - name: Name of the target.
-    func staticDependencies(path: AbsolutePath, name: String) -> [GraphDependencyReference]
-
-    /// Returns the resource bundle dependencies for the given target.
-    /// - Parameters:
-    ///   - path: Path to the directory where the project that defines the target is located.
-    ///   - name: Name of the target.
-    func resourceBundleDependencies(path: AbsolutePath, name: String) -> [TargetNode]
-
-    /// Returns all package dependencies for the given target.
-    /// - Parameters:
-    ///   - path: Path to the directory where the project that defines the target is located.
-    ///   - name: Name of the target.
-    func packages(path: AbsolutePath, name: String) throws -> [PackageNode]
-
-    /// It returns the libraries a given target should be linked against.
-    /// - Parameters:
-    ///   - path: Path to the directory where the project that defines the target is located.
-    ///   - name: Name of the target.
-    func linkableDependencies(path: AbsolutePath, name: String) throws -> [GraphDependencyReference]
-
-    /// Returns the paths for the given target to be able to import the headers from its library dependencies.
-    /// - Parameters:
-    ///   - path: Path to the directory where the project that defines the target is located.
-    ///   - name: Name of the target.
-    func librariesPublicHeadersFolders(path: AbsolutePath, name: String) -> [AbsolutePath]
-
-    /// Returns the search paths for the given target to be able to link its library dependencies.
-    /// - Parameters:
-    ///   - path: Path to the directory where the project that defines the target is located.
-    ///   - name: Name of the target.
-    func librariesSearchPaths(path: AbsolutePath, name: String) -> [AbsolutePath]
-
-    /// Returns all the include paths of the library dependencies form the given target.
-    /// - Parameters:
-    ///   - path: Path to the directory where the project that defines the target is located.
-    ///   - name: Name of the target.
-    func librariesSwiftIncludePaths(path: AbsolutePath, name: String) -> [AbsolutePath]
-
-    /// Returns the list of products that should be embedded into the product of the given target.
-    /// - Parameters:
-    ///   - path: Path to the directory where the project that defines the target is located.
-    ///   - name: Name of the target.
-    func embeddableFrameworks(path: AbsolutePath, name: String) throws -> [GraphDependencyReference]
-
-    /// Returns that are added to a dummy copy files phase to enforce build order between dependencies that Xcode doesn't usually respect (e.g. Resouce Bundles)
-    /// - Parameters:
-    ///   - path: Path to the directory where the project that defines the target is located.
-    ///   - target: Target.
-    func copyProductDependencies(path: AbsolutePath, target: Target) -> [GraphDependencyReference]
-
-    /// For the given project it returns all its expected dependency references.
-    /// This method is useful to know which references should be added to the products directory in the generated project.
-    /// - Parameter project: Project whose dependency references will be returned.
-    func allDependencyReferences(for project: Project) throws -> [GraphDependencyReference]
-
-    /// Finds all the app extension dependencies for the target at the given path with the given name.
-    /// - Parameters:
-    ///   - path: Path to the directory where the project that defines the target is located.
-    ///   - name: Name of the target.
-    func appExtensionDependencies(path: AbsolutePath, name: String) -> [TargetNode]
-
-    /// Depth-first search (DFS) is an algorithm for traversing graph data structures. It starts at a source node
-    /// and explores as far as possible along each branch before backtracking.
-    ///
-    /// This implementation looks for TargetNode's and traverses their dependencies so that we are able to build
-    /// up a graph of dependencies to later be used to define the "Link Binary with Library" in an xcodeproj.
-    func findAll<T: GraphNode>(path: AbsolutePath) -> Set<T>
-
-    /// Find a target with the given name and in the given directory.
-    /// - Parameters:
-    ///   - path: Path to the directory where the project that defines the target is located.
-    ///   - name: Name of the target.
-    func findTargetNode(path: AbsolutePath, name: String) -> TargetNode?
-
-    /// Returns all the transitive dependencies of the given target that are static libraries.
-    /// - Parameter targetNode: Target node whose transitive static libraries will be returned.
-    func transitiveStaticTargetNodes(for targetNode: TargetNode) -> Set<TargetNode>
-
-    /// Retuns the first host target node for a given target node
-    ///
-    /// (e.g. finding host application for an extension)
-    ///
-    /// - Parameter path: Path of the hosted target
-    /// - Parameter name: Name of the hosted target
-    ///
-    /// - Note: Search is limited to nodes with a matching path (i.e. targets within the same project)
-    func hostTargetNodeFor(path: AbsolutePath, name: String) -> TargetNode?
-}
-
 // swiftlint:disable:next type_body_length
-public class Graph: Graphing {
+public class Graph: Encodable {
     // MARK: - Attributes
 
     private let cache: GraphLoaderCaching
@@ -199,34 +62,44 @@ public class Graph: Graphing {
 
     // MARK: - Graphing
 
+    /// List of projects that are part of the dependency graph.
     public var projects: [Project] {
         Array(cache.projects.values)
     }
 
+    /// Paths to the projects that are part of the dependency graph.
     public var projectPaths: [AbsolutePath] {
         Array(cache.projects.keys)
     }
 
+    /// Returns all the CocoaPods nodes that are part of the graph.
     public var cocoapods: [CocoaPodsNode] {
         Array(cache.cocoapodsNodes.values)
     }
 
+    /// Returns all the SwiftPM package nodes that are part of the graph.
     public var packages: [PackageNode] {
         cache.packages.values.flatMap { $0 }
     }
 
+    /// Returns all the frameorks that are part of the graph.
     public var frameworks: [FrameworkNode] {
         cache.precompiledNodes.values.compactMap { $0 as? FrameworkNode }
     }
 
+    /// Returns all the precompiled nodes that are part of the graph.
     public var precompiled: [PrecompiledNode] {
         Array(cache.precompiledNodes.values)
     }
 
+    /// Returns all the targets that are part of the graph.
     public var targets: [TargetNode] {
         cache.targetNodes.flatMap { $0.value.values }
     }
 
+    /// Returns all target nodes at a given path (i.e. all target nodes in a project)
+    /// - Parameters:
+    ///   - path: Path to the directory where the project is located
     public func targets(at path: AbsolutePath) -> [TargetNode] {
         guard let nodes = cache.targetNodes[path] else {
             return []
@@ -234,10 +107,18 @@ public class Graph: Graphing {
         return Array(nodes.values)
     }
 
+    /// Returns the target with the given name and at the given directory.
+    /// - Parameters:
+    ///   - path: Path to the directory where the project that defines the target is located.
+    ///   - name: Name of the target.
     public func target(path: AbsolutePath, name: String) -> TargetNode? {
         findTargetNode(path: path, name: name)
     }
 
+    /// Returns all the non-transitive target dependencies for the given target.
+    /// - Parameters:
+    ///   - path: Path to the directory where the project that defines the target is located.
+    ///   - name: Name of the target.
     public func targetDependencies(path: AbsolutePath, name: String) -> [TargetNode] {
         guard let targetNode = findTargetNode(path: path, name: name) else {
             return []
@@ -247,6 +128,10 @@ public class Graph: Graphing {
             .filter { $0.path == path }
     }
 
+    /// Returns all test targets directly dependent on the given target
+    /// - Parameters:
+    ///   - path: Path to the directory where the project that defines the target is located.
+    ///   - name: Name of the target.
     public func testTargetsDependingOn(path: AbsolutePath, name: String) -> [TargetNode] {
         guard let targetNode = findTargetNode(path: path, name: name) else {
             return []
@@ -257,6 +142,10 @@ public class Graph: Graphing {
             .sorted { $0.target.name < $1.target.name }
     }
 
+    /// Returns all non-transitive target static dependencies for the given target.
+    /// - Parameters:
+    ///   - path: Path to the directory where the project that defines the target is located.
+    ///   - name: Name of the target.
     public func staticDependencies(path: AbsolutePath, name: String) -> [GraphDependencyReference] {
         guard let targetNode = findTargetNode(path: path, name: name) else {
             return []
@@ -267,6 +156,10 @@ public class Graph: Graphing {
             .map(productDependencyReference)
     }
 
+    /// Returns the resource bundle dependencies for the given target.
+    /// - Parameters:
+    ///   - path: Path to the directory where the project that defines the target is located.
+    ///   - name: Name of the target.
     public func resourceBundleDependencies(path: AbsolutePath, name: String) -> [TargetNode] {
         guard let targetNode = findTargetNode(path: path, name: name) else {
             return []
@@ -276,10 +169,18 @@ public class Graph: Graphing {
             .filter { $0.target.product == .bundle }
     }
 
+    /// Returns all package dependencies for the given target.
+    /// - Parameters:
+    ///   - path: Path to the directory where the project that defines the target is located.
+    ///   - name: Name of the target.
     public func packages(path: AbsolutePath, name _: String) throws -> [PackageNode] {
         cache.packages[path] ?? []
     }
 
+    /// It returns the libraries a given target should be linked against.
+    /// - Parameters:
+    ///   - path: Path to the directory where the project that defines the target is located.
+    ///   - name: Name of the target.
     public func linkableDependencies(path: AbsolutePath, name: String) throws -> [GraphDependencyReference] {
         guard let targetNode = findTargetNode(path: path, name: name) else {
             return []
@@ -346,6 +247,10 @@ public class Graph: Graphing {
         return Array(references).sorted()
     }
 
+    /// Returns the paths for the given target to be able to import the headers from its library dependencies.
+    /// - Parameters:
+    ///   - path: Path to the directory where the project that defines the target is located.
+    ///   - name: Name of the target.
     public func librariesPublicHeadersFolders(path: AbsolutePath, name: String) -> [AbsolutePath] {
         guard let targetNode = findTargetNode(path: path, name: name) else {
             return []
@@ -355,6 +260,10 @@ public class Graph: Graphing {
             .map(\.publicHeaders)
     }
 
+    /// Returns the search paths for the given target to be able to link its library dependencies.
+    /// - Parameters:
+    ///   - path: Path to the directory where the project that defines the target is located.
+    ///   - name: Name of the target.
     public func librariesSearchPaths(path: AbsolutePath, name: String) -> [AbsolutePath] {
         guard let targetNode = findTargetNode(path: path, name: name) else {
             return []
@@ -364,6 +273,10 @@ public class Graph: Graphing {
             .map { $0.path.removingLastComponent() }
     }
 
+    /// Returns all the include paths of the library dependencies form the given target.
+    /// - Parameters:
+    ///   - path: Path to the directory where the project that defines the target is located.
+    ///   - name: Name of the target.
     public func librariesSwiftIncludePaths(path: AbsolutePath, name: String) -> [AbsolutePath] {
         guard let targetNode = findTargetNode(path: path, name: name) else {
             return []
@@ -373,6 +286,10 @@ public class Graph: Graphing {
             .compactMap { $0.swiftModuleMap?.removingLastComponent() }
     }
 
+    /// Returns the list of products that should be embedded into the product of the given target.
+    /// - Parameters:
+    ///   - path: Path to the directory where the project that defines the target is located.
+    ///   - name: Name of the target.
     public func embeddableFrameworks(path: AbsolutePath, name: String) throws -> [GraphDependencyReference] {
         guard let targetNode = findTargetNode(path: path, name: name),
             canEmbedProducts(targetNode: targetNode) else {
@@ -410,6 +327,10 @@ public class Graph: Graphing {
         return references.sorted()
     }
 
+    /// Returns that are added to a dummy copy files phase to enforce build order between dependencies that Xcode doesn't usually respect (e.g. Resouce Bundles)
+    /// - Parameters:
+    ///   - path: Path to the directory where the project that defines the target is located.
+    ///   - target: Target.
     public func copyProductDependencies(path: AbsolutePath, target: Target) -> [GraphDependencyReference] {
         var dependencies = [GraphDependencyReference]()
 
@@ -424,6 +345,9 @@ public class Graph: Graphing {
         return Set(dependencies).sorted()
     }
 
+    /// For the given project it returns all its expected dependency references.
+    /// This method is useful to know which references should be added to the products directory in the generated project.
+    /// - Parameter project: Project whose dependency references will be returned.
     public func allDependencyReferences(for project: Project) throws -> [GraphDependencyReference] {
         let linkableDependencies = try project.targets.flatMap {
             try self.linkableDependencies(path: project.path, name: $0.name)
@@ -441,6 +365,10 @@ public class Graph: Graphing {
         return Set(allDepdendencies).sorted()
     }
 
+    /// Finds all the app extension dependencies for the target at the given path with the given name.
+    /// - Parameters:
+    ///   - path: Path to the directory where the project that defines the target is located.
+    ///   - name: Name of the target.
     public func appExtensionDependencies(path: AbsolutePath, name: String) -> [TargetNode] {
         guard let targetNode = findTargetNode(path: path, name: name) else {
             return []
@@ -454,6 +382,11 @@ public class Graph: Graphing {
             .filter { validProducts.contains($0.target.product) }
     }
 
+    /// Depth-first search (DFS) is an algorithm for traversing graph data structures. It starts at a source node
+    /// and explores as far as possible along each branch before backtracking.
+    ///
+    /// This implementation looks for TargetNode's and traverses their dependencies so that we are able to build
+    /// up a graph of dependencies to later be used to define the "Link Binary with Library" in an xcodeproj.
     public func findAll<T: GraphNode>(path: AbsolutePath) -> Set<T> {
         guard let targetNodes = cache.targetNodes[path] else {
             return []
@@ -505,6 +438,10 @@ public class Graph: Graphing {
         return references
     }
 
+    /// Find a target with the given name and in the given directory.
+    /// - Parameters:
+    ///   - path: Path to the directory where the project that defines the target is located.
+    ///   - name: Name of the target.
     public func findTargetNode(path: AbsolutePath, name: String) -> TargetNode? {
         func isPathAndNameEqual(node: TargetNode) -> Bool {
             node.path == path && node.target.name == name
@@ -523,12 +460,22 @@ public class Graph: Graphing {
         return cachedTargetNodesForPath[name]
     }
 
+    /// Returns all the transitive dependencies of the given target that are static libraries.
+    /// - Parameter targetNode: Target node whose transitive static libraries will be returned.
     public func transitiveStaticTargetNodes(for targetNode: TargetNode) -> Set<TargetNode> {
         findAll(targetNode: targetNode,
                 test: isStaticLibrary,
                 skip: canLinkStaticProducts)
     }
 
+    /// Retuns the first host target node for a given target node
+    ///
+    /// (e.g. finding host application for an extension)
+    ///
+    /// - Parameter path: Path of the hosted target
+    /// - Parameter name: Name of the hosted target
+    ///
+    /// - Note: Search is limited to nodes with a matching path (i.e. targets within the same project)
     public func hostTargetNodeFor(path: AbsolutePath, name: String) -> TargetNode? {
         guard let cachedTargetNodesForPath = cache.targetNodes[path] else {
             return nil

--- a/Sources/TuistCore/Models/Project.swift
+++ b/Sources/TuistCore/Models/Project.swift
@@ -75,7 +75,7 @@ public struct Project: Equatable, CustomStringConvertible {
     ///
     /// - Parameter graph: Dependencies graph.
     /// - Returns: Sorted targets.
-    public func sortedTargetsForProjectScheme(graph: Graphing) -> [Target] {
+    public func sortedTargetsForProjectScheme(graph: Graph) -> [Target] {
         targets.sorted { (first, second) -> Bool in
             // First criteria: Test bundles at the end
             if first.product.testsBundle, !second.product.testsBundle {

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -32,7 +32,7 @@ enum BuildPhaseGenerationError: FatalError, Equatable {
 protocol BuildPhaseGenerating: AnyObject {
     func generateBuildPhases(path: AbsolutePath,
                              target: Target,
-                             graph: Graphing,
+                             graph: Graph,
                              pbxTarget: PBXTarget,
                              fileElements: ProjectFileElements,
                              pbxproj: PBXProj,
@@ -58,7 +58,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
 
     func generateBuildPhases(path: AbsolutePath,
                              target: Target,
-                             graph: Graphing,
+                             graph: Graph,
                              pbxTarget: PBXTarget,
                              fileElements: ProjectFileElements,
                              pbxproj: PBXProj,
@@ -170,7 +170,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
 
     func generateResourcesBuildPhase(path: AbsolutePath,
                                      target: Target,
-                                     graph: Graphing,
+                                     graph: Graph,
                                      pbxTarget: PBXTarget,
                                      fileElements: ProjectFileElements,
                                      pbxproj: PBXProj) throws {
@@ -260,7 +260,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
 
     private func generateResourceBundle(path: AbsolutePath,
                                         target: Target,
-                                        graph: Graphing,
+                                        graph: Graph,
                                         fileElements: ProjectFileElements,
                                         pbxproj: PBXProj,
                                         resourcesBuildPhase: PBXResourcesBuildPhase) {
@@ -277,7 +277,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
 
     func generateAppExtensionsBuildPhase(path: AbsolutePath,
                                          target: Target,
-                                         graph: Graphing,
+                                         graph: Graph,
                                          pbxTarget: PBXTarget,
                                          fileElements: ProjectFileElements,
                                          pbxproj: PBXProj) throws {
@@ -300,7 +300,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
 
     func generateEmbedWatchBuildPhase(path: AbsolutePath,
                                       target: Target,
-                                      graph: Graphing,
+                                      graph: Graph,
                                       pbxTarget: PBXTarget,
                                       fileElements: ProjectFileElements,
                                       pbxproj: PBXProj) throws {

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -14,7 +14,7 @@ protocol ConfigGenerating: AnyObject {
                               pbxproj: PBXProj,
                               projectSettings: Settings,
                               fileElements: ProjectFileElements,
-                              graph: Graphing,
+                              graph: Graph,
                               sourceRootPath: AbsolutePath) throws
 }
 
@@ -61,7 +61,7 @@ final class ConfigGenerator: ConfigGenerating {
                               pbxproj: PBXProj,
                               projectSettings: Settings,
                               fileElements: ProjectFileElements,
-                              graph: Graphing,
+                              graph: Graph,
                               sourceRootPath: AbsolutePath) throws {
         let defaultConfiguration = projectSettings.defaultReleaseBuildConfiguration()
             ?? projectSettings.defaultDebugBuildConfiguration()
@@ -128,7 +128,7 @@ final class ConfigGenerator: ConfigGenerating {
                                            buildConfiguration: BuildConfiguration,
                                            configuration: Configuration?,
                                            fileElements: ProjectFileElements,
-                                           graph: Graphing,
+                                           graph: Graph,
                                            pbxproj: PBXProj,
                                            configurationList: XCConfigurationList,
                                            sourceRootPath: AbsolutePath) throws {
@@ -158,7 +158,7 @@ final class ConfigGenerator: ConfigGenerating {
 
     private func updateTargetDerived(buildSettings settings: inout [String: SettingValue],
                                      target: Target,
-                                     graph: Graphing,
+                                     graph: Graph,
                                      sourceRootPath: AbsolutePath) {
         settings.merge(generalTargetDerivedSettings(target: target, sourceRootPath: sourceRootPath)) { $1 }
         settings.merge(testBundleTargetDerivedSettings(target: target, graph: graph, sourceRootPath: sourceRootPath)) { $1 }
@@ -197,7 +197,7 @@ final class ConfigGenerator: ConfigGenerating {
     }
 
     private func testBundleTargetDerivedSettings(target: Target,
-                                                 graph: Graphing,
+                                                 graph: Graph,
                                                  sourceRootPath: AbsolutePath) -> [String: SettingValue] {
         guard target.product.testsBundle else {
             return [:]
@@ -250,7 +250,7 @@ final class ConfigGenerator: ConfigGenerating {
     }
 
     private func watchTargetDerivedSettings(target: Target,
-                                            graph: Graphing,
+                                            graph: Graph,
                                             sourceRootPath: AbsolutePath) -> [String: SettingValue] {
         guard target.product == .watch2App else {
             return [:]

--- a/Sources/TuistGenerator/Generator/DerivedFileGenerator.swift
+++ b/Sources/TuistGenerator/Generator/DerivedFileGenerator.swift
@@ -14,7 +14,7 @@ protocol DerivedFileGenerating {
     /// - Throws: An error if the generation of the derived files errors.
     /// - Returns: A project that might have got mutated after the generation of derived files, and a
     ///     function to be called after the project generation to delete the derived files that are not necessary anymore.
-    func generate(graph: Graphing, project: Project, sourceRootPath: AbsolutePath) throws -> (Project, [SideEffectDescriptor])
+    func generate(graph: Graph, project: Project, sourceRootPath: AbsolutePath) throws -> (Project, [SideEffectDescriptor])
 }
 
 final class DerivedFileGenerator: DerivedFileGenerating {
@@ -33,7 +33,7 @@ final class DerivedFileGenerator: DerivedFileGenerating {
         self.infoPlistContentProvider = infoPlistContentProvider
     }
 
-    func generate(graph: Graphing, project: Project, sourceRootPath: AbsolutePath) throws -> (Project, [SideEffectDescriptor]) {
+    func generate(graph: Graph, project: Project, sourceRootPath: AbsolutePath) throws -> (Project, [SideEffectDescriptor]) {
         let transformation = try generateInfoPlists(graph: graph, project: project, sourceRootPath: sourceRootPath)
 
         return (transformation.project, transformation.sideEffects)
@@ -47,7 +47,7 @@ final class DerivedFileGenerator: DerivedFileGenerating {
     ///   - sourceRootPath: Path to the directory in which the project is getting generated.
     /// - Returns: A set with paths to the Info.plist files that are no longer necessary and therefore need to be removed.
     /// - Throws: An error if the encoding of the Info.plist content fails.
-    func generateInfoPlists(graph: Graphing,
+    func generateInfoPlists(graph: Graph,
                             project: Project,
                             sourceRootPath: AbsolutePath) throws -> ProjectTransformation {
         let targetsWithGeneratableInfoPlists = project.targets.filter {
@@ -102,7 +102,7 @@ final class DerivedFileGenerator: DerivedFileGenerating {
     private func infoPlistDictionary(infoPlist: InfoPlist,
                                      project: Project,
                                      target: Target,
-                                     graph: Graphing) -> [String: Any]? {
+                                     graph: Graph) -> [String: Any]? {
         switch infoPlist {
         case let .dictionary(content):
             return content.mapValues { $0.value }

--- a/Sources/TuistGenerator/Generator/Generator.swift
+++ b/Sources/TuistGenerator/Generator/Generator.swift
@@ -17,7 +17,7 @@ public protocol Generating {
     /// - Returns: An absolute path to the generated Xcode project many of which adopt `FatalError`
     /// - Throws: Errors encountered during the generation process
     /// - seealso: TuistCore.FatalError
-    func generateProject(at path: AbsolutePath) throws -> (AbsolutePath, Graphing)
+    func generateProject(at path: AbsolutePath) throws -> (AbsolutePath, Graph)
 
     /// Generates the given project in the same directory where it's defined.
     /// - Parameters:
@@ -25,7 +25,7 @@ public protocol Generating {
     ///     - graph: The dependencies graph.
     ///     - sourceRootPath: The path all the files in the Xcode project will be realtived to. When it's nil, it's assumed that all the paths are relative to the directory that contains the manifest.
     ///     - xcodeprojPath: Path where the .xcodeproj directory will be generated. When the attribute is nil, the project is generated in the manifest's directory.
-    func generateProject(_ project: Project, graph: Graphing, sourceRootPath: AbsolutePath?, xcodeprojPath: AbsolutePath?) throws -> AbsolutePath
+    func generateProject(_ project: Project, graph: Graph, sourceRootPath: AbsolutePath?, xcodeprojPath: AbsolutePath?) throws -> AbsolutePath
 
     /// Generate an Xcode workspace for the project at a given path. All the project's dependencies will also be generated and included.
     ///
@@ -39,7 +39,7 @@ public protocol Generating {
     ///           many of which adopt `FatalError`
     /// - seealso: TuistCore.FatalError
     @discardableResult
-    func generateProjectWorkspace(at path: AbsolutePath, workspaceFiles: [AbsolutePath]) throws -> (AbsolutePath, Graphing)
+    func generateProjectWorkspace(at path: AbsolutePath, workspaceFiles: [AbsolutePath]) throws -> (AbsolutePath, Graph)
 
     /// Generate an Xcode workspace at a given path. All referenced projects and their dependencies will be generated and included.
     ///
@@ -53,7 +53,7 @@ public protocol Generating {
     ///           many of which adopt `FatalError`
     /// - seealso: TuistCore.FatalError
     @discardableResult
-    func generateWorkspace(at path: AbsolutePath, workspaceFiles: [AbsolutePath]) throws -> (AbsolutePath, Graphing)
+    func generateWorkspace(at path: AbsolutePath, workspaceFiles: [AbsolutePath]) throws -> (AbsolutePath, Graph)
 }
 
 /// A default implementation of `Generating`
@@ -124,7 +124,7 @@ public class Generator: Generating {
     }
 
     public func generateProject(_ project: Project,
-                                graph: Graphing,
+                                graph: Graph,
                                 sourceRootPath: AbsolutePath? = nil,
                                 xcodeprojPath: AbsolutePath? = nil) throws -> AbsolutePath {
         /// When the source root path is not given, we assume paths
@@ -140,7 +140,7 @@ public class Generator: Generating {
         return descriptor.xcodeprojPath
     }
 
-    public func generateProject(at path: AbsolutePath) throws -> (AbsolutePath, Graphing) {
+    public func generateProject(at path: AbsolutePath) throws -> (AbsolutePath, Graph) {
         let config = try graphLoader.loadConfig(path: path)
         try environmentLinter.lint(config: config).printAndThrowIfNeeded()
 
@@ -157,7 +157,7 @@ public class Generator: Generating {
     }
 
     public func generateProjectWorkspace(at path: AbsolutePath,
-                                         workspaceFiles: [AbsolutePath]) throws -> (AbsolutePath, Graphing) {
+                                         workspaceFiles: [AbsolutePath]) throws -> (AbsolutePath, Graph) {
         let config = try graphLoader.loadConfig(path: path)
         try environmentLinter.lint(config: config).printAndThrowIfNeeded()
 
@@ -180,7 +180,7 @@ public class Generator: Generating {
     }
 
     public func generateWorkspace(at path: AbsolutePath,
-                                  workspaceFiles: [AbsolutePath]) throws -> (AbsolutePath, Graphing) {
+                                  workspaceFiles: [AbsolutePath]) throws -> (AbsolutePath, Graph) {
         let config = try graphLoader.loadConfig(path: path)
         try environmentLinter.lint(config: config).printAndThrowIfNeeded()
         let (graph, workspace) = try graphLoader.loadWorkspace(path: path)

--- a/Sources/TuistGenerator/Generator/InfoPlistContentProvider.swift
+++ b/Sources/TuistGenerator/Generator/InfoPlistContentProvider.swift
@@ -13,7 +13,7 @@ protocol InfoPlistContentProviding {
     ///   - target: Target whose Info.plist content will be returned.
     ///   - extendedWith: Values provided by the user to extend the default ones.
     /// - Returns: Content to generate the Info.plist file.
-    func content(graph: Graphing, project: Project, target: Target, extendedWith: [String: InfoPlist.Value]) -> [String: Any]?
+    func content(graph: Graph, project: Project, target: Target, extendedWith: [String: InfoPlist.Value]) -> [String: Any]?
 }
 
 final class InfoPlistContentProvider: InfoPlistContentProviding {
@@ -27,7 +27,7 @@ final class InfoPlistContentProvider: InfoPlistContentProviding {
     ///   - target: Target whose Info.plist content will be returned.
     ///   - extendedWith: Values provided by the user to extend the default ones.
     /// - Returns: Content to generate the Info.plist file.
-    func content(graph: Graphing, project: Project, target: Target, extendedWith: [String: InfoPlist.Value]) -> [String: Any]? {
+    func content(graph: Graph, project: Project, target: Target, extendedWith: [String: InfoPlist.Value]) -> [String: Any]? {
         if target.product == .staticLibrary || target.product == .dynamicLibrary {
             return nil
         }

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -49,7 +49,7 @@ protocol LinkGenerating: AnyObject {
                        fileElements: ProjectFileElements,
                        path: AbsolutePath,
                        sourceRootPath: AbsolutePath,
-                       graph: Graphing) throws
+                       graph: Graph) throws
 }
 
 // swiftlint:disable type_body_length
@@ -77,7 +77,7 @@ final class LinkGenerator: LinkGenerating {
                        fileElements: ProjectFileElements,
                        path: AbsolutePath,
                        sourceRootPath: AbsolutePath,
-                       graph: Graphing) throws {
+                       graph: Graph) throws {
         let embeddableFrameworks = try graph.embeddableFrameworks(path: path, name: target.name)
         let linkableModules = try graph.linkableDependencies(path: path, name: target.name)
 
@@ -115,7 +115,7 @@ final class LinkGenerator: LinkGenerating {
                                             pbxTarget: PBXTarget,
                                             sourceRootPath: AbsolutePath,
                                             path: AbsolutePath,
-                                            graph: Graphing,
+                                            graph: Graph,
                                             linkableModules: [GraphDependencyReference]) throws {
         let headersSearchPaths = graph.librariesPublicHeadersFolders(path: path, name: target.name)
         let librarySearchPaths = graph.librariesSearchPaths(path: path, name: target.name)
@@ -317,7 +317,7 @@ final class LinkGenerator: LinkGenerating {
 
     func generateCopyProductsdBuildPhase(path: AbsolutePath,
                                          target: Target,
-                                         graph: Graphing,
+                                         graph: Graph,
                                          pbxTarget: PBXTarget,
                                          pbxproj: PBXProj,
                                          fileElements: ProjectFileElements) throws {

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -44,7 +44,7 @@ class ProjectFileElements {
     }
 
     func generateProjectFiles(project: Project,
-                              graph: Graphing,
+                              graph: Graph,
                               groups: ProjectGroups,
                               pbxproj: PBXProj,
                               sourceRootPath: AbsolutePath) throws {

--- a/Sources/TuistGenerator/Generator/ProjectGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGenerator.swift
@@ -31,7 +31,7 @@ protocol ProjectGenerating: AnyObject {
     ///   - xcodeprojPath: Path to the Xcode project. When not given, the xcodeproj is generated at sourceRootPath.
     /// - Returns: Generated project descriptor
     func generate(project: Project,
-                  graph: Graphing,
+                  graph: Graph,
                   sourceRootPath: AbsolutePath?,
                   xcodeprojPath: AbsolutePath?) throws -> ProjectDescriptor
 }
@@ -74,7 +74,7 @@ final class ProjectGenerator: ProjectGenerating {
 
     // swiftlint:disable:next function_body_length
     func generate(project: Project,
-                  graph: Graphing,
+                  graph: Graph,
                   sourceRootPath: AbsolutePath? = nil,
                   xcodeprojPath: AbsolutePath? = nil) throws -> ProjectDescriptor {
         logger.notice("Generating project \(project.name)")
@@ -174,7 +174,7 @@ final class ProjectGenerator: ProjectGenerating {
                                  pbxProject: PBXProject,
                                  fileElements: ProjectFileElements,
                                  sourceRootPath: AbsolutePath,
-                                 graph: Graphing) throws -> [String: PBXNativeTarget] {
+                                 graph: Graph) throws -> [String: PBXNativeTarget] {
         var nativeTargets: [String: PBXNativeTarget] = [:]
         try project.targets.forEach { target in
             let nativeTarget = try targetGenerator.generateTarget(target: target,
@@ -258,7 +258,7 @@ final class ProjectGenerator: ProjectGenerating {
         pbxProject.packages = packageReferences.sorted { $0.key < $1.key }.map { $1 }
     }
 
-    private func determineProjectConstants(graph: Graphing) throws -> ProjectConstants {
+    private func determineProjectConstants(graph: Graph) throws -> ProjectConstants {
         if !graph.packages.isEmpty {
             return .xcode11
         } else {

--- a/Sources/TuistGenerator/Generator/SchemesGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemesGenerator.swift
@@ -16,7 +16,7 @@ protocol SchemesGenerating {
     /// - Throws: A FatalError if the generation of the schemes fails.
     func generateWorkspaceSchemes(workspace: Workspace,
                                   generatedProjects: [AbsolutePath: GeneratedProject],
-                                  graph: Graphing) throws -> [SchemeDescriptor]
+                                  graph: Graph) throws -> [SchemeDescriptor]
 
     /// Generates the schemes for the project targets.
     ///
@@ -28,7 +28,7 @@ protocol SchemesGenerating {
     /// - Throws: A FatalError if the generation of the schemes fails.
     func generateProjectSchemes(project: Project,
                                 generatedProject: GeneratedProject,
-                                graph: Graphing) throws -> [SchemeDescriptor]
+                                graph: Graph) throws -> [SchemeDescriptor]
 }
 
 // swiftlint:disable:next type_body_length
@@ -41,7 +41,7 @@ final class SchemesGenerator: SchemesGenerating {
 
     func generateWorkspaceSchemes(workspace: Workspace,
                                   generatedProjects: [AbsolutePath: GeneratedProject],
-                                  graph: Graphing) throws -> [SchemeDescriptor] {
+                                  graph: Graph) throws -> [SchemeDescriptor] {
         let schemes = try workspace.schemes.map { scheme in
             try generateScheme(scheme: scheme,
                                path: workspace.path,
@@ -54,7 +54,7 @@ final class SchemesGenerator: SchemesGenerating {
 
     func generateProjectSchemes(project: Project,
                                 generatedProject: GeneratedProject,
-                                graph: Graphing) throws -> [SchemeDescriptor] {
+                                graph: Graph) throws -> [SchemeDescriptor] {
         let customSchemes: [SchemeDescriptor] = try project.schemes.map { scheme in
             try generateScheme(scheme: scheme,
                                path: project.path,
@@ -91,7 +91,7 @@ final class SchemesGenerator: SchemesGenerating {
         if fileHandler.exists(sharedPath) { try fileHandler.delete(sharedPath) }
     }
 
-    func createDefaultScheme(target: Target, project: Project, buildConfiguration: String, graph: Graphing) -> Scheme {
+    func createDefaultScheme(target: Target, project: Project, buildConfiguration: String, graph: Graph) -> Scheme {
         let targetReference = TargetReference(projectPath: project.path, name: target.name)
 
         let testTargets: [TestableTarget]
@@ -123,7 +123,7 @@ final class SchemesGenerator: SchemesGenerating {
     ///     - generatedProjects: Project paths mapped to generated projects.
     private func generateScheme(scheme: Scheme,
                                 path: AbsolutePath,
-                                graph: Graphing,
+                                graph: Graph,
                                 generatedProjects: [AbsolutePath: GeneratedProject]) throws -> SchemeDescriptor {
         let generatedBuildAction = try schemeBuildAction(scheme: scheme,
                                                          graph: graph,
@@ -172,7 +172,7 @@ final class SchemesGenerator: SchemesGenerating {
     ///   - generatedProjects: Project paths mapped to generated projects.
     /// - Returns: Scheme build action.
     func schemeBuildAction(scheme: Scheme,
-                           graph: Graphing,
+                           graph: Graph,
                            rootPath: AbsolutePath,
                            generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.BuildAction? {
         guard let buildAction = scheme.buildAction else { return nil }
@@ -218,7 +218,7 @@ final class SchemesGenerator: SchemesGenerating {
     /// - Returns: Scheme test action.
     // swiftlint:disable:next function_body_length
     func schemeTestAction(scheme: Scheme,
-                          graph: Graphing,
+                          graph: Graph,
                           rootPath: AbsolutePath,
                           generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.TestAction? {
         guard let testAction = scheme.testAction else { return nil }
@@ -290,7 +290,7 @@ final class SchemesGenerator: SchemesGenerating {
     ///   - generatedProjects: Project paths mapped to generated projects.
     /// - Returns: Scheme launch action.
     func schemeLaunchAction(scheme: Scheme,
-                            graph: Graphing,
+                            graph: Graph,
                             rootPath: AbsolutePath,
                             generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.LaunchAction? {
         guard var target = try defaultTargetReference(scheme: scheme) else { return nil }
@@ -347,7 +347,7 @@ final class SchemesGenerator: SchemesGenerating {
     ///   - generatedProjects: Project paths mapped to generated projects.
     /// - Returns: Scheme profile action.
     func schemeProfileAction(scheme: Scheme,
-                             graph: Graphing,
+                             graph: Graph,
                              rootPath: AbsolutePath,
                              generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.ProfileAction? {
         guard var target = try defaultTargetReference(scheme: scheme) else { return nil }
@@ -400,7 +400,7 @@ final class SchemesGenerator: SchemesGenerating {
     ///     - generatedProjects: Project paths mapped to generated projects.
     /// - Returns: Scheme analyze action.
     func schemeAnalyzeAction(scheme: Scheme,
-                             graph: Graphing,
+                             graph: Graph,
                              rootPath _: AbsolutePath,
                              generatedProjects _: [AbsolutePath: GeneratedProject]) throws -> XCScheme.AnalyzeAction? {
         guard let target = try defaultTargetReference(scheme: scheme),
@@ -419,7 +419,7 @@ final class SchemesGenerator: SchemesGenerating {
     ///     - generatedProjects: Project paths mapped to generated projects.
     /// - Returns: Scheme archive action.
     func schemeArchiveAction(scheme: Scheme,
-                             graph: Graphing,
+                             graph: Graph,
                              rootPath: AbsolutePath,
                              generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.ArchiveAction? {
         guard let target = try defaultTargetReference(scheme: scheme),
@@ -445,7 +445,7 @@ final class SchemesGenerator: SchemesGenerating {
     }
 
     func schemeExecutionAction(action: ExecutionAction,
-                               graph: Graphing,
+                               graph: Graph,
                                generatedProjects: [AbsolutePath: GeneratedProject],
                                rootPath _: AbsolutePath) throws -> XCScheme.ExecutionAction {
         guard let targetReference = action.target,
@@ -509,7 +509,7 @@ final class SchemesGenerator: SchemesGenerating {
     ///     - rootPath: Path to the project or workspace.
     ///     - generatedProjects: Project paths mapped to generated projects.
     private func createBuildableReference(targetReference: TargetReference,
-                                          graph: Graphing,
+                                          graph: Graph,
                                           rootPath: AbsolutePath,
                                           generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.BuildableReference? {
         let projectPath = targetReference.projectPath
@@ -535,7 +535,7 @@ final class SchemesGenerator: SchemesGenerating {
     ///   - rootPath: Root path to workspace or project.
     /// - Returns: Array of buildable references.
     private func testCoverageTargetReferences(target: TargetReference,
-                                              graph: Graphing,
+                                              graph: Graph,
                                               generatedProjects: [AbsolutePath: GeneratedProject],
                                               rootPath: AbsolutePath) throws -> XCScheme.BuildableReference? {
         try createBuildableReference(targetReference: target,

--- a/Sources/TuistGenerator/Generator/TargetGenerator.swift
+++ b/Sources/TuistGenerator/Generator/TargetGenerator.swift
@@ -12,12 +12,12 @@ protocol TargetGenerating: AnyObject {
                         fileElements: ProjectFileElements,
                         path: AbsolutePath,
                         sourceRootPath: AbsolutePath,
-                        graph: Graphing) throws -> PBXNativeTarget
+                        graph: Graph) throws -> PBXNativeTarget
 
     func generateTargetDependencies(path: AbsolutePath,
                                     targets: [Target],
                                     nativeTargets: [String: PBXNativeTarget],
-                                    graph: Graphing) throws
+                                    graph: Graph) throws
 }
 
 final class TargetGenerator: TargetGenerating {
@@ -50,7 +50,7 @@ final class TargetGenerator: TargetGenerating {
                         fileElements: ProjectFileElements,
                         path: AbsolutePath,
                         sourceRootPath: AbsolutePath,
-                        graph: Graphing) throws -> PBXNativeTarget {
+                        graph: Graph) throws -> PBXNativeTarget {
         /// Products reference.
         let productFileReference = fileElements.products[target.name]!
 
@@ -111,7 +111,7 @@ final class TargetGenerator: TargetGenerating {
     func generateTargetDependencies(path: AbsolutePath,
                                     targets: [Target],
                                     nativeTargets: [String: PBXNativeTarget],
-                                    graph: Graphing) throws {
+                                    graph: Graph) throws {
         try targets.forEach { targetSpec in
             let dependencies = graph.targetDependencies(path: path, name: targetSpec.name)
             try dependencies.forEach { dependency in

--- a/Sources/TuistGenerator/Generator/WorkspaceGenerator.swift
+++ b/Sources/TuistGenerator/Generator/WorkspaceGenerator.swift
@@ -32,7 +32,7 @@ protocol WorkspaceGenerating: AnyObject {
     /// - Throws: An error if the generation fails.
     func generate(workspace: Workspace,
                   path: AbsolutePath,
-                  graph: Graphing) throws -> WorkspaceDescriptor
+                  graph: Graph) throws -> WorkspaceDescriptor
 }
 
 final class WorkspaceGenerator: WorkspaceGenerating {
@@ -78,7 +78,7 @@ final class WorkspaceGenerator: WorkspaceGenerating {
 
     // MARK: - WorkspaceGenerating
 
-    func generate(workspace: Workspace, path: AbsolutePath, graph: Graphing) throws -> WorkspaceDescriptor {
+    func generate(workspace: Workspace, path: AbsolutePath, graph: Graph) throws -> WorkspaceDescriptor {
         let workspaceName = "\(graph.name).xcworkspace"
 
         logger.notice("Generating workspace \(workspaceName)", metadata: .section)

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -4,7 +4,7 @@ import TuistCore
 import TuistSupport
 
 public protocol GraphLinting: AnyObject {
-    func lint(graph: Graphing) -> [LintingIssue]
+    func lint(graph: Graph) -> [LintingIssue]
 }
 
 // swiftlint:disable type_body_length
@@ -31,7 +31,7 @@ public class GraphLinter: GraphLinting {
 
     // MARK: - GraphLinting
 
-    public func lint(graph: Graphing) -> [LintingIssue] {
+    public func lint(graph: Graph) -> [LintingIssue] {
         var issues: [LintingIssue] = []
         issues.append(contentsOf: graph.projects.flatMap(projectLinter.lint))
         issues.append(contentsOf: lintDependencies(graph: graph))
@@ -42,7 +42,7 @@ public class GraphLinter: GraphLinting {
 
     // MARK: - Fileprivate
 
-    func lintDependencies(graph: Graphing) -> [LintingIssue] {
+    func lintDependencies(graph: Graph) -> [LintingIssue] {
         var issues: [LintingIssue] = []
         var evaluatedNodes: [GraphNode] = []
         graph.entryNodes.forEach {
@@ -103,7 +103,7 @@ public class GraphLinter: GraphLinting {
         return issues
     }
 
-    private func lintMismatchingConfigurations(graph: Graphing) -> [LintingIssue] {
+    private func lintMismatchingConfigurations(graph: Graph) -> [LintingIssue] {
         let entryNodeProjects = graph.entryNodes.compactMap { $0 as? TargetNode }.map { $0.project }
 
         let knownConfigurations = entryNodeProjects.reduce(into: Set()) {
@@ -131,7 +131,7 @@ public class GraphLinter: GraphLinting {
     ///
     /// - Parameter graph: Project graph.
     /// - Returns: Linting issues.
-    private func lintPackageDependencies(graph: Graphing) -> [LintingIssue] {
+    private func lintPackageDependencies(graph: Graph) -> [LintingIssue] {
         let containsPackageDependency = graph.packages.count > 0
 
         guard containsPackageDependency else { return [] }
@@ -155,7 +155,7 @@ public class GraphLinter: GraphLinting {
     ///
     /// - Parameter graph: Project graph.
     /// - Returns: Linting issues.
-    private func lintCocoaPodsDependencies(graph: Graphing) -> [LintingIssue] {
+    private func lintCocoaPodsDependencies(graph: Graph) -> [LintingIssue] {
         graph.cocoapods.compactMap { node in
             let podfilePath = node.podfilePath
             if !FileHandler.shared.exists(podfilePath) {
@@ -165,7 +165,7 @@ public class GraphLinter: GraphLinting {
         }
     }
 
-    private func lintCarthageDependencies(graph: Graphing) -> [LintingIssue] {
+    private func lintCarthageDependencies(graph: Graph) -> [LintingIssue] {
         let frameworks = graph.frameworks
         let carthageFrameworks = frameworks.filter { $0.isCarthage }
         let nonCarthageFrameworks = frameworks.filter { !$0.isCarthage }
@@ -184,7 +184,7 @@ public class GraphLinter: GraphLinting {
         return issues
     }
 
-    private func lintWatchBundleIndentifiers(graph: Graphing) -> [LintingIssue] {
+    private func lintWatchBundleIndentifiers(graph: Graph) -> [LintingIssue] {
         let apps = graph
             .targets
             .filter { $0.target.product == .app }
@@ -226,13 +226,13 @@ public class GraphLinter: GraphLinting {
         return []
     }
 
-    private func watchAppsFor(targetNode: TargetNode, graph: Graphing) -> [TargetNode] {
+    private func watchAppsFor(targetNode: TargetNode, graph: Graph) -> [TargetNode] {
         graph.targetDependencies(path: targetNode.path,
                                  name: targetNode.name)
             .filter { $0.target.product == .watch2App }
     }
 
-    private func watchExtensionsFor(targetNode: TargetNode, graph: Graphing) -> [TargetNode] {
+    private func watchExtensionsFor(targetNode: TargetNode, graph: Graph) -> [TargetNode] {
         graph.targetDependencies(path: targetNode.path,
                                  name: targetNode.name)
             .filter { $0.target.product == .watch2Extension }

--- a/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -8,11 +8,11 @@ import TuistCore
 /// static products are linked multiple times.
 ///
 protocol StaticProductsGraphLinting {
-    func lint(graph: Graphing) -> [LintingIssue]
+    func lint(graph: Graph) -> [LintingIssue]
 }
 
 class StaticProductsGraphLinter: StaticProductsGraphLinting {
-    func lint(graph: Graphing) -> [LintingIssue] {
+    func lint(graph: Graph) -> [LintingIssue] {
         let nodes = graph.entryNodes
         return warnings(in: nodes)
             .sorted()

--- a/Sources/TuistGenerator/Utils/CocoaPodsInteractor.swift
+++ b/Sources/TuistGenerator/Utils/CocoaPodsInteractor.swift
@@ -33,7 +33,7 @@ public protocol CocoaPodsInteracting {
     ///
     /// - Parameter graph: Project graph.
     /// - Throws: An error if the installation of the pods fails.
-    func install(graph: Graphing) throws
+    func install(graph: Graph) throws
 }
 
 public final class CocoaPodsInteractor: CocoaPodsInteracting {
@@ -43,7 +43,7 @@ public final class CocoaPodsInteractor: CocoaPodsInteracting {
     ///
     /// - Parameter graph: Project graph.
     /// - Throws: An error if the installation of the pods fails.
-    public func install(graph: Graphing) throws {
+    public func install(graph: Graph) throws {
         do {
             try install(graph: graph, updatingRepo: false)
         } catch let error as CocoaPodsInteractorError {
@@ -56,7 +56,7 @@ public final class CocoaPodsInteractor: CocoaPodsInteracting {
         }
     }
 
-    fileprivate func install(graph: Graphing, updatingRepo: Bool) throws {
+    fileprivate func install(graph: Graph, updatingRepo: Bool) throws {
         guard !graph.cocoapods.isEmpty else {
             return
         }

--- a/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
+++ b/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
@@ -22,7 +22,7 @@ public protocol SwiftPackageManagerInteracting {
     /// - Parameters:
     ///   - graph: The graph of projects
     ///   - workspaceName: The name of the generated workspace (e.g. `MyWorkspace.xcworkspace`)
-    func install(graph: Graphing, workspaceName: String) throws
+    func install(graph: Graph, workspaceName: String) throws
 }
 
 public class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting {
@@ -31,7 +31,7 @@ public class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting {
         self.fileHandler = fileHandler
     }
 
-    public func install(graph: Graphing, workspaceName: String) throws {
+    public func install(graph: Graph, workspaceName: String) throws {
         try generatePackageDependencyManager(at: graph.entryPath,
                                              workspaceName: workspaceName,
                                              graph: graph)
@@ -40,7 +40,7 @@ public class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting {
     private func generatePackageDependencyManager(
         at path: AbsolutePath,
         workspaceName: String,
-        graph: Graphing
+        graph: Graph
     ) throws {
         let packages = graph.packages
         guard !packages.remotePackages.isEmpty else {

--- a/Sources/TuistGeneratorTesting/Linter/MockGraphLinter.swift
+++ b/Sources/TuistGeneratorTesting/Linter/MockGraphLinter.swift
@@ -9,7 +9,7 @@ public class MockGraphLinter: GraphLinting {
 
     public init() {}
 
-    public func lint(graph _: Graphing) -> [LintingIssue] {
+    public func lint(graph _: Graph) -> [LintingIssue] {
         lintStub ?? []
     }
 }

--- a/Sources/TuistKit/Cache/CacheController.swift
+++ b/Sources/TuistKit/Cache/CacheController.swift
@@ -52,7 +52,7 @@ final class CacheController: CacheControlling {
 
     /// Returns all the targets that are cacheable and their hashes.
     /// - Parameter graph: Graph that contains all the dependency graph nodes.
-    fileprivate func cacheableTargets(graph: Graphing) throws -> [TargetNode: String] {
+    fileprivate func cacheableTargets(graph: Graph) throws -> [TargetNode: String] {
         try graphContentHasher.contentHashes(for: graph)
             .filter { target, hash in
                 if let exists = try self.cache.exists(hash: hash).toBlocking().first(), exists {

--- a/Sources/TuistKit/Commands/LintCommand.swift
+++ b/Sources/TuistKit/Commands/LintCommand.swift
@@ -76,7 +76,7 @@ class LintCommand: NSObject, Command {
 
         // Load graph
         let manifests = manifestLoading.manifests(at: path)
-        var graph: Graphing!
+        var graph: Graph!
 
         logger.notice("Loading the dependency graph")
         if manifests.contains(.workspace) {

--- a/Sources/TuistKit/ProjectGenerator/ProjectGenerator.swift
+++ b/Sources/TuistKit/ProjectGenerator/ProjectGenerator.swift
@@ -7,7 +7,7 @@ import TuistLoader
 protocol ProjectGenerating {
     @discardableResult
     func generate(path: AbsolutePath, projectOnly: Bool) throws -> AbsolutePath
-    func generateWithGraph(path: AbsolutePath, projectOnly: Bool) throws -> (AbsolutePath, Graphing)
+    func generateWithGraph(path: AbsolutePath, projectOnly: Bool) throws -> (AbsolutePath, Graph)
 }
 
 class ProjectGenerator: ProjectGenerating {
@@ -33,7 +33,7 @@ class ProjectGenerator: ProjectGenerating {
         return generatedPath
     }
 
-    func generateWithGraph(path: AbsolutePath, projectOnly: Bool) throws -> (AbsolutePath, Graphing) {
+    func generateWithGraph(path: AbsolutePath, projectOnly: Bool) throws -> (AbsolutePath, Graph) {
         let manifests = manifestLoader.manifests(at: path)
 
         if projectOnly {
@@ -107,7 +107,7 @@ class ProjectGenerator: ProjectGenerating {
         return (workspaceDescriptor.xcworkspacePath, graph)
     }
 
-    private func lint(graph: Graphing) throws {
+    private func lint(graph: Graph) throws {
         let config = try graphLoader.loadConfig(path: graph.entryPath)
 
         try environmentLinter.lint(config: config).printAndThrowIfNeeded()

--- a/Tests/TuistGeneratorIntegrationTests/Utils/Mocks/MockCocoaPodsInteractor.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Utils/Mocks/MockCocoaPodsInteractor.swift
@@ -3,10 +3,10 @@ import TuistCore
 @testable import TuistGenerator
 
 final class MockCocoaPodsInteractor: CocoaPodsInteracting {
-    var installArgs: [Graphing] = []
+    var installArgs: [Graph] = []
     var installStub: Error?
 
-    func install(graph: Graphing) throws {
+    func install(graph: Graph) throws {
         installArgs.append(graph)
         if let error = installStub { throw error }
     }

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -22,7 +22,7 @@ final class BuildPhaseGenerationErrorTests: XCTestCase {
 final class BuildPhaseGeneratorTests: XCTestCase {
     var subject: BuildPhaseGenerator!
     var errorHandler: MockErrorHandler!
-    var graph: Graphing!
+    var graph: Graph!
 
     override func setUp() {
         subject = BuildPhaseGenerator()

--- a/Tests/TuistGeneratorTests/Generator/Mocks/MockInfoPlistContentProvider.swift
+++ b/Tests/TuistGeneratorTests/Generator/Mocks/MockInfoPlistContentProvider.swift
@@ -4,10 +4,10 @@ import TuistCoreTesting
 @testable import TuistGenerator
 
 final class MockInfoPlistContentProvider: InfoPlistContentProviding {
-    var contentArgs: [(graph: Graphing, project: Project, target: Target, extendedWith: [String: InfoPlist.Value])] = []
+    var contentArgs: [(graph: Graph, project: Project, target: Target, extendedWith: [String: InfoPlist.Value])] = []
     var contentStub: [String: Any]?
 
-    func content(graph: Graphing, project: Project, target: Target, extendedWith: [String: InfoPlist.Value]) -> [String: Any]? {
+    func content(graph: Graph, project: Project, target: Target, extendedWith: [String: InfoPlist.Value]) -> [String: Any]? {
         contentArgs.append((graph: graph, project: project, target: target, extendedWith: extendedWith))
         return contentStub ?? [:]
     }

--- a/Tests/TuistGeneratorTests/Generator/Mocks/MockProjectGenerator.swift
+++ b/Tests/TuistGeneratorTests/Generator/Mocks/MockProjectGenerator.swift
@@ -12,9 +12,9 @@ final class MockProjectGenerator: ProjectGenerating {
     }
 
     var generatedProjects: [Project] = []
-    var generateStub: ((Project, Graphing, AbsolutePath?, AbsolutePath?) throws -> ProjectDescriptor)?
+    var generateStub: ((Project, Graph, AbsolutePath?, AbsolutePath?) throws -> ProjectDescriptor)?
 
-    func generate(project: Project, graph: Graphing, sourceRootPath: AbsolutePath?, xcodeprojPath: AbsolutePath?) throws -> ProjectDescriptor {
+    func generate(project: Project, graph: Graph, sourceRootPath: AbsolutePath?, xcodeprojPath: AbsolutePath?) throws -> ProjectDescriptor {
         guard let generateStub = generateStub else {
             throw MockError.stubNotImplemented
         }

--- a/Tests/TuistGeneratorTests/Generator/Mocks/MockSchemesGenerator.swift
+++ b/Tests/TuistGeneratorTests/Generator/Mocks/MockSchemesGenerator.swift
@@ -5,11 +5,11 @@ import TuistCoreTesting
 @testable import TuistGenerator
 
 final class MockSchemesGenerator: SchemesGenerating {
-    func generateProjectSchemes(project _: Project, generatedProject _: GeneratedProject, graph _: Graphing) throws -> [SchemeDescriptor] {
+    func generateProjectSchemes(project _: Project, generatedProject _: GeneratedProject, graph _: Graph) throws -> [SchemeDescriptor] {
         []
     }
 
-    func generateWorkspaceSchemes(workspace _: Workspace, generatedProjects _: [AbsolutePath: GeneratedProject], graph _: Graphing) throws -> [SchemeDescriptor] {
+    func generateWorkspaceSchemes(workspace _: Workspace, generatedProjects _: [AbsolutePath: GeneratedProject], graph _: Graph) throws -> [SchemeDescriptor] {
         []
     }
 }

--- a/Tests/TuistGeneratorTests/Generator/Mocks/MockTargetGenerator.swift
+++ b/Tests/TuistGeneratorTests/Generator/Mocks/MockTargetGenerator.swift
@@ -9,9 +9,9 @@ import XcodeProj
 class MockTargetGenerator: TargetGenerating {
     var generateTargetStub: (() -> PBXNativeTarget)?
 
-    func generateTarget(target: Target, pbxproj _: PBXProj, pbxProject _: PBXProject, projectSettings _: Settings, fileElements _: ProjectFileElements, path _: AbsolutePath, sourceRootPath _: AbsolutePath, graph _: Graphing) throws -> PBXNativeTarget {
+    func generateTarget(target: Target, pbxproj _: PBXProj, pbxProject _: PBXProject, projectSettings _: Settings, fileElements _: ProjectFileElements, path _: AbsolutePath, sourceRootPath _: AbsolutePath, graph _: Graph) throws -> PBXNativeTarget {
         generateTargetStub?() ?? PBXNativeTarget(name: target.name)
     }
 
-    func generateTargetDependencies(path _: AbsolutePath, targets _: [Target], nativeTargets _: [String: PBXNativeTarget], graph _: Graphing) throws {}
+    func generateTargetDependencies(path _: AbsolutePath, targets _: [Target], nativeTargets _: [String: PBXNativeTarget], graph _: Graph) throws {}
 }

--- a/Tests/TuistGeneratorTests/Generator/Mocks/MockWorkspaceGenerator.swift
+++ b/Tests/TuistGeneratorTests/Generator/Mocks/MockWorkspaceGenerator.swift
@@ -12,9 +12,9 @@ final class MockWorkspaceGenerator: WorkspaceGenerating {
     }
 
     var generateWorkspaces: [Workspace] = []
-    var generateStub: ((Workspace, AbsolutePath, Graphing) throws -> WorkspaceDescriptor)?
+    var generateStub: ((Workspace, AbsolutePath, Graph) throws -> WorkspaceDescriptor)?
 
-    func generate(workspace: Workspace, path: AbsolutePath, graph: Graphing) throws -> WorkspaceDescriptor {
+    func generate(workspace: Workspace, path: AbsolutePath, graph: Graph) throws -> WorkspaceDescriptor {
         guard let generateStub = generateStub else {
             throw MockError.stubNotImplemented
         }

--- a/Tests/TuistGeneratorTests/Linter/Mocks/MockStaticProductsGraphLinter.swift
+++ b/Tests/TuistGeneratorTests/Linter/Mocks/MockStaticProductsGraphLinter.swift
@@ -3,8 +3,8 @@ import TuistCore
 @testable import TuistGenerator
 
 class MockStaticProductsGraphLinter: StaticProductsGraphLinting {
-    var lintStub: ((Graphing) -> [LintingIssue])?
-    func lint(graph: Graphing) -> [LintingIssue] {
+    var lintStub: ((Graph) -> [LintingIssue])?
+    func lint(graph: Graph) -> [LintingIssue] {
         lintStub?(graph) ?? []
     }
 }

--- a/Tests/TuistKitTests/Cache/CacheControllerTests.swift
+++ b/Tests/TuistKitTests/Cache/CacheControllerTests.swift
@@ -66,7 +66,7 @@ final class CacheControllerTests: TuistUnitTestCase {
             XCTAssertEqual(loadPath, path)
             return Set(arrayLiteral: .project)
         }
-        generator.generateWithGraphStub = { (loadPath, _) -> (AbsolutePath, Graphing) in
+        generator.generateWithGraphStub = { (loadPath, _) -> (AbsolutePath, Graph) in
             XCTAssertEqual(loadPath, path)
             return (xcworkspacePath, graph)
         }

--- a/Tests/TuistKitTests/Generator/Mocks/MockProjectGenerator.swift
+++ b/Tests/TuistKitTests/Generator/Mocks/MockProjectGenerator.swift
@@ -21,8 +21,8 @@ final class MockProjectGenerator: ProjectGenerating {
     }
 
     var generateWithGraphCalls: [(path: AbsolutePath, projectOnly: Bool)] = []
-    var generateWithGraphStub: ((AbsolutePath, Bool) throws -> (AbsolutePath, Graphing))?
-    func generateWithGraph(path: AbsolutePath, projectOnly: Bool) throws -> (AbsolutePath, Graphing) {
+    var generateWithGraphStub: ((AbsolutePath, Bool) throws -> (AbsolutePath, Graph))?
+    func generateWithGraph(path: AbsolutePath, projectOnly: Bool) throws -> (AbsolutePath, Graph) {
         guard let generateWithGraphStub = generateWithGraphStub else {
             throw MockError.stubNotImplemented
         }


### PR DESCRIPTION
### Short description 📝
`Graphing` is a good example of how protocols shouldn't be used:
- They don't define behavior that multiple elements of the codebase can conform to *(alike Equatable)*.
- It doesn't define a contract to do dependency injection for testing purposes. 

For that reason, I'm removing it from the codebase. This PR removes the protocol, moves the documentation to the class, and update all the usages of `Graphing` to `Graph`. After doing all the renames, the project compiled and the tests ran successfully.

In a follow-up PR, I'll change the implementation of Graph to be initialized with the properties from the cache instead of having a dependency with the cache and overriding the getters. The cache is only necessary during the process of loading the models. Once loaded, the cache is no longer necessary.