### PR TITLE
Throw an error when Xcode is not selected

### DIFF
--- a/Tests/TuistSupportTests/Xcode/XcodeTests.swift
+++ b/Tests/TuistSupportTests/Xcode/XcodeTests.swift
@@ -4,6 +4,16 @@ import XCTest
 @testable import TuistSupport
 @testable import TuistSupportTesting
 
+final class XcodeErrorTests: TuistUnitTestCase {
+    func test_description() {
+        XCTAssertEqual(XcodeError.infoPlistNotFound(.root).description, "Couldn't find Xcode's Info.plist at /. Make sure your Xcode installation is selected by running: sudo xcode-select -s /Applications/Xcode.app")
+    }
+
+    func test_type() {
+        XCTAssertEqual(XcodeError.infoPlistNotFound(.root).type, .abort)
+    }
+}
+
 final class XcodeTests: TuistUnitTestCase {
     var plistEncoder: PropertyListEncoder!
 
@@ -33,5 +43,15 @@ final class XcodeTests: TuistUnitTestCase {
         // Then
         XCTAssertEqual(xcode.infoPlist.version, "3.2.1")
         XCTAssertEqual(xcode.path, temporaryPath)
+    }
+
+    func test_read_when_infoPlist_doesnt_exist() throws {
+        // Given
+        let temporaryPath = try self.temporaryPath()
+        let contentsPath = temporaryPath.appending(component: "Contents")
+        let infoPlistPath = contentsPath.appending(component: "Info.plist")
+
+        // When
+        XCTAssertThrowsSpecific(try Xcode.read(path: temporaryPath), XcodeError.infoPlistNotFound(infoPlistPath))
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1444

### Short description 📝
If Xcode is not selected, Tuist errors when it tries to read the Xcode version. I'm improving the user experience by throwing an error telling the user that they might need to select Xcode because it's not selected in their environment.