### PR TITLE
Remove Homebrew from the list of installation options

### DIFF
--- a/website/markdown/docs/usage/getting-started.mdx
+++ b/website/markdown/docs/usage/getting-started.mdx
@@ -12,7 +12,7 @@ Tuist is a command line tool \(CLI\) that aims to facilitate the generation, mai
 
 ### Install
 
-The first thing that we need to do to get started is installing the tool. There are two recommended ways of doing it: using [Homebrew](https://brew.sh) or running a script. In either way, you need to run the following commands in your terminal:
+The first thing that we need to do to get started is installing the tool. To do so, you can run the following commands in your terminal:
 
 ```bash
 bash <(curl -Ls https://install.tuist.io)


### PR DESCRIPTION
### Short description 📝
Homebrew is not supported as an installation option and therefore I'm removing the mention from the "Getting Started" document.