### PR TITLE
Model Mappers

### DIFF
--- a/Sources/TuistCore/Graph/Mappers/ProjectMapper.swift
+++ b/Sources/TuistCore/Graph/Mappers/ProjectMapper.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public protocol ProjectMapping {
+    func map(project: Project) throws -> (Project, [SideEffectDescriptor])
+}
+
+public class SequentialProjectMapper: ProjectMapping {
+    private let mappers: [ProjectMapping]
+
+    public init(mappers: [ProjectMapping]) {
+        self.mappers = mappers
+    }
+
+    public func map(project: Project) throws -> (Project, [SideEffectDescriptor]) {
+        var results = (project: project, sideEffects: [SideEffectDescriptor]())
+        results = try mappers.reduce(into: results) { results, mapper in
+            let (updatedProject, sideEffects) = try mapper.map(project: results.project)
+            results.project = updatedProject
+            results.sideEffects.append(contentsOf: sideEffects)
+        }
+        return results
+    }
+}
+
+public class TargetProjectMapper: ProjectMapping {
+    private let mapper: TargetMapping
+
+    public init(mapper: TargetMapping) {
+        self.mapper = mapper
+    }
+
+    public func map(project: Project) throws -> (Project, [SideEffectDescriptor]) {
+        var results = (targets: [Target](), sideEffects: [SideEffectDescriptor]())
+        results = try project.targets.reduce(into: results) { results, target in
+            let (updatedTarget, sideEffects) = try mapper.map(target: target)
+            results.targets.append(updatedTarget)
+            results.sideEffects.append(contentsOf: sideEffects)
+        }
+        return (project.with(targets: results.targets), results.sideEffects)
+    }
+}

--- a/Sources/TuistCore/Graph/Mappers/TargetMapper.swift
+++ b/Sources/TuistCore/Graph/Mappers/TargetMapper.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol TargetMapping {
+    func map(target: Target) throws -> (Target, [SideEffectDescriptor])
+}

--- a/Sources/TuistCore/Models/Project.swift
+++ b/Sources/TuistCore/Models/Project.swift
@@ -2,7 +2,7 @@ import Foundation
 import TSCBasic
 import TuistSupport
 
