### PR TITLE
Add the option to enable/disable the main thread checker from the generated schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Support for enabling the cloud insights feature [#1335](https://github.com/tuist/tuist/pull/1335) by [@pepibumur](https://github.com/pepibumur)
 - Value graph model [#1336](https://github.com/tuist/tuist/pull/1336) by [@pepibumur](https://github.com/pepibumur)
+- **Breaking** Support for setting diagnostics options to the test and run actions [#1382](https://github.com/tuist/tuist/pull/1382) by [@pepibumur](https://github.com/pepibumur)
 
 ### Fixed
 

--- a/Sources/ProjectDescription/RunAction.swift
+++ b/Sources/ProjectDescription/RunAction.swift
@@ -1,23 +1,48 @@
 import Foundation
 
+/// It represents the test action of a scheme.
 public struct RunAction: Equatable, Codable {
+    /// Name of the configuration that should be used for building the runnable targets.
     public let configurationName: String
+
+    /// Executable that will be run.
     public let executable: TargetReference?
+
+    /// Arguments passed to the process running the app.
     public let arguments: Arguments?
 
+    /// Diagnostics options.
+    public let diagnosticsOptions: [SchemeDiagnosticsOption]
+
+    /// Initializes a new instance of a run action.
+    /// - Parameters:
+    ///   - configurationName: Name of the configuration that should be used for building the runnable targets.
+    ///   - executable: Executable that will be run.
+    ///   - arguments: Arguments passed to the process running the app.
+    ///   - diagnosticsOptions: Diagnostics options.
     public init(configurationName: String,
                 executable: TargetReference? = nil,
-                arguments: Arguments? = nil) {
+                arguments: Arguments? = nil,
+                diagnosticsOptions: [SchemeDiagnosticsOption] = []) {
         self.configurationName = configurationName
         self.executable = executable
         self.arguments = arguments
+        self.diagnosticsOptions = diagnosticsOptions
     }
 
+    /// Initializes a new instance of a run action.
+    /// - Parameters:
+    ///   - config: Configuration that should be used for building the test targets.
+    ///   - executable: Executable that will be run.
+    ///   - arguments: Arguments passed to the process running the app.
+    ///   - diagnosticsOptions: Diagnostics options.
     public init(config: PresetBuildConfiguration = .debug,
                 executable: TargetReference? = nil,
-                arguments: Arguments? = nil) {
+                arguments: Arguments? = nil,
+                diagnosticsOptions: [SchemeDiagnosticsOption] = []) {
         self.init(configurationName: config.name,
                   executable: executable,
-                  arguments: arguments)
+                  arguments: arguments,
+                  diagnosticsOptions: diagnosticsOptions)
     }
 }

--- a/Sources/ProjectDescription/SchemeDiagnosticsOption.swift
+++ b/Sources/ProjectDescription/SchemeDiagnosticsOption.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public enum SchemeDiagnosticsOption: String, Equatable, Codable {
+    /// Enable the main thread cheker
+    case mainThreadChecker
+}

--- a/Sources/ProjectDescription/TestAction.swift
+++ b/Sources/ProjectDescription/TestAction.swift
@@ -1,21 +1,49 @@
 import Foundation
 
+/// It represents the test action of a scheme.
 public struct TestAction: Equatable, Codable {
+    /// List of targets to be tested.
     public let targets: [TestableTarget]
+
+    /// Arguments passed to the process running the tests.
     public let arguments: Arguments?
+
+    /// Name of the configuration that should be used for building the test targets.
     public let configurationName: String
+
+    /// True to collect the test coverage results.
     public let coverage: Bool
+
+    /// List of targets for which Xcode will collect the coverage results.
     public let codeCoverageTargets: [TargetReference]
+
+    /// List of actions to be executed before running the tests.
     public let preActions: [ExecutionAction]
+
+    /// List of actions to be executed after running the tests.
     public let postActions: [ExecutionAction]
 
+    /// Diagnostics options.
+    public let diagnosticsOptions: [SchemeDiagnosticsOption]
+
+    /// Initializes a new instance of a test action
+    /// - Parameters:
+    ///   - targets: List of targets to be tested.
+    ///   - arguments: Arguments passed to the process running the tests.
+    ///   - configurationName: Name of the configuration that should be used for building the test targets.
+    ///   - coverage: True to collect the test coverage results.
+    ///   - codeCoverageTargets: List of targets for which Xcode will collect the coverage results.
+    ///   - preActions: ist of actions to be executed before running the tests.
+    ///   - postActions: List of actions to be executed after running the tests.
+    ///   - diagnosticsOptions: Diagnostics options.
     public init(targets: [TestableTarget] = [],
                 arguments: Arguments? = nil,
                 configurationName: String,
                 coverage: Bool = false,
                 codeCoverageTargets: [TargetReference] = [],
                 preActions: [ExecutionAction] = [],
-                postActions: [ExecutionAction] = []) {
+                postActions: [ExecutionAction] = [],
+                diagnosticsOptions: [SchemeDiagnosticsOption] = []) {
         self.targets = targets
         self.arguments = arguments
         self.configurationName = configurationName
@@ -23,21 +51,34 @@ public struct TestAction: Equatable, Codable {
         self.preActions = preActions
         self.postActions = postActions
         self.codeCoverageTargets = codeCoverageTargets
+        self.diagnosticsOptions = diagnosticsOptions
     }
 
+    /// Initializes a new instance of a test action
+    /// - Parameters:
+    ///   - targets: List of targets to be tested.
+    ///   - arguments: Arguments passed to the process running the tests.
+    ///   - config: Configuration that should be used for building the test targets.
+    ///   - coverage: True to collect the test coverage results.
+    ///   - codeCoverageTargets: List of targets for which Xcode will collect the coverage results.
+    ///   - preActions: ist of actions to be executed before running the tests.
+    ///   - postActions: List of actions to be executed after running the tests.
+    ///   - diagnosticsOptions: Diagnostics options.
     public init(targets: [TestableTarget],
                 arguments: Arguments? = nil,
                 config: PresetBuildConfiguration = .debug,
                 coverage: Bool = false,
                 codeCoverageTargets: [TargetReference] = [],
                 preActions: [ExecutionAction] = [],
-                postActions: [ExecutionAction] = []) {
+                postActions: [ExecutionAction] = [],
+                diagnosticsOptions: [SchemeDiagnosticsOption] = []) {
         self.init(targets: targets,
                   arguments: arguments,
                   configurationName: config.name,
                   coverage: coverage,
                   codeCoverageTargets: codeCoverageTargets,
                   preActions: preActions,
-                  postActions: postActions)
+                  postActions: postActions,
+                  diagnosticsOptions: diagnosticsOptions)
     }
 }

--- a/Sources/TuistCore/Models/RunAction.swift
+++ b/Sources/TuistCore/Models/RunAction.swift
@@ -8,16 +8,19 @@ public struct RunAction: Equatable {
     public let executable: TargetReference?
     public let filePath: AbsolutePath?
     public let arguments: Arguments?
+    public let diagnosticsOptions: Set<SchemeDiagnosticsOption>
 
     // MARK: - Init
 
     public init(configurationName: String,
-                executable: TargetReference? = nil,
-                filePath: AbsolutePath? = nil,
-                arguments: Arguments? = nil) {
+                executable: TargetReference?,
+                filePath: AbsolutePath?,
+                arguments: Arguments?,
+                diagnosticsOptions: Set<SchemeDiagnosticsOption>) {
         self.configurationName = configurationName
         self.executable = executable
         self.filePath = filePath
         self.arguments = arguments
+        self.diagnosticsOptions = diagnosticsOptions
     }
 }

--- a/Sources/TuistCore/Models/SchemeDiagnosticsOption.swift
+++ b/Sources/TuistCore/Models/SchemeDiagnosticsOption.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public enum SchemeDiagnosticsOption: Equatable {
+    case mainThreadChecker
+}

--- a/Sources/TuistCore/Models/TestAction.swift
+++ b/Sources/TuistCore/Models/TestAction.swift
@@ -11,16 +11,18 @@ public struct TestAction: Equatable {
     public let codeCoverageTargets: [TargetReference]
     public let preActions: [ExecutionAction]
     public let postActions: [ExecutionAction]
+    public let diagnosticsOptions: Set<SchemeDiagnosticsOption>
 
     // MARK: - Init
 
-    public init(targets: [TestableTarget] = [],
-                arguments: Arguments? = nil,
+    public init(targets: [TestableTarget],
+                arguments: Arguments?,
                 configurationName: String,
-                coverage: Bool = false,
-                codeCoverageTargets: [TargetReference] = [],
-                preActions: [ExecutionAction] = [],
-                postActions: [ExecutionAction] = []) {
+                coverage: Bool,
+                codeCoverageTargets: [TargetReference],
+                preActions: [ExecutionAction],
+                postActions: [ExecutionAction],
+                diagnosticsOptions: Set<SchemeDiagnosticsOption>) {
         self.targets = targets
         self.arguments = arguments
         self.configurationName = configurationName
@@ -28,5 +30,6 @@ public struct TestAction: Equatable {
         self.preActions = preActions
         self.postActions = postActions
         self.codeCoverageTargets = codeCoverageTargets
+        self.diagnosticsOptions = diagnosticsOptions
     }
 }

--- a/Sources/TuistCoreTesting/Models/RunAction+TestData.swift
+++ b/Sources/TuistCoreTesting/Models/RunAction+TestData.swift
@@ -6,10 +6,12 @@ public extension RunAction {
     static func test(configurationName: String = BuildConfiguration.debug.name,
                      executable: TargetReference? = TargetReference(projectPath: "/Project", name: "App"),
                      filePath: AbsolutePath? = nil,
-                     arguments: Arguments? = Arguments.test()) -> RunAction {
+                     arguments: Arguments? = Arguments.test(),
+                     diagnosticsOptions: Set<SchemeDiagnosticsOption> = Set()) -> RunAction {
         RunAction(configurationName: configurationName,
                   executable: executable,
                   filePath: filePath,
-                  arguments: arguments)
+                  arguments: arguments,
+                  diagnosticsOptions: diagnosticsOptions)
     }
 }

--- a/Sources/TuistCoreTesting/Models/TestAction+TestData.swift
+++ b/Sources/TuistCoreTesting/Models/TestAction+TestData.swift
@@ -9,13 +9,15 @@ public extension TestAction {
                      coverage: Bool = false,
                      codeCoverageTargets: [TargetReference] = [],
                      preActions: [ExecutionAction] = [],
-                     postActions: [ExecutionAction] = []) -> TestAction {
+                     postActions: [ExecutionAction] = [],
+                     diagnosticsOptions: Set<SchemeDiagnosticsOption> = Set()) -> TestAction {
         TestAction(targets: targets,
                    arguments: arguments,
                    configurationName: configurationName,
                    coverage: coverage,
                    codeCoverageTargets: codeCoverageTargets,
                    preActions: preActions,
-                   postActions: postActions)
+                   postActions: postActions,
+                   diagnosticsOptions: diagnosticsOptions)
     }
 }

--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -72,8 +72,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
         // Run Scheme
         let buildAction = BuildAction(targets: targets.map { TargetReference(projectPath: sourceRootPath, name: $0.name) })
         let arguments = Arguments(launch: ["generate --path \(sourceRootPath)": true])
-
-        let runAction = RunAction(configurationName: "Debug", filePath: tuistPath, arguments: arguments)
+        let runAction = RunAction(configurationName: "Debug", executable: nil, filePath: tuistPath, arguments: arguments, diagnosticsOptions: Set())
         let scheme = Scheme(name: "Manifests", shared: true, buildAction: buildAction, runAction: runAction)
 
         // Project

--- a/Sources/TuistLoader/Models+ManifestMappers/RunAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/RunAction+ManifestMapper.swift
@@ -18,9 +18,11 @@ extension TuistCore.RunAction {
             executableResolved = TargetReference(projectPath: try generatorPaths.resolveSchemeActionProjectPath(executable.projectPath),
                                                  name: executable.targetName)
         }
-
-        return RunAction(configurationName: configurationName,
-                         executable: executableResolved,
-                         arguments: arguments)
+        let diagnosticsOptions = Set(manifest.diagnosticsOptions.map { TuistCore.SchemeDiagnosticsOption.from(manifest: $0) })
+        return TuistCore.RunAction(configurationName: configurationName,
+                                   executable: executableResolved,
+                                   filePath: nil,
+                                   arguments: arguments,
+                                   diagnosticsOptions: diagnosticsOptions)
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/SchemeDiagnosticsOption+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/SchemeDiagnosticsOption+ManifestMapper.swift
@@ -1,0 +1,12 @@
+import Foundation
+import ProjectDescription
+import TSCBasic
+import TuistCore
+
+extension TuistCore.SchemeDiagnosticsOption {
+    static func from(manifest: ProjectDescription.SchemeDiagnosticsOption) -> TuistCore.SchemeDiagnosticsOption {
+        switch manifest {
+        case .mainThreadChecker: return .mainThreadChecker
+        }
+    }
+}

--- a/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
@@ -21,6 +21,7 @@ extension TuistCore.TestAction {
                                                                                           generatorPaths: generatorPaths) }
         let postActions = try manifest.postActions.map { try TuistCore.ExecutionAction.from(manifest: $0,
                                                                                             generatorPaths: generatorPaths) }
