### PR TITLE
Add support for resources to static libraries

### DIFF
--- a/Sources/TuistKit/GraphMappers/GraphMapperProvider.swift
+++ b/Sources/TuistKit/GraphMappers/GraphMapperProvider.swift
@@ -33,6 +33,9 @@ final class GraphMapperProvider: GraphMapperProviding {
         if let cloud = config.cloud, cloud.options.contains(.insights) {
             mappers.append(CloudInsightsGraphMapper())
         }
+        
+        // Support for resources in static libraries
+        mappers.append(StaticLibWithResourcesGraphMapper())
 
         return mappers
     }

--- a/Sources/TuistKit/GraphMappers/StaticLibWithResourcesGraphMapper.swift
+++ b/Sources/TuistKit/GraphMappers/StaticLibWithResourcesGraphMapper.swift
@@ -1,0 +1,34 @@
+import Foundation
+import TuistCore
+import TSCBasic
+
+class StaticLibWithResourcesGraphMapper: GraphMapping {
+    func map(graph: Graph) throws -> (Graph, [SideEffectDescriptor]) {
+        
+        
+        
+        return (graph, sideEffects(graph))
+    }
+    
+    fileprivate func sideEffects(_ graph: Graph) -> [SideEffectDescriptor] {
+        graph.targets.flatMap({$0.value}).compactMap { (target) -> SideEffectDescriptor? in
+            switch target.target.product {
+            case .framework, .staticFramework, .staticLibrary, .dynamicLibrary:
+                let content = """
+import Foundation
+
+extension Bundle {
+}
+"""
+                return .file(.init(path: swiftFilePath(target: target), contents: content.data(using: .utf8), state: .present))
+            default:
+                return nil
+            }
+        }
+    }
+    
+    fileprivate func swiftFilePath(target: TargetNode) -> AbsolutePath {
+        target.project.path.appending(RelativePath("Derived/Resources/Bundle+\(target.target.name).swift"))
+    }
+    
+}


### PR DESCRIPTION
### Short description 📝
I started doing some pairing with @matiasvillaverde to onboard him on the codebase. What we are doing in this PR is adding support for specifying resources from libraries. The idea is the following:

- A mapper creates an extension of `Bundle`, `Bundle+TargetName.swift`, with a static Bundle variable to access the bundle. For example, `Bundle.myFramework`.
- That gives Tuist the flexibility to point the bundle to the right place depending on whether it's a library or a framework.
- In the case of a framework, `Bundle.myFramework` will point to `MyFramework.framework`.
- In the case of a library, we'll add a Bundle dependency to `MyFramework` with all the resources. The resources will end up being part of that bundle. The `Bundle.myFramework` will point to that bundle.

### Implementation 👩‍💻👨‍💻

- Implement a new mapper, `StaticLibWithResourcesGraphMapper`, that:
  - Generates the Bundle extensions (side effects)
  - Add the `.bundle` dependencies for libraries.
  - Adds `Bundle+XXX.swift` to the sources of the targets.