-public class Project: Equatable, CustomStringConvertible {
+public struct Project: Equatable, CustomStringConvertible {
     public static func == (lhs: Project, rhs: Project) -> Bool {
         lhs.path == rhs.path &&
             lhs.name == rhs.name &&
@@ -20,37 +20,37 @@ public class Project: Equatable, CustomStringConvertible {
     // MARK: - Attributes
 
     /// Path to the folder that contains the project manifest.
-    public let path: AbsolutePath
+    public var path: AbsolutePath
 
     /// Project name.
-    public let name: String
+    public var name: String
 
     /// Organization name.
-    public let organizationName: String?
+    public var organizationName: String?
 
     /// Project file name.
-    public let fileName: String
+    public var fileName: String
 
     /// Project targets.
-    public private(set) var targets: [Target]
+    public var targets: [Target]
 
     /// Project swift packages.
-    public let packages: [Package]
+    public var packages: [Package]
 
     /// Project schemes
-    public let schemes: [Scheme]
+    public var schemes: [Scheme]
 
     /// Auto generate default schemes
-    public let autogenerateSchemes: Bool
+    public var autogenerateSchemes: Bool
 
     /// Project settings.
-    public let settings: Settings
+    public var settings: Settings
 
     /// The group to place project files within
-    public let filesGroup: ProjectGroup
+    public var filesGroup: ProjectGroup
 
     /// Additional files to include in the project
-    public let additionalFiles: [FileElement]
+    public var additionalFiles: [FileElement]
 
     // MARK: - Init
 

--- a/Sources/TuistCore/Models/Target.swift
+++ b/Sources/TuistCore/Models/Target.swift
@@ -13,26 +13,26 @@ public struct Target: Equatable, Hashable {
 
     // MARK: - Attributes
 
-    public let name: String
-    public let platform: Platform
-    public let product: Product
-    public let bundleId: String
-    public let productName: String
-    public let deploymentTarget: DeploymentTarget?
+    public var name: String
+    public var platform: Platform
+    public var product: Product
+    public var bundleId: String
+    public var productName: String
+    public var deploymentTarget: DeploymentTarget?
 
     // An info.plist file is needed for (dynamic) frameworks, applications and executables
     // however is not needed for other products such as static libraries.
-    public private(set) var infoPlist: InfoPlist?
-    public let entitlements: AbsolutePath?
-    public let settings: Settings?
-    public let dependencies: [Dependency]
-    public let sources: [SourceFile]
-    public let resources: [FileElement]
-    public let headers: Headers?
-    public let coreDataModels: [CoreDataModel]
-    public private(set) var actions: [TargetAction]
-    public let environment: [String: String]
-    public let filesGroup: ProjectGroup
+    public var infoPlist: InfoPlist?
+    public var entitlements: AbsolutePath?
+    public var settings: Settings?
+    public var dependencies: [Dependency]
+    public var sources: [SourceFile]
+    public var resources: [FileElement]
+    public var headers: Headers?
+    public var coreDataModels: [CoreDataModel]
+    public var actions: [TargetAction]
+    public var environment: [String: String]
+    public var filesGroup: ProjectGroup
 
     // MARK: - Init
 

--- a/Sources/TuistCore/Utils/RootDirectoryLocator.swift
+++ b/Sources/TuistCore/Utils/RootDirectoryLocator.swift
@@ -13,7 +13,7 @@ public protocol RootDirectoryLocating {
 public final class RootDirectoryLocator: RootDirectoryLocating {
     private let fileHandler: FileHandling = FileHandler.shared
     /// This cache avoids having to traverse the directories hierarchy every time the locate method is called.
-    fileprivate var cache: [AbsolutePath: AbsolutePath] = [:]
+    @Atomic private var cache: [AbsolutePath: AbsolutePath] = [:]
 
     /// Constructor
     public init() {}
@@ -53,10 +53,10 @@ public final class RootDirectoryLocator: RootDirectoryLocating {
     ///   - path: Path for which we are caching the root directory.
     fileprivate func cache(rootDirectory: AbsolutePath, for path: AbsolutePath) {
         if path != rootDirectory {
-            cache[path] = rootDirectory
+            _cache.modify { $0[path] = rootDirectory }
             cache(rootDirectory: rootDirectory, for: path.parentDirectory)
         } else if path == rootDirectory {
-            cache[path] = rootDirectory
+            _cache.modify { $0[path] = rootDirectory }
         }
     }
 }

--- a/Sources/TuistKit/ProjectGenerator/ProjectGenerator.swift
+++ b/Sources/TuistKit/ProjectGenerator/ProjectGenerator.swift
@@ -203,7 +203,7 @@ class ProjectGenerator: ProjectGenerating {
     }
 
     private func convert(manifests: LoadedProjects,
-                         context: ExecutionContext = .serial) throws -> [TuistCore.Project] {
+                         context: ExecutionContext = .concurrent) throws -> [TuistCore.Project] {
         let tuples = manifests.projects.map { (path: $0.key, manifest: $0.value) }
         return try tuples.map(context: context) {
             try converter.convert(manifest: $0.manifest, path: $0.path)
@@ -211,7 +211,7 @@ class ProjectGenerator: ProjectGenerating {
     }
 
     private func convert(manifests: LoadedWorkspace,
-                         context: ExecutionContext = .serial) throws -> (workspace: Workspace, projects: [TuistCore.Project]) {
+                         context: ExecutionContext = .concurrent) throws -> (workspace: Workspace, projects: [TuistCore.Project]) {
         let workspace = try converter.convert(manifest: manifests.workspace, path: manifests.path)
         let tuples = manifests.projects.map { (path: $0.key, manifest: $0.value) }
         let projects = try tuples.map(context: context) {

--- a/Sources/TuistKit/ProjectGenerator/ProjectGenerator.swift
+++ b/Sources/TuistKit/ProjectGenerator/ProjectGenerator.swift
@@ -12,7 +12,7 @@ protocol ProjectGenerating {
 }
 
 class ProjectGenerator: ProjectGenerating {
-    private let recursiveManifestLoader: RecursiveManifestLoading = RecursiveManifestLoader()
+    private let recursiveManifestLoader: RecursiveManifestLoading
     private let converter: ManifestModelConverting
     private let manifestLinter: ManifestLinting = ManifestLinter()
     private let graphLinter: GraphLinting = GraphLinter()
@@ -28,9 +28,10 @@ class ProjectGenerator: ProjectGenerating {
     private let graphMapperProvider: GraphMapperProviding
     private let manifestLoader: ManifestLoading
 
-    init(graphMapperProvider: GraphMapperProviding = GraphMapperProvider(useCache: false), 
+    init(graphMapperProvider: GraphMapperProviding = GraphMapperProvider(useCache: false),
          manifestLoaderFactory: ManifestLoaderFactory = ManifestLoaderFactory()) {
         let manifestLoader = manifestLoaderFactory.createManifestLoader()
+        recursiveManifestLoader = RecursiveManifestLoader(manifestLoader: manifestLoader)
         let modelLoader = GeneratorModelLoader(manifestLoader: manifestLoader,
                                                manifestLinter: manifestLinter)
         converter = modelLoader

--- a/Sources/TuistKit/ProjectGenerator/ProjectGenerator.swift
+++ b/Sources/TuistKit/ProjectGenerator/ProjectGenerator.swift
@@ -3,6 +3,7 @@ import TSCBasic
 import TuistCore
 import TuistGenerator
 import TuistLoader
+import TuistSupport
 
 protocol ProjectGenerating {
     @discardableResult
@@ -11,6 +12,8 @@ protocol ProjectGenerating {
 }
 
 class ProjectGenerator: ProjectGenerating {
+    private let recursiveManifestLoader: RecursiveManifestLoading = RecursiveManifestLoader()
+    private let converter: ManifestModelConverting
     private let manifestLinter: ManifestLinting = ManifestLinter()
     private let graphLinter: GraphLinting = GraphLinter()
     private let environmentLinter: EnvironmentLinting = EnvironmentLinter()
@@ -21,17 +24,21 @@ class ProjectGenerator: ProjectGenerating {
     private let modelLoader: GeneratorModelLoading
     private let graphLoader: GraphLoading
     private let sideEffectDescriptorExecutor: SideEffectDescriptorExecuting
+    private let projectMapper: ProjectMapping
     private let graphMapperProvider: GraphMapperProviding
     private let manifestLoader: ManifestLoading
 
-    init(graphMapperProvider: GraphMapperProviding = GraphMapperProvider(useCache: false),
+    init(graphMapperProvider: GraphMapperProviding = GraphMapperProvider(useCache: false), 
          manifestLoaderFactory: ManifestLoaderFactory = ManifestLoaderFactory()) {
         let manifestLoader = manifestLoaderFactory.createManifestLoader()
-        modelLoader = GeneratorModelLoader(manifestLoader: manifestLoader,
-                                           manifestLinter: manifestLinter)
+        let modelLoader = GeneratorModelLoader(manifestLoader: manifestLoader,
+                                               manifestLinter: manifestLinter)
+        converter = modelLoader
         graphLoader = GraphLoader(modelLoader: modelLoader)
         sideEffectDescriptorExecutor = SideEffectDescriptorExecutor()
+        self.modelLoader = modelLoader
         self.graphMapperProvider = graphMapperProvider
+        projectMapper = SequentialProjectMapper(mappers: [])
         self.manifestLoader = manifestLoader
     }
 
@@ -56,10 +63,7 @@ class ProjectGenerator: ProjectGenerating {
 
     private func generateProject(path: AbsolutePath) throws -> (AbsolutePath, Graph) {
         // Load
-        var (graph, project) = try graphLoader.loadProject(path: path)
-        let config = try graphLoader.loadConfig(path: graph.entryPath)
-        let sideEffects: [SideEffectDescriptor]
-        (graph, sideEffects) = try graphMapperProvider.mapper(config: config).map(graph: graph)
+        let (project, graph, sideEffects) = try loadProject(path: path)
 
         // Lint
         try lint(graph: graph)
@@ -81,10 +85,7 @@ class ProjectGenerator: ProjectGenerating {
 
     private func generateWorkspace(path: AbsolutePath) throws -> (AbsolutePath, Graph) {
         // Load
-        var (graph, workspace) = try graphLoader.loadWorkspace(path: path)
-        let config = try graphLoader.loadConfig(path: graph.entryPath)
-        let sideEffects: [SideEffectDescriptor]
-        (graph, sideEffects) = try graphMapperProvider.mapper(config: config).map(graph: graph)
+        let (workspace, graph, sideEffects) = try loadWorkspace(path: path)
 
         // Lint
         try lint(graph: graph)
@@ -108,10 +109,7 @@ class ProjectGenerator: ProjectGenerating {
 
     private func generateProjectWorkspace(path: AbsolutePath) throws -> (AbsolutePath, Graph) {
         // Load
-        var (graph, project) = try graphLoader.loadProject(path: path)
-        let config = try graphLoader.loadConfig(path: graph.entryPath)
-        let sideEffects: [SideEffectDescriptor]
-        (graph, sideEffects) = try graphMapperProvider.mapper(config: config).map(graph: graph)
+        let (project, graph, sideEffects) = try loadProject(path: path)
 
         // Lint
         try lint(graph: graph)
@@ -142,5 +140,83 @@ class ProjectGenerator: ProjectGenerating {
     private func postGenerationActions(for graph: Graph, workspaceName: String) throws {
         try swiftPackageManagerInteractor.install(graph: graph, workspaceName: workspaceName)
         try cocoapodsInteractor.install(graph: graph)
+    }
+
+    // MARK: -
+
+    private func loadProject(path: AbsolutePath) throws -> (Project, Graph, [SideEffectDescriptor]) {
+        // Load all manifests
+        let manifests = try recursiveManifestLoader.loadProject(at: path)
+
+        // Lint Manifests
+        try manifests.projects.flatMap {
+            manifestLinter.lint(project: $0.value)
+        }.printAndThrowIfNeeded()
+
+        // Convert to models
+        let models = try convert(manifests: manifests)
+
+        // Apply any registered model mappers
+        let updatedModels = try models.map(projectMapper.map)
+        let updatedProjects = updatedModels.map(\.0)
+        let modelMapperSideEffects = updatedModels.flatMap { $0.1 }
+
+        // Load Graph
+        let cachedModelLoader = CachedModelLoader(projects: updatedProjects)
+        let cachedGraphLoader = GraphLoader(modelLoader: cachedModelLoader)
+        let (graph, project) = try cachedGraphLoader.loadProject(path: path)
+
+        // Apply graph mappers
+        let config = try graphLoader.loadConfig(path: graph.entryPath)
+        let (updatedGraph, graphMapperSideEffects) = try graphMapperProvider.mapper(config: config).map(graph: graph)
+
+        return (project, updatedGraph, modelMapperSideEffects + graphMapperSideEffects)
+    }
+
+    private func loadWorkspace(path: AbsolutePath) throws -> (Workspace, Graph, [SideEffectDescriptor]) {
+        // Load all manifests
+        let manifests = try recursiveManifestLoader.loadWorkspace(at: path)
+
+        // Lint Manifests
+        try manifests.projects.flatMap {
+            manifestLinter.lint(project: $0.value)
+        }.printAndThrowIfNeeded()
+
+        // Convert to models
+        let models = try convert(manifests: manifests)
+
+        // Apply model mappers
+        let updatedModels = try models.projects.map(projectMapper.map)
+        let updatedProjects = updatedModels.map(\.0)
+        let modelMapperSideEffects = updatedModels.flatMap { $0.1 }
+
+        // Load Graph
+        let cachedModelLoader = CachedModelLoader(workspace: [models.workspace], projects: updatedProjects)
+        let cachedGraphLoader = GraphLoader(modelLoader: cachedModelLoader)
+        let (graph, workspace) = try cachedGraphLoader.loadWorkspace(path: path)
+
+        // Apply graph mappers
+        let config = try graphLoader.loadConfig(path: graph.entryPath)
+        let (updatedGraph, graphMapperSideEffects) = try graphMapperProvider.mapper(config: config).map(graph: graph)
+
+        return (workspace, updatedGraph, modelMapperSideEffects + graphMapperSideEffects)
+    }
+
+    private func convert(manifests: LoadedProjects,
+                         context: ExecutionContext = .serial) throws -> [TuistCore.Project] {
+        let tuples = manifests.projects.map { (path: $0.key, manifest: $0.value) }
+        return try tuples.map(context: context) {
+            try converter.convert(manifest: $0.manifest, path: $0.path)
+        }
+    }
+
+    private func convert(manifests: LoadedWorkspace,
+                         context: ExecutionContext = .serial) throws -> (workspace: Workspace, projects: [TuistCore.Project]) {
+        let workspace = try converter.convert(manifest: manifests.workspace, path: manifests.path)
+        let tuples = manifests.projects.map { (path: $0.key, manifest: $0.value) }
+        let projects = try tuples.map(context: context) {
+            try converter.convert(manifest: $0.manifest, path: $0.path)
+        }
+        return (workspace, projects)
     }
 }

--- a/Sources/TuistLoader/Loaders/CachedModelLoader.swift
+++ b/Sources/TuistLoader/Loaders/CachedModelLoader.swift
@@ -1,0 +1,43 @@
+import Foundation
+import TSCBasic
+import TuistCore
+
+/// An in-memory model loader implementation which can be configured
+/// at instantiation time with a cache of all preloaded models.
+public class CachedModelLoader: GeneratorModelLoading {
+    private let workspaces: [AbsolutePath: Workspace]
+    private let projects: [AbsolutePath: Project]
+    private let configs: [AbsolutePath: Config]
+    public init(workspace: [Workspace] = [],
+                projects: [Project] = [],
+                configs: [AbsolutePath: Config] = [:]) {
+        workspaces = Dictionary(uniqueKeysWithValues: workspace.map {
+            ($0.path, $0)
+        })
+        self.projects = Dictionary(uniqueKeysWithValues: projects.map {
+            ($0.path, $0)
+        })
+        self.configs = configs
+    }
+
+    public func loadProject(at path: AbsolutePath) throws -> Project {
+        guard let project = projects[path] else {
+            throw ManifestLoaderError.manifestNotFound(.project, path)
+        }
+        return project
+    }
+
+    public func loadWorkspace(at path: AbsolutePath) throws -> Workspace {
+        guard let workspace = workspaces[path] else {
+            throw ManifestLoaderError.manifestNotFound(.workspace, path)
+        }
+        return workspace
+    }
+
+    public func loadConfig(at path: AbsolutePath) throws -> Config {
+        guard let config = configs[path] else {
+            throw ManifestLoaderError.manifestNotFound(.config, path)
+        }
+        return config
+    }
+}

--- a/Sources/TuistLoader/Loaders/ManifestModelConverter.swift
+++ b/Sources/TuistLoader/Loaders/ManifestModelConverter.swift
@@ -1,0 +1,11 @@
+import Foundation
+import ProjectDescription
+import TSCBasic
+import TuistCore
+import TuistSupport
+
+/// A component responsible for converting Manifests (`ProjectDescription`) to Models (`TuistCore`)
+public protocol ManifestModelConverting {
+    func convert(manifest: ProjectDescription.Workspace, path: AbsolutePath) throws -> TuistCore.Workspace
+    func convert(manifest: ProjectDescription.Project, path: AbsolutePath) throws -> TuistCore.Project
+}

--- a/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
@@ -1,0 +1,88 @@
+import Foundation
+import ProjectDescription
+import TSCBasic
+import TuistSupport
+
+/// A component that can load a manifest and all its (transitive) manifest dependencies
+public protocol RecursiveManifestLoading {
+    func loadProject(at path: AbsolutePath) throws -> LoadedProjects
+    func loadWorkspace(at path: AbsolutePath) throws -> LoadedWorkspace
+}
+
+public struct LoadedProjects {
+    public var projects: [AbsolutePath: Project]
+}
+
+public struct LoadedWorkspace {
+    public var path: AbsolutePath
+    public var workspace: Workspace
+    public var projects: [AbsolutePath: Project]
+}
+
+public class RecursiveManifestLoader: RecursiveManifestLoading {
+    private let manifestLoader: ManifestLoading
+    private let fileHandler: FileHandling
+    public init(manifestLoader: ManifestLoading = ManifestLoader(),
+                fileHandler: FileHandling = FileHandler.shared) {
+        self.manifestLoader = manifestLoader
+        self.fileHandler = fileHandler
+    }
+
+    public func loadProject(at path: AbsolutePath) throws -> LoadedProjects {
+        try loadProjects(paths: [path])
+    }
+
+    public func loadWorkspace(at path: AbsolutePath) throws -> LoadedWorkspace {
+        let workspace = try manifestLoader.loadWorkspace(at: path)
+
+        let generatorPaths = GeneratorPaths(manifestDirectory: path)
+        let projectPaths = try workspace.projects.map {
+            try generatorPaths.resolve(path: $0)
+        }.flatMap {
+            fileHandler.glob($0, glob: "")
+        }.filter {
+            fileHandler.isFolder($0)
+        }.filter {
+            manifestLoader.manifests(at: $0).contains(.project)
+        }
+
+        let projects = try loadProjects(paths: projectPaths)
+        return LoadedWorkspace(path: path,
+                               workspace: workspace,
+                               projects: projects.projects)
+    }
+
+    // MARK: - Private
+
+    private func loadProjects(paths: [AbsolutePath]) throws -> LoadedProjects {
+        var cache = [AbsolutePath: Project]()
+
+        var paths = paths
+        while let path = paths.popLast() {
+            guard cache[path] == nil else {
+                continue
+            }
+
+            let project = try manifestLoader.loadProject(at: path)
+            cache[path] = project
+            paths.append(contentsOf: try dependencyPaths(for: project, path: path))
+        }
+
+        return LoadedProjects(projects: cache)
+    }
+
+    private func dependencyPaths(for project: Project, path: AbsolutePath) throws -> [AbsolutePath] {
+        let generatorPaths = GeneratorPaths(manifestDirectory: path)
+        let paths: [AbsolutePath] = try project.targets.flatMap {
+            try $0.dependencies.compactMap {
+                switch $0 {
+                case let .project(target: _, path: projectPath):
+                    return try generatorPaths.resolve(path: projectPath)
+                default:
+                    return nil
+                }
+            }
+        }
+        return paths.uniqued()
+    }
+}

--- a/Sources/TuistSupport/Atomic.swift
+++ b/Sources/TuistSupport/Atomic.swift
@@ -3,17 +3,23 @@ import Foundation
 /// Ensures that writing and reading from property annotated with this property wrapper is thread safe
 /// Taken from https://www.onswiftwings.com/posts/atomic-property-wrapper/
 @propertyWrapper
-class Atomic<Value> {
+public class Atomic<Value> {
     private var value: Value
     private let lock = NSLock()
 
-    init(wrappedValue value: Value) {
+    public init(wrappedValue value: Value) {
         self.value = value
     }
 
-    var wrappedValue: Value {
+    public var wrappedValue: Value {
         get { load() }
         set { store(newValue: newValue) }
+    }
+
+    public func modify(_ accessBlock: (inout Value) -> Void) {
+        lock.lock()
+        defer { lock.unlock() }
+        accessBlock(&value)
     }
 
     private func load() -> Value {
@@ -23,8 +29,8 @@ class Atomic<Value> {
     }
 
     private func store(newValue: Value) {
-        lock.lock()
-        defer { lock.unlock() }
-        value = newValue
+        modify {
+            $0 = newValue
+        }
     }
 }

--- a/Tests/TuistCoreTests/Graph/Mappers/ProjectMapperTests.swift
+++ b/Tests/TuistCoreTests/Graph/Mappers/ProjectMapperTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import TSCBasic
+import TuistCore
+import TuistCoreTesting
+import XCTest
+
+@testable import TuistSupportTesting
+
+final class TargetProjectMapperTests: XCTestCase {
+    func test_map_project() throws {
+        // Given
+        let targetMapper = TargetMapper {
+            var updated = $0
+            updated.name = "Updated_\($0.name)"
+            return (updated, [])
+        }
+        let subject = TargetProjectMapper(mapper: targetMapper)
+        let targetA = Target.test(name: "A")
+        let targetB = Target.test(name: "B")
+        let project = Project.test(targets: [targetA, targetB])
+
+        // When
+        let (updatedProject, sideEffects) = try subject.map(project: project)
+
+        // Then
+        XCTAssertEqual(updatedProject.targets.map(\.name), [
+            "Updated_A",
+            "Updated_B",
+        ])
+        XCTAssertTrue(sideEffects.isEmpty)
+    }
+
+    func test_map_sideEffects() throws {
+        // Given
+        let targetMapper = TargetMapper {
+            var updated = $0
+            updated.name = "Updated_\($0.name)"
+            return (updated, [
+                .file(.init(path: AbsolutePath("/Targets/\($0.name).swift"))),
+            ])
+        }
+        let subject = TargetProjectMapper(mapper: targetMapper)
+        let targetA = Target.test(name: "A")
+        let targetB = Target.test(name: "B")
+        let project = Project.test(targets: [targetA, targetB])
+
+        // When
+        let (_, sideEffects) = try subject.map(project: project)
+
+        // Then
+        XCTAssertEqual(sideEffects, [
+            .file(.init(path: AbsolutePath("/Targets/A.swift"))),
+            .file(.init(path: AbsolutePath("/Targets/B.swift"))),
+        ])
+    }
+
+    // MARK: - Helpers
+
+    private class TargetMapper: TargetMapping {
+        let mapper: (Target) -> (Target, [SideEffectDescriptor])
+        init(mapper: @escaping (Target) -> (Target, [SideEffectDescriptor])) {
+            self.mapper = mapper
+        }
+
+        func map(target: Target) throws -> (Target, [SideEffectDescriptor]) {
+            return mapper(target)
+        }
+    }
+}
+
+final class SequentialProjectMapperTests: XCTestCase {
+    func test_map_project() throws {
+        // Given
+        let mapper1 = ProjectMapper {
+            (Project.test(name: "Update1_\($0.name)"), [])
+        }
+        let mapper2 = ProjectMapper {
+            (Project.test(name: "Update2_\($0.name)"), [])
+        }
+        let subject = SequentialProjectMapper(mappers: [mapper1, mapper2])
+        let project = Project.test(name: "Project")
+
+        // When
+        let (updatedProject, sideEffects) = try subject.map(project: project)
+
+        // Then
+        XCTAssertEqual(updatedProject.name, "Update2_Update1_Project")
+        XCTAssertTrue(sideEffects.isEmpty)
+    }
+
+    func test_map_sideEffects() throws {
+        // Given
+        let mapper1 = ProjectMapper {
+            (Project.test(name: "Update1_\($0.name)"), [
+                .command(.init(command: ["command 1"])),
+            ])
+        }
+        let mapper2 = ProjectMapper {
+            (Project.test(name: "Update2_\($0.name)"), [
+                .command(.init(command: ["command 2"])),
+            ])
+        }
+        let subject = SequentialProjectMapper(mappers: [mapper1, mapper2])
+        let project = Project.test(name: "Project")
+
+        // When
+        let (_, sideEffects) = try subject.map(project: project)
+
+        // Then
+        XCTAssertEqual(sideEffects, [
+            .command(.init(command: ["command 1"])),
+            .command(.init(command: ["command 2"])),
+        ])
+    }
+
+    // MARK: - Helpers
+
+    private class ProjectMapper: ProjectMapping {
+        let mapper: (Project) -> (Project, [SideEffectDescriptor])
+        init(mapper: @escaping (Project) -> (Project, [SideEffectDescriptor])) {
+            self.mapper = mapper
+        }
+
+        func map(project: Project) throws -> (Project, [SideEffectDescriptor]) {
+            return mapper(project)
+        }
+    }
+}

--- a/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
@@ -1,0 +1,288 @@
+import Foundation
+import ProjectDescription
+import TSCBasic
+import TuistSupport
+import XCTest
+
+@testable import TuistLoader
+@testable import TuistLoaderTesting
+@testable import TuistSupportTesting
+
+final class RecursiveManifestLoaderTests: TuistUnitTestCase {
+    private var path: AbsolutePath!
+    private var manifestLoader: MockManifestLoader!
+    private var projectManifests: [AbsolutePath: Project] = [:]
+    private var workspaceManifests: [AbsolutePath: Workspace] = [:]
+
+    private var subject: RecursiveManifestLoader!
+
+    override func setUp() {
+        super.setUp()
+        do {
+            path = try temporaryPath()
+        } catch {
+            XCTFail("Could not create temporary path.")
+        }
+
+        manifestLoader = createManifestLoader()
+        subject = RecursiveManifestLoader(manifestLoader: manifestLoader,
+                                          fileHandler: fileHandler)
+    }
+
+    // MARK: - Tests
+
+    func test_loadProject_loadingSingleProject() throws {
+        // Given
+        let projectA = createProject(name: "ProjectA")
+        stub(manifest: projectA, at: "/Some/Path/A")
+
+        // When
+        let manifests = try subject.loadProject(at: "/Some/Path/A")
+
+        // Then
+        XCTAssertEqual(manifests.projects, [
+            "/Some/Path/A": projectA,
+        ])
+    }
+
+    func test_loadProject_projectWithDependencies() throws {
+        // Given
+        let projectA = createProject(name: "ProjectA",
+                                     targets: [
+                                         "TargetA": [
+                                             .project(target: "TargetB", path: "../B"),
+                                             .project(target: "TargetC", path: "../C"),
+                                         ],
+                                     ])
+        let projectB = createProject(name: "ProjectB",
+                                     targets: [
+                                         "TargetB": [],
+                                     ])
+        let projectC = createProject(name: "ProjectC",
+                                     targets: [
+                                         "TargetC": [],
+                                     ])
+        stub(manifest: projectA, at: "/Some/Path/A")
+        stub(manifest: projectB, at: "/Some/Path/B")
+        stub(manifest: projectC, at: "/Some/Path/C")
+
+        // When
+        let manifests = try subject.loadProject(at: "/Some/Path/A")
+
+        // Then
+        XCTAssertEqual(manifests.projects, [
+            "/Some/Path/A": projectA,
+            "/Some/Path/B": projectB,
+            "/Some/Path/C": projectC,
+        ])
+    }
+
+    func test_loadProject_projectWithTransitiveDependencies() throws {
+        // Given
+        let projectA = createProject(name: "ProjectA",
+                                     targets: [
+                                         "TargetA": [.project(target: "TargetB", path: "../B")],
+                                     ])
+        let projectB = createProject(name: "ProjectB",
+                                     targets: [
+                                         "TargetB": [.project(target: "TargetC", path: "../C")],
+                                     ])
+        let projectC = createProject(name: "ProjectC",
+                                     targets: [
+                                         "TargetC": [
+                                             .project(target: "TargetD", path: "../D"),
+                                             .project(target: "TargetE", path: "../E"),
+                                         ],
+                                     ])
+        let projectD = createProject(name: "ProjectD",
+                                     targets: [
+                                         "TargetD": [],
+                                     ])
+        let projectE = createProject(name: "ProjectE",
+                                     targets: [
+                                         "TargetE": [],
+                                     ])
+        stub(manifest: projectA, at: "/Some/Path/A")
+        stub(manifest: projectB, at: "/Some/Path/B")
+        stub(manifest: projectC, at: "/Some/Path/C")
+        stub(manifest: projectD, at: "/Some/Path/D")
+        stub(manifest: projectE, at: "/Some/Path/E")
+
+        // When
+        let manifests = try subject.loadProject(at: "/Some/Path/A")
+
+        // Then
+        XCTAssertEqual(manifests.projects, [
+            "/Some/Path/A": projectA,
+            "/Some/Path/B": projectB,
+            "/Some/Path/C": projectC,
+            "/Some/Path/D": projectD,
+            "/Some/Path/E": projectE,
+        ])
+    }
+
+    func test_loadProject_missingManifest() throws {
+        // Given
+        let projectA = createProject(name: "ProjectA",
+                                     targets: [
+                                         "TargetA": [
+                                             .project(target: "TargetB", path: "../B"),
+                                         ],
+                                     ])
+        stub(manifest: projectA, at: "/Some/Path/A")
+
+        // When / Then
+        XCTAssertThrowsSpecific(try subject.loadProject(at: "/Some/Path/A"),
+                                ManifestLoaderError.manifestNotFound(.project, "/Some/Path/B"))
+    }
+
+    func test_loadWorkspace() throws {
+        // Given
+        let workspace = Workspace.test(name: "Workspace",
+                                       projects: [
+                                           "A",
+                                           "B",
+                                       ])
+
+        let projectA = createProject(name: "ProjectA",
+                                     targets: [
+                                         "TargetA": [],
+                                     ])
+        let projectB = createProject(name: "ProjectB",
+                                     targets: [
+                                         "TargetB": [.project(target: "TargetC", path: "../C")],
+                                     ])
+        let projectC = createProject(name: "ProjectC",
+                                     targets: [
+                                         "TargetC": [],
+                                     ])
+
+        try stub(manifest: projectA, at: RelativePath("Some/Path/A"))
+        try stub(manifest: projectB, at: RelativePath("Some/Path/B"))
+        try stub(manifest: projectC, at: RelativePath("Some/Path/C"))
+        try stub(manifest: workspace, at: RelativePath("Some/Path"))
+
+        // When
+        let manifests = try subject.loadWorkspace(at: path.appending(RelativePath("Some/Path")))
+
+        // Then
+        XCTAssertEqual(manifests.path, path.appending(RelativePath("Some/Path")))
+        XCTAssertEqual(manifests.workspace, workspace)
+        XCTAssertEqual(withRelativePaths(manifests.projects), [
+            "Some/Path/A": projectA,
+            "Some/Path/B": projectB,
+            "Some/Path/C": projectC,
+        ])
+    }
+
+    func test_loadWorkspace_withGlobPattern() throws {
+        // Given
+        let workspace = Workspace.test(name: "Workspace",
+                                       projects: [
+                                           "*",
+                                       ])
+
+        let projectA = createProject(name: "ProjectA",
+                                     targets: [
+                                         "TargetA": [],
+                                     ])
+        let projectB = createProject(name: "ProjectB",
+                                     targets: [
+                                         "TargetB": [.project(target: "TargetC", path: "../C")],
+                                     ])
+        let projectC = createProject(name: "ProjectC",
+                                     targets: [
+                                         "TargetC": [],
+                                     ])
+
+        try stub(manifest: projectA, at: RelativePath("Some/Path/A"))
+        try stub(manifest: projectB, at: RelativePath("Some/Path/B"))
+        try stub(manifest: projectC, at: RelativePath("Some/Path/C"))
+        try stub(manifest: workspace, at: RelativePath("Some/Path"))
+
+        // When
+        let manifests = try subject.loadWorkspace(at: path.appending(RelativePath("Some/Path")))
+
+        // Then
+        XCTAssertEqual(manifests.path, path.appending(RelativePath("Some/Path")))
+        XCTAssertEqual(manifests.workspace, workspace)
+        XCTAssertEqual(withRelativePaths(manifests.projects), [
+            "Some/Path/A": projectA,
+            "Some/Path/B": projectB,
+            "Some/Path/C": projectC,
+        ])
+    }
+
+    // MARK: - Helpers
+
+    private func createProject(name: String,
+                               targets: [String: [TargetDependency]] = [:]) -> Project {
+        let targets: [Target] = targets.map {
+            Target.test(name: $0.key, dependencies: $0.value)
+        }
+        return .test(name: name, targets: targets)
+    }
+
+    private func withRelativePaths(_ projects: [AbsolutePath: Project]) -> [String: Project] {
+        Dictionary(uniqueKeysWithValues: projects.map {
+            ($0.key.relative(to: path).pathString, $0.value)
+        })
+    }
+
+    private func stub(manifest: Project,
+                      at path: AbsolutePath) {
+        projectManifests[path] = manifest
+    }
+
+    private func stub(manifest: Workspace,
+                      at path: AbsolutePath) {
+        workspaceManifests[path] = manifest
+    }
+
+    private func stub(manifest: Project,
+                      at relativePath: RelativePath) throws {
+        let manifestPath = path
+            .appending(relativePath)
+            .appending(component: Manifest.project.fileName)
+        try fileHandler.touch(manifestPath)
+        projectManifests[manifestPath.parentDirectory] = manifest
+    }
+
+    private func stub(manifest: Workspace,
+                      at relativePath: RelativePath) throws {
+        let manifestPath = path
+            .appending(relativePath)
+            .appending(component: Manifest.workspace.fileName)
+        try fileHandler.touch(manifestPath)
+        workspaceManifests[manifestPath.parentDirectory] = manifest
+    }
+
+    private func createManifestLoader() -> MockManifestLoader {
+        let manifestLoader = MockManifestLoader()
+        manifestLoader.loadProjectStub = { [unowned self] path in
+            guard let manifest = self.projectManifests[path] else {
+                throw ManifestLoaderError.manifestNotFound(.project, path)
+            }
+            return manifest
+        }
+
+        manifestLoader.loadWorkspaceStub = { [unowned self] path in
+            guard let manifest = self.workspaceManifests[path] else {
+                throw ManifestLoaderError.manifestNotFound(.workspace, path)
+            }
+            return manifest
+        }
+
+        manifestLoader.manifestsAtStub = { [unowned self] path in
+            var manifests = Set<Manifest>()
+            if let _ = self.projectManifests[path] {
+                manifests.insert(.project)
+            }
+            if let _ = self.workspaceManifests[path] {
+                manifests.insert(.workspace)
+            }
+            return manifests
+        }
+        return manifestLoader
+    }
+}


### PR DESCRIPTION
(Based on https://github.com/tuist/tuist/pull/1227)

### Short description 📝

Applying modifications to the `Project` and `Target` models within `GraphMappers` may not always be possible due to the current `Graph` structure. To create a mapper that can generate info plists for example, the both the `Target` and the hosting `Project` needs to be modified. 

e.g.

- #1357 
- #1206

### Solution 📦

Add "model mappers" that map `TuistCore` models ahead of converting them to a `Graph` representation.

### Implementation 👩‍💻👨‍💻

_Note: Those can be split into separate PRs to ease the review process but grouped here to demo the concept_

- [x] Add model mappers
- [x] Add recursive manifest loader (loads all manifests without converting them)
- [x] Modify loading process to accommodate model mappers
  - [x] Load all manifests upfront without conversion
  - [x] Lint manifests
  - [x] Convert manifests concurrently to models
  - [x] Apply model mappers

### Test Plan 🛠

- Run `tuist generate` within any of the fixtures
- Verify projects can still be generated as before
- Verify acceptance tests pass