### PR TITLE
Don't show logs when resolving packages

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,7 +3,7 @@ name: Checks
 
 on:
   push:
-    branches:    
+    branches:
       - master
     paths:
       - Sources/**/*
@@ -26,7 +26,7 @@ jobs:
       - name: Select Xcode 11.4
         run: sudo xcode-select -switch /Applications/Xcode_11.4.app
       - name: Install swiftformat by homebrew
-        run: brew install swiftformat
+        run: brew install swiftformat && brew upgrade swiftformat
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: '2.x'

--- a/Package.swift
+++ b/Package.swift
@@ -207,7 +207,7 @@ let package = Package(
         ),
         .target(
             name: "TuistLoaderTesting",
-            dependencies: ["TuistLoader", "SwiftToolsSupport-auto", "TuistCore", "ProjectDescription"]
+            dependencies: ["TuistLoader", "SwiftToolsSupport-auto", "TuistCore", "ProjectDescription", "TuistSupportTesting"]
         ),
         .testTarget(
             name: "TuistLoaderTests",

--- a/Sources/TuistCore/Graph/Nodes/FrameworkNode.swift
+++ b/Sources/TuistCore/Graph/Nodes/FrameworkNode.swift
@@ -33,7 +33,7 @@ public class FrameworkNode: PrecompiledNode {
     }
 
     /// Return the framework's binary path.
-    public override var binaryPath: AbsolutePath {
+    override public var binaryPath: AbsolutePath {
         FrameworkNode.binaryPath(frameworkPath: path)
     }
 
@@ -51,7 +51,7 @@ public class FrameworkNode: PrecompiledNode {
         super.init(path: path)
     }
 
-    public override func encode(to encoder: Encoder) throws {
+    override public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(path.pathString, forKey: .path)
         try container.encode(name, forKey: .name)

--- a/Sources/TuistCore/Graph/Nodes/LibraryNode.swift
+++ b/Sources/TuistCore/Graph/Nodes/LibraryNode.swift
@@ -40,7 +40,7 @@ public class LibraryNode: PrecompiledNode {
         super.init(path: path)
     }
 
-    public override func hash(into hasher: inout Hasher) {
+    override public func hash(into hasher: inout Hasher) {
         super.hash(into: &hasher)
         hasher.combine(publicHeaders)
         hasher.combine(swiftModuleMap)
@@ -63,11 +63,11 @@ public class LibraryNode: PrecompiledNode {
             && linking == otherLibraryNode.linking
     }
 
-    public override var binaryPath: AbsolutePath {
+    override public var binaryPath: AbsolutePath {
         path
     }
 
-    public override func encode(to encoder: Encoder) throws {
+    override public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(path.pathString, forKey: .path)
         try container.encode(name, forKey: .name)

--- a/Sources/TuistCore/Graph/Nodes/TargetNode.swift
+++ b/Sources/TuistCore/Graph/Nodes/TargetNode.swift
@@ -32,7 +32,7 @@ public class TargetNode: GraphNode {
 
     // MARK: - Hashable
 
-    public override func hash(into hasher: inout Hasher) {
+    override public func hash(into hasher: inout Hasher) {
         super.hash(into: &hasher)
         hasher.combine(target.name)
     }
@@ -53,7 +53,7 @@ public class TargetNode: GraphNode {
 
     // MARK: - Encodable
 
-    public override func encode(to encoder: Encoder) throws {
+    override public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(path.pathString, forKey: .path)
         try container.encode(target.name, forKey: .name)

--- a/Sources/TuistCore/Graph/Nodes/XCFrameworkNode.swift
+++ b/Sources/TuistCore/Graph/Nodes/XCFrameworkNode.swift
@@ -47,7 +47,7 @@ public class XCFrameworkNode: PrecompiledNode {
     public private(set) var dependencies: [Dependency]
 
     /// Path to the binary.
-    public override var binaryPath: AbsolutePath { primaryBinaryPath }
+    override public var binaryPath: AbsolutePath { primaryBinaryPath }
 
     /// Initializes the node with its attributes.
     /// - Parameters:
@@ -68,7 +68,7 @@ public class XCFrameworkNode: PrecompiledNode {
         super.init(path: path)
     }
 
-    public override func encode(to encoder: Encoder) throws {
+    override public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: XCFrameworkNodeCodingKeys.self)
         try container.encode(path.pathString, forKey: .path)
         try container.encode(name, forKey: .name)

--- a/Sources/TuistGenerator/Dot/DotGraph.swift
+++ b/Sources/TuistGenerator/Dot/DotGraph.swift
@@ -30,7 +30,7 @@ struct DotGraph: Equatable, CustomStringConvertible {
         return """
         digraph \"\(name)\" {
         \(sortedNodes.map { "  \($0.description)" }.joined(separator: "\n"))
-        
+
         \(sortedDependencies.map { "  \"\($0.from)\" \(edgeCharacter) \"\($0.to)\"" }.joined(separator: "\n"))
         }
         """

--- a/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
+++ b/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
@@ -103,21 +103,21 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
         set -e
         set -u
         set -o pipefail
-        
+
         function on_error {
           echo "$(realpath -mq "${0}"):$1: error: Unexpected failure"
         }
         trap 'on_error $LINENO' ERR
-        
+
         if [ -z ${FRAMEWORKS_FOLDER_PATH+x} ]; then
           # If FRAMEWORKS_FOLDER_PATH is not set, then there's nowhere for us to copy
           # frameworks to, so exit 0 (signalling the script phase was successful).
           exit 0
         fi
-        
+
         echo "mkdir -p ${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
         mkdir -p "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
-        
+
         SWIFT_STDLIB_PATH="${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}"
         # Used as a return value for each invocation of `strip_invalid_archs` function.
         STRIP_BINARY_RETVAL=0
@@ -159,21 +159,21 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
           # Resign the code if required by the build settings to avoid unstable apps
           code_sign_if_enabled "${destination}/$(basename "$1")"
         }
-        
-        
+
+
         # Copies and strips a vendored dSYM
         install_dsym() {
           local source="$1"
           if [ -r "$source" ]; then
-            
+
             # Copy the dSYM into a the targets temp dir.
             echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter \\"- CVS/\\" --filter \\"- .svn/\\" --filter \\"- .git/\\" --filter \\"- .hg/\\" --filter \\"- Headers\\" --filter \\"- PrivateHeaders\\" --filter \\"- Modules\\" \\"${source}\\" \\"${DERIVED_FILES_DIR}\\""
             rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${source}" "${DERIVED_FILES_DIR}"
-            
+
             local basename
             basename="$(basename -s .framework.dSYM "$source")"
             binary="${DERIVED_FILES_DIR}/${basename}.framework.dSYM/Contents/Resources/DWARF/${basename}"
-            
+
             # Strip invalid architectures so "fat" simulator / device frameworks work on device
             if [[ "$(file "$binary")" == *"Mach-O "*"dSYM companion"* ]]; then
               strip_invalid_archs "$binary"
@@ -186,11 +186,11 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
               # The dSYM was not stripped at all, in this case touch a fake folder so the input/output paths from Xcode do not reexecute this script because the file is missing.
               touch "${DWARF_DSYM_FOLDER_PATH}/${basename}.framework.dSYM"
             fi
-        
+
           fi
         }
-        
-        
+
+
         # Copies the bcsymbolmap files of a vendored framework
         install_bcsymbolmap() {
             local bcsymbolmap_path="$1"
@@ -198,8 +198,8 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
             echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter \"- CVS/\" --filter \"- .svn/\" --filter \"- .git/\" --filter \"- .hg/\" --filter \"- Headers\" --filter \"- PrivateHeaders\" --filter \"- Modules\" \"${bcsymbolmap_path}\" \"${destination}\""
             rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${bcsymbolmap_path}" "${destination}"
         }
-        
-        
+
+
         # Signs a framework with the provided identity
         code_sign_if_enabled() {
           if [ -n "${EXPANDED_CODE_SIGN_IDENTITY:-}" -a "${CODE_SIGNING_REQUIRED:-}" != "NO" -a "${CODE_SIGNING_ALLOWED}" != "NO" ]; then
@@ -211,8 +211,8 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
             eval "$code_sign_cmd"
           fi
         }
-        
-        
+
+
         # Strip invalid architectures
         strip_invalid_archs() {
           binary="$1"

--- a/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
@@ -40,7 +40,7 @@ public extension XCTestCase {
         The standard output:
         ===========
         \(standardOutput)
-        
+
         Doesn't contain the expected output:
         ===========
         \(pattern)

--- a/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
+++ b/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
@@ -15,10 +15,10 @@ public final class MockFileHandler: FileHandler {
     }
 
     // swiftlint:disable:next force_try
-    public override var currentPath: AbsolutePath { try! temporaryDirectory() }
+    override public var currentPath: AbsolutePath { try! temporaryDirectory() }
 
     public var stubInTemporaryDirectory: AbsolutePath?
-    public override func inTemporaryDirectory(_ closure: (AbsolutePath) throws -> Void) throws {
+    override public func inTemporaryDirectory(_ closure: (AbsolutePath) throws -> Void) throws {
         guard let stubInTemporaryDirectory = stubInTemporaryDirectory else {
             try super.inTemporaryDirectory(closure)
             return
@@ -30,7 +30,7 @@ public final class MockFileHandler: FileHandler {
 public class TuistTestCase: XCTestCase {
     fileprivate var temporaryDirectory: TemporaryDirectory!
 
-    public override static func setUp() {
+    override public static func setUp() {
         super.setUp()
         DispatchQueue.once(token: "io.tuist.test.logging") {
             LoggingSystem.bootstrap(TestingLogHandler.init)
@@ -40,7 +40,7 @@ public class TuistTestCase: XCTestCase {
     public var fileHandler: MockFileHandler!
     public var environment: MockEnvironment!
 
-    public override func setUp() {
+    override public func setUp() {
         super.setUp()
 
         do {
@@ -56,7 +56,7 @@ public class TuistTestCase: XCTestCase {
         FileHandler.shared = fileHandler
     }
 
-    public override func tearDown() {
+    override public func tearDown() {
         temporaryDirectory = nil
         super.tearDown()
     }
@@ -111,7 +111,7 @@ public class TuistTestCase: XCTestCase {
         The output:
         ===========
         \(output)
-        
+
         Doesn't contain the expected:
         ===========
         \(expected)

--- a/Sources/TuistSupportTesting/TestCase/TuistUnitTestCase.swift
+++ b/Sources/TuistSupportTesting/TestCase/TuistUnitTestCase.swift
@@ -7,7 +7,7 @@ public class TuistUnitTestCase: TuistTestCase {
     public var system: MockSystem!
     public var xcodeController: MockXcodeController!
 
-    public override func setUp() {
+    override public func setUp() {
         super.setUp()
         // System
         system = MockSystem()
@@ -18,7 +18,7 @@ public class TuistUnitTestCase: TuistTestCase {
         XcodeController.shared = xcodeController
     }
 
-    public override func tearDown() {
+    override public func tearDown() {
         // System
         system = nil
         System.shared = System()

--- a/Tests/TuistGeneratorTests/Generator/InfoPlistContentProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/InfoPlistContentProviderTests.swift
@@ -264,10 +264,10 @@ final class InfoPlistContentProviderTests: XCTestCase {
         let lhsNSDictionary = NSDictionary(dictionary: lhs ?? [:])
         let rhsNSDictionary = NSDictionary(dictionary: rhs)
         let message = """
-        
+
         The dictionary:
         \(lhs ?? [:])
-        
+
         Is not equal to the expected dictionary:
         \(rhs)
         """

--- a/Tests/TuistLoaderIntegrationTests/Loaders/ManifestLoaderIntegrationTests.swift
+++ b/Tests/TuistLoaderIntegrationTests/Loaders/ManifestLoaderIntegrationTests.swift
@@ -107,7 +107,7 @@ final class ManifestLoaderTests: TuistTestCase {
         let temporaryPath = try self.temporaryPath()
         let content = """
         import ProjectDescription
-        
+
         let template = Template(
             description: "Template description"
         )


### PR DESCRIPTION
### Short description 📝
While recording a video using Tuist, I noticed that we show the raw logs from `xcodebuild`, which I don't think is relevant for the user. For that reason, I'm changing the implementation on this PR to only show the logs if the user passes the `--verbose` argument.