### PR TITLE
Implements two arguments on the `graph` command. #1538

### DIFF
--- a/Sources/TuistGenerator/Dot/DotGraphGenerator.swift
+++ b/Sources/TuistGenerator/Dot/DotGraphGenerator.swift
@@ -9,14 +9,14 @@ public protocol DotGraphGenerating {
     /// - Parameter path: Path to the folder that contains the project.
     /// - Returns: Dot graph representation.
     /// - Throws: An error if the project can't be loaded.
-    func generateProject(at path: AbsolutePath) throws -> String
+    func generateProject(at path: AbsolutePath, skipTestTargets: Bool, skipExternalDependencies: Bool) throws -> String
 
     /// Generates the dot graph from the workspace in the current directory and returns it.
     ///
     /// - Parameter path: Path to the folder that contains the workspace.
     /// - Returns: Dot graph representation.
     /// - Throws: An error if the workspace can't be loaded.
-    func generateWorkspace(at path: AbsolutePath) throws -> String
+    func generateWorkspace(at path: AbsolutePath, skipTestTargets: Bool, skipExternalDependencies: Bool) throws -> String
 }
 
 public final class DotGraphGenerator: DotGraphGenerating {
@@ -51,9 +51,9 @@ public final class DotGraphGenerator: DotGraphGenerating {
     /// - Parameter path: Path to the folder that contains the project.
     /// - Returns: Dot graph representation.
     /// - Throws: An error if the project can't be loaded.
-    public func generateProject(at path: AbsolutePath) throws -> String {
+    public func generateProject(at path: AbsolutePath, skipTestTargets: Bool, skipExternalDependencies: Bool) throws -> String {
         let (graph, _) = try graphLoader.loadProject(path: path)
-        return graphToDotGraphMapper.map(graph: graph).description
+        return graphToDotGraphMapper.map(graph: graph, skipTestTargets: skipTestTargets, skipExternalDependencies: skipExternalDependencies).description
     }
 
     /// Generates the dot graph from the workspace in the current directory and returns it.
@@ -61,8 +61,8 @@ public final class DotGraphGenerator: DotGraphGenerating {
     /// - Parameter path: Path to the folder that contains the workspace.
     /// - Returns: Dot graph representation.
     /// - Throws: An error if the workspace can't be loaded.
-    public func generateWorkspace(at path: AbsolutePath) throws -> String {
+    public func generateWorkspace(at path: AbsolutePath, skipTestTargets: Bool, skipExternalDependencies: Bool) throws -> String {
         let (graph, _) = try graphLoader.loadWorkspace(path: path)
-        return graphToDotGraphMapper.map(graph: graph).description
+        return graphToDotGraphMapper.map(graph: graph, skipTestTargets: skipTestTargets, skipExternalDependencies: skipExternalDependencies).description
     }
 }

--- a/Sources/TuistGenerator/Dot/GraphToDotGraphMapper.swift
+++ b/Sources/TuistGenerator/Dot/GraphToDotGraphMapper.swift
@@ -22,7 +22,7 @@ class GraphToDotGraphMapper: GraphToDotGraphMapping {
         // Targets
         graph.targets.forEach { targetsList in
             targetsList.value.forEach { target in
-                if skipTestTargets && target.dependsOnXCTest {
+                if skipTestTargets, target.dependsOnXCTest {
                     return
                 }
                 if skipExternalDependencies, target.isExternal {
@@ -79,5 +79,4 @@ private extension GraphNode {
 
         return false
     }
-
 }

--- a/Sources/TuistGenerator/Dot/GraphToDotGraphMapper.swift
+++ b/Sources/TuistGenerator/Dot/GraphToDotGraphMapper.swift
@@ -7,7 +7,7 @@ protocol GraphToDotGraphMapping {
     ///
     /// - Parameter graph: Graph to be converted into a dot graph.
     /// - Returns: The dot graph representation.
-    func map(graph: Graph) -> DotGraph
+    func map(graph: Graph, skipTestTargets: Bool, skipExternalDependencies: Bool) -> DotGraph
 }
 
 class GraphToDotGraphMapper: GraphToDotGraphMapping {
@@ -15,17 +15,28 @@ class GraphToDotGraphMapper: GraphToDotGraphMapping {
     ///
     /// - Parameter graph: Graph to be converted into a dot graph.
     /// - Returns: The dot graph representation.
-    func map(graph: Graph) -> DotGraph {
+    func map(graph: Graph, skipTestTargets: Bool, skipExternalDependencies: Bool) -> DotGraph {
         var nodes: [DotGraphNode] = []
         var dependencies: [DotGraphDependency] = []
 
         // Targets
         graph.targets.forEach { targetsList in
             targetsList.value.forEach { target in
+                if skipTestTargets && target.dependsOnXCTest {
+                    return
+                }
+                if skipExternalDependencies, target.isExternal {
+                    return
+                }
+
                 nodes.append(DotGraphNode(name: target.target.name))
 
                 // Dependencies
                 target.dependencies.forEach { dependency in
+                    if skipExternalDependencies, dependency.isExternal {
+                        return
+                    }
+
                     dependencies.append(DotGraphDependency(from: target.name, to: dependency.name))
 
                     if let sdk = dependency as? SDKNode {
@@ -43,4 +54,30 @@ class GraphToDotGraphMapper: GraphToDotGraphMapping {
                         nodes: Set(nodes),
                         dependencies: Set(dependencies))
     }
+}
+
+private extension GraphNode {
+    var isExternal: Bool {
+        if self is SDKNode {
+            return true
+        }
+        if self is CocoaPodsNode {
+            return true
+        }
+        if self is FrameworkNode {
+            return true
+        }
+        if self is LibraryNode {
+            return true
+        }
+        if self is PackageProductNode {
+            return true
+        }
+        if self is PrecompiledNode {
+            return true
+        }
+
+        return false
+    }
+
 }

--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -12,7 +12,17 @@ struct GraphCommand: ParsableCommand {
                              abstract: "Generates a dot graph from the workspace or project in the current directory")
     }
 
+    @Flag(
+        help: "Skip Test targets during graph rendering."
+    )
+    var skipTestTargets: Bool
+
+    @Flag(
+        help: "Skip external dependencies."
+    )
+    var skipExternalParty: Bool
+
     func run() throws {
-        try GraphService().run()
+        try GraphService().run(skipTestTargets: skipTestTargets, skipExternalDependencies: skipExternalParty)
     }
 }

--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -20,9 +20,9 @@ struct GraphCommand: ParsableCommand {
     @Flag(
         help: "Skip external dependencies."
     )
-    var skipExternalParty: Bool
+    var skipExternalDependencies: Bool
 
     func run() throws {
-        try GraphService().run(skipTestTargets: skipTestTargets, skipExternalDependencies: skipExternalParty)
+        try GraphService().run(skipTestTargets: skipTestTargets, skipExternalDependencies: skipExternalDependencies)
     }
 }

--- a/Sources/TuistKit/Dot/DotGraphGenerating+Extras.swift
+++ b/Sources/TuistKit/Dot/DotGraphGenerating+Extras.swift
@@ -5,13 +5,15 @@ import TuistLoader
 
 extension DotGraphGenerating {
     func generate(at path: AbsolutePath,
-                  manifestLoader: ManifestLoading) throws -> String {
+                  manifestLoader: ManifestLoading,
+                  skipTestTargets: Bool,
+                  skipExternalDependencies: Bool) throws -> String {
         let manifests = manifestLoader.manifests(at: path)
 
         if manifests.contains(.workspace) {
-            return try generateWorkspace(at: path)
+            return try generateWorkspace(at: path, skipTestTargets: skipTestTargets, skipExternalDependencies: skipExternalDependencies)
         } else if manifests.contains(.project) {
-            return try generateProject(at: path)
+            return try generateProject(at: path, skipTestTargets: skipTestTargets, skipExternalDependencies: skipExternalDependencies)
         } else {
             throw ManifestLoaderError.manifestNotFound(path)
         }

--- a/Sources/TuistKit/Services/GraphService.swift
+++ b/Sources/TuistKit/Services/GraphService.swift
@@ -18,9 +18,11 @@ final class GraphService {
         self.manifestLoader = manifestLoader
     }
 
-    func run() throws {
+    func run(skipTestTargets: Bool, skipExternalDependencies: Bool) throws {
         let graph = try dotGraphGenerator.generate(at: FileHandler.shared.currentPath,
-                                                   manifestLoader: manifestLoader)
+                                                   manifestLoader: manifestLoader,
+                                                   skipTestTargets: skipTestTargets,
+                                                   skipExternalDependencies: skipExternalDependencies)
 
         let path = FileHandler.shared.currentPath.appending(component: "graph.dot")
         if FileHandler.shared.exists(path) {

--- a/Tests/TuistGeneratorTests/DotGraph/GraphToDotGraphMapperTests.swift
+++ b/Tests/TuistGeneratorTests/DotGraph/GraphToDotGraphMapperTests.swift
@@ -89,6 +89,5 @@ final class GraphToDotGraphMapperTests: XCTestCase {
                                     .init(from: "Tuist watchOS", to: "Core"),
                                 ])
         XCTAssertEqual(got, expected)
-
     }
 }

--- a/Tests/TuistGeneratorTests/DotGraph/GraphToDotGraphMapperTests.swift
+++ b/Tests/TuistGeneratorTests/DotGraph/GraphToDotGraphMapperTests.swift
@@ -32,7 +32,7 @@ final class GraphToDotGraphMapperTests: XCTestCase {
                                targets: [project.path: [core, iOSApp, watchApp]])
 
         // When
-        let got = subject.map(graph: graph)
+        let got = subject.map(graph: graph, skipTestTargets: false, skipExternalDependencies: false)
 
         // Then
         let expected = DotGraph(name: "Project Dependencies Graph",
@@ -52,5 +52,43 @@ final class GraphToDotGraphMapperTests: XCTestCase {
                                     .init(from: "Core", to: "CoreData"),
                                 ])
         XCTAssertEqual(got, expected)
+    }
+
+    func test_map_skipping_external_dependencies() throws {
+        // Given
+        let project = Project.test()
+        let framework = FrameworkNode.test(path: AbsolutePath("/XcodeProj.framework"))
+        let library = LibraryNode.test(path: AbsolutePath("/RxSwift.a"))
+        let sdk = try SDKNode(name: "CoreData.framework", platform: .iOS, status: .required, source: .developer)
+
+        let core = TargetNode.test(target: Target.test(name: "Core"), dependencies: [
+            framework, library, sdk,
+        ])
+        let iOSApp = TargetNode.test(target: Target.test(name: "Tuist iOS"), dependencies: [core])
+        let watchApp = TargetNode.test(target: Target.test(name: "Tuist watchOS"), dependencies: [core])
+
+        let graph = Graph.test(entryNodes: [iOSApp, watchApp],
+                               projects: [project],
+                               precompiled: [framework, library],
+                               targets: [project.path: [core, iOSApp, watchApp]])
+
+        // When
+        let got = subject.map(graph: graph, skipTestTargets: false, skipExternalDependencies: true)
+
+        // Then
+        let expected = DotGraph(name: "Project Dependencies Graph",
+                                type: .directed,
+                                nodes: Set([
+                                    .init(name: "Tuist iOS"),
+                                    .init(name: "RxSwift"),
+                                    .init(name: "XcodeProj"),
+                                    .init(name: "Core"),
+                                    .init(name: "Tuist watchOS"),
+                                ]), dependencies: [
+                                    .init(from: "Tuist iOS", to: "Core"),
+                                    .init(from: "Tuist watchOS", to: "Core"),
+                                ])
+        XCTAssertEqual(got, expected)
+
     }
 }

--- a/Tests/TuistKitTests/Dot/MockDotGraphGenerator.swift
+++ b/Tests/TuistKitTests/Dot/MockDotGraphGenerator.swift
@@ -8,12 +8,12 @@ final class MockDotGraphGenerator: DotGraphGenerating {
     var generateProjectStub: String = ""
     var generateWorkspaceStub: String = ""
 
-    func generateProject(at path: AbsolutePath) throws -> String {
+    func generateProject(at path: AbsolutePath, skipTestTargets: Bool, skipExternalDependencies: Bool) throws -> String {
         generateProjectArgs.append(path)
         return generateProjectStub
     }
 
-    func generateWorkspace(at path: AbsolutePath) throws -> String {
+    func generateWorkspace(at path: AbsolutePath, skipTestTargets: Bool, skipExternalDependencies: Bool) throws -> String {
         generateWorkspaceArgs.append(path)
         return generateWorkspaceStub
     }

--- a/Tests/TuistKitTests/Dot/MockDotGraphGenerator.swift
+++ b/Tests/TuistKitTests/Dot/MockDotGraphGenerator.swift
@@ -8,12 +8,12 @@ final class MockDotGraphGenerator: DotGraphGenerating {
     var generateProjectStub: String = ""
     var generateWorkspaceStub: String = ""
 
-    func generateProject(at path: AbsolutePath, skipTestTargets: Bool, skipExternalDependencies: Bool) throws -> String {
+    func generateProject(at path: AbsolutePath, skipTestTargets _: Bool, skipExternalDependencies _: Bool) throws -> String {
         generateProjectArgs.append(path)
         return generateProjectStub
     }
 
-    func generateWorkspace(at path: AbsolutePath, skipTestTargets: Bool, skipExternalDependencies: Bool) throws -> String {
+    func generateWorkspace(at path: AbsolutePath, skipTestTargets _: Bool, skipExternalDependencies _: Bool) throws -> String {
         generateWorkspaceArgs.append(path)
         return generateWorkspaceStub
     }

--- a/Tests/TuistKitTests/Services/GraphServiceTests.swift
+++ b/Tests/TuistKitTests/Services/GraphServiceTests.swift
@@ -46,7 +46,7 @@ final class GraphServiceTests: TuistUnitTestCase {
         dotGraphGenerator.generateProjectStub = graph
 
         // When
-        try subject.run()
+        try subject.run(skipTestTargets: false, skipExternalDependencies: false)
 
         // Then
         XCTAssertEqual(try FileHandler.shared.readTextFile(graphPath), graph)

--- a/website/markdown/docs/commands/graph.mdx
+++ b/website/markdown/docs/commands/graph.mdx
@@ -15,6 +15,12 @@ Being in a directory that contains a workspace or project manifest, run the foll
 tuist graph
 ```
 
+### Besides running the plain graph command, an enduser can opt to exclude either tests and/or third party dependencies
+
+The additional arguments are:
+- `skipTestTargets`
+- `skipExternalDependencies`
+
 The command will output a human-readable file, `graph.dot` that describes the dependencies graph using the [DOT](<https://en.wikipedia.org/wiki/DOT_(graph_description_language)>) description language.
 
 ## A visual representation of the graph


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1538

### Short description 📝

> Add and implement two additinal arguments on the `graph` command.

### Solution 📦

> Two flags were added to the `graph` command. Those arguments are passed into the graph command's execution.

### Implementation 👩‍💻👨‍💻

- [x] Extend unit tests.
- [x] Implement mapper to turn unit tests green.
- [x] Adopt new mapper contract towards call sites.
