### PR TITLE
Add support for specifying the build configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Add support for watch architectures [#1417](https://github.com/tuist/tuist/pull/1417) by [@davidbrunow](https://github.com/davidbrunow)
 - Add method to XcodeBuildController to show the build settings of a project [#1422](https://github.com/tuist/tuist/pull/1422) by [@pepibumur](https://github.com/pepibumur)
+- Support for passing the configuration to the `tuist build` command [#1422](https://github.com/tuist/tuist/pull/1442) by [@pepibumur](https://github.com/pepibumur)
 
 ### Fixed
 

--- a/Sources/TuistAutomation/Log/Logger.swift
+++ b/Sources/TuistAutomation/Log/Logger.swift
@@ -1,0 +1,2 @@
+import TuistSupport
+let logger = Logger(label: "io.tuist.automation")

--- a/Sources/TuistAutomationTesting/Utilities/MockBuildGraphInspector.swift
+++ b/Sources/TuistAutomationTesting/Utilities/MockBuildGraphInspector.swift
@@ -30,10 +30,10 @@ public final class MockBuildGraphInspector: BuildGraphInspecting {
         }
     }
 
-    public var buildArgumentsStub: ((Target) -> [XcodeBuildArgument])?
-    public func buildArguments(target: Target) -> [XcodeBuildArgument] {
+    public var buildArgumentsStub: ((Target, String?) -> [XcodeBuildArgument])?
+    public func buildArguments(target: Target, configuration: String?) -> [XcodeBuildArgument] {
         if let buildArgumentsStub = buildArgumentsStub {
-            return buildArgumentsStub(target)
+            return buildArgumentsStub(target, configuration)
         } else {
             return []
         }

--- a/Sources/TuistCore/Automation/XcodeBuildArgument.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildArgument.swift
@@ -6,6 +6,9 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
     /// Use SDK as the name or path of the base SDK when building the project
     case sdk(String)
 
+    /// Use the given configuration for building the scheme.
+    case configuration(String)
+
     /// Use the destination described by DESTINATIONSPECIFIER (a comma-separated set of key=value pairs describing the destination to use)
     case destination(String)
 
@@ -20,6 +23,8 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
         switch self {
         case let .sdk(sdk):
             return ["-sdk", sdk]
+        case let .configuration(configuration):
+            return ["-configuration", configuration]
         case let .destination(destination):
             return ["-destination", "\(destination)"]
         case let .derivedDataPath(path):
@@ -34,6 +39,8 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
         switch self {
         case let .sdk(sdk):
             return "Xcodebuild's SDK argument: \(sdk)"
+        case let .configuration(configuration):
+            return "Xcodebuild's configuration argument: \(configuration)"
         case let .destination(destination):
             return "Xcodebuild's destination argument: \(destination)"
         case let .derivedDataPath(path):

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -31,6 +31,10 @@ struct BuildCommand: ParsableCommand {
     )
     var path: String?
 
+    @Option(name: .customShort("C"),
+            help: "The configuration to be used when building the scheme.")
+    var configuration: String?
+
     func run() throws {
         let absolutePath: AbsolutePath
         if let path = path {
@@ -41,6 +45,7 @@ struct BuildCommand: ParsableCommand {
         try BuildService().run(schemeName: scheme,
                                generate: generate,
                                clean: clean,
+                               configuration: configuration,
                                path: absolutePath)
     }
 }

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -31,7 +31,7 @@ struct BuildCommand: ParsableCommand {
     )
     var path: String?
 
-    @Option(name: .customShort("C"),
+    @Option(name: [.long, .customShort("C")],
             help: "The configuration to be used when building the scheme.")
     var configuration: String?
 

--- a/Sources/TuistKit/Services/BuildService.swift
+++ b/Sources/TuistKit/Services/BuildService.swift
@@ -48,7 +48,7 @@ final class BuildService {
         self.buildGraphInspector = buildGraphInspector
     }
 
-    func run(schemeName: String?, generate: Bool, clean: Bool, path: AbsolutePath) throws {
+    func run(schemeName: String?, generate: Bool, clean: Bool, configuration: String?, path: AbsolutePath) throws {
         let graph: Graph
         if generate || buildGraphInspector.workspacePath(directory: path) == nil {
             graph = try projectGenerator.generateWithGraph(path: path, projectOnly: false).1
@@ -63,11 +63,11 @@ final class BuildService {
             guard let scheme = buildableSchemes.first(where: { $0.name == schemeName }) else {
                 throw BuildServiceError.schemeNotFound(scheme: schemeName, existing: buildableSchemes.map(\.name))
             }
-            try buildScheme(scheme: scheme, graph: graph, path: path, clean: true)
+            try buildScheme(scheme: scheme, graph: graph, path: path, clean: true, configuration: configuration)
         } else {
             var cleaned: Bool = false
             try buildableSchemes.forEach {
-                try buildScheme(scheme: $0, graph: graph, path: path, clean: !cleaned && clean)
+                try buildScheme(scheme: $0, graph: graph, path: path, clean: !cleaned && clean, configuration: configuration)
                 cleaned = true
             }
         }
@@ -77,7 +77,7 @@ final class BuildService {
 
     // MARK: - private
 
-    private func buildScheme(scheme: Scheme, graph: Graph, path: AbsolutePath, clean: Bool) throws {
+    private func buildScheme(scheme: Scheme, graph: Graph, path: AbsolutePath, clean: Bool, configuration: String?) throws {
         logger.log(level: .notice, "Building scheme \(scheme.name)", metadata: .section)
         guard let buildableTarget = buildGraphInspector.buildableTarget(scheme: scheme, graph: graph) else {
             throw BuildServiceError.schemeWithoutBuildableTargets(scheme: scheme.name)
@@ -86,7 +86,7 @@ final class BuildService {
         _ = try xcodebuildController.build(.workspace(workspacePath),
                                            scheme: scheme.name,
                                            clean: clean,
-                                           arguments: buildGraphInspector.buildArguments(target: buildableTarget))
+                                           arguments: buildGraphInspector.buildArguments(target: buildableTarget, configuration: configuration))
             .printFormattedOutput()
             .toBlocking()
             .last()

--- a/Tests/TuistAutomationTests/Utilities/BuildGraphInspectorTests.swift
+++ b/Tests/TuistAutomationTests/Utilities/BuildGraphInspectorTests.swift
@@ -26,7 +26,7 @@ final class BuildGraphInspectorTests: TuistUnitTestCase {
         let target = Target.test(platform: .macOS)
 
         // When
-        let got = subject.buildArguments(target: target)
+        let got = subject.buildArguments(target: target, configuration: nil)
 
         // Then
         XCTAssertEqual(got, [
@@ -39,7 +39,7 @@ final class BuildGraphInspectorTests: TuistUnitTestCase {
         let target = Target.test(platform: .iOS)
 
         // When
-        let got = subject.buildArguments(target: target)
+        let got = subject.buildArguments(target: target, configuration: nil)
 
         // Then
         XCTAssertEqual(got, [
@@ -52,7 +52,7 @@ final class BuildGraphInspectorTests: TuistUnitTestCase {
         let target = Target.test(platform: .watchOS)
 
         // When
-        let got = subject.buildArguments(target: target)
+        let got = subject.buildArguments(target: target, configuration: nil)
 
         // Then
         XCTAssertEqual(got, [
@@ -65,12 +65,36 @@ final class BuildGraphInspectorTests: TuistUnitTestCase {
         let target = Target.test(platform: .tvOS)
 
         // When
-        let got = subject.buildArguments(target: target)
+        let got = subject.buildArguments(target: target, configuration: nil)
 
         // Then
         XCTAssertEqual(got, [
             .sdk(Platform.tvOS.xcodeSimulatorSDK!),
         ])
+    }
+
+    func test_buildArguments_when_theGivenConfigurationExists() throws {
+        // Given
+        let settings = Settings.test(base: [:], debug: .test(), release: .test())
+        let target = Target.test(settings: settings)
+
+        // When
+        let got = subject.buildArguments(target: target, configuration: "Release")
+
+        // Then
+        XCTAssertTrue(got.contains(.configuration("Release")))
+    }
+
+    func test_buildArguments_when_theGivenConfigurationDoesntExist() throws {
+        // Given
+        let settings = Settings.test(base: [:], configurations: [:])
+        let target = Target.test(settings: settings)
+
+        // When
+        let got = subject.buildArguments(target: target, configuration: "Release")
+
+        // Then
+        XCTAssertFalse(got.contains(.configuration("Release")))
     }
 
     func test_buildableTarget() throws {

--- a/Tests/TuistKitTests/Services/BuildServiceTests.swift
+++ b/Tests/TuistKitTests/Services/BuildServiceTests.swift
@@ -70,7 +70,7 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_path, path)
             return workspacePath
         }
-        buildgraphInspector.buildArgumentsStub = { _target in
+        buildgraphInspector.buildArgumentsStub = { _target, _ in
             XCTAssertEqual(_target, target)
             return buildArguments
         }
@@ -83,7 +83,7 @@ final class BuildServiceTests: TuistUnitTestCase {
         }
 
         // Then
-        try subject.run(schemeName: scheme.name, generate: true, clean: true, path: path)
+        try subject.run(schemeName: scheme.name, generate: true, clean: true, configuration: nil, path: path)
     }
 
     func test_run_when_the_project_is_already_generated() throws {
@@ -110,7 +110,7 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_path, path)
             return workspacePath
         }
-        buildgraphInspector.buildArgumentsStub = { _target in
+        buildgraphInspector.buildArgumentsStub = { _target, _ in
             XCTAssertEqual(_target, target)
             return buildArguments
         }
@@ -123,7 +123,7 @@ final class BuildServiceTests: TuistUnitTestCase {
         }
 
         // Then
-        try subject.run(schemeName: scheme.name, generate: false, clean: true, path: path)
+        try subject.run(schemeName: scheme.name, generate: false, clean: true, configuration: nil, path: path)
     }
 
     func test_run_only_cleans_the_first_time() throws {
@@ -153,7 +153,7 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_path, path)
             return workspacePath
         }
-        buildgraphInspector.buildArgumentsStub = { _ in
+        buildgraphInspector.buildArgumentsStub = { _, _ in
             buildArguments
         }
         xcodebuildController.buildStub = { _target, _scheme, _clean, _arguments in
@@ -174,7 +174,7 @@ final class BuildServiceTests: TuistUnitTestCase {
         }
 
         // Then
-        try subject.run(schemeName: nil, generate: false, clean: true, path: path)
+        try subject.run(schemeName: nil, generate: false, clean: true, configuration: nil, path: path)
     }
 
     func test_run_only_runs_the_given_scheme_when_passed() throws {
@@ -204,7 +204,7 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_path, path)
             return workspacePath
         }
-        buildgraphInspector.buildArgumentsStub = { _ in
+        buildgraphInspector.buildArgumentsStub = { _, _ in
             buildArguments
         }
         xcodebuildController.buildStub = { _target, _scheme, _clean, _arguments in
@@ -221,6 +221,6 @@ final class BuildServiceTests: TuistUnitTestCase {
         }
 
         // Then
-        try subject.run(schemeName: "A", generate: false, clean: true, path: path)
+        try subject.run(schemeName: "A", generate: false, clean: true, configuration: nil, path: path)
     }
 }

--- a/features/build.feature
+++ b/features/build.feature
@@ -6,3 +6,4 @@ Feature: Build projects using Tuist build
     When I initialize a ios application named MyApp
     Then tuist builds the project
     Then tuist builds the scheme MyApp from the project
+    Then tuist builds the scheme MyApp and configuration Debug from the project

--- a/features/step_definitions/build.rb
+++ b/features/step_definitions/build.rb
@@ -1,11 +1,11 @@
 Then(/^tuist builds the project$/) do
   system("swift", "run", "tuist", "build", "--path", @dir)
 end
-Then(/^tuist builds the scheme (.+) from the project$/) do |scheme|
+Then(/^tuist builds the scheme ([a-zA-Z]+) from the project$/) do |scheme|
   system("swift", "run", "tuist", "build", scheme, "--path", @dir)
 end
 
-Then(/^tuist builds the scheme (.+) and configuration (.+) from the project$/) do |scheme, configuration|
+Then(/^tuist builds the scheme ([a-zA-Z]+) and configuration ([a-zA-Z]+) from the project$/) do |scheme, configuration|
   system("swift", "run", "tuist", "build", scheme, "--path", @dir, "--configuration", configuration)
 end
 

--- a/features/step_definitions/build.rb
+++ b/features/step_definitions/build.rb
@@ -5,6 +5,10 @@ Then(/^tuist builds the scheme (.+) from the project$/) do |scheme|
   system("swift", "run", "tuist", "build", scheme, "--path", @dir)
 end
 
+Then(/^tuist builds the scheme (.+) and configuration (.+) from the project$/) do |scheme, configuration|
+  system("swift", "run", "tuist", "build", scheme, "--path", @dir, "--configuration", configuration)
+end
+
 Then(/^tuist builds the project at (.+)$/) do |path|
   system("swift", "run", "tuist", "build", "--path", File.join(@dir, path))
 end


### PR DESCRIPTION
### Short description 📝

As @fortmarek suggested, I'm adding support for specifying the build configuration to be used when building a scheme:

```
tuist build --configuration Debug
```

When not passed, it defaults to the scheme's configuration.