### PR TITLE
Add ProjectGeneratorGraphMapping protocol and use it from ProjectGenerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 - Encrypt/decrypt command https://github.com/tuist/tuist/pull/1127 by @fortmarek
+- Add ProjectGeneratorGraphMapping protocol and use it from ProjectGenerator https://github.com/tuist/tuist/pull/1178 by @pepibumur
 
 ## 1.5.4
 

--- a/Sources/TuistKit/ProjectGenerator/ProjectGenerator.swift
+++ b/Sources/TuistKit/ProjectGenerator/ProjectGenerator.swift
@@ -21,11 +21,13 @@ class ProjectGenerator: ProjectGenerating {
     private let swiftPackageManagerInteractor: SwiftPackageManagerInteracting = SwiftPackageManagerInteractor()
     private let modelLoader: GeneratorModelLoading
     private let graphLoader: GraphLoading
+    private let graphMapper: ProjectGeneratorGraphMapping
 
-    init() {
+    init(graphMapper: ProjectGeneratorGraphMapping = AnyProjectGeneratorGraphMapper(mapper: { $0 })) {
         modelLoader = GeneratorModelLoader(manifestLoader: manifestLoader,
                                            manifestLinter: manifestLinter)
         graphLoader = GraphLoader(modelLoader: modelLoader)
+        self.graphMapper = graphMapper
     }
 
     func generate(path: AbsolutePath, projectOnly: Bool) throws -> AbsolutePath {
@@ -49,7 +51,8 @@ class ProjectGenerator: ProjectGenerating {
 
     private func generateProject(path: AbsolutePath) throws -> (AbsolutePath, Graph) {
         // Load
-        let (graph, project) = try graphLoader.loadProject(path: path)
+        var (graph, project) = try graphLoader.loadProject(path: path)
+        graph = try graphMapper.map(graph: graph)
 
         // Lint
         try lint(graph: graph)
@@ -68,7 +71,8 @@ class ProjectGenerator: ProjectGenerating {
 
     private func generateWorkspace(path: AbsolutePath) throws -> (AbsolutePath, Graph) {
         // Load
-        let (graph, workspace) = try graphLoader.loadWorkspace(path: path)
+        var (graph, workspace) = try graphLoader.loadWorkspace(path: path)
+        graph = try graphMapper.map(graph: graph)
 
         // Lint
         try lint(graph: graph)
@@ -89,7 +93,8 @@ class ProjectGenerator: ProjectGenerating {
 
     private func generateProjectWorkspace(path: AbsolutePath) throws -> (AbsolutePath, Graph) {
         // Load
-        let (graph, project) = try graphLoader.loadProject(path: path)
+        var (graph, project) = try graphLoader.loadProject(path: path)
+        graph = try graphMapper.map(graph: graph)
 
         // Lint
         try lint(graph: graph)

--- a/Sources/TuistKit/ProjectGenerator/ProjectGeneratorGraphMapper.swift
+++ b/Sources/TuistKit/ProjectGenerator/ProjectGeneratorGraphMapper.swift
@@ -31,7 +31,7 @@ final class ProjectGeneratorSequentialGraphMapper: ProjectGeneratorGraphMapping 
 
     /// Default initializer
     /// - Parameter mappers: List of mappers to be executed sequentially.
-    init(mappers: [ProjectGeneratorGraphMapping]) {
+    init(_ mappers: [ProjectGeneratorGraphMapping]) {
         self.mappers = mappers
     }
 

--- a/Sources/TuistKit/ProjectGenerator/ProjectGeneratorGraphMapper.swift
+++ b/Sources/TuistKit/ProjectGenerator/ProjectGeneratorGraphMapper.swift
@@ -1,0 +1,41 @@
+import Basic
+import Foundation
+import TuistCore
+
+/// A protocol that defines an interface to map dependency graphs.
+protocol ProjectGeneratorGraphMapping {
+    /// Given a graph, it maps it into another graph.
+    /// - Parameter graph: Graph to be mapped.
+    func map(graph: Graph) throws -> Graph
+}
+
+/// A mapper that is initialized with a mapping function.
+final class AnyProjectGeneratorGraphMapper: ProjectGeneratorGraphMapping {
+    /// A function to map the graph.
+    let mapper: (Graph) throws -> Graph
+
+    /// Default initializer
+    /// - Parameter mapper: Function to map the graph.
+    init(mapper: @escaping (Graph) throws -> Graph) {
+        self.mapper = mapper
+    }
+
+    func map(graph: Graph) throws -> Graph {
+        try mapper(graph)
+    }
+}
+
+final class ProjectGeneratorSequentialGraphMapper: ProjectGeneratorGraphMapping {
+    /// List of mappers to be executed sequentially.
+    private let mappers: [ProjectGeneratorGraphMapping]
+
+    /// Default initializer
+    /// - Parameter mappers: List of mappers to be executed sequentially.
+    init(mappers: [ProjectGeneratorGraphMapping]) {
+        self.mappers = mappers
+    }
+
+    func map(graph: Graph) throws -> Graph {
+        try mappers.reduce(graph) { try $1.map(graph: $0) }
+    }
+}

--- a/Tests/TuistKitTests/ProjectGenerator/ProjectGeneratorGraphMapperTests.swift
+++ b/Tests/TuistKitTests/ProjectGenerator/ProjectGeneratorGraphMapperTests.swift
@@ -1,0 +1,49 @@
+import Basic
+import Foundation
+import TuistCore
+import TuistCoreTesting
+import TuistSupport
+import XCTest
+
+@testable import TuistKit
+@testable import TuistSupportTesting
+
+final class AnyProjectGeneratorGraphMapperTests: TuistUnitTestCase {
+    func test_map() throws {
+        // Given
+        let input = Graph.test(name: "input")
+        let output = Graph.test(name: "output")
+        let subject = AnyProjectGeneratorGraphMapper(mapper: { graph in
+            XCTAssertEqual(graph.name, input.name)
+            return output
+        })
+
+        // When
+        let got = try subject.map(graph: input)
+
+        // Then
+        XCTAssertEqual(got.name, output.name)
+    }
+}
+
+final class ProjectGeneratorSequentialGraphMapperTests: TuistUnitTestCase {
+    func test_map() throws {
+        // Given
+        let input = Graph.test(name: "0")
+        let first = AnyProjectGeneratorGraphMapper(mapper: { graph in
+            XCTAssertEqual(graph.name, "0")
+            return Graph.test(name: "1")
+        })
+        let second = AnyProjectGeneratorGraphMapper(mapper: { graph in
+            XCTAssertEqual(graph.name, "1")
+            return Graph.test(name: "2")
+        })
+        let subject = ProjectGeneratorSequentialGraphMapper([first, second])
+
+        // When
+        let got = try subject.map(graph: input)
+
+        // Then
+        XCTAssertEqual(got.name, "2")
+    }
+}


### PR DESCRIPTION
Related https://github.com/tuist/tuist/pull/1056

### Short description 📝
In this PR I'm adding a new protocol, `ProjectGeneratorGraphMapping`, and some implementations, `AnyProjectGeneratorGraphMapper` and `ProjectGeneratorSequentialGraphMapper`. I also updated the `ProjectGenerator` class to be initialized with a mapper. The mapper is used to map the graph after it's loaded into memory.

The goal is to leverage this from the `tuist focus` to support linking against frameworks from a cache.