### PR TITLE
Add a method to show the build settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 - Add support for watch architectures [#1417](https://github.com/tuist/tuist/pull/1417) by [@davidbrunow](https://github.com/davidbrunow)
+- Add method to XcodeBuildController to show the build settings of a project [#1422](https://github.com/tuist/tuist/pull/1422) by [@pepibumur](https://github.com/pepibumur)
 
 ## 1.10.0 - Alma
 

--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -8,6 +8,15 @@ import XcbeautifyLib
 public final class XcodeBuildController: XcodeBuildControlling {
     // MARK: - Attributes
 
+    /// Matches lines of the forms:
+    ///
+    /// Build settings for action build and target "Tuist Mac":
+    /// Build settings for action test and target TuistTests:
+    private static let targetSettingsRegex = try! NSRegularExpression( // swiftlint:disable:this force_try
+        pattern: "^Build settings for action (?:\\S+) and target \\\"?([^\":]+)\\\"?:$",
+        options: [.caseInsensitive, .anchorsMatchLines]
+    )
+
     /// Instance to format xcodebuild output.
     private let parser: Parsing
 
@@ -76,6 +85,76 @@ public final class XcodeBuildController: XcodeBuildControlling {
         command.append(contentsOf: frameworks.flatMap { ["-framework", $0.pathString] })
         command.append(contentsOf: ["-output", output.pathString])
         return run(command: command)
+    }
+
+    public func showBuildSettings(_ target: XcodeBuildTarget,
+                                  scheme: String,
+                                  configuration: String) -> Single<[String: XcodeBuildSettings]> {
+        var command = ["/usr/bin/xcrun", "xcodebuild", "archive", "-showBuildSettings", "-skipUnavailableActions"]
+
+        // Configuration
+        command.append(contentsOf: ["-configuration", configuration])
+
+        // Scheme
+        command.append(contentsOf: ["-scheme", scheme])
+
+        // Target
+        command.append(contentsOf: target.xcodebuildArguments)
+
+        return System.shared.observable(command)
+            .mapToString()
+            .collectAndMergeOutput()
+            // xcodebuild has a bug where xcodebuild -showBuildSettings
+            // can sometimes hang indefinitely on projects that don't
+            // share any schemes, so automatically bail out if it looks
+            // like that's happening.
+            .timeout(DispatchTimeInterval.seconds(20), scheduler: ConcurrentDispatchQueueScheduler(queue: .global()))
+            .retry(5)
+            .flatMap { string -> Observable<XcodeBuildSettings> in
+                Observable.create { (observer) -> Disposable in
+                    var currentSettings: [String: String] = [:]
+                    var currentTarget: String?
+
+                    let flushTarget = { () -> Void in
+                        if let currentTarget = currentTarget {
+                            let buildSettings = XcodeBuildSettings(currentSettings, target: currentTarget, configuration: configuration)
+                            observer.onNext(buildSettings)
+                        }
+
+                        currentTarget = nil
+                        currentSettings = [:]
+                    }
+
+                    string.enumerateLines { line, _ in
+                        if let result = XcodeBuildController.targetSettingsRegex.firstMatch(in: line, range: NSRange(line.startIndex..., in: line)) {
+                            let targetRange = Range(result.range(at: 1), in: line)!
+
+                            flushTarget()
+                            currentTarget = String(line[targetRange])
+                            return
+                        }
+
+                        let trimSet = CharacterSet.whitespacesAndNewlines
+                        let components = line
+                            .split(maxSplits: 1) { $0 == "=" }
+                            .map { $0.trimmingCharacters(in: trimSet) }
+
+                        if components.count == 2 {
+                            currentSettings[components[0]] = components[1]
+                        }
+                    }
+
+                    flushTarget()
+                    observer.onCompleted()
+                    return Disposables.create()
+                }
+            }
+            .reduce([String: XcodeBuildSettings](), accumulator: { (acc, buildSettings) -> [String: XcodeBuildSettings] in
+                var acc = acc
+                acc[buildSettings.target] = buildSettings
+                return acc
+            })
+            .asSingle()
     }
 
     fileprivate func run(command: [String]) -> Observable<SystemEvent<XcodeBuildOutput>> {

--- a/Sources/TuistCore/Automation/XcodeBuildControlling.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildControlling.swift
@@ -33,4 +33,13 @@ public protocol XcodeBuildControlling {
     ///   - frameworks: Frameworks to be combined.
     ///   - output: Path to the output .xcframework.
     func createXCFramework(frameworks: [AbsolutePath], output: AbsolutePath) -> Observable<SystemEvent<XcodeBuildOutput>>
+
+    /// Gets the build settings of a scheme targets.
+    /// - Parameters:
+    ///   - target: Project of workspace where the scheme is defined.
+    ///   - scheme: Scheme whose target build settings will be obtained.
+    ///   - configuration: Build configuration.
+    func showBuildSettings(_ target: XcodeBuildTarget,
+                           scheme: String,
+                           configuration: String) -> Single<[String: XcodeBuildSettings]>
 }

--- a/Sources/TuistCore/Automation/XcodeBuildSettings.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildSettings.swift
@@ -1,0 +1,90 @@
+import Foundation
+import TSCBasic
+
+public struct XcodeBuildSettings {
+    public typealias DictionaryType = [String: String]
+    private let settings: DictionaryType
+
+    /// The target to which these settings apply.
+    public let target: String
+
+    /// Build configuration.
+    public let configuration: String
+
+    public init(_ settings: DictionaryType,
+                target: String,
+                configuration: String) {
+        self.settings = settings
+        self.target = target
+        self.configuration = configuration
+    }
+
+    /// The relative path (from the build folder) to the built executable.
+    public var executablePath: String? {
+        settings["EXECUTABLE_PATH"]
+    }
+
+    /// The name of the built product's wrapper bundle.
+    public var wrapperName: String? {
+        settings["WRAPPER_NAME"]
+    }
+
+    /// Whether bitcode is enabled.
+    public var bitcodeEnabled: Bool {
+        settings["BITCODE_ENABLED"] == "YES"
+    }
+
+    /// Code signing identity.
+    public var codeSigningIdentity: String? {
+        settings["CODE_SIGN_IDENTITY"]
+    }
+
+    /// Whether ad hoc code signing is allowed.
+    public var adHocCodeSigningAllowed: Bool {
+        settings["AD_HOC_CODE_SIGNING_ALLOWED"] == "YES"
+    }
+
+    /// The path to the project that contains the current target.
+    public var projectPath: String? {
+        settings["PROJECT_FILE_PATH"]
+    }
+
+    /// The target build dir.
+    public var targetBuildDirectory: String? {
+        settings["TARGET_BUILD_DIR"]
+    }
+
+    /// The target product name.
+    public var productName: String? {
+        settings["PRODUCT_NAME"]
+    }
+
+    ///  The target swift version.
+    public var swiftVersion: String? {
+        settings["SWIFT_VERSION"]
+    }
+}
+
+extension XcodeBuildSettings: CustomStringConvertible {
+    public var description: String {
+        "Build settings for target \(target) and configuration \(configuration):\n\(settings.map { "\($0)=\($1)" }.joined(separator: "\n"))"
+    }
+}
+
+extension XcodeBuildSettings: Collection {
+    // Required nested types, that tell Swift what our collection contains
+    public typealias Index = DictionaryType.Index
+    public typealias Element = DictionaryType.Element
+
+    // The upper and lower bounds of the collection, used in iterations
+    public var startIndex: Index { settings.startIndex }
+    public var endIndex: Index { settings.endIndex }
+
+    // Required subscript, based on a dictionary index
+    public subscript(index: Index) -> Iterator.Element { settings[index] }
+
+    // Method that returns the next index when iterating
+    public func index(after i: Index) -> Index {
+        settings.index(after: i)
+    }
+}

--- a/Sources/TuistCoreTesting/Automation/MockXcodeBuildController.swift
+++ b/Sources/TuistCoreTesting/Automation/MockXcodeBuildController.swift
@@ -39,4 +39,13 @@ final class MockXcodeBuildController: XcodeBuildControlling {
             return Observable.error(TestError("\(String(describing: MockXcodeBuildController.self)) received an unexpected call to createXCFramework"))
         }
     }
+
+    var showBuildSettingsStub: ((XcodeBuildTarget, String, String) -> Single<[String: XcodeBuildSettings]>)?
+    func showBuildSettings(_ target: XcodeBuildTarget, scheme: String, configuration: String) -> Single<[String: XcodeBuildSettings]> {
+        if let showBuildSettingsStub = showBuildSettingsStub {
+            return showBuildSettingsStub(target, scheme, configuration)
+        } else {
+            return Single.error(TestError("\(String(describing: MockXcodeBuildController.self)) received an unexpected call to showBuildSettings"))
+        }
+    }
 }

--- a/Tests/TuistAutomationIntegrationTests/XcodeBuild/XcodeBuildControllerIntegrationTests.swift
+++ b/Tests/TuistAutomationIntegrationTests/XcodeBuild/XcodeBuildControllerIntegrationTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import RxBlocking
+import RxSwift
+import TSCBasic
+import TuistCore
+import TuistSupport
+import XCTest
+
+@testable import TuistAutomation
+@testable import TuistSupportTesting
+
+final class XcodeBuildControllerIntegrationTests: TuistTestCase {
+    var subject: XcodeBuildController!
+
+    override func setUp() {
+        super.setUp()
+        subject = XcodeBuildController()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        subject = nil
+    }
+
+    func test_showBuildSettings() throws {
+        // Given
+        let target = XcodeBuildTarget.project(fixturePath(path: RelativePath("Frameworks/Frameworks.xcodeproj")))
+
+        // When
+        let got = try subject.showBuildSettings(target, scheme: "iOS", configuration: "Debug")
+            .toBlocking()
+            .single()
+
+        // Then
+        XCTAssertEqual(got.count, 1)
+        let buildSettings = try XCTUnwrap(got["iOS"])
+        XCTAssertEqual(buildSettings.productName, "iOS")
+    }
+}


### PR DESCRIPTION
### Short description 📝
This PR adds a new method to the Xcode build controller to show the build settings of the targets that are part of a scheme. The idea is to use this utility to read some build settings that will be needed when building cacheable fat frameworks _(like Carthage does)_.
