### PR TITLE
Update config name in the default template

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -47,6 +47,15 @@
         }
       },
       {
+        "package": "PathKit",
+        "repositoryURL": "https://github.com/kylef/PathKit.git",
+        "state": {
+          "branch": null,
+          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
+          "version": "1.0.0"
+        }
+      },
+      {
         "package": "RxSwift",
         "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
         "state": {

--- a/Sources/TuistCore/Graph/GraphDependencyReference.swift
+++ b/Sources/TuistCore/Graph/GraphDependencyReference.swift
@@ -56,12 +56,12 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
 
     public func hash(into hasher: inout Hasher) {
         switch self {
-        case let .library(metadata):
-            hasher.combine(metadata.0)
-        case let .framework(metadata):
-            hasher.combine(metadata.0)
-        case let .xcframework(metadata):
-            hasher.combine(metadata.0)
+        case let .library(path, _, _, _, _):
+            hasher.combine(path)
+        case let .framework(path, _, _, _, _, _, _, _):
+            hasher.combine(path)
+        case let .xcframework(path, _, _, _):
+            hasher.combine(path)
         case let .product(target, productName):
             hasher.combine(target)
             hasher.combine(productName)
@@ -75,12 +75,12 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
     /// this attribute returns the path to them.
     public var precompiledPath: AbsolutePath? {
         switch self {
-        case let .framework(metadata):
-            return metadata.path
-        case let .library(metadata):
-            return metadata.path
-        case let .xcframework(metadata):
-            return metadata.path
+        case let .framework(path, _, _, _, _, _, _, _):
+            return path
+        case let .library(path, _, _, _, _):
+            return path
+        case let .xcframework(path, _, _, _):
+            return path
         default:
             return nil
         }
@@ -88,12 +88,12 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
 
     public static func < (lhs: GraphDependencyReference, rhs: GraphDependencyReference) -> Bool {
         switch (lhs, rhs) {
-        case let (.framework(lhsMetadata), .framework(rhsMetadata)):
-            return lhsMetadata.path < rhsMetadata.path
-        case let (.xcframework(lhsMetadata), .xcframework(rhsMetadata)):
-            return lhsMetadata.path < rhsMetadata.path
-        case let (.library(lhsMetadata), .library(rhsMetadata)):
-            return lhsMetadata.path < rhsMetadata.path
+        case let (.framework(lhsPath, _, _, _, _, _, _, _), .framework(rhsPath, _, _, _, _, _, _, _)):
+            return lhsPath < rhsPath
+        case let (.xcframework(lhsPath, _, _, _), .xcframework(rhsPath, _, _, _)):
+            return lhsPath < rhsPath
+        case let (.library(lhsPath, _, _, _, _), .library(rhsPath, _, _, _, _)):
+            return lhsPath < rhsPath
         case let (.product(lhsTarget, lhsProductName), .product(rhsTarget, rhsProductName)):
             if lhsTarget == rhsTarget {
                 return lhsProductName < rhsProductName

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -174,9 +174,9 @@ final class LinkGenerator: LinkGenerating {
             case .library:
                 // Do nothing
                 break
-            case let .xcframework(metadata):
-                guard let fileRef = fileElements.file(path: metadata.path) else {
-                    throw LinkGeneratorError.missingReference(path: metadata.path)
+            case let .xcframework(path, _, _, _):
+                guard let fileRef = fileElements.file(path: path) else {
+                    throw LinkGeneratorError.missingReference(path: path)
                 }
                 let buildFile = PBXBuildFile(
                     file: fileRef,
@@ -187,9 +187,9 @@ final class LinkGenerator: LinkGenerating {
             case .sdk:
                 // Do nothing
                 break
-            case let .product(metadata):
-                guard let fileRef = fileElements.product(target: metadata.target) else {
-                    throw LinkGeneratorError.missingProduct(name: metadata.target)
+            case let .product(target, _):
+                guard let fileRef = fileElements.product(target: target) else {
+                    throw LinkGeneratorError.missingProduct(name: target)
                 }
                 let buildFile = PBXBuildFile(file: fileRef,
                                              settings: ["ATTRIBUTES": ["CodeSignOnCopy", "RemoveHeadersOnCopy"]])
@@ -290,12 +290,12 @@ final class LinkGenerator: LinkGenerating {
             .sorted()
             .forEach { dependency in
                 switch dependency {
-                case let .framework(metadata):
-                    try addBuildFile(metadata.path)
-                case let .library(metadata):
-                    try addBuildFile(metadata.path)
-                case let .xcframework(metadata):
-                    try addBuildFile(metadata.path)
+                case let .framework(path, _, _, _, _, _, _, _):
+                    try addBuildFile(path)
+                case let .library(path, _, _, _, _):
+                    try addBuildFile(path)
+                case let .xcframework(path, _, _, _):
+                    try addBuildFile(path)
                 case let .product(target, _):
                     guard let fileRef = fileElements.product(target: target) else {
                         throw LinkGeneratorError.missingProduct(name: target)

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -190,12 +190,12 @@ class ProjectFileElements {
 
         try sortedDependencies.forEach { dependency in
             switch dependency {
-            case let .xcframework(metadata):
-                try generatePrecompiled(metadata.path)
-            case let .framework(metadata):
-                try generatePrecompiled(metadata.path)
-            case let .library(metadata):
-                try generatePrecompiled(metadata.path)
+            case let .xcframework(path, _, _, _):
+                try generatePrecompiled(path)
+            case let .framework(path, _, _, _, _, _, _, _):
+                try generatePrecompiled(path)
+            case let .library(path, _, _, _, _):
+                try generatePrecompiled(path)
             case let .sdk(sdkNodePath, _):
                 generateSDKFileElement(sdkNodePath: sdkNodePath,
                                        toGroup: groups.frameworks,

--- a/Sources/TuistGenerator/Generator/SchemesGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemesGenerator.swift
@@ -307,7 +307,7 @@ final class SchemesGenerator: SchemesGenerating {
         if let filePath = scheme.runAction?.filePath {
             pathRunnable = XCScheme.PathRunnable(filePath: filePath.pathString)
         } else {
-            guard let targetNode = try graph.target(path: target.projectPath, name: target.name) else { return nil }
+            guard let targetNode = graph.target(path: target.projectPath, name: target.name) else { return nil }
             defaultBuildConfiguration = defaultDebugBuildConfigurationName(in: targetNode.project)
             guard let buildableReference = try createBuildableReference(targetReference: target,
                                                                         graph: graph,
@@ -368,7 +368,7 @@ final class SchemesGenerator: SchemesGenerating {
             }
         }
 
-        guard let targetNode = try graph.target(path: target.projectPath, name: target.name) else { return nil }
+        guard let targetNode = graph.target(path: target.projectPath, name: target.name) else { return nil }
         guard let buildableReference = try createBuildableReference(targetReference: target,
                                                                     graph: graph,
                                                                     rootPath: rootPath,
@@ -404,7 +404,7 @@ final class SchemesGenerator: SchemesGenerating {
                              rootPath _: AbsolutePath,
                              generatedProjects _: [AbsolutePath: GeneratedProject]) throws -> XCScheme.AnalyzeAction? {
         guard let target = try defaultTargetReference(scheme: scheme),
-            let targetNode = try graph.target(path: target.projectPath, name: target.name) else { return nil }
+            let targetNode = graph.target(path: target.projectPath, name: target.name) else { return nil }
 
         let buildConfiguration = scheme.analyzeAction?.configurationName ?? defaultDebugBuildConfigurationName(in: targetNode.project)
         return XCScheme.AnalyzeAction(buildConfiguration: buildConfiguration)
@@ -423,7 +423,7 @@ final class SchemesGenerator: SchemesGenerating {
                              rootPath: AbsolutePath,
                              generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.ArchiveAction? {
         guard let target = try defaultTargetReference(scheme: scheme),
-            let targetNode = try graph.target(path: target.projectPath, name: target.name) else { return nil }
+            let targetNode = graph.target(path: target.projectPath, name: target.name) else { return nil }
 
         guard let archiveAction = scheme.archiveAction else {
             return defaultSchemeArchiveAction(for: targetNode.project)
@@ -449,7 +449,7 @@ final class SchemesGenerator: SchemesGenerating {
                                generatedProjects: [AbsolutePath: GeneratedProject],
                                rootPath _: AbsolutePath) throws -> XCScheme.ExecutionAction {
         guard let targetReference = action.target,
-            let targetNode = try graph.target(path: targetReference.projectPath, name: targetReference.name),
+            let targetNode = graph.target(path: targetReference.projectPath, name: targetReference.name),
             let generatedProject = generatedProjects[targetReference.projectPath] else {
             return schemeExecutionAction(action: action)
         }
@@ -513,7 +513,7 @@ final class SchemesGenerator: SchemesGenerating {
                                           rootPath: AbsolutePath,
                                           generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.BuildableReference? {
         let projectPath = targetReference.projectPath
-        guard let target = try graph.target(path: projectPath, name: targetReference.name) else { return nil }
+        guard let target = graph.target(path: projectPath, name: targetReference.name) else { return nil }
         guard let generatedProject = generatedProjects[projectPath] else { return nil }
         guard let pbxTarget = generatedProject.targets[targetReference.name] else { return nil }
         let relativeXcodeProjectPath = resolveRelativeProjectPath(targetNode: target,

--- a/Templates/default/Template.swift
+++ b/Templates/default/Template.swift
@@ -60,10 +60,10 @@ import Foundation
 
 """
 
-let tuistConfigContent = """
+let configContent = """
 import ProjectDescription
 
-let config = TuistConfig(generationOptions: [
+let config = Config(generationOptions: [
 ])
 """
 
@@ -102,8 +102,8 @@ let template = Template(
                 contents: playgroundContent),
         .file(path: supportFrameworkPath + "/Playgrounds/\(nameAttribute)Support.playground" + "/contents.xcplayground",
               templatePath: "Playground.stencil"),
-        .string(path: "TuistConfig.swift",
-                contents: tuistConfigContent),
+        .string(path: "Tuist/Config.swift",
+                contents: configContent),
         .file(path: ".gitignore",
               templatePath: "Gitignore.stencil"),
     ]


### PR DESCRIPTION
### Short description 📝
Testing 1.5.0 I noticed that the template keeps the old version and location for `TuistConfig.swift`. This PR updates it to `Config.swift` under the `Tuist/` directory. 