### PR TITLE
Reading versions from the system

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -221,5 +221,5 @@ let package = Package(
             dependencies: ["TuistGenerator", "TuistSupportTesting", "TuistSupport", "TuistCoreTesting"]
         ),
     ],
-    swiftLanguageVersions: [.version("5.1"), .version("5.2")]
+    swiftLanguageVersions: [.v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -220,5 +220,6 @@ let package = Package(
             name: "TuistIntegrationTests",
             dependencies: ["TuistGenerator", "TuistSupportTesting", "TuistSupport", "TuistCoreTesting"]
         ),
-    ]
+    ],
+    swiftLanguageVersions: [.version("5.1"), .version("5.2")]
 )

--- a/Sources/TuistCore/Protocols/GeneratorModelLoading.swift
+++ b/Sources/TuistCore/Protocols/GeneratorModelLoading.swift
@@ -1,5 +1,6 @@
 import Basic
 import Foundation
+import TuistSupport
 
 /// Entity responsible for providing generator models
 ///
@@ -14,21 +15,24 @@ public protocol GeneratorModelLoading {
     ///
     /// - Parameters:
     ///   - path: The absolute path for the project model to load.
+    ///   - versions: Versions of system components that Tuist interacts with.
     /// - Returns: The Project loaded from the specified path
     /// - Throws: Error encountered during the loading process (e.g. Missing project)
-    func loadProject(at path: AbsolutePath) throws -> Project
+    func loadProject(at path: AbsolutePath, versions: Versions) throws -> Project
 
     /// Load a Workspace model at the specified path
     ///
-    /// - Parameter path: The absolute path for the workspace model to load
+    /// - Parameter path: The absolute path for the workspace model to load.
+    /// - Parameter versions: Versions of system components that Tuist interacts with.
     /// - Returns: The workspace loaded from the specified path
     /// - Throws: Error encountered during the loading process (e.g. Missing workspace)
-    func loadWorkspace(at path: AbsolutePath) throws -> Workspace
+    func loadWorkspace(at path: AbsolutePath, versions: Versions) throws -> Workspace
 
     /// Load a Config model at the specified path
     ///
-    /// - Parameter path: The absolute path for the Config model to load
+    /// - Parameter path: The absolute path for the Config model to load.
+    /// - Parameter versions: Versions of system components that Tuist interacts with.
     /// - Returns: The config loaded from the specified path
     /// - Throws: Error encountered during the loading process (e.g. Missing Config file)
-    func loadConfig(at path: AbsolutePath) throws -> Config
+    func loadConfig(at path: AbsolutePath, versions: Versions) throws -> Config
 }

--- a/Sources/TuistCore/Versions/Versions.swift
+++ b/Sources/TuistCore/Versions/Versions.swift
@@ -1,0 +1,8 @@
+//
+//  Versions.swift
+//  TuistCore
+//
+//  Created by Pedro on 4/7/20.
+//
+
+import Foundation

--- a/Sources/TuistCore/Versions/Versions.swift
+++ b/Sources/TuistCore/Versions/Versions.swift
@@ -1,8 +1,0 @@
-//
-//  Versions.swift
-//  TuistCore
-//
-//  Created by Pedro on 4/7/20.
-//
-
-import Foundation

--- a/Sources/TuistCore/Versions/VersionsFetcher.swift
+++ b/Sources/TuistCore/Versions/VersionsFetcher.swift
@@ -1,8 +1,0 @@
-//
-//  VersionsFetcher.swift
-//  TuistCore
-//
-//  Created by Pedro on 4/7/20.
-//
-
-import Foundation

--- a/Sources/TuistCore/Versions/VersionsFetcher.swift
+++ b/Sources/TuistCore/Versions/VersionsFetcher.swift
@@ -1,0 +1,8 @@
+//
+//  VersionsFetcher.swift
+//  TuistCore
+//
+//  Created by Pedro on 4/7/20.
+//
+
+import Foundation

--- a/Sources/TuistCoreTesting/Graph/MockGraphLoader.swift
+++ b/Sources/TuistCoreTesting/Graph/MockGraphLoader.swift
@@ -1,22 +1,23 @@
 import Basic
 import Foundation
