### PR TITLE
Make RootDirectoryLocator search for .git folder, not file

### DIFF
--- a/Sources/TuistCore/Utils/RootDirectoryLocator.swift
+++ b/Sources/TuistCore/Utils/RootDirectoryLocator.swift
@@ -32,7 +32,7 @@ public final class RootDirectoryLocator: RootDirectoryLocating {
         } else if fileHandler.exists(path.appending(RelativePath(Constants.tuistDirectoryName))) {
             cache(rootDirectory: path, for: source)
             return path
-        } else if fileHandler.exists(path.appending(RelativePath(".git"))) {
+        } else if fileHandler.isFolder(path.appending(RelativePath(".git"))) {
             cache(rootDirectory: path, for: source)
             return path
         } else if !path.isRoot {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY

### Short description 📝

When using Git submodules, a folder might contain a .git file, while, at the same time, not being the "root" directory of a Tuist project. Therefore, `RootDirectoryLocator` would return a wrong directory as the root.

### Solution 📦

Instead of checking for a file or folder named `.git`, `RootDirectoryLocator` looks exclusively for a `.git` directory to make sure it's the root.