### PR TITLE
Adding fix for tuist bundle issue 1466 caused by trailing whitespace

### DIFF
--- a/Sources/TuistEnvKit/Services/BundleService.swift
+++ b/Sources/TuistEnvKit/Services/BundleService.swift
@@ -46,14 +46,15 @@ final class BundleService {
         }
 
         let version = try String(contentsOf: versionFilePath.url)
-        logger.notice("Bundling the version \(version) in the directory \(binFolderPath.pathString)", metadata: .section)
+        let cleanVersion = version.filter { !$0.isWhitespace }
+        logger.notice("Bundling the version \(cleanVersion) in the directory \(binFolderPath.pathString)", metadata: .section)
 
-        let versionPath = versionsController.path(version: version)
+        let versionPath = versionsController.path(version: cleanVersion)
 
         // Installing
         if !FileHandler.shared.exists(versionPath) {
-            logger.notice("Version \(version) not available locally. Installing...")
-            try installer.install(version: version, force: false)
+            logger.notice("Version \(cleanVersion) not available locally. Installing...")
+            try installer.install(version: cleanVersion, force: false)
         }
 
         // Copying

--- a/Sources/TuistEnvKit/Services/BundleService.swift
+++ b/Sources/TuistEnvKit/Services/BundleService.swift
@@ -45,16 +45,15 @@ final class BundleService {
             throw BundleServiceError.missingVersionFile(FileHandler.shared.currentPath)
         }
 
-        let version = try String(contentsOf: versionFilePath.url)
-        let cleanVersion = version.filter { !$0.isWhitespace }
-        logger.notice("Bundling the version \(cleanVersion) in the directory \(binFolderPath.pathString)", metadata: .section)
+        let version = try String(contentsOf: versionFilePath.url).trimmingCharacters(in: .whitespacesAndNewlines)
+        logger.notice("Bundling the version \(version) in the directory \(binFolderPath.pathString)", metadata: .section)
 
-        let versionPath = versionsController.path(version: cleanVersion)
+        let versionPath = versionsController.path(version: version)
 
         // Installing
         if !FileHandler.shared.exists(versionPath) {
-            logger.notice("Version \(cleanVersion) not available locally. Installing...")
-            try installer.install(version: cleanVersion, force: false)
+            logger.notice("Version \(version) not available locally. Installing...")
+            try installer.install(version: version, force: false)
         }
 
         // Copying

--- a/Tests/TuistEnvKitTests/Services/BundleServiceTests.swift
+++ b/Tests/TuistEnvKitTests/Services/BundleServiceTests.swift
@@ -78,6 +78,19 @@ final class BundleServiceTests: TuistUnitTestCase {
         XCTAssertEqual(installer.installCallCount, 0)
     }
 
+    func test_run_doesnt_install_the_app_if_it_already_exists_with_whitespace_in_version_file() throws {
+        let temporaryPath = try self.temporaryPath()
+
+        let tuistVersionPath = temporaryPath.appending(component: Constants.versionFileName)
+        try "3.2.1\n\t".write(to: tuistVersionPath.url, atomically: true, encoding: .utf8)
+        let versionPath = versionsController.path(version: "3.2.1")
+        try FileHandler.shared.createFolder(versionPath)
+
+        try subject.run()
+
+        XCTAssertEqual(installer.installCallCount, 0)
+    }
+
     func test_run_prints_the_right_messages() throws {
         let temporaryPath = try self.temporaryPath()
         let tuistVersionPath = temporaryPath.appending(component: Constants.versionFileName)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1466

### Short description 📝

This fixes an issue with the `tuist bundle` failing when ran inside Terminal

### Solution 📦

After debugging this issue I was able to diagnose it was happening due to a trailing \n being appended when using `let version = try String(contentsOf: versionFilePath.url)` inside BundleService.swift this was returning "1.11.0\n"

Which was then used to lookup the version inside `.tuist/Versions` E.g. `/Users/mmiscampbell/.tuist/Versions/1.11.0\n`

### Implementation 👩‍💻👨‍💻

The fix I have implemented is after verifying we could retrieve a version from the .tuist-version file we clean the String using filter and only allowing characters that are not whitespace.

- [ ] Added Unit test to validate the install does not run when the version file contains whitespace characters
