### PR TITLE
Treat SceneKit catalog the same way as asset catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - `UpHomebrew` (`Up.homebrew(packages:)`) in `Setup.swift` correctly checks package installation if the executable doesn't match the package name [#1544](https://github.com/tuist/tuist/pull/1544) by [@MatyasKriz](https://github.com/MatyasKriz).
 - Update Package.swift to correctly encode revision kind as "revision" [#1558](https://github.com/tuist/tuist/pull/1558) by [@ollieatkinson](https://github.com/ollieatkinson).
+- Treat SceneKit catalog the same way as asset catalog [#1546], by [@natanrolnik](https://github.com/natanrolnik)
 
 ## 1.12.0 - Arabesque
 

--- a/Sources/TuistCore/Models/Target.swift
+++ b/Sources/TuistCore/Models/Target.swift
@@ -9,7 +9,7 @@ public struct Target: Equatable, Hashable {
     // MARK: - Static
 
     public static let validSourceExtensions: [String] = ["m", "swift", "mm", "cpp", "c", "d", "intentdefinition", "xcmappingmodel", "metal"]
-    public static let validFolderExtensions: [String] = ["framework", "bundle", "app", "xcassets", "appiconset"]
+    public static let validFolderExtensions: [String] = ["framework", "bundle", "app", "xcassets", "appiconset", "scnassets"]
 
     // MARK: - Attributes
 

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -227,12 +227,12 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
             let pathString = buildFilePath.pathString
             let isLocalized = pathString.contains(".lproj/")
             let isLproj = buildFilePath.extension == "lproj"
-            let isAssetWithinXCAssets = pathString.contains(".xcassets/")
+            let isWithinAssets = pathString.contains(".xcassets/") || pathString.contains(".scnassets/")
 
-            /// Assets that are part of a .xcassets folder
+            /// Assets that are part of a .xcassets or .scnassets folder
             /// are not added individually. The whole folder is added
             /// instead as a group.
-            if isAssetWithinXCAssets {
+            if isWithinAssets {
                 return
             }
 

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -312,7 +312,7 @@ class ProjectFileElements {
                                           name: name,
                                           toGroup: toGroup,
                                           pbxproj: pbxproj)
-        } else if !(isXcassets(path: absolutePath) || isLeaf) {
+        } else if !(isXcassets(path: absolutePath) || isScnassets(path: absolutePath) || isLeaf) {
             return addGroupElement(from: from,
                                    folderAbsolutePath: absolutePath,
                                    folderRelativePath: relativePath,
@@ -482,6 +482,10 @@ class ProjectFileElements {
 
     func isXcassets(path: AbsolutePath) -> Bool {
         path.extension == "xcassets"
+    }
+
+    func isScnassets(path: AbsolutePath) -> Bool {
+        path.extension == "scnassets"
     }
 
     /// Normalizes a path. Some paths have no direct representation in Xcode,

--- a/Tests/TuistCoreTests/Models/TargetTests.swift
+++ b/Tests/TuistCoreTests/Models/TargetTests.swift
@@ -153,6 +153,7 @@ final class TargetTests: TuistUnitTestCase {
         let temporaryPath = try self.temporaryPath()
         let folders = try createFolders([
             "resources/d.xcassets",
+            "resources/d.scnassets",
             "resources/g.bundle",
         ])
 
@@ -174,6 +175,7 @@ final class TargetTests: TuistUnitTestCase {
         let relativeResources = resources.map { $0.relative(to: temporaryPath).pathString }
         XCTAssertEqual(relativeResources, [
             "resources/d.xcassets",
+            "resources/d.scnassets",
             "resources/g.bundle",
             "resources/a.png",
             "resources/b.jpg",

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -154,13 +154,34 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         ])
     }
 
-    func test_addElement_xcassets_multiple_files() throws {
+    func test_addElement_scnassets() throws {
+        // Given
+        let element = GroupFileElement(path: "/path/myfolder/resources/assets.scnassets/foo.exr",
+                                       group: .group(name: "Project"))
+
+        // When
+        try subject.generate(fileElement: element,
+                             groups: groups,
+                             pbxproj: pbxproj,
+                             sourceRootPath: "/path")
+
+        // Then
+        let projectGroup = groups.sortedMain.group(named: "Project")
+        XCTAssertEqual(projectGroup?.flattenedChildren, [
+            "myfolder/resources/assets.scnassets",
+        ])
+    }
+
+    func test_addElement_xcassets_and_scnassets_multiple_files() throws {
         // Given
         let resouces = [
             "/path/myfolder/resources/assets.xcassets/foo/a.png",
             "/path/myfolder/resources/assets.xcassets/foo/abc/b.png",
             "/path/myfolder/resources/assets.xcassets/foo/def/c.png",
             "/path/myfolder/resources/assets.xcassets",
+            "/path/myfolder/resources/assets.scnassets/foo.exr",
+            "/path/myfolder/resources/assets.scnassets/bar.exr",
+            "/path/myfolder/resources/assets.scnassets",
         ]
         let elements = resouces.map {
             GroupFileElement(path: AbsolutePath($0),
@@ -179,6 +200,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         let projectGroup = groups.sortedMain.group(named: "Project")
         XCTAssertEqual(projectGroup?.flattenedChildren, [
             "myfolder/resources/assets.xcassets",
+            "myfolder/resources/assets.scnassets",
         ])
     }
 


### PR DESCRIPTION
When dealing with SceneKit catalog (a `.scnassets` directory), Tuist wouldn't recognize it as such.

This PR makes Tuist treat these directories the same way as asset catalogs. 