### PR TITLE
Add support for watch architectures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Added
+
+- Add support for watch architectures [#1417](https://github.com/tuist/tuist/pull/1417) by [@davidbrunow](https://github.com/davidbrunow)
+
 ## 1.10.0 - Alma
 
 ### Added

--- a/Package.swift
+++ b/Package.swift
@@ -175,7 +175,7 @@ let package = Package(
         ),
         .testTarget(
             name: "TuistAutomationTests",
-            dependencies: ["TuistAutomation", "TuistSupportTesting"]
+            dependencies: ["TuistAutomation", "TuistSupportTesting", "TuistCoreTesting"]
         ),
         .target(
             name: "TuistAutomationTesting",

--- a/Sources/TuistCore/Models/BinaryArchitecture.swift
+++ b/Sources/TuistCore/Models/BinaryArchitecture.swift
@@ -6,6 +6,8 @@ public enum BinaryArchitecture: String, Codable {
     case armv7
     case armv7s
     case arm64
+    case armv7k
+    case arm6432 = "arm64_32"
 }
 
 public enum BinaryLinking: String, Codable {

--- a/Tests/TuistCoreTests/Models/BinaryArchitectureTests.swift
+++ b/Tests/TuistCoreTests/Models/BinaryArchitectureTests.swift
@@ -12,5 +12,8 @@ final class BinaryArchitectureTests: TuistTestCase {
         XCTAssertEqual(BinaryArchitecture.i386.rawValue, "i386")
         XCTAssertEqual(BinaryArchitecture.armv7.rawValue, "armv7")
         XCTAssertEqual(BinaryArchitecture.armv7s.rawValue, "armv7s")
+        XCTAssertEqual(BinaryArchitecture.arm64.rawValue, "arm64")
+        XCTAssertEqual(BinaryArchitecture.armv7k.rawValue, "armv7k")
+        XCTAssertEqual(BinaryArchitecture.arm6432.rawValue, "arm64_32")
     }
 }


### PR DESCRIPTION
### Short description 📝

This pull request adds support for Apple Watch architectures. I ran into the need for these architectures when I was using Tuist to add an XCFramework dependency that had watch architectures.

### Solution 📦

Add the watch architectures.

### Implementation 👩‍💻👨‍💻

> Detail in a checklist the steps that you took to implement the PR.

- [x] Added watch architectures
- [x] Added unit tests
