### PR TITLE
Add support for specifying whether it should clean or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - `tuist edit` always creates a project in a new temp dir [#1424](https://github.com/tuist/tuist/pull/1424) by [@fortmarek](https://github.com/fortmarek)
 - Fix `tuist init` and `tuist scaffold` with new ArgumentParser version [#1425](https://github.com/tuist/tuist/pull/1425) by [@fortmarek](https://github.com/fortmarek)
+- `--clean` argument ot the build command [#1421](https://github.com/tuist/tuist/pull/1421) by [@pepibumur](https://github.com/pepibumur)
 
 ## 1.10.0 - Alma
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift",
         "state": {
           "branch": null,
-          "revision": "39f08ac5269361a50c08ce1e2f41989bfc4b1ec8",
-          "version": "1.3.1"
+          "revision": "a44caef0550c346e0ab9172f7c9a3852c1833599",
+          "version": "1.3.0"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/kishikawakatsumi/KeychainAccess.git",
         "state": {
           "branch": null,
-          "revision": "3d0ea2c0806791abcc5d7f0d9f62f1cfd4a7264d",
-          "version": "4.2.0"
+          "revision": "b920ad7df3c73189dcdd4aa05c540849b2010dbf",
+          "version": "4.1.0"
         }
       },
       {
@@ -96,7 +96,7 @@
         "repositoryURL": "https://github.com/stencilproject/Stencil",
         "state": {
           "branch": "master",
-          "revision": "124df01d3c5defdce07872fe1828c764bb969b38",
+          "revision": "9c3468e300ba75ede0d7eb4c495897e0ac3591c3",
           "version": null
         }
       },
@@ -132,8 +132,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core",
         "state": {
           "branch": null,
-          "revision": "912919ab8441306c86c514b78800e4498ab60b60",
-          "version": "0.1.3"
+          "revision": "ae8ccef3274e38eb5ae3189c357883510da74a01",
+          "version": "0.1.1"
         }
       },
       {
@@ -159,8 +159,8 @@
         "repositoryURL": "https://github.com/tuist/XcodeProj",
         "state": {
           "branch": null,
-          "revision": "6eaf24df094990f74bb3459f3e5d7bce44c2163a",
-          "version": "7.11.1"
+          "revision": "b8798bc3544c083dc5dc290f0f30f50971d5d8d9",
+          "version": "7.11.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift",
         "state": {
           "branch": null,
-          "revision": "a44caef0550c346e0ab9172f7c9a3852c1833599",
-          "version": "1.3.0"
+          "revision": "39f08ac5269361a50c08ce1e2f41989bfc4b1ec8",
+          "version": "1.3.1"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/kishikawakatsumi/KeychainAccess.git",
         "state": {
           "branch": null,
-          "revision": "b920ad7df3c73189dcdd4aa05c540849b2010dbf",
-          "version": "4.1.0"
+          "revision": "3d0ea2c0806791abcc5d7f0d9f62f1cfd4a7264d",
+          "version": "4.2.0"
         }
       },
       {
@@ -96,7 +96,7 @@
         "repositoryURL": "https://github.com/stencilproject/Stencil",
         "state": {
           "branch": "master",
-          "revision": "9c3468e300ba75ede0d7eb4c495897e0ac3591c3",
+          "revision": "124df01d3c5defdce07872fe1828c764bb969b38",
           "version": null
         }
       },
@@ -132,8 +132,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core",
         "state": {
           "branch": null,
-          "revision": "ae8ccef3274e38eb5ae3189c357883510da74a01",
-          "version": "0.1.1"
+          "revision": "912919ab8441306c86c514b78800e4498ab60b60",
+          "version": "0.1.3"
         }
       },
       {
@@ -159,8 +159,8 @@
         "repositoryURL": "https://github.com/tuist/XcodeProj",
         "state": {
           "branch": null,
-          "revision": "b8798bc3544c083dc5dc290f0f30f50971d5d8d9",
-          "version": "7.11.0"
+          "revision": "6eaf24df094990f74bb3459f3e5d7bce44c2163a",
+          "version": "7.11.1"
         }
       },
       {

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -19,7 +19,7 @@ struct BuildCommand: ParsableCommand {
         help: "Force the generation of the project before building."
     )
     var generate: Bool
-    
+
     @Flag(
         help: "When passed, it cleans the project before building it"
     )

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -19,6 +19,11 @@ struct BuildCommand: ParsableCommand {
         help: "Force the generation of the project before building."
     )
     var generate: Bool
+    
+    @Flag(
+        help: "When passed, it cleans the project before building it"
+    )
+    var clean: Bool
 
     @Option(
         name: .shortAndLong,
@@ -33,6 +38,9 @@ struct BuildCommand: ParsableCommand {
         } else {
             absolutePath = FileHandler.shared.currentPath
         }
-        try BuildService().run(schemeName: scheme, generate: generate, path: absolutePath)
+        try BuildService().run(schemeName: scheme,
+                               generate: generate,
+                               clean: clean,
+                               path: absolutePath)
     }
 }

--- a/Sources/TuistKit/Services/BuildService.swift
+++ b/Sources/TuistKit/Services/BuildService.swift
@@ -48,7 +48,7 @@ final class BuildService {
         self.buildGraphInspector = buildGraphInspector
     }
 
-    func run(schemeName: String?, generate: Bool, path: AbsolutePath) throws {
+    func run(schemeName: String?, generate: Bool, clean: Bool, path: AbsolutePath) throws {
         let graph: Graph
         if generate || buildGraphInspector.workspacePath(directory: path) == nil {
             graph = try projectGenerator.generateWithGraph(path: path, projectOnly: false).1
@@ -67,7 +67,7 @@ final class BuildService {
         } else {
             var cleaned: Bool = false
             try buildableSchemes.forEach {
-                try buildScheme(scheme: $0, graph: graph, path: path, clean: !cleaned)
+                try buildScheme(scheme: $0, graph: graph, path: path, clean: !cleaned && clean)
                 cleaned = true
             }
         }

--- a/Tests/TuistKitTests/Services/BuildServiceTests.swift
+++ b/Tests/TuistKitTests/Services/BuildServiceTests.swift
@@ -83,7 +83,7 @@ final class BuildServiceTests: TuistUnitTestCase {
         }
 
         // Then
-        try subject.run(schemeName: scheme.name, generate: true, path: path)
+        try subject.run(schemeName: scheme.name, generate: true, clean: true, path: path)
     }
 
     func test_run_when_the_project_is_already_generated() throws {
@@ -123,7 +123,7 @@ final class BuildServiceTests: TuistUnitTestCase {
         }
 
         // Then
-        try subject.run(schemeName: scheme.name, generate: false, path: path)
+        try subject.run(schemeName: scheme.name, generate: false, clean: true, path: path)
     }
 
     func test_run_only_cleans_the_first_time() throws {
@@ -174,7 +174,7 @@ final class BuildServiceTests: TuistUnitTestCase {
         }
 
         // Then
-        try subject.run(schemeName: nil, generate: false, path: path)
+        try subject.run(schemeName: nil, generate: false, clean: true, path: path)
     }
 
     func test_run_only_runs_the_given_scheme_when_passed() throws {
@@ -221,6 +221,6 @@ final class BuildServiceTests: TuistUnitTestCase {
         }
 
         // Then
-        try subject.run(schemeName: "A", generate: false, path: path)
+        try subject.run(schemeName: "A", generate: false, clean: true, path: path)
     }
 }


### PR DESCRIPTION
### Short description 📝
This PR extends the build command to support the `--clean` argument. Before this change, Tuist always cleaned before starting the build, and now it defaults to not cleaning giving the users the option to enable it:

```
tuist build --clean
```