### PR TITLE
Inherit defaultSettings from the project when the target's defaultSettings is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Support for enabling the cloud insights feature [#1335](https://github.com/tuist/tuist/pull/1335) by [@pepibumur](https://github.com/pepibumur)
 
+### Changed
+
+- **Breaking** Inherit defaultSettings from the project when the target's defaultSettings is nil [#1138](https://github.com/tuist/tuist/pull/1338) by [@pepibumur](https://github.com/pepibumur)
+
 ## 1.8.0
 
 ### Changed

--- a/Sources/TuistCore/Graph/Nodes/FrameworkNode.swift
+++ b/Sources/TuistCore/Graph/Nodes/FrameworkNode.swift
@@ -33,7 +33,7 @@ public class FrameworkNode: PrecompiledNode {
     }
 
     /// Return the framework's binary path.
-    public override var binaryPath: AbsolutePath {
+    override public var binaryPath: AbsolutePath {
         FrameworkNode.binaryPath(frameworkPath: path)
     }
 
@@ -51,7 +51,7 @@ public class FrameworkNode: PrecompiledNode {
         super.init(path: path)
     }
 
-    public override func encode(to encoder: Encoder) throws {
+    override public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(path.pathString, forKey: .path)
         try container.encode(name, forKey: .name)

--- a/Sources/TuistCore/Graph/Nodes/LibraryNode.swift
+++ b/Sources/TuistCore/Graph/Nodes/LibraryNode.swift
@@ -40,7 +40,7 @@ public class LibraryNode: PrecompiledNode {
         super.init(path: path)
     }
 
-    public override func hash(into hasher: inout Hasher) {
+    override public func hash(into hasher: inout Hasher) {
         super.hash(into: &hasher)
         hasher.combine(publicHeaders)
         hasher.combine(swiftModuleMap)
@@ -63,11 +63,11 @@ public class LibraryNode: PrecompiledNode {
             && linking == otherLibraryNode.linking
     }
 
-    public override var binaryPath: AbsolutePath {
+    override public var binaryPath: AbsolutePath {
         path
     }
 
-    public override func encode(to encoder: Encoder) throws {
+    override public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(path.pathString, forKey: .path)
         try container.encode(name, forKey: .name)

--- a/Sources/TuistCore/Graph/Nodes/TargetNode.swift
+++ b/Sources/TuistCore/Graph/Nodes/TargetNode.swift
@@ -32,7 +32,7 @@ public class TargetNode: GraphNode {
 
     // MARK: - Hashable
 
-    public override func hash(into hasher: inout Hasher) {
+    override public func hash(into hasher: inout Hasher) {
         super.hash(into: &hasher)
         hasher.combine(target.name)
     }
@@ -53,7 +53,7 @@ public class TargetNode: GraphNode {
 
     // MARK: - Encodable
 
-    public override func encode(to encoder: Encoder) throws {
+    override public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(path.pathString, forKey: .path)
         try container.encode(target.name, forKey: .name)

--- a/Sources/TuistCore/Graph/Nodes/XCFrameworkNode.swift
+++ b/Sources/TuistCore/Graph/Nodes/XCFrameworkNode.swift
@@ -47,7 +47,7 @@ public class XCFrameworkNode: PrecompiledNode {
     public private(set) var dependencies: [Dependency]
 
     /// Path to the binary.
-    public override var binaryPath: AbsolutePath { primaryBinaryPath }
+    override public var binaryPath: AbsolutePath { primaryBinaryPath }
 
     /// Initializes the node with its attributes.
     /// - Parameters:
@@ -68,7 +68,7 @@ public class XCFrameworkNode: PrecompiledNode {
         super.init(path: path)
     }
 
-    public override func encode(to encoder: Encoder) throws {
+    override public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: XCFrameworkNodeCodingKeys.self)
         try container.encode(path.pathString, forKey: .path)
         try container.encode(name, forKey: .name)

--- a/Sources/TuistCoreTesting/Models/Settings+TestData.swift
+++ b/Sources/TuistCoreTesting/Models/Settings+TestData.swift
@@ -21,4 +21,11 @@ public extension Settings {
                      configurations: [BuildConfiguration: Configuration?] = [:]) -> Settings {
         Settings(base: base, configurations: configurations)
     }
+
+    static func test(defaultSettings: DefaultSettings) -> Settings {
+        Settings(base: [:],
+                 configurations: [.debug: Configuration(settings: [:]),
+                                  .release: Configuration(settings: [:])],
+                 defaultSettings: defaultSettings)
+    }
 }

--- a/Sources/TuistGenerator/Dot/DotGraph.swift
+++ b/Sources/TuistGenerator/Dot/DotGraph.swift
@@ -30,7 +30,7 @@ struct DotGraph: Equatable, CustomStringConvertible {
         return """
         digraph \"\(name)\" {
         \(sortedNodes.map { "  \($0.description)" }.joined(separator: "\n"))
-        
+
         \(sortedDependencies.map { "  \"\($0.from)\" \(edgeCharacter) \"\($0.to)\"" }.joined(separator: "\n"))
         }
         """

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -10,6 +10,7 @@ protocol ConfigGenerating: AnyObject {
                                fileElements: ProjectFileElements) throws -> XCConfigurationList
 
     func generateTargetConfig(_ target: Target,
+                              project: Project,
                               pbxTarget: PBXTarget,
                               pbxproj: PBXProj,
                               projectSettings: Settings,
@@ -57,6 +58,7 @@ final class ConfigGenerator: ConfigGenerating {
     }
 
     func generateTargetConfig(_ target: Target,
+                              project: Project,
                               pbxTarget: PBXTarget,
                               pbxproj: PBXProj,
                               projectSettings: Settings,
@@ -87,6 +89,7 @@ final class ConfigGenerator: ConfigGenerating {
         let swiftVersion = try System.shared.swiftVersion()
         try orderedConfigurations.forEach {
             try generateTargetSettingsFor(target: target,
+                                          project: project,
                                           buildConfiguration: $0.key,
                                           configuration: $0.value,
                                           fileElements: fileElements,
@@ -127,6 +130,7 @@ final class ConfigGenerator: ConfigGenerating {
     }
 
     private func generateTargetSettingsFor(target: Target,
+                                           project: Project,
                                            buildConfiguration: BuildConfiguration,
                                            configuration: Configuration?,
                                            fileElements: ProjectFileElements,
@@ -137,6 +141,7 @@ final class ConfigGenerator: ConfigGenerating {
                                            sourceRootPath: AbsolutePath) throws {
         let settingsHelper = SettingsHelper()
         var settings = try defaultSettingsProvider.targetSettings(target: target,
+                                                                  project: project,
                                                                   buildConfiguration: buildConfiguration)
         updateTargetDerived(buildSettings: &settings,
                             target: target,

--- a/Sources/TuistGenerator/Generator/ProjectGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGenerator.swift
@@ -177,6 +177,7 @@ final class ProjectGenerator: ProjectGenerating {
         var nativeTargets: [String: PBXNativeTarget] = [:]
         try project.targets.forEach { target in
             let nativeTarget = try targetGenerator.generateTarget(target: target,
+                                                                  project: project,
                                                                   pbxproj: pbxproj,
                                                                   pbxProject: pbxProject,
                                                                   projectSettings: project.settings,

--- a/Sources/TuistGenerator/Generator/TargetGenerator.swift
+++ b/Sources/TuistGenerator/Generator/TargetGenerator.swift
@@ -6,6 +6,7 @@ import XcodeProj
 
 protocol TargetGenerating: AnyObject {
     func generateTarget(target: Target,
+                        project: Project,
                         pbxproj: PBXProj,
                         pbxProject: PBXProject,
                         projectSettings: Settings,
@@ -44,6 +45,7 @@ final class TargetGenerator: TargetGenerating {
 
     // swiftlint:disable:next function_body_length
     func generateTarget(target: Target,
+                        project: Project,
                         pbxproj: PBXProj,
                         pbxProject: PBXProject,
                         projectSettings: Settings,
@@ -75,6 +77,7 @@ final class TargetGenerator: TargetGenerating {
 
         /// Build configuration
         try configGenerator.generateTargetConfig(target,
+                                                 project: project,
                                                  pbxTarget: pbxTarget,
                                                  pbxproj: pbxproj,
                                                  projectSettings: projectSettings,

--- a/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
+++ b/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
@@ -9,6 +9,7 @@ public protocol DefaultSettingsProviding {
                          buildConfiguration: BuildConfiguration) throws -> SettingsDictionary
 
     func targetSettings(target: Target,
+                        project: Project,
                         buildConfiguration: BuildConfiguration) throws -> SettingsDictionary
 }
 
@@ -89,9 +90,10 @@ public final class DefaultSettingsProvider: DefaultSettingsProviding {
     }
 
     public func targetSettings(target: Target,
+                               project: Project,
                                buildConfiguration: BuildConfiguration) throws -> SettingsDictionary {
         let settingsHelper = SettingsHelper()
-        let defaultSettings = target.settings?.defaultSettings ?? .recommended
+        let defaultSettings = target.settings?.defaultSettings ?? project.settings.defaultSettings
         let product = settingsHelper.settingsProviderProduct(target)
         let platform = settingsHelper.settingsProviderPlatform(target)
         let variant = settingsHelper.variant(buildConfiguration)

--- a/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
+++ b/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
@@ -103,21 +103,21 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
         set -e
         set -u
         set -o pipefail
-        
+
         function on_error {
           echo "$(realpath -mq "${0}"):$1: error: Unexpected failure"
         }
         trap 'on_error $LINENO' ERR
-        
+
         if [ -z ${FRAMEWORKS_FOLDER_PATH+x} ]; then
           # If FRAMEWORKS_FOLDER_PATH is not set, then there's nowhere for us to copy
           # frameworks to, so exit 0 (signalling the script phase was successful).
           exit 0
         fi
-        
+
         echo "mkdir -p ${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
         mkdir -p "${CONFIGURATION_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
-        
+
         SWIFT_STDLIB_PATH="${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}"
         # Used as a return value for each invocation of `strip_invalid_archs` function.
         STRIP_BINARY_RETVAL=0
@@ -159,21 +159,21 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
           # Resign the code if required by the build settings to avoid unstable apps
           code_sign_if_enabled "${destination}/$(basename "$1")"
         }
-        
-        
+
+
         # Copies and strips a vendored dSYM
         install_dsym() {
           local source="$1"
           if [ -r "$source" ]; then
-            
+
             # Copy the dSYM into a the targets temp dir.
             echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter \\"- CVS/\\" --filter \\"- .svn/\\" --filter \\"- .git/\\" --filter \\"- .hg/\\" --filter \\"- Headers\\" --filter \\"- PrivateHeaders\\" --filter \\"- Modules\\" \\"${source}\\" \\"${DERIVED_FILES_DIR}\\""
             rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${source}" "${DERIVED_FILES_DIR}"
-            
+
             local basename
             basename="$(basename -s .framework.dSYM "$source")"
             binary="${DERIVED_FILES_DIR}/${basename}.framework.dSYM/Contents/Resources/DWARF/${basename}"
-            
+
             # Strip invalid architectures so "fat" simulator / device frameworks work on device
             if [[ "$(file "$binary")" == *"Mach-O "*"dSYM companion"* ]]; then
               strip_invalid_archs "$binary"
@@ -186,11 +186,11 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
               # The dSYM was not stripped at all, in this case touch a fake folder so the input/output paths from Xcode do not reexecute this script because the file is missing.
               touch "${DWARF_DSYM_FOLDER_PATH}/${basename}.framework.dSYM"
             fi
-        
+
           fi
         }
-        
-        
+
+
         # Copies the bcsymbolmap files of a vendored framework
         install_bcsymbolmap() {
             local bcsymbolmap_path="$1"
@@ -198,8 +198,8 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
             echo "rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter \"- CVS/\" --filter \"- .svn/\" --filter \"- .git/\" --filter \"- .hg/\" --filter \"- Headers\" --filter \"- PrivateHeaders\" --filter \"- Modules\" \"${bcsymbolmap_path}\" \"${destination}\""
             rsync --delete -av "${RSYNC_PROTECT_TMP_FILES[@]}" --filter "- CVS/" --filter "- .svn/" --filter "- .git/" --filter "- .hg/" --filter "- Headers" --filter "- PrivateHeaders" --filter "- Modules" "${bcsymbolmap_path}" "${destination}"
         }
-        
-        
+
+
         # Signs a framework with the provided identity
         code_sign_if_enabled() {
           if [ -n "${EXPANDED_CODE_SIGN_IDENTITY:-}" -a "${CODE_SIGNING_REQUIRED:-}" != "NO" -a "${CODE_SIGNING_ALLOWED}" != "NO" ]; then
@@ -211,8 +211,8 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
             eval "$code_sign_cmd"
           fi
         }
-        
-        
+
+
         # Strip invalid architectures
         strip_invalid_archs() {
           binary="$1"

--- a/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
@@ -40,7 +40,7 @@ public extension XCTestCase {
         The standard output:
         ===========
         \(standardOutput)
-        
+
         Doesn't contain the expected output:
         ===========
         \(pattern)

--- a/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
+++ b/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
@@ -15,10 +15,10 @@ public final class MockFileHandler: FileHandler {
     }
 
     // swiftlint:disable:next force_try
-    public override var currentPath: AbsolutePath { try! temporaryDirectory() }
+    override public var currentPath: AbsolutePath { try! temporaryDirectory() }
 
     public var stubInTemporaryDirectory: AbsolutePath?
-    public override func inTemporaryDirectory(_ closure: (AbsolutePath) throws -> Void) throws {
+    override public func inTemporaryDirectory(_ closure: (AbsolutePath) throws -> Void) throws {
         guard let stubInTemporaryDirectory = stubInTemporaryDirectory else {
             try super.inTemporaryDirectory(closure)
             return
@@ -30,7 +30,7 @@ public final class MockFileHandler: FileHandler {
 public class TuistTestCase: XCTestCase {
     fileprivate var temporaryDirectory: TemporaryDirectory!
 
-    public override static func setUp() {
+    override public static func setUp() {
         super.setUp()
         DispatchQueue.once(token: "io.tuist.test.logging") {
             LoggingSystem.bootstrap(TestingLogHandler.init)
@@ -40,7 +40,7 @@ public class TuistTestCase: XCTestCase {
     public var fileHandler: MockFileHandler!
     public var environment: MockEnvironment!
 
-    public override func setUp() {
+    override public func setUp() {
         super.setUp()
 
         do {
@@ -56,7 +56,7 @@ public class TuistTestCase: XCTestCase {
         FileHandler.shared = fileHandler
     }
 
-    public override func tearDown() {
+    override public func tearDown() {
         temporaryDirectory = nil
         super.tearDown()
     }
@@ -111,7 +111,7 @@ public class TuistTestCase: XCTestCase {
         The output:
         ===========
         \(output)
-        
+
         Doesn't contain the expected:
         ===========
         \(expected)

--- a/Sources/TuistSupportTesting/TestCase/TuistUnitTestCase.swift
+++ b/Sources/TuistSupportTesting/TestCase/TuistUnitTestCase.swift
@@ -7,7 +7,7 @@ public class TuistUnitTestCase: TuistTestCase {
     public var system: MockSystem!
     public var xcodeController: MockXcodeController!
 
-    public override func setUp() {
+    override public func setUp() {
         super.setUp()
         // System
         system = MockSystem()
@@ -18,7 +18,7 @@ public class TuistUnitTestCase: TuistTestCase {
         XcodeController.shared = xcodeController
     }
 
-    public override func tearDown() {
+    override public func tearDown() {
         // System
         system = nil
         System.shared = System()

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -137,10 +137,12 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
 
     func test_generateTargetWithDeploymentTarget_whenIOS() throws {
         // Given
+        let project = Project.test()
         let target = Target.test(deploymentTarget: .iOS("12.0", [.iphone, .ipad]))
 
         // When
         try subject.generateTargetConfig(target,
+                                         project: project,
                                          pbxTarget: pbxTarget,
                                          pbxproj: pbxproj,
                                          projectSettings: .default,
@@ -164,10 +166,12 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
 
     func test_generateTargetWithDeploymentTarget_whenMac() throws {
         // Given
+        let project = Project.test()
         let target = Target.test(deploymentTarget: .macOS("10.14.1"))
 
         // When
         try subject.generateTargetConfig(target,
+                                         project: project,
                                          pbxTarget: pbxTarget,
                                          pbxproj: pbxproj,
                                          projectSettings: .default,
@@ -190,10 +194,12 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
 
     func test_generateTargetWithDeploymentTarget_whenCatalyst() throws {
         // Given
+        let project = Project.test()
         let target = Target.test(deploymentTarget: .iOS("13.1", [.iphone, .ipad, .mac]))
 
         // When
         try subject.generateTargetConfig(target,
+                                         project: project,
                                          pbxTarget: pbxTarget,
                                          pbxproj: pbxproj,
                                          projectSettings: .default,
@@ -259,10 +265,12 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             .debug("AnotherDebug"): nil,
             .release("CustomRelease"): nil,
         ])
+        let project = Project.test()
         let target = Target.test()
 
         // When
         try subject.generateTargetConfig(target,
+                                         project: project,
                                          pbxTarget: pbxTarget,
                                          pbxproj: pbxproj,
                                          projectSettings: projectSettings,
@@ -281,10 +289,12 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             .debug("CustomDebug"): nil,
             .debug("AnotherDebug"): nil,
         ])
+        let project = Project.test()
         let target = Target.test()
 
         // When
         try subject.generateTargetConfig(target,
+                                         project: project,
                                          pbxTarget: pbxTarget,
                                          pbxproj: pbxproj,
                                          projectSettings: projectSettings,
@@ -357,6 +367,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
                                               pbxproj: pbxproj,
                                               sourceRootPath: project.path)
         _ = try subject.generateTargetConfig(target,
+                                             project: project,
                                              pbxTarget: pbxTarget,
                                              pbxproj: pbxproj,
                                              projectSettings: project.settings,
@@ -379,6 +390,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         let graph = Graph.test(entryNodes: [appTargetNode, testTargetNode])
 
         _ = try subject.generateTargetConfig(target,
+                                             project: project,
                                              pbxTarget: pbxTarget,
                                              pbxproj: pbxproj,
                                              projectSettings: project.settings,

--- a/Tests/TuistGeneratorTests/Generator/InfoPlistContentProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/InfoPlistContentProviderTests.swift
@@ -264,10 +264,10 @@ final class InfoPlistContentProviderTests: XCTestCase {
         let lhsNSDictionary = NSDictionary(dictionary: lhs ?? [:])
         let rhsNSDictionary = NSDictionary(dictionary: rhs)
         let message = """
-        
+
         The dictionary:
         \(lhs ?? [:])
-        
+
         Is not equal to the expected dictionary:
         \(rhs)
         """

--- a/Tests/TuistGeneratorTests/Generator/Mocks/MockTargetGenerator.swift
+++ b/Tests/TuistGeneratorTests/Generator/Mocks/MockTargetGenerator.swift
@@ -9,7 +9,7 @@ import XcodeProj
 class MockTargetGenerator: TargetGenerating {
     var generateTargetStub: (() -> PBXNativeTarget)?
 
-    func generateTarget(target: Target, project: Project, pbxproj _: PBXProj, pbxProject _: PBXProject, projectSettings _: Settings, fileElements _: ProjectFileElements, path _: AbsolutePath, sourceRootPath _: AbsolutePath, graph _: Graph) throws -> PBXNativeTarget {
+    func generateTarget(target: Target, project _: Project, pbxproj _: PBXProj, pbxProject _: PBXProject, projectSettings _: Settings, fileElements _: ProjectFileElements, path _: AbsolutePath, sourceRootPath _: AbsolutePath, graph _: Graph) throws -> PBXNativeTarget {
         generateTargetStub?() ?? PBXNativeTarget(name: target.name)
     }
 

--- a/Tests/TuistGeneratorTests/Generator/Mocks/MockTargetGenerator.swift
+++ b/Tests/TuistGeneratorTests/Generator/Mocks/MockTargetGenerator.swift
@@ -9,7 +9,7 @@ import XcodeProj
 class MockTargetGenerator: TargetGenerating {
     var generateTargetStub: (() -> PBXNativeTarget)?
 
-    func generateTarget(target: Target, pbxproj _: PBXProj, pbxProject _: PBXProject, projectSettings _: Settings, fileElements _: ProjectFileElements, path _: AbsolutePath, sourceRootPath _: AbsolutePath, graph _: Graph) throws -> PBXNativeTarget {
+    func generateTarget(target: Target, project: Project, pbxproj _: PBXProj, pbxProject _: PBXProject, projectSettings _: Settings, fileElements _: ProjectFileElements, path _: AbsolutePath, sourceRootPath _: AbsolutePath, graph _: Graph) throws -> PBXNativeTarget {
         generateTargetStub?() ?? PBXNativeTarget(name: target.name)
     }
 

--- a/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
@@ -56,6 +56,7 @@ final class TargetGeneratorTests: XCTestCase {
 
         // When
         let generatedTarget = try subject.generateTarget(target: target,
+                                                         project: project,
                                                          pbxproj: pbxproj,
                                                          pbxProject: pbxProject,
                                                          projectSettings: Settings.test(),
@@ -133,6 +134,7 @@ final class TargetGeneratorTests: XCTestCase {
 
         // When
         let pbxTarget = try subject.generateTarget(target: target,
+                                                   project: project,
                                                    pbxproj: pbxproj,
                                                    pbxProject: pbxProject,
                                                    projectSettings: Settings.test(),

--- a/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -159,10 +159,12 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let settings = Settings(base: [:],
                                 configurations: [buildConfiguration: nil],
                                 defaultSettings: .essential)
+        let project = Project.test()
         let target = Target.test(product: .app, settings: settings)
 
         // When
         let got = try subject.targetSettings(target: target,
+                                             project: project,
                                              buildConfiguration: buildConfiguration)
 
         // Then
@@ -175,10 +177,12 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let settings = Settings(base: [:],
                                 configurations: [buildConfiguration: nil],
                                 defaultSettings: .essential)
+        let project = Project.test()
         let target = Target.test(product: .framework, settings: settings)
 
         // When
         let got = try subject.targetSettings(target: target,
+                                             project: project,
                                              buildConfiguration: buildConfiguration)
 
         // Then
@@ -191,10 +195,12 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let settings = Settings(base: [:],
                                 configurations: [buildConfiguration: nil],
                                 defaultSettings: .essential)
+        let project = Project.test()
         let target = Target.test(product: .framework, settings: settings)
 
         // When
         let got = try subject.targetSettings(target: target,
+                                             project: project,
                                              buildConfiguration: buildConfiguration)
 
         // Then
@@ -274,16 +280,32 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let settings = Settings(base: [:],
                                 configurations: [buildConfiguration: nil],
                                 defaultSettings: .recommended)
+        let project = Project.test()
         let target = Target.test(settings: settings)
         xcodeController.selectedVersionStub = .success(Version(11, 0, 0))
 
         // When
         let got = try subject.targetSettings(target: target,
+                                             project: project,
                                              buildConfiguration: buildConfiguration)
 
         // Then
         XCTAssertSettings(got, containsAll: appTargetEssentialDebugSettings)
         XCTAssertEqual(got.count, 9)
+    }
+
+    func testTargetSettings_inheritsProjectDefaultSettings_when_targetBuildSettings_are_nil() throws {
+        // Given
+        let project = Project.test(settings: .test(defaultSettings: .essential))
+        let target = Target.test(settings: nil)
+
+        // When
+        let got = try subject.targetSettings(target: target,
+                                             project: project,
+                                             buildConfiguration: .debug)
+
+        // Then
+        XCTAssertSettings(got, containsAll: appTargetEssentialDebugSettings)
     }
 
     func testTargetSettings_whenXcode10() throws {
@@ -293,10 +315,12 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
                                 configurations: [buildConfiguration: nil],
                                 defaultSettings: .recommended)
         let target = Target.test(settings: settings)
+        let project = Project.test()
         xcodeController.selectedVersionStub = .success(Version(10, 0, 0))
 
         // When
         let got = try subject.targetSettings(target: target,
+                                             project: project,
                                              buildConfiguration: buildConfiguration)
 
         // Then
@@ -310,10 +334,12 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
                                 configurations: [buildConfiguration: nil],
                                 defaultSettings: .recommended)
         let target = Target.test(settings: settings)
+        let project = Project.test()
         xcodeController.selectedVersionStub = .success(Version(11, 0, 0))
 
         // When
         let got = try subject.targetSettings(target: target,
+                                             project: project,
                                              buildConfiguration: buildConfiguration)
 
         // Then
@@ -327,10 +353,12 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
                                 configurations: [buildConfiguration: nil],
                                 defaultSettings: .recommended)
         let target = Target.test(product: .app, settings: settings)
+        let project = Project.test()
         xcodeController.selectedVersionStub = .success(Version(11, 0, 0))
 
         // When
         let got = try subject.targetSettings(target: target,
+                                             project: project,
                                              buildConfiguration: buildConfiguration)
 
         // Then
@@ -344,10 +372,12 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let settings = Settings(base: [:],
                                 configurations: [buildConfiguration: nil],
                                 defaultSettings: .recommended)
+        let project = Project.test()
         let target = Target.test(product: .framework, settings: settings)
 
         // When
         let got = try subject.targetSettings(target: target,
+                                             project: project,
                                              buildConfiguration: buildConfiguration)
 
         // Then
@@ -361,10 +391,12 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let settings = Settings(base: [:],
                                 configurations: [buildConfiguration: nil],
                                 defaultSettings: .recommended)
+        let project = Project.test()
         let target = Target.test(product: .framework, settings: settings)
 
         // When
         let got = try subject.targetSettings(target: target,
+                                             project: project,
                                              buildConfiguration: buildConfiguration)
 
         // Then
@@ -378,10 +410,12 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let settings = Settings(base: [:],
                                 configurations: [buildConfiguration: nil],
                                 defaultSettings: .none)
+        let project = Project.test()
         let target = Target.test(product: .framework, settings: settings)
 
         // When
         let got = try subject.targetSettings(target: target,
+                                             project: project,
                                              buildConfiguration: buildConfiguration)
 
         // Then
@@ -394,10 +428,12 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let settings = Settings(base: [:],
                                 configurations: [buildConfiguration: nil],
                                 defaultSettings: .none)
+        let project = Project.test()
         let target = Target.test(product: .framework, settings: settings)
 
         // When
         let got = try subject.targetSettings(target: target,
+                                             project: project,
                                              buildConfiguration: buildConfiguration)
 
         // Then
@@ -410,10 +446,12 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let settings = Settings(base: [:],
                                 configurations: [buildConfiguration: nil],
                                 defaultSettings: .recommended)
+        let project = Project.test()
         let target = Target.test(product: .unitTests, settings: settings)
 
         // When
         let got = try subject.targetSettings(target: target,
+                                             project: project,
                                              buildConfiguration: buildConfiguration)
 
         // Then
@@ -426,10 +464,12 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let settings = Settings(base: [:],
                                 configurations: [buildConfiguration: nil],
                                 defaultSettings: .recommended)
+        let project = Project.test()
         let target = Target.test(product: .uiTests, settings: settings)
 
         // When
         let got = try subject.targetSettings(target: target,
+                                             project: project,
                                              buildConfiguration: buildConfiguration)
 
         // Then
@@ -442,10 +482,12 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let settings = Settings(base: [:],
                                 configurations: [buildConfiguration: nil],
                                 defaultSettings: .essential)
+        let project = Project.test()
         let target = Target.test(product: .unitTests, settings: settings)
 
         // When
         let got = try subject.targetSettings(target: target,
+                                             project: project,
                                              buildConfiguration: buildConfiguration)
 
         // Then
@@ -458,10 +500,12 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         let settings = Settings(base: [:],
                                 configurations: [buildConfiguration: nil],
                                 defaultSettings: .essential)
+        let project = Project.test()
         let target = Target.test(product: .uiTests, settings: settings)
 
         // When
         let got = try subject.targetSettings(target: target,
+                                             project: project,
                                              buildConfiguration: buildConfiguration)
 
         // Then

--- a/Tests/TuistLoaderIntegrationTests/Loaders/ManifestLoaderIntegrationTests.swift
+++ b/Tests/TuistLoaderIntegrationTests/Loaders/ManifestLoaderIntegrationTests.swift
@@ -107,7 +107,7 @@ final class ManifestLoaderTests: TuistTestCase {
         let temporaryPath = try self.temporaryPath()
         let content = """
         import ProjectDescription
-        
+
         let template = Template(
             description: "Template description"
         )


### PR DESCRIPTION
### Short description 📝
Someone reported that their project targets got build settings even though `defaultSettings` was set to nil at the target level, and to `none` at the project level. As @kwridan found out, it happens because the `DefaultSettingsProvider` defaulted to essential when the target's defaultSettings is nil.

I'm this PR I'm changing that behavior to inherit the `defaultSettings` from the project that contains the target.
