### PR TITLE
Generate example template.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- Fix example framework template not being generated https://github.com/tuist/tuist/pull/1149 by @fortmarek 
+
 ## 1.5.0
 
 ### Added

--- a/Templates/default/ExampleProject.stencil
+++ b/Templates/default/ExampleProject.stencil
@@ -1,0 +1,12 @@
+import ProjectDescription
+let project = Project(name: "{{ name }}",
+                      targets: [
+                          Target(name: "{{ name }}",
+                                 platform: .{{ platform }},
+                                 product: .framework,
+                                 productName: "{{ name }}",
+                                 bundleId: "io.tuist.{{ name }}",
+                                 infoPlist: .default,
+                                 sources: "Sources/**",
+                                 dependencies: []),
+])

--- a/Templates/default/ExampleTemplate.stencil
+++ b/Templates/default/ExampleTemplate.stencil
@@ -1,0 +1,15 @@
+import ProjectDescription
+let nameAttribute: Template.Attribute = .required("name")
+let exampleContents = """
+struct \(nameAttribute) { }
+"""
+let template = Template(
+    description: "Framework template",
+    attributes: [
+        nameAttribute,
+    ],
+    files: [
+        .string(path: "\(nameAttribute)/Sources/\(nameAttribute).swift", contents: exampleContents),
+        .file(path: "\(nameAttribute)/Project.swift", templatePath: "project.stencil"),
+    ]
+)

--- a/Templates/default/Template.swift
+++ b/Templates/default/Template.swift
@@ -106,5 +106,9 @@ let template = Template(
                 contents: tuistConfigContent),
         .file(path: ".gitignore",
               templatePath: "Gitignore.stencil"),
+        .file(path: "Tuist/Templates/framework/Template.swift",
+              templatePath: "ExampleTemplate.stencil"),
+        .file(path: "Tuist/Templates/framework/project.stencil",
+              templatePath: "ExampleProject.stencil")
     ]
 )


### PR DESCRIPTION
### Short description 📝

During the rewriting of `Init` command to [use](https://github.com/tuist/tuist/pull/1129) `scaffold`, I forgot to include example framework [template](https://github.com/tuist/tuist/pull/1126)

### Solution 📦

Add files to default `Template.swift`

### Implementation 👩‍💻👨‍💻

- [x] Add files
- [x] Edit changelog
