### PR TITLE
Read the Swift version from the system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Changed
 
+- Read the Swift version from the environment [#1317](https://github.com/tuist/tuist/pull/1317) by [@pepibumur](https://github.com/pepibumur)
+
 ### Added
 
 ### Removed

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -188,8 +188,9 @@ final class ConfigGenerator: ConfigGenerating {
         }
         settings["SDKROOT"] = .string(target.platform.xcodeSdkRoot)
         settings["SUPPORTED_PLATFORMS"] = .string(target.platform.xcodeSupportedPlatforms)
-        // TODO: We should show a warning here
+
         if settings["SWIFT_VERSION"] == nil {
+            logger.log(level: .warning, "Setting the build setting SWIFT_VERSION to \(swiftVersion) for target '\(target.name)'. We recommend setting it on the manifest.")
             settings["SWIFT_VERSION"] = .string(swiftVersion)
         }
 

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -84,6 +84,7 @@ final class ConfigGenerator: ConfigGenerating {
         let configurations = Dictionary(uniqueKeysWithValues: configurationsTuples)
         let nonEmptyConfigurations = !configurations.isEmpty ? configurations : Settings.default.configurations
         let orderedConfigurations = nonEmptyConfigurations.sortedByBuildConfigurationName()
+        let swiftVersion = try System.shared.swiftVersion()
         try orderedConfigurations.forEach {
             try generateTargetSettingsFor(target: target,
                                           buildConfiguration: $0.key,
@@ -92,6 +93,7 @@ final class ConfigGenerator: ConfigGenerating {
                                           graph: graph,
                                           pbxproj: pbxproj,
                                           configurationList: configurationList,
+                                          swiftVersion: swiftVersion,
                                           sourceRootPath: sourceRootPath)
         }
     }
@@ -131,6 +133,7 @@ final class ConfigGenerator: ConfigGenerating {
                                            graph: Graph,
                                            pbxproj: PBXProj,
                                            configurationList: XCConfigurationList,
+                                           swiftVersion: String,
                                            sourceRootPath: AbsolutePath) throws {
         let settingsHelper = SettingsHelper()
         var settings = try defaultSettingsProvider.targetSettings(target: target,
@@ -138,6 +141,7 @@ final class ConfigGenerator: ConfigGenerating {
         updateTargetDerived(buildSettings: &settings,
                             target: target,
                             graph: graph,
+                            swiftVersion: swiftVersion,
                             sourceRootPath: sourceRootPath)
 
         settingsHelper.extend(buildSettings: &settings, with: target.settings?.base ?? [:])
@@ -159,14 +163,16 @@ final class ConfigGenerator: ConfigGenerating {
     private func updateTargetDerived(buildSettings settings: inout SettingsDictionary,
                                      target: Target,
                                      graph: Graph,
+                                     swiftVersion: String,
                                      sourceRootPath: AbsolutePath) {
-        settings.merge(generalTargetDerivedSettings(target: target, sourceRootPath: sourceRootPath)) { $1 }
+        settings.merge(generalTargetDerivedSettings(target: target, swiftVersion: swiftVersion, sourceRootPath: sourceRootPath)) { $1 }
         settings.merge(testBundleTargetDerivedSettings(target: target, graph: graph, sourceRootPath: sourceRootPath)) { $1 }
         settings.merge(deploymentTargetDerivedSettings(target: target)) { $1 }
         settings.merge(watchTargetDerivedSettings(target: target, graph: graph, sourceRootPath: sourceRootPath)) { $1 }
     }
 
     private func generalTargetDerivedSettings(target: Target,
+                                              swiftVersion: String,
                                               sourceRootPath: AbsolutePath) -> SettingsDictionary {
         var settings: SettingsDictionary = [:]
         settings["PRODUCT_BUNDLE_IDENTIFIER"] = .string(target.bundleId)
@@ -184,7 +190,7 @@ final class ConfigGenerator: ConfigGenerating {
         settings["SUPPORTED_PLATFORMS"] = .string(target.platform.xcodeSupportedPlatforms)
         // TODO: We should show a warning here
         if settings["SWIFT_VERSION"] == nil {
-            settings["SWIFT_VERSION"] = .string(Constants.swiftVersion)
+            settings["SWIFT_VERSION"] = .string(swiftVersion)
         }
 
         if target.product == .staticFramework {

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -190,7 +190,6 @@ final class ConfigGenerator: ConfigGenerating {
         settings["SUPPORTED_PLATFORMS"] = .string(target.platform.xcodeSupportedPlatforms)
 
         if settings["SWIFT_VERSION"] == nil {
-            logger.log(level: .warning, "Setting the build setting SWIFT_VERSION to \(swiftVersion) for target '\(target.name)'. We recommend setting it on the manifest.")
             settings["SWIFT_VERSION"] = .string(swiftVersion)
         }
 

--- a/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
@@ -93,12 +93,12 @@ final class ProjectEditor: ProjectEditing {
         // To be sure that we are using the same binary of Tuist that invoked `edit`
         let tuistPath = AbsolutePath(TuistCommand.processArguments()!.first!)
 
-        let (project, graph) = projectEditorMapper.map(tuistPath: tuistPath,
-                                                       sourceRootPath: at,
-                                                       manifests: manifests.map { $0.1 },
-                                                       helpers: helpers,
-                                                       templates: templates,
-                                                       projectDescriptionPath: projectDesciptionPath)
+        let (project, graph) = try projectEditorMapper.map(tuistPath: tuistPath,
+                                                           sourceRootPath: at,
+                                                           manifests: manifests.map { $0.1 },
+                                                           helpers: helpers,
+                                                           templates: templates,
+                                                           projectDescriptionPath: projectDesciptionPath)
 
         let config = ProjectGenerationConfig(sourceRootPath: project.path,
                                              xcodeprojPath: xcodeprojPath)

--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -9,7 +9,7 @@ protocol ProjectEditorMapping: AnyObject {
              manifests: [AbsolutePath],
              helpers: [AbsolutePath],
              templates: [AbsolutePath],
-             projectDescriptionPath: AbsolutePath) -> (Project, Graph)
+             projectDescriptionPath: AbsolutePath) throws -> (Project, Graph)
 }
 
 final class ProjectEditorMapper: ProjectEditorMapping {
@@ -19,13 +19,14 @@ final class ProjectEditorMapper: ProjectEditorMapping {
              manifests: [AbsolutePath],
              helpers: [AbsolutePath],
              templates: [AbsolutePath],
-             projectDescriptionPath: AbsolutePath) -> (Project, Graph) {
+             projectDescriptionPath: AbsolutePath) throws -> (Project, Graph) {
         // Settings
         let projectSettings = Settings(base: [:],
                                        configurations: Settings.default.configurations,
                                        defaultSettings: .recommended)
 
-        let targetSettings = Settings(base: settings(projectDescriptionPath: projectDescriptionPath),
+        let swiftVersion = try System.shared.swiftVersion()
+        let targetSettings = Settings(base: settings(projectDescriptionPath: projectDescriptionPath, swiftVersion: swiftVersion),
                                       configurations: Settings.default.configurations,
                                       defaultSettings: .recommended)
 
@@ -112,13 +113,14 @@ final class ProjectEditorMapper: ProjectEditorMapping {
 
     /// It returns the build settings that should be used in the manifests target.
     /// - Parameter projectDescriptionPath: Path to the ProjectDescription framework.
-    fileprivate func settings(projectDescriptionPath: AbsolutePath) -> SettingsDictionary {
+    /// - Parameter swiftVersion: The system's Swift version.
+    fileprivate func settings(projectDescriptionPath: AbsolutePath, swiftVersion: String) -> SettingsDictionary {
         let frameworkParentDirectory = projectDescriptionPath.parentDirectory
         var buildSettings = SettingsDictionary()
         buildSettings["FRAMEWORK_SEARCH_PATHS"] = .string(frameworkParentDirectory.pathString)
         buildSettings["LIBRARY_SEARCH_PATHS"] = .string(frameworkParentDirectory.pathString)
         buildSettings["SWIFT_INCLUDE_PATHS"] = .string(frameworkParentDirectory.pathString)
-        buildSettings["SWIFT_VERSION"] = .string(Constants.swiftVersion)
+        buildSettings["SWIFT_VERSION"] = .string(swiftVersion)
         return buildSettings
     }
 

--- a/Sources/TuistLoader/ProjectDEscriptionHelpers/ProjectDescriptionHelpersHasher.swift
+++ b/Sources/TuistLoader/ProjectDEscriptionHelpers/ProjectDescriptionHelpersHasher.swift
@@ -31,7 +31,7 @@ final class ProjectDescriptionHelpersHasher: ProjectDescriptionHelpersHashing {
             .compactMap { $0.sha256() }
             .compactMap { $0.compactMap { byte in String(format: "%02x", byte) }.joined() }
         let tuistEnvVariables = Environment.shared.tuistVariables.map { "\($0.key)=\($0.value)" }.sorted()
-        let swiftVersion = try System.shared.swiftVersion() ?? ""
+        let swiftVersion = try System.shared.swiftVersion()
 
         let identifiers = [swiftVersion, tuistVersion] + fileHashes + tuistEnvVariables
 

--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -6,7 +6,6 @@ public struct Constants {
     public static let binName = "tuist"
     public static let gitRepositoryURL = "https://github.com/tuist/tuist.git"
     public static let version = "1.7.1"
-    public static let swiftVersion: String = "5.2"
     public static let bundleName: String = "tuist.zip"
     public static let trueValues: [String] = ["1", "true", "TRUE", "yes", "YES"]
     public static let tuistDirectoryName: String = "Tuist"

--- a/Sources/TuistSupportTesting/Utils/MockSystem.swift
+++ b/Sources/TuistSupportTesting/Utils/MockSystem.swift
@@ -9,7 +9,6 @@ public final class MockSystem: Systeming {
     // swiftlint:disable:next large_tuple
     private var stubs: [String: (stderror: String?, stdout: String?, exitstatus: Int?)] = [:]
     private var calls: [String] = []
-    var swiftVersionStub: (() throws -> String?)?
     var whichStub: ((String) throws -> String?)?
 
     public init() {}
@@ -145,8 +144,13 @@ public final class MockSystem: Systeming {
         }
     }
 
-    public func swiftVersion() throws -> String? {
-        try swiftVersionStub?()
+    var swiftVersionStub: (() throws -> String)?
+    public func swiftVersion() throws -> String {
+        if let swiftVersionStub = self.swiftVersionStub {
+            return try swiftVersionStub()
+        } else {
+            throw TestError("Call to non-stubbed method swiftVersion")
+        }
     }
 
     public func which(_ name: String) throws -> String {

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -18,6 +18,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         super.setUp()
         pbxproj = PBXProj()
         pbxTarget = PBXNativeTarget(name: "Test")
+        system.swiftVersionStub = { "5.2" }
         pbxproj.add(object: pbxTarget)
         subject = ConfigGenerator()
     }
@@ -65,7 +66,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             "INFOPLIST_FILE": "Info.plist",
             "PRODUCT_BUNDLE_IDENTIFIER": "com.test.bundle_id",
             "CODE_SIGN_ENTITLEMENTS": "$(SRCROOT)/Test.entitlements",
-            "SWIFT_VERSION": Constants.swiftVersion,
+            "SWIFT_VERSION": "5.2",
         ]
 
         let debugSettings = [

--- a/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
@@ -14,6 +14,7 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
 
     override func setUp() {
         super.setUp()
+        system.swiftVersionStub = { "5.2" }
         subject = ProjectGenerator()
     }
 

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceGeneratorTests.swift
@@ -13,6 +13,7 @@ final class WorkspaceGeneratorTests: TuistUnitTestCase {
 
     override func setUp() {
         super.setUp()
+        system.swiftVersionStub = { "5.2" }
         subject = WorkspaceGenerator(config: .init(projectGenerationContext: .serial))
     }
 

--- a/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -11,6 +11,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
     override func setUp() {
         super.setUp()
         do {
+            system.swiftVersionStub = { "5.2" }
             xcodeController.selectedVersionStub = .success("11.0.0")
             try setupTestProject()
         } catch {

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
@@ -12,6 +12,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
 
     override func setUp() {
         super.setUp()
+        system.swiftVersionStub = { "5.2" }
         subject = ProjectEditorMapper()
     }
 
@@ -30,12 +31,12 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         let tuistPath = AbsolutePath("/usr/bin/foo/bar/tuist")
 
         // When
-        let (project, graph) = subject.map(tuistPath: tuistPath,
-                                           sourceRootPath: sourceRootPath,
-                                           manifests: manifestPaths,
-                                           helpers: helperPaths,
-                                           templates: templates,
-                                           projectDescriptionPath: projectDescriptionPath)
+        let (project, graph) = try subject.map(tuistPath: tuistPath,
+                                               sourceRootPath: sourceRootPath,
+                                               manifests: manifestPaths,
+                                               helpers: helperPaths,
+                                               templates: templates,
+                                               projectDescriptionPath: projectDescriptionPath)
 
         // Then
         let targetNodes = graph.targets.values.lazy.flatMap { targets in targets.compactMap { $0 } }.sorted(by: { $0.target.name < $1.target.name })
@@ -110,12 +111,12 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         let tuistPath = AbsolutePath("/usr/bin/foo/bar/tuist")
 
         // When
-        let (project, graph) = subject.map(tuistPath: tuistPath,
-                                           sourceRootPath: sourceRootPath,
-                                           manifests: manifestPaths,
-                                           helpers: helperPaths,
-                                           templates: templates,
-                                           projectDescriptionPath: projectDescriptionPath)
+        let (project, graph) = try subject.map(tuistPath: tuistPath,
+                                               sourceRootPath: sourceRootPath,
+                                               manifests: manifestPaths,
+                                               helpers: helperPaths,
+                                               templates: templates,
+                                               projectDescriptionPath: projectDescriptionPath)
 
         // Then
         let targetNodes = graph.targets.values.flatMap { targets in targets.compactMap { $0 } }.sorted(by: { $0.target.name < $1.target.name })
@@ -170,12 +171,12 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         let tuistPath = AbsolutePath("/usr/bin/foo/bar/tuist")
 
         // When
-        let (project, graph) = subject.map(tuistPath: tuistPath,
-                                           sourceRootPath: sourceRootPath,
-                                           manifests: manifestPaths,
-                                           helpers: helperPaths,
-                                           templates: templates,
-                                           projectDescriptionPath: projectDescriptionPath)
+        let (project, graph) = try subject.map(tuistPath: tuistPath,
+                                               sourceRootPath: sourceRootPath,
+                                               manifests: manifestPaths,
+                                               helpers: helperPaths,
+                                               templates: templates,
+                                               projectDescriptionPath: projectDescriptionPath)
 
         // Then
         let targetNodes = graph.targets.values.flatMap { targets in targets.compactMap { $0 } }.sorted(by: { $0.target.name < $1.target.name })
@@ -234,7 +235,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             "FRAMEWORK_SEARCH_PATHS": .string(sourceRootPath.pathString),
             "LIBRARY_SEARCH_PATHS": .string(sourceRootPath.pathString),
             "SWIFT_INCLUDE_PATHS": .string(sourceRootPath.pathString),
-            "SWIFT_VERSION": .string(Constants.swiftVersion),
+            "SWIFT_VERSION": .string("5.2"),
         ]
         return Settings(base: base,
                         configurations: Settings.default.configurations,

--- a/Tests/TuistLoaderTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasherTests.swift
+++ b/Tests/TuistLoaderTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasherTests.swift
@@ -12,6 +12,7 @@ class ProjectDescriptionHelpersHasherTests: TuistUnitTestCase {
 
     override func setUp() {
         super.setUp()
+        system.swiftVersionStub = { "5.2" }
         subject = ProjectDescriptionHelpersHasher(tuistVersion: "3.2.1")
     }
 
@@ -25,7 +26,7 @@ class ProjectDescriptionHelpersHasherTests: TuistUnitTestCase {
         // Then
         for _ in 0 ..< 20 {
             let got = try subject.hash(helpersDirectory: temporaryDir)
-            XCTAssertEqual(got, "d19835f96b16a558457fc33b169adb9c")
+            XCTAssertEqual(got, "c9910732734d9dcf509bdb7538aed526")
         }
     }
 


### PR DESCRIPTION
### Short description 📝
Using the Swift version hardcoded in `Constants.swiftVersion` might yield unexpected results for the user, which might be using a different Swift version in their environment. 

### Solution 📦
This PR removes `Cosntant.swiftVersion` and updates the usages to read the version from the system by calling `System.shared.swiftVersion()`. We'll explore an alternative approach to do this in a more efficient way such that the version is only read once, and passed down to the components that might need to access it.