### PR TITLE
Fix argument parser error with missing CodingKey.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Add support for watch architectures [#1417](https://github.com/tuist/tuist/pull/1417) by [@davidbrunow](https://github.com/davidbrunow)
 
+### Fixed
+
+- Fix `tuist init` and `tuist scaffold` with new ArgumentParser version [#1425](https://github.com/tuist/tuist/pull/1425) by [@fortmarek](https://github.com/fortmarek)
+
 ## 1.10.0 - Alma
 
 ### Added

--- a/Package.resolved
+++ b/Package.resolved
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "8d31a0905c346a45c87773ad50862b5b3df8dff6",
-          "version": "0.0.4"
+          "revision": "3d79b2b5a2e5af52c14e462044702ea7728f5770",
+          "version": "0.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", .upToNextMajor(from: "4.1.0")),
         .package(url: "https://github.com/httpswift/swifter.git", .upToNextMajor(from: "1.4.7")),
         .package(url: "https://github.com/apple/swift-tools-support-core", .upToNextMinor(from: "0.1.1")),
-        .package(url: "https://github.com/apple/swift-argument-parser", .exact("0.0.4")),
+        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "0.0.6")),
     ],
     targets: [
         .target(

--- a/Sources/TuistEnvKit/Commands/TuistCommand.swift
+++ b/Sources/TuistEnvKit/Commands/TuistCommand.swift
@@ -25,7 +25,8 @@ public struct TuistCommand: ParsableCommand {
             if processedArguments.dropFirst().first == "--help-env" {
                 throw CleanExit.helpRequest(self)
             } else if let parsedArguments = try parse() {
-                try parseAsRoot(parsedArguments).run()
+                var command = try parseAsRoot(parsedArguments)
+                try command.run()
             } else {
                 try CommandRunner().run()
             }

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -10,8 +10,9 @@ struct BuildCommand: ParsableCommand {
                              abstract: "Builds a project")
     }
 
-    @Argument(default: nil,
-              help: "The scheme to be built. By default it builds all the buildable schemes of the project in the current directory.")
+    @Argument(
+        help: "The scheme to be built. By default it builds all the buildable schemes of the project in the current directory."
+    )
     var scheme: String?
 
     @Flag(

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -141,7 +141,7 @@ extension InitCommand {
                 return optional
             }
         }
-        
+
         init?(stringValue: String) {
             switch stringValue {
             case "platform":
@@ -177,18 +177,18 @@ extension InitCommand: CustomReflectable {
             .map { Mirror.Child(label: $0.name, value: $0.option) }
         let optionalTemplateChildren = InitCommand.optionalTemplateOptions
             .map { Mirror.Child(label: $0.name, value: $0.option) }
-        
+
         let children = [
             Mirror.Child(label: "platform", value: _platform),
             Mirror.Child(label: "name", value: _name),
             Mirror.Child(label: "template", value: _template),
             Mirror.Child(label: "path", value: _path),
-            ].filter {
-                // Prefer attributes defined in a template if it clashes with predefined ones
-                $0.label.map { label in
-                    !(InitCommand.requiredTemplateOptions.map(\.name) + InitCommand.optionalTemplateOptions.map(\.name))
-                        .contains(label)
-                    } ?? true
+        ].filter {
+            // Prefer attributes defined in a template if it clashes with predefined ones
+            $0.label.map { label in
+                !(InitCommand.requiredTemplateOptions.map(\.name) + InitCommand.optionalTemplateOptions.map(\.name))
+                    .contains(label)
+            } ?? true
         }
         return Mirror(InitCommand(), children: children + requiredTemplateChildren + optionalTemplateChildren)
     }

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -17,7 +17,6 @@ struct InitCommand: ParsableCommand {
     }
 
     @Option(
-        name: .shortAndLong,
         help: "The platform (ios, tvos or macos) the product will be for (Default: ios)"
     )
     var platform: String?
@@ -107,10 +106,10 @@ extension InitCommand {
                                                                          path: command.path)
 
         InitCommand.requiredTemplateOptions = required.map {
-            (name: $0, option: Option<String>(name: .shortAndLong))
+            (name: $0, option: Option<String>())
         }
         InitCommand.optionalTemplateOptions = optional.map {
-            (name: $0, option: Option<String?>(name: .shortAndLong))
+            (name: $0, option: Option<String?>())
         }
     }
 }
@@ -142,11 +141,31 @@ extension InitCommand {
                 return optional
             }
         }
+        
+        init?(stringValue: String) {
+            switch stringValue {
+            case "platform":
+                self = .platform
+            case "name":
+                self = .template
+            case "template":
+                self = .template
+            case "path":
+                self = .path
+            default:
+                if InitCommand.requiredTemplateOptions.map(\.name).contains(stringValue) {
+                    self = .required(stringValue)
+                } else if InitCommand.optionalTemplateOptions.map(\.name).contains(stringValue) {
+                    self = .optional(stringValue)
+                } else {
+                    return nil
+                }
+            }
+        }
 
         // Not used
         var intValue: Int? { nil }
         init?(intValue _: Int) { nil }
-        init?(stringValue _: String) { nil }
     }
 }
 
