### PR TITLE
Added helper method to retrieve Environment variables

### DIFF
--- a/Sources/ProjectDescription/Environment.swift
+++ b/Sources/ProjectDescription/Environment.swift
@@ -6,14 +6,14 @@ public struct Environment {
         case boolean(Bool)
         case string(String)
 
-        public func getString(default defaultString: String = "") -> String {
+        public func getString(default defaultString: String) -> String {
             if case let .string(value) = self { return value }
             return defaultString
         }
 
-        public func getBoolean() -> Bool {
+        public func getBoolean(default defaultBoolean: Bool) -> Bool {
             if case let .boolean(value) = self { return value }
-            return false
+            return defaultBoolean
         }
     }
 

--- a/Sources/ProjectDescription/Environment.swift
+++ b/Sources/ProjectDescription/Environment.swift
@@ -5,6 +5,16 @@ public struct Environment {
     public enum Value {
         case boolean(Bool)
         case string(String)
+
+        public func getString(default defaultString: String = "") -> String? {
+            if case let .string(value) = self { return value }
+            return defaultString
+        }
+
+        public func getBoolean() -> Bool {
+            if case let .boolean(value) = self { return value }
+            return false
+        }
     }
 
     public static subscript(dynamicMember member: String) -> Value? {

--- a/Sources/ProjectDescription/Environment.swift
+++ b/Sources/ProjectDescription/Environment.swift
@@ -6,7 +6,7 @@ public struct Environment {
         case boolean(Bool)
         case string(String)
 
-        public func getString(default defaultString: String = "") -> String? {
+        public func getString(default defaultString: String = "") -> String {
             if case let .string(value) = self { return value }
             return defaultString
         }

--- a/Sources/ProjectDescription/Environment.swift
+++ b/Sources/ProjectDescription/Environment.swift
@@ -6,11 +6,19 @@ public struct Environment {
         case boolean(Bool)
         case string(String)
 
+        /// Retrieve the Environment value as a string or return the specified default string value
+        /// - Parameters:
+        ///   - default: default String value to be returned
+        /// - Returns: String
         public func getString(default defaultString: String) -> String {
             if case let .string(value) = self { return value }
             return defaultString
         }
 
+        /// Retrieve the Environment value as a boolean or return the specified default boolean value
+        /// - Parameters:
+        ///   - default: default Boolean value to be returned
+        /// - Returns: Bool
         public func getBoolean(default defaultBoolean: Bool) -> Bool {
             if case let .boolean(value) = self { return value }
             return defaultBoolean

--- a/website/markdown/docs/usage/projectswift.mdx
+++ b/website/markdown/docs/usage/projectswift.mdx
@@ -152,6 +152,16 @@ Accessing variables returns an instance of type `Environment.Value?` which can t
   ]}
 />
 
+You can also retrieve the string or boolean Environment variable using either of the helper methods defined below, these methods require a default value to be passed to ensure the user gets consistent results each time. This avoids the need to define the function appName() defined above.
+
+```swift
+Environment.appName?.getString(default: "TuistApp")
+```
+
+```swift
+Environment.isCI?.getBoolean(default: false)
+```
+
 ## Package
 
 You can add Swift Packages very similarly to how you add dependencies in a `Package.swift`:


### PR DESCRIPTION
### Short description 📝

This pull request simplifies the logic required to retrieve the primitive type from an Environment variable. You are able to retrieve the Environment variable as either a String or Boolean directly

_Previous method to retrieve the Environment variable_

> ```
> func frameworkName() -> String {
>     if case let .string(environmentFrameworkName) = Environment.frameworkName {
>         return environmentFrameworkName
>     } else {
>         return "Framework"
>     }
> }
> ```

### Solution 📦

This solution ensures that the Environment variable must exist and enables the ability to add a defaultValue when the Environment.Value is not of type .string

**Tuist Generate Command**
`TUIST_BUNDLE_ID=com.test.com tuist generate`

**Inside Project.swift**
```
return Target(name: name,
           platform: .iOS,
           product: .app,
           bundleId: Environment.bundleId?.getString(default: "com.tuist.io"),
```



### Implementation 👩‍💻👨‍💻

- [ ] Tested with tuist generate using multiple Environment variable options
