### PR TITLE
Version 1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+## 1.5.4
+
+### Fixed
+
+- Tuist not working with Xcode < 11.4 by @pepibumur.
+
 ## 1.5.3
 
 ### Added

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,7 +13,8 @@ This document describes the process of releasing new versions of tuist.
 4.  Update the version in the `Constants.swift` file.
 5.  Update the `CHANGELOG.md` to include the version section.
 6.  Commit the changes and tag the commit with the version `git tag x.y.z`.
-7.  Package and upload the release to GCS by running `bundle exec rake release`.
-8.  Upload the installation scripts to GCS by running `bundle exec rake release_scripts`.
-9.  Create a release on GitHub with the version as a title, the body from the CHANGELOG file, and attach the artifacts in the `build/` directory.
-10. Run `tuist update` and verify that the new version is installed and runs.
+7.  Select the Xcode version 11.3.1 before building the binaries: `sudo xcode-select -s /Applications/Xcode_11.3.1.app`.
+8.  Package and upload the release to GCS by running `bundle exec rake release`.
+9.  Upload the installation scripts to GCS by running `bundle exec rake release_scripts`.
+10. Create a release on GitHub with the version as a title, the body from the CHANGELOG file, and attach the artifacts in the `build/` directory.
+11. Run `tuist update` and verify that the new version is installed and runs.

