### PR TITLE
Feature/rome support

### DIFF
--- a/Sources/ProjectDescription/Up/Up.swift
+++ b/Sources/ProjectDescription/Up/Up.swift
@@ -51,6 +51,17 @@ public class Up: Codable, Equatable {
         UpMint(linkPackagesGlobally: linkPackagesGlobally)
     }
 
+    /// Returns an up that updates Carthage dependencies in the project directory using Rome.
+    ///
+    /// - Parameters
+    ///     - platforms: The platforms Rome dependencies should be updated for. If the argument is not passed, the frameworks will be updated for all the platforms.
+    ///     - cachePrefix: The cachePrefix that Rome should use when retrieving the cached dependencies
+    /// - Returns: Up to pull dependencies from Carthage via Rome.
+    public static func rome(platforms: [Platform]? = nil, cachePrefix: String? = nil) -> Up {
+        let platforms = platforms ?? [.iOS, .macOS, .tvOS, .watchOS]
+        return UpRome(platforms: platforms, cachePrefix: cachePrefix)
+    }
+
     public static func == (lhs: Up, rhs: Up) -> Bool {
         lhs.equals(rhs)
     }

--- a/Sources/ProjectDescription/Up/UpRome.swift
+++ b/Sources/ProjectDescription/Up/UpRome.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Up that updates Rome dependencies that need to be updated
+class UpRome: Up {
+    /// The platforms Rome dependencies should be updated for.
+    let platforms: [Platform]
+
+    /// The prefix Rome should use when retrieving depdencies.
+    let cachePrefix: String?
+
+    /// Initializes the Rome up.
+    ///
+    /// - Parameter platforms:   The platforms Rome dependencies should be updated for.
+    /// - Parameter cachePrefix: The cachePrefix Rome should use to retrieve dependencies.
+    init(platforms: [Platform], cachePrefix: String? = nil) {
+        self.platforms = platforms
+        self.cachePrefix = cachePrefix
+        super.init()
+    }
+
+    public enum CodingKeys: String, CodingKey {
+        case type
+        case platforms
+        case cachePrefix
+    }
+
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        platforms = try container.decode([Platform].self, forKey: .platforms)
+        cachePrefix = try container.decode(String.self, forKey: .cachePrefix)
+        try super.init(from: decoder)
+    }
+
+    override func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode("rome", forKey: .type)
+        try container.encode(platforms, forKey: .platforms)
+        try container.encode(cachePrefix, forKey: .cachePrefix)
+    }
+
+    override func equals(_ other: Up) -> Bool {
+        guard let otherUpRome = other as? UpRome else { return false }
+        return platforms == otherUpRome.platforms && cachePrefix == otherUpRome.cachePrefix
+    }
+}

--- a/Sources/TuistLoader/Up/Rome.swift
+++ b/Sources/TuistLoader/Up/Rome.swift
@@ -8,11 +8,18 @@ protocol Romeaging {
     /// Retrieves the dependencies in the given directory.
     ///
     /// - Parameters:
-    ///   - path: Directory where the Carthage dependencies are defined.
     ///   - platforms: Platforms the dependencies will be updated for.
     ///   - cachePrefix: Cache Prefix to use when downloading dependencies
     /// - Throws: An error if the dependencies download fails.
     func download(platforms: [Platform], cachePrefix: String?) throws
+
+    /// Retrieves the list of dependencies that are missing
+    ///
+    /// - Parameters:
+    ///   - platforms: Platforms the dependencies will be updated for.
+    ///   - cachePrefix: Cache Prefix to use when downloading dependencies
+    /// - Throws: An error if the dependencies download fails.
+    func missing(platforms: [Platform], cachePrefix: String?) throws -> String?
 }
 
 final class Rome: Romeaging {
@@ -40,5 +47,31 @@ final class Rome: Romeaging {
         }
 
         try System.shared.run(command)
+    }
+
+    /// Retrieves the list of dependencies that are missing
+    ///
+    /// - Parameters:
+    ///   - platforms: Platforms the dependencies will be updated for.
+    ///   - cachePrefix: Cache Prefix to use when downloading dependencies
+    /// - Throws: An error if the dependencies download fails.
+    func missing(platforms: [Platform], cachePrefix: String?) throws -> String?  {
+        let romePath = try System.shared.which("rome")
+
+        var command: [String] = [romePath]
+        command.append("list")
+        command.append("--missing")
+
+        if let cachePrefix = cachePrefix {
+            command.append("--cache-prefix")
+            command.append(cachePrefix)
+        }
+
+        if !platforms.isEmpty {
+            command.append("--platform")
+            command.append(platforms.map { $0.caseValue }.joined(separator: ","))
+        }
+
+        return try System.shared.capture(command)
     }
 }

