### PR TITLE
Some cloud auth fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Support for enabling the cloud insights feature [#1335](https://github.com/tuist/tuist/pull/1335) by [@pepibumur](https://github.com/pepibumur)
 - Value graph model [#1336](https://github.com/tuist/tuist/pull/1336) by [@pepibumur](https://github.com/pepibumur)
 
+### Fixed
+
+- Storing the cloud credentials failed because the Keychain syncing was enabled [#1355](https://github.com/tuist/tuist/pull/1355) by [@pepibumur](https://github.com/pepibumur)
+
 ### Changed
 
 - **Breaking** Inherit defaultSettings from the project when the target's defaultSettings is nil [#1138](https://github.com/tuist/tuist/pull/1338) by [@pepibumur](https://github.com/pepibumur)

--- a/Sources/TuistSupport/Credentials/CredentialsStore.swift
+++ b/Sources/TuistSupport/Credentials/CredentialsStore.swift
@@ -31,8 +31,8 @@ public final class CredentialsStore: CredentialsStoring {
 
     public func read(serverURL: URL) throws -> Credentials? {
         let keychain = self.keychain(serverURL: serverURL)
-        guard let account = keychain.allKeys().first else { return nil }
-        guard let token = try keychain.get(account) else { return nil }
+        guard let token = keychain.allKeys().first else { return nil }
+        guard let account = try keychain.get(token) else { return nil }
         return Credentials(token: token, account: account)
     }
 
@@ -47,7 +47,7 @@ public final class CredentialsStore: CredentialsStoring {
 
     fileprivate func keychain(serverURL: URL) -> Keychain {
         Keychain(server: serverURL, protocolType: .https, authenticationType: .default)
-            .synchronizable(true)
+            .synchronizable(false)
             .label("\(serverURL.absoluteString)")
     }
 }


### PR DESCRIPTION
### Short description 📝
- Disables keychain syncing because it results in the following error https://github.com/kishikawakatsumi/KeychainAccess#keychain-sharing-capability
- We were reading the token as the account, and the account as the token. 