### PR TITLE
Add `tuist cloud print-hashes` command

### DIFF
--- a/Sources/TuistCacheTesting/ContentHashing/Mocks/MockGraphContentHasher.swift
+++ b/Sources/TuistCacheTesting/ContentHashing/Mocks/MockGraphContentHasher.swift
@@ -4,7 +4,7 @@ import TuistCore
 
 public final class MockGraphContentHasher: GraphContentHashing {
     public init() {}
-    
+
     public var invokedContentHashes = false
     public var invokedContentHashesCount = 0
     public var invokedContentHashesParameters: (graph: TuistCore.Graph, Void)?

--- a/Sources/TuistCacheTesting/ContentHashing/Mocks/MockGraphContentHasher.swift
+++ b/Sources/TuistCacheTesting/ContentHashing/Mocks/MockGraphContentHasher.swift
@@ -3,11 +3,23 @@ import TuistCore
 @testable import TuistCache
 
 public final class MockGraphContentHasher: GraphContentHashing {
-    public var contentHashesStub: [TargetNode: String] = [:]
-
     public init() {}
+    
+    public var invokedContentHashes = false
+    public var invokedContentHashesCount = 0
+    public var invokedContentHashesParameters: (graph: TuistCore.Graph, Void)?
+    public var invokedContentHashesParametersList = [(graph: TuistCore.Graph, Void)]()
+    public var stubbedContentHashesError: Error?
+    public var contentHashesStub: [TargetNode: String]! = [:]
 
-    public func contentHashes(for _: TuistCore.Graph) throws -> [TargetNode: String] {
-        contentHashesStub
+    public func contentHashes(for graph: TuistCore.Graph) throws -> [TargetNode: String] {
+        invokedContentHashes = true
+        invokedContentHashesCount += 1
+        invokedContentHashesParameters = (graph, ())
+        invokedContentHashesParametersList.append((graph, ()))
+        if let error = stubbedContentHashesError {
+            throw error
+        }
+        return contentHashesStub
     }
 }

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -21,7 +21,8 @@ enum GraphError: FatalError {
 }
 
 // swiftlint:disable:next type_body_length
-public class Graph: Encodable {
+public class Graph: Encodable, Equatable {
+    
     // MARK: - Attributes
 
     /// Name of the graph.
@@ -576,5 +577,19 @@ public class Graph: Encodable {
         ]
 
         return validProducts.contains(targetNode.target.product)
+    }
+    
+    // MARK: - Equatable
+    
+    public static func == (lhs: Graph, rhs: Graph) -> Bool {
+        return lhs.name == rhs.name &&
+        lhs.entryPath == rhs.entryPath &&
+        lhs.entryNodes == rhs.entryNodes &&
+        lhs.projects == rhs.projects &&
+        lhs.cocoapods == rhs.cocoapods &&
+        lhs.packages == rhs.packages &&
+        lhs.precompiled == rhs.precompiled &&
+        lhs.frameworks == rhs.frameworks &&
+        lhs.targets == rhs.targets
     }
 }

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -22,7 +22,6 @@ enum GraphError: FatalError {
 
 // swiftlint:disable:next type_body_length
 public class Graph: Encodable, Equatable {
-    
     // MARK: - Attributes
 
     /// Name of the graph.
@@ -578,18 +577,18 @@ public class Graph: Encodable, Equatable {
 
         return validProducts.contains(targetNode.target.product)
     }
-    
+
     // MARK: - Equatable
-    
+
     public static func == (lhs: Graph, rhs: Graph) -> Bool {
-        return lhs.name == rhs.name &&
-        lhs.entryPath == rhs.entryPath &&
-        lhs.entryNodes == rhs.entryNodes &&
-        lhs.projects == rhs.projects &&
-        lhs.cocoapods == rhs.cocoapods &&
-        lhs.packages == rhs.packages &&
-        lhs.precompiled == rhs.precompiled &&
-        lhs.frameworks == rhs.frameworks &&
-        lhs.targets == rhs.targets
+        lhs.name == rhs.name &&
+            lhs.entryPath == rhs.entryPath &&
+            lhs.entryNodes == rhs.entryNodes &&
+            lhs.projects == rhs.projects &&
+            lhs.cocoapods == rhs.cocoapods &&
+            lhs.packages == rhs.packages &&
+            lhs.precompiled == rhs.precompiled &&
+            lhs.frameworks == rhs.frameworks &&
+            lhs.targets == rhs.targets
     }
 }

--- a/Sources/TuistKit/Commands/Cloud/CloudPrintHashesCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudPrintHashesCommand.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import TSCBasic
+import TuistSupport
 
 struct CloudPrintHashesCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
@@ -8,7 +9,13 @@ struct CloudPrintHashesCommand: ParsableCommand {
                              abstract: "Print the hashes of the frameworks used by the given project.")
     }
 
+    @Option(
+        name: .shortAndLong,
+        help: "The path where the project will be generated."
+    )
+    var path: String?
+
     func run() throws {
-        try CloudPrintHashesService().print()
+        try CloudPrintHashesService().run(path: path.map { AbsolutePath($0) } ?? FileHandler.shared.currentPath)
     }
 }

--- a/Sources/TuistKit/Commands/Cloud/CloudPrintHashesCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudPrintHashesCommand.swift
@@ -1,0 +1,14 @@
+import ArgumentParser
+import Foundation
+import TSCBasic
+
+struct CloudPrintHashesCommand: ParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(commandName: "print-hashes",
+                             abstract: "Print the hashes of the frameworks used by the given project.")
+    }
+
+    func run() throws {
+        try CloudPrintHashesService().print()
+    }
+}

