### PR TITLE
Add RxBlocking to TuistGenerator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - `tuist secret` command to generate cryptographically secure secrets [#1471](https://github.com/tuist/tuist/pull/1471) by [@pepibumur](https://github.com/pepibumur).
 
+### Changed
+
+- Added `RxBlocking` to list of dependencies for `TuistGenerator` [#1514](https://github.com/tuist/tuist/pull/1514) by [@fortmarek](https://github.com/fortmarek).
+
 ## 1.11.1 - Volare far
 
 ### Fixed

--- a/Package.swift
+++ b/Package.swift
@@ -112,7 +112,7 @@ let package = Package(
         ),
         .target(
             name: "TuistGenerator",
-            dependencies: ["XcodeProj", "SwiftToolsSupport-auto", "TuistCore", "TuistSupport"]
+            dependencies: ["XcodeProj", "SwiftToolsSupport-auto", "TuistCore", "TuistSupport", "RxBlocking"]
         ),
         .target(
             name: "TuistGeneratorTesting",


### PR DESCRIPTION
### Short description 📝

I am not sure how this could have worked so far, but `RxBlocking` was missing in the list of dependencies for `TuistGenerator`. With it I could no longer import `tuist` in a different project (tapestry - I am finally starting with figuring how to properly automate our release process!)

### Solution 📦

When I added `RxBlocking` to `dependencies` and pointed to this branch, everything started to work

### Implementation 👩‍💻👨‍💻

> Detail in a checklist the steps that you took to implement the PR.

- [x] Change `dependencies`
- [x] Edit changelog
