### PR TITLE
Some minor improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - A link to the example app in the uFeatures documentation https://github.com/tuist/tuist/pull/1176 by @pepibumur.
 - Add ProjectGeneratorGraphMapping protocol and use it from ProjectGenerator https://github.com/tuist/tuist/pull/1178 by @pepibumur
 - `CloudSessionController` component to authenticate users https://github.com/tuist/tuist/pull/1174 by @pepibumur.
+- Minor improvements https://github.com/tuist/tuist/pull/1179 by @pepibumur
 
 ## 1.5.4
 

--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -22,7 +22,7 @@ public final class XcodeBuildController: XcodeBuildControlling {
     public func build(_ target: XcodeBuildTarget,
                       scheme: String,
                       clean: Bool = false,
-                      arguments: XcodeBuildArgument...) -> Observable<SystemEvent<XcodeBuildOutput>> {
+                      arguments: [XcodeBuildArgument]) -> Observable<SystemEvent<XcodeBuildOutput>> {
         var command = ["/usr/bin/xcrun", "xcodebuild"]
 
         // Action
@@ -47,7 +47,7 @@ public final class XcodeBuildController: XcodeBuildControlling {
                         scheme: String,
                         clean: Bool,
                         archivePath: AbsolutePath,
-                        arguments: XcodeBuildArgument...) -> Observable<SystemEvent<XcodeBuildOutput>> {
+                        arguments: [XcodeBuildArgument]) -> Observable<SystemEvent<XcodeBuildOutput>> {
         var command = ["/usr/bin/xcrun", "xcodebuild"]
 
         // Action
@@ -81,16 +81,33 @@ public final class XcodeBuildController: XcodeBuildControlling {
     fileprivate func run(command: [String]) -> Observable<SystemEvent<XcodeBuildOutput>> {
         let colored = Environment.shared.shouldOutputBeColoured
         return System.shared.observable(command, verbose: false)
-            .compactMap { event -> SystemEvent<XcodeBuildOutput>? in
+            .flatMap { event -> Observable<SystemEvent<XcodeBuildOutput>> in
                 switch event {
                 case let .standardError(errorData):
-                    guard let line = String(data: errorData, encoding: .utf8) else { return nil }
-                    let formatedOutput = self.parser.parse(line: line, colored: colored)
-                    return .standardError(XcodeBuildOutput(raw: line, formatted: formatedOutput))
+                    guard let line = String(data: errorData, encoding: .utf8) else { return Observable.empty() }
+                    return Observable.create { observer in
+                        let lines = line.split(separator: "\n")
+                        lines.map { line in
+                            let formatedOutput = self.parser.parse(line: String(line), colored: colored)
+                            return SystemEvent.standardError(XcodeBuildOutput(raw: "\(String(line))\n", formatted: formatedOutput.map { "\($0)\n" }))
+                        }
+                        .forEach(observer.onNext)
+                        observer.onCompleted()
+                        return Disposables.create()
+                    }
                 case let .standardOutput(outputData):
-                    guard let line = String(data: outputData, encoding: .utf8) else { return nil }
-                    let formatedOutput = self.parser.parse(line: line, colored: colored)
-                    return .standardOutput(XcodeBuildOutput(raw: line, formatted: formatedOutput))
+                    guard let line = String(data: outputData, encoding: .utf8) else { return Observable.empty() }
+
+                    return Observable.create { observer in
+                        let lines = line.split(separator: "\n")
+                        lines.map { line in
+                            let formatedOutput = self.parser.parse(line: String(line), colored: colored)
+                            return SystemEvent.standardOutput(XcodeBuildOutput(raw: "\(String(line))\n", formatted: formatedOutput.map { "\($0)\n" }))
+                        }
+                        .forEach(observer.onNext)
+                        observer.onCompleted()
+                        return Disposables.create()
+                    }
                 }
             }
     }

--- a/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
@@ -15,17 +15,31 @@ public final class GraphContentHasher: GraphContentHashing {
     }
 
     public func contentHashes(for graph: Graph) throws -> [TargetNode: String] {
+        var visitedNodes: [TargetNode: Bool] = [:]
+        
         let hashableTargets = graph.targets.values.flatMap { (targets: [TargetNode]) -> [TargetNode] in
             targets.compactMap { target in
-                if target.target.product == .framework { return target }
+                if self.isCacheable(target, visited: &visitedNodes) { return target }
                 return nil
             }
         }
         let hashes = try hashableTargets.map { try makeContentHash(of: $0) }
         return Dictionary(uniqueKeysWithValues: zip(hashableTargets, hashes))
     }
+    
+    fileprivate func isCacheable(_ target: TargetNode, visited: inout [TargetNode: Bool]) -> Bool {
+        if let visitedValue = visited[target] { return visitedValue }
+        
+        let isFramework = target.target.product == .framework
+        let noXCTestDependency = target.sdkDependencies.first(where: { $0.name == "XCTest.framework" }) != nil
+        let allTargetDependenciesAreHasheable = target.targetDependencies.allSatisfy({ isCacheable($0, visited: &visited) })
+        
+        let cacheable = isFramework && noXCTestDependency && allTargetDependenciesAreHasheable
+        visited[target] = cacheable
+        return cacheable
+    }
 
-    private func makeContentHash(of targetNode: TargetNode) throws -> String {
+    fileprivate func makeContentHash(of targetNode: TargetNode) throws -> String {
         // TODO: extend function to consider build settings, compiler flags, dependencies, and a lot more
         let sourcesHash = try hashSources(of: targetNode)
         let productHash = try hash(string: targetNode.target.productName)
@@ -33,27 +47,27 @@ public final class GraphContentHasher: GraphContentHashing {
         return try hash(strings: [sourcesHash, productHash, platformHash])
     }
 
-    private func hashSources(of targetNode: TargetNode) throws -> String {
+    fileprivate func hashSources(of targetNode: TargetNode) throws -> String {
         let hashes = try targetNode.target.sources.sorted(by: { $0.path < $1.path }).map(md5)
         let joinedHash = try hash(strings: hashes)
         return joinedHash
     }
 
-    private func hash(string: String) throws -> String {
+    fileprivate func hash(string: String) throws -> String {
         guard let hash = string.checksum(algorithm: .md5) else {
             throw ContentHashingError.stringHashingFailed(string)
         }
         return hash
     }
 
-    private func hash(strings: [String]) throws -> String {
+    fileprivate func hash(strings: [String]) throws -> String {
         guard let joinedHash = strings.joined().checksum(algorithm: .md5) else {
             throw ContentHashingError.stringHashingFailed(strings.joined())
         }
         return joinedHash
     }
 
-    private func md5(of source: Target.SourceFile) throws -> String {
+    fileprivate func md5(of source: Target.SourceFile) throws -> String {
         guard let sourceData = try? fileHandler.readFile(source.path) else {
             throw ContentHashingError.fileNotFound(source.path)
         }

--- a/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
@@ -31,7 +31,7 @@ public final class GraphContentHasher: GraphContentHashing {
         if let visitedValue = visited[target] { return visitedValue }
         
         let isFramework = target.target.product == .framework
-        let noXCTestDependency = target.sdkDependencies.first(where: { $0.name == "XCTest.framework" }) != nil
+        let noXCTestDependency = target.sdkDependencies.first(where: { $0.name == "XCTest.framework" }) == nil
         let allTargetDependenciesAreHasheable = target.targetDependencies.allSatisfy({ isCacheable($0, visited: &visited) })
         
         let cacheable = isFramework && noXCTestDependency && allTargetDependenciesAreHasheable

--- a/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
@@ -16,7 +16,7 @@ public final class GraphContentHasher: GraphContentHashing {
 
     public func contentHashes(for graph: Graph) throws -> [TargetNode: String] {
         var visitedNodes: [TargetNode: Bool] = [:]
-        
+
         let hashableTargets = graph.targets.values.flatMap { (targets: [TargetNode]) -> [TargetNode] in
             targets.compactMap { target in
                 if self.isCacheable(target, visited: &visitedNodes) { return target }
@@ -26,14 +26,14 @@ public final class GraphContentHasher: GraphContentHashing {
         let hashes = try hashableTargets.map { try makeContentHash(of: $0) }
         return Dictionary(uniqueKeysWithValues: zip(hashableTargets, hashes))
     }
-    
+
     fileprivate func isCacheable(_ target: TargetNode, visited: inout [TargetNode: Bool]) -> Bool {
         if let visitedValue = visited[target] { return visitedValue }
-        
+
         let isFramework = target.target.product == .framework
         let noXCTestDependency = target.sdkDependencies.first(where: { $0.name == "XCTest.framework" }) == nil
-        let allTargetDependenciesAreHasheable = target.targetDependencies.allSatisfy({ isCacheable($0, visited: &visited) })
-        
+        let allTargetDependenciesAreHasheable = target.targetDependencies.allSatisfy { isCacheable($0, visited: &visited) }
+
         let cacheable = isFramework && noXCTestDependency && allTargetDependenciesAreHasheable
         visited[target] = cacheable
         return cacheable

--- a/Sources/TuistCache/Utilities/XCFrameworkBuilder.swift
+++ b/Sources/TuistCache/Utilities/XCFrameworkBuilder.swift
@@ -80,7 +80,7 @@ public final class XCFrameworkBuilder: XCFrameworkBuilding {
         let outputDirectory = try TemporaryDirectory(removeTreeOnDeinit: false)
         let temporaryPath = try TemporaryDirectory(removeTreeOnDeinit: false)
 
-        logger.notice("Building .xcframework for \(target.name)", metadata: .section)
+        logger.notice("Building .xcframework for \(target.name)... (it might take a while)", metadata: .section)
 
         // Build for the device
         // Without the BUILD_LIBRARY_FOR_DISTRIBUTION argument xcodebuild doesn't generate the .swiftinterface file
@@ -94,8 +94,9 @@ public final class XCFrameworkBuilder: XCFrameworkBuilding {
                                                                    .derivedDataPath(temporaryPath.path),
                                                                    .buildSetting("SKIP_INSTALL", "NO"),
                                                                    .buildSetting("BUILD_LIBRARY_FOR_DISTRIBUTION", "YES"))
+            .printRawErrors()
             .do(onSubscribed: {
-                logger.notice("Building \(target.name) for device", metadata: .subsection)
+                logger.notice("Building \(target.name) for device... (it might take a while)", metadata: .subsection)
             })
 
         // Build for the simulator
@@ -112,6 +113,7 @@ public final class XCFrameworkBuilder: XCFrameworkBuilding {
                                                                       .derivedDataPath(temporaryPath.path),
                                                                       .buildSetting("SKIP_INSTALL", "NO"),
                                                                       .buildSetting("BUILD_LIBRARY_FOR_DISTRIBUTION", "YES"))
+                .printRawErrors()
                 .do(onSubscribed: {
                     logger.notice("Building \(target.name) for simulator", metadata: .subsection)
                 })

--- a/Sources/TuistCache/Utilities/XCFrameworkBuilder.swift
+++ b/Sources/TuistCache/Utilities/XCFrameworkBuilder.swift
@@ -89,12 +89,13 @@ public final class XCFrameworkBuilder: XCFrameworkBuilding {
                                                                    scheme: scheme,
                                                                    clean: true,
                                                                    archivePath: deviceArchivePath,
-                                                                   arguments:
-                                                                   .sdk(target.platform.xcodeDeviceSDK),
-                                                                   .derivedDataPath(temporaryPath.path),
-                                                                   .buildSetting("SKIP_INSTALL", "NO"),
-                                                                   .buildSetting("BUILD_LIBRARY_FOR_DISTRIBUTION", "YES"))
-            .printRawErrors()
+                                                                   arguments: [
+                                                                       .sdk(target.platform.xcodeDeviceSDK),
+                                                                       .derivedDataPath(temporaryPath.path),
+                                                                       .buildSetting("SKIP_INSTALL", "NO"),
+                                                                       .buildSetting("BUILD_LIBRARY_FOR_DISTRIBUTION", "YES"),
+                                                                   ])
+            .printFormattedOutput()
             .do(onSubscribed: {
                 logger.notice("Building \(target.name) for device...", metadata: .subsection)
             })
@@ -108,12 +109,13 @@ public final class XCFrameworkBuilder: XCFrameworkBuilding {
                                                                       scheme: scheme,
                                                                       clean: false,
                                                                       archivePath: simulatorArchivePath!,
-                                                                      arguments:
-                                                                      .sdk(target.platform.xcodeSimulatorSDK!),
-                                                                      .derivedDataPath(temporaryPath.path),
-                                                                      .buildSetting("SKIP_INSTALL", "NO"),
-                                                                      .buildSetting("BUILD_LIBRARY_FOR_DISTRIBUTION", "YES"))
-                .printRawErrors()
+                                                                      arguments: [
+                                                                          .sdk(target.platform.xcodeSimulatorSDK!),
+                                                                          .derivedDataPath(temporaryPath.path),
+                                                                          .buildSetting("SKIP_INSTALL", "NO"),
+                                                                          .buildSetting("BUILD_LIBRARY_FOR_DISTRIBUTION", "YES"),
+                                                                      ])
+                .printFormattedOutput()
                 .do(onSubscribed: {
                     logger.notice("Building \(target.name) for simulator", metadata: .subsection)
                 })

--- a/Sources/TuistCache/Utilities/XCFrameworkBuilder.swift
+++ b/Sources/TuistCache/Utilities/XCFrameworkBuilder.swift
@@ -80,7 +80,7 @@ public final class XCFrameworkBuilder: XCFrameworkBuilding {
         let outputDirectory = try TemporaryDirectory(removeTreeOnDeinit: false)
         let temporaryPath = try TemporaryDirectory(removeTreeOnDeinit: false)
 
-        logger.notice("Building .xcframework for \(target.name)... (it might take a while)", metadata: .section)
+        logger.notice("Building .xcframework for \(target.name)...", metadata: .section)
 
         // Build for the device
         // Without the BUILD_LIBRARY_FOR_DISTRIBUTION argument xcodebuild doesn't generate the .swiftinterface file
@@ -96,7 +96,7 @@ public final class XCFrameworkBuilder: XCFrameworkBuilding {
                                                                    .buildSetting("BUILD_LIBRARY_FOR_DISTRIBUTION", "YES"))
             .printRawErrors()
             .do(onSubscribed: {
-                logger.notice("Building \(target.name) for device... (it might take a while)", metadata: .subsection)
+                logger.notice("Building \(target.name) for device...", metadata: .subsection)
             })
 
         // Build for the simulator

--- a/Sources/TuistCore/Automation/Extensions/Observable+XcodeBuildOutput.swift
+++ b/Sources/TuistCore/Automation/Extensions/Observable+XcodeBuildOutput.swift
@@ -19,4 +19,15 @@ public extension Observable where Element == SystemEvent<XcodeBuildOutput> {
             }
         })
     }
+
+    func printRawErrors() -> Observable<SystemEvent<XcodeBuildOutput>> {
+        `do`(onNext: { event in
+            switch event {
+            case let .standardError(error):
+                logger.error("\(error.raw)")
+            default:
+                break
+            }
+        })
+    }
 }

--- a/Sources/TuistCore/Automation/Extensions/Observable+XcodeBuildOutput.swift
+++ b/Sources/TuistCore/Automation/Extensions/Observable+XcodeBuildOutput.swift
@@ -7,15 +7,15 @@ public extension Observable where Element == SystemEvent<XcodeBuildOutput> {
         `do`(onNext: { event in
             switch event {
             case let .standardError(error):
-                let string = error.formatted ?? error.raw
-                if let data = string.data(using: .utf8) {
-                    FileHandle.standardError.write(data)
+                if let string = error.formatted {
+                    logger.error("\(string)")
                 }
+                logger.debug("\(error.raw)")
             case let .standardOutput(output):
-                let string = output.formatted ?? output.raw
-                if let data = string.data(using: .utf8) {
-                    FileHandle.standardOutput.write(data)
+                if let string = output.formatted {
+                    logger.notice("\(string)")
                 }
+                logger.debug("\(output.raw)")
             }
         })
     }

--- a/Sources/TuistCore/Automation/XcodeBuildControlling.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildControlling.swift
@@ -13,7 +13,7 @@ public protocol XcodeBuildControlling {
     func build(_ target: XcodeBuildTarget,
                scheme: String,
                clean: Bool,
-               arguments: XcodeBuildArgument...) -> Observable<SystemEvent<XcodeBuildOutput>>
+               arguments: [XcodeBuildArgument]) -> Observable<SystemEvent<XcodeBuildOutput>>
 
     /// Returns an observable that archives the given project using xcodebuild.
     /// - Parameters:
@@ -26,7 +26,7 @@ public protocol XcodeBuildControlling {
                  scheme: String,
                  clean: Bool,
                  archivePath: AbsolutePath,
-                 arguments: XcodeBuildArgument...) -> Observable<SystemEvent<XcodeBuildOutput>>
+                 arguments: [XcodeBuildArgument]) -> Observable<SystemEvent<XcodeBuildOutput>>
 
     /// Creates an .xcframework combining the list of given frameworks.
     /// - Parameters:

--- a/Sources/TuistCoreTesting/Automation/MockXcodeBuildController.swift
+++ b/Sources/TuistCoreTesting/Automation/MockXcodeBuildController.swift
@@ -7,11 +7,10 @@ import TuistSupport
 
 final class MockXcodeBuildController: XcodeBuildControlling {
     var buildStub: ((XcodeBuildTarget, String, Bool, [XcodeBuildArgument]) -> Observable<SystemEvent<XcodeBuildOutput>>)?
-
     func build(_ target: XcodeBuildTarget,
                scheme: String,
                clean: Bool,
-               arguments: XcodeBuildArgument...) -> Observable<SystemEvent<XcodeBuildOutput>> {
+               arguments: [XcodeBuildArgument]) -> Observable<SystemEvent<XcodeBuildOutput>> {
         if let buildStub = buildStub {
             return buildStub(target, scheme, clean, arguments)
         } else {
@@ -24,7 +23,7 @@ final class MockXcodeBuildController: XcodeBuildControlling {
                  scheme: String,
                  clean: Bool,
                  archivePath: AbsolutePath,
-                 arguments: XcodeBuildArgument...) -> Observable<SystemEvent<XcodeBuildOutput>> {
+                 arguments: [XcodeBuildArgument]) -> Observable<SystemEvent<XcodeBuildOutput>> {
         if let archiveStub = archiveStub {
             return archiveStub(target, scheme, clean, archivePath, arguments)
         } else {

--- a/Sources/TuistSupport/System/System.swift
+++ b/Sources/TuistSupport/System/System.swift
@@ -154,7 +154,7 @@ extension ProcessResult {
         switch exitStatus {
         case let .signalled(code):
             let data = try Data(stderrOutput.dematerialize())
-            throw TuistSupport.SystemError.signalled(command: command(), code: code,  standardError: data)
+            throw TuistSupport.SystemError.signalled(command: command(), code: code, standardError: data)
         case let .terminated(code):
             if code != 0 {
                 let data = try Data(stderrOutput.dematerialize())

--- a/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
+++ b/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
@@ -105,19 +105,19 @@ public class TuistTestCase: XCTestCase {
         _ comparison: (Logger.Level, Logger.Level) -> Bool,
         file: StaticString = #file, line: UInt = #line
     ) {
-        let standardError = TestingLogHandler.collected[level, comparison]
+        let output = TestingLogHandler.collected[level, comparison]
 
         let message = """
-        The standard error:
+        The output:
         ===========
-        \(standardError)
+        \(output)
         
-        Doesn't contain the expected output:
+        Doesn't contain the expected:
         ===========
         \(expected)
         """
 
-        XCTAssertTrue(standardError.contains(expected), message, file: file, line: line)
+        XCTAssertTrue(output.contains(expected), message, file: file, line: line)
     }
 
     public func temporaryFixture(_ pathString: String) throws -> AbsolutePath {

--- a/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildControllerTests.swift
+++ b/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildControllerTests.swift
@@ -52,7 +52,7 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
         }
 
         // When
-        let events = subject.build(target, scheme: scheme, clean: true)
+        let events = subject.build(target, scheme: scheme, clean: true, arguments: [])
             .toBlocking()
             .materialize()
 
@@ -63,7 +63,7 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
 
         switch events {
         case let .completed(output):
-            XCTAssertEqual(output, [.standardOutput(XcodeBuildOutput(raw: "output", formatted: "formated-output"))])
+            XCTAssertEqual(output, [.standardOutput(XcodeBuildOutput(raw: "output\n", formatted: "formated-output\n"))])
         case .failed:
             XCTFail("The command was not expected to fail")
         }

--- a/Tests/TuistKitIntegrationTests/Automation/XCFrameworkBuilderIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Automation/XCFrameworkBuilderIntegrationTests.swift
@@ -41,12 +41,6 @@ final class XCFrameworkBuilderIntegrationTests: TuistTestCase {
         XCTAssertNotNil(infoPlist.availableLibraries.first(where: { $0.supportedArchitectures.contains("arm64") }))
         XCTAssertNotNil(infoPlist.availableLibraries.first(where: { $0.supportedArchitectures.contains("x86_64") }))
         XCTAssertTrue(infoPlist.availableLibraries.allSatisfy { $0.supportedPlatform == "ios" })
-        XCTAssertPrinterOutputContains("""
-        Building .xcframework for iOS
-        Building iOS for device
-        Building iOS for simulator
-        Exporting xcframework for iOS
-        """)
         try FileHandler.shared.delete(xcframeworkPath)
     }
 
@@ -64,11 +58,6 @@ final class XCFrameworkBuilderIntegrationTests: TuistTestCase {
         XCTAssertTrue(FileHandler.shared.exists(xcframeworkPath))
         XCTAssertNotNil(infoPlist.availableLibraries.first(where: { $0.supportedArchitectures.contains("x86_64") }))
         XCTAssertTrue(infoPlist.availableLibraries.allSatisfy { $0.supportedPlatform == "macos" })
-        XCTAssertPrinterOutputContains("""
-        Building .xcframework for macOS
-        Building macOS for device
-        Exporting xcframework for macOS
-        """)
         try FileHandler.shared.delete(xcframeworkPath)
     }
 
@@ -87,12 +76,6 @@ final class XCFrameworkBuilderIntegrationTests: TuistTestCase {
         XCTAssertNotNil(infoPlist.availableLibraries.first(where: { $0.supportedArchitectures.contains("x86_64") }))
         XCTAssertNotNil(infoPlist.availableLibraries.first(where: { $0.supportedArchitectures.contains("arm64") }))
         XCTAssertTrue(infoPlist.availableLibraries.allSatisfy { $0.supportedPlatform == "tvos" })
-        XCTAssertPrinterOutputContains("""
-        Building .xcframework for tvOS
-        Building tvOS for device
-        Building tvOS for simulator
-        Exporting xcframework for tvOS
-        """)
         try FileHandler.shared.delete(xcframeworkPath)
     }
 
@@ -112,12 +95,6 @@ final class XCFrameworkBuilderIntegrationTests: TuistTestCase {
         XCTAssertNotNil(infoPlist.availableLibraries.first(where: { $0.supportedArchitectures.contains("armv7k") }))
         XCTAssertNotNil(infoPlist.availableLibraries.first(where: { $0.supportedArchitectures.contains("arm64_32") }))
         XCTAssertTrue(infoPlist.availableLibraries.allSatisfy { $0.supportedPlatform == "watchos" })
-        XCTAssertPrinterOutputContains("""
-        Building .xcframework for watchOS
-        Building watchOS for device
-        Building watchOS for simulator
-        Exporting xcframework for watchOS
-        """)
         try FileHandler.shared.delete(xcframeworkPath)
     }
 

--- a/website/markdown/docs/contribution/scratch.mdx
+++ b/website/markdown/docs/contribution/scratch.mdx
@@ -5,6 +5,10 @@ excerpt: Random ideas and notes for Tuist. Pseudocode and braindumps.
 
 # Scratch
 
+## April 1st 2020 - Explicitness for the cache to work reliably.
+
+In order to be able to reliably build .xcframeworks and cache them, it's important that the definition of the targets is as explicit as possible. For instance, if a framework doesn't declare a dependency with `XCTest` and it imports it, that'll cause the compilation of the framework for a device to fail. We should include a section in the cache documentation with some best practices.
+
 ## March 31th 2020 - Compiling ProjectDescription with the Swift version of the minimum supported version of Xcode
 
 A recent release of Tuist, 1.5.3 caused Tuist to stop working with versions of Xcode older than 11.4. After some debugging, we found out that it was the result of building the `ProjectDescription` framework with the version of Swift that is bundled with Xcode 11.4, 5.2. We should compile the framework with the Swift version of the minium supported Xcode version. We added a note to the `RELEASE.md` document for now, but we should consider automating this process on CI so that we don't make the same mistake again.


### PR DESCRIPTION
### Short description 📝
This PR fixes some minor issues that I found while testing Tuist with the microfeatures example project:
- Improve the hashing logic to not include frameworks that have a dependency with XCTest. Those cannot be compiled for device.
- Print errors that are raised while building the .xcframeworks. It'll make it easier to debug issues.
- The system class was swallowing the standard error when the command was killed with a signal. I changed that to print the errors.
- I added a note to the scratch document about the important of configuring things explicitly in order for the cache to work reliably.