### PR TITLE
Generate a tests file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ## Next
 
 ### Added
+
 - `Derived` to `.gitignore` when running `tuist init` https://github.com/tuist/tuist/pull/1171 by @fortmarek
 
 ### Fixed
+
 - Prevent `Multiple commands produce XXXXX` error produced by multiple test targets using “Embed Precompiled Frameworks” script https://github.com/tuist/tuist/pull/1118 by @paulsamuels
 - Add possibility to skip generation of default schemes https://github.com/tuist/tuist/pull/1130 by @olejnjak
 - Errors during the manifest parsing are not printed https://github.com/tuist/tuist/pull/1125 by @pepibumur.
+- Warnings because test files are missing in the project scaffolded using the default `framework` template https://github.com/tuist/tuist/pull/1172 by @pepibumur.
 
 ## 1.5.2
 

--- a/Templates/default/ExampleTemplate.stencil
+++ b/Templates/default/ExampleTemplate.stencil
@@ -2,8 +2,32 @@ import ProjectDescription
 let nameAttribute: Template.Attribute = .required("name")
 
 let exampleContents = """
+import Foundation
+
 struct \(nameAttribute) { }
 """
+
+let testContents = """
+import Foundation
+import XCTest
+
+final class \(nameAttribute)Tests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func test_example() {
+        // Add your test here
+    }
+
+}
+"""
+
 let template = Template(
     description: "Framework template",
     attributes: [
@@ -12,6 +36,7 @@ let template = Template(
     ],
     files: [
         .string(path: "\(nameAttribute)/Sources/\(nameAttribute).swift", contents: exampleContents),
+        .string(path: "\(nameAttribute)/Tests/\(nameAttribute)Tests.swift", contents: testContents),
         .file(path: "\(nameAttribute)/Project.swift", templatePath: "project.stencil"),
     ]
 )

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -15,3 +15,4 @@ Feature: Scaffold a project using Tuist
     And tuist scaffolds a framework template to Projects/ named MyFeature
     When tuist generates the project at Projects/MyFeature
     Then I should be able to build for iOS the scheme MyFeature
+    Then I should be able to test for iOS the scheme MyFeature


### PR DESCRIPTION
### Short description 📝
I recently changed the template that gets generated with `tuist init` so that it leverages the helpers that are generated. Those helpers define for each framework 2 targets, one with the source, and the other one with the tests.
Since I forgot to update the template to generate a tests file, running `tuist generate` on the project scaffolded with `tuist scaffold framework MyFramework` results in warnings because the tests target contains no files.

This PR fixes that by extending the template to generate an empty test case. I added an acceptance test to make sure that the generated tests target is testable.