### PR TITLE
Mention that lproj files are supported

### DIFF
--- a/website/markdown/docs/usage/projectswift.mdx
+++ b/website/markdown/docs/usage/projectswift.mdx
@@ -245,7 +245,8 @@ Each target in the list of project targets can be initialized with the following
     },
     {
       name: 'Resources',
-      description: 'List of files to include in the resources build phase',
+      description:
+        'List of files to include in the resources build phase. Note that localizable files, `*.lproj`, are supported.',
       type: '[FileElement]',
       typeLink: '#fileelement',
       optional: true,


### PR DESCRIPTION
### Short description 📝
It might not be obvious from the documentation that localizable files need to be referenced as resources. This PR updates the documentation accordingly.