### PR TITLE
feat: Add support for not specifying a platform to build for

### DIFF
--- a/Sources/ProjectDescription/Platform.swift
+++ b/Sources/ProjectDescription/Platform.swift
@@ -7,4 +7,5 @@ public enum Platform: String, Codable, Equatable {
     case macOS = "macos"
     case watchOS = "watchos"
     case tvOS = "tvos"
+    case notSpecified = ""
 }

--- a/Sources/TuistAutomation/Utilities/BuildGraphInspector.swift
+++ b/Sources/TuistAutomation/Utilities/BuildGraphInspector.swift
@@ -28,7 +28,7 @@ public class BuildGraphInspector: BuildGraphInspecting {
     public func buildArguments(target: Target) -> [XcodeBuildArgument] {
         let arguments: [XcodeBuildArgument]
         if target.platform == .macOS {
-            arguments = [.sdk(target.platform.xcodeDeviceSDK)]
+            arguments = [.sdk(target.platform.xcodeDeviceSDK!)]
         } else {
             arguments = [.sdk(target.platform.xcodeSimulatorSDK!)]
         }

--- a/Sources/TuistCore/Graph/GraphLoader.swift
+++ b/Sources/TuistCore/Graph/GraphLoader.swift
@@ -159,7 +159,7 @@ public class GraphLoader: GraphLoading {
         let targetNode = TargetNode(project: project, target: target, dependencies: [])
         graphLoaderCache.add(targetNode: targetNode)
 
-        let dependencies: [GraphNode] = try target.dependencies.map {
+        let dependencies: [GraphNode] = try target.dependencies.compactMap {
             try loadDependency(for: $0,
                                path: path,
                                name: name,
@@ -188,7 +188,7 @@ public class GraphLoader: GraphLoading {
                                     name: String,
                                     platform: Platform,
                                     graphLoaderCache: GraphLoaderCaching,
-                                    graphCircularDetector: GraphCircularDetecting) throws -> GraphNode {
+                                    graphCircularDetector: GraphCircularDetecting) throws -> GraphNode? {
         switch dependency {
         // A target within the same project.
         case let .target(target):

--- a/Sources/TuistCore/Graph/Nodes/SDKNode.swift
+++ b/Sources/TuistCore/Graph/Nodes/SDKNode.swift
@@ -6,7 +6,7 @@ public class SDKNode: GraphNode {
     public let status: SDKStatus
     public let type: Type
 
-    public init(name: String,
+    public init?(name: String,
                 platform: Platform,
                 status: SDKStatus) throws {
         let sdk = AbsolutePath("/\(name)")
@@ -20,7 +20,9 @@ public class SDKNode: GraphNode {
         self.status = status
         self.type = type
 
-        let sdkRootPath = AbsolutePath(platform.xcodeSdkRootPath,
+        guard let xcodeSdkRootPath = platform.xcodeSdkRootPath else { return nil }
+
+        let sdkRootPath = AbsolutePath(xcodeSdkRootPath,
                                        relativeTo: AbsolutePath("/"))
 
         let path: AbsolutePath

--- a/Sources/TuistCore/Models/Platform.swift
+++ b/Sources/TuistCore/Models/Platform.swift
@@ -5,6 +5,7 @@ public enum Platform: String, CaseIterable {
     case macOS = "macos"
     case tvOS = "tvos"
     case watchOS = "watchos"
+    case notSpecified = ""
 
     public var caseValue: String {
         switch self {
@@ -12,12 +13,13 @@ public enum Platform: String, CaseIterable {
         case .macOS: return "macOS"
         case .tvOS: return "tvOS"
         case .watchOS: return "watchOS"
+        case .notSpecified: return ""
         }
     }
 }
 
 extension Platform {
-    public var xcodeSdkRoot: String {
+    public var xcodeSdkRoot: String? {
         switch self {
         case .macOS:
             return "macosx"
@@ -27,6 +29,8 @@ extension Platform {
             return "appletvos"
         case .watchOS:
             return "watchos"
+        case .notSpecified:
+            return nil
         }
     }
 
@@ -55,11 +59,12 @@ extension Platform {
         case .iOS: return "iphonesimulator"
         case .watchOS: return "watchsimulator"
         case .macOS: return nil
+        case .notSpecified: return nil
         }
     }
 
     /// Returns the SDK to build for the platform's device.
-    public var xcodeDeviceSDK: String {
+    public var xcodeDeviceSDK: String? {
         switch self {
         case .tvOS:
             return "appletvos"
@@ -69,10 +74,12 @@ extension Platform {
             return "macosx"
         case .watchOS:
             return "watchos"
+        case .notSpecified:
+            return nil
         }
     }
 
-    public var xcodeSupportedPlatforms: String {
+    public var xcodeSupportedPlatforms: String? {
         switch self {
         case .tvOS:
             return "appletvsimulator appletvos"
@@ -82,11 +89,13 @@ extension Platform {
             return "macosx"
         case .watchOS:
             return "watchsimulator watchos"
+        case .notSpecified:
+            return nil
         }
     }
 
     /// The SDK Root Path within Xcode's developer directory
-    public var xcodeSdkRootPath: String {
+    public var xcodeSdkRootPath: String? {
         switch self {
         case .iOS:
             return "Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk"
@@ -96,6 +105,8 @@ extension Platform {
             return "Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk"
         case .watchOS:
             return "Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk"
+        case .notSpecified:
+            return nil
         }
     }
 }

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -191,8 +191,14 @@ final class ConfigGenerator: ConfigGenerating {
         if let entitlements = target.entitlements {
             settings["CODE_SIGN_ENTITLEMENTS"] = .string("$(SRCROOT)/\(entitlements.relative(to: sourceRootPath).pathString)")
         }
-        settings["SDKROOT"] = .string(target.platform.xcodeSdkRoot)
-        settings["SUPPORTED_PLATFORMS"] = .string(target.platform.xcodeSupportedPlatforms)
+
+        if let xcodeSdkRoot = target.platform.xcodeSdkRoot {
+            settings["SDKROOT"] = .string(xcodeSdkRoot)
+        }
+
+        if let xcodeSupportedPlatforms = target.platform.xcodeSupportedPlatforms {
+            settings["SUPPORTED_PLATFORMS"] = .string(xcodeSupportedPlatforms)
+        }
 
         if settings["SWIFT_VERSION"] == nil {
             settings["SWIFT_VERSION"] = .string(swiftVersion)

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -261,6 +261,7 @@ public class GraphLinter: GraphLinting {
             LintableTarget(platform: .iOS, product: .appExtension),
             //            LintableTarget(platform: .iOS, product: .messagesExtension),
             LintableTarget(platform: .iOS, product: .stickerPackExtension),
+            LintableTarget(platform: .notSpecified, product: .framework),
             LintableTarget(platform: .watchOS, product: .watch2App),
 //            LintableTarget(platform: .watchOS, product: .watchApp),
         ],
@@ -290,6 +291,7 @@ public class GraphLinter: GraphLinting {
             LintableTarget(platform: .iOS, product: .framework),
             LintableTarget(platform: .iOS, product: .staticFramework),
             LintableTarget(platform: .iOS, product: .bundle),
+            LintableTarget(platform: .notSpecified, product: .framework),
         ],
         LintableTarget(platform: .iOS, product: .uiTests): [
             LintableTarget(platform: .iOS, product: .app),

--- a/Sources/TuistGenerator/Utils/SettingsHelper.swift
+++ b/Sources/TuistGenerator/Utils/SettingsHelper.swift
@@ -23,6 +23,7 @@ final class SettingsHelper {
         case .macOS: return .macOS
         case .tvOS: return .tvOS
         case .watchOS: return .watchOS
+        case .notSpecified: return nil
         }
     }
 

--- a/Sources/TuistLoader/Models+ManifestMappers/Platform+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Platform+ManifestMapper.swift
@@ -17,6 +17,8 @@ extension TuistCore.Platform {
             return .tvOS
         case .watchOS:
             return .watchOS
+        case .notSpecified:
+            return .notSpecified
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY

### Short description 📝

This pull request is meant to aid a conversation about potential ways to implement support for "universal frameworks".

Should we decide to move forward with this effort I will need to add tests.

### Solution 📦

This solution leaves build settings related to the platform empty so that XCConfig files can be used to provide the settings.

### Implementation 👩‍💻👨‍💻

> Detail in a checklist the steps that you took to implement the PR.

- [ ] Step 1
- [ ] Step 2
