### PR TITLE
Adopt ArgumentParser library for Up command

### DIFF
--- a/Sources/TuistKit/Commands/CommandRegistry.swift
+++ b/Sources/TuistKit/Commands/CommandRegistry.swift
@@ -24,7 +24,6 @@ public final class CommandRegistry {
         register(command: VersionCommand.self)
         register(command: CreateIssueCommand.self)
         register(command: FocusCommand.self)
-        register(command: UpCommand.self)
         register(command: GraphCommand.self)
         register(command: EditCommand.self)
         register(command: CacheCommand.self)

--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -6,9 +6,12 @@ public struct TuistCommand: ParsableCommand {
     public init() {}
 
     public static var configuration: CommandConfiguration {
-        CommandConfiguration(commandName: "tuist",
-                             abstract: "Generate, build and test your Xcode projects.",
-                             subcommands: [GenerateCommand.self])
+		CommandConfiguration(commandName: "tuist",
+							 abstract: "Generate, build and test your Xcode projects.",
+							 subcommands: [
+								GenerateCommand.self,
+								UpCommand.self
+		])
     }
 
     public static func main(_ arguments: [String]? = nil) -> Never {

--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -6,12 +6,12 @@ public struct TuistCommand: ParsableCommand {
     public init() {}
 
     public static var configuration: CommandConfiguration {
-		CommandConfiguration(commandName: "tuist",
-							 abstract: "Generate, build and test your Xcode projects.",
-							 subcommands: [
-								GenerateCommand.self,
-								UpCommand.self
-		])
+        CommandConfiguration(commandName: "tuist",
+                             abstract: "Generate, build and test your Xcode projects.",
+                             subcommands: [
+                                 GenerateCommand.self,
+                                 UpCommand.self,
+                             ])
     }
 
     public static func main(_ arguments: [String]? = nil) -> Never {

--- a/Sources/TuistKit/Commands/UpCommand.swift
+++ b/Sources/TuistKit/Commands/UpCommand.swift
@@ -3,21 +3,21 @@ import Foundation
 
 /// Command that configures the environment to work on the project.
 struct UpCommand: ParsableCommand {
-	static var configuration: CommandConfiguration {
-		CommandConfiguration(
-			commandName: "up",
-			abstract: "Configures the environment for the project.",
-			subcommands: []
-		)
-	}
-	
-	@Option(
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "up",
+            abstract: "Configures the environment for the project.",
+            subcommands: []
+        )
+    }
+
+    @Option(
         name: .shortAndLong,
         help: "The path to the directory that contains the project."
     )
     var path: String?
-	
-	func run() throws {
-		try UpService().run(path: path)
-	}
+
+    func run() throws {
+        try UpService().run(path: path)
+    }
 }

--- a/Sources/TuistKit/Commands/UpCommand.swift
+++ b/Sources/TuistKit/Commands/UpCommand.swift
@@ -1,67 +1,23 @@
-import Basic
+import ArgumentParser
 import Foundation
-import SPMUtility
-import TuistLoader
-import TuistSupport
 
 /// Command that configures the environment to work on the project.
-class UpCommand: NSObject, Command {
-    // MARK: - Attributes
-
-    /// Name of the command.
-    static let command = "up"
-
-    /// Description of the command.
-    static let overview = "Configures the environment for the project."
-
-    /// Path to the project directory.
-    let pathArgument: OptionArgument<String>
-
-    /// Instance to load the setup manifest and perform the project setup.
-    private let setupLoader: SetupLoading
-
-    // MARK: - Init
-
-    /// Initializes the command with the CLI parser.
-    ///
-    /// - Parameter parser: CLI parser where the command should register itself.
-    public required convenience init(parser: ArgumentParser) {
-        self.init(parser: parser,
-                  setupLoader: SetupLoader())
-    }
-
-    /// Initializes the command with its arguments.
-    ///
-    /// - Parameters:
-    ///   - parser: CLI parser where the command should register itself.
-    ///   - setupLoader: Instance to load the setup manifest and perform the project setup.
-    init(parser: ArgumentParser,
-         setupLoader: SetupLoading) {
-        let subParser = parser.add(subparser: UpCommand.command, overview: UpCommand.overview)
-        pathArgument = subParser.add(option: "--path",
-                                     shortName: "-p",
-                                     kind: String.self,
-                                     usage: "The path to the directory that contains the project.",
-                                     completion: .filename)
-        self.setupLoader = setupLoader
-    }
-
-    /// Runs the command using the result from parsing the command line arguments.
-    ///
-    /// - Throws: An error if the the configuration of the environment fails.
-    func run(with arguments: ArgumentParser.Result) throws {
-        try setupLoader.meet(at: path(arguments: arguments))
-    }
-
-    /// Parses the arguments and returns the path to the directory where
-    /// the up command should be ran.
-    ///
-    /// - Parameter arguments: Result from parsing the command line arguments.
-    /// - Returns: Path to be used for the up command.
-    private func path(arguments: ArgumentParser.Result) -> AbsolutePath {
-        guard let path = arguments.get(pathArgument) else {
-            return FileHandler.shared.currentPath
-        }
-        return AbsolutePath(path, relativeTo: FileHandler.shared.currentPath)
-    }
+struct UpCommand: ParsableCommand {
+	static var configuration: CommandConfiguration {
+		CommandConfiguration(
+			commandName: "up",
+			abstract: "Configures the environment for the project.",
+			subcommands: []
+		)
+	}
+	
+	@Option(
+        name: .shortAndLong,
+        help: "The path to the directory that contains the project."
+    )
+    var path: String?
+	
+	func run() throws {
+		try UpService().run(path: path)
+	}
 }

--- a/Sources/TuistKit/Services/UpService.swift
+++ b/Sources/TuistKit/Services/UpService.swift
@@ -8,26 +8,26 @@ class UpService {
 
     /// Instance to load the setup manifest and perform the project setup.
     private let setupLoader: SetupLoading
-	
-	// MARK: - Init
+
+    // MARK: - Init
 
     init(setupLoader: SetupLoading = SetupLoader()) {
         self.setupLoader = setupLoader
     }
 
     func run(path: String?) throws {
-		let path = self.path(path)
-		try setupLoader.meet(at: path)
+        let path = self.path(path)
+        try setupLoader.meet(at: path)
     }
-	
-	// MARK: - Fileprivate
+
+    // MARK: - Fileprivate
 
     /// Parses the arguments and returns the path to the directory where
     /// the up command should be ran.
     ///
     /// - Parameter path: The path from parsing the command line arguments.
     /// - Returns: Path to be used for the up command.
-	private func path(_ path: String?) -> AbsolutePath {
+    private func path(_ path: String?) -> AbsolutePath {
         guard let path = path else {
             return FileHandler.shared.currentPath
         }

--- a/Sources/TuistKit/Services/UpService.swift
+++ b/Sources/TuistKit/Services/UpService.swift
@@ -1,0 +1,36 @@
+import Basic
+import TuistGenerator
+import TuistLoader
+import TuistSupport
+
+class UpService {
+    // MARK: - Attributes
+
+    /// Instance to load the setup manifest and perform the project setup.
+    private let setupLoader: SetupLoading
+	
+	// MARK: - Init
+
+    init(setupLoader: SetupLoading = SetupLoader()) {
+        self.setupLoader = setupLoader
+    }
+
+    func run(path: String?) throws {
+		let path = self.path(path)
+		try setupLoader.meet(at: path)
+    }
+	
+	// MARK: - Fileprivate
+
+    /// Parses the arguments and returns the path to the directory where
+    /// the up command should be ran.
+    ///
+    /// - Parameter path: The path from parsing the command line arguments.
+    /// - Returns: Path to be used for the up command.
+	private func path(_ path: String?) -> AbsolutePath {
+        guard let path = path else {
+            return FileHandler.shared.currentPath
+        }
+        return AbsolutePath(path, relativeTo: FileHandler.shared.currentPath)
+    }
+}

--- a/Tests/TuistKitTests/Services/UpServiceTests.swift
+++ b/Tests/TuistKitTests/Services/UpServiceTests.swift
@@ -1,52 +1,41 @@
 import Basic
 import Foundation
-import SPMUtility
+import TuistCore
 import TuistLoader
+import TuistSupport
+import XcodeProj
 import XCTest
-
+@testable import TuistCoreTesting
 @testable import TuistKit
 @testable import TuistLoaderTesting
 @testable import TuistSupportTesting
 
-final class UpCommandTests: TuistUnitTestCase {
-    var subject: UpCommand!
-    var parser: ArgumentParser!
+final class UpServiceTests: TuistUnitTestCase {
+	var subject: UpService!
     var setupLoader: MockSetupLoader!
 
     override func setUp() {
         super.setUp()
-        parser = ArgumentParser.test()
         setupLoader = MockSetupLoader()
-        subject = UpCommand(parser: parser,
-                            setupLoader: setupLoader)
+        subject = UpService(setupLoader: setupLoader)
     }
 
     override func tearDown() {
         subject = nil
-        parser = nil
         setupLoader = nil
         super.tearDown()
-    }
-
-    func test_command() {
-        XCTAssertEqual(UpCommand.command, "up")
-    }
-
-    func test_overview() {
-        XCTAssertEqual(UpCommand.overview, "Configures the environment for the project.")
     }
 
     func test_run_configures_the_environment() throws {
         // given
         let temporaryPath = try self.temporaryPath()
-        let result = try parser.parse([UpCommand.command])
         var receivedPaths = [String]()
         setupLoader.meetStub = { path in
             receivedPaths.append(path.pathString)
         }
 
         // when
-        try subject.run(with: result)
+		try subject.run(path: temporaryPath.pathString)
 
         // then
         XCTAssertEqual(receivedPaths, [temporaryPath.pathString])
@@ -56,14 +45,13 @@ final class UpCommandTests: TuistUnitTestCase {
     func test_run_uses_the_given_path() throws {
         // given
         let path = AbsolutePath("/path")
-        let result = try parser.parse([UpCommand.command, "-p", path.pathString])
         var receivedPaths = [String]()
         setupLoader.meetStub = { path in
             receivedPaths.append(path.pathString)
         }
 
         // when
-        try subject.run(with: result)
+		try subject.run(path: path.pathString)
 
         // then
         XCTAssertEqual(receivedPaths, ["/path"])

--- a/Tests/TuistKitTests/Services/UpServiceTests.swift
+++ b/Tests/TuistKitTests/Services/UpServiceTests.swift
@@ -11,7 +11,7 @@ import XCTest
 @testable import TuistSupportTesting
 
 final class UpServiceTests: TuistUnitTestCase {
-	var subject: UpService!
+    var subject: UpService!
     var setupLoader: MockSetupLoader!
 
     override func setUp() {
@@ -35,7 +35,7 @@ final class UpServiceTests: TuistUnitTestCase {
         }
 
         // when
-		try subject.run(path: temporaryPath.pathString)
+        try subject.run(path: temporaryPath.pathString)
 
         // then
         XCTAssertEqual(receivedPaths, [temporaryPath.pathString])
@@ -51,7 +51,7 @@ final class UpServiceTests: TuistUnitTestCase {
         }
 
         // when
-		try subject.run(path: path.pathString)
+        try subject.run(path: path.pathString)
 
         // then
         XCTAssertEqual(receivedPaths, ["/path"])


### PR DESCRIPTION
### Short description 📝

Adopt [ArgumentParser](https://github.com/apple/swift-argument-parser) library for Up command.

Parent pull request: https://github.com/tuist/tuist/pull/1154.

### Implementation 👩‍💻👨‍💻

- [x] Rewrite `UpCommand`
- [x] Rewrite `UpCommandTests`

### Testing 🧪

- [x] Unit tests 
- [x] Manual testing 👇 

```bash
$ tuist up --verbose --path /Users/mollyiv/Projects/demo/tuist-demo              
Checking if /Users/mollyiv/.tuist exists... true
...
/usr/bin/env which mint
/usr/local/bin/mint

/usr/bin/env which brew
/usr/local/bin/brew

/usr/bin/env which mint
/usr/local/bin/mint

/usr/bin/env which brew
/usr/local/bin/brew

Checking if /Users/mollyiv/Projects/demo/tuist-demo/Mintfile exists... true
Reading contents of text file at path /Users/mollyiv/Projects/demo/tuist-demo/Mintfile
mint which apple/swift-format@swift-5.1-branch
/usr/local/lib/mint/packages/github.com_apple_swift-format/build/swift-5.1-branch/swift-format
```

🎊 🎊 