### PR TITLE
Update docs: "Using on CI"

### DIFF
--- a/website/markdown/docs/usage/best-practices.mdx
+++ b/website/markdown/docs/usage/best-practices.mdx
@@ -30,3 +30,12 @@ let target = Target(name: "MyFramework", sources: ["MyFramework/Sources"])
 // Discouraged
 let target = Target(name: "MyFramework", sources: ["MyFramework/**/*.swift"])
 ```
+
+## Using on CI
+
+Adding `tuist` to your project will require you to have installed it in your CI system. You can avoid it by bundling specific version in your repo:
+
+- Define your local version: `tuist local 1.7.1`
+- Bundle it: `tuist bundle 1.7.1`
+- Commit the added files into git
+- Run `tuist` using `.tuist-bin/tuist generate` in your CI

--- a/website/markdown/docs/usage/best-practices.mdx
+++ b/website/markdown/docs/usage/best-practices.mdx
@@ -36,6 +36,6 @@ let target = Target(name: "MyFramework", sources: ["MyFramework/**/*.swift"])
 Adding `tuist` to your project will require you to have installed it in your CI system. You can avoid it by bundling specific version in your repo:
 
 - Define your local version: `tuist local 1.7.1`
-- Bundle it: `tuist bundle 1.7.1`
+- Bundle it: `tuist bundle`
 - Commit the added files into git
 - Run `tuist` using `.tuist-bin/tuist generate` in your CI

--- a/website/markdown/docs/usage/managing-versions.mdx
+++ b/website/markdown/docs/usage/managing-versions.mdx
@@ -55,7 +55,7 @@ Bundling the version 0.4.0 in the directory /Tuist/.tuist-bin
 ✅ Success: tuist bundled successfully at /Tuist/.tuist-bin
 ```
 
-It creates a `.tuist-bin` directory in the current directory that contains the `tuist` binary and its artifacts.
+It creates a `.tuist-bin` directory in the current directory that contains the `tuist` binary and its artifacts. You can use bundled version of `tuist` by running `.tuist-bin/tuist generate`.
 
 ### tuist install
 

--- a/website/markdown/docs/usage/managing-versions.mdx
+++ b/website/markdown/docs/usage/managing-versions.mdx
@@ -49,7 +49,7 @@ Note that it pins the version by creating a `.tuist-version` file in the current
 You might want to bundle `tuist` in your repository so that each git snapshot contains all the necessary elements to interact with the projects in it. The `tuist bundle` command is precisely for that:
 
 ```text
-tuist bundle 0.4.0
+tuist bundle
 
 Bundling the version 0.4.0 in the directory /Tuist/.tuist-bin
 ✅ Success: tuist bundled successfully at /Tuist/.tuist-bin


### PR DESCRIPTION
### Short description 📝

Release of failable "1.7.0" was causing workflows fails on Bitrise. I didn't detect it because I was using 1.6.x locally and Bitrise was using always the newest version. 

@sgrgrsn helped me on Slack. He explained me how to bundle specific version of Tuist. 

This PR introduces some addiction in documentation to help future folks with currently usage of Tuist on CI. 