### PR TITLE
Remove redundant SDK paths from FRAMEWORK_SEARCH_PATHS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- Remove redundant SDK paths from `FRAMEWORK_SEARCH_PATHS` https://github.com/tuist/tuist/pull/1145 by @kwridan
+
 ### Removed
 
 - `Graphing` protocol https://github.com/tuist/tuist/pull/1128 by @pepibumur

--- a/Sources/TuistCore/Graph/GraphDependencyReference.swift
+++ b/Sources/TuistCore/Graph/GraphDependencyReference.swift
@@ -71,16 +71,15 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
         }
     }
 
-    /// For dependencies that exists in the file system. This attribute returns the path to them.
-    public var path: AbsolutePath? {
+    /// For dependencies that exists in the file system (precompiled frameworks & libraries),
+    /// this attribute returns the path to them.
+    public var precompiledPath: AbsolutePath? {
         switch self {
         case let .framework(metadata):
             return metadata.path
         case let .library(metadata):
             return metadata.path
         case let .xcframework(metadata):
-            return metadata.path
-        case let .sdk(metadata):
             return metadata.path
         default:
             return nil

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -211,7 +211,7 @@ final class LinkGenerator: LinkGenerating {
     func setupFrameworkSearchPath(dependencies: [GraphDependencyReference],
                                   pbxTarget: PBXTarget,
                                   sourceRootPath: AbsolutePath) throws {
-        let paths = dependencies.compactMap { $0.path }
+        let paths = dependencies.compactMap { $0.precompiledPath }
             .map { $0.removingLastComponent() }
 
         let uniquePaths = Array(Set(paths))

--- a/Tests/TuistGeneratorTests/Utils/EmbedScriptGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/EmbedScriptGeneratorTests.swift
@@ -30,7 +30,7 @@ final class EmbedScriptGeneratorTests: TuistUnitTestCase {
                                                                dsymPath: dsymPath,
                                                                bcsymbolmapPaths: [bcsymbolPath])
         // When
-        let got = try subject.script(sourceRootPath: framework.path!.parentDirectory, frameworkReferences: [framework])
+        let got = try subject.script(sourceRootPath: framework.precompiledPath!.parentDirectory, frameworkReferences: [framework])
 
         // Then
         XCTAssertEqual(got.inputPaths, [


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/1144

### Short description 📝

Generating a project that has a .sdk dependency will result in in a project that includes a relative path to the SDK directory from the source root (which will be different on different machines).


```diff
buildSettings = {
        ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
        CODE_SIGN_IDENTITY = "iPhone Developer";
        ENABLE_PREVIEWS = YES;
+        FRAMEWORK_SEARCH_PATHS = (
+            "$(inherited)",
+            "$(SRCROOT)/../../../../../../../Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks",
+            "$(SRCROOT)/../../../../../../../Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib",
+        );
        INFOPLIST_FILE = "Support/App-Info.plist";
        LD_RUNPATH_SEARCH_PATHS = (
            "$(inherited)",
            "@executable_path/Frameworks",
        );
        PRODUCT_BUNDLE_IDENTIFIER = io.tuist.App;
        PRODUCT_NAME = App;
        SDKROOT = iphoneos;
        SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
        SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
        SWIFT_COMPILATION_MODE = singlefile;
        SWIFT_OPTIMIZATION_LEVEL = "-Onone";
        SWIFT_VERSION = 5.1;
        TARGETED_DEVICE_FAMILY = "1,2";
    };
    name = Debug;
};
```
This appears to be a side effect of some tidy ups to `GraphDependencyReference` which accidentally removed the filtering `LinkGenerator` used to perform to only add paths to precompiled frameworks and libraries

### Solution 📦

Ensure `LinkGenerator` only includes paths to precompiled frameworks and libraries.

### Implementation 👩‍💻👨‍💻

- [x] To help make the usage clearer, rename the `path` variable to `precompiledPath`
- [x] Update tests to catch this (or similar issues) in the future
- [x] Update change log

### Test Plan 🛠

- Run tuist generate within `fixtures/ios_app_with_sdk`
- Open the generated project
- Inspect the `FRAMEWORK_SEARCH_PATH` build setting
- Verify it doesn't contain entires for the relative SDK paths
