### PR TITLE
Prettify the redirect screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Search the `Setup.swift` file upwards if it doesn't exist in the current directory [#1513](https://github.com/tuist/tuist/pull/1513) by [@pepibumur](https://github.com/pepibumur).
 - Added `RxBlocking` to list of dependencies for `TuistGenerator` [#1514](https://github.com/tuist/tuist/pull/1514) by [@fortmarek](https://github.com/fortmarek).
 - Uncommented iMessage extension product type [#1515](https://github.com/tuist/tuist/pull/1515) by [@olejnjak](https://github.com/olejnjak).
+- Prettify the redirect page [#1521](https://github.com/tuist/tuist/pull/1521) by [@pepibumur](https://github.com/pepibumur).
 
 ### Added
 

--- a/Sources/TuistCloud/Session/CloudSessionController.swift
+++ b/Sources/TuistCloud/Session/CloudSessionController.swift
@@ -85,7 +85,7 @@ public final class CloudSessionController: CloudSessionControlling {
         logger.notice("Opening \(authURL.absoluteString) to start the authentication flow")
         try opener.open(url: authURL)
 
-        let logoURL = serverURL.appendingPathComponent("logo.svg")
+        let logoURL = serverURL.appendingPathComponent("redirect-logo.svg")
         let redirectMessage = "Switch back to your terminal to continue the authentication."
         let result = httpRedirectListener.listen(port: CloudSessionController.port,
                                                  path: "auth",

--- a/Sources/TuistCloud/Session/CloudSessionController.swift
+++ b/Sources/TuistCloud/Session/CloudSessionController.swift
@@ -85,10 +85,12 @@ public final class CloudSessionController: CloudSessionControlling {
         logger.notice("Opening \(authURL.absoluteString) to start the authentication flow")
         try opener.open(url: authURL)
 
+        let logoURL = serverURL.appendingPathComponent("logo.svg")
         let redirectMessage = "Switch back to your terminal to continue the authentication."
         let result = httpRedirectListener.listen(port: CloudSessionController.port,
                                                  path: "auth",
-                                                 redirectMessage: redirectMessage)
+                                                 redirectMessage: redirectMessage,
+                                                 logoURL: logoURL)
         switch result {
         case let .failure(error): throw error
         case let .success(parameters):

--- a/Sources/TuistSupport/Utils/HTTPRedirectListener.swift
+++ b/Sources/TuistSupport/Utils/HTTPRedirectListener.swift
@@ -9,8 +9,9 @@ public protocol HTTPRedirectListening: Any {
     ///   - port: Port for the HTTP server.
     ///   - path: Path we are expecting the browser to redirect the user to.
     ///   - redirectMessage: Text returned to the browser when it redirects the user to the given path.
+    ///   - logoURL: The logo to show in the redirect page.
     /// - Returns: Either the query parameterrs of the redirect URL, or an error if the HTTP server fails to start.
-    func listen(port: UInt16, path: String, redirectMessage: String) -> Swift.Result<[String: String]?, HTTPRedirectListenerError>
+    func listen(port: UInt16, path: String, redirectMessage: String, logoURL: URL) -> Swift.Result<[String: String]?, HTTPRedirectListenerError>
 }
 
 public enum HTTPRedirectListenerError: FatalError {
@@ -40,7 +41,7 @@ public final class HTTPRedirectListener: HTTPRedirectListening {
 
     // MARK: - HTTPRedirectListening
 
-    public func listen(port: UInt16, path: String, redirectMessage: String) -> Swift.Result<[String: String]?, HTTPRedirectListenerError> {
+    public func listen(port: UInt16, path: String, redirectMessage: String, logoURL: URL) -> Swift.Result<[String: String]?, HTTPRedirectListenerError> {
         precondition(runningSemaphore == nil, "Trying to start a redirect server for localhost:\(port)\(path) when there's already one running.")
         let httpServer = HttpServer()
         var result: Swift.Result<[String: String]?, HTTPRedirectListenerError> = .success(nil)
@@ -49,7 +50,7 @@ public final class HTTPRedirectListener: HTTPRedirectListening {
         httpServer[path] = { request in
             result = .success(request.queryParams.reduce(into: [String: String]()) { $0[$1.0] = $1.1 })
             DispatchQueue.global().async { runningSemaphore.signal() }
-            return HttpResponse.ok(.text(redirectMessage))
+            return HttpResponse.ok(.html(self.html(logoURL: logoURL, redirectMessage: redirectMessage)))
         }
 
         // If the user sends an interruption signal by pressing CTRL+C, we stop the server.
@@ -65,5 +66,56 @@ public final class HTTPRedirectListener: HTTPRedirectListening {
 
         runningSemaphore = nil
         return result
+    }
+
+    private func html(logoURL: URL, redirectMessage: String) -> String {
+        """
+        <!DOCTYPE html>
+
+        <html lang="en">
+          <head>
+            <meta charset="utf-8" />
+            <link
+              rel="icon"
+              href="\(logoURL.absoluteString)"
+            />
+            <title>Redirecting</title>
+            <meta name="description" content="Redirecting to Tuist" />
+            <link
+              href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css"
+              rel="stylesheet"
+            />
+          </head>
+
+          <body
+            class="flex h-screen w-screen flex-col justify-center items-center bg-gray-200"
+          >
+            <img
+              class="w-40 h-40 mb-10"
+              src="\(logoURL.absoluteString)"
+            />
+            <div class="bg-white shadow sm:rounded-lg">
+              <div class="px-4 py-5 sm:p-6">
+                <h3 class="text-lg leading-6 font-medium text-gray-900">
+                  Open your terminal 👩‍💻
+                </h3>
+                <div class="mt-2 max-w-xl text-sm leading-5 text-gray-500">
+                  <p>
+                    \(redirectMessage)
+                  </p>
+                </div>
+                <!-- <div class="mt-3 text-sm leading-5">
+                  <a
+                    href="https://tuist.io/"
+                    class="font-medium text-blue-600 hover:text-blue-500 transition ease-in-out duration-150"
+                  >
+                    Link &rarr;
+                  </a> -->
+                </div>
+              </div>
+            </div>
+          </body>
+        </html>
+        """
     }
 }

--- a/Sources/TuistSupportTesting/Utils/MockHTTPRedirectListener.swift
+++ b/Sources/TuistSupportTesting/Utils/MockHTTPRedirectListener.swift
@@ -4,11 +4,11 @@ import Foundation
 public final class MockHTTPRedirectListener: HTTPRedirectListening {
     public init() {}
 
-    public var listenStub: ((UInt16, String, String) -> Swift.Result<[String: String]?, HTTPRedirectListenerError>)?
+    public var listenStub: ((UInt16, String, String, URL) -> Swift.Result<[String: String]?, HTTPRedirectListenerError>)?
 
-    public func listen(port: UInt16, path: String, redirectMessage: String) -> Swift.Result<[String: String]?, HTTPRedirectListenerError> {
+    public func listen(port: UInt16, path: String, redirectMessage: String, logoURL: URL) -> Swift.Result<[String: String]?, HTTPRedirectListenerError> {
         if let listenStub = listenStub {
-            return listenStub(port, path, redirectMessage)
+            return listenStub(port, path, redirectMessage, logoURL)
         } else {
             return Result.failure(.httpServer(TestError("non-stubbed called to listen")))
         }

--- a/Tests/TuistCloudTests/Session/CloudSessionControllerTests.swift
+++ b/Tests/TuistCloudTests/Session/CloudSessionControllerTests.swift
@@ -107,7 +107,7 @@ final class CloudSessionControllerTests: TuistUnitTestCase {
 
     func test_authenticate_when_parametersAreMissing() throws {
         // Given
-        httpRedirectListener.listenStub = { (port, path, message) -> (Swift.Result<[String: String]?, HTTPRedirectListenerError>) in
+        httpRedirectListener.listenStub = { (port, path, message, _) -> (Swift.Result<[String: String]?, HTTPRedirectListenerError>) in
             XCTAssertEqual(port, CloudSessionController.port)
             XCTAssertEqual(path, "auth")
             XCTAssertEqual(message, "Switch back to your terminal to continue the authentication.")
@@ -123,7 +123,7 @@ final class CloudSessionControllerTests: TuistUnitTestCase {
 
     func test_authenticate_when_parametersIncludeError() throws {
         // Given
-        httpRedirectListener.listenStub = { (port, path, message) -> (Swift.Result<[String: String]?, HTTPRedirectListenerError>) in
+        httpRedirectListener.listenStub = { (port, path, message, _) -> (Swift.Result<[String: String]?, HTTPRedirectListenerError>) in
             XCTAssertEqual(port, CloudSessionController.port)
             XCTAssertEqual(path, "auth")
             XCTAssertEqual(message, "Switch back to your terminal to continue the authentication.")
@@ -139,7 +139,7 @@ final class CloudSessionControllerTests: TuistUnitTestCase {
 
     func test_authenticate_when_tokenAndAccountParametersAreIncluded() throws {
         // Given
-        httpRedirectListener.listenStub = { (port, path, message) -> (Swift.Result<[String: String]?, HTTPRedirectListenerError>) in
+        httpRedirectListener.listenStub = { (port, path, message, _) -> (Swift.Result<[String: String]?, HTTPRedirectListenerError>) in
             XCTAssertEqual(port, CloudSessionController.port)
             XCTAssertEqual(path, "auth")
             XCTAssertEqual(message, "Switch back to your terminal to continue the authentication.")
@@ -161,7 +161,7 @@ final class CloudSessionControllerTests: TuistUnitTestCase {
 
     func test_authenticate_when_parametersContainInvalidKeys() throws {
         // Given
-        httpRedirectListener.listenStub = { (port, path, message) -> (Swift.Result<[String: String]?, HTTPRedirectListenerError>) in
+        httpRedirectListener.listenStub = { (port, path, message, _) -> (Swift.Result<[String: String]?, HTTPRedirectListenerError>) in
             XCTAssertEqual(port, CloudSessionController.port)
             XCTAssertEqual(path, "auth")
             XCTAssertEqual(message, "Switch back to your terminal to continue the authentication.")


### PR DESCRIPTION
### Short description 📝
I love paying attention to the little details and I think our cloud redirect page looked a bit ugly with the raw plain text. In this PR I'm prettifying it a bit adding a bit of CSS.

The cloud provider specifies the logo by providing the logo at the path `/redirect-logo.svg`.

![image](https://user-images.githubusercontent.com/663605/86484223-0cee4380-bd56-11ea-9ddf-3228696fc11d.png)