+        let diagnosticsOptions = Set(manifest.diagnosticsOptions.map { TuistCore.SchemeDiagnosticsOption.from(manifest: $0) })
 
         return TestAction(targets: targets,
                           arguments: arguments,
@@ -28,6 +29,7 @@ extension TuistCore.TestAction {
                           coverage: coverage,
                           codeCoverageTargets: codeCoverageTargets,
                           preActions: preActions,
-                          postActions: postActions)
+                          postActions: postActions,
+                          diagnosticsOptions: diagnosticsOptions)
     }
 }

--- a/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
@@ -460,7 +460,9 @@ final class SchemesGeneratorTests: XCTestCase {
         let target = Target.test(name: "Library", platform: .iOS, product: .dynamicLibrary)
 
         let buildAction = BuildAction.test(targets: [TargetReference(projectPath: projectPath, name: "Library")])
-        let launchAction = RunAction.test(configurationName: "Debug", filePath: "/usr/bin/foo")
+        let launchAction = RunAction.test(configurationName: "Debug",
+                                          filePath: "/usr/bin/foo",
+                                          diagnosticsOptions: Set(arrayLiteral: .mainThreadChecker))
 
         let scheme = Scheme.test(name: "Library", buildAction: buildAction, runAction: launchAction)
         let project = Project.test(path: projectPath, targets: [target])
@@ -477,6 +479,7 @@ final class SchemesGeneratorTests: XCTestCase {
         XCTAssertNil(result.runnable?.buildableReference)
         XCTAssertEqual(result.buildConfiguration, "Debug")
         XCTAssertEqual(result.pathRunnable?.filePath, "/usr/bin/foo")
+        XCTAssertFalse(result.disableMainThreadChecker)
     }
 
     func test_schemeLaunchAction_with_path() throws {
@@ -485,7 +488,8 @@ final class SchemesGeneratorTests: XCTestCase {
         let target = Target.test(name: "Library", platform: .iOS, product: .dynamicLibrary)
 
         let buildAction = BuildAction.test(targets: [TargetReference(projectPath: projectPath, name: "Library")])
-        let testAction = TestAction.test(targets: [TestableTarget(target: TargetReference(projectPath: projectPath, name: "Library"))])
+        let testAction = TestAction.test(targets: [TestableTarget(target: TargetReference(projectPath: projectPath, name: "Library"))],
+                                         diagnosticsOptions: Set(arrayLiteral: .mainThreadChecker))
 
         let scheme = Scheme.test(name: "Library", buildAction: buildAction, testAction: testAction, runAction: nil)
         let project = Project.test(path: projectPath, targets: [target])
@@ -506,6 +510,7 @@ final class SchemesGeneratorTests: XCTestCase {
         XCTAssertEqual(result.macroExpansion?.buildableName, "libLibrary.dylib")
         XCTAssertEqual(result.macroExpansion?.blueprintName, "Library")
         XCTAssertEqual(result.macroExpansion?.buildableIdentifier, "primary")
+        XCTAssertFalse(result.disableMainThreadChecker)
     }
 
     // MARK: - Profile Action Tests

--- a/Tests/TuistGeneratorTests/Linter/SchemeLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/SchemeLinterTests.swift
@@ -79,7 +79,14 @@ class SchemeLinterTests: XCTestCase {
                                    schemes: [
                                        .init(name: "SchemeWithTargetThatDoesNotExist",
                                              shared: true,
-                                             testAction: .init(targets: [.init(target: .init(projectPath: AbsolutePath("/Project/../Framework"), name: "Framework"))], configurationName: "Beta")),
+                                             testAction: .init(targets: [.init(target: .init(projectPath: AbsolutePath("/Project/../Framework"), name: "Framework"))],
+                                                               arguments: nil,
+                                                               configurationName: "Beta",
+                                                               coverage: false,
+                                                               codeCoverageTargets: [],
+                                                               preActions: [],
+                                                               postActions: [],
+                                                               diagnosticsOptions: Set())),
                                    ])
 
         // When

--- a/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
@@ -291,6 +291,7 @@ final class StableXcodeProjIntegrationTests: TuistTestCase {
         let targets = try ([appTarget] + frameworkTargets).map(targetReference(from:))
         return (0 ..< 10).map {
             let boolStub = $0 % 2 == 0
+
             return Scheme(
                 name: "Scheme \($0)",
                 shared: boolStub,
@@ -303,10 +304,13 @@ final class StableXcodeProjIntegrationTests: TuistTestCase {
                                        coverage: boolStub,
                                        codeCoverageTargets: targets,
                                        preActions: createExecutionActions(),
-                                       postActions: createExecutionActions()),
+                                       postActions: createExecutionActions(),
+                                       diagnosticsOptions: Set()),
                 runAction: RunAction(configurationName: "Debug",
                                      executable: nil,
-                                     arguments: createArguments()),
+                                     filePath: nil,
+                                     arguments: createArguments(),
+                                     diagnosticsOptions: Set()),
                 archiveAction: ArchiveAction(configurationName: "Debug",
                                              revealArchiveInOrganizer: boolStub,
                                              preActions: createExecutionActions(),

--- a/website/markdown/docs/usage/projectswift.mdx
+++ b/website/markdown/docs/usage/projectswift.mdx
@@ -817,6 +817,14 @@ It represents the scheme action that runs the built products on the supported pl
       optional: true,
       default: 'nil',
     },
+    {
+      name: 'Diagnostics options',
+      description: 'List of diagnostics options to set to the action.',
+      type: '[SchemeDiagnosticsOption]',
+      typeLink: '#scheme-diagnostics-option',
+      optional: true,
+      default: '[]',
+    },
   ]}
 />
 
@@ -896,6 +904,14 @@ Alternatively, when leveraging custom configurations, the configuration name can
         'A list of actions that are executed after the tests-run process.',
       type: '[ExecutionAction]',
       typeLink: '#execution-action',
+      optional: true,
+      default: '[]',
+    },
+    {
+      name: 'Diagnostics options',
+      description: 'List of diagnostics options to set to the action.',
+      type: '[SchemeDiagnosticsOption]',
+      typeLink: '#scheme-diagnostics-option',
       optional: true,
       default: '[]',
     },
