### PR TITLE
Include a framework for planning work and triaging issues

### DIFF
--- a/website/markdown/docs/components/next-release.jsx
+++ b/website/markdown/docs/components/next-release.jsx
@@ -5,16 +5,7 @@ import moment from 'moment'
 
 const NextRelease = () => {
   const week = moment().week()
-  let releaseDate
-  if (week % 2 == 0) {
-    releaseDate = moment()
-      .endOf('week')
-      .day(5)
-  } else {
-    releaseDate = moment()
-      .endOf('week')
-      .day(-2)
-  }
+  let releaseDate = moment().endOf('week').day(-2)
   return (
     <Styled.p>
       The next version of might get released on September{' '}

--- a/website/markdown/docs/contribution/planning-work.mdx
+++ b/website/markdown/docs/contribution/planning-work.mdx
@@ -15,11 +15,17 @@ When the release time comes, the content in the done board should be consistent 
 
 ## Planning on Monday
 
-The planning is done every Monday, a member from the [core team](/docs/contribution/core-team/) decides what should go into the next release.
+The planning is done every Monday, Pedro from the [core team](/docs/contribution/core-team/) decides what should go into the next release.
 The list should include those tasks that are high-priority, and a good balance between new features, improvements, and minor bug fixes.
 Doing only bug fixes is boring yet necessary, and doing only new features might make users feel unsupported.
 
-After doing the planning, the to do board should only contain those tasks.
+After doing the planning, the to-do board should only contain those tasks.
+
+<Message
+  info
+  title="Unplanned tasks"
+  description="Although there's a framework in place to make sure we tackle issues that are important for the users, contributors are welcomed to tackle other issues as well. Most of us devote our free time to the project so it's important that we spend that time on tasks that we find fulfilling."
+/>
 
 ## Releasing on Friday
 
@@ -46,7 +52,7 @@ and prioritized over the other tasks.
 As part of triaging, it's also important to make sure that the issues have enough context for debugging.
 We should encourage users to follow our [reporting bugs guidelines](/docs/contribution/reporting-bugs/) and include a reproducible test case.
 
-After labelling the issues and ensuring they contain all the context necessary for debugging,
+After labeling the issues and ensuring they contain all the context necessary for debugging,
 we should post a comment thanking the user for reporting it,
 and setting some expectations on when we think it'll be fixed.
 This is a subtle action that helps build strong connections with the users.

--- a/website/markdown/docs/contribution/planning-work.mdx
+++ b/website/markdown/docs/contribution/planning-work.mdx
@@ -1,0 +1,52 @@
+---
+name: Planning work
+excerpt: This documents describes a framework that we follow at Tuist for planning work and triaging issues.
+---
+
+# Planning work
+
+This document describes the framework that the organization follows to plan the work, as well as the strategy for triaging and prioritize issues that users create.
+
+## GitHub Project
+
+The backlog of tasks, work in progress, and completed tasks are represented on a [project](https://github.com/orgs/tuist/projects/8) on GitHub.
+The board is set up to move the tasks along the boards as the state of the PR or issue associated to the task changes.
+When the release time comes, the content in the done board should be consistent with the content in the `CHANGELOG.md`.
+
+## Planning on Monday
+
+The planning is done every Monday, a member from the [core team](/docs/contribution/core-team/) decides what should go into the next release.
+The list should include those tasks that are high-priority, and a good balance between new features, improvements, and minor bug fixes.
+Doing only bug fixes is boring yet necessary, and doing only new features might make users feel unsupported.
+
+After doing the planning, the to do board should only contain those tasks.
+
+## Releasing on Friday
+
+[Releases](/docs/contribution/release/) are done every Friday.
+Before proceeding with the release, the captain should share the CHANGELOG with the rest of the core team and get their approval.
+This is a good step to double-check if there's important work that hasn't been completed yet and that would be great to include in the release.
+What goes into the release is ultimately the captain's decision, but they should aim to find a consensus with the rest of the team.
+
+Once the release is done, all issues should be closed and the tasks from the done board archived.
+
+## Triaging issues
+
+It's everyone's responsibility to help with triaging.
+The goal of triaging is twofold.
+First,
+we need to categorize the issue accordingly using labels.
+That makes it easier to filter and search for issues in the future.
+Second,
+we need to set the right priority to help prioritize them accordingly.
+Only issues that either are impacting a lot of users or are blocking users should be considered **high-priority.**
+High-priority issues should be moved straight to the weekly backlog,
+and prioritized over the other tasks.
+
+As part of triaging, it's also important to make sure that the issues have enough context for debugging.
+We should encourage users to follow our [reporting bugs guidelines](/docs/contribution/reporting-bugs/) and include a reproducible test case.
+
+After labelling the issues and ensuring they contain all the context necessary for debugging,
+we should post a comment thanking the user for reporting it,
+and setting some expectations on when we think it'll be fixed.
+This is a subtle action that helps build strong connections with the users.

--- a/website/markdown/docs/contribution/release.mdx
+++ b/website/markdown/docs/contribution/release.mdx
@@ -14,10 +14,7 @@ and are allowed to champion releases.
 
 ## Cadence
 
-Tuist is released in a 2-week cadence because one week is too short as to have enough features to justify a release,
-and more than 2 weeks might leave users waiting for bug fixes and improvements landing on the project.
-
-We **might skip** the release train if there aren't enough changes to justify a release,
+Tuist is released following a weekly cadence. Note that we **might skip** the release train if there aren't enough changes to justify a release,
 or if there aren't people available to champion it.
 
 <NextRelease />

--- a/website/markdown/docs/links.mdx
+++ b/website/markdown/docs/links.mdx
@@ -51,6 +51,7 @@ import {
 
 - [Contributors](/docs/contribution/getting-started/)
   - [Getting started](/docs/contribution/getting-started/)
+  - [Planning work](/docs/contribution/planning-work/)
   - [Code reviews](/docs/contribution/code-reviews/)
   - [Reporting bugs](/docs/contribution/reporting-bugs/)
   - [Architecture](/docs/contribution/architecture/)


### PR DESCRIPTION
### Short description 📝
Until now, we've had no framework for deciding what to work on. We mostly work on tasks that we found challenging, interesting, or that affected us.

Although that has worked fine, as our list of issues keeps growing, and more people start contributing to the project, I think having a framework for planning work and triaging issues is key for the growth of the community. A framework gives users transparency, and ensures we are working on the right things.

Please, take a look at the draft and share your thoughts.