--- a/Sources/TuistKit/Commands/CloudCommand.swift
+++ b/Sources/TuistKit/Commands/CloudCommand.swift
@@ -12,7 +12,7 @@ struct CloudCommand: ParsableCommand {
                                  CloudStartTargetBuildCommand.self,
                                  CloudFinishTargetBuildCommand.self,
                                  CloudWarmCacheCommand.self,
-                                 CloudPrintHashesCommand.self
+                                 CloudPrintHashesCommand.self,
                              ])
     }
 }

--- a/Sources/TuistKit/Commands/CloudCommand.swift
+++ b/Sources/TuistKit/Commands/CloudCommand.swift
@@ -12,6 +12,7 @@ struct CloudCommand: ParsableCommand {
                                  CloudStartTargetBuildCommand.self,
                                  CloudFinishTargetBuildCommand.self,
                                  CloudWarmCacheCommand.self,
+                                 CloudPrintHashesCommand.self
                              ])
     }
 }

--- a/Sources/TuistKit/Services/Cloud/CloudPrintHashesService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudPrintHashesService.swift
@@ -9,11 +9,11 @@ final class CloudPrintHashesService {
     /// Project generator
     let projectGenerator: ProjectGenerating
 
-    let graphContentHasher: GraphContentHasher
+    let graphContentHasher: GraphContentHashing
     private let clock: Clock
 
     init(projectGenerator: ProjectGenerating = ProjectGenerator(),
-         graphContentHasher: GraphContentHasher = GraphContentHasher(),
+         graphContentHasher: GraphContentHashing = GraphContentHasher(),
          clock: Clock = WallClock()) {
         self.projectGenerator = projectGenerator
         self.graphContentHasher = graphContentHasher

--- a/Sources/TuistKit/Services/Cloud/CloudPrintHashesService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudPrintHashesService.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+final class CloudPrintHashesService {
+    func print() {}
+}

--- a/Sources/TuistKit/Services/Cloud/CloudPrintHashesService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudPrintHashesService.swift
@@ -1,5 +1,37 @@
 import Foundation
+import TSCBasic
+import TuistAutomation
+import TuistCache
+import TuistCore
+import TuistSupport
 
 final class CloudPrintHashesService {
-    func print() {}
+    /// Project generator
+    let projectGenerator: ProjectGenerating
+
+    let graphContentHasher: GraphContentHasher
+    private let clock: Clock
+
+    init(projectGenerator: ProjectGenerating = ProjectGenerator(),
+         graphContentHasher: GraphContentHasher = GraphContentHasher(),
+         clock: Clock = WallClock()) {
+        self.projectGenerator = projectGenerator
+        self.graphContentHasher = graphContentHasher
+        self.clock = clock
+    }
+
+    func run(path: AbsolutePath) throws -> TimeInterval {
+        let timer = clock.startTimer()
+
+        let graph = try projectGenerator.load(path: path)
+        let hashes = try graphContentHasher.contentHashes(for: graph)
+        let duration = timer.stop()
+        let time = String(format: "%.3f", duration)
+
+        for (target, hash) in hashes {
+            logger.info("\(target.name) - \(hash)")
+        }
+        logger.notice("Total time taken: \(time)s")
+        return duration
+    }
 }

--- a/Tests/TuistKitTests/Generator/Mocks/MockProjectGenerator.swift
+++ b/Tests/TuistKitTests/Generator/Mocks/MockProjectGenerator.swift
@@ -48,8 +48,10 @@ final class MockProjectGenerator: ProjectGenerating {
         return stubbedGenerateProjectWorkspaceResult
     }
 
+    var invokedLoadParameterPath: AbsolutePath?
     var loadStub: ((AbsolutePath) throws -> Graph)?
     func load(path: AbsolutePath) throws -> Graph {
+        invokedLoadParameterPath = path
         if let loadStub = loadStub {
             return try loadStub(path)
         } else {

--- a/Tests/TuistKitTests/Services/Cloud/CloudPrintHashesServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudPrintHashesServiceTests.swift
@@ -1,9 +1,9 @@
 import Foundation
 import TSCBasic
-import XCTest
-import TuistSupport
-import TuistCore
 import TuistCacheTesting
+import TuistCore
+import TuistSupport
+import XCTest
 
 @testable import TuistKit
 @testable import TuistSupportTesting
@@ -14,12 +14,12 @@ final class CloudPrintHashesServiceTests: TuistUnitTestCase {
     var graphContentHasher: MockGraphContentHasher!
     var clock: Clock!
     var path: AbsolutePath!
-    
+
     override func setUp() {
         super.setUp()
         path = AbsolutePath("/Test")
         projectGenerator = MockProjectGenerator()
-        
+
         graphContentHasher = MockGraphContentHasher()
         clock = StubClock()
 
@@ -27,7 +27,7 @@ final class CloudPrintHashesServiceTests: TuistUnitTestCase {
                                           graphContentHasher: graphContentHasher,
                                           clock: clock)
     }
-    
+
     override func tearDown() {
         projectGenerator = nil
         graphContentHasher = nil
@@ -35,20 +35,20 @@ final class CloudPrintHashesServiceTests: TuistUnitTestCase {
         subject = nil
         super.tearDown()
     }
-    
+
     func test_run_loads_the_graph() throws {
         // Given
         subject = CloudPrintHashesService(projectGenerator: projectGenerator,
                                           graphContentHasher: graphContentHasher,
                                           clock: clock)
-        
+
         // When
         _ = try subject.run(path: path)
-        
+
         // Then
         XCTAssertEqual(projectGenerator.invokedLoadParameterPath, path)
     }
-    
+
     func test_run_content_hasher_gets_correct_graph() throws {
         // Given
         subject = CloudPrintHashesService(projectGenerator: projectGenerator,
@@ -56,14 +56,14 @@ final class CloudPrintHashesServiceTests: TuistUnitTestCase {
                                           clock: clock)
         let graph: Graph = Graph.test()
         projectGenerator.loadStub = { _ in graph }
-        
+
         // When
         _ = try subject.run(path: path)
-        
+
         // Then
         XCTAssertEqual(graphContentHasher.invokedContentHashesParameters?.graph, graph)
     }
-    
+
     func test_run_outputs_correct_hashes() throws {
         // Given
         let target1 = TargetNode.test(target: .test(name: "ShakiOne"))
@@ -76,7 +76,7 @@ final class CloudPrintHashesServiceTests: TuistUnitTestCase {
 
         // When
         _ = try subject.run(path: path)
-        
+
         // Then
         XCTAssertPrinterOutputContains("ShakiOne - hash1")
         XCTAssertPrinterOutputContains("ShakiTwo - hash2")

--- a/Tests/TuistKitTests/Services/Cloud/CloudPrintHashesServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudPrintHashesServiceTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import TSCBasic
+import XCTest
+import TuistSupport
+import TuistCore
+import TuistCacheTesting
+
+@testable import TuistKit
+@testable import TuistSupportTesting
+
+final class CloudPrintHashesServiceTests: TuistUnitTestCase {
+    var subject: CloudPrintHashesService!
+    var projectGenerator: MockProjectGenerator!
+    var graphContentHasher: MockGraphContentHasher!
+    var clock: Clock!
+    var path: AbsolutePath!
+    
+    override func setUp() {
+        super.setUp()
+        path = AbsolutePath("/Test")
+        projectGenerator = MockProjectGenerator()
+        
+        graphContentHasher = MockGraphContentHasher()
+        clock = StubClock()
+
+        subject = CloudPrintHashesService(projectGenerator: projectGenerator,
+                                          graphContentHasher: graphContentHasher,
+                                          clock: clock)
+    }
+    
+    override func tearDown() {
+        projectGenerator = nil
+        graphContentHasher = nil
+        clock = nil
+        subject = nil
+        super.tearDown()
+    }
+    
+    func test_run_loads_the_graph() throws {
+        // Given
+        subject = CloudPrintHashesService(projectGenerator: projectGenerator,
+                                          graphContentHasher: graphContentHasher,
+                                          clock: clock)
+        
+        // When
+        _ = try subject.run(path: path)
+        
+        // Then
+        XCTAssertEqual(projectGenerator.invokedLoadParameterPath, path)
+    }
+    
+    func test_run_content_hasher_gets_correct_graph() throws {
+        // Given
+        subject = CloudPrintHashesService(projectGenerator: projectGenerator,
+                                          graphContentHasher: graphContentHasher,
+                                          clock: clock)
+        let graph: Graph = Graph.test()
+        projectGenerator.loadStub = { _ in graph }
+        
+        // When
+        _ = try subject.run(path: path)
+        
+        // Then
+        XCTAssertEqual(graphContentHasher.invokedContentHashesParameters?.graph, graph)
+    }
+    
+    func test_run_outputs_correct_hashes() throws {
+        // Given
+        let target1 = TargetNode.test(target: .test(name: "ShakiOne"))
+        let target2 = TargetNode.test(target: .test(name: "ShakiTwo"))
+        graphContentHasher.contentHashesStub = [target1: "hash1", target2: "hash2"]
+
+        subject = CloudPrintHashesService(projectGenerator: projectGenerator,
+                                          graphContentHasher: graphContentHasher,
+                                          clock: clock)
+
+        // When
+        _ = try subject.run(path: path)
+        
+        // Then
+        XCTAssertPrinterOutputContains("ShakiOne - hash1")
+        XCTAssertPrinterOutputContains("ShakiTwo - hash2")
+    }
+}

--- a/website/markdown/docs/cloud/caching.mdx
+++ b/website/markdown/docs/cloud/caching.mdx
@@ -32,3 +32,15 @@ All we need to do is run the following command:
 ```
 tuist focus
 ```
+
+## Debugging
+
+### Print target hashes
+
+Targets are uniquely identified in the cache. The identifier (hash) is obtained by hashing the attributes of the target, its project,
+the environment (e.g. Tuist version) and the hashes of its dependencies.
+To facilitate debugging, Tuist exposes a command that prints the hash of every target of the dependency tree:
+
+```
+tuist cloud print-hashes
+```


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY

### Short description 📝

> `tuist cloud print-hashes` loads the graph to the project at given path and prints every target name and its associated hash