### PR TITLE
Update the default Info.plist values to not include storyboards

### DIFF
--- a/Sources/TuistGenerator/Generator/InfoPlistContentProvider.swift
+++ b/Sources/TuistGenerator/Generator/InfoPlistContentProvider.swift
@@ -123,8 +123,6 @@ final class InfoPlistContentProvider: InfoPlistContentProviding {
     func iosApp() -> [String: Any] {
         [
             "LSRequiresIPhoneOS": true,
-            "UILaunchStoryboardName": "LaunchScreen",
-            "UIMainStoryboardFile": "Main",
             "UIRequiredDeviceCapabilities": [
                 "armv7",
             ],

--- a/Tests/TuistGeneratorTests/Generator/InfoPlistContentProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/InfoPlistContentProviderTests.swift
@@ -33,10 +33,8 @@ final class InfoPlistContentProviderTests: XCTestCase {
                 "UIInterfaceOrientationLandscapeRight",
             ],
             "CFBundleShortVersionString": "1.0",
-            "UIMainStoryboardFile": "Main",
             "LSRequiresIPhoneOS": true,
             "CFBundleDevelopmentRegion": "$(DEVELOPMENT_LANGUAGE)",
-            "UILaunchStoryboardName": "LaunchScreen",
             "CFBundlePackageType": "APPL",
             "UISupportedInterfaceOrientations~ipad": [
                 "UIInterfaceOrientationPortrait",


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1288

### Short description 📝
When users use `extendingDefault(with: [String: Value])` for defining the Info.plist from an iOS application, we automatically set `UILaunchStoryboardName` and `UIMainStoryboardFile` assuming their values will be `Main` and `LaunchScreen` respectively.

As @Evylon reported [here](https://github.com/tuist/tuist/issues/1288) that results in an app that crashes at launch time. 

### What
This PR updates the `InfoPlistContentProvider` to not set those values. If users want to use a launch or main storyboard, they should indicate it explicitly using the passed dictionary.