### PR TITLE
Fix clean exit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Removed
 
+### Fixed
+
+- Fix help commands (argument parser regression) [#1250](https://github.com/tuist/tuist/pull/1250) by [@fortmarek](https://github.com/fortmarek)
+
 ## 1.7.1
 
 ### Fixed

--- a/Sources/TuistEnvKit/Commands/TuistCommand.swift
+++ b/Sources/TuistEnvKit/Commands/TuistCommand.swift
@@ -30,14 +30,17 @@ public struct TuistCommand: ParsableCommand {
                 try CommandRunner().run()
             }
             exit()
-        } catch let error as CleanExit {
-            _exit(exitCode(for: error).rawValue)
         } catch let error as FatalError {
             errorHandler.fatal(error: error)
             _exit(exitCode(for: error).rawValue)
         } catch {
-            errorHandler.fatal(error: UnhandledError(error: error))
-            _exit(exitCode(for: error).rawValue)
+            // Exit cleanly
+            if exitCode(for: error).rawValue == 0 {
+                exit(withError: error)
+            } else {
+                errorHandler.fatal(error: UnhandledError(error: error))
+                _exit(exitCode(for: error).rawValue)
+            }
         }
     }
 

--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -46,14 +46,17 @@ public struct TuistCommand: ParsableCommand {
         do {
             try command.run()
             exit()
-        } catch let error as CleanExit {
-            _exit(exitCode(for: error).rawValue)
         } catch let error as FatalError {
             errorHandler.fatal(error: error)
             _exit(exitCode(for: error).rawValue)
         } catch {
-            errorHandler.fatal(error: UnhandledError(error: error))
-            _exit(exitCode(for: error).rawValue)
+            // Exit cleanly
+            if exitCode(for: error).rawValue == 0 {
+                exit(withError: error)
+            } else {
+                errorHandler.fatal(error: UnhandledError(error: error))
+                _exit(exitCode(for: error).rawValue)
+            }
         }
     }
 


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/1246

### Short description 📝

Some help commands have not been working as expected.

### Solution 📦

Currently, I was checking for `CleanExit` error only, but `.helpRequested` type of `CommandError` was not caught by such a case.

### Implementation 👩‍💻👨‍💻

- [x] Exit cleanly when exit code is 0
