### PR TITLE
Runpaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - `tuist build` cleaning even if the `--clean` argument is not passed [#1458](https://github.com/tuist/tuist/pull/1458) by [@pepibumur](https://github.com/pepibumur).
 
+### Changed
+
+- Use `LD_RUNPATH_SEARCH_PATHS` instead of embedding dynamic frameworks for unit test targets [#1463](https://github.com/tuist/tuist/pull/1463) by [@fortmarek](https://github.com/fortmarek)
+
 ## 1.11.0 - Volare
 
 ### Added

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -293,7 +293,7 @@ public class Graph: Encodable {
         var references: Set<AbsolutePath> = Set([])
 
         /// Precompiled frameworks
-        let precompiledFrameworks = findAll(targetNode: targetNode, test: isDynamicAndLinkable, skip: canEmbedProducts)
+        let precompiledFrameworks = findAll(targetNode: targetNode, test: { ($0 as PrecompiledNode).isDynamicAndLinkable() }, skip: canEmbedProducts)
             .lazy
             .map(\.path)
             .map(\.parentDirectory)
@@ -316,7 +316,7 @@ public class Graph: Encodable {
         var references: Set<GraphDependencyReference> = Set([])
 
         /// Precompiled frameworks
-        let precompiledFrameworks = findAll(targetNode: targetNode, test: isDynamicAndLinkable, skip: canEmbedProducts)
+        let precompiledFrameworks = findAll(targetNode: targetNode, test: { ($0 as PrecompiledNode).isDynamicAndLinkable() }, skip: canEmbedProducts)
             .lazy
             .map(GraphDependencyReference.init)
 
@@ -520,12 +520,6 @@ public class Graph: Encodable {
     }
 
     // MARK: - Fileprivate
-
-    fileprivate func isDynamicAndLinkable(node: PrecompiledNode) -> Bool {
-        if let framework = node as? FrameworkNode { return framework.linking == .dynamic }
-        if let xcframework = node as? XCFrameworkNode { return xcframework.linking == .dynamic }
-        return false
-    }
 
     fileprivate func productDependencyReference(for targetNode: TargetNode) -> GraphDependencyReference {
         .product(target: targetNode.target.name, productName: targetNode.target.productNameWithExtension)

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -297,7 +297,6 @@ public class Graph: Encodable {
             .lazy
             .map(\.path)
             .map(\.parentDirectory)
-            .map { AbsolutePath($0.pathString.lowercased()) }
         
         references.formUnion(precompiledFrameworks)
 

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -293,7 +293,8 @@ public class Graph: Encodable {
         var references: Set<AbsolutePath> = Set([])
 
         /// Precompiled frameworks
-        let precompiledFrameworks = findAll(targetNode: targetNode, test: { ($0 as PrecompiledNode).isDynamicAndLinkable() }, skip: canEmbedProducts)
+        let precompiledFrameworkNodes: Set<PrecompiledNode> = findAll(targetNode: targetNode, test: { $0.isDynamicAndLinkable() }, skip: canEmbedProducts)
+        let precompiledFrameworks = precompiledFrameworkNodes
             .lazy
             .map(\.path)
             .map(\.parentDirectory)
@@ -316,7 +317,9 @@ public class Graph: Encodable {
         var references: Set<GraphDependencyReference> = Set([])
 
         /// Precompiled frameworks
-        let precompiledFrameworks = findAll(targetNode: targetNode, test: { ($0 as PrecompiledNode).isDynamicAndLinkable() }, skip: canEmbedProducts)
+        let precompiledFrameworkNodes: Set<PrecompiledNode> = findAll(targetNode: targetNode, test: { $0.isDynamicAndLinkable() }, skip: canEmbedProducts)
+
+        let precompiledFrameworks = precompiledFrameworkNodes
             .lazy
             .map(GraphDependencyReference.init)
 

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -274,7 +274,7 @@ public class Graph: Encodable {
         return targetNode.libraryDependencies
             .compactMap { $0.swiftModuleMap?.removingLastComponent() }
     }
-    
+
     /// Returns all runpath search paths of the given target
     /// Currently applied only to test targets with no host application
     /// - Parameters:
@@ -297,7 +297,7 @@ public class Graph: Encodable {
             .lazy
             .map(\.path)
             .map(\.parentDirectory)
-        
+
         references.formUnion(precompiledFrameworks)
 
         return references.sorted()
@@ -520,7 +520,7 @@ public class Graph: Encodable {
     }
 
     // MARK: - Fileprivate
-    
+
     fileprivate func isDynamicAndLinkable(node: PrecompiledNode) -> Bool {
         if let framework = node as? FrameworkNode { return framework.linking == .dynamic }
         if let xcframework = node as? XCFrameworkNode { return xcframework.linking == .dynamic }

--- a/Sources/TuistCore/Graph/Nodes/PrecompiledNode.swift
+++ b/Sources/TuistCore/Graph/Nodes/PrecompiledNode.swift
@@ -15,6 +15,13 @@ public class PrecompiledNode: GraphNode {
         fatalError("This method should be overriden by the subclasses")
     }
 
+    /// - Returns: True if node is dynamic and linkable
+    public func isDynamicAndLinkable() -> Bool {
+        if let framework = self as? FrameworkNode { return framework.linking == .dynamic }
+        if let xcframework = self as? XCFrameworkNode { return xcframework.linking == .dynamic }
+        return false
+    }
+
     enum CodingKeys: String, CodingKey {
         case path
         case name

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -155,10 +155,10 @@ final class LinkGenerator: LinkGenerating {
         try setupSwiftIncludePaths(swiftIncludePaths,
                                    pbxTarget: pbxTarget,
                                    sourceRootPath: sourceRootPath)
-        
+
         try setupRunPathSearchPaths(runPathSearchPaths,
-                                     pbxTarget: pbxTarget,
-                                     sourceRootPath: sourceRootPath)
+                                    pbxTarget: pbxTarget,
+                                    sourceRootPath: sourceRootPath)
     }
 
     func generatePackages(target: Target,
@@ -281,7 +281,7 @@ final class LinkGenerator: LinkGenerating {
                   pbxTarget: pbxTarget,
                   sourceRootPath: sourceRootPath)
     }
-    
+
     func setupRunPathSearchPaths(_ paths: [AbsolutePath],
                                  pbxTarget: PBXTarget,
                                  sourceRootPath: AbsolutePath) throws {

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -138,6 +138,7 @@ final class LinkGenerator: LinkGenerating {
         let headersSearchPaths = graph.librariesPublicHeadersFolders(path: path, name: target.name)
         let librarySearchPaths = graph.librariesSearchPaths(path: path, name: target.name)
         let swiftIncludePaths = graph.librariesSwiftIncludePaths(path: path, name: target.name)
+        let runPathSearchPaths = graph.runPathSearchPaths(path: path, name: target.name)
 
         try setupFrameworkSearchPath(dependencies: linkableModules,
                                      pbxTarget: pbxTarget,
@@ -154,6 +155,10 @@ final class LinkGenerator: LinkGenerating {
         try setupSwiftIncludePaths(swiftIncludePaths,
                                    pbxTarget: pbxTarget,
                                    sourceRootPath: sourceRootPath)
+        
+        try setupRunPathSearchPaths(runPathSearchPaths,
+                                     pbxTarget: pbxTarget,
+                                     sourceRootPath: sourceRootPath)
     }
 
     func generatePackages(target: Target,
@@ -272,6 +277,15 @@ final class LinkGenerator: LinkGenerating {
                                 pbxTarget: PBXTarget,
                                 sourceRootPath: AbsolutePath) throws {
         try setup(setting: "SWIFT_INCLUDE_PATHS",
+                  paths: paths.map(LinkGeneratorPath.absolutePath),
+                  pbxTarget: pbxTarget,
+                  sourceRootPath: sourceRootPath)
+    }
+    
+    func setupRunPathSearchPaths(_ paths: [AbsolutePath],
+                                 pbxTarget: PBXTarget,
+                                 sourceRootPath: AbsolutePath) throws {
+        try setup(setting: "LD_RUNPATH_SEARCH_PATHS",
                   paths: paths.map(LinkGeneratorPath.absolutePath),
                   pbxTarget: pbxTarget,
                   sourceRootPath: sourceRootPath)

--- a/Sources/TuistKit/Commands/EditCommand.swift
+++ b/Sources/TuistKit/Commands/EditCommand.swift
@@ -18,7 +18,7 @@ struct EditCommand: ParsableCommand {
     var path: String?
 
     @Flag(
-        name: .shortAndLong,
+        name: [.long, .customShort("P")],
         help: "It creates the project in the current directory or the one indicated by -p and doesn't block the process"
     )
     var permanent: Bool

--- a/Tests/TuistCoreTests/Graph/GraphTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTests.swift
@@ -724,7 +724,7 @@ final class GraphTests: TuistUnitTestCase {
         // Then
         XCTAssertTrue(result.isEmpty)
     }
-    
+
     func test_embeddableDependencies_when_nonHostedTestTarget_dynamic_dependencies() throws {
         // Given
         let precompiledNode = mockDynamicFrameworkNode(at: AbsolutePath("/test/test.framework"))
@@ -804,7 +804,7 @@ final class GraphTests: TuistUnitTestCase {
         // Then
         XCTAssertTrue(result.isEmpty)
     }
-    
+
     func test_runPathSearchPaths() throws {
         // Given
         let precompiledNode = mockDynamicFrameworkNode(at: AbsolutePath("/test/test.framework"))
@@ -834,7 +834,7 @@ final class GraphTests: TuistUnitTestCase {
             [AbsolutePath("/path/to")]
         )
     }
-    
+
     func test_runPathSearchPaths_when_unit_tests_with_hosted_target() throws {
         // Given
         let precompiledNode = mockDynamicFrameworkNode(at: AbsolutePath("/test/test.framework"))

--- a/Tests/TuistCoreTests/Graph/Nodes/PrecompiledNodeTests.swift
+++ b/Tests/TuistCoreTests/Graph/Nodes/PrecompiledNodeTests.swift
@@ -23,4 +23,37 @@ final class PrecompiledNodeTests: XCTestCase {
         // Then
         XCTAssertEqual(got, "Alamofire")
     }
+
+    func test_is_dynamic_and_linkable_when_xcframework() {
+        // Given
+        let subject = XCFrameworkNode.test()
+
+        // When
+        let got = subject.isDynamicAndLinkable()
+
+        // Then
+        XCTAssertTrue(got)
+    }
+
+    func test_is_dynamic_and_linkable_when_dynamic_framework() {
+        // Given
+        let subject = FrameworkNode.test(linking: .dynamic)
+
+        // When
+        let got = subject.isDynamicAndLinkable()
+
+        // Then
+        XCTAssertTrue(got)
+    }
+
+    func test_is_dynamic_and_linkable_when_static_framework() {
+        // Given
+        let subject = FrameworkNode.test(linking: .static)
+
+        // When
+        let got = subject.isDynamicAndLinkable()
+
+        // Then
+        XCTAssertFalse(got)
+    }
 }

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -191,7 +191,7 @@ final class LinkGeneratorErrorTests: XCTestCase {
             ["ATTRIBUTES": ["CodeSignOnCopy", "RemoveHeadersOnCopy"]],
         ])
     }
-    
+
     func test_setupRunPathSearchPath() throws {
         // Given
         let paths = [

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -191,6 +191,33 @@ final class LinkGeneratorErrorTests: XCTestCase {
             ["ATTRIBUTES": ["CodeSignOnCopy", "RemoveHeadersOnCopy"]],
         ])
     }
+    
+    func test_setupRunPathSearchPath() throws {
+        // Given
+        let paths = [
+            AbsolutePath("/path/Dependencies/Frameworks/"),
+            AbsolutePath("/path/Dependencies/XCFrameworks/"),
+        ].shuffled()
+        let sourceRootPath = AbsolutePath("/path")
+        let xcodeprojElements = createXcodeprojElements()
+        xcodeprojElements.config.buildSettings["LD_RUNPATH_SEARCH_PATHS"] = "my/custom/path"
+
+        // When
+        try subject.setupRunPathSearchPaths(
+            paths,
+            pbxTarget: xcodeprojElements.pbxTarget,
+            sourceRootPath: sourceRootPath
+        )
+
+        // Then
+        let config = xcodeprojElements.config
+        XCTAssertEqual(config.buildSettings["LD_RUNPATH_SEARCH_PATHS"] as? [String], [
+            "$(inherited)",
+            "$(SRCROOT)/Dependencies/Frameworks",
+            "$(SRCROOT)/Dependencies/XCFrameworks",
+            "my/custom/path",
+        ])
+    }
 
     func test_setupFrameworkSearchPath() throws {
         // Given

--- a/fixtures/ios_app_with_carthage_frameworks/Derived/InfoPlists/App.plist
+++ b/fixtures/ios_app_with_carthage_frameworks/Derived/InfoPlists/App.plist
@@ -20,10 +20,6 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>UILaunchStoryboardName</key>
-	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1443

### Short description 📝

To increase performance and disk usage efficiency we should try to minimize frameworks that are embed in embed frameworks build phase

### Solution 📦

Do not add embed frameworks in aforementioned build phases when a framework is dynamic and the target is unit test without a host target

### Implementation 👩‍💻👨‍💻

- [x] Do not embed frameworks + add find runpath search paths
- [x] Add tests
- [x] Add changelog 

### Notes 📝 

@thedavidharris has pointed out that they have a framework that has to be embedded no matter what. As a workaround they can add a host target for the unit test target which is causing problems. Since it's a closed-source framework, there's not really a way to investigate. If other users report the same problem, we can add `embed` option into our `ProjectDescription` where user could eg specify if they want `.automatic, .embed, .skip` to force `.embed`. But I believe that this is something that should be an implementation detail, so I feel it'd be better if we can solve it internally.