### PR TITLE
Fix "Core team link" link

### DIFF
--- a/website/markdown/docs/links.mdx
+++ b/website/markdown/docs/links.mdx
@@ -40,7 +40,7 @@ import { Cloud, Users, Contributors, Architectures } from "./components/icons"
   - [Release](/docs/contribution/release/)
   - [Changelog guidelines](/docs/contribution/changelog-guidelines/)
   - [Code of conduct](/docs/contribution/code-of-conduct/)
-  - [Core team](/docs/contribution/changelog-guidelines/)
+  - [Core team](/docs/contribution/core-team/)
   - [Manifesto](/docs/contribution/manifesto/)
   - [Scratch](/docs/contribution/scratch/)
   - [Performance](/docs/contribution/performance/)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1175

As it was pointed out [here](https://github.com/tuist/tuist/issues/1175) the link was pointing to the wrong page.