--- a/Sources/TuistLoader/Up/Rome.swift
+++ b/Sources/TuistLoader/Up/Rome.swift
@@ -12,7 +12,7 @@ protocol Romeaging {
     ///   - platforms: Platforms the dependencies will be updated for.
     ///   - cachePrefix: Cache Prefix to use when downloading dependencies
     /// - Throws: An error if the dependencies download fails.
-    func download(path: AbsolutePath, platforms: [Platform], cachePrefix: String?) throws
+    func download(platforms: [Platform], cachePrefix: String?) throws
 }
 
 final class Rome: Romeaging {
@@ -23,7 +23,7 @@ final class Rome: Romeaging {
     ///   - platforms: Platforms the dependencies will be updated for.
     ///   - cachePrefix: Cache Prefix to use when downloading dependencies
     /// - Throws: An error if the dependencies update fails.
-    func download(path: AbsolutePath, platforms: [Platform], cachePrefix: String?) throws {
+    func download(platforms: [Platform], cachePrefix: String?) throws {
         let romePath = try System.shared.which("rome")
 
         var command: [String] = [romePath]
@@ -42,4 +42,3 @@ final class Rome: Romeaging {
         try System.shared.run(command)
     }
 }
-

--- a/Sources/TuistLoader/Up/Rome.swift
+++ b/Sources/TuistLoader/Up/Rome.swift
@@ -1,0 +1,45 @@
+import Foundation
+import TSCBasic
+import TuistCore
+import TuistSupport
+
+/// Protocol that defines an interface to interact with a local Rome setup.
+protocol Romeaging {
+    /// Retrieves the dependencies in the given directory.
+    ///
+    /// - Parameters:
+    ///   - path: Directory where the Carthage dependencies are defined.
+    ///   - platforms: Platforms the dependencies will be updated for.
+    ///   - cachePrefix: Cache Prefix to use when downloading dependencies
+    /// - Throws: An error if the dependencies download fails.
+    func download(path: AbsolutePath, platforms: [Platform], cachePrefix: String?) throws
+}
+
+final class Rome: Romeaging {
+    /// Retrieves the dependencies in the given directory.
+    ///
+    /// - Parameters:
+    ///   - path: Directory where the Carthage dependencies are defined.
+    ///   - platforms: Platforms the dependencies will be updated for.
+    ///   - cachePrefix: Cache Prefix to use when downloading dependencies
+    /// - Throws: An error if the dependencies update fails.
+    func download(path: AbsolutePath, platforms: [Platform], cachePrefix: String?) throws {
+        let romePath = try System.shared.which("rome")
+
+        var command: [String] = [romePath]
+        command.append("download")
+
+        if let cachePrefix = cachePrefix {
+            command.append("--cache-prefix")
+            command.append(cachePrefix)
+        }
+
+        if !platforms.isEmpty {
+            command.append("--platform")
+            command.append(platforms.map { $0.caseValue }.joined(separator: ","))
+        }
+
+        try System.shared.run(command)
+    }
+}
+

--- a/Sources/TuistLoader/Up/Rome.swift
+++ b/Sources/TuistLoader/Up/Rome.swift
@@ -55,7 +55,7 @@ final class Rome: Romeaging {
     ///   - platforms: Platforms the dependencies will be updated for.
     ///   - cachePrefix: Cache Prefix to use when downloading dependencies
     /// - Throws: An error if the dependencies download fails.
-    func missing(platforms: [Platform], cachePrefix: String?) throws -> String?  {
+    func missing(platforms: [Platform], cachePrefix: String?) throws -> String? {
         let romePath = try System.shared.which("rome")
 
         var command: [String] = [romePath]

--- a/Sources/TuistLoader/Up/Up.swift
+++ b/Sources/TuistLoader/Up/Up.swift
@@ -76,6 +76,8 @@ class Up: Upping {
             return try UpCarthage(dictionary: dictionary, projectPath: projectPath)
         } else if type == "mint" {
             return try UpMint(dictionary: dictionary, projectPath: projectPath)
+        } else if type == "rome" {
+            return try UpRome(dictionary: dictionary, projectPath: projectPath)
         }
         return nil
     }

--- a/Sources/TuistLoader/Up/UpRome.swift
+++ b/Sources/TuistLoader/Up/UpRome.swift
@@ -1,0 +1,87 @@
+import Foundation
+import TSCBasic
+import TuistCore
+import TuistSupport
+
+/// Up that updates outdated Rome dependencies.
+class UpRome: Up, GraphInitiatable {
+    /// The platforms Rome dependencies should be updated for.
+    let platforms: [Platform]
+
+    /// The cache prefix to use when downloading dependencies
+    let cachePrefix: String?
+
+    /// Up homebrew for installing Rome.
+    let upHomebrew: Upping
+
+    /// Rome instace to interact with the project Romefile setup.
+    let rome: Romeaging
+
+    /// Initializes the Carthage command.
+    ///
+    /// - Parameters:
+    ///   - platforms:      The platforms Carthage dependencies should be updated for.
+    ///   - cachePrefix:    The cachePrefix used when downloading Rome dependencies.
+    ///   - upHomebrew:     Up homebrew for installing Carthage.
+    ///   - rome:           Rome instace to interact with the projects Rome setup.
+    init(platforms: [Platform],
+         cachePrefix: String?,
+         upHomebrew: Upping = UpHomebrewTap(
+                                repositories: ["tmspzz/tap"]),
+         rome: Romeaging = Rome()) {
+        self.platforms = platforms
+        self.cachePrefix = cachePrefix
+        self.upHomebrew = upHomebrew
+        self.rome = rome
+        super.init(name: "Rome download")
+    }
+
+    /// Default constructor of entities that are part of the manifest.
+    ///
+    /// - Parameters:
+    ///   - dictionary: Dictionary with the object representation.
+    ///   - projectPath: Absolute path to the folder that contains the manifest. This is useful to obtain absolute paths from the relative paths provided in the manifest by the user.
+    /// - Throws: A decoding error if an expected property is missing or has an invalid value.
+    required convenience init(dictionary: JSON, projectPath _: AbsolutePath) throws {
+        var platforms: [Platform] = []
+        var cachePrefix: String? = nil
+        if let platformStrings: [String] = try? dictionary.get("platforms") {
+            platforms = platformStrings.compactMap {
+                Platform(rawValue: $0)
+            }
+        }
+
+        if let cachePrefixString: String = dictionary.get("cachePrefix") {
+            cachePrefix = cachePrefixString
+        }
+        self.init(platforms: platforms, cachePrefix: cachePrefix)
+    }
+
+    /// Returns true when the command doesn't need to be run.
+    ///
+    /// - Parameters
+    ///   - projectPath: Path to the directory that contains the project manifest.
+    /// - Returns: True if the command doesn't need to be run.
+    /// - Throws: An error if the check fails.
+    override func isMet(projectPath: AbsolutePath) throws -> Bool {
+        if try !upHomebrew.isMet(projectPath: projectPath) { return false }
+        return true
+    }
+
+    /// When the command is not met, this method runs it.
+    ///
+    /// - Parameters:
+    ///   - projectPath: Path to the directory that contains the project manifest.
+    /// - Throws: An error if any error is thrown while running it.
+    override func meet(projectPath: AbsolutePath) throws {
+        /// Installing Rome
+        if try !upHomebrew.isMet(projectPath: projectPath) {
+            try upHomebrew.meet(projectPath: projectPath)
+        }
+
+        /// Downloading Rome dependencies.
+        try rome.download(path: projectPath, platforms: platforms, cachePrefix: cachePrefix)
+    }
+
+    func whatever() {}
+}

--- a/Sources/TuistLoader/Up/UpRome.swift
+++ b/Sources/TuistLoader/Up/UpRome.swift
@@ -64,7 +64,8 @@ class UpRome: Up, GraphInitiatable {
     /// - Throws: An error if the check fails.
     override func isMet(projectPath: AbsolutePath) throws -> Bool {
         if try !upHomebrew.isMet(projectPath: projectPath) { return false }
-        return true
+        guard let missing = try rome.missing(platforms: platforms, cachePrefix: cachePrefix) else { return false }
+        return missing.isEmpty
     }
 
     /// When the command is not met, this method runs it.
@@ -81,6 +82,4 @@ class UpRome: Up, GraphInitiatable {
         /// Downloading Rome dependencies.
         try rome.download(platforms: platforms, cachePrefix: cachePrefix)
     }
-
-    func whatever() {}
 }

--- a/Sources/TuistLoader/Up/UpRome.swift
+++ b/Sources/TuistLoader/Up/UpRome.swift
@@ -26,8 +26,7 @@ class UpRome: Up, GraphInitiatable {
     ///   - rome:           Rome instace to interact with the projects Rome setup.
     init(platforms: [Platform],
          cachePrefix: String?,
-         upHomebrew: Upping = UpHomebrewTap(
-                                repositories: ["tmspzz/tap"]),
+         upHomebrew: Upping = UpHomebrewTap(repositories: ["tmspzz/tap"]),
          rome: Romeaging = Rome()) {
         self.platforms = platforms
         self.cachePrefix = cachePrefix
@@ -44,7 +43,7 @@ class UpRome: Up, GraphInitiatable {
     /// - Throws: A decoding error if an expected property is missing or has an invalid value.
     required convenience init(dictionary: JSON, projectPath _: AbsolutePath) throws {
         var platforms: [Platform] = []
-        var cachePrefix: String? = nil
+        var cachePrefix: String?
         if let platformStrings: [String] = try? dictionary.get("platforms") {
             platforms = platformStrings.compactMap {
                 Platform(rawValue: $0)
@@ -80,7 +79,7 @@ class UpRome: Up, GraphInitiatable {
         }
 
         /// Downloading Rome dependencies.
-        try rome.download(path: projectPath, platforms: platforms, cachePrefix: cachePrefix)
+        try rome.download(platforms: platforms, cachePrefix: cachePrefix)
     }
 
     func whatever() {}

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
@@ -307,7 +307,7 @@ class WorkspaceStructureGeneratorTests: XCTestCase {
         }
 
         func readPlistFile<T>(_: AbsolutePath) throws -> T where T: Decodable {
-            return try JSONDecoder().decode(T.self, from: Data())
+            try JSONDecoder().decode(T.self, from: Data())
         }
 
         func inTemporaryDirectory(_: (AbsolutePath) throws -> Void) throws {}

--- a/Tests/TuistLoaderTests/Up/Mocks/MockRome.swift
+++ b/Tests/TuistLoaderTests/Up/Mocks/MockRome.swift
@@ -7,9 +7,16 @@ import TuistCore
 final class MockRome: Romeaging {
     var downloadStub: (([Platform], String?) throws -> Void)?
     var downloadCallCount: UInt = 0
+    var missingStub: (([Platform], String?) throws -> String?)?
+    var missingCallCount: UInt = 0
 
     func download(platforms: [Platform], cachePrefix: String?) throws {
         downloadCallCount += 1
         try downloadStub?(platforms, cachePrefix)
+    }
+
+    func missing(platforms: [Platform], cachePrefix: String?) throws -> String? {
+        missingCallCount += 1
+        return try missingStub?(platforms, cachePrefix)
     }
 }

--- a/Tests/TuistLoaderTests/Up/Mocks/MockRome.swift
+++ b/Tests/TuistLoaderTests/Up/Mocks/MockRome.swift
@@ -1,0 +1,15 @@
+import Foundation
+import TSCBasic
+import TuistCore
+
+@testable import TuistLoader
+
+final class MockRome: Romeaging {
+    var downloadStub: ((AbsolutePath, [Platform], String?) throws -> Void)?
+    var downloadCallCount: UInt = 0
+
+    func download(path: AbsolutePath, platforms: [Platform], cachePrefix: String?) throws {
+        downloadCallCount += 1
+        try downloadStub?(path, platforms, cachePrefix)
+    }
+}

--- a/Tests/TuistLoaderTests/Up/Mocks/MockRome.swift
+++ b/Tests/TuistLoaderTests/Up/Mocks/MockRome.swift
@@ -5,11 +5,11 @@ import TuistCore
 @testable import TuistLoader
 
 final class MockRome: Romeaging {
-    var downloadStub: ((AbsolutePath, [Platform], String?) throws -> Void)?
+    var downloadStub: (([Platform], String?) throws -> Void)?
     var downloadCallCount: UInt = 0
 
-    func download(path: AbsolutePath, platforms: [Platform], cachePrefix: String?) throws {
+    func download(platforms: [Platform], cachePrefix: String?) throws {
         downloadCallCount += 1
-        try downloadStub?(path, platforms, cachePrefix)
+        try downloadStub?(platforms, cachePrefix)
     }
 }

--- a/Tests/TuistLoaderTests/Up/UpRomeTests.swift
+++ b/Tests/TuistLoaderTests/Up/UpRomeTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import TSCBasic
+import TuistCore
+import TuistSupport
+import XCTest
+
+@testable import TuistLoader
+@testable import TuistSupportTesting
+
+final class UpRomeTests: TuistUnitTestCase {
+    var platforms: [Platform]!
+    var cachePrefix: String!
+    var upHomebrew: MockUp!
+    var rome: MockRome!
+    var subject: UpRome!
+
+    override func setUp() {
+        super.setUp()
+        platforms = [.iOS]
+        cachePrefix = "Swift_1_2"
+        rome = MockRome()
+        upHomebrew = MockUp()
+        subject = UpRome(platforms: platforms,
+                         cachePrefix: cachePrefix,
+                         upHomebrew: upHomebrew,
+                         rome: rome)
+    }
+
+    override func tearDown() {
+        platforms = nil
+        cachePrefix = nil
+        rome = nil
+        upHomebrew = nil
+        subject = nil
+        super.tearDown()
+    }
+
+    func test_init() throws {
+        let temporaryPath = try self.temporaryPath()
+        let json = JSON(["platforms": JSON.array([JSON.string("ios")]), "cachePrefix": "Swift_5_1"])
+        let got = try UpRome(dictionary: json, projectPath: temporaryPath)
+        XCTAssertEqual(got.platforms, [.iOS])
+        XCTAssertEqual(got.cachePrefix, "Swift_5_1")
+    }
+
+    func test_isMet_when_rome_is_not_met() throws {
+        let temporaryPath = try self.temporaryPath()
+
+        upHomebrew.isMetStub = { _ in false }
+        rome.downloadStub = { (_,_,_) in }
+
+        XCTAssertFalse(try subject.isMet(projectPath: temporaryPath))
+    }
+
+
+    func test_isMet() throws {
+        let temporaryPath = try self.temporaryPath()
+
+        upHomebrew.isMetStub = { _ in true }
+        rome.downloadStub = { (_,_,_) in }
+
+        XCTAssertTrue(try subject.isMet(projectPath: temporaryPath))
+    }
+
+    func test_meet_when_homebrew_is_not_met() throws {
+        let temporaryPath = try self.temporaryPath()
+        upHomebrew.isMetStub = { _ in false }
+
+        upHomebrew.meetStub = { projectPath in
+            XCTAssertEqual(temporaryPath, projectPath)
+        }
+        try subject.meet(projectPath: temporaryPath)
+
+        XCTAssertEqual(upHomebrew.meetCallCount, 1)
+    }
+
+    func test_meet() throws {
+        let temporaryPath = try self.temporaryPath()
+
+        upHomebrew.isMetStub = { _ in true }
+
+        rome.downloadStub = { projectPath, platforms, cachePrefix in
+            XCTAssertEqual(projectPath, temporaryPath)
+            XCTAssertEqual(platforms, self.platforms)
+            XCTAssertEqual(cachePrefix, self.cachePrefix)
+        }
+
+        try subject.meet(projectPath: temporaryPath)
+
+        XCTAssertEqual(upHomebrew.meetCallCount, 0)
+        XCTAssertEqual(rome.downloadCallCount, 1)
+    }
+}

--- a/Tests/TuistLoaderTests/Up/UpRomeTests.swift
+++ b/Tests/TuistLoaderTests/Up/UpRomeTests.swift
@@ -47,17 +47,16 @@ final class UpRomeTests: TuistUnitTestCase {
         let temporaryPath = try self.temporaryPath()
 
         upHomebrew.isMetStub = { _ in false }
-        rome.downloadStub = { (_,_,_) in }
+        rome.downloadStub = { _, _ in }
 
         XCTAssertFalse(try subject.isMet(projectPath: temporaryPath))
     }
-
 
     func test_isMet() throws {
         let temporaryPath = try self.temporaryPath()
 
         upHomebrew.isMetStub = { _ in true }
-        rome.downloadStub = { (_,_,_) in }
+        rome.downloadStub = { _, _ in }
 
         XCTAssertTrue(try subject.isMet(projectPath: temporaryPath))
     }
@@ -79,8 +78,7 @@ final class UpRomeTests: TuistUnitTestCase {
 
         upHomebrew.isMetStub = { _ in true }
 
-        rome.downloadStub = { projectPath, platforms, cachePrefix in
-            XCTAssertEqual(projectPath, temporaryPath)
+        rome.downloadStub = { platforms, cachePrefix in
             XCTAssertEqual(platforms, self.platforms)
             XCTAssertEqual(cachePrefix, self.cachePrefix)
         }

--- a/Tests/TuistLoaderTests/Up/UpRomeTests.swift
+++ b/Tests/TuistLoaderTests/Up/UpRomeTests.swift
@@ -80,7 +80,8 @@ final class UpRomeTests: TuistUnitTestCase {
 
         upHomebrew.isMetStub = { _ in true }
         rome.downloadStub = { _, _ in }
-        rome.missingStub = { _, _ in return "" }
+        /// Returns empty string to indicate that no frameworks are missing
+        rome.missingStub = { _, _ in "" }
 
         //  Then
         let result = try subject.isMet(projectPath: temporaryPath)

--- a/Tests/TuistLoaderTests/Up/UpRomeTests.swift
+++ b/Tests/TuistLoaderTests/Up/UpRomeTests.swift
@@ -96,7 +96,7 @@ final class UpRomeTests: TuistUnitTestCase {
 
         upHomebrew.isMetStub = { _ in true }
         rome.downloadStub = { _, _ in }
-        rome.missingStub = { _, _ in return "MissingFramework ABC, Other framework missing" }
+        rome.missingStub = { _, _ in "MissingFramework ABC, Other framework missing" }
 
         //  Then
         let result = try subject.isMet(projectPath: temporaryPath)

--- a/website/markdown/docs/commands/up.mdx
+++ b/website/markdown/docs/commands/up.mdx
@@ -78,6 +78,17 @@ It runs [Carthage](https://github.com/carthage) dependencies for those dependenc
 
 It installs all the packages in a [Mintfile](https://github.com/yonaskolb/Mint) if they don’t exist in the system.
 
+### Rome
+
+```swift
+.rome(platforms: [.iOS], cachePrefix: "Swift_5_1")
+```
+
+It installs all the dependencies in a [Romefile](https://github.com/tmspzz/Rome) if they don’t exist in the local Carthage folder.
+
+- **Platforms:** Platforms to run against
+- **CachePrefix:** The CachePrefix
+
 ### Custom
 
 ```swift


### PR DESCRIPTION
### Short description 📝

Adds support to retrieve Carthage dependencies using [Rome](https://github.com/tmspzz/Rome). This framework enables you to retrieve the dependencies from a cached repository such as AWS S3.

### Solution 📦

The solution implemented follows the same pattern added for UpCarthage. I have only implemented the method rome download as this is the only function I see users wanting to use under `tuist up`

### Implementation 👩‍💻👨‍💻

Adds support for the command `rome download --platforms [Specified In Code] --cache-prefix [Specified In Code]
We also check if the Rome tap is available before when running the UpRome command

- [ ] Run Unit Tests from UpRomeTests
- [ ] Add .rome() to your Setup.swift file to test
