### PR TITLE
Update Package.swift to correctly encode revision kind as "revision"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - `UpHomebrew` (`Up.homebrew(packages:)`) in `Setup.swift` correctly checks package installation if the executable doesn't match the package name [#1544](https://github.com/tuist/tuist/pull/1544) by [@MatyasKriz](https://github.com/MatyasKriz).
+- Update Package.swift to correctly encode revision kind as "revision" [#1558](https://github.com/tuist/tuist/pull/1558) by [@ollieatkinson](https://github.com/ollieatkinson).
 
 ## 1.12.0 - Arabesque
 

--- a/Sources/ProjectDescription/Package.swift
+++ b/Sources/ProjectDescription/Package.swift
@@ -124,7 +124,7 @@ extension Package {
                 try container.encode("branch", forKey: .kind)
                 try container.encode(branch, forKey: .branch)
             case let .revision(revision):
-                try container.encode("revision", forKey: .revision)
+                try container.encode("revision", forKey: .kind)
                 try container.encode(revision, forKey: .revision)
             }
         }


### PR DESCRIPTION
### Short description 📝

@natanrolnik noticed that we had a bug when specifying a requirement to a revision:

```
We received an error that we couldn't handle:
    - Localized description: The data couldn't be read because it is missing.
    - Error: keyNotFound(CodingKeys(stringValue: "kind", intValue: nil), Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "packages", intValue: nil), _JSONKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "requirement", intValue: nil)], debugDescription: "No value associated with key CodingKeys(stringValue: \"kind\", intValue: nil) (\"kind\").", underlyingError: nil))"
```

### Solution 📦

Correctly encode "revision" to `kind`
