### PR TITLE
Add Derived folder to .gitignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ## Next
 
 ### Added
+- `Derived` to `.gitignore` when running `tuist init` https://github.com/tuist/tuist/pull/1171 by @fortmarek
 - Prevent `Multiple commands produce XXXXX` error produced by multiple test targets using “Embed Precompiled Frameworks” script https://github.com/tuist/tuist/pull/1118 by @paulsamuels
 - Add possibility to skip generation of default schemes https://github.com/tuist/tuist/pull/1130 by @olejnjak
 

--- a/Templates/default/Gitignore.stencil
+++ b/Templates/default/Gitignore.stencil
@@ -64,3 +64,4 @@ DerivedData/
 
 ### Tuist derived files ###
 graph.dot
+Derived/


### PR DESCRIPTION
### Short description 📝

`tuist init` generates `.gitignore` file where project and workspace files are ignored, but not `Derived` directory, which should be added, too

### Solution 📦

Add it to generated `.gitignore` in `default` template

### Implementation 👩‍💻👨‍💻

- [x] Add `.gitignore`
- [x] Edit changelog