@@ -1004,6 +1020,19 @@ Arguments contain commandline arguments passed on launch and Environment variabl
       type: '[String: Bool]',
       optional: true,
       default: '[:]',
+    },
+  ]}
+/>
+
+### Scheme Diagnostics Option
+
+Diagnostics options represent the configurable diagnostics-related settings in the schemes' run and test actions.
+
+<EnumTable
+  cases={[
+    {
+      case: '.mainThreadChecker',
+      description: 'Enable the main thread checker.',
     },
   ]}
 />
@@ -1246,76 +1275,78 @@ Here is the list of functions provided by Tuist:
   methods={[
     {
       subject: 'Code Signing',
-      signature: 'func manualCodeSigning(identity: String? = nil, provisioningProfileSpecifier: String? = nil) -> SettingsDictionary',
+      signature:
+        'func manualCodeSigning(identity: String? = nil, provisioningProfileSpecifier: String? = nil) -> SettingsDictionary',
       description:
         'Sets `"CODE_SIGN_STYLE"` to `"Manual"`, `"CODE_SIGN_IDENTITY"` to `identity`, and `"PROVISIONING_PROFILE_SPECIFIER"` to `provisioningProfileSpecifier`',
     },
     {
       subject: 'Code Signing',
-      signature: 'func automaticCodeSigning(devTeam: String) -> SettingsDictionary',
+      signature:
+        'func automaticCodeSigning(devTeam: String) -> SettingsDictionary',
       description:
         'Sets `"CODE_SIGN_STYLE"` to `"Automatic"` and `"DEVELOPMENT_TEAM"` to `devTeam`',
     },
     {
       subject: 'Code Signing',
-      signature: 'func codeSignIdentityAppleDevelopment() -> SettingsDictionary',
-      description:
-        'Sets `"CODE_SIGN_IDENTITY"` to `"Apple Development"`',
+      signature:
+        'func codeSignIdentityAppleDevelopment() -> SettingsDictionary',
+      description: 'Sets `"CODE_SIGN_IDENTITY"` to `"Apple Development"`',
     },
     {
       subject: 'Code Signing',
-      signature: 'func codeSignIdentity(_ identity: String) -> SettingsDictionary',
-      description:
-        'Sets `"CODE_SIGN_IDENTITY"` to `identity`',
+      signature:
+        'func codeSignIdentity(_ identity: String) -> SettingsDictionary',
+      description: 'Sets `"CODE_SIGN_IDENTITY"` to `identity`',
     },
     {
       subject: 'Versioning',
-      signature: 'func currentProjectVersion(_ version: String) -> SettingsDictionary',
-      description:
-        'Sets `"CURRENT_PROJECT_VERSION"` to `version`',
+      signature:
+        'func currentProjectVersion(_ version: String) -> SettingsDictionary',
+      description: 'Sets `"CURRENT_PROJECT_VERSION"` to `version`',
     },
     {
       subject: 'Versioning',
       signature: 'func appleGenericVersioningSystem() -> SettingsDictionary',
-      description:
-        'Sets `"VERSIONING_SYSTEM"` to `"apple-generic"`',
+      description: 'Sets `"VERSIONING_SYSTEM"` to `"apple-generic"`',
     },
     {
       subject: 'Versioning',
-      signature: 'func versionInfo(_ version: String, prefix: String? = nil, suffix: String? = nil) -> SettingsDictionary',
+      signature:
+        'func versionInfo(_ version: String, prefix: String? = nil, suffix: String? = nil) -> SettingsDictionary',
       description:
         'Sets `"VERSION_INFO_PREFIX"` to `version`. If `prefix` and `suffix` are not `nil`, they\'re used as `"VERSION_INFO_PREFIX"` and `"VERSION_INFO_SUFFIX"` respectively.',
     },
     {
       subject: 'Swift Settings',
       signature: 'func swiftVersion(_ version: String) -> SettingsDictionary',
-      description:
-        'Sets `"SWIFT_VERSION"` to `version`',
+      description: 'Sets `"SWIFT_VERSION"` to `version`',
     },
     {
       subject: 'Swift Settings',
-      signature: 'func otherSwiftFlags(_ flags: String...) -> SettingsDictionary',
-      description:
-        'Sets `"OTHER_SWIFT_FLAGS"` to `flags`',
+      signature:
+        'func otherSwiftFlags(_ flags: String...) -> SettingsDictionary',
+      description: 'Sets `"OTHER_SWIFT_FLAGS"` to `flags`',
     },
     {
       subject: 'Swift Settings',
-      signature: 'func swiftCompilationMode(_ mode: SwiftCompilationMode) -> SettingsDictionary',
+      signature:
+        'func swiftCompilationMode(_ mode: SwiftCompilationMode) -> SettingsDictionary',
       description:
         'Sets `"SWIFT_COMPILATION_MODE"` to the available `SwiftCompilationMode` (`"singlefile"` or `"wholemodule"`)',
     },
     {
       subject: 'Swift Settings',
-      signature: 'func swiftOptimizationLevel(_ level: SwiftOptimizationLevel) -> SettingsDictionary',
+      signature:
+        'func swiftOptimizationLevel(_ level: SwiftOptimizationLevel) -> SettingsDictionary',
       description:
         'Sets `"SWIFT_OPTIMIZATION_LEVEL"` to the available `SwiftOptimizationLevel` (`"-O"`, `"-Onone"` or `"-Osize"`)',
     },
     {
       subject: 'Bitcode',
       signature: 'func bitcodeEnabled(_ enabled: Bool) -> SettingsDictionary',
-      description:
-        'Sets `"ENABLE_BITCODE"` to `"YES"` or `"NO"`',
-    }
+      description: 'Sets `"ENABLE_BITCODE"` to `"YES"` or `"NO"`',
+    },
   ]}
 />
 
