### PR TITLE
Use the given clean argument when building a single target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- `tuist build` cleaning even if the `--clean` argument is not passed [#1458](https://github.com/tuist/tuist/pull/1458) by [@pepibumur](https://github.com/pepibumur).
+
 ## 1.11.0 - Volare
 
 ### Added

--- a/Sources/TuistKit/Services/BuildService.swift
+++ b/Sources/TuistKit/Services/BuildService.swift
@@ -63,7 +63,7 @@ final class BuildService {
             guard let scheme = buildableSchemes.first(where: { $0.name == schemeName }) else {
                 throw BuildServiceError.schemeNotFound(scheme: schemeName, existing: buildableSchemes.map(\.name))
             }
-            try buildScheme(scheme: scheme, graph: graph, path: path, clean: true, configuration: configuration)
+            try buildScheme(scheme: scheme, graph: graph, path: path, clean: clean, configuration: configuration)
         } else {
             var cleaned: Bool = false
             try buildableSchemes.forEach {


### PR DESCRIPTION
### Short description 📝
I noticed that `tuist build MyTarget` was passing `clean` to `xcodebuild` when it shouldn't. After looking at the code, it turns out that we were not passing the argument.