### PR TITLE
Only delete file if it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- Don't try to delete a file if it doesn't exist https://github.com/tuist/tuist/pull/1177 by @pepibumur
+
 ### Added
 
 - Encrypt/decrypt command https://github.com/tuist/tuist/pull/1127 by @fortmarek

--- a/Sources/TuistSupport/Utils/FileHandler.swift
+++ b/Sources/TuistSupport/Utils/FileHandler.swift
@@ -240,7 +240,9 @@ public class FileHandler: FileHandling {
 
     public func delete(_ path: AbsolutePath) throws {
         logger.debug("Deleting item at path \(path)")
-        try fileManager.removeItem(atPath: path.pathString)
+        if exists(path) {
+            try fileManager.removeItem(atPath: path.pathString)
+        }
     }
 
     public func touch(_ path: AbsolutePath) throws {


### PR DESCRIPTION
### Short description 📝
While using Tuist, I got this error that indicates that we are trying to delete files even if they don't exist:

```
We received an error that we couldn't handle:
    - Localized description: “contents.xcworkspacedata” couldn’t be removed.
    - Error: Error Domain=NSCocoaErrorDomain Code=4 "“contents.xcworkspacedata” couldn’t be removed." UserInfo={NSUserStringVariant=(
    Remove
), NSFilePath=/Users/pepibumur/src/github.com/tuist/microfeatures-example/Projects/uFeatures/uFeatures.xcodeproj/project.xcworkspace/contents.xcworkspacedata, NSUnderlyingError=0x7fb643d31b90 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}"
```

To prevent that from happening, I extended the `delete` method from `FileHandler` to do a check before deleting the file. This doesn't prevent race conditions that might happen if we delete files from multiple threads, but at least should minimize the occurrences.