### PR TITLE
Add support for localized sources(.intentdefinition)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Added
 
+- Support for localized sources(e.g., .intentdefinition) [#1269](https://github.com/tuist/tuist/pull/1269) by [@Rag0n](https://github.com/Rag0n)
+
 ### Removed
 
 ### Fixed

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -132,7 +132,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
 
             let element: PBXFileElement
             if !isLocalized {
-                guard let fileReference = fileElements.file(path: buildFile.path) else  {
+                guard let fileReference = fileElements.file(path: buildFile.path) else {
                     throw BuildPhaseGenerationError.missingFileReference(buildFile.path)
                 }
                 element = fileReference

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -125,24 +125,25 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
         pbxproj.add(object: sourcesBuildPhase)
         pbxTarget.buildPhases.append(sourcesBuildPhase)
 
+        var buildFilesCache = Set<AbsolutePath>()
         let sortedFiles = files.sorted(by: { $0.path < $1.path })
         try sortedFiles.forEach { buildFile in
             let buildFilePath = buildFile.path
             let isLocalized = buildFilePath.pathString.contains(".lproj/")
 
-            let element: PBXFileElement
+            let element: (element: PBXFileElement, path: AbsolutePath)
             if !isLocalized {
                 guard let fileReference = fileElements.file(path: buildFile.path) else {
                     throw BuildPhaseGenerationError.missingFileReference(buildFile.path)
                 }
-                element = fileReference
+                element = (fileReference, buildFilePath)
             } else {
                 let name = buildFilePath.basename
                 let path = buildFilePath.parentDirectory.parentDirectory.appending(component: name)
                 guard let group = fileElements.group(path: path) else {
                     throw BuildPhaseGenerationError.missingFileReference(buildFilePath)
                 }
-                element = group
+                element = (group, path)
             }
 
             var settings: [String: Any]?
@@ -152,9 +153,12 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
                 ]
             }
 
-            let pbxBuildFile = PBXBuildFile(file: element, settings: settings)
-            pbxproj.add(object: pbxBuildFile)
-            sourcesBuildPhase.files?.append(pbxBuildFile)
+            if buildFilesCache.contains(element.path) == false {
+                let pbxBuildFile = PBXBuildFile(file: element.element, settings: settings)
+                pbxproj.add(object: pbxBuildFile)
+                sourcesBuildPhase.files?.append(pbxBuildFile)
+                buildFilesCache.insert(element.path)
+            }
         }
     }
 

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -86,6 +86,39 @@ final class BuildPhaseGeneratorTests: XCTestCase {
         }
     }
 
+    func test_generateSourcesBuildPhase_whenLocalizedFile() throws {
+        // Given
+        let target = PBXNativeTarget(name: "Test")
+        let pbxproj = PBXProj()
+        pbxproj.add(object: target)
+
+        let files: [AbsolutePath] = [
+           "/path/sources/Base.lproj/OTTSiriExtension.intentdefinition",
+           "/path/resources/en.lproj/OTTSiriExtension.intentdefinition",
+       ]
+
+       let fileElements = createLocalizedResourceFileElements(for: [
+           "/path/resources/OTTSiriExtension.intentdefinition",
+       ])
+
+        // When
+        try subject.generateSourcesBuildPhase(files: sources,
+                                              pbxTarget: target,
+                                              fileElements: fileElements,
+                                              pbxproj: pbxproj)
+
+        // Then
+        let buildPhase = try target.sourcesBuildPhase()
+        let buildFiles = buildPhase?.files ?? []
+        let buildFilesNames = buildFiles.map {
+            $0.file?.name
+        }
+
+        XCTAssertEqual(buildFilesNames, [
+           fileElements.elements["/path/resources/OTTSiriExtension.intentdefinition"],
+       ])
+    }
+
     func test_generateHeadersBuildPhase() throws {
         // Given
         let target = PBXNativeTarget(name: "Test")

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -112,7 +112,7 @@ final class BuildPhaseGeneratorTests: XCTestCase {
         let buildFiles = buildPhase?.files ?? []
 
         XCTAssertEqual(buildFiles.map { $0.file }, [
-             fileElements.elements["/path/sources/OTTSiriExtension.intentdefinition"],
+            fileElements.elements["/path/sources/OTTSiriExtension.intentdefinition"],
         ])
     }
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1225

### Short description 📝

Add support for localized sources(eg .intentdefinition)

### Solution 📦

I tried to be consistent with code base, so solution looks similar to other code related to generating build phases(generateResourcesBuildPhase).

I'm having an issue with tests. I'm receiving `No such module 'TuistSupportTesting'` error when trying to compile test target.