### PR TITLE
Make --project-only a Flag again

### DIFF
--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -14,9 +14,7 @@ struct GenerateCommand: ParsableCommand {
     )
     var path: String?
 
-    @Option(
-        name: .shortAndLong,
-        default: false,
+    @Flag(
         help: "Only generate the local project (without generating its dependencies)."
     )
     var projectOnly: Bool


### PR DESCRIPTION
I just found a little regression related to the argument parser PR.

When using `tuist generate` with `--project-only` enabled, one gets:

```
Error: Missing value for '--project-only <project-only>'
Usage: tuist generate [--path <path>] [--project-only <project-only>]
```

This is because in `Option` always expects a value, true or false in this case.
The previous behavior didn’t require passing a value. This PR fixes it.