### PR TITLE
Fix scaffold example.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
+- Fix example in documentation for `scaffold` [#1273](https://github.com/tuist/tuist/pull/1273) by [@fortmarek](https://github.com/fortmarek)
 - Fix help commands (argument parser regression) [#1250](https://github.com/tuist/tuist/pull/1250) by [@fortmarek](https://github.com/fortmarek)
 
 ## 1.7.1

--- a/website/markdown/docs/commands/scaffold.mdx
+++ b/website/markdown/docs/commands/scaffold.mdx
@@ -33,7 +33,7 @@ let template = Template(
                 contents: "My template contents of name \(nameAttribute)"),
         .file(path: "generated/Up.swift",
               templatePath: "generate.stencil"),
-    ],
+    ]
 )
 ```
 


### PR DESCRIPTION
### Short description 📝

I was following `scaffold` documentation when I was implementing `scaffold` in our app and found there is a redundant comma in the example.

### Solution 📦

remove it 😛 

