### PR TITLE
Wait when editing the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
-- Storing the cloud credentials failed because the Keychain syncing was enabled [#1355](https://github.com/tuist/tuist/pull/1355) by [@pepibumur](https://github.com/pepibumur)
+- Storing the cloud credentials failed because the Keychain syncing was enabled [#1355](https://github.com/tuist/tuist/pull/1355) by [@pepibumur](https://github.com/pepibumur).
+- `tuist edit` doesn't wait while the user edits the project in Xcode [#1650](https://github.com/Shopify/react-native/pull/1650) by [@pepibumur](https://github.com/pepibumur).
 
 ### Changed
 

--- a/Sources/TuistKit/Services/EditService.swift
+++ b/Sources/TuistKit/Services/EditService.swift
@@ -27,7 +27,7 @@ final class EditService {
                 exit(0)
             }
             logger.pretty("Opening Xcode to edit the project. Press \(.keystroke("CTRL + C")) once you are done editing")
-            try opener.open(path: xcodeprojPath)
+            try opener.open(path: xcodeprojPath, wait: true)
         } else {
             logger.notice("Xcode project generated at \(xcodeprojPath.pathString)", metadata: .success)
         }

--- a/Sources/TuistSupport/Utils/Opener.swift
+++ b/Sources/TuistSupport/Utils/Opener.swift
@@ -27,6 +27,7 @@ enum OpeningError: FatalError, Equatable {
 }
 
 public protocol Opening: AnyObject {
+    func open(path: AbsolutePath, wait: Bool) throws
     func open(path: AbsolutePath) throws
     func open(url: URL) throws
     func open(target: String, wait: Bool) throws
@@ -37,11 +38,15 @@ public class Opener: Opening {
 
     // MARK: - Opening
 
-    public func open(path: AbsolutePath) throws {
+    public func open(path: AbsolutePath, wait: Bool) throws {
         if !FileHandler.shared.exists(path) {
             throw OpeningError.notFound(path)
         }
-        try open(target: path.pathString, wait: false)
+        try open(target: path.pathString, wait: wait)
+    }
+
+    public func open(path: AbsolutePath) throws {
+        try open(path: path, wait: false)
     }
 
     public func open(url: URL) throws {

--- a/Sources/TuistSupportTesting/Utils/MockOpener.swift
+++ b/Sources/TuistSupportTesting/Utils/MockOpener.swift
@@ -13,6 +13,10 @@ public final class MockOpener: Opening {
         if let openStub = openStub { throw openStub }
     }
 
+    public func open(path: AbsolutePath, wait: Bool) throws {
+        try open(target: path.pathString, wait: wait)
+    }
+
     public func open(path: AbsolutePath) throws {
         try open(target: path.pathString, wait: false)
     }


### PR DESCRIPTION
### Short description 📝
We introduced a regression that caused Tuist's process not to wait while the user was editing the manifests using Xcode. This PR fixes it.