### PR TITLE
Add `CachedManifestLoader`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Changed
 
 - **Breaking** Inherit defaultSettings from the project when the target's defaultSettings is nil [#1138](https://github.com/tuist/tuist/pull/1338) by [@pepibumur](https://github.com/pepibumur)
+- Manifests are now cached to speed up generation times _(opt out via setting `TUIST_CACHE_MANIFESTS=0`)_ [1341](https://github.com/tuist/tuist/pull/1341) by [@kwridan](https://github.com/kwridan) 
 
 ## 1.8.0
 

--- a/Sources/TuistKit/ProjectGenerator/ProjectGenerator.swift
+++ b/Sources/TuistKit/ProjectGenerator/ProjectGenerator.swift
@@ -11,7 +11,6 @@ protocol ProjectGenerating {
 }
 
 class ProjectGenerator: ProjectGenerating {
-    private let manifestLoader: ManifestLoading = ManifestLoader()
     private let manifestLinter: ManifestLinting = ManifestLinter()
     private let graphLinter: GraphLinting = GraphLinter()
     private let environmentLinter: EnvironmentLinting = EnvironmentLinter()
@@ -23,13 +22,17 @@ class ProjectGenerator: ProjectGenerating {
     private let graphLoader: GraphLoading
     private let sideEffectDescriptorExecutor: SideEffectDescriptorExecuting
     private let graphMapperProvider: GraphMapperProviding
+    private let manifestLoader: ManifestLoading
 
-    init(graphMapperProvider: GraphMapperProviding = GraphMapperProvider(useCache: false)) {
+    init(graphMapperProvider: GraphMapperProviding = GraphMapperProvider(useCache: false),
+         manifestLoaderFactory: ManifestLoaderFactory = ManifestLoaderFactory()) {
+        let manifestLoader = manifestLoaderFactory.createManifestLoader()
         modelLoader = GeneratorModelLoader(manifestLoader: manifestLoader,
                                            manifestLinter: manifestLinter)
         graphLoader = GraphLoader(modelLoader: modelLoader)
         sideEffectDescriptorExecutor = SideEffectDescriptorExecutor()
         self.graphMapperProvider = graphMapperProvider
+        self.manifestLoader = manifestLoader
     }
 
     func generate(path: AbsolutePath, projectOnly: Bool) throws -> AbsolutePath {

--- a/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -1,0 +1,183 @@
+import Foundation
+import ProjectDescription
+import TSCBasic
+import TuistSupport
+
+/// Cached Manifest Loader
+///
+/// A manifest loader that caches json representations of the manifests it loads to disk (`~/.tuist/Cache/Manifests`)
+/// along with their hashes. This allows speeding up the loading process in the event the manifest hasn't changed since the last
+/// time a load was performed.
+///
+public class CachedManifestLoader: ManifestLoading {
+    private let manifestLoader: ManifestLoading
+    private let projectDescriptionHelpersHasher: ProjectDescriptionHelpersHashing
+    private let helpersDirectoryLocator: HelpersDirectoryLocating
+    private let cacheDirectory: AbsolutePath
+    private let fileHandler: FileHandling
+    private let decoder: JSONDecoder = JSONDecoder()
+    private let encoder: JSONEncoder = JSONEncoder()
+    private var helpersCache: [AbsolutePath: String?] = [:]
+
+    public convenience init(manifestLoader: ManifestLoading = ManifestLoader()) {
+        self.init(manifestLoader: manifestLoader,
+                  projectDescriptionHelpersHasher: ProjectDescriptionHelpersHasher(),
+                  helpersDirectoryLocator: HelpersDirectoryLocator(),
+                  cacheDirectory: Environment.shared.cacheDirectory.appending(component: "Manifests"),
+                  fileHandler: FileHandler.shared)
+    }
+
+    init(manifestLoader: ManifestLoading,
+         projectDescriptionHelpersHasher: ProjectDescriptionHelpersHashing,
+         helpersDirectoryLocator: HelpersDirectoryLocating,
+         cacheDirectory: AbsolutePath,
+         fileHandler: FileHandling) {
+        self.manifestLoader = manifestLoader
+        self.projectDescriptionHelpersHasher = projectDescriptionHelpersHasher
+        self.helpersDirectoryLocator = helpersDirectoryLocator
+        self.cacheDirectory = cacheDirectory
+        self.fileHandler = fileHandler
+    }
+
+    public func loadConfig(at path: AbsolutePath) throws -> Config {
+        try manifestLoader.loadConfig(at: path)
+    }
+
+    public func loadProject(at path: AbsolutePath) throws -> Project {
+        try load(manifest: .project, at: path) {
+            try manifestLoader.loadProject(at: path)
+        }
+    }
+
+    public func loadWorkspace(at path: AbsolutePath) throws -> Workspace {
+        try load(manifest: .workspace, at: path) {
+            try manifestLoader.loadWorkspace(at: path)
+        }
+    }
+
+    public func loadSetup(at path: AbsolutePath) throws -> [Upping] {
+        try manifestLoader.loadSetup(at: path)
+    }
+
+    public func loadTemplate(at path: AbsolutePath) throws -> Template {
+        try load(manifest: .template, at: path) {
+            try manifestLoader.loadTemplate(at: path)
+        }
+    }
+
+    public func manifests(at path: AbsolutePath) -> Set<Manifest> {
+        manifestLoader.manifests(at: path)
+    }
+
+    // MARK: - Private
+
+    private func load<T: Codable>(manifest: Manifest, at path: AbsolutePath, loader: () throws -> T) throws -> T {
+        let manifestPath = path.appending(component: manifest.fileName)
+        guard fileHandler.exists(manifestPath) else {
+            throw ManifestLoaderError.manifestNotFound(manifest, path)
+        }
+
+        let manifestHash = try calculateManifestHash(for: manifest, at: manifestPath)
+        let helpersHash = try calculateHelpersCache(at: path)
+
+        let cachedManifestPath = cachedPath(for: manifestPath)
+        if let cached: T = loadCachedManifest(at: cachedManifestPath,
+                                              manifestHash: manifestHash,
+                                              helpersHash: helpersHash) {
+            return cached
+        }
+
+        let loadedManifest = try loader()
+
+        try cacheManifest(manifest: manifest,
+                          loadedManifest: loadedManifest,
+                          manifestHash: manifestHash,
+                          helpersHash: helpersHash,
+                          to: cachedManifestPath)
+
+        return loadedManifest
+    }
+
+    private func calculateManifestHash(for manifest: Manifest, at path: AbsolutePath) throws -> Data {
+        guard let hash = path.sha256() else {
+            throw ManifestLoaderError.manifestCachingFailed(manifest, path)
+        }
+        return hash
+    }
+
+    private func calculateHelpersCache(at path: AbsolutePath) throws -> String? {
+        guard let helpersDirectory = helpersDirectoryLocator.locate(at: path) else {
+            return nil
+        }
+
+        if let cached = helpersCache[helpersDirectory] {
+            return cached
+        }
+
+        let hash = try projectDescriptionHelpersHasher.hash(helpersDirectory: helpersDirectory)
+        helpersCache[helpersDirectory] = hash
+
+        return hash
+    }
+
+    private func cachedPath(for manifestPath: AbsolutePath) -> AbsolutePath {
+        let pathHash = manifestPath.pathString.md5
+        let cacheVersion = CachedManifest.currentVersion.description
+        let fileName = [cacheVersion, pathHash].joined(separator: ".")
+        return cacheDirectory.appending(component: fileName)
+    }
+
+    private func loadCachedManifest<T: Decodable>(at cachedManifestPath: AbsolutePath,
+                                                  manifestHash: Data,
+                                                  helpersHash: String?) -> T? {
+        guard fileHandler.exists(cachedManifestPath) else {
+            return nil
+        }
+
+        guard let data = try? fileHandler.readFile(cachedManifestPath) else {
+            return nil
+        }
+
+        guard let cachedManifest = try? decoder.decode(CachedManifest.self, from: data) else {
+            return nil
+        }
+
+        guard cachedManifest.version == CachedManifest.currentVersion,
+            cachedManifest.helpersHash == helpersHash,
+            cachedManifest.manifestHash == manifestHash else {
+            return nil
+        }
+
+        return try? decoder.decode(T.self, from: cachedManifest.manifest)
+    }
+
+    private func cacheManifest<T: Encodable>(manifest: Manifest,
+                                             loadedManifest: T,
+                                             manifestHash: Data,
+                                             helpersHash: String?,
+                                             to cachedManifestPath: AbsolutePath) throws {
+        let cachedManifest = CachedManifest(manifestHash: manifestHash,
+                                            helpersHash: helpersHash,
+                                            manifest: try encoder.encode(loadedManifest))
+
+        let cachedManifestData = try encoder.encode(cachedManifest)
+        guard let cachedManifestContent = String(data: cachedManifestData, encoding: .utf8) else {
+            throw ManifestLoaderError.manifestCachingFailed(manifest, cachedManifestPath)
+        }
+
+        try fileHandler.touch(cachedManifestPath)
+        try fileHandler.write(
+            cachedManifestContent,
+            path: cachedManifestPath,
+            atomically: true
+        )
+    }
+}
+
+private struct CachedManifest: Codable {
+    static let currentVersion = 1
+    var version: Int = currentVersion
+    var manifestHash: Data
+    var helpersHash: String?
+    var manifest: Data
+}

--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -9,6 +9,7 @@ public enum ManifestLoaderError: FatalError, Equatable {
     case projectDescriptionNotFound(AbsolutePath)
     case unexpectedOutput(AbsolutePath)
     case manifestNotFound(Manifest?, AbsolutePath)
+    case manifestCachingFailed(Manifest?, AbsolutePath)
 
     public static func manifestNotFound(_ path: AbsolutePath) -> ManifestLoaderError {
         .manifestNotFound(nil, path)
@@ -22,6 +23,8 @@ public enum ManifestLoaderError: FatalError, Equatable {
             return "Unexpected output trying to parse the manifest at path \(path.pathString)"
         case let .manifestNotFound(manifest, path):
             return "\(manifest?.fileName ?? "Manifest") not found at path \(path.pathString)"
+        case let .manifestCachingFailed(manifest, path):
+            return "Could not cache \(manifest?.fileName ?? "Manifest") at path \(path.pathString)"
         }
     }
 
@@ -32,6 +35,8 @@ public enum ManifestLoaderError: FatalError, Equatable {
         case .projectDescriptionNotFound:
             return .bug
         case .manifestNotFound:
+            return .abort
+        case .manifestCachingFailed:
             return .abort
         }
     }

--- a/Sources/TuistLoader/Loaders/ManifestLoaderFactory.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoaderFactory.swift
@@ -1,0 +1,21 @@
+import Foundation
+import TuistSupport
+
+public final class ManifestLoaderFactory {
+    private let useCache: Bool
+    public convenience init() {
+        let cacheSetting = Environment.shared.tuistVariables["TUIST_CACHE_MANIFESTS"] ?? "1"
+        self.init(useCache: cacheSetting == "1")
+    }
+
+    public init(useCache: Bool) {
+        self.useCache = useCache
+    }
+
+    public func createManifestLoader() -> ManifestLoading {
+        if useCache {
+            return CachedManifestLoader()
+        }
+        return ManifestLoader()
+    }
+}

--- a/Sources/TuistLoader/Loaders/ManifestLoaderFactory.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoaderFactory.swift
@@ -4,7 +4,8 @@ import TuistSupport
 public final class ManifestLoaderFactory {
     private let useCache: Bool
     public convenience init() {
-        let cacheSetting = Environment.shared.tuistVariables["TUIST_CACHE_MANIFESTS"] ?? "1"
+        let key = Constants.EnvironmentVariables.cacheManifests
+        let cacheSetting = Environment.shared.tuistVariables[key, default: "1"]
         self.init(useCache: cacheSetting == "1")
     }
 

--- a/Sources/TuistLoader/ProjectDEscriptionHelpers/ProjectDescriptionHelpersBuilder.swift
+++ b/Sources/TuistLoader/ProjectDEscriptionHelpers/ProjectDescriptionHelpersBuilder.swift
@@ -51,9 +51,12 @@ final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding 
         let helpersCachePath = cacheDirectory.appending(component: prefixHash)
         let helpersModuleCachePath = helpersCachePath.appending(component: hash)
         let dylibName = "libProjectDescriptionHelpers.dylib"
+        let modulePath = helpersModuleCachePath.appending(component: dylibName)
+
+        builtHelpers[helpersDirectory] = modulePath
 
         if FileHandler.shared.exists(helpersModuleCachePath) {
-            return helpersModuleCachePath.appending(component: dylibName)
+            return modulePath
         }
 
         // If the same helpers directory has been previously compiled
@@ -68,8 +71,6 @@ final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding 
                                    projectDescriptionPath: projectDescriptionPath)
         try System.shared.runAndPrint(command, verbose: false, environment: Environment.shared.tuistVariables)
 
-        let modulePath = helpersModuleCachePath.appending(component: dylibName)
-        builtHelpers[helpersDirectory] = modulePath
         return modulePath
     }
 

--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -21,6 +21,7 @@ public struct Constants {
         public static let versionsDirectory = "TUIST_VERSIONS_DIRECTORY"
         public static let cacheDirectory = "TUIST_CACHE_DIRECTORY"
         public static let cloudToken = "TUIST_CLOUD_TOKEN"
+        public static let cacheManifests = "TUIST_CACHE_MANIFESTS"
     }
 
     public struct GoogleCloud {

--- a/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import ProjectDescription
+import TSCBasic
+import TuistSupport
+import XCTest
+
+@testable import TuistLoader
+@testable import TuistLoaderTesting
+@testable import TuistSupportTesting
+
+final class CachedManifestLoaderTests: TuistUnitTestCase {
+    private var cacheDirectory: AbsolutePath!
+    private var manifestLoader = MockManifestLoader()
+    private var projectDescriptionHelpersHasher = MockProjectDescriptionHelpersHasher()
+    private var helpersDirectoryLocator = MockHelpersDirectoryLocator()
+    private var subject: CachedManifestLoader!
+    private var projectManifests: [AbsolutePath: Project] = [:]
+    private var recordedLoadProjectCalls: Int = 0
+
+    override func setUp() {
+        super.setUp()
+
+        do {
+            cacheDirectory = try temporaryPath().appending(components: "tuist", "Cache", "Manifests")
+        } catch {
+            XCTFail("Failed to create temporary directory")
+        }
+
+        subject = createSubject()
+
+        manifestLoader.loadProjectStub = { [unowned self] path in
+            guard let manifest = self.projectManifests[path] else {
+                throw ManifestLoaderError.manifestNotFound(.project, path)
+            }
+            self.recordedLoadProjectCalls += 1
+            return manifest
+        }
+    }
+
+    // MARK: - Tests
+
+    func test_load_manifestNotCached() throws {
+        // Given
+        let path = try temporaryPath().appending(component: "App")
+        let project = Project.test(name: "App")
+        try stub(manifest: project, at: path)
+
+        // When
+        let result = try subject.loadProject(at: path)
+
+        // Then
+        XCTAssertEqual(result, project)
+        XCTAssertEqual(result.name, "App")
+    }
+
+    func test_load_manifestCached() throws {
+        // Given
+        let path = try temporaryPath().appending(component: "App")
+        let project = Project.test(name: "App")
+        try stub(manifest: project, at: path)
+
+        // When
+        _ = try subject.loadProject(at: path)
+        _ = try subject.loadProject(at: path)
+        _ = try subject.loadProject(at: path)
+        let result = try subject.loadProject(at: path)
+
+        // Then
+        XCTAssertEqual(result, project)
+        XCTAssertEqual(recordedLoadProjectCalls, 1)
+    }
+
+    func test_load_manifestHashChanged() throws {
+        // Given
+        let path = try temporaryPath().appending(component: "App")
+        let originalProject = Project.test(name: "Original")
+        try stub(manifest: originalProject, at: path)
+        _ = try subject.loadProject(at: path)
+
+        // When
+        let modifiedProject = Project.test(name: "Modified")
+        try stub(manifest: modifiedProject, at: path)
+        let result = try subject.loadProject(at: path)
+
+        // Then
+        XCTAssertEqual(result, modifiedProject)
+        XCTAssertEqual(result.name, "Modified")
+    }
+
+    func test_load_helpersHashChanged() throws {
+        // Given
+        let path = try temporaryPath().appending(component: "App")
+        let project = Project.test(name: "App")
+        try stub(manifest: project, at: path)
+        try stubHelpers(withHash: "hash")
+
+        _ = try subject.loadProject(at: path)
+
+        // When
+        try stubHelpers(withHash: "updatedHash")
+        subject = createSubject() // we need to re-create the subject as it internally caches hashes
+        _ = try subject.loadProject(at: path)
+
+        // Then
+        XCTAssertEqual(recordedLoadProjectCalls, 2)
+    }
+
+    func test_load_corruptedCache() throws {
+        // Given
+        let path = try temporaryPath().appending(component: "App")
+        let project = Project.test(name: "App")
+        try stub(manifest: project, at: path)
+        _ = try subject.loadProject(at: path)
+
+        // When
+        try corruptFiles(at: cacheDirectory)
+        let result = try subject.loadProject(at: path)
+
+        // Then
+        XCTAssertEqual(result, project)
+        XCTAssertEqual(recordedLoadProjectCalls, 2)
+    }
+
+    // MARK: - Helpers
+
+    private func createSubject() -> CachedManifestLoader {
+        CachedManifestLoader(manifestLoader: manifestLoader,
+                             projectDescriptionHelpersHasher: projectDescriptionHelpersHasher,
+                             helpersDirectoryLocator: helpersDirectoryLocator,
+                             cacheDirectory: cacheDirectory,
+                             fileHandler: fileHandler)
+    }
+
+    private func stub(manifest: Project,
+                      at path: AbsolutePath) throws {
+        let manifestPath = path.appending(component: Manifest.project.fileName)
+        try fileHandler.touch(manifestPath)
+        let manifestData = try JSONEncoder().encode(manifest)
+        try fileHandler.write(String(data: manifestData, encoding: .utf8)!, path: manifestPath, atomically: true)
+        projectManifests[path] = manifest
+    }
+
+    private func stubHelpers(withHash hash: String) throws {
+        let path = try temporaryPath().appending(components: "Tuist", "ProjectDescriptionHelpers")
+        helpersDirectoryLocator.locateStub = path
+        projectDescriptionHelpersHasher.stubHash = { _ in
+            hash
+        }
+    }
+
+    private func corruptFiles(at path: AbsolutePath) throws {
+        for filePath in try fileHandler.contentsOfDirectory(path) {
+            try fileHandler.write("corruptedData", path: filePath, atomically: true)
+        }
+    }
+}

--- a/Tests/TuistLoaderTests/ProjectDescriptionHelpers/Mocks/MockProjectDescriptionHelpersHasher.swift
+++ b/Tests/TuistLoaderTests/ProjectDescriptionHelpers/Mocks/MockProjectDescriptionHelpersHasher.swift
@@ -1,0 +1,15 @@
+import Foundation
+import TSCBasic
+@testable import TuistLoader
+
+final class MockProjectDescriptionHelpersHasher: ProjectDescriptionHelpersHashing {
+    var stubHash: ((AbsolutePath) -> String)?
+    func hash(helpersDirectory: AbsolutePath) throws -> String {
+        stubHash?(helpersDirectory) ?? ""
+    }
+
+    var stubPrefixHash: ((AbsolutePath) -> String)?
+    func prefixHash(helpersDirectory: AbsolutePath) -> String {
+        stubPrefixHash?(helpersDirectory) ?? ""
+    }
+}


### PR DESCRIPTION
Part of: https://github.com/tuist/tuist/issues/1042

### Short description 📝

One of the areas that contribute to slow generation times is the manifest loading process (see #1042). Loading a single Swift manifest involves compiling and running that manifest along with any helper files if present. While an individual manifest doesn't take a huge amount of time, it adds up over a large workspace with several manifests.

### Solution 📦

Caching the Swift manifest in json format can significantly speed up the loading process. This can be achieved while keeping the Swift manifests the source of truth via:

- Adding a new caching implementation of the manifest loader
- It works by wrapping the existing manifest loader and adds a caching layer ontop of it
- It attempts to first load a cached JSON representation of the manifest from `~/.tuist/Cache/Manifests` and then falls back to loading the manifest using the default implementation
- The hashes of the manifest content as well the helpers (`ProjectDescriptionHelpers`) are included with the cached manifest
- This allows comparing those hashes during the loading process and ensure the cache is updated from source when needed
- Additionally a version number is also included in the cached data should the caching format change in the future
- Overall this helps speed up the manifest loading process significantly as loading JSON from disk is much faster than compiling and running Swift manifest
- This approach ensures Swift manifests continue to be the source of truth while offering an optimization for the cases where the manifest doesn't change
- Caching can be enabled / disabled via `TUIST_CACHE_MANIFESTS=1` or `TUIST_CACHE_MANIFESTS=0`
- By default its enabled however this can be changed if we find any issues with this feature

### Implementation 👩‍💻👨‍💻

- [x] Add `CachedManifestLoader`
- [x] Benchmark generation times
- [x] Profile / benchmark manifest loading times in instruments using sign posts
- [x] Update change log

### Test Plan 🛠

Modifying manifests:
- Run `tuist generate` on any of the fixtures
- Inspect the generation time
- Re-run `tuist generate`
- Inspect the generation time, which should be faster
  - Note: most gains will be seen in larger projects with several manifests
- Modify any the project manifest (e.g. update the name)
- Re-run `tuist generate`
- Verify the updates are reflected in the generated project (i.e. the cache isn't incorrectly being used)

Modifying helpers:
- Repeat the test using a `fixture/ios_app_with_helpers`
- This time modify `Tuist/ProjectDescriptionHelpers`
- Re-run `tuist generate`
- Verify the updates are reflected in the generated project

Disabling caching:
- Remove the contents of `~/.tuist/Cache/Manifests`
- Run `TUIST_CACHE_MANIFESTS=0 tuist generate` on any of the fixtures
- Inspect the generation time
- Verify no cached manifests are added to `~/.tuist/Cache/Manifests`

### Benchmark Results ⏱

With this approach there is a small increase to initial generation time (cold run) **~1.5%**, however subsequent generation times (warm run) is **~ 50%** faster!

- **New** is this PR
- **Old** is latest release (1.8.0)

| Fixture         | New    | Old  | Delta    |
| --------------- | ------ | ---- | -------- |
| 20_projects _(cold)_ | 10.14s | 10.00s | ⬆︎ +0.15s +1.48% |
| 20_projects _(warm)_ | 4.63s | 9.79s | ⬇︎ -5.16s -52.72% |
| 50_projects _(cold)_ | 23.90s | 24.12s | ⬇︎ -0.22s -0.92% |
| 50_projects _(warm)_ | 11.65s | 23.90s | ⬇︎ -12.26s -51.27% |
| ios_app_with_helpers _(cold)_ | 2.26s | 2.23s | ⬆︎ +0.03s +1.15% |
| ios_app_with_helpers _(warm)_ | 1.12s | 5.06s | ⬇︎ -3.93s -77.80% |
| ios_app_with_tests _(cold)_ | 0.85s | 0.86s | ≈ |
| ios_app_with_tests _(warm)_ | 0.66s | 0.86s | ⬇︎ -0.20s -23.63% |
| ios_app_with_custom_workspace _(cold)_ | 1.75s | 1.73s | ⬆︎ +0.02s +1.29% |
| ios_app_with_custom_workspace _(warm)_ | 0.99s | 1.74s | ⬇︎ -0.75s -42.95% |

Here are the steps taken to get those measurements, some were generated fixtures while others were existing ones within `fixtures/`

- Create a large fixture:

```sh
cd tools/fixturegen
swift run fixturegen --projects 50

FIXTURE_PATH="$(pwd)/Fixture"
```

- Benchmark:

```sh
swift build -c release --product ProjectDescription
swift build -c release --product tuist

LOCAL_TUIST="$(swift build -c release --show-bin-path)/tuist"
REFERENCE_TUIST="$(which tuist)"

cd tools/tuistbench
swift run tuistbench -b "$LOCAL_TUIST" -r "$REFERENCE_TUIST" -f "$FIXTURE_PATH" --format markdown
```

### Profiling Results

For a workspace with 50 projects and a Tuist config file

**Caching disabled**
| Component       |       Count       |       Duration      |       Min Duration      |       Avg Duration   |      Std Dev Duration         |        Max Duration        |      
| --------------- | -------- | ---------- | ----------- |  ------------- | ---------- | -------- |
| ManifestLoader.loadManifest | 103 | 36.52 s | 281.19 ms | 354.53 ms | 88.05 ms | 1.03 s | 

**Caching enabled**

When there is no cache:
| Component       |       Count       |       Duration      |       Min Duration      |       Avg Duration   |      Std Dev Duration         |        Max Duration        |      
| --------------- | -------- | ---------- | ----------- |  ------------- | ---------- | -------- |
| CachedManifestLoader.load    |   103 |  25.63 s  |    601.28 µs | 248.84 ms    |   332.86 ms   |  2.65 s |  
| CachedManifestLoader.cacheManifests   |   52 |   252.14 ms    | 3.14 ms |    4.85 ms  |  1.67 ms   |   9.78 ms    |   

When cache is warm:

| Component       |       Count       |       Duration      |       Min Duration      |       Avg Duration   |      Std Dev Duration         |        Max Duration        |      
| --------------- | -------- | ---------- | ----------- |  ------------- | ---------- | -------- |
| CachedManifestLoader.load | 103 | 451.41 ms | 464.56 µs | 4.38 ms | 8.62 ms | 83.16 ms | 

**This PR improves the manifest loading process by ~98%*  🎉

---

You'll notice the count is 103 even though the workspace has 50 projects and 1 Config files. Looks like we're redundantly loading `Config.swift` once per manifest 😱 - this can be fixed in a separate PR.

![Screen Shot 2020-05-27 at 6 32 11 PM](https://user-images.githubusercontent.com/11914919/83053287-68872c00-a048-11ea-9602-b06cddd02400.png)
