### PR TITLE
Linting: Only warn when copying the target Info.plist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Changed
+
+- Only warn about copying Info.plist when it's the target's Info.plist https://github.com/tuist/tuist/pull/1203 by @sgrgrsn
+
 ## 1.6.0
 
 ### Fixed

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -94,13 +94,13 @@ class TargetLinter: TargetLinting {
         var issues: [LintingIssue] = []
 
         let files = target.resources.map(\.path)
-        let infoPlists = files.filter { $0.pathString.contains("Info.plist") }
         let entitlements = files.filter { $0.pathString.contains(".entitlements") }
 
-        issues.append(contentsOf: infoPlists.map {
-            let reason = "Info.plist at path \($0.pathString) being copied into the target \(target.name) product."
-            return LintingIssue(reason: reason, severity: .warning)
-        })
+        if let targetInfoPlistPath = target.infoPlist?.path, files.contains(targetInfoPlistPath) {
+            let reason = "Info.plist at path \(targetInfoPlistPath) being copied into the target \(target.name) product."
+            issues.append(LintingIssue(reason: reason, severity: .warning))
+        }
+
         issues.append(contentsOf: entitlements.map {
             let reason = "Entitlements file at path \($0.pathString) being copied into the target \(target.name) product."
             return LintingIssue(reason: reason, severity: .warning)

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -70,12 +70,21 @@ final class TargetLinterTests: TuistUnitTestCase {
     }
 
     func test_lint_when_a_infoplist_file_is_being_copied() {
-        let path = AbsolutePath("/Info.plist")
-        let target = Target.test(resources: [.file(path: path)])
+        let infoPlistPath = AbsolutePath("/Info.plist")
+        let googeServiceInfoPlistPath = AbsolutePath("/GoogleService-Info.plist")
+
+        let target = Target.test(
+            infoPlist: .file(path: infoPlistPath),
+            resources: [
+                .file(path: infoPlistPath),
+                .file(path: googeServiceInfoPlistPath),
+            ]
+        )
 
         let got = subject.lint(target: target)
 
-        XCTContainsLintingIssue(got, LintingIssue(reason: "Info.plist at path \(path.pathString) being copied into the target \(target.name) product.", severity: .warning))
+        XCTContainsLintingIssue(got, LintingIssue(reason: "Info.plist at path \(infoPlistPath.pathString) being copied into the target \(target.name) product.", severity: .warning))
+        XCTDoesNotContainLintingIssue(got, LintingIssue(reason: "Info.plist at path \(googeServiceInfoPlistPath.pathString) being copied into the target \(target.name) product.", severity: .warning))
     }
 
     func test_lint_when_a_entitlements_file_is_being_copied() {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1170

### Short description 📝

When adding a framework (eg. Firebase) that requires you to add a .plist file as a resource Tuist will raise an unnecessary warning about copying an Info.plist file.

While it's still useful to get the warning if you by mistake copy the actual Info.plist file for the target to the resources, I still think we should keep the check as a part of the target linting.

### Solution 📦

Instead of checking all the copied file paths to contain the phrase "Info.plist" we should instead check if the defined Info.plist path on the target is contained in the copied resources.

### Implementation 👩‍💻👨‍💻

- [x] Reproduce the issue in the TargetLinterTests
- [x] Adjust the check in `lintCopiedFiles` in `TargetLinter` to check if the target's Info.plist path is contained the list of copied files