+import TuistSupport
 @testable import TuistCore
 
 public final class MockGraphLoader: GraphLoading {
     public init() {}
 
-    public var loadProjectStub: ((AbsolutePath) throws -> (Graph, Project))?
-    public func loadProject(path: AbsolutePath) throws -> (Graph, Project) {
-        return try loadProjectStub?(path) ?? (Graph.test(), Project.test())
+    public var loadProjectStub: ((AbsolutePath, Versions) throws -> (Graph, Project))?
+    public func loadProject(path: AbsolutePath, versions: Versions) throws -> (Graph, Project) {
+        return try loadProjectStub?(path, versions) ?? (Graph.test(), Project.test())
     }
 
-    public var loadWorkspaceStub: ((AbsolutePath) throws -> (Graph, Workspace))?
-    public func loadWorkspace(path: AbsolutePath) throws -> (Graph, Workspace) {
-        return try loadWorkspaceStub?(path) ?? (Graph.test(), Workspace.test())
+    public var loadWorkspaceStub: ((AbsolutePath, Versions) throws -> (Graph, Workspace))?
+    public func loadWorkspace(path: AbsolutePath, versions: Versions) throws -> (Graph, Workspace) {
+        return try loadWorkspaceStub?(path, versions) ?? (Graph.test(), Workspace.test())
     }
 
-    public var loadConfigStub: ((AbsolutePath) throws -> (Config))?
-    public func loadConfig(path: AbsolutePath) throws -> Config {
-        try loadConfigStub?(path) ?? Config.test()
+    public var loadConfigStub: ((AbsolutePath, Versions) throws -> (Config))?
+    public func loadConfig(path: AbsolutePath, versions: Versions) throws -> Config {
+        try loadConfigStub?(path, versions) ?? Config.test()
     }
 }

--- a/Sources/TuistGenerator/Dot/DotGraphGenerator.swift
+++ b/Sources/TuistGenerator/Dot/DotGraphGenerator.swift
@@ -26,13 +26,18 @@ public final class DotGraphGenerator: DotGraphGenerating {
     /// Mapper to map graphs into a dot graphs.
     private let graphToDotGraphMapper: GraphToDotGraphMapping
 
+    /// Utility to fetch the versions of system components that Tuist interacts with.
+    private let versionsFetcher: VersionsFetching
+
     /// Initializes the dot graph generator by taking its dependencies.
     ///
     /// - Parameters:
     ///   - modelLoader: Instance to load the models.
     public convenience init(modelLoader: GeneratorModelLoading) {
         let graphLoader = GraphLoader(modelLoader: modelLoader)
-        self.init(graphLoader: graphLoader, graphToDotGraphMapper: GraphToDotGraphMapper())
+        self.init(graphLoader: graphLoader,
+                  graphToDotGraphMapper: GraphToDotGraphMapper(),
+                  versionsFetcher: VersionsFetcher())
     }
 
     /// Initializes the generator with an instance to load the graph.
@@ -40,10 +45,13 @@ public final class DotGraphGenerator: DotGraphGenerating {
     /// - Parameters:
     ///   - graphLoader: Graph loader instance.
     ///   - graphToDotGraphMapper: Mapper to map the graph into a dot graph.
+    ///   - versionsFetcher: Mapper to map the graph into a dot graph.
     init(graphLoader: GraphLoading,
-         graphToDotGraphMapper: GraphToDotGraphMapping) {
+         graphToDotGraphMapper: GraphToDotGraphMapping,
+         versionsFetcher: VersionsFetching) {
         self.graphLoader = graphLoader
         self.graphToDotGraphMapper = graphToDotGraphMapper
+        self.versionsFetcher = versionsFetcher
     }
 
     /// Generates the dot graph from the project in the current directory and returns it.
@@ -52,7 +60,8 @@ public final class DotGraphGenerator: DotGraphGenerating {
     /// - Returns: Dot graph representation.
     /// - Throws: An error if the project can't be loaded.
     public func generateProject(at path: AbsolutePath) throws -> String {
-        let (graph, _) = try graphLoader.loadProject(path: path)
+        let versions = try versionsFetcher.fetch()
+        let (graph, _) = try graphLoader.loadProject(path: path, versions: versions)
         return graphToDotGraphMapper.map(graph: graph).description
     }
 
@@ -62,7 +71,8 @@ public final class DotGraphGenerator: DotGraphGenerating {
     /// - Returns: Dot graph representation.
     /// - Throws: An error if the workspace can't be loaded.
     public func generateWorkspace(at path: AbsolutePath) throws -> String {
-        let (graph, _) = try graphLoader.loadWorkspace(path: path)
+        let versions = try versionsFetcher.fetch()
+        let (graph, _) = try graphLoader.loadWorkspace(path: path, versions: versions)
         return graphToDotGraphMapper.map(graph: graph).description
     }
 }

--- a/Sources/TuistGenerator/Generator/DescriptorGenerator.swift
+++ b/Sources/TuistGenerator/Generator/DescriptorGenerator.swift
@@ -67,7 +67,8 @@ public final class DescriptorGenerator: DescriptorGenerating {
     private let workspaceGenerator: WorkspaceGenerating
     private let projectGenerator: ProjectGenerating
 
-    public convenience init(defaultSettingsProvider: DefaultSettingsProviding = DefaultSettingsProvider()) {
+    public convenience init(defaultSettingsProvider: DefaultSettingsProviding = DefaultSettingsProvider(),
+                            versionsFetcher: VersionsFetching = VersionsFetcher()) {
         let configGenerator = ConfigGenerator(defaultSettingsProvider: defaultSettingsProvider)
         let targetGenerator = TargetGenerator(configGenerator: configGenerator)
         let schemesGenerator = SchemesGenerator()
@@ -78,7 +79,7 @@ public final class DescriptorGenerator: DescriptorGenerating {
         let workspaceGenerator = WorkspaceGenerator(projectGenerator: projectGenerator,
                                                     workspaceStructureGenerator: workspaceStructureGenerator,
                                                     schemesGenerator: schemesGenerator,
-                                                    versionsFetcher: VersionsFetcher())
+                                                    versionsFetcher: versionsFetcher)
         self.init(workspaceGenerator: workspaceGenerator,
                   projectGenerator: projectGenerator)
     }

--- a/Sources/TuistGenerator/Generator/DescriptorGenerator.swift
+++ b/Sources/TuistGenerator/Generator/DescriptorGenerator.swift
@@ -38,7 +38,7 @@ public protocol DescriptorGenerating {
     ///   - graph: Graph model
     ///
     /// - Seealso: `GraphLoader`
-    func generateProject(project: Project, graph: Graph) throws -> ProjectDescriptor
+    func generateProject(project: Project, graph: Graph, versions: Versions) throws -> ProjectDescriptor
 
     /// Generate an individual project descriptor with some additional configuration
     ///
@@ -48,7 +48,7 @@ public protocol DescriptorGenerating {
     ///   - config: The project generation configuration
     ///
     /// - Seealso: `GraphLoader`
-    func generateProject(project: Project, graph: Graph, config: ProjectGenerationConfig) throws -> ProjectDescriptor
+    func generateProject(project: Project, graph: Graph, config: ProjectGenerationConfig, versions: Versions) throws -> ProjectDescriptor
 
     /// Generate a workspace descriptor
     ///
@@ -77,7 +77,8 @@ public final class DescriptorGenerator: DescriptorGenerating {
                                                 schemesGenerator: schemesGenerator)
         let workspaceGenerator = WorkspaceGenerator(projectGenerator: projectGenerator,
                                                     workspaceStructureGenerator: workspaceStructureGenerator,
-                                                    schemesGenerator: schemesGenerator)
+                                                    schemesGenerator: schemesGenerator,
+                                                    versionsFetcher: VersionsFetcher())
         self.init(workspaceGenerator: workspaceGenerator,
                   projectGenerator: projectGenerator)
     }
@@ -88,18 +89,20 @@ public final class DescriptorGenerator: DescriptorGenerating {
         self.projectGenerator = projectGenerator
     }
 
-    public func generateProject(project: Project, graph: Graph) throws -> ProjectDescriptor {
+    public func generateProject(project: Project, graph: Graph, versions: Versions) throws -> ProjectDescriptor {
         try projectGenerator.generate(project: project,
                                       graph: graph,
                                       sourceRootPath: nil,
-                                      xcodeprojPath: nil)
+                                      xcodeprojPath: nil,
+                                      versions: versions)
     }
 
-    public func generateProject(project: Project, graph: Graph, config: ProjectGenerationConfig) throws -> ProjectDescriptor {
+    public func generateProject(project: Project, graph: Graph, config: ProjectGenerationConfig, versions: Versions) throws -> ProjectDescriptor {
         try projectGenerator.generate(project: project,
                                       graph: graph,
                                       sourceRootPath: config.sourceRootPath,
-                                      xcodeprojPath: config.xcodeprojPath)
+                                      xcodeprojPath: config.xcodeprojPath,
+                                      versions: versions)
     }
 
     public func generateWorkspace(workspace: Workspace, graph: Graph) throws -> WorkspaceDescriptor {

--- a/Sources/TuistGenerator/Generator/ProjectGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGenerator.swift
@@ -29,11 +29,13 @@ protocol ProjectGenerating: AnyObject {
     ///   - graph: Dependencies graph.
     ///   - sourceRootPath: Directory where the files are relative to.
     ///   - xcodeprojPath: Path to the Xcode project. When not given, the xcodeproj is generated at sourceRootPath.
+    ///   - versions: Versions of the system components that Tuist interacts with.
     /// - Returns: Generated project descriptor
     func generate(project: Project,
                   graph: Graph,
                   sourceRootPath: AbsolutePath?,
-                  xcodeprojPath: AbsolutePath?) throws -> ProjectDescriptor
+                  xcodeprojPath: AbsolutePath?,
+                  versions: Versions) throws -> ProjectDescriptor
 }
 
 final class ProjectGenerator: ProjectGenerating {
@@ -76,7 +78,8 @@ final class ProjectGenerator: ProjectGenerating {
     func generate(project: Project,
                   graph: Graph,
                   sourceRootPath: AbsolutePath? = nil,
-                  xcodeprojPath: AbsolutePath? = nil) throws -> ProjectDescriptor {
+                  xcodeprojPath: AbsolutePath? = nil,
+                  versions: Versions) throws -> ProjectDescriptor {
         logger.notice("Generating project \(project.name)")
 
         // Getting the path.
@@ -114,7 +117,8 @@ final class ProjectGenerator: ProjectGenerating {
                                                 pbxProject: pbxProject,
                                                 fileElements: fileElements,
                                                 sourceRootPath: sourceRootPath,
-                                                graph: graph)
+                                                graph: graph,
+                                                versions: versions)
 
         generateTestTargetIdentity(project: project,
                                    pbxproj: pbxproj,
@@ -174,7 +178,8 @@ final class ProjectGenerator: ProjectGenerating {
                                  pbxProject: PBXProject,
                                  fileElements: ProjectFileElements,
                                  sourceRootPath: AbsolutePath,
-                                 graph: Graph) throws -> [String: PBXNativeTarget] {
+                                 graph: Graph,
+                                 versions: Versions) throws -> [String: PBXNativeTarget] {
         var nativeTargets: [String: PBXNativeTarget] = [:]
         try project.targets.forEach { target in
             let nativeTarget = try targetGenerator.generateTarget(target: target,
@@ -184,7 +189,8 @@ final class ProjectGenerator: ProjectGenerating {
                                                                   fileElements: fileElements,
                                                                   path: project.path,
                                                                   sourceRootPath: sourceRootPath,
-                                                                  graph: graph)
+                                                                  graph: graph,
+                                                                  versions: versions)
             nativeTargets[target.name] = nativeTarget
         }
 

--- a/Sources/TuistGenerator/Generator/TargetGenerator.swift
+++ b/Sources/TuistGenerator/Generator/TargetGenerator.swift
@@ -12,7 +12,8 @@ protocol TargetGenerating: AnyObject {
                         fileElements: ProjectFileElements,
                         path: AbsolutePath,
                         sourceRootPath: AbsolutePath,
-                        graph: Graph) throws -> PBXNativeTarget
+                        graph: Graph,
+                        versions: Versions) throws -> PBXNativeTarget
 
     func generateTargetDependencies(path: AbsolutePath,
                                     targets: [Target],
@@ -50,7 +51,8 @@ final class TargetGenerator: TargetGenerating {
                         fileElements: ProjectFileElements,
                         path: AbsolutePath,
                         sourceRootPath: AbsolutePath,
-                        graph: Graph) throws -> PBXNativeTarget {
+                        graph: Graph,
+                        versions: Versions) throws -> PBXNativeTarget {
         /// Products reference.
         let productFileReference = fileElements.products[target.name]!
 
@@ -80,7 +82,8 @@ final class TargetGenerator: TargetGenerating {
                                                  projectSettings: projectSettings,
                                                  fileElements: fileElements,
                                                  graph: graph,
-                                                 sourceRootPath: sourceRootPath)
+                                                 sourceRootPath: sourceRootPath,
+                                                 versions: versions)
 
         /// Build phases
         try buildPhaseGenerator.generateBuildPhases(path: path,

--- a/Sources/TuistGenerator/Generator/WorkspaceGenerator.swift
+++ b/Sources/TuistGenerator/Generator/WorkspaceGenerator.swift
@@ -51,6 +51,7 @@ final class WorkspaceGenerator: WorkspaceGenerating {
     private let workspaceStructureGenerator: WorkspaceStructureGenerating
     private let schemesGenerator: SchemesGenerating
     private let config: Config
+    private let versionsFetcher: VersionsFetching
 
     // MARK: - Init
 
@@ -63,23 +64,27 @@ final class WorkspaceGenerator: WorkspaceGenerating {
         self.init(projectGenerator: projectGenerator,
                   workspaceStructureGenerator: WorkspaceStructureGenerator(),
                   schemesGenerator: SchemesGenerator(),
-                  config: config)
+                  config: config,
+                  versionsFetcher: VersionsFetcher())
     }
 
     init(projectGenerator: ProjectGenerating,
          workspaceStructureGenerator: WorkspaceStructureGenerating,
          schemesGenerator: SchemesGenerating,
-         config: Config = .default) {
+         config: Config = .default,
+         versionsFetcher: VersionsFetching) {
         self.projectGenerator = projectGenerator
         self.workspaceStructureGenerator = workspaceStructureGenerator
         self.schemesGenerator = schemesGenerator
         self.config = config
+        self.versionsFetcher = versionsFetcher
     }
 
     // MARK: - WorkspaceGenerating
 
     func generate(workspace: Workspace, path: AbsolutePath, graph: Graph) throws -> WorkspaceDescriptor {
         let workspaceName = "\(graph.name).xcworkspace"
+        let versions = try versionsFetcher.fetch()
 
         logger.notice("Generating workspace \(workspaceName)", metadata: .section)
 
@@ -88,7 +93,8 @@ final class WorkspaceGenerator: WorkspaceGenerating {
             try projectGenerator.generate(project: project,
                                           graph: graph,
                                           sourceRootPath: project.path,
-                                          xcodeprojPath: nil)
+                                          xcodeprojPath: nil,
+                                          versions: versions)
         }
 
         let generatedProjects: [AbsolutePath: GeneratedProject] = Dictionary(uniqueKeysWithValues: projects.map { project in

--- a/Sources/TuistGenerator/Generator/WorkspaceGenerator.swift
+++ b/Sources/TuistGenerator/Generator/WorkspaceGenerator.swift
@@ -56,7 +56,8 @@ final class WorkspaceGenerator: WorkspaceGenerating {
     // MARK: - Init
 
     convenience init(defaultSettingsProvider: DefaultSettingsProviding = DefaultSettingsProvider(),
-                     config: Config = .default) {
+                     config: Config = .default,
+                     versionsFetcher: VersionsFetching = VersionsFetcher()) {
         let configGenerator = ConfigGenerator(defaultSettingsProvider: defaultSettingsProvider)
         let targetGenerator = TargetGenerator(configGenerator: configGenerator)
         let projectGenerator = ProjectGenerator(targetGenerator: targetGenerator,
@@ -65,7 +66,7 @@ final class WorkspaceGenerator: WorkspaceGenerating {
                   workspaceStructureGenerator: WorkspaceStructureGenerator(),
                   schemesGenerator: SchemesGenerator(),
                   config: config,
-                  versionsFetcher: VersionsFetcher())
+                  versionsFetcher: versionsFetcher)
     }
 
     init(projectGenerator: ProjectGenerating,

--- a/Sources/TuistGeneratorTesting/Generator/MockDescriptorGenerator.swift
+++ b/Sources/TuistGeneratorTesting/Generator/MockDescriptorGenerator.swift
@@ -1,6 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
+import TuistSupport
 import XcodeProj
 @testable import TuistGenerator
 
@@ -9,17 +10,17 @@ final class MockDescriptorGenerator: DescriptorGenerating {
         case stubNotImplemented
     }
 
-    var generateProjectSub: ((Project, Graph) throws -> ProjectDescriptor)?
-    func generateProject(project: Project, graph: Graph) throws -> ProjectDescriptor {
+    var generateProjectSub: ((Project, Graph, Versions) throws -> ProjectDescriptor)?
+    func generateProject(project: Project, graph: Graph, versions: Versions) throws -> ProjectDescriptor {
         guard let generateProjectSub = generateProjectSub else {
             throw MockError.stubNotImplemented
         }
 
-        return try generateProjectSub(project, graph)
+        return try generateProjectSub(project, graph, versions)
     }
 
     var generateProjectWithConfigStub: ((Project, Graph, ProjectGenerationConfig) throws -> ProjectDescriptor)?
-    func generateProject(project: Project, graph: Graph, config: ProjectGenerationConfig) throws -> ProjectDescriptor {
+    func generateProject(project: Project, graph: Graph, config: ProjectGenerationConfig, versions _: Versions) throws -> ProjectDescriptor {
         guard let generateProjectWithConfigStub = generateProjectWithConfigStub else {
             throw MockError.stubNotImplemented
         }

--- a/Sources/TuistKit/Commands/DumpCommand.swift
+++ b/Sources/TuistKit/Commands/DumpCommand.swift
@@ -13,19 +13,23 @@ class DumpCommand: NSObject, Command {
     // MARK: - Attributes
 
     private let manifestLoader: ManifestLoading
+    private let versionsFetcher: VersionsFetching
     let pathArgument: OptionArgument<String>
 
     // MARK: - Init
 
     public required convenience init(parser: ArgumentParser) {
         self.init(manifestLoader: ManifestLoader(),
+                  versionsFetcher: VersionsFetcher(),
                   parser: parser)
     }
 
     init(manifestLoader: ManifestLoading,
+         versionsFetcher: VersionsFetching,
          parser: ArgumentParser) {
         let subParser = parser.add(subparser: DumpCommand.command, overview: DumpCommand.overview)
         self.manifestLoader = manifestLoader
+        self.versionsFetcher = versionsFetcher
         pathArgument = subParser.add(option: "--path",
                                      shortName: "-p",
                                      kind: String.self,
@@ -42,7 +46,8 @@ class DumpCommand: NSObject, Command {
         } else {
             path = AbsolutePath.current
         }
-        let project = try manifestLoader.loadProject(at: path)
+        let versions = try versionsFetcher.fetch()
+        let project = try manifestLoader.loadProject(at: path, versions: versions)
         let json: JSON = try project.toJSON()
         logger.notice("\(json.toString(prettyPrint: true))")
     }

--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -9,7 +9,8 @@ protocol ProjectEditorMapping: AnyObject {
              manifests: [AbsolutePath],
              helpers: [AbsolutePath],
              templates: [AbsolutePath],
-             projectDescriptionPath: AbsolutePath) -> (Project, Graph)
+             projectDescriptionPath: AbsolutePath,
+             versions: Versions) -> (Project, Graph)
 }
 
 final class ProjectEditorMapper: ProjectEditorMapping {
@@ -19,13 +20,14 @@ final class ProjectEditorMapper: ProjectEditorMapping {
              manifests: [AbsolutePath],
              helpers: [AbsolutePath],
              templates: [AbsolutePath],
-             projectDescriptionPath: AbsolutePath) -> (Project, Graph) {
+             projectDescriptionPath: AbsolutePath,
+             versions: Versions) -> (Project, Graph) {
         // Settings
         let projectSettings = Settings(base: [:],
                                        configurations: Settings.default.configurations,
                                        defaultSettings: .recommended)
 
-        let targetSettings = Settings(base: settings(projectDescriptionPath: projectDescriptionPath),
+        let targetSettings = Settings(base: settings(projectDescriptionPath: projectDescriptionPath, versions: versions),
                                       configurations: Settings.default.configurations,
                                       defaultSettings: .recommended)
 
@@ -108,13 +110,13 @@ final class ProjectEditorMapper: ProjectEditorMapping {
 
     /// It returns the build settings that should be used in the manifests target.
     /// - Parameter projectDescriptionPath: Path to the ProjectDescription framework.
-    fileprivate func settings(projectDescriptionPath: AbsolutePath) -> [String: SettingValue] {
+    fileprivate func settings(projectDescriptionPath: AbsolutePath, versions: Versions) -> [String: SettingValue] {
         let frameworkParentDirectory = projectDescriptionPath.parentDirectory
         var buildSettings = [String: SettingValue]()
         buildSettings["FRAMEWORK_SEARCH_PATHS"] = .string(frameworkParentDirectory.pathString)
         buildSettings["LIBRARY_SEARCH_PATHS"] = .string(frameworkParentDirectory.pathString)
         buildSettings["SWIFT_INCLUDE_PATHS"] = .string(frameworkParentDirectory.pathString)
-        buildSettings["SWIFT_VERSION"] = .string(Constants.swiftVersion)
+        buildSettings["SWIFT_VERSION"] = .string(versions.swift.description)
         return buildSettings
     }
 }

--- a/Sources/TuistKit/Services/Cloud/CloudAuthService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudAuthService.swift
@@ -32,11 +32,9 @@ enum CloudAuthServiceError: FatalError, Equatable {
 }
 
 final class CloudAuthService: CloudAuthServicing {
-    /// Cloud session controller.
     let cloudSessionController: CloudSessionControlling
-
-    /// Generator model loader.
     let generatorModelLoader: GeneratorModelLoading
+    let versionsFetcher: VersionsFetching
 
     // MARK: - Init
 
@@ -46,20 +44,24 @@ final class CloudAuthService: CloudAuthServicing {
         let generatorModelLoader = GeneratorModelLoader(manifestLoader: manifetLoader,
                                                         manifestLinter: manifestLinter)
         self.init(cloudSessionController: CloudSessionController(),
-                  generatorModelLoader: generatorModelLoader)
+                  generatorModelLoader: generatorModelLoader,
+                  versionsFetcher: VersionsFetcher())
     }
 
     init(cloudSessionController: CloudSessionControlling,
-         generatorModelLoader: GeneratorModelLoading) {
+         generatorModelLoader: GeneratorModelLoading,
+         versionsFetcher: VersionsFetching) {
         self.cloudSessionController = cloudSessionController
         self.generatorModelLoader = generatorModelLoader
+        self.versionsFetcher = versionsFetcher
     }
 
     // MARK: - CloudAuthServicing
 
     func authenticate() throws {
         let path = FileHandler.shared.currentPath
-        let config = try generatorModelLoader.loadConfig(at: path)
+        let versions = try versionsFetcher.fetch()
+        let config = try generatorModelLoader.loadConfig(at: path, versions: versions)
         guard let cloudURL = config.cloudURL else {
             throw CloudAuthServiceError.missingCloudURL
         }

--- a/Sources/TuistKit/Services/Cloud/CloudLogoutService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudLogoutService.swift
@@ -32,11 +32,9 @@ enum CloudLogoutServiceError: FatalError, Equatable {
 }
 
 final class CloudLogoutService: CloudLogoutServicing {
-    /// Cloud session controller.
     let cloudSessionController: CloudSessionControlling
-
-    /// Generator model loader.
     let generatorModelLoader: GeneratorModelLoading
+    let versionsFetcher: VersionsFetching
 
     // MARK: - Init
 
@@ -46,20 +44,25 @@ final class CloudLogoutService: CloudLogoutServicing {
         let generatorModelLoader = GeneratorModelLoader(manifestLoader: manifetLoader,
                                                         manifestLinter: manifestLinter)
         self.init(cloudSessionController: CloudSessionController(),
-                  generatorModelLoader: generatorModelLoader)
+                  generatorModelLoader: generatorModelLoader,
+                  versionsFetcher: VersionsFetcher())
     }
 
     init(cloudSessionController: CloudSessionControlling,
-         generatorModelLoader: GeneratorModelLoading) {
+         generatorModelLoader: GeneratorModelLoading,
+         versionsFetcher: VersionsFetching) {
         self.cloudSessionController = cloudSessionController
         self.generatorModelLoader = generatorModelLoader
+        self.versionsFetcher = versionsFetcher
     }
 
     // MARK: - CloudAuthServicing
 
     func logout() throws {
         let path = FileHandler.shared.currentPath
-        let config = try generatorModelLoader.loadConfig(at: path)
+        let versions = try versionsFetcher.fetch()
+        let config = try generatorModelLoader.loadConfig(at: path, versions: versions)
+
         guard let cloudURL = config.cloudURL else {
             throw CloudLogoutServiceError.missingCloudURL
         }

--- a/Sources/TuistKit/Services/Cloud/CloudSessionService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudSessionService.swift
@@ -32,11 +32,9 @@ enum CloudSessionServiceError: FatalError, Equatable {
 }
 
 final class CloudSessionService: CloudSessionServicing {
-    /// Cloud session controller.
     let cloudSessionController: CloudSessionControlling
-
-    /// Generator model loader.
     let generatorModelLoader: GeneratorModelLoading
+    let versionsFetcher: VersionsFetching
 
     // MARK: - Init
 
@@ -46,20 +44,24 @@ final class CloudSessionService: CloudSessionServicing {
         let generatorModelLoader = GeneratorModelLoader(manifestLoader: manifetLoader,
                                                         manifestLinter: manifestLinter)
         self.init(cloudSessionController: CloudSessionController(),
-                  generatorModelLoader: generatorModelLoader)
+                  generatorModelLoader: generatorModelLoader,
+                  versionsFetcher: VersionsFetcher())
     }
 
     init(cloudSessionController: CloudSessionControlling,
-         generatorModelLoader: GeneratorModelLoading) {
+         generatorModelLoader: GeneratorModelLoading,
+         versionsFetcher: VersionsFetching) {
         self.cloudSessionController = cloudSessionController
         self.generatorModelLoader = generatorModelLoader
+        self.versionsFetcher = versionsFetcher
     }
 
     // MARK: - CloudAuthServicing
 
     func printSession() throws {
         let path = FileHandler.shared.currentPath
-        let config = try generatorModelLoader.loadConfig(at: path)
+        let versions = try versionsFetcher.fetch()
+        let config = try generatorModelLoader.loadConfig(at: path, versions: versions)
         guard let cloudURL = config.cloudURL else {
             throw CloudSessionServiceError.missingCloudURL
         }

--- a/Sources/TuistLoader/Loaders/TemplateLoader.swift
+++ b/Sources/TuistLoader/Loaders/TemplateLoader.swift
@@ -9,8 +9,9 @@ public protocol TemplateLoading {
     /// Load `TuistScaffold.Template` at given `path`
     /// - Parameters:
     ///     - path: Path of template manifest file `Template.swift`
+    ///     - versions: Versions of system components that Tuist interacts with.
     /// - Returns: Loaded `TuistScaffold.Template`
-    func loadTemplate(at path: AbsolutePath) throws -> TuistCore.Template
+    func loadTemplate(at path: AbsolutePath, versions: Versions) throws -> TuistCore.Template
 }
 
 public class TemplateLoader: TemplateLoading {
@@ -25,8 +26,8 @@ public class TemplateLoader: TemplateLoading {
         self.manifestLoader = manifestLoader
     }
 
-    public func loadTemplate(at path: AbsolutePath) throws -> TuistCore.Template {
-        let template = try manifestLoader.loadTemplate(at: path)
+    public func loadTemplate(at path: AbsolutePath, versions: Versions) throws -> TuistCore.Template {
+        let template = try manifestLoader.loadTemplate(at: path, versions: versions)
         let generatorPaths = GeneratorPaths(manifestDirectory: path)
         return try TuistCore.Template.from(manifest: template,
                                            generatorPaths: generatorPaths)

--- a/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
+++ b/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
@@ -10,7 +10,8 @@ protocol ProjectDescriptionHelpersBuilding: AnyObject {
     /// - Parameters:
     ///   - at: Path to the directory that contains the manifest being loaded.
     ///   - projectDescriptionPath: Path to the project description module.
-    func build(at: AbsolutePath, projectDescriptionPath: AbsolutePath) throws -> AbsolutePath?
+    ///   - versions: Versions of system components that Tuist interacts with.
+    func build(at: AbsolutePath, projectDescriptionPath: AbsolutePath, versions: Versions) throws -> AbsolutePath?
 }
 
 final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding {
@@ -40,11 +41,11 @@ final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding 
         self.helpersDirectoryLocator = helpersDirectoryLocator
     }
 
-    func build(at: AbsolutePath, projectDescriptionPath: AbsolutePath) throws -> AbsolutePath? {
+    func build(at: AbsolutePath, projectDescriptionPath: AbsolutePath, versions: Versions) throws -> AbsolutePath? {
         guard let helpersDirectory = helpersDirectoryLocator.locate(at: at) else { return nil }
         if let cachedPath = builtHelpers[helpersDirectory] { return cachedPath }
 
-        let hash = try projectDescriptionHelpersHasher.hash(helpersDirectory: helpersDirectory)
+        let hash = try projectDescriptionHelpersHasher.hash(helpersDirectory: helpersDirectory, versions: versions)
         let prefixHash = projectDescriptionHelpersHasher.prefixHash(helpersDirectory: helpersDirectory)
 
         // Get paths

--- a/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasher.swift
+++ b/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasher.swift
@@ -1,12 +1,14 @@
 import Basic
 import Foundation
+import TuistCore
 import TuistSupport
 
 protocol ProjectDescriptionHelpersHashing: AnyObject {
     /// Given the path to the directory that contains the helpers, it returns a hash that includes
     /// the hash of the files, the environment, as well as the versions of Swift and Tuist.
     /// - Parameter helpersDirectory: Path to the helpers directory.
-    func hash(helpersDirectory: AbsolutePath) throws -> String
+    /// - Parameter versions: Versions of system components Tuist interacts with.
+    func hash(helpersDirectory: AbsolutePath, versions: Versions) throws -> String
 
     /// Gets the prefix hash for the given helpers directory.
     /// This is useful to uniquely identify a helpers directory in the cache.
@@ -24,14 +26,14 @@ final class ProjectDescriptionHelpersHasher: ProjectDescriptionHelpersHashing {
 
     // MARK: - ProjectDescriptionHelpersHashing
 
-    func hash(helpersDirectory: AbsolutePath) throws -> String {
+    func hash(helpersDirectory: AbsolutePath, versions: Versions) throws -> String {
         let fileHashes = FileHandler.shared
             .glob(helpersDirectory, glob: "**/*.swift")
             .sorted()
             .compactMap { $0.sha256() }
             .compactMap { $0.compactMap { byte in String(format: "%02x", byte) }.joined() }
         let tuistEnvVariables = Environment.shared.tuistVariables.map { "\($0.key)=\($0.value)" }.sorted()
-        let swiftVersion = try System.shared.swiftVersion() ?? ""
+        let swiftVersion = versions.swift.description
 
         let identifiers = [swiftVersion, tuistVersion] + fileHashes + tuistEnvVariables
 

--- a/Sources/TuistLoaderTesting/Loaders/Mocks/MockGeneratorModelLoader.swift
+++ b/Sources/TuistLoaderTesting/Loaders/Mocks/MockGeneratorModelLoader.swift
@@ -15,15 +15,15 @@ public class MockGeneratorModelLoader: GeneratorModelLoading {
 
     // MARK: - GeneratorModelLoading
 
-    public func loadProject(at path: AbsolutePath) throws -> Project {
+    public func loadProject(at path: AbsolutePath, versions _: Versions) throws -> Project {
         try projects[path.pathString]!(path)
     }
 
-    public func loadWorkspace(at path: AbsolutePath) throws -> Workspace {
+    public func loadWorkspace(at path: AbsolutePath, versions _: Versions) throws -> Workspace {
         try workspaces[path.pathString]!(path)
     }
 
-    public func loadConfig(at path: AbsolutePath) throws -> Config {
+    public func loadConfig(at path: AbsolutePath, versions _: Versions) throws -> Config {
         try configs[path.pathString]!(path)
     }
 

--- a/Sources/TuistLoaderTesting/Loaders/Mocks/MockManifestLoader.swift
+++ b/Sources/TuistLoaderTesting/Loaders/Mocks/MockManifestLoader.swift
@@ -1,14 +1,15 @@
 import Basic
 import Foundation
 import ProjectDescription
+import TuistSupport
 @testable import TuistLoader
 
 public final class MockManifestLoader: ManifestLoading {
     public var loadProjectCount: UInt = 0
-    public var loadProjectStub: ((AbsolutePath) throws -> ProjectDescription.Project)?
+    public var loadProjectStub: ((AbsolutePath, Versions) throws -> ProjectDescription.Project)?
 
     public var loadWorkspaceCount: UInt = 0
-    public var loadWorkspaceStub: ((AbsolutePath) throws -> ProjectDescription.Workspace)?
+    public var loadWorkspaceStub: ((AbsolutePath, Versions) throws -> ProjectDescription.Workspace)?
 
     public var manifestsAtCount: UInt = 0
     public var manifestsAtStub: ((AbsolutePath) -> Set<Manifest>)?
@@ -17,22 +18,22 @@ public final class MockManifestLoader: ManifestLoading {
     public var manifestPathStub: ((AbsolutePath, Manifest) throws -> AbsolutePath)?
 
     public var loadSetupCount: UInt = 0
-    public var loadSetupStub: ((AbsolutePath) throws -> [Upping])?
+    public var loadSetupStub: ((AbsolutePath, Versions) throws -> [Upping])?
 
     public var loadConfigCount: UInt = 0
-    public var loadConfigStub: ((AbsolutePath) throws -> ProjectDescription.Config)?
+    public var loadConfigStub: ((AbsolutePath, Versions) throws -> ProjectDescription.Config)?
 
     public var loadTemplateCount: UInt = 0
-    public var loadTemplateStub: ((AbsolutePath) throws -> ProjectDescription.Template)?
+    public var loadTemplateStub: ((AbsolutePath, Versions) throws -> ProjectDescription.Template)?
 
     public init() {}
 
-    public func loadProject(at path: AbsolutePath) throws -> ProjectDescription.Project {
-        try loadProjectStub?(path) ?? ProjectDescription.Project.test()
+    public func loadProject(at path: AbsolutePath, versions: Versions) throws -> ProjectDescription.Project {
+        try loadProjectStub?(path, versions) ?? ProjectDescription.Project.test()
     }
 
-    public func loadWorkspace(at path: AbsolutePath) throws -> ProjectDescription.Workspace {
-        try loadWorkspaceStub?(path) ?? ProjectDescription.Workspace.test()
+    public func loadWorkspace(at path: AbsolutePath, versions: Versions) throws -> ProjectDescription.Workspace {
+        try loadWorkspaceStub?(path, versions) ?? ProjectDescription.Workspace.test()
     }
 
     public func manifests(at path: AbsolutePath) -> Set<Manifest> {
@@ -45,18 +46,18 @@ public final class MockManifestLoader: ManifestLoading {
         return try manifestPathStub?(path, manifest) ?? TemporaryDirectory(removeTreeOnDeinit: true).path
     }
 
-    public func loadSetup(at path: AbsolutePath) throws -> [Upping] {
+    public func loadSetup(at path: AbsolutePath, versions: Versions) throws -> [Upping] {
         loadSetupCount += 1
-        return try loadSetupStub?(path) ?? []
+        return try loadSetupStub?(path, versions) ?? []
     }
 
-    public func loadConfig(at path: AbsolutePath) throws -> Config {
+    public func loadConfig(at path: AbsolutePath, versions: Versions) throws -> Config {
         loadConfigCount += 1
-        return try loadConfigStub?(path) ?? ProjectDescription.Config.test()
+        return try loadConfigStub?(path, versions) ?? ProjectDescription.Config.test()
     }
 
-    public func loadTemplate(at path: AbsolutePath) throws -> Template {
+    public func loadTemplate(at path: AbsolutePath, versions: Versions) throws -> Template {
         loadTemplateCount += 1
-        return try loadTemplateStub?(path) ?? ProjectDescription.Template.test()
+        return try loadTemplateStub?(path, versions) ?? ProjectDescription.Template.test()
     }
 }

--- a/Sources/TuistLoaderTesting/Loaders/Mocks/MockTemplateLoader.swift
+++ b/Sources/TuistLoaderTesting/Loaders/Mocks/MockTemplateLoader.swift
@@ -2,10 +2,11 @@ import Basic
 import Foundation
 import TuistCore
 import TuistLoader
+import TuistSupport
 
 public final class MockTemplateLoader: TemplateLoading {
-    public var loadTemplateStub: ((AbsolutePath) throws -> Template)?
-    public func loadTemplate(at path: AbsolutePath) throws -> Template {
-        try loadTemplateStub?(path) ?? Template(description: "", attributes: [], files: [])
+    public var loadTemplateStub: ((AbsolutePath, Versions) throws -> Template)?
+    public func loadTemplate(at path: AbsolutePath, versions: Versions) throws -> Template {
+        try loadTemplateStub?(path, versions) ?? Template(description: "", attributes: [], files: [])
     }
 }

--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -6,7 +6,6 @@ public struct Constants {
     public static let binName = "tuist"
     public static let gitRepositoryURL = "https://github.com/tuist/tuist.git"
     public static let version = "1.6.0"
-    public static let swiftVersion: String = "5.2"
     public static let bundleName: String = "tuist.zip"
     public static let trueValues: [String] = ["1", "true", "TRUE", "yes", "YES"]
     public static let tuistDirectoryName: String = "Tuist"

--- a/Sources/TuistSupport/Extensions/Version+Extras.swift
+++ b/Sources/TuistSupport/Extensions/Version+Extras.swift
@@ -1,0 +1,23 @@
+import Foundation
+import SPMUtility
+
+extension Version {
+    static func swiftVersion(_ value: String) -> Version {
+        let components = value.split(separator: ".")
+        let major = Int(String(components[0]))!
+        let minor: Int
+        let patch: Int
+
+        if components.count == 3 {
+            minor = Int(String(components[1]))!
+            patch = Int(String(components[2]))!
+        } else if components.count == 2 {
+            minor = Int(String(components[1]))!
+            patch = 0
+        } else {
+            minor = 0
+            patch = 0
+        }
+        return Version(major, minor, patch)
+    }
+}

--- a/Sources/TuistSupport/Versions/Versions.swift
+++ b/Sources/TuistSupport/Versions/Versions.swift
@@ -1,0 +1,14 @@
+import Basic
+import Foundation
+import SPMUtility
+
+/// Contains the versions of some system components that Tuist depends on (e.g. Xcode)
+/// Since versions won't change during the execution of Tuist, we load them into an instance
+/// of this struct, and pass them down to the utilities that might need to access them.
+public struct Versions {
+    /// Version of Xcode
+    public let xcode: Version
+
+    /// Version of Swift
+    public let swift: Version
+}

--- a/Sources/TuistSupport/Versions/Versions.swift
+++ b/Sources/TuistSupport/Versions/Versions.swift
@@ -11,4 +11,9 @@ public struct Versions {
 
     /// Version of Swift
     public let swift: Version
+
+    public init(xcode: Version, swift: Version) {
+        self.xcode = xcode
+        self.swift = swift
+    }
 }

--- a/Sources/TuistSupport/Versions/VersionsFetcher.swift
+++ b/Sources/TuistSupport/Versions/VersionsFetcher.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+public protocol VersionsFetching {
+    /// Reads the versions of some system utilities that
+    /// Tuist depends on and returns them grouped in an
+    /// instance of Versions.
+    func fetch() throws -> Versions
+}
+
+public final class VersionsFetcher: VersionsFetching {
+    /// Xcode controller.
+    fileprivate let xcodeController: XcodeControlling
+
+    /// System instance.
+    fileprivate let system: Systeming
+
+    public convenience init() {
+        self.init(xcodeController: XcodeController.shared,
+                  system: System.shared)
+    }
+
+    internal init(xcodeController: XcodeControlling,
+                  system: Systeming) {
+        self.xcodeController = xcodeController
+        self.system = system
+    }
+
+    public func fetch() throws -> Versions {
+        let xcodeVersion = try xcodeController.selectedVersion()
+        let swiftVersion = try system.swiftVersion()
+        return Versions(xcode: xcodeVersion, swift: swiftVersion)
+    }
+}

--- a/Sources/TuistSupportTesting/Utils/MockSystem.swift
+++ b/Sources/TuistSupportTesting/Utils/MockSystem.swift
@@ -1,6 +1,7 @@
 import Basic
 import Foundation
 import RxSwift
+import SPMUtility
 import TuistSupport
 import XCTest
 
@@ -9,8 +10,8 @@ public final class MockSystem: Systeming {
     // swiftlint:disable:next large_tuple
     private var stubs: [String: (stderror: String?, stdout: String?, exitstatus: Int?)] = [:]
     private var calls: [String] = []
-    var swiftVersionStub: (() throws -> String?)?
-    var whichStub: ((String) throws -> String?)?
+    var swiftVersionStub: (() throws -> Version)?
+    var whichStub: ((String) throws -> String)?
 
     public init() {}
 
@@ -145,8 +146,12 @@ public final class MockSystem: Systeming {
         }
     }
 
-    public func swiftVersion() throws -> String? {
-        try swiftVersionStub?()
+    public func swiftVersion() throws -> Version {
+        if let swiftVersionStub = swiftVersionStub {
+            return try swiftVersionStub()
+        } else {
+            throw TestError("Call to non-stubbed method swiftVersion")
+        }
     }
 
     public func which(_ name: String) throws -> String {

--- a/Sources/TuistSupportTesting/Versions/MockVersionsFetcher.swift
+++ b/Sources/TuistSupportTesting/Versions/MockVersionsFetcher.swift
@@ -1,0 +1,13 @@
+import Foundation
+import TuistSupport
+
+final class MockVersionsFetcher: VersionsFetching {
+    var fetchStub: Versions?
+    func fetch() throws -> Versions {
+        if let fetchStub = fetchStub {
+            return fetchStub
+        } else {
+            return Versions.test()
+        }
+    }
+}

--- a/Sources/TuistSupportTesting/Versions/MockVersionsFetcher.swift
+++ b/Sources/TuistSupportTesting/Versions/MockVersionsFetcher.swift
@@ -2,6 +2,8 @@ import Foundation
 import TuistSupport
 
 final class MockVersionsFetcher: VersionsFetching {
+    public init() {}
+
     var fetchStub: Versions?
     func fetch() throws -> Versions {
         if let fetchStub = fetchStub {

--- a/Sources/TuistSupportTesting/Versions/Versions+TestData.swift
+++ b/Sources/TuistSupportTesting/Versions/Versions+TestData.swift
@@ -1,0 +1,10 @@
+import Foundation
+import SPMUtility
+import TuistSupport
+
+public extension Versions {
+    static func test(xcode: Version = "11.4.0",
+                     swift: Version = "5.2.0") -> Versions {
+        Versions(xcode: xcode, swift: swift)
+    }
+}

--- a/Tests/TuistGeneratorIntegrationTests/Generator/WorkspaceGeneratorIntegrationTests.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Generator/WorkspaceGeneratorIntegrationTests.swift
@@ -10,14 +10,17 @@ import XCTest
 
 final class WorkspaceGeneratorIntegrationTests: TuistTestCase {
     var subject: WorkspaceGenerator!
+    var versionsFetcher: MockVersionsFetcher!
 
     override func setUp() {
         super.setUp()
-        subject = WorkspaceGenerator(config: .init(projectGenerationContext: .concurrent))
+        versionsFetcher = MockVersionsFetcher()
+        subject = WorkspaceGenerator(config: .init(projectGenerationContext: .concurrent), versionsFetcher: versionsFetcher)
     }
 
     override func tearDown() {
         subject = nil
+        versionsFetcher = nil
         super.tearDown()
     }
 

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -60,12 +60,13 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
 
     func test_generateTargetConfig() throws {
         // Given
+        let versions = Versions.test()
         let commonSettings = [
             "Base": "Base",
             "INFOPLIST_FILE": "Info.plist",
             "PRODUCT_BUNDLE_IDENTIFIER": "com.test.bundle_id",
             "CODE_SIGN_ENTITLEMENTS": "$(SRCROOT)/Test.entitlements",
-            "SWIFT_VERSION": Constants.swiftVersion,
+            "SWIFT_VERSION": versions.swift.description,
         ]
 
         let debugSettings = [
@@ -137,6 +138,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
     func test_generateTargetWithDeploymentTarget_whenIOS() throws {
         // Given
         let target = Target.test(deploymentTarget: .iOS("12.0", [.iphone, .ipad]))
+        let versions = Versions.test()
 
         // When
         try subject.generateTargetConfig(target,
@@ -145,7 +147,8 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
                                          projectSettings: .default,
                                          fileElements: ProjectFileElements(),
                                          graph: Graph.test(),
-                                         sourceRootPath: AbsolutePath("/project"))
+                                         sourceRootPath: AbsolutePath("/project"),
+                                         versions: versions)
 
         // Then
         let configurationList = pbxTarget.buildConfigurationList
@@ -164,6 +167,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
     func test_generateTargetWithDeploymentTarget_whenMac() throws {
         // Given
         let target = Target.test(deploymentTarget: .macOS("10.14.1"))
+        let versions = Versions.test()
 
         // When
         try subject.generateTargetConfig(target,
@@ -172,7 +176,8 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
                                          projectSettings: .default,
                                          fileElements: ProjectFileElements(),
                                          graph: Graph.test(),
-                                         sourceRootPath: AbsolutePath("/project"))
+                                         sourceRootPath: AbsolutePath("/project"),
+                                         versions: versions)
 
         // Then
         let configurationList = pbxTarget.buildConfigurationList
@@ -190,6 +195,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
     func test_generateTargetWithDeploymentTarget_whenCatalyst() throws {
         // Given
         let target = Target.test(deploymentTarget: .iOS("13.1", [.iphone, .ipad, .mac]))
+        let versions = Versions.test()
 
         // When
         try subject.generateTargetConfig(target,
@@ -198,7 +204,8 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
                                          projectSettings: .default,
                                          fileElements: ProjectFileElements(),
                                          graph: Graph.test(),
-                                         sourceRootPath: AbsolutePath("/project"))
+                                         sourceRootPath: AbsolutePath("/project"),
+                                         versions: versions)
 
         // Then
         let configurationList = pbxTarget.buildConfigurationList
@@ -259,6 +266,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             .release("CustomRelease"): nil,
         ])
         let target = Target.test()
+        let versions = Versions.test()
 
         // When
         try subject.generateTargetConfig(target,
@@ -267,7 +275,8 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
                                          projectSettings: projectSettings,
                                          fileElements: ProjectFileElements(),
                                          graph: Graph.test(),
-                                         sourceRootPath: AbsolutePath("/project"))
+                                         sourceRootPath: AbsolutePath("/project"),
+                                         versions: versions)
 
         // Then
         let result = pbxTarget.buildConfigurationList
@@ -280,6 +289,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             .debug("CustomDebug"): nil,
             .debug("AnotherDebug"): nil,
         ])
+        let versions = Versions.test()
         let target = Target.test()
 
         // When
@@ -289,7 +299,8 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
                                          projectSettings: projectSettings,
                                          fileElements: ProjectFileElements(),
                                          graph: Graph.test(),
-                                         sourceRootPath: AbsolutePath("/project"))
+                                         sourceRootPath: AbsolutePath("/project"),
+                                         versions: versions)
 
         // Then
         let result = pbxTarget.buildConfigurationList
@@ -326,6 +337,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
 
     private func generateTargetConfig() throws {
         let dir = try TemporaryDirectory(removeTreeOnDeinit: true)
+        let versions = Versions.test()
         let xcconfigsDir = dir.path.appending(component: "xcconfigs")
         try FileHandler.shared.createFolder(xcconfigsDir)
         try "".write(to: xcconfigsDir.appending(component: "debug.xcconfig").url, atomically: true, encoding: .utf8)
@@ -361,12 +373,13 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
                                              projectSettings: project.settings,
                                              fileElements: fileElements,
                                              graph: graph,
-                                             sourceRootPath: AbsolutePath("/"))
+                                             sourceRootPath: AbsolutePath("/"),
+                                             versions: versions)
     }
 
     private func generateTestTargetConfig(uiTest: Bool = false) throws {
         let dir = try TemporaryDirectory(removeTreeOnDeinit: true)
-
+        let versions = Versions.test()
         let appTarget = Target.test(name: "App", platform: .iOS, product: .app)
 
         let target = Target.test(name: "Test", product: uiTest ? .uiTests : .unitTests)
@@ -383,7 +396,8 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
                                              projectSettings: project.settings,
                                              fileElements: .init(),
                                              graph: graph,
-                                             sourceRootPath: dir.path)
+                                             sourceRootPath: dir.path,
+                                             versions: versions)
     }
 
     func assert(config: XCBuildConfiguration?,

--- a/Tests/TuistGeneratorTests/Generator/Mocks/MockProjectGenerator.swift
+++ b/Tests/TuistGeneratorTests/Generator/Mocks/MockProjectGenerator.swift
@@ -12,13 +12,13 @@ final class MockProjectGenerator: ProjectGenerating {
     }
 
     var generatedProjects: [Project] = []
-    var generateStub: ((Project, Graph, AbsolutePath?, AbsolutePath?) throws -> ProjectDescriptor)?
+    var generateStub: ((Project, Graph, AbsolutePath?, AbsolutePath?, Versions) throws -> ProjectDescriptor)?
 
-    func generate(project: Project, graph: Graph, sourceRootPath: AbsolutePath?, xcodeprojPath: AbsolutePath?) throws -> ProjectDescriptor {
+    func generate(project: Project, graph: Graph, sourceRootPath: AbsolutePath?, xcodeprojPath: AbsolutePath?, versions: Versions) throws -> ProjectDescriptor {
         guard let generateStub = generateStub else {
             throw MockError.stubNotImplemented
         }
         generatedProjects.append(project)
-        return try generateStub(project, graph, sourceRootPath, xcodeprojPath)
+        return try generateStub(project, graph, sourceRootPath, xcodeprojPath, versions)
     }
 }

--- a/Tests/TuistGeneratorTests/Generator/Mocks/MockTargetGenerator.swift
+++ b/Tests/TuistGeneratorTests/Generator/Mocks/MockTargetGenerator.swift
@@ -9,7 +9,7 @@ import XcodeProj
 class MockTargetGenerator: TargetGenerating {
     var generateTargetStub: (() -> PBXNativeTarget)?
 
-    func generateTarget(target: Target, pbxproj _: PBXProj, pbxProject _: PBXProject, projectSettings _: Settings, fileElements _: ProjectFileElements, path _: AbsolutePath, sourceRootPath _: AbsolutePath, graph _: Graph) throws -> PBXNativeTarget {
+    func generateTarget(target: Target, pbxproj _: PBXProj, pbxProject _: PBXProject, projectSettings _: Settings, fileElements _: ProjectFileElements, path _: AbsolutePath, sourceRootPath _: AbsolutePath, graph _: Graph, versions: Versions) throws -> PBXNativeTarget {
         generateTargetStub?() ?? PBXNativeTarget(name: target.name)
     }
 

--- a/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
@@ -25,6 +25,7 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
     func test_generate_testTargetIdentity() throws {
         // Given
         let temporaryPath = try self.temporaryPath()
+        let versions = Versions.test()
         let app = Target.test(name: "App",
                               platform: .iOS,
                               product: .app)
@@ -45,7 +46,7 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
                                targets: [project.path: [testTargetNode, appNode]])
 
         // When
-        let generatedProject = try subject.generate(project: project, graph: graph)
+        let generatedProject = try subject.generate(project: project, graph: graph, versions: versions)
 
         // Then
         let pbxproj = generatedProject.xcodeProj.pbxproj
@@ -66,6 +67,7 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
 
     func test_generate_testUsingFileName() throws {
         // Given
+        let versions = Versions.test()
         let project = Project.test(name: "Project",
                                    fileName: "SomeAwesomeName",
                                    targets: [])
@@ -74,17 +76,16 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
                                  ])
 
         // When
-        let got = try subject.generate(project: project, graph: graph)
+        let got = try subject.generate(project: project, graph: graph, versions: versions)
 
         // Then
         XCTAssertEqual(got.xcodeprojPath.basename, "SomeAwesomeName.xcodeproj")
     }
 
     func test_objectVersion_when_xcode11_and_spm() throws {
-        xcodeController.selectedVersionStub = .success(Version(11, 0, 0))
-
         // Given
         let temporaryPath = try self.temporaryPath()
+        let versions = Versions.test(xcode: "11.0.0")
         let project = Project.test(path: temporaryPath,
                                    name: "Project",
                                    fileName: "SomeAwesomeName",
@@ -102,7 +103,7 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
                                packages: [packageNode])
 
         // When
-        let got = try subject.generate(project: project, graph: graph)
+        let got = try subject.generate(project: project, graph: graph, versions: versions)
 
         // Then
         let pbxproj = got.xcodeProj.pbxproj
@@ -111,9 +112,8 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
     }
 
     func test_objectVersion_when_xcode11() throws {
-        xcodeController.selectedVersionStub = .success(Version(11, 0, 0))
-
         // Given
+        let versions = Versions.test(xcode: "11.0.0")
         let temporaryPath = try self.temporaryPath()
         let project = Project.test(path: temporaryPath,
                                    name: "Project",
@@ -122,7 +122,7 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
         let graph = Graph.test(entryPath: temporaryPath)
 
         // When
-        let got = try subject.generate(project: project, graph: graph)
+        let got = try subject.generate(project: project, graph: graph, versions: versions)
 
         // Then
         let pbxproj = got.xcodeProj.pbxproj
@@ -131,9 +131,8 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
     }
 
     func test_objectVersion_when_xcode10() throws {
-        xcodeController.selectedVersionStub = .success(Version(10, 2, 1))
-
         // Given
+        let versions = Versions.test(xcode: "10.2.1")
         let temporaryPath = try self.temporaryPath()
         let project = Project.test(path: temporaryPath,
                                    name: "Project",
@@ -142,7 +141,7 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
         let graph = Graph.test(entryPath: temporaryPath)
 
         // When
-        let got = try subject.generate(project: project, graph: graph)
+        let got = try subject.generate(project: project, graph: graph, versions: versions)
 
         // Then
         let pbxproj = got.xcodeProj.pbxproj
@@ -153,6 +152,7 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
     func test_knownRegions() throws {
         // Given
         let path = try temporaryPath()
+        let versions = Versions.test()
         let graph = Graph.test(entryPath: path)
         let resources = [
             "resources/en.lproj/App.strings",
@@ -170,7 +170,7 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
                                    ])
 
         // When
-        let got = try subject.generate(project: project, graph: graph)
+        let got = try subject.generate(project: project, graph: graph, versions: versions)
 
         // Then
         let pbxProject = try XCTUnwrap(try got.xcodeProj.pbxproj.rootProject())
@@ -184,12 +184,13 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
     func test_generate_setsDefaultKnownRegions() throws {
         // Given
         let path = try temporaryPath()
+        let versions = Versions.test()
         let graph = Graph.test(entryPath: path)
         let project = Project.test(path: path,
                                    targets: [])
 
         // When
-        let got = try subject.generate(project: project, graph: graph)
+        let got = try subject.generate(project: project, graph: graph, versions: versions)
 
         // Then
         let pbxProject = try XCTUnwrap(try got.xcodeProj.pbxproj.rootProject())
@@ -202,13 +203,14 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
     func test_generate_setsOrganizationName() throws {
         // Given
         let path = try temporaryPath()
+        let versions = Versions.test()
         let graph = Graph.test(entryPath: path)
         let project = Project.test(path: path,
                                    organizationName: "tuist",
                                    targets: [])
 
         // When
-        let got = try subject.generate(project: project, graph: graph)
+        let got = try subject.generate(project: project, graph: graph, versions: versions)
 
         // Then
         let pbxProject = try XCTUnwrap(try got.xcodeProj.pbxproj.rootProject())

--- a/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
@@ -2,6 +2,8 @@ import Basic
 import Foundation
 import TuistCore
 import TuistCoreTesting
+import TuistSupport
+import TuistSupportTesting
 import XcodeProj
 import XCTest
 @testable import TuistGenerator
@@ -26,6 +28,7 @@ final class TargetGeneratorTests: XCTestCase {
 
     func test_generateTarget_productName() throws {
         // Given
+        let versions = Versions.test()
         let target = Target.test(name: "MyFramework",
                                  product: .framework,
                                  actions: [
@@ -62,7 +65,8 @@ final class TargetGeneratorTests: XCTestCase {
                                                          fileElements: fileElements,
                                                          path: path,
                                                          sourceRootPath: path,
-                                                         graph: graph)
+                                                         graph: graph,
+                                                         versions: versions)
 
         // Then
         XCTAssertEqual(generatedTarget.productName, "MyFramework")
@@ -113,6 +117,7 @@ final class TargetGeneratorTests: XCTestCase {
     func test_generateTarget_actions() throws {
         // Given
         let graph = Graph.test()
+        let versions = Versions.test()
         let target = Target.test(sources: [],
                                  resources: [],
                                  actions: [
@@ -139,7 +144,8 @@ final class TargetGeneratorTests: XCTestCase {
                                                    fileElements: fileElements,
                                                    path: path,
                                                    sourceRootPath: path,
-                                                   graph: graph)
+                                                   graph: graph,
+                                                   versions: versions)
 
         // Then
         let preBuildPhase = pbxTarget.buildPhases.first as? PBXShellScriptBuildPhase

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceGeneratorTests.swift
@@ -10,14 +10,17 @@ import XCTest
 
 final class WorkspaceGeneratorTests: TuistUnitTestCase {
     var subject: WorkspaceGenerator!
+    var versionsFetcher: MockVersionsFetcher!
 
     override func setUp() {
         super.setUp()
-        subject = WorkspaceGenerator(config: .init(projectGenerationContext: .serial))
+        versionsFetcher = MockVersionsFetcher()
+        subject = WorkspaceGenerator(config: .init(projectGenerationContext: .serial), versionsFetcher: versionsFetcher)
     }
 
     override func tearDown() {
         subject = nil
+        versionsFetcher = nil
         super.tearDown()
     }
 

--- a/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -294,7 +294,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         let temporaryPath = try self.temporaryPath()
 
         let modelLoader = try createModelLoader(projectSettings: projectSettings, targetSettings: targetSettings)
-        let subject = DescriptorGenerator()
+        let subject = DescriptorGenerator(versionsFetcher: MockVersionsFetcher())
         let writer = XcodeProjWriter()
         let linter = GraphLinter()
         let graphLoader = GraphLoader(modelLoader: modelLoader)

--- a/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -298,8 +298,9 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         let writer = XcodeProjWriter()
         let linter = GraphLinter()
         let graphLoader = GraphLoader(modelLoader: modelLoader)
+        let versions = Versions.test()
 
-        let (graph, workspace) = try graphLoader.loadWorkspace(path: temporaryPath)
+        let (graph, workspace) = try graphLoader.loadWorkspace(path: temporaryPath, versions: versions)
         try linter.lint(graph: graph).printAndThrowIfNeeded()
         let descriptor = try subject.generateWorkspace(workspace: workspace, graph: graph)
         try writer.write(workspace: descriptor)

--- a/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
@@ -61,6 +61,7 @@ final class StableXcodeProjIntegrationTests: TuistTestCase {
         let subject = DescriptorGenerator()
         let writer = XcodeProjWriter()
         let linter = GraphLinter()
+        let versions = Versions.test()
         let frameworkNodeLoader = MockFrameworkNodeLoader()
         let libraryNodeLoader = MockLibraryNodeLoader()
         let xcframeworkNodeLoader = MockXCFrameworkNodeLoader()
@@ -70,7 +71,7 @@ final class StableXcodeProjIntegrationTests: TuistTestCase {
                                       xcframeworkNodeLoader: xcframeworkNodeLoader,
                                       libraryNodeLoader: libraryNodeLoader)
 
-        let (graph, workspace) = try graphLoader.loadWorkspace(path: path)
+        let (graph, workspace) = try graphLoader.loadWorkspace(path: path, versions: versions)
         try linter.lint(graph: graph).printAndThrowIfNeeded()
         let descriptor = try subject.generateWorkspace(workspace: workspace, graph: graph)
         try writer.write(workspace: descriptor)

--- a/Tests/TuistKitIntegrationTests/Commands/DumpCommandIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Commands/DumpCommandIntegrationTests.swift
@@ -13,13 +13,16 @@ final class DumpCommandTests: TuistTestCase {
     var subject: DumpCommand!
     var parser: ArgumentParser!
     var manifestLoading: ManifestLoading!
+    var versionsFetcher: MockVersionsFetcher!
 
     override func setUp() {
         super.setUp()
         errorHandler = MockErrorHandler()
         parser = ArgumentParser.test()
         manifestLoading = ManifestLoader()
+        versionsFetcher = MockVersionsFetcher()
         subject = DumpCommand(manifestLoader: manifestLoading,
+                              versionsFetcher: versionsFetcher,
                               parser: parser)
     }
 
@@ -28,6 +31,7 @@ final class DumpCommandTests: TuistTestCase {
         parser = nil
         manifestLoading = nil
         subject = nil
+        versionsFetcher = nil
         super.tearDown()
     }
 

--- a/Tests/TuistKitTests/Commands/DumpCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/DumpCommandTests.swift
@@ -14,13 +14,16 @@ final class DumpCommandTests: TuistUnitTestCase {
     var subject: DumpCommand!
     var parser: ArgumentParser!
     var manifestLoading: ManifestLoading!
+    var versionsFetcher: MockVersionsFetcher!
 
     override func setUp() {
         super.setUp()
         errorHandler = MockErrorHandler()
         parser = ArgumentParser.test()
         manifestLoading = ManifestLoader()
+        versionsFetcher = MockVersionsFetcher()
         subject = DumpCommand(manifestLoader: manifestLoading,
+                              versionsFetcher: versionsFetcher,
                               parser: parser)
     }
 
@@ -29,6 +32,7 @@ final class DumpCommandTests: TuistUnitTestCase {
         parser = nil
         manifestLoading = nil
         subject = nil
+        versionsFetcher = nil
         super.tearDown()
     }
 

--- a/Tests/TuistKitTests/Commands/InitCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/InitCommandTests.swift
@@ -16,9 +16,11 @@ final class InitCommandTests: TuistUnitTestCase {
     var templatesDirectoryLocator: MockTemplatesDirectoryLocator!
     var templateGenerator: MockTemplateGenerator!
     var templateLoader: MockTemplateLoader!
+    var versionsFetcher: MockVersionsFetcher!
 
     override func setUp() {
         super.setUp()
+        versionsFetcher = MockVersionsFetcher()
         parser = ArgumentParser.test()
         templatesDirectoryLocator = MockTemplatesDirectoryLocator()
         templateGenerator = MockTemplateGenerator()
@@ -26,10 +28,12 @@ final class InitCommandTests: TuistUnitTestCase {
         subject = InitCommand(parser: parser,
                               templatesDirectoryLocator: templatesDirectoryLocator,
                               templateGenerator: templateGenerator,
-                              templateLoader: templateLoader)
+                              templateLoader: templateLoader,
+                              versionsFetcher: versionsFetcher)
     }
 
     override func tearDown() {
+        versionsFetcher = nil
         parser = nil
         subject = nil
         templatesDirectoryLocator = nil

--- a/Tests/TuistKitTests/Commands/LintCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/LintCommandTests.swift
@@ -17,6 +17,7 @@ final class LintCommandTests: TuistUnitTestCase {
     var manifestLoader: MockManifestLoader!
     var graphLoader: MockGraphLoader!
     var subject: LintCommand!
+    var versionsFetcher: MockVersionsFetcher!
 
     override func setUp() {
         parser = ArgumentParser.test()
@@ -24,11 +25,13 @@ final class LintCommandTests: TuistUnitTestCase {
         environmentLinter = MockEnvironmentLinter()
         manifestLoader = MockManifestLoader()
         graphLoader = MockGraphLoader()
+        versionsFetcher = MockVersionsFetcher()
         subject = LintCommand(graphLinter: graphLinter,
                               environmentLinter: environmentLinter,
                               manifestLoading: manifestLoader,
                               graphLoader: graphLoader,
-                              parser: parser)
+                              parser: parser,
+                              versionsFetcher: versionsFetcher)
         super.setUp()
     }
 
@@ -39,6 +42,7 @@ final class LintCommandTests: TuistUnitTestCase {
         manifestLoader = nil
         graphLoader = nil
         subject = nil
+        versionsFetcher = nil
     }
 
     func test_command() {

--- a/Tests/TuistKitTests/Commands/ScaffoldCommandTests.swift
+++ b/Tests/TuistKitTests/Commands/ScaffoldCommandTests.swift
@@ -18,6 +18,7 @@ final class ScaffoldCommandTests: TuistUnitTestCase {
     var templateLoader: MockTemplateLoader!
     var templatesDirectoryLocator: MockTemplatesDirectoryLocator!
     var templateGenerator: MockTemplateGenerator!
+    var versionsFetcher: MockVersionsFetcher!
 
     override func setUp() {
         super.setUp()
@@ -25,10 +26,12 @@ final class ScaffoldCommandTests: TuistUnitTestCase {
         templateLoader = MockTemplateLoader()
         templatesDirectoryLocator = MockTemplatesDirectoryLocator()
         templateGenerator = MockTemplateGenerator()
+        versionsFetcher = MockVersionsFetcher()
         subject = ScaffoldCommand(parser: parser,
                                   templateLoader: templateLoader,
                                   templatesDirectoryLocator: templatesDirectoryLocator,
-                                  templateGenerator: templateGenerator)
+                                  templateGenerator: templateGenerator,
+                                  versionsFetcher: versionsFetcher)
     }
 
     override func tearDown() {
@@ -37,6 +40,7 @@ final class ScaffoldCommandTests: TuistUnitTestCase {
         templateLoader = nil
         templatesDirectoryLocator = nil
         templateGenerator = nil
+        versionsFetcher = nil
         super.tearDown()
     }
 
@@ -56,7 +60,7 @@ final class ScaffoldCommandTests: TuistUnitTestCase {
 
     func test_adds_attributes_when_parsing() throws {
         // Given
-        templateLoader.loadTemplateStub = { _ in
+        templateLoader.loadTemplateStub = { _, _ in
             Template(description: "test",
                      attributes: [.required("name")])
         }
@@ -75,7 +79,7 @@ final class ScaffoldCommandTests: TuistUnitTestCase {
 
     func test_fails_when_attributes_not_added() throws {
         // Given
-        templateLoader.loadTemplateStub = { _ in
+        templateLoader.loadTemplateStub = { _, _ in
             Template(description: "test")
         }
 
@@ -90,7 +94,7 @@ final class ScaffoldCommandTests: TuistUnitTestCase {
 
     func test_fails_when_required_attribute_not_provided() throws {
         // Given
-        templateLoader.loadTemplateStub = { _ in
+        templateLoader.loadTemplateStub = { _, _ in
             Template.test(attributes: [.required("required")])
         }
 
@@ -111,7 +115,7 @@ final class ScaffoldCommandTests: TuistUnitTestCase {
 
     func test_optional_attribute_is_taken_from_template() throws {
         // Given
-        templateLoader.loadTemplateStub = { _ in
+        templateLoader.loadTemplateStub = { _, _ in
             Template.test(attributes: [.optional("optional", default: "optionalValue")])
         }
 
@@ -138,7 +142,7 @@ final class ScaffoldCommandTests: TuistUnitTestCase {
 
     func test_attributes_are_passed_to_generator() throws {
         // Given
-        templateLoader.loadTemplateStub = { _ in
+        templateLoader.loadTemplateStub = { _, _ in
             Template.test(attributes: [.optional("optional", default: ""),
                                        .required("required")])
         }

--- a/Tests/TuistKitTests/ProjectEditor/Mocks/MockProjectEditorMapper.swift
+++ b/Tests/TuistKitTests/ProjectEditor/Mocks/MockProjectEditorMapper.swift
@@ -1,6 +1,7 @@
 import Basic
 import Foundation
 import TuistCore
+import TuistSupport
 
 @testable import TuistCoreTesting
 @testable import TuistKit
@@ -21,7 +22,8 @@ final class MockProjectEditorMapper: ProjectEditorMapping {
              manifests: [AbsolutePath],
              helpers: [AbsolutePath],
              templates: [AbsolutePath],
-             projectDescriptionPath: AbsolutePath) -> (Project, Graph) {
+             projectDescriptionPath: AbsolutePath,
+             versions _: Versions) -> (Project, Graph) {
         mapArgs.append((tuistPath: tuistPath,
                         sourceRootPath: sourceRootPath,
                         manifests: manifests,

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
@@ -29,6 +29,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
     var helpersDirectoryLocator: MockHelpersDirectoryLocator!
     var writer: MockXcodeProjWriter!
     var templatesDirectoryLocator: MockTemplatesDirectoryLocator!
+    var versionsFetcher: MockVersionsFetcher!
     var subject: ProjectEditor!
 
     override func setUp() {
@@ -40,13 +41,15 @@ final class ProjectEditorTests: TuistUnitTestCase {
         helpersDirectoryLocator = MockHelpersDirectoryLocator()
         writer = MockXcodeProjWriter()
         templatesDirectoryLocator = MockTemplatesDirectoryLocator()
+        versionsFetcher = MockVersionsFetcher()
         subject = ProjectEditor(generator: generator,
                                 projectEditorMapper: projectEditorMapper,
                                 resourceLocator: resourceLocator,
                                 manifestFilesLocator: manifestFilesLocator,
                                 helpersDirectoryLocator: helpersDirectoryLocator,
                                 writer: writer,
-                                templatesDirectoryLocator: templatesDirectoryLocator)
+                                templatesDirectoryLocator: templatesDirectoryLocator,
+                                versionsFetcher: versionsFetcher)
     }
 
     override func tearDown() {
@@ -57,6 +60,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         manifestFilesLocator = nil
         helpersDirectoryLocator = nil
         templatesDirectoryLocator = nil
+        versionsFetcher = nil
         subject = nil
     }
 

--- a/Tests/TuistKitTests/Services/Cloud/CloudAuthServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudAuthServiceTests.swift
@@ -39,13 +39,16 @@ final class CloudAuthServiceTests: TuistUnitTestCase {
     var cloudSessionController: MockCloudSessionController!
     var generatorModelLoader: MockGeneratorModelLoader!
     var subject: CloudAuthService!
+    var versionsFetcher: MockVersionsFetcher!
 
     override func setUp() {
         super.setUp()
         cloudSessionController = MockCloudSessionController()
         generatorModelLoader = MockGeneratorModelLoader(basePath: FileHandler.shared.currentPath)
+        versionsFetcher = MockVersionsFetcher()
         subject = CloudAuthService(cloudSessionController: cloudSessionController,
-                                   generatorModelLoader: generatorModelLoader)
+                                   generatorModelLoader: generatorModelLoader,
+                                   versionsFetcher: versionsFetcher)
     }
 
     override func tearDown() {
@@ -53,6 +56,7 @@ final class CloudAuthServiceTests: TuistUnitTestCase {
         cloudSessionController = nil
         generatorModelLoader = nil
         subject = nil
+        versionsFetcher = nil
     }
 
     func test_authenticate_when_cloudURL_is_missing() {

--- a/Tests/TuistKitTests/Services/Cloud/CloudLogoutServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudLogoutServiceTests.swift
@@ -38,20 +38,24 @@ final class CloudLogoutServiceErrorTests: TuistUnitTestCase {
 final class CloudLogoutServiceTests: TuistUnitTestCase {
     var cloudSessionController: MockCloudSessionController!
     var generatorModelLoader: MockGeneratorModelLoader!
+    var versionsFetcher: MockVersionsFetcher!
     var subject: CloudLogoutService!
 
     override func setUp() {
         super.setUp()
         cloudSessionController = MockCloudSessionController()
         generatorModelLoader = MockGeneratorModelLoader(basePath: FileHandler.shared.currentPath)
+        versionsFetcher = MockVersionsFetcher()
         subject = CloudLogoutService(cloudSessionController: cloudSessionController,
-                                     generatorModelLoader: generatorModelLoader)
+                                     generatorModelLoader: generatorModelLoader,
+                                     versionsFetcher: versionsFetcher)
     }
 
     override func tearDown() {
         super.tearDown()
         cloudSessionController = nil
         generatorModelLoader = nil
+        versionsFetcher = nil
         subject = nil
     }
 

--- a/Tests/TuistKitTests/Services/Cloud/CloudSessionServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudSessionServiceTests.swift
@@ -39,19 +39,23 @@ final class CloudSessionServiceTests: TuistUnitTestCase {
     var cloudSessionController: MockCloudSessionController!
     var generatorModelLoader: MockGeneratorModelLoader!
     var subject: CloudSessionService!
+    var versionsFetcher: MockVersionsFetcher!
 
     override func setUp() {
         super.setUp()
         cloudSessionController = MockCloudSessionController()
         generatorModelLoader = MockGeneratorModelLoader(basePath: FileHandler.shared.currentPath)
+        versionsFetcher = MockVersionsFetcher()
         subject = CloudSessionService(cloudSessionController: cloudSessionController,
-                                      generatorModelLoader: generatorModelLoader)
+                                      generatorModelLoader: generatorModelLoader,
+                                      versionsFetcher: versionsFetcher)
     }
 
     override func tearDown() {
         super.tearDown()
         cloudSessionController = nil
         generatorModelLoader = nil
+        versionsFetcher = nil
         subject = nil
     }
 

--- a/Tests/TuistLoaderIntegrationTests/Loaders/ManifestLoaderIntegrationTests.swift
+++ b/Tests/TuistLoaderIntegrationTests/Loaders/ManifestLoaderIntegrationTests.swift
@@ -21,6 +21,7 @@ final class ManifestLoaderTests: TuistTestCase {
 
     func test_loadConfig() throws {
         // Given
+        let versions = Versions.test()
         let temporaryPath = try self.temporaryPath()
         let content = """
         import ProjectDescription
@@ -33,12 +34,13 @@ final class ManifestLoaderTests: TuistTestCase {
                           encoding: .utf8)
 
         // When
-        _ = try subject.loadConfig(at: temporaryPath)
+        _ = try subject.loadConfig(at: temporaryPath, versions: versions)
     }
 
     func test_loadProject() throws {
         // Given
         let temporaryPath = try self.temporaryPath()
+        let versions = Versions.test()
         let content = """
         import ProjectDescription
         let project = Project(name: "tuist")
@@ -50,7 +52,7 @@ final class ManifestLoaderTests: TuistTestCase {
                           encoding: .utf8)
 
         // When
-        let got = try subject.loadProject(at: temporaryPath)
+        let got = try subject.loadProject(at: temporaryPath, versions: versions)
 
         // Then
         XCTAssertEqual(got.name, "tuist")
@@ -59,6 +61,7 @@ final class ManifestLoaderTests: TuistTestCase {
     func test_loadWorkspace() throws {
         // Given
         let temporaryPath = try self.temporaryPath()
+        let versions = Versions.test()
         let content = """
         import ProjectDescription
         let workspace = Workspace(name: "tuist", projects: [])
@@ -70,7 +73,7 @@ final class ManifestLoaderTests: TuistTestCase {
                           encoding: .utf8)
 
         // When
-        let got = try subject.loadWorkspace(at: temporaryPath)
+        let got = try subject.loadWorkspace(at: temporaryPath, versions: versions)
 
         // Then
         XCTAssertEqual(got.name, "tuist")
@@ -79,6 +82,7 @@ final class ManifestLoaderTests: TuistTestCase {
     func test_loadSetup() throws {
         // Given
         let temporaryPath = try self.temporaryPath()
+        let versions = Versions.test()
         let content = """
         import ProjectDescription
         let setup = Setup([
@@ -92,7 +96,7 @@ final class ManifestLoaderTests: TuistTestCase {
                           encoding: .utf8)
 
         // When
-        let got = try subject.loadSetup(at: temporaryPath)
+        let got = try subject.loadSetup(at: temporaryPath, versions: versions)
 
         // Then
         let customUp = got.first as? UpCustom
@@ -105,6 +109,7 @@ final class ManifestLoaderTests: TuistTestCase {
     func test_loadTemplate() throws {
         // Given
         let temporaryPath = try self.temporaryPath()
+        let versions = Versions.test()
         let content = """
         import ProjectDescription
         
@@ -119,7 +124,7 @@ final class ManifestLoaderTests: TuistTestCase {
                           encoding: .utf8)
 
         // When
-        let got = try subject.loadTemplate(at: temporaryPath)
+        let got = try subject.loadTemplate(at: temporaryPath, versions: versions)
 
         // Then
         XCTAssertEqual(got.description, "Template description")
@@ -128,6 +133,7 @@ final class ManifestLoaderTests: TuistTestCase {
     func test_load_invalidFormat() throws {
         // Given
         let temporaryPath = try self.temporaryPath()
+        let versions = Versions.test()
         let content = """
         import ABC
         let project
@@ -140,14 +146,15 @@ final class ManifestLoaderTests: TuistTestCase {
 
         // When / Then
         XCTAssertThrowsError(
-            try subject.loadProject(at: temporaryPath)
+            try subject.loadProject(at: temporaryPath, versions: versions)
         )
     }
 
     func test_load_missingManifest() throws {
         let temporaryPath = try self.temporaryPath()
+        let versions = Versions.test()
         XCTAssertThrowsError(
-            try subject.loadProject(at: temporaryPath)
+            try subject.loadProject(at: temporaryPath, versions: versions)
         ) { error in
             XCTAssertEqual(error as? ManifestLoaderError, ManifestLoaderError.manifestNotFound(.project, temporaryPath))
         }

--- a/Tests/TuistLoaderIntegrationTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilderIntegrationTests.swift
+++ b/Tests/TuistLoaderIntegrationTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilderIntegrationTests.swift
@@ -28,6 +28,7 @@ final class ProjectDescriptionHelpersBuilderIntegrationTests: TuistTestCase {
     func test_build_when_the_helpers_is_a_dylib() throws {
         // Given
         let path = try temporaryPath()
+        let versions = Versions.test()
         subject = ProjectDescriptionHelpersBuilder(cacheDirectory: path,
                                                    helpersDirectoryLocator: helpersDirectoryLocator)
         let helpersPath = path.appending(RelativePath("\(Constants.tuistDirectoryName)/\(Constants.helpersDirectoryName)"))
@@ -38,7 +39,7 @@ final class ProjectDescriptionHelpersBuilderIntegrationTests: TuistTestCase {
         print(helpersPath)
 
         // When
-        let paths = try (0 ..< 3).map { _ in try subject.build(at: path, projectDescriptionPath: projectDescriptionPath) }
+        let paths = try (0 ..< 3).map { _ in try subject.build(at: path, projectDescriptionPath: projectDescriptionPath, versions: versions) }
 
         // Then
         XCTAssertEqual(Set(paths).count, 1)

--- a/Tests/TuistLoaderTests/Loaders/GeneratorModelLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/GeneratorModelLoaderTests.swift
@@ -23,14 +23,17 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
     typealias ArgumentsManifest = ProjectDescription.Arguments
 
     private var manifestLinter: MockManifestLinter!
+    private var versions: Versions!
 
     override func setUp() {
         super.setUp()
+        versions = Versions.test()
         manifestLinter = MockManifestLinter()
     }
 
     override func tearDown() {
         manifestLinter = nil
+        versions = nil
         super.tearDown()
     }
 
@@ -45,7 +48,7 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
         let subject = createGeneratorModelLoader(with: manifestLoader)
 
         // When
-        let model = try subject.loadProject(at: temporaryPath)
+        let model = try subject.loadProject(at: temporaryPath, versions: versions)
 
         // Then
         XCTAssertEqual(model.name, "SomeProject")
@@ -69,7 +72,7 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
         let subject = createGeneratorModelLoader(with: manifestLoader)
 
         // When
-        let model = try subject.loadProject(at: temporaryPath)
+        let model = try subject.loadProject(at: temporaryPath, versions: versions)
 
         // Then
         XCTAssertEqual(model.targets.count, 2)
@@ -99,7 +102,7 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
         let subject = createGeneratorModelLoader(with: manifestLoader)
 
         // When
-        let model = try subject.loadProject(at: temporaryPath)
+        let model = try subject.loadProject(at: temporaryPath, versions: versions)
 
         // Then
         XCTAssertEqual(model.targets.map(\.name), [
@@ -127,7 +130,7 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
         let subject = createGeneratorModelLoader(with: manifestLoader)
 
         // When
-        let model = try subject.loadProject(at: temporaryPath)
+        let model = try subject.loadProject(at: temporaryPath, versions: versions)
 
         // Then
         XCTAssertEqual(model.additionalFiles, files.map { .file(path: $0) })
@@ -151,7 +154,7 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
         let subject = createGeneratorModelLoader(with: manifestLoader)
 
         // When
-        let model = try subject.loadProject(at: temporaryPath)
+        let model = try subject.loadProject(at: temporaryPath, versions: versions)
 
         // Then
         XCTAssertEqual(model.additionalFiles, files.map { .folderReference(path: $0) })
@@ -178,7 +181,7 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
                                            manifestLinter: manifestLinter)
 
         // When
-        let model = try subject.loadProject(at: temporaryPath)
+        let model = try subject.loadProject(at: temporaryPath, versions: versions)
 
         // Then
         XCTAssertEqual(model.fileName, "one SomeProject two")
@@ -206,7 +209,7 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
                                            manifestLinter: manifestLinter)
 
         // When
-        let model = try subject.loadProject(at: temporaryPath)
+        let model = try subject.loadProject(at: temporaryPath, versions: versions)
 
         // Then
         XCTAssertEqual(model.fileName, "one SomeProject two")
@@ -234,7 +237,7 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
                                            manifestLinter: manifestLinter)
 
         // When
-        let model = try subject.loadProject(at: temporaryPath)
+        let model = try subject.loadProject(at: temporaryPath, versions: versions)
 
         // Then
         XCTAssertEqual(model.organizationName, "SomeOrganization")
@@ -262,7 +265,7 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
                                            manifestLinter: manifestLinter)
 
         // When
-        let model = try subject.loadProject(at: temporaryPath)
+        let model = try subject.loadProject(at: temporaryPath, versions: versions)
 
         // Then
         XCTAssertEqual(model.organizationName, "tuist")
@@ -286,7 +289,7 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
                                            manifestLinter: manifestLinter)
 
         // When
-        let model = try subject.loadProject(at: temporaryPath)
+        let model = try subject.loadProject(at: temporaryPath, versions: versions)
 
         // Then
         XCTAssertFalse(model.autogenerateSchemes)
@@ -303,7 +306,7 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
         let subject = createGeneratorModelLoader(with: manifestLoader)
 
         // When
-        let model = try subject.loadWorkspace(at: temporaryPath)
+        let model = try subject.loadWorkspace(at: temporaryPath, versions: versions)
 
         // Then
         XCTAssertEqual(model.name, "SomeWorkspace")
@@ -326,7 +329,7 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
         let subject = createGeneratorModelLoader(with: manifestLoader)
 
         // When
-        let model = try subject.loadWorkspace(at: temporaryPath)
+        let model = try subject.loadWorkspace(at: temporaryPath, versions: versions)
 
         // Then
         XCTAssertEqual(model.name, "SomeWorkspace")
@@ -354,7 +357,7 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
         let subject = createGeneratorModelLoader(with: manifestLoader)
 
         // When
-        let model = try subject.loadWorkspace(at: temporaryPath)
+        let model = try subject.loadWorkspace(at: temporaryPath, versions: versions)
 
         // Then
         XCTAssertEqual(model.name, "SomeWorkspace")
@@ -380,7 +383,7 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
         let subject = createGeneratorModelLoader(with: manifestLoader)
 
         // When
-        let model = try subject.loadWorkspace(at: temporaryPath)
+        let model = try subject.loadWorkspace(at: temporaryPath, versions: versions)
 
         // Then
         XCTAssertEqual(model.name, "SomeWorkspace")
@@ -401,7 +404,7 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
         let subject = createGeneratorModelLoader(with: manifestLoader)
 
         // When
-        let model = try subject.loadWorkspace(at: temporaryPath)
+        let model = try subject.loadWorkspace(at: temporaryPath, versions: versions)
 
         // Then
         XCTAssertPrinterOutputContains("""
@@ -421,13 +424,13 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
     func createManifestLoader(with projects: [AbsolutePath: ProjectDescription.Project],
                               configs: [AbsolutePath: ProjectDescription.Config] = [:]) -> ManifestLoading {
         let manifestLoader = MockManifestLoader()
-        manifestLoader.loadProjectStub = { path in
+        manifestLoader.loadProjectStub = { path, _ in
             guard let manifest = projects[path] else {
                 throw ManifestLoaderError.manifestNotFound(path)
             }
             return manifest
         }
-        manifestLoader.loadConfigStub = { path in
+        manifestLoader.loadConfigStub = { path, _ in
             guard let manifest = configs[path] else {
                 throw ManifestLoaderError.manifestNotFound(path)
             }
@@ -450,7 +453,7 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
     func createManifestLoader(with workspaces: [AbsolutePath: ProjectDescription.Workspace],
                               projects: [AbsolutePath] = []) -> ManifestLoading {
         let manifestLoader = MockManifestLoader()
-        manifestLoader.loadWorkspaceStub = { path in
+        manifestLoader.loadWorkspaceStub = { path, _ in
             guard let manifest = workspaces[path] else {
                 throw ManifestLoaderError.manifestNotFound(path)
             }

--- a/Tests/TuistLoaderTests/Loaders/SetupLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/SetupLoaderTests.swift
@@ -11,18 +11,21 @@ final class SetupLoaderTests: TuistUnitTestCase {
     var subject: SetupLoader!
     var upLinter: MockUpLinter!
     var manifestLoader: MockManifestLoader!
+    var versionsFetcher: MockVersionsFetcher!
 
     override func setUp() {
         super.setUp()
         upLinter = MockUpLinter()
         manifestLoader = MockManifestLoader()
-        subject = SetupLoader(upLinter: upLinter, manifestLoader: manifestLoader)
+        versionsFetcher = MockVersionsFetcher()
+        subject = SetupLoader(upLinter: upLinter, manifestLoader: manifestLoader, versionsFetcher: versionsFetcher)
     }
 
     override func tearDown() {
         upLinter = nil
         manifestLoader = nil
         subject = nil
+        versionsFetcher = nil
         super.tearDown()
     }
 
@@ -30,7 +33,7 @@ final class SetupLoaderTests: TuistUnitTestCase {
         // given
         let projectPath = AbsolutePath("/test/test1")
         var receivedPaths = [String]()
-        manifestLoader.loadSetupStub = { gotPath in
+        manifestLoader.loadSetupStub = { gotPath, _ in
             receivedPaths.append(gotPath.pathString)
             return []
         }
@@ -51,7 +54,7 @@ final class SetupLoaderTests: TuistUnitTestCase {
         mockUp2.isMetStub = { _ in false }
         var lintedUps = [Upping]()
         upLinter.lintStub = { up in lintedUps.append(up); return [] }
-        manifestLoader.loadSetupStub = { _ in [mockUp1, mockUp2] }
+        manifestLoader.loadSetupStub = { _, _ in [mockUp1, mockUp2] }
 
         // when / then
         XCTAssertNoThrow(try subject.meet(at: projectPath))
@@ -68,7 +71,7 @@ final class SetupLoaderTests: TuistUnitTestCase {
     func test_meet_when_loadSetup_throws() {
         // given
         let projectPath = AbsolutePath("/test/test1")
-        manifestLoader.loadSetupStub = { _ in throw ManifestLoaderError.manifestNotFound(.setup, projectPath) }
+        manifestLoader.loadSetupStub = { _, _ in throw ManifestLoaderError.manifestNotFound(.setup, projectPath) }
 
         // when / then
         XCTAssertThrowsSpecific(try subject.meet(at: projectPath),
@@ -101,7 +104,7 @@ final class SetupLoaderTests: TuistUnitTestCase {
             }
             return []
         }
-        manifestLoader.loadSetupStub = { _ in mockUps }
+        manifestLoader.loadSetupStub = { _, _ in mockUps }
 
         // when / then
         XCTAssertThrowsSpecific(try subject.meet(at: projectPath),

--- a/Tests/TuistLoaderTests/Loaders/TemplateLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/TemplateLoaderTests.swift
@@ -27,26 +27,28 @@ final class TemplateLoaderTests: TuistUnitTestCase {
     func test_loadTemplate_when_not_found() throws {
         // Given
         let temporaryPath = try self.temporaryPath()
-        manifestLoader.loadTemplateStub = { path in
+        let versions = Versions.test()
+        manifestLoader.loadTemplateStub = { path, _ in
             throw ManifestLoaderError.manifestNotFound(path)
         }
 
         // Then
-        XCTAssertThrowsSpecific(try subject.loadTemplate(at: temporaryPath),
+        XCTAssertThrowsSpecific(try subject.loadTemplate(at: temporaryPath, versions: versions),
                                 ManifestLoaderError.manifestNotFound(temporaryPath))
     }
 
     func test_loadTemplate_files() throws {
         // Given
         let temporaryPath = try self.temporaryPath()
-        manifestLoader.loadTemplateStub = { _ in
+        let versions = Versions.test()
+        manifestLoader.loadTemplateStub = { _, _ in
             ProjectDescription.Template(description: "desc",
                                         files: [ProjectDescription.Template.File(path: "generateOne",
                                                                                  contents: .file("fileOne"))])
         }
 
         // When
-        let got = try subject.loadTemplate(at: temporaryPath)
+        let got = try subject.loadTemplate(at: temporaryPath, versions: versions)
 
         // Then
         XCTAssertEqual(got, TuistCore.Template(description: "desc",

--- a/Tests/TuistLoaderTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasherTests.swift
+++ b/Tests/TuistLoaderTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasherTests.swift
@@ -18,13 +18,14 @@ class ProjectDescriptionHelpersHasherTests: TuistUnitTestCase {
     func test_hash() throws {
         // Given
         let temporaryDir = try temporaryPath()
+        let versions = Versions.test()
         let helperPath = temporaryDir.appending(component: "Project+Templates.swift")
         try FileHandler.shared.write("import ProjectDescription", path: helperPath, atomically: true)
         environment.tuistVariables = ["TUIST_VARIABLE": "TEST"]
 
         // Then
         for _ in 0 ..< 20 {
-            let got = try subject.hash(helpersDirectory: temporaryDir)
+            let got = try subject.hash(helpersDirectory: temporaryDir, versions: versions)
             XCTAssertEqual(got, "d19835f96b16a558457fc33b169adb9c")
         }
     }

--- a/Tests/TuistLoaderTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasherTests.swift
+++ b/Tests/TuistLoaderTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasherTests.swift
@@ -26,7 +26,7 @@ class ProjectDescriptionHelpersHasherTests: TuistUnitTestCase {
         // Then
         for _ in 0 ..< 20 {
             let got = try subject.hash(helpersDirectory: temporaryDir, versions: versions)
-            XCTAssertEqual(got, "d19835f96b16a558457fc33b169adb9c")
+            XCTAssertEqual(got, "80bd818a3c6eb57110056c17592caf0a")
         }
     }
 

--- a/Tests/TuistLoaderTests/Up/UpHomebrewTests.swift
+++ b/Tests/TuistLoaderTests/Up/UpHomebrewTests.swift
@@ -47,7 +47,7 @@ final class UpHomebrewTests: TuistUnitTestCase {
         let temporaryPath = try self.temporaryPath()
         let subject = UpHomebrew(packages: ["swiftlint"])
 
-        system.whichStub = { _ in nil }
+        system.whichStub = { _ in throw TestError("swiftlint doesn't exist") }
         system.succeedCommand("/usr/bin/ruby",
                               "-e",
                               "\"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)\"")

--- a/Tests/TuistSupportIntegrationTests/System/SystemIntegrationTests.swift
+++ b/Tests/TuistSupportIntegrationTests/System/SystemIntegrationTests.swift
@@ -84,6 +84,10 @@ final class SystemIntegrationTests: TuistTestCase {
         }
     }
 
+    func test_swiftVersion() throws {
+        XCTAssertNoThrow(try subject.swiftVersion())
+    }
+
     func sandbox(_ name: String, value: String, do block: () throws -> Void) rethrows {
         try? ProcessEnv.setVar(name, value: value)
         _ = try? block()

--- a/Tests/TuistSupportTests/Extensions/Version+ExtrasTests.swift
+++ b/Tests/TuistSupportTests/Extensions/Version+ExtrasTests.swift
@@ -1,0 +1,21 @@
+import Basic
+import Foundation
+import SPMUtility
+import XCTest
+
+@testable import TuistSupport
+
+final class VersionExtrasTests: XCTestCase {
+    func test_swiftVersion_when_patchComponentIsMissing() {
+        // Given
+        let version = "5.2"
+
+        // When
+        let got = Version.swiftVersion(version)
+
+        // Then
+        XCTAssertEqual(got.major, 5)
+        XCTAssertEqual(got.minor, 2)
+        XCTAssertEqual(got.patch, 0)
+    }
+}

--- a/Tests/TuistSupportTests/Versions/VersionsFetcherTests.swift
+++ b/Tests/TuistSupportTests/Versions/VersionsFetcherTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import TuistSupport
+import XCTest
+@testable import TuistSupportTesting
+
+final class VersionsFetcherTests: TuistUnitTestCase {
+    var subject: VersionsFetcher!
+
+    override func setUp() {
+        subject = VersionsFetcher()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        subject = nil
+    }
+
+    func test_fetch() throws {
+        // When
+        XCTAssertNoThrow(try subject.fetch())
+    }
+}


### PR DESCRIPTION
### Context 📝
:warning: Sorry for the long PR in advance, but it's mostly changes in the method definitions to inject a new parameter, `version`, that is used further down in the generation process.

While using Tuist, I realized that some of our logic relies on a `Constants.swiftVersion` attribute that is hardcoded. That variable always point to the latest available version of Swift. By doing that, some of our logic **assumes that users of Tuist have the same version of Swift in their environment**, and that might not be true. Although it hasn't been a big issue so far, it might be, and for that reason I opened a PR to remove that static variable.

Instead, I defined a new struct, `Versions`, that contains versions of system tools that Tuist interacts with *(e.g. Swift, Xcode)*. Versions are obtained as one of the first steps in some of the commands, and then passed down for some generation components to use them. 

As you can note, I intentionally decided to use dependency injection for 2 reasons:
- Make explicit that this is an operation with the system and therefore needs to be explicit and executed before anything else.
- To avoid ending up with a shared and cached state that might lead to race conditions or complicate writing tests.

I'm aware this required a lot of refactoring of the method definitions, but I think it's worth it to make sure that Tuist works deterministically and free of side effects.