--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -191,8 +191,7 @@ public class ManifestLoader: ManifestLoading {
 
         switch result {
         case let .completed(elements):
-            if let output = elements.first(where: { $0.isStandardOutput }) { return output.value }
-            throw ManifestLoaderError.unexpectedOutput(path)
+            return elements.filter({ $0.isStandardOutput }).map({ $0.value }).reduce(into: Data(), { $0.append($1) })
         case let .failed(_, error):
             throw error
         }

--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -191,7 +191,7 @@ public class ManifestLoader: ManifestLoading {
 
         switch result {
         case let .completed(elements):
-            return elements.filter({ $0.isStandardOutput }).map({ $0.value }).reduce(into: Data(), { $0.append($1) })
+            return elements.filter { $0.isStandardOutput }.map { $0.value }.reduce(into: Data()) { $0.append($1) }
         case let .failed(_, error):
             throw error
         }

--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -5,7 +5,7 @@ public struct Constants {
     public static let binFolderName = ".tuist-bin"
     public static let binName = "tuist"
     public static let gitRepositoryURL = "https://github.com/tuist/tuist.git"
-    public static let version = "1.5.3"
+    public static let version = "1.5.4"
     public static let swiftVersion: String = "5.2"
     public static let bundleName: String = "tuist.zip"
     public static let trueValues: [String] = ["1", "true", "TRUE", "yes", "YES"]

--- a/features/generate-5.feature
+++ b/features/generate-5.feature
@@ -32,3 +32,9 @@ Scenario: The project contains an invalid manifest and tuist should surface comp
     And I have a working directory
     Then I copy the fixture invalid_manifest into the working directory
     Then tuist generate yields error "error: expected ',' separator"
+
+Scenario: The project contains a project with a large manifest (ios_app_large)
+    Given that tuist is available
+    And I have a working directory
+    Then I copy the fixture ios_app_large into the working directory
+    Then tuist generates the project

--- a/fixtures/ios_app_large/.gitignore
+++ b/fixtures/ios_app_large/.gitignore
@@ -1,0 +1,63 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two 
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace

--- a/fixtures/ios_app_large/Info.plist
+++ b/fixtures/ios_app_large/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/fixtures/ios_app_large/Project.swift
+++ b/fixtures/ios_app_large/Project.swift
@@ -1,0 +1,14 @@
+import ProjectDescription
+
+func target(name: String) -> Target {
+    return Target(name: name,
+                    platform: .iOS,
+                    product: .app,
+                    bundleId: "io.tuist.\(name)",
+                    infoPlist: .file(path: .relativeToManifest("Info.plist")),
+                    sources: .paths([.relativeToManifest("Sources/**")]),
+                    settings: Settings(base: ["CODE_SIGN_IDENTITY": "", "CODE_SIGNING_REQUIRED": "NO"]))
+}
+
+let project = Project(name: "App",
+                      targets: (1...300).map({ target(name: "App\($0)") }))

--- a/fixtures/ios_app_large/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_large/Sources/AppDelegate.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        let viewController = UIViewController()
+        viewController.view.backgroundColor = .white
+        window?.rootViewController = viewController
+        window?.makeKeyAndVisible()
+        return true
+    }
+    
+    func hello() -> String {
+        return "AppDelegate.hello()"
+    }
+    
+}

--- a/fixtures/ios_app_large/Tests.plist
+++ b/fixtures/ios_app_large/Tests.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_large/Tuist/Config.swift
+++ b/fixtures/ios_app_large/Tuist/Config.swift
@@ -1,0 +1,6 @@
+import ProjectDescription
+
+let config = Config(
+  generationOptions: [
+  ]
+)

--- a/website/markdown/docs/contribution/architecture.mdx
+++ b/website/markdown/docs/contribution/architecture.mdx
@@ -1,6 +1,5 @@
 ---
 name: Architecture
-order: 4
 excerpt: 'This document describes how the project is architected and what are different areas of responsibilities.'
 ---
 

--- a/website/markdown/docs/contribution/changelog-guidelines.mdx
+++ b/website/markdown/docs/contribution/changelog-guidelines.mdx
@@ -1,6 +1,5 @@
 ---
 name: Changelog guidelines
-order: 7
 excerpt: Read about the guidelines that the project embrace for the style of the CHANGELOG file. Every user-facing change added to the project requires changes in this file that is useful for users to know what's coming with every new version of Tuist.
 ---
 

--- a/website/markdown/docs/contribution/code-of-conduct.mdx
+++ b/website/markdown/docs/contribution/code-of-conduct.mdx
@@ -1,6 +1,5 @@
 ---
 name: Code of conduct
-order: 8
 excerpt: This document contains rules of behaviour and good conduct to have a healthy community of users, contributors, and maintainers. In a nutshell, every person involved in this project should be nice with everyone around them.
 ---
 

--- a/website/markdown/docs/contribution/code-reviews.mdx
+++ b/website/markdown/docs/contribution/code-reviews.mdx
@@ -1,6 +1,5 @@
 ---
 name: Code reviews
-order: 2
 excerpt: For contributors and maintainers that help review pull requests on GitHub, this page includes a checklist with some important aspects that they should look at. It's not meant to be an exhaustive checklist but rather a reference.
 ---
 

--- a/website/markdown/docs/contribution/core-team.mdx
+++ b/website/markdown/docs/contribution/core-team.mdx
@@ -1,6 +1,5 @@
 ---
 name: Core team
-order: 9
 excerpt: The core team is a group of contributors that demonstrated a lasting enthusiasm for the project and the community. This document contains who they are, what are their responsibilities, and what's the process for adding new members.
 ---
 

--- a/website/markdown/docs/contribution/getting-started.mdx
+++ b/website/markdown/docs/contribution/getting-started.mdx
@@ -1,6 +1,5 @@
 ---
 name: Getting started
-order: 1
 excerpt: This is page contains a handful of resources and tips for users that are interested in contributing to the project. From how the project is structured to what utilities are available, including bits about the testing strategies that we follow.
 ---
 

--- a/website/markdown/docs/contribution/manifesto.mdx
+++ b/website/markdown/docs/contribution/manifesto.mdx
@@ -1,6 +1,5 @@
 ---
 name: Manifesto
-order: 10
 excerpt: This page describes principles that are pillars to the design and development of Tuist. They evolve with the project and are meant to ensure a sustainable growth that is well-aligned with the project foundation.
 ---
 
@@ -90,10 +89,10 @@ but prevent future developers from breaking that logic.
 
 <!-- ## 7. Write code for humans
 
-The code that we write can make a huge difference between a buggy and unmaintainable code base, 
+The code that we write can make a huge difference between a buggy and unmaintainable code base,
 and a stable and maintainable one.
 Write beautiful and concise code that is **easy to read and understand**.
-Leverage the abstractions and primitives provided by the programming language, 
+Leverage the abstractions and primitives provided by the programming language,
 Swift,
 to create a solid structure made of simple pieces with scoped responsibilities.
 Don't add code to Tuist that reads like a long and mysterious bash script.
@@ -101,5 +100,5 @@ The programming patterns and paradigms that you might apply when building apps m
 In fact, a pattern like MVP, is also valid in the context of CLIs with the difference that the view is the CLI output *(chunks of data sent through the standard output and error)*.
 
 
-Code that reads like a book encourages contributions, 
+Code that reads like a book encourages contributions,
 and contributions bring new ideas to the table that  -->

--- a/website/markdown/docs/contribution/performance.mdx
+++ b/website/markdown/docs/contribution/performance.mdx
@@ -1,6 +1,5 @@
 ---
 name: Performance
-order: 12
 excerpt: This page describes the project's performance testing strategy.
 ---
 
@@ -11,7 +10,7 @@ To test out generation speeds and to provide some utilities to aid profiling Tui
 - `fixturegen`: A tool to generate large fixtures
 - `tuistbench`: A tool to benchmark Tuist
 
-Those tools are located within the [`tools/`](https://github.com/tuist/tuist/blob/master/tools) directory. 
+Those tools are located within the [`tools/`](https://github.com/tuist/tuist/blob/master/tools) directory.
 
 ## Fixture Generator (`fixturegen`)
 
@@ -55,7 +54,7 @@ Runs          : 5
 Result
     - cold : 0.72s
     - warm : 0.74s
-    
+
 ```
 
 Markdown format:
@@ -68,10 +67,8 @@ swift run tuistbench \
 ```
 
 | Fixture            | Cold  | Warm  |
-| ------------------ | ------| ----- |
+| ------------------ | ----- | ----- |
 | ios_app_with_tests | 0.72s | 0.72s |
-
-
 
 **Benchmark (single fixture):**
 
@@ -90,7 +87,6 @@ Result
     - warm : 0.75s  vs  0.79s (⬇︎ 0.04s 5.63%)
 ```
 
-
 Markdown format:
 
 ```sh
@@ -101,11 +97,10 @@ swift run tuistbench \
      --format markdown
 ```
 
-| Fixture         | New    | Old  | Delta    |
-| --------------- | ------ | ---- | -------- |
-| ios_app_with_tests _(cold)_ | 0.73s | 0.79s | ⬇︎ 7.92% |
-| ios_app_with_tests _(warm)_ | 0.79s | 0.79s | ≈ |
-
+| Fixture                      | New   | Old   | Delta    |
+| ---------------------------- | ----- | ----- | -------- |
+| ios*app_with_tests *(cold)\_ | 0.73s | 0.79s | ⬇︎ 7.92% |
+| ios*app_with_tests *(warm)\_ | 0.79s | 0.79s | ≈        |
 
 **Benchmark (multiple fixtures):**
 
@@ -113,11 +108,11 @@ A fixture list `json` file is needed to specify multiple fixtures, here's an exa
 
 ```json
 {
-    "paths": [
-        "/path/to/fixtures/ios_app_with_tests",
-        "/path/to/fixtures/ios_app_with_carthage_frameworks",
-        "/path/to/fixtures/ios_app_with_helpers"
-    ]
+  "paths": [
+    "/path/to/fixtures/ios_app_with_tests",
+    "/path/to/fixtures/ios_app_with_carthage_frameworks",
+    "/path/to/fixtures/ios_app_with_helpers"
+  ]
 }
 ```
 
@@ -161,12 +156,11 @@ swift run tuistbench \
      --format markdown
 ```
 
-
-| Fixture         | New    | Old  | Delta    |
-| --------------- | ------ | ---- | -------- |
-| ios_app_with_tests _(cold)_ | 0.73s | 0.79s   | ⬇︎ 7.92% |
-| ios_app_with_tests _(warm)_ | 0.79s | 0.79s | ≈ |
-| ios_app_with_carthage_frameworks _(cold)_ | 0.79s | 0.85s   | ⬇︎ 7.36% |
-| ios_app_with_carthage_frameworks _(warm)_ | 0.77s | 0.81s | ⬇︎ 5.26% |
-| ios_app_with_helpers _(cold)_ | 2.29s | 2.43s | ⬇︎ 5.80% |
-| ios_app_with_helpers _(warm)_ | 1.97s | 2.15s | ⬇︎ 8.05% |
+| Fixture                                    | New   | Old   | Delta    |
+| ------------------------------------------ | ----- | ----- | -------- |
+| ios*app_with_tests *(cold)\_               | 0.73s | 0.79s | ⬇︎ 7.92% |
+| ios*app_with_tests *(warm)\_               | 0.79s | 0.79s | ≈        |
+| ios*app_with_carthage_frameworks *(cold)\_ | 0.79s | 0.85s | ⬇︎ 7.36% |
+| ios*app_with_carthage_frameworks *(warm)\_ | 0.77s | 0.81s | ⬇︎ 5.26% |
+| ios*app_with_helpers *(cold)\_             | 2.29s | 2.43s | ⬇︎ 5.80% |
+| ios*app_with_helpers *(warm)\_             | 1.97s | 2.15s | ⬇︎ 8.05% |

--- a/website/markdown/docs/contribution/release.mdx
+++ b/website/markdown/docs/contribution/release.mdx
@@ -1,6 +1,5 @@
 ---
 name: Release
-order: 6
 excerpt: Know more about the release process and cadence of Tuist.
 ---
 

--- a/website/markdown/docs/contribution/reporting-bugs.mdx
+++ b/website/markdown/docs/contribution/reporting-bugs.mdx
@@ -1,6 +1,5 @@
 ---
 name: Reporting bugs
-order: 3
 excerpt: This documentation page contains guidelines for reporting bugs that are found while using Tuist.
 ---
 

--- a/website/markdown/docs/contribution/scratch.mdx
+++ b/website/markdown/docs/contribution/scratch.mdx
@@ -1,13 +1,16 @@
 ---
 name: Scratch
-order: 11
 excerpt: Random ideas and notes for Tuist. Pseudocode and braindumps.
 ---
 
 # Scratch
 
+## March 31th 2020 - Compiling ProjectDescription with the Swift version of the minimum supported version of Xcode
+
+A recent release of Tuist, 1.5.3 caused Tuist to stop working with versions of Xcode older than 11.4. After some debugging, we found out that it was the result of building the `ProjectDescription` framework with the version of Swift that is bundled with Xcode 11.4, 5.2. We should compile the framework with the Swift version of the minium supported Xcode version. We added a note to the `RELEASE.md` document for now, but we should consider automating this process on CI so that we don't make the same mistake again.
+
 ## March 26th 2020 - Acceptance tests and multiple versions of Xcode
 
-I attempted to add set up GitHub actions to run the tests on multiple versions of Xcode and I realized that the acceptance tests that depend on precompiled frameworks an libraries can only run with a version of Xcode. 
+I attempted to add set up GitHub actions to run the tests on multiple versions of Xcode and I realized that the acceptance tests that depend on precompiled frameworks an libraries can only run with a version of Xcode.
 I made the tradeoff of **always running the acceptance tests with the latest version of Xcode** to avoid increasing the cost of maintaining those tests.
 This is a decision that we should revisit if we notice that we ship changes that break the backwards compatibility without us realizing it.

--- a/website/markdown/docs/contribution/testing-strategy.mdx
+++ b/website/markdown/docs/contribution/testing-strategy.mdx
@@ -1,6 +1,5 @@
 ---
 name: Testing strategy
-order: 5
 excerpt: This page describes the project's testing strategy and what's the most suitable case for each of them.
 ---
 

--- a/website/markdown/docs/links.mdx
+++ b/website/markdown/docs/links.mdx
@@ -42,4 +42,5 @@ import { Cloud, Users, Contributors, Architectures } from "./components/icons"
   - [Code of conduct](/docs/contribution/code-of-conduct/)
   - [Core team](/docs/contribution/changelog-guidelines/)
   - [Manifesto](/docs/contribution/manifesto/)
+  - [Scratch](/docs/contribution/scratch/)
   - [Performance](/docs/contribution/performance/)

--- a/website/markdown/docs/usage/dependencies.mdx
+++ b/website/markdown/docs/usage/dependencies.mdx
@@ -107,7 +107,7 @@ Tuist looks up CocoaPods using Bundler. If it's not defined, it falls back to th
 <Message
   info
   title="Repository update"
-  description="The underlying 'pod install' is executed with the '--update-repo' argument to ensure the local repository of pod specs is up to date."
+  description="The underlying 'pod install' is executed with the `--update-repo` argument to ensure the local repository of pod specs is up to date."
 />
 <Message
   warning


### PR DESCRIPTION
### Short description 📝
This PR includes a new patch release for Tuist to fix the issue that causes Tuist not to work with Xcode 11.3.1. In order for Tuist to work with Xcode 11.3.1, we need to compile the `ProjectDescription` framework with the Swift version that is bundled with that version of Xcode.

Since the release process is manual, I updated the `RELEASE.md` to indicate that Xcode 11.3.1 should be selected before running the release command.

Moreover, we uncovered another issue that this release is fixing, the load of large manifests fails because we were not concatenating all the standard output events. I added an acceptance tests to prevent introducing regressions there.
