### PR TITLE
Allow declaring modulemap file in Target

### DIFF
--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -53,6 +53,9 @@ public struct Target: Codable, Equatable {
     /// Environment variables to be exposed to the target.
     public let environment: [String: String]
 
+    /// Relative path to the modulemap file.
+    public let modulemap: Path?
+
     public enum CodingKeys: String, CodingKey {
         case name
         case platform
@@ -70,6 +73,7 @@ public struct Target: Codable, Equatable {
         case actions
         case environment
         case deploymentTarget
+        case modulemap
     }
 
     /// Initializes the target.
@@ -89,6 +93,7 @@ public struct Target: Codable, Equatable {
     ///   - settings: target settings.
     ///   - coreDataModels: CoreData models.
     ///   - environment: Environment variables to be exposed to the target.
+    ///   - modulemap: Relative path to the modulemap file
     public init(name: String,
                 platform: Platform,
                 product: Product,
@@ -104,7 +109,8 @@ public struct Target: Codable, Equatable {
                 dependencies: [TargetDependency] = [],
                 settings: Settings? = nil,
                 coreDataModels: [CoreDataModel] = [],
-                environment: [String: String] = [:]) {
+                environment: [String: String] = [:],
+                modulemap: Path? = nil) {
         self.name = name
         self.platform = platform
         self.bundleId = bundleId
@@ -121,5 +127,6 @@ public struct Target: Codable, Equatable {
         self.coreDataModels = coreDataModels
         self.environment = environment
         self.deploymentTarget = deploymentTarget
+        self.modulemap = modulemap
     }
 }

--- a/Sources/TuistCore/Models/Target.swift
+++ b/Sources/TuistCore/Models/Target.swift
@@ -33,6 +33,7 @@ public struct Target: Equatable, Hashable {
     public let actions: [TargetAction]
     public let environment: [String: String]
     public let filesGroup: ProjectGroup
+    public let modulemap: AbsolutePath?
 
     // MARK: - Init
 
@@ -52,7 +53,8 @@ public struct Target: Equatable, Hashable {
                 actions: [TargetAction] = [],
                 environment: [String: String] = [:],
                 filesGroup: ProjectGroup,
-                dependencies: [Dependency] = []) {
+                dependencies: [Dependency] = [],
+                modulemap: AbsolutePath? = nil) {
         self.name = name
         self.product = product
         self.platform = platform
@@ -70,6 +72,7 @@ public struct Target: Equatable, Hashable {
         self.environment = environment
         self.filesGroup = filesGroup
         self.dependencies = dependencies
+        self.modulemap = modulemap
     }
 
     /// Target can be included in the link phase of other targets

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -184,15 +184,15 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
         }
     }
 
-    func generateCopyHeadersBuildPhase(path: AbsolutePath,
+    func generateCopyHeadersBuildPhase(path _: AbsolutePath,
                                        modulemap: AbsolutePath,
                                        target: Target,
-                                       graph: Graph,
+                                       graph _: Graph,
                                        pbxTarget: PBXTarget,
                                        fileElements: ProjectFileElements,
                                        pbxproj: PBXProj,
                                        sourceRootPath: AbsolutePath) throws {
-        var references = target.headers?.public.compactMap({ fileElements.file(path: $0) }) ?? []
+        var references = target.headers?.public.compactMap { fileElements.file(path: $0) } ?? []
         if let moduleMapReference = fileElements.file(path: modulemap) {
             references.append(moduleMapReference)
         }

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -128,6 +128,10 @@ class ProjectFileElements {
             files.insert(entitlements)
         }
 
+        if let modulemap = target.modulemap {
+            files.insert(modulemap)
+        }
+
         // Config files
         target.settings?.configurations.xcconfigs().forEach { configFilePath in
             files.insert(configFilePath)

--- a/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
@@ -51,6 +51,8 @@ extension TuistCore.Target {
 
         let environment = manifest.environment
 
+        let modulemap = try manifest.modulemap.map { try generatorPaths.resolve(path: $0) }
+
         return TuistCore.Target(name: name,
                                 platform: platform,
                                 product: product,
@@ -67,6 +69,7 @@ extension TuistCore.Target {
                                 actions: actions,
                                 environment: environment,
                                 filesGroup: .group(name: "Project"),
-                                dependencies: dependencies)
+                                dependencies: dependencies,
+                                modulemap: modulemap)
     }
 }


### PR DESCRIPTION
In order to be able to include a Copy Headers build phase including the modulemap and other public headers, which will support .a libraries.

Resolves https://github.com/tuist/tuist/issues/1254

Thanks to @pepibumur for guiding me, over the step described in the issue above by @kwridan.

This PR still requires adding tests and in a later stage (or commit) we will add the suggested linting as well.