### PR TITLE
Correct a number of missing `tearDown()` implementations in unit tests.

### DIFF
--- a/Tests/TuistCoreTests/Graph/Nodes/PrecompiledNodeTests.swift
+++ b/Tests/TuistCoreTests/Graph/Nodes/PrecompiledNodeTests.swift
@@ -13,6 +13,12 @@ final class PrecompiledNodeTests: XCTestCase {
         system = MockSystem()
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        system = nil
+    }
+
     func test_name() {
         // Given
         let subject = PrecompiledNode(path: AbsolutePath("/Alamofire.framework"))

--- a/Tests/TuistCoreTests/Utils/GraphCircularDetectorTests.swift
+++ b/Tests/TuistCoreTests/Utils/GraphCircularDetectorTests.swift
@@ -11,6 +11,12 @@ final class GraphCircularDetectorTests: XCTestCase {
         subject = GraphCircularDetector()
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
     func test_cycleDetected_1() throws {
         // Given
         let a = node("a")

--- a/Tests/TuistEnvKitTests/Installer/BuildCopierTests.swift
+++ b/Tests/TuistEnvKitTests/Installer/BuildCopierTests.swift
@@ -15,6 +15,13 @@ final class BuildCopierTests: XCTestCase {
         subject = BuildCopier()
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        fileManager = nil
+        subject = nil
+    }
+
     func test_files() {
         XCTAssertEqual(BuildCopier.files, [
             "tuist",

--- a/Tests/TuistEnvKitTests/Versions/VersionResolverTests.swift
+++ b/Tests/TuistEnvKitTests/Versions/VersionResolverTests.swift
@@ -27,6 +27,13 @@ final class VersionResolverTests: XCTestCase {
         subject = VersionResolver(settingsController: settingsController)
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        settingsController = nil
+        subject = nil
+    }
+
     func test_resolve_when_version_and_bin() throws {
         let tmp_dir = try TemporaryDirectory(removeTreeOnDeinit: true)
         let versionPath = tmp_dir.path.appending(component: Constants.versionFileName)

--- a/Tests/TuistGeneratorTests/DotGraph/GraphToDotGraphMapperTests.swift
+++ b/Tests/TuistGeneratorTests/DotGraph/GraphToDotGraphMapperTests.swift
@@ -13,6 +13,12 @@ final class GraphToDotGraphMapperTests: XCTestCase {
         subject = GraphToDotGraphMapper()
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
     func test_map() throws {
         // Given
         let project = Project.test()

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -31,6 +31,14 @@ final class BuildPhaseGeneratorTests: XCTestCase {
         graph = Graph.test()
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+        errorHandler = nil
+        graph = nil
+    }
+
     func test_generateSourcesBuildPhase() throws {
         // Given
         let target = PBXNativeTarget(name: "Test")

--- a/Tests/TuistGeneratorTests/Generator/InfoPlistContentProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/InfoPlistContentProviderTests.swift
@@ -12,6 +12,12 @@ final class InfoPlistContentProviderTests: XCTestCase {
         subject = InfoPlistContentProvider()
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
     func test_content_wheniOSApp() {
         // Given
         let target = Target.test(platform: .iOS, product: .app)

--- a/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
@@ -37,6 +37,16 @@ final class ProjectGroupsTests: XCTestCase {
         pbxproj = PBXProj()
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        pbxproj = nil
+        project = nil
+        sourceRootPath = nil
+        playgrounds = nil
+        subject = nil
+    }
+
     func test_generate() {
         playgrounds.pathsStub = { projectPath in
             if projectPath == self.sourceRootPath {

--- a/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemesGeneratorTests.swift
@@ -17,6 +17,12 @@ final class SchemesGeneratorTests: XCTestCase {
         subject = SchemesGenerator()
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
     // MARK: - Build Action Tests
 
     func test_schemeBuildAction_whenSingleProject() throws {

--- a/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
@@ -24,6 +24,16 @@ final class TargetGeneratorTests: XCTestCase {
         subject = TargetGenerator()
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+        fileElements = nil
+        pbxProject = nil
+        pbxproj = nil
+        path = nil
+    }
+
     func test_generateTarget_productName() throws {
         // Given
         let target = Target.test(name: "MyFramework",

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
@@ -17,6 +17,7 @@ class WorkspaceStructureGeneratorTests: XCTestCase {
 
     override func tearDown() {
         fileHandler = nil
+        subject = nil
     }
 
     func test_generateStructure_projects() throws {

--- a/Tests/TuistGeneratorTests/Linter/ProjectLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/ProjectLinterTests.swift
@@ -23,6 +23,15 @@ final class ProjectLinterTests: XCTestCase {
                                 schemeLinter: schemeLinter)
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+        settingsLinter = nil
+        schemeLinter = nil
+        targetLinter = nil
+    }
+
     func test_validate_when_there_are_duplicated_targets() throws {
         let target = Target.test(name: "A")
         let project = Project.test(targets: [target, target])

--- a/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
@@ -10,7 +10,14 @@ class StaticProductsGraphLinterTests: XCTestCase {
     var subject: StaticProductsGraphLinter!
 
     override func setUp() {
+        super.setUp()
         subject = StaticProductsGraphLinter()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
     }
 
     func test_lint_whenPackageDependencyLinkedTwice() throws {

--- a/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -121,6 +121,12 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         subject = DefaultSettingsProvider()
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
     func testProjectSettings_whenEssentialDebug() throws {
         // Given
         let buildConfiguration: BuildConfiguration = .debug

--- a/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
@@ -6,13 +6,20 @@ import XCTest
 @testable import TuistGenerator
 
 final class SettingsHelpersTests: XCTestCase {
-    private var subject = SettingsHelper()
-    private var settings: [String: SettingValue] = [:]
+    private var subject: SettingsHelper!
+    private var settings: [String: SettingValue]!
 
     override func setUp() {
         super.setUp()
         subject = SettingsHelper()
         settings = [:]
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        settings = nil
+        subject = nil
     }
 
     func testExtend_whenNoSettings() {

--- a/Tests/TuistLoaderTests/Linters/ManifestLinterTests.swift
+++ b/Tests/TuistLoaderTests/Linters/ManifestLinterTests.swift
@@ -9,7 +9,14 @@ class ManifestLinterTests: XCTestCase {
     var subject: ManifestLinter!
 
     override func setUp() {
+        super.setUp()
         subject = ManifestLinter()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
     }
 
     // MARK: - Tests

--- a/Tests/TuistLoaderTests/Linters/UpLinterTests.swift
+++ b/Tests/TuistLoaderTests/Linters/UpLinterTests.swift
@@ -13,6 +13,12 @@ final class UpLinterTests: XCTestCase {
         subject = UpLinter()
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
     func test_lint_when_a_custom_up_has_an_empty_meet() {
         let up = UpCustom(name: "test", meet: [], isMet: ["which", "tool"])
         let got = subject.lint(up: up)

--- a/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
@@ -48,6 +48,13 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
         }
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+        cacheDirectory = nil
+    }
+
     // MARK: - Tests
 
     func test_load_manifestNotCached() throws {

--- a/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
@@ -29,6 +29,14 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
                                           fileHandler: fileHandler)
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        path = nil
+        manifestLoader = nil
+        subject = nil
+    }
+
     // MARK: - Tests
 
     func test_loadProject_loadingSingleProject() throws {

--- a/Tests/TuistLoaderTests/Models/GeneratorPathsTests.swift
+++ b/Tests/TuistLoaderTests/Models/GeneratorPathsTests.swift
@@ -44,6 +44,7 @@ class GeneratorPathsTests: TuistUnitTestCase {
     }
 
     override func tearDown() {
+        subject = nil
         rootDirectoryLocator = nil
         path = nil
         super.tearDown()

--- a/Tests/TuistLoaderTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasherTests.swift
+++ b/Tests/TuistLoaderTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasherTests.swift
@@ -16,6 +16,12 @@ class ProjectDescriptionHelpersHasherTests: TuistUnitTestCase {
         subject = ProjectDescriptionHelpersHasher(tuistVersion: "3.2.1")
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
     func test_hash() throws {
         // Given
         let temporaryDir = try temporaryPath()

--- a/Tests/TuistSupportTests/Utils/FileHandlerTests.swift
+++ b/Tests/TuistSupportTests/Utils/FileHandlerTests.swift
@@ -23,6 +23,12 @@ final class FileHandlerTests: TuistUnitTestCase {
         subject = FileHandler()
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
     // MARK: - Tests
 
     func test_replace() throws {


### PR DESCRIPTION
### Short description 📝

I noticed a few missing or incomplete teardown implementations in the codebase.

### Solution 📦

Checked all 145 call sites of setUp in unit tests and fixed these,
