### PR TITLE
Update XcodeProj to 7.11.0

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -9,12 +9,16 @@ on:
       - Tests/**/*
       - fixtures/**/*
       - .github/workflows/tuist.yml
+      - Package.swift
+      - Package.resolved
   pull_request:
     paths:
       - Sources/**/*
       - Tests/**/*
       - fixtures/**/*
       - .github/workflows/tuist.yml
+      - Package.swift
+      - Package.resolved
 
 jobs:
   unit_tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Changed
+
+- Upgrade XcodeProj to 7.11.0 [#1398](https://github.com/tuist/tuist/pull/1398) by [@pepibumur](https://github.com/pepibumur)
+
 ## 1.9.0 - Speedy Gonzales
 
 ### Added

--- a/Package.resolved
+++ b/Package.resolved
@@ -159,8 +159,8 @@
         "repositoryURL": "https://github.com/tuist/XcodeProj",
         "state": {
           "branch": null,
-          "revision": "912d40cc2ea4a300eff6dd7c6a10b4f4dedbcbec",
-          "version": "7.10.0"
+          "revision": "b8798bc3544c083dc5dc290f0f30f50971d5d8d9",
+          "version": "7.11.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
                  targets: ["TuistGenerator"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tuist/XcodeProj", .upToNextMajor(from: "7.10.0")),
+        .package(url: "https://github.com/tuist/XcodeProj", .upToNextMajor(from: "7.11.0")),
         .package(url: "https://github.com/IBM-Swift/BlueSignals", .upToNextMajor(from: "1.0.21")),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.1")),
         .package(url: "https://github.com/rnine/Checksum.git", .upToNextMajor(from: "1.0.2")),


### PR DESCRIPTION
I just [released XcodeProj 7.11.0](https://github.com/tuist/XcodeProj/releases/tag/7.11.0) so this PR updates the dependency to point to the latest version. It does not contain breaking changes so the PR should be green.