@@ -1323,13 +1354,13 @@ Notice that you don't depend exclusively on Tuist's built-in functions.
 You can create your own `SettingsDictionary` extension methods and add them to your
 [Project description helpers](/docs/usage/helpers/) this way:
 
-  ```swift
-  public extension SettingsDictionary {
-    func setSomeBuildSetting(_ value: String) -> SettingsDictionary {
-        merging(["SOME_BUILD_SETTING": SettingValue(stringLiteral: value)])
-    }
+```swift
+public extension SettingsDictionary {
+  func setSomeBuildSetting(_ value: String) -> SettingsDictionary {
+      merging(["SOME_BUILD_SETTING": SettingValue(stringLiteral: value)])
   }
-  ```
+}
+```
 
 ## Configuration
 
@@ -1367,7 +1398,8 @@ For example, a `.debug` configuration would get `SWIFT_OPTIMIZATION_LEVEL = -Ono
 <EnumTable
   cases={[
     {
-      case: '.debug(name: String, settings: SettingsDictionary, xcconfig: Path?)',
+      case:
+        '.debug(name: String, settings: SettingsDictionary, xcconfig: Path?)',
       description: 'A custom debug configuration',
     },
     {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1321

### Short description 📝
As @gbasile pointed out [here](https://github.com/tuist/tuist/issues/1321) we are enabling the main thread checker by default. This PR adds a new API to the `RunAction` and `TestAction` model to set diagnostics options. 