@@ -158,12 +177,19 @@ extension InitCommand: CustomReflectable {
             .map { Mirror.Child(label: $0.name, value: $0.option) }
         let optionalTemplateChildren = InitCommand.optionalTemplateOptions
             .map { Mirror.Child(label: $0.name, value: $0.option) }
+        
         let children = [
             Mirror.Child(label: "platform", value: _platform),
             Mirror.Child(label: "name", value: _name),
             Mirror.Child(label: "template", value: _template),
             Mirror.Child(label: "path", value: _path),
-        ]
+            ].filter {
+                // Prefer attributes defined in a template if it clashes with predefined ones
+                $0.label.map { label in
+                    !(InitCommand.requiredTemplateOptions.map(\.name) + InitCommand.optionalTemplateOptions.map(\.name))
+                        .contains(label)
+                    } ?? true
+        }
         return Mirror(InitCommand(), children: children + requiredTemplateChildren + optionalTemplateChildren)
     }
 }

--- a/Sources/TuistKit/Commands/ScaffoldCommand.swift
+++ b/Sources/TuistKit/Commands/ScaffoldCommand.swift
@@ -132,7 +132,7 @@ extension ScaffoldCommand {
                 return optional
             }
         }
-        
+
         init?(stringValue: String) {
             switch stringValue {
             case "template":
@@ -167,12 +167,12 @@ extension ScaffoldCommand: CustomReflectable {
         let children = [
             Mirror.Child(label: "template", value: _template),
             Mirror.Child(label: "path", value: _path),
-            ].filter {
-                // Prefer attributes defined in a template if it clashes with predefined ones
-                $0.label.map { label in
-                    !(ScaffoldCommand.requiredTemplateOptions.map(\.name) + ScaffoldCommand.optionalTemplateOptions.map(\.name))
-                        .contains(label)
-                    } ?? true
+        ].filter {
+            // Prefer attributes defined in a template if it clashes with predefined ones
+            $0.label.map { label in
+                !(ScaffoldCommand.requiredTemplateOptions.map(\.name) + ScaffoldCommand.optionalTemplateOptions.map(\.name))
+                    .contains(label)
+            } ?? true
         }
         return Mirror(ScaffoldCommand(), children: children + requiredTemplateChildren + optionalTemplateChildren)
     }

--- a/Sources/TuistKit/Commands/ScaffoldCommand.swift
+++ b/Sources/TuistKit/Commands/ScaffoldCommand.swift
@@ -103,10 +103,10 @@ extension ScaffoldCommand {
                                                                              path: command.path)
 
         ScaffoldCommand.requiredTemplateOptions = required.map {
-            (name: $0, option: Option<String>(name: .shortAndLong))
+            (name: $0, option: Option<String>())
         }
         ScaffoldCommand.optionalTemplateOptions = optional.map {
-            (name: $0, option: Option<String?>(name: .shortAndLong))
+            (name: $0, option: Option<String?>())
         }
     }
 }
@@ -132,11 +132,27 @@ extension ScaffoldCommand {
                 return optional
             }
         }
+        
+        init?(stringValue: String) {
+            switch stringValue {
+            case "template":
+                self = .template
+            case "path":
+                self = .path
+            default:
+                if ScaffoldCommand.requiredTemplateOptions.map(\.name).contains(stringValue) {
+                    self = .required(stringValue)
+                } else if ScaffoldCommand.optionalTemplateOptions.map(\.name).contains(stringValue) {
+                    self = .optional(stringValue)
+                } else {
+                    return nil
+                }
+            }
+        }
 
         // Not used
         var intValue: Int? { nil }
         init?(intValue _: Int) { nil }
-        init?(stringValue _: String) { nil }
     }
 }
 
@@ -151,7 +167,13 @@ extension ScaffoldCommand: CustomReflectable {
         let children = [
             Mirror.Child(label: "template", value: _template),
             Mirror.Child(label: "path", value: _path),
-        ]
+            ].filter {
+                // Prefer attributes defined in a template if it clashes with predefined ones
+                $0.label.map { label in
+                    !(ScaffoldCommand.requiredTemplateOptions.map(\.name) + ScaffoldCommand.optionalTemplateOptions.map(\.name))
+                        .contains(label)
+                    } ?? true
+        }
         return Mirror(ScaffoldCommand(), children: children + requiredTemplateChildren + optionalTemplateChildren)
     }
 }

--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -29,7 +29,7 @@ public struct TuistCommand: ParsableCommand {
 
     public static func main(_ arguments: [String]? = nil) -> Never {
         let errorHandler = ErrorHandler()
-        let command: ParsableCommand
+        var command: ParsableCommand
         do {
             let processedArguments = Array(processArguments(arguments)?.dropFirst() ?? [])
             if processedArguments.first == ScaffoldCommand.configuration.commandName {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1414

### Short description 📝

In the new Argument Parser version, there are additional checks and since we rely on an internal implementation for loading dynamic arguments, `tuist init` and `tuist scaffold` were failing after the version bump.

### Solution 📦

Bump Argument Parser and resolve error (mainly, add `init?(stringValue)` initializer)

### Implementation 👩‍💻👨‍💻

- [x] Fix failing command
- [x] Add Changelog
