### PR TITLE
Fix checking for installed brew packages using `which`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- `UpHomebrew` (`Up.homebrew(packages:)`) in `Setup.swift` correctly checks package installation if the executable doesn't match the package name [#1544](https://github.com/tuist/tuist/pull/1544) by [@MatyasKriz](https://github.com/MatyasKriz).
+
 ## 1.12.0 - Arabesque
 
 ### Changed

--- a/Sources/TuistLoader/Up/UpHomebrew.swift
+++ b/Sources/TuistLoader/Up/UpHomebrew.swift
@@ -62,6 +62,6 @@ class UpHomebrew: Up, GraphInitiatable {
     }
 
     private func packageInstalled(_ name: String) -> Bool {
-        return (try? System.shared.run("/usr/local/bin/brew", "list", name)) != nil
+        (try? System.shared.run("/usr/local/bin/brew", "list", name)) != nil
     }
 }

--- a/Sources/TuistLoader/Up/UpHomebrew.swift
+++ b/Sources/TuistLoader/Up/UpHomebrew.swift
@@ -34,7 +34,7 @@ class UpHomebrew: Up, GraphInitiatable {
     /// - Returns: True if the command doesn't need to be run.
     /// - Throws: An error if the check fails.
     override func isMet(projectPath _: AbsolutePath) throws -> Bool {
-        let packagesInstalled = packages.allSatisfy { toolInstalled($0) }
+        let packagesInstalled = packages.allSatisfy { packageInstalled($0) }
         return toolInstalled("brew") && packagesInstalled
     }
 
@@ -52,12 +52,16 @@ class UpHomebrew: Up, GraphInitiatable {
                                           verbose: true,
                                           environment: System.shared.env)
         }
-        let nonInstalledPackages = packages.filter { !toolInstalled($0) }
+        let nonInstalledPackages = packages.filter { !packageInstalled($0) }
         try nonInstalledPackages.forEach { package in
             logger.notice("Installing Homebrew package: \(package)")
             try System.shared.runAndPrint("/usr/local/bin/brew", "install", package,
                                           verbose: true,
                                           environment: System.shared.env)
         }
+    }
+
+    private func packageInstalled(_ name: String) -> Bool {
+        return (try? System.shared.run("/usr/local/bin/brew", "list", name)) != nil
     }
 }

--- a/Tests/TuistLoaderTests/Up/UpHomebrewTests.swift
+++ b/Tests/TuistLoaderTests/Up/UpHomebrewTests.swift
@@ -25,12 +25,13 @@ final class UpHomebrewTests: TuistUnitTestCase {
         let temporaryPath = try self.temporaryPath()
         let subject = UpHomebrew(packages: ["swiftlint"])
         system.whichStub = { tool in
-            if tool == "swiftlint" {
-                throw NSError.test()
-            } else {
+            if tool == "brew" {
                 return ""
+            } else {
+                throw NSError.test()
             }
         }
+        system.errorCommand("/usr/local/bin/brew", "list", "swiftlint")
         let got = try subject.isMet(projectPath: temporaryPath)
         XCTAssertFalse(got)
     }
@@ -38,7 +39,14 @@ final class UpHomebrewTests: TuistUnitTestCase {
     func test_isMet() throws {
         let temporaryPath = try self.temporaryPath()
         let subject = UpHomebrew(packages: ["swiftlint"])
-        system.whichStub = { _ in "" }
+        system.whichStub = { tool in
+            if tool == "brew" {
+                return ""
+            } else {
+                throw NSError.test()
+            }
+        }
+        system.succeedCommand("/usr/local/bin/brew", "list", "swiftlint")
         let got = try subject.isMet(projectPath: temporaryPath)
         XCTAssertTrue(got)
     }
@@ -48,6 +56,7 @@ final class UpHomebrewTests: TuistUnitTestCase {
         let subject = UpHomebrew(packages: ["swiftlint"])
 
         system.whichStub = { _ in nil }
+        system.errorCommand("/usr/local/bin/brew", "list", "swiftlint")
         system.succeedCommand("/usr/bin/ruby",
                               "-e",
                               "\"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)\"")


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1089

### Description 📝

The Homebrew package name doesn't necessarily need to be the exact same as the executable that is used later on (e.g. `swift-protobuf`, `magic-wormhole`). This leads to false negatives when checking whether the packages are installed.

Let's take a look at `swift-protobuf` as an example. Up until now, `tuist` tried `which swift-protobuf` (which always failed, the executable is called `protoc`), so `brew install swift-protobuf` ensues.
After that, one of 3 scenarios occurs:
- Package is not installed and is promptly installed by the command.
- Package is installed and updated to its latest released version; `tuist` outputs the warning, but it returns zero, so the setup continues as expected.
- Package is installed but not updated to its latest released version; `tuist` outputs the error that `Homebrew` prints and stops execution because it's an error in its book. `tuist` then stops execution as well, reading a non-zero code.

### Solution 📦

This is solved by replacing `which PACKAGE_NAME` with `brew list PACKAGE_NAME`.

There's also `brew info PACKAGE_NAME`, though it seems to take longer and try to find previously deleted package. I didn't do much research into using that over `brew list`, as it also outputs way more info than is needed for a simple installation check.

### Implementation 👩‍💻👨‍💻

I was thinking of overriding `Up.toolInstalled`, but it seemed too radical to me having to use `super.toolInstalled("brew")` where I didn't want to check the `Homebrew` packages.

Adding a new private method to `UpHomebrew` seemed like the better choice while at the same time not leaking any info about how the class internally checks for installed packages.

- [x] Add a new private method to `UpHomebrew` that uses `brew list` instead of `which`.
- [x] Test on my project with multiple `Homebrew` packages that have different package name and executable name.
- [x] Compare with the current functionality and verify that the implementation does what it's supposed to.
- [x] Change tests to reflect the improvements in `UpHomebrew`.
- [ ] ???
- [ ] Profit!
