### PR TITLE
Correct macOS fixture class name

### DIFF
--- a/Tests/Fixtures/Frameworks/macOS/macOS.swift
+++ b/Tests/Fixtures/Frameworks/macOS/macOS.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-public final class watchOS {
+public final class macOS {
     public init() {}
 }


### PR DESCRIPTION
### Short description 📝

Noticed that the macOS fixture defined a class with name `watchOS`. 

### Solution 📦

`s/watchOS/macOS/g`
