### PR TITLE
Edit project in a new temp directory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Add support for watch architectures [#1417](https://github.com/tuist/tuist/pull/1417) by [@davidbrunow](https://github.com/davidbrunow)
 
+### Fixed
+
+- `tuist edit` always creates a project in a new temp dir [#1424](https://github.com/tuist/tuist/pull/1424) by [@fortmarek](https://github.com/fortmarek)
+
 ## 1.10.0 - Alma
 
 ### Added

--- a/Sources/TuistKit/Services/EditService.swift
+++ b/Sources/TuistKit/Services/EditService.swift
@@ -21,13 +21,13 @@ final class EditService {
         if !permanent {
             try withTemporaryDirectory { generationDirectory in
                 EditService.temporaryDirectory = generationDirectory
-                
+
                 Signals.trap(signals: [.int, .abrt]) { _ in
                     // swiftlint:disable:next force_try
                     try! EditService.temporaryDirectory.map(FileHandler.shared.delete)
                     exit(0)
                 }
-                
+
                 let xcodeprojPath = try projectEditor.edit(at: path, in: generationDirectory)
                 logger.pretty("Opening Xcode to edit the project. Press \(.keystroke("CTRL + C")) once you are done editing")
                 try opener.open(path: xcodeprojPath, wait: true)

--- a/Sources/TuistKit/Services/EditService.swift
+++ b/Sources/TuistKit/Services/EditService.swift
@@ -17,18 +17,23 @@ final class EditService {
     func run(path: String?,
              permanent: Bool) throws {
         let path = self.path(path)
-        let generationDirectory = permanent ? path : EditService.temporaryDirectory
-        let xcodeprojPath = try projectEditor.edit(at: path, in: generationDirectory)
 
         if !permanent {
-            Signals.trap(signals: [.int, .abrt]) { _ in
-                // swiftlint:disable:next force_try
-                try! FileHandler.shared.delete(EditService.temporaryDirectory)
-                exit(0)
+            try withTemporaryDirectory { generationDirectory in
+                EditService.temporaryDirectory = generationDirectory
+                
+                Signals.trap(signals: [.int, .abrt]) { _ in
+                    // swiftlint:disable:next force_try
+                    try! EditService.temporaryDirectory.map(FileHandler.shared.delete)
+                    exit(0)
+                }
+                
+                let xcodeprojPath = try projectEditor.edit(at: path, in: generationDirectory)
+                logger.pretty("Opening Xcode to edit the project. Press \(.keystroke("CTRL + C")) once you are done editing")
+                try opener.open(path: xcodeprojPath, wait: true)
             }
-            logger.pretty("Opening Xcode to edit the project. Press \(.keystroke("CTRL + C")) once you are done editing")
-            try opener.open(path: xcodeprojPath, wait: true)
         } else {
+            let xcodeprojPath = try projectEditor.edit(at: path, in: path)
             logger.notice("Xcode project generated at \(xcodeprojPath.pathString)", metadata: .success)
         }
     }
@@ -43,12 +48,5 @@ final class EditService {
         }
     }
 
-    private static var _temporaryDirectory: AbsolutePath?
-    private static var temporaryDirectory: AbsolutePath {
-        // swiftlint:disable:next identifier_name
-        if let _temporaryDirectory = _temporaryDirectory { return _temporaryDirectory }
-        // swiftlint:disable:next force_try
-        _temporaryDirectory = try! determineTempDirectory()
-        return _temporaryDirectory!
-    }
+    private static var temporaryDirectory: AbsolutePath?
 }


### PR DESCRIPTION
### Short description 📝

During the migration to ArgumentParser, we have ditched the `TemporaryDirectory` class. This has changed the behavior of `tuist edit` because we were running `determineTempDirectory()` method - but this temporary directory does not change on every invocation! (my fault for not realizing that). This means that `tuist edit` was creating the project to the same directory which lead to some weird incosistencies.

### Solution 📦

Create a directory with a `withTemporaryDirectory` closure to always edit the project in a new directory.

### Implementation 👩‍💻👨‍💻

- [x] Implement closure behavior
- [x] Add changelog
