### PR TITLE
Add sourceRootPath to the Project model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Treat SceneKit catalog the same way as asset catalog [#1546], by [@natanrolnik](https://github.com/natanrolnik)
 - Add core data models to the sources build phase [#1542](https://github.com/tuist/tuist/pull/1542) by [@kwridan](https://github.com/kwridan)
 
+### Changed
+
+- Add a `sourceRootPath` attribute to `TuistCore.Project` to control where Xcode projects are generated [#1559](https://github.com/tuist/tuist/pull/1559) by [@pepibumur](https://github.com/pepibumur).
+
 ## 1.12.0 - Arabesque
 
 ### Changed

--- a/Sources/TuistCore/Models/Project.swift
+++ b/Sources/TuistCore/Models/Project.swift
@@ -5,9 +5,10 @@ import TuistSupport
 public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebugStringConvertible {
     public static func == (lhs: Project, rhs: Project) -> Bool {
         lhs.path == rhs.path &&
+            lhs.sourceRootPath == rhs.sourceRootPath &&
+            lhs.xcodeProjPath == rhs.xcodeProjPath &&
             lhs.name == rhs.name &&
             lhs.organizationName == rhs.organizationName &&
-            lhs.fileName == rhs.fileName &&
             lhs.targets == rhs.targets &&
             lhs.packages == rhs.packages &&
             lhs.schemes == rhs.schemes &&
@@ -21,17 +22,17 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
     /// Path to the folder that contains the project manifest.
     public var path: AbsolutePath
 
-    /// Path to the directory where the Xcode project will be generated.
+    /// Path to the root of the project sources.
     public var sourceRootPath: AbsolutePath
+
+    /// Path to the Xcode project that will be generated.
+    public var xcodeProjPath: AbsolutePath
 
     /// Project name.
     public var name: String
 
     /// Organization name.
     public var organizationName: String?
-
-    /// Project file name.
-    public var fileName: String
 
     /// Project targets.
     public var targets: [Target]
@@ -58,6 +59,7 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
     /// - Parameters:
     ///   - path: Path to the folder that contains the project manifest.
     ///   - sourceRootPath: Path to the directory where the Xcode project will be generated.
+    ///   - xcodeProjPath: Path to the Xcode project that will be generated.
     ///   - name: Project name.
     ///   - organizationName: Organization name.
     ///   - settings: The settings to apply at the project level
@@ -67,9 +69,9 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
     ///                      *(Those won't be included in any build phases)*
     public init(path: AbsolutePath,
                 sourceRootPath: AbsolutePath,
+                xcodeProjPath: AbsolutePath,
                 name: String,
                 organizationName: String?,
-                fileName: String?,
                 settings: Settings,
                 filesGroup: ProjectGroup,
                 targets: [Target],
@@ -78,9 +80,9 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
                 additionalFiles: [FileElement]) {
         self.path = path
         self.sourceRootPath = sourceRootPath
+        self.xcodeProjPath = xcodeProjPath
         self.name = name
         self.organizationName = organizationName
-        self.fileName = fileName ?? name
         self.targets = targets
         self.packages = packages
         self.schemes = schemes
@@ -149,9 +151,9 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
     public func with(targets: [Target]) -> Project {
         Project(path: path,
                 sourceRootPath: sourceRootPath,
+                xcodeProjPath: xcodeProjPath,
                 name: name,
                 organizationName: organizationName,
-                fileName: fileName,
                 settings: settings,
                 filesGroup: filesGroup,
                 targets: targets,
@@ -165,9 +167,9 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
     public func with(schemes: [Scheme]) -> Project {
         Project(path: path,
                 sourceRootPath: sourceRootPath,
+                xcodeProjPath: xcodeProjPath,
                 name: name,
                 organizationName: organizationName,
-                fileName: fileName,
                 settings: settings,
                 filesGroup: filesGroup,
                 targets: targets,

--- a/Sources/TuistCore/Models/Project.swift
+++ b/Sources/TuistCore/Models/Project.swift
@@ -21,6 +21,9 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
     /// Path to the folder that contains the project manifest.
     public var path: AbsolutePath
 
+    /// Path to the directory where the Xcode project will be generated.
+    public var sourceRootPath: AbsolutePath
+
     /// Project name.
     public var name: String
 
@@ -54,6 +57,7 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
     ///
     /// - Parameters:
     ///   - path: Path to the folder that contains the project manifest.
+    ///   - sourceRootPath: Path to the directory where the Xcode project will be generated.
     ///   - name: Project name.
     ///   - organizationName: Organization name.
     ///   - settings: The settings to apply at the project level
@@ -62,6 +66,7 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
     ///   - additionalFiles: The additional files to include in the project
     ///                      *(Those won't be included in any build phases)*
     public init(path: AbsolutePath,
+                sourceRootPath: AbsolutePath,
                 name: String,
                 organizationName: String?,
                 fileName: String?,
@@ -72,6 +77,7 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
                 schemes: [Scheme],
                 additionalFiles: [FileElement]) {
         self.path = path
+        self.sourceRootPath = sourceRootPath
         self.name = name
         self.organizationName = organizationName
         self.fileName = fileName ?? name
@@ -142,6 +148,7 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
     /// - Parameter targets: Targets to be set to the copy.
     public func with(targets: [Target]) -> Project {
         Project(path: path,
+                sourceRootPath: sourceRootPath,
                 name: name,
                 organizationName: organizationName,
                 fileName: fileName,
@@ -157,6 +164,7 @@ public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebug
     /// - Parameter schemes: Schemes to be set to the copy.
     public func with(schemes: [Scheme]) -> Project {
         Project(path: path,
+                sourceRootPath: sourceRootPath,
                 name: name,
                 organizationName: organizationName,
                 fileName: fileName,

--- a/Sources/TuistCoreTesting/Models/Project+TestData.swift
+++ b/Sources/TuistCoreTesting/Models/Project+TestData.swift
@@ -4,6 +4,7 @@ import TSCBasic
 
 public extension Project {
     static func test(path: AbsolutePath = AbsolutePath("/Project"),
+                     sourceRootPath: AbsolutePath = AbsolutePath("/Project"),
                      name: String = "Project",
                      organizationName: String? = nil,
                      fileName: String? = nil,
@@ -14,6 +15,7 @@ public extension Project {
                      schemes: [Scheme] = [],
                      additionalFiles: [FileElement] = []) -> Project {
         Project(path: path,
+                sourceRootPath: sourceRootPath,
                 name: name,
                 organizationName: organizationName,
                 fileName: fileName,
@@ -26,6 +28,7 @@ public extension Project {
     }
 
     static func empty(path: AbsolutePath = AbsolutePath("/test/"),
+                      sourceRootPath: AbsolutePath = AbsolutePath("/test/"),
                       name: String = "Project",
                       organizationName: String? = nil,
                       fileName: String? = nil,
@@ -36,6 +39,7 @@ public extension Project {
                       schemes: [Scheme] = [],
                       additionalFiles: [FileElement] = []) -> Project {
         Project(path: path,
+                sourceRootPath: sourceRootPath,
                 name: name,
                 organizationName: organizationName,
                 fileName: fileName,

--- a/Sources/TuistCoreTesting/Models/Project+TestData.swift
+++ b/Sources/TuistCoreTesting/Models/Project+TestData.swift
@@ -5,9 +5,9 @@ import TSCBasic
 public extension Project {
     static func test(path: AbsolutePath = AbsolutePath("/Project"),
                      sourceRootPath: AbsolutePath = AbsolutePath("/Project"),
+                     xcodeProjPath: AbsolutePath = AbsolutePath("/Project/Project.xcodeproj"),
                      name: String = "Project",
                      organizationName: String? = nil,
-                     fileName: String? = nil,
                      settings: Settings = Settings.test(),
                      filesGroup: ProjectGroup = .group(name: "Project"),
                      targets: [Target] = [Target.test()],
@@ -16,9 +16,9 @@ public extension Project {
                      additionalFiles: [FileElement] = []) -> Project {
         Project(path: path,
                 sourceRootPath: sourceRootPath,
+                xcodeProjPath: xcodeProjPath,
                 name: name,
                 organizationName: organizationName,
-                fileName: fileName,
                 settings: settings,
                 filesGroup: filesGroup,
                 targets: targets,
@@ -29,9 +29,9 @@ public extension Project {
 
     static func empty(path: AbsolutePath = AbsolutePath("/test/"),
                       sourceRootPath: AbsolutePath = AbsolutePath("/test/"),
+                      xcodeProjPath: AbsolutePath = AbsolutePath("/test/text.xcodeproj"),
                       name: String = "Project",
                       organizationName: String? = nil,
-                      fileName: String? = nil,
                       settings: Settings = .default,
                       filesGroup: ProjectGroup = .group(name: "Project"),
                       targets: [Target] = [],
@@ -40,9 +40,9 @@ public extension Project {
                       additionalFiles: [FileElement] = []) -> Project {
         Project(path: path,
                 sourceRootPath: sourceRootPath,
+                xcodeProjPath: xcodeProjPath,
                 name: name,
                 organizationName: organizationName,
-                fileName: fileName,
                 settings: settings,
                 filesGroup: filesGroup,
                 targets: targets,

--- a/Sources/TuistGenerator/Generator/DescriptorGenerator.swift
+++ b/Sources/TuistGenerator/Generator/DescriptorGenerator.swift
@@ -8,15 +8,11 @@ import TuistSupport
 /// Allow specifying additional generation options
 /// for an individual project.
 public struct ProjectGenerationConfig {
-    /// The source root path of the generated Xcode project
-    public var sourceRootPath: AbsolutePath?
-
     /// The xcodeproj file path
     public var xcodeprojPath: AbsolutePath?
 
-    public init(sourceRootPath: AbsolutePath? = nil,
+    public init(sourceRootPath _: AbsolutePath? = nil,
                 xcodeprojPath: AbsolutePath? = nil) {
-        self.sourceRootPath = sourceRootPath
         self.xcodeprojPath = xcodeprojPath
     }
 }
@@ -89,17 +85,11 @@ public final class DescriptorGenerator: DescriptorGenerating {
     }
 
     public func generateProject(project: Project, graph: Graph) throws -> ProjectDescriptor {
-        try projectGenerator.generate(project: project,
-                                      graph: graph,
-                                      sourceRootPath: nil,
-                                      xcodeprojPath: nil)
+        try projectGenerator.generate(project: project, graph: graph)
     }
 
-    public func generateProject(project: Project, graph: Graph, config: ProjectGenerationConfig) throws -> ProjectDescriptor {
-        try projectGenerator.generate(project: project,
-                                      graph: graph,
-                                      sourceRootPath: config.sourceRootPath,
-                                      xcodeprojPath: config.xcodeprojPath)
+    public func generateProject(project: Project, graph: Graph, config _: ProjectGenerationConfig) throws -> ProjectDescriptor {
+        try projectGenerator.generate(project: project, graph: graph)
     }
 
     public func generateWorkspace(workspace: Workspace, graph: Graph) throws -> WorkspaceDescriptor {

--- a/Sources/TuistGenerator/Generator/DescriptorGenerator.swift
+++ b/Sources/TuistGenerator/Generator/DescriptorGenerator.swift
@@ -3,20 +3,6 @@ import TSCBasic
 import TuistCore
 import TuistSupport
 
-/// Project Generation Configuration
-///
-/// Allow specifying additional generation options
-/// for an individual project.
-public struct ProjectGenerationConfig {
-    /// The xcodeproj file path
-    public var xcodeprojPath: AbsolutePath?
-
-    public init(sourceRootPath _: AbsolutePath? = nil,
-                xcodeprojPath: AbsolutePath? = nil) {
-        self.xcodeprojPath = xcodeprojPath
-    }
-}
-
 /// Descriptor Generator
 ///
 /// This component genertes`XcodeProj` representations of a given graph model.
@@ -35,16 +21,6 @@ public protocol DescriptorGenerating {
     ///
     /// - Seealso: `GraphLoader`
     func generateProject(project: Project, graph: Graph) throws -> ProjectDescriptor
-
-    /// Generate an individual project descriptor with some additional configuration
-    ///
-    /// - Parameters:
-    ///   - project: Project model
-    ///   - graph: Graph model
-    ///   - config: The project generation configuration
-    ///
-    /// - Seealso: `GraphLoader`
-    func generateProject(project: Project, graph: Graph, config: ProjectGenerationConfig) throws -> ProjectDescriptor
 
     /// Generate a workspace descriptor
     ///
@@ -85,10 +61,6 @@ public final class DescriptorGenerator: DescriptorGenerating {
     }
 
     public func generateProject(project: Project, graph: Graph) throws -> ProjectDescriptor {
-        try projectGenerator.generate(project: project, graph: graph)
-    }
-
-    public func generateProject(project: Project, graph: Graph, config _: ProjectGenerationConfig) throws -> ProjectDescriptor {
         try projectGenerator.generate(project: project, graph: graph)
     }
 

--- a/Sources/TuistGenerator/Generator/Generator.swift
+++ b/Sources/TuistGenerator/Generator/Generator.swift
@@ -23,9 +23,7 @@ public protocol Generating {
     /// - Parameters:
     ///     - project: The project to be generated.
     ///     - graph: The dependencies graph.
-    ///     - sourceRootPath: The path all the files in the Xcode project will be realtived to. When it's nil, it's assumed that all the paths are relative to the directory that contains the manifest.
-    ///     - xcodeprojPath: Path where the .xcodeproj directory will be generated. When the attribute is nil, the project is generated in the manifest's directory.
-    func generateProject(_ project: Project, graph: Graph, sourceRootPath: AbsolutePath?, xcodeprojPath: AbsolutePath?) throws -> AbsolutePath
+    func generateProject(_ project: Project, graph: Graph) throws -> AbsolutePath
 
     /// Generate an Xcode workspace for the project at a given path. All the project's dependencies will also be generated and included.
     ///
@@ -123,10 +121,7 @@ public class Generator: Generating {
         self.swiftPackageManagerInteractor = swiftPackageManagerInteractor
     }
 
-    public func generateProject(_ project: Project,
-                                graph: Graph,
-                                sourceRootPath _: AbsolutePath? = nil,
-                                xcodeprojPath _: AbsolutePath? = nil) throws -> AbsolutePath {
+    public func generateProject(_ project: Project, graph: Graph) throws -> AbsolutePath {
         let descriptor = try projectGenerator.generate(project: project, graph: graph)
 
         try writer.write(project: descriptor)

--- a/Sources/TuistGenerator/Generator/Generator.swift
+++ b/Sources/TuistGenerator/Generator/Generator.swift
@@ -125,16 +125,9 @@ public class Generator: Generating {
 
     public func generateProject(_ project: Project,
                                 graph: Graph,
-                                sourceRootPath: AbsolutePath? = nil,
-                                xcodeprojPath: AbsolutePath? = nil) throws -> AbsolutePath {
-        /// When the source root path is not given, we assume paths
-        /// are relative to the directory that contains the manifest.
-        let sourceRootPath = sourceRootPath ?? project.path
-
-        let descriptor = try projectGenerator.generate(project: project,
-                                                       graph: graph,
-                                                       sourceRootPath: sourceRootPath,
-                                                       xcodeprojPath: xcodeprojPath)
+                                sourceRootPath _: AbsolutePath? = nil,
+                                xcodeprojPath _: AbsolutePath? = nil) throws -> AbsolutePath {
+        let descriptor = try projectGenerator.generate(project: project, graph: graph)
 
         try writer.write(project: descriptor)
         return descriptor.xcodeprojPath
@@ -147,10 +140,7 @@ public class Generator: Generating {
         let (graph, project) = try graphLoader.loadProject(path: path)
         try graphLinter.lint(graph: graph).printAndThrowIfNeeded()
 
-        let descriptor = try projectGenerator.generate(project: project,
-                                                       graph: graph,
-                                                       sourceRootPath: path,
-                                                       xcodeprojPath: nil)
+        let descriptor = try projectGenerator.generate(project: project, graph: graph)
 
         try writer.write(project: descriptor)
         return (descriptor.xcodeprojPath, graph)

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -46,8 +46,7 @@ class ProjectFileElements {
     func generateProjectFiles(project: Project,
                               graph: Graph,
                               groups: ProjectGroups,
-                              pbxproj: PBXProj,
-                              sourceRootPath: AbsolutePath) throws {
+                              pbxproj: PBXProj) throws {
         var files = Set<GroupFileElement>()
 
         try project.targets.forEach { target in
@@ -64,13 +63,13 @@ class ProjectFileElements {
         try generate(files: sortedFiles,
                      groups: groups,
                      pbxproj: pbxproj,
-                     sourceRootPath: sourceRootPath)
+                     sourceRootPath: project.sourceRootPath)
 
         /// Playgrounds
         generatePlaygrounds(path: project.path,
                             groups: groups,
                             pbxproj: pbxproj,
-                            sourceRootPath: sourceRootPath)
+                            sourceRootPath: project.sourceRootPath)
 
         // Products
         let directProducts = project.targets.map {
@@ -83,7 +82,7 @@ class ProjectFileElements {
         try generate(dependencyReferences: Set(directProducts + dependencies),
                      groups: groups,
                      pbxproj: pbxproj,
-                     sourceRootPath: sourceRootPath,
+                     sourceRootPath: project.sourceRootPath,
                      filesGroup: project.filesGroup)
     }
 

--- a/Sources/TuistGenerator/Generator/ProjectGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGenerator.swift
@@ -65,16 +65,13 @@ final class ProjectGenerator: ProjectGenerating {
                   graph: Graph) throws -> ProjectDescriptor {
         logger.notice("Generating project \(project.name)")
 
-        // If the xcodeproj path is not given, we generate it under the source root path.
-        let xcodeprojPath = project.sourceRootPath.appending(component: "\(project.fileName).xcodeproj")
-
         let workspaceData = XCWorkspaceData(children: [])
         let workspace = XCWorkspace(data: workspaceData)
         let projectConstants = try determineProjectConstants(graph: graph)
         let pbxproj = PBXProj(objectVersion: projectConstants.objectVersion,
                               archiveVersion: projectConstants.archiveVersion,
                               classes: [:])
-        let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj, xcodeprojPath: xcodeprojPath, sourceRootPath: project.sourceRootPath)
+        let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
         let fileElements = ProjectFileElements()
         try fileElements.generateProjectFiles(project: project,
                                               graph: graph,
@@ -102,9 +99,9 @@ final class ProjectGenerator: ProjectGenerating {
                                            pbxProject: pbxProject)
 
         let generatedProject = GeneratedProject(pbxproj: pbxproj,
-                                                path: xcodeprojPath,
+                                                path: project.xcodeProjPath,
                                                 targets: nativeTargets,
-                                                name: xcodeprojPath.basename)
+                                                name: project.xcodeProjPath.basename)
 
         let schemes = try schemesGenerator.generateProjectSchemes(project: project,
                                                                   generatedProject: generatedProject,
@@ -112,7 +109,7 @@ final class ProjectGenerator: ProjectGenerating {
 
         let xcodeProj = XcodeProj(workspace: workspace, pbxproj: pbxproj)
         return ProjectDescriptor(path: project.path,
-                                 xcodeprojPath: xcodeprojPath,
+                                 xcodeprojPath: project.xcodeProjPath,
                                  xcodeProj: xcodeProj,
                                  schemeDescriptors: schemes,
                                  sideEffectDescriptors: [])

--- a/Sources/TuistGenerator/Generator/ProjectGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGenerator.swift
@@ -26,13 +26,8 @@ protocol ProjectGenerating: AnyObject {
     /// - Parameters:
     ///   - project: Project to be generated.
     ///   - graph: Dependencies graph.
-    ///   - sourceRootPath: Directory where the files are relative to.
-    ///   - xcodeprojPath: Path to the Xcode project. When not given, the xcodeproj is generated at sourceRootPath.
     /// - Returns: Generated project descriptor
-    func generate(project: Project,
-                  graph: Graph,
-                  sourceRootPath: AbsolutePath?,
-                  xcodeprojPath: AbsolutePath?) throws -> ProjectDescriptor
+    func generate(project: Project, graph: Graph) throws -> ProjectDescriptor
 }
 
 final class ProjectGenerator: ProjectGenerating {
@@ -67,16 +62,11 @@ final class ProjectGenerator: ProjectGenerating {
 
     // swiftlint:disable:next function_body_length
     func generate(project: Project,
-                  graph: Graph,
-                  sourceRootPath: AbsolutePath? = nil,
-                  xcodeprojPath: AbsolutePath? = nil) throws -> ProjectDescriptor {
+                  graph: Graph) throws -> ProjectDescriptor {
         logger.notice("Generating project \(project.name)")
 
-        // Getting the path.
-        let sourceRootPath = sourceRootPath ?? project.path
-
         // If the xcodeproj path is not given, we generate it under the source root path.
-        let xcodeprojPath = xcodeprojPath ?? sourceRootPath.appending(component: "\(project.fileName).xcodeproj")
+        let xcodeprojPath = project.sourceRootPath.appending(component: "\(project.fileName).xcodeproj")
 
         let workspaceData = XCWorkspaceData(children: [])
         let workspace = XCWorkspace(data: workspaceData)
@@ -84,13 +74,12 @@ final class ProjectGenerator: ProjectGenerating {
         let pbxproj = PBXProj(objectVersion: projectConstants.objectVersion,
                               archiveVersion: projectConstants.archiveVersion,
                               classes: [:])
-        let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj, xcodeprojPath: xcodeprojPath, sourceRootPath: sourceRootPath)
+        let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj, xcodeprojPath: xcodeprojPath, sourceRootPath: project.sourceRootPath)
         let fileElements = ProjectFileElements()
         try fileElements.generateProjectFiles(project: project,
                                               graph: graph,
                                               groups: groups,
-                                              pbxproj: pbxproj,
-                                              sourceRootPath: sourceRootPath)
+                                              pbxproj: pbxproj)
         let configurationList = try configGenerator.generateProjectConfig(project: project, pbxproj: pbxproj, fileElements: fileElements)
         let pbxProject = try generatePbxproject(project: project,
                                                 projectFileElements: fileElements,
@@ -102,7 +91,6 @@ final class ProjectGenerator: ProjectGenerating {
                                                 pbxproj: pbxproj,
                                                 pbxProject: pbxProject,
                                                 fileElements: fileElements,
-                                                sourceRootPath: sourceRootPath,
                                                 graph: graph)
 
         generateTestTargetIdentity(project: project,
@@ -162,7 +150,6 @@ final class ProjectGenerator: ProjectGenerating {
                                  pbxproj: PBXProj,
                                  pbxProject: PBXProject,
                                  fileElements: ProjectFileElements,
-                                 sourceRootPath: AbsolutePath,
                                  graph: Graph) throws -> [String: PBXNativeTarget] {
         var nativeTargets: [String: PBXNativeTarget] = [:]
         try project.targets.forEach { target in
@@ -173,7 +160,6 @@ final class ProjectGenerator: ProjectGenerating {
                                                                   projectSettings: project.settings,
                                                                   fileElements: fileElements,
                                                                   path: project.path,
-                                                                  sourceRootPath: sourceRootPath,
                                                                   graph: graph)
             nativeTargets[target.name] = nativeTarget
         }

--- a/Sources/TuistGenerator/Generator/ProjectGroups.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGroups.swift
@@ -66,11 +66,9 @@ class ProjectGroups {
 
     static func generate(project: Project,
                          pbxproj: PBXProj,
-                         xcodeprojPath: AbsolutePath,
-                         sourceRootPath: AbsolutePath,
                          playgrounds: Playgrounding = Playgrounds()) -> ProjectGroups {
         /// Main
-        let projectRelativePath = sourceRootPath.relative(to: xcodeprojPath.parentDirectory).pathString
+        let projectRelativePath = project.sourceRootPath.relative(to: project.xcodeProjPath.parentDirectory).pathString
         let mainGroup = PBXGroup(children: [],
                                  sourceTree: .group,
                                  path: (projectRelativePath != ".") ? projectRelativePath : nil)

--- a/Sources/TuistGenerator/Generator/TargetGenerator.swift
+++ b/Sources/TuistGenerator/Generator/TargetGenerator.swift
@@ -12,7 +12,6 @@ protocol TargetGenerating: AnyObject {
                         projectSettings: Settings,
                         fileElements: ProjectFileElements,
                         path: AbsolutePath,
-                        sourceRootPath: AbsolutePath,
                         graph: Graph) throws -> PBXNativeTarget
 
     func generateTargetDependencies(path: AbsolutePath,
@@ -51,7 +50,6 @@ final class TargetGenerator: TargetGenerating {
                         projectSettings: Settings,
                         fileElements: ProjectFileElements,
                         path: AbsolutePath,
-                        sourceRootPath: AbsolutePath,
                         graph: Graph) throws -> PBXNativeTarget {
         /// Products reference.
         let productFileReference = fileElements.products[target.name]!
@@ -73,7 +71,7 @@ final class TargetGenerator: TargetGenerating {
         try buildPhaseGenerator.generateActions(actions: target.actions.preActions,
                                                 pbxTarget: pbxTarget,
                                                 pbxproj: pbxproj,
-                                                sourceRootPath: sourceRootPath)
+                                                sourceRootPath: project.sourceRootPath)
 
         /// Build configuration
         try configGenerator.generateTargetConfig(target,
@@ -83,7 +81,7 @@ final class TargetGenerator: TargetGenerating {
                                                  projectSettings: projectSettings,
                                                  fileElements: fileElements,
                                                  graph: graph,
-                                                 sourceRootPath: sourceRootPath)
+                                                 sourceRootPath: project.sourceRootPath)
 
         /// Build phases
         try buildPhaseGenerator.generateBuildPhases(path: path,
@@ -92,7 +90,7 @@ final class TargetGenerator: TargetGenerating {
                                                     pbxTarget: pbxTarget,
                                                     fileElements: fileElements,
                                                     pbxproj: pbxproj,
-                                                    sourceRootPath: sourceRootPath)
+                                                    sourceRootPath: project.sourceRootPath)
 
         /// Links
         try linkGenerator.generateLinks(target: target,
@@ -100,14 +98,14 @@ final class TargetGenerator: TargetGenerating {
                                         pbxproj: pbxproj,
                                         fileElements: fileElements,
                                         path: path,
-                                        sourceRootPath: sourceRootPath,
+                                        sourceRootPath: project.sourceRootPath,
                                         graph: graph)
 
         /// Post actions
         try buildPhaseGenerator.generateActions(actions: target.actions.postActions,
                                                 pbxTarget: pbxTarget,
                                                 pbxproj: pbxproj,
-                                                sourceRootPath: sourceRootPath)
+                                                sourceRootPath: project.sourceRootPath)
         return pbxTarget
     }
 

--- a/Sources/TuistGenerator/Generator/WorkspaceGenerator.swift
+++ b/Sources/TuistGenerator/Generator/WorkspaceGenerator.swift
@@ -85,10 +85,7 @@ final class WorkspaceGenerator: WorkspaceGenerating {
 
         /// Projects
         let projects = try Array(graph.projects).compactMap(context: config.projectGenerationContext) { project -> ProjectDescriptor? in
-            try projectGenerator.generate(project: project,
-                                          graph: graph,
-                                          sourceRootPath: project.path,
-                                          xcodeprojPath: nil)
+            try projectGenerator.generate(project: project, graph: graph)
         }
 
         let generatedProjects: [AbsolutePath: GeneratedProject] = Dictionary(uniqueKeysWithValues: projects.map { project in

--- a/Sources/TuistGeneratorTesting/Generator/MockDescriptorGenerator.swift
+++ b/Sources/TuistGeneratorTesting/Generator/MockDescriptorGenerator.swift
@@ -18,15 +18,6 @@ final class MockDescriptorGenerator: DescriptorGenerating {
         return try generateProjectSub(project, graph)
     }
 
-    var generateProjectWithConfigStub: ((Project, Graph, ProjectGenerationConfig) throws -> ProjectDescriptor)?
-    func generateProject(project: Project, graph: Graph, config: ProjectGenerationConfig) throws -> ProjectDescriptor {
-        guard let generateProjectWithConfigStub = generateProjectWithConfigStub else {
-            throw MockError.stubNotImplemented
-        }
-
-        return try generateProjectWithConfigStub(project, graph, config)
-    }
-
     var generateWorkspaceStub: ((Workspace, Graph) throws -> WorkspaceDescriptor)?
     func generateWorkspace(workspace: Workspace, graph: Graph) throws -> WorkspaceDescriptor {
         guard let generateWorkspaceStub = generateWorkspaceStub else {

--- a/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
@@ -112,6 +112,7 @@ final class ProjectEditor: ProjectEditing {
 
         let (project, graph) = try projectEditorMapper.map(tuistPath: tuistPath,
                                                            sourceRootPath: at,
+                                                           xcodeProjPath: xcodeprojPath,
                                                            manifests: manifests.map { $0.1 },
                                                            helpers: helpers,
                                                            templates: templates,
@@ -119,12 +120,7 @@ final class ProjectEditor: ProjectEditing {
 
         let (mappedProject, sideEffects) = try projectMapper.map(project: project)
         try sideEffectDescriptorExecutor.execute(sideEffects: sideEffects)
-
-        let config = ProjectGenerationConfig(sourceRootPath: project.path,
-                                             xcodeprojPath: xcodeprojPath)
-        let descriptor = try generator.generateProject(project: mappedProject,
-                                                       graph: graph,
-                                                       config: config)
+        let descriptor = try generator.generateProject(project: mappedProject, graph: graph)
         try writer.write(project: descriptor)
         return descriptor.xcodeprojPath
     }

--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -77,6 +77,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
 
         // Project
         let project = Project(path: sourceRootPath,
+                              sourceRootPath: sourceRootPath,
                               name: "Manifests",
                               organizationName: nil,
                               fileName: nil,

--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -6,6 +6,7 @@ import TuistSupport
 protocol ProjectEditorMapping: AnyObject {
     func map(tuistPath: AbsolutePath,
              sourceRootPath: AbsolutePath,
+             xcodeProjPath: AbsolutePath,
              manifests: [AbsolutePath],
              helpers: [AbsolutePath],
              templates: [AbsolutePath],
@@ -16,6 +17,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
     // swiftlint:disable:next function_body_length
     func map(tuistPath: AbsolutePath,
              sourceRootPath: AbsolutePath,
+             xcodeProjPath: AbsolutePath,
              manifests: [AbsolutePath],
              helpers: [AbsolutePath],
              templates: [AbsolutePath],
@@ -78,9 +80,9 @@ final class ProjectEditorMapper: ProjectEditorMapping {
         // Project
         let project = Project(path: sourceRootPath,
                               sourceRootPath: sourceRootPath,
+                              xcodeProjPath: xcodeProjPath,
                               name: "Manifests",
                               organizationName: nil,
-                              fileName: nil,
                               settings: projectSettings,
                               filesGroup: .group(name: "Manifests"),
                               targets: targets,

--- a/Sources/TuistLoader/Loaders/GeneratorModelLoader.swift
+++ b/Sources/TuistLoader/Loaders/GeneratorModelLoader.swift
@@ -94,8 +94,11 @@ extension GeneratorModelLoader {
         var enrichedModel = model
 
         // Xcode project file name
-        let xcodeFileName = xcodeFileNameOverride(from: config, for: model)
-        enrichedModel = enrichedModel.replacing(fileName: xcodeFileName)
+        var xcodeProjPath: AbsolutePath = enrichedModel.xcodeProjPath
+        if let xcodeFileName = xcodeFileNameOverride(from: config, for: model) {
+            xcodeProjPath = enrichedModel.xcodeProjPath.parentDirectory.appending(component: xcodeFileName)
+        }
+        enrichedModel = enrichedModel.replacing(xcodeProjPath: xcodeProjPath)
 
         // Xcode project organization name
         if let organizationName = organizationNameOverride(from: config) {

--- a/Sources/TuistLoader/Loaders/GeneratorModelLoader.swift
+++ b/Sources/TuistLoader/Loaders/GeneratorModelLoader.swift
@@ -96,7 +96,7 @@ extension GeneratorModelLoader {
         // Xcode project file name
         var xcodeProjPath: AbsolutePath = enrichedModel.xcodeProjPath
         if let xcodeFileName = xcodeFileNameOverride(from: config, for: model) {
-            xcodeProjPath = enrichedModel.xcodeProjPath.parentDirectory.appending(component: xcodeFileName)
+            xcodeProjPath = enrichedModel.xcodeProjPath.parentDirectory.appending(component: "\(xcodeFileName).xcodeproj")
         }
         enrichedModel = enrichedModel.replacing(xcodeProjPath: xcodeProjPath)
 

--- a/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
@@ -19,6 +19,7 @@ extension TuistCore.Project {
         let additionalFiles = try manifest.additionalFiles.flatMap { try TuistCore.FileElement.from(manifest: $0, generatorPaths: generatorPaths) }
         let packages = try manifest.packages.map { try TuistCore.Package.from(manifest: $0, generatorPaths: generatorPaths) }
         return Project(path: generatorPaths.manifestDirectory,
+                       sourceRootPath: generatorPaths.manifestDirectory,
                        name: name,
                        organizationName: organizationName,
                        fileName: nil,
@@ -32,6 +33,7 @@ extension TuistCore.Project {
 
     func adding(target: TuistCore.Target) -> TuistCore.Project {
         Project(path: path,
+                sourceRootPath: sourceRootPath,
                 name: name,
                 organizationName: organizationName,
                 fileName: fileName,
@@ -45,6 +47,7 @@ extension TuistCore.Project {
 
     func replacing(fileName: String?) -> TuistCore.Project {
         Project(path: path,
+                sourceRootPath: sourceRootPath,
                 name: name,
                 organizationName: organizationName,
                 fileName: fileName,
@@ -58,6 +61,7 @@ extension TuistCore.Project {
 
     func replacing(organizationName: String?) -> TuistCore.Project {
         Project(path: path,
+                sourceRootPath: sourceRootPath,
                 name: name,
                 organizationName: organizationName,
                 fileName: fileName,

--- a/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
@@ -20,9 +20,9 @@ extension TuistCore.Project {
         let packages = try manifest.packages.map { try TuistCore.Package.from(manifest: $0, generatorPaths: generatorPaths) }
         return Project(path: generatorPaths.manifestDirectory,
                        sourceRootPath: generatorPaths.manifestDirectory,
+                       xcodeProjPath: generatorPaths.manifestDirectory.appending(component: "\(name).xcodeproj"),
                        name: name,
                        organizationName: organizationName,
-                       fileName: nil,
                        settings: settings ?? .default,
                        filesGroup: .group(name: "Project"),
                        targets: targets,
@@ -34,9 +34,9 @@ extension TuistCore.Project {
     func adding(target: TuistCore.Target) -> TuistCore.Project {
         Project(path: path,
                 sourceRootPath: sourceRootPath,
+                xcodeProjPath: xcodeProjPath,
                 name: name,
                 organizationName: organizationName,
-                fileName: fileName,
                 settings: settings,
                 filesGroup: filesGroup,
                 targets: targets + [target],
@@ -45,12 +45,12 @@ extension TuistCore.Project {
                 additionalFiles: additionalFiles)
     }
 
-    func replacing(fileName: String?) -> TuistCore.Project {
+    func replacing(xcodeProjPath: AbsolutePath) -> TuistCore.Project {
         Project(path: path,
                 sourceRootPath: sourceRootPath,
+                xcodeProjPath: xcodeProjPath,
                 name: name,
                 organizationName: organizationName,
-                fileName: fileName,
                 settings: settings,
                 filesGroup: filesGroup,
                 targets: targets,
@@ -62,9 +62,9 @@ extension TuistCore.Project {
     func replacing(organizationName: String?) -> TuistCore.Project {
         Project(path: path,
                 sourceRootPath: sourceRootPath,
+                xcodeProjPath: xcodeProjPath,
                 name: name,
                 organizationName: organizationName,
-                fileName: fileName,
                 settings: settings,
                 filesGroup: filesGroup,
                 targets: targets,

--- a/Tests/TuistCoreTests/Models/ProjectTests.swift
+++ b/Tests/TuistCoreTests/Models/ProjectTests.swift
@@ -32,23 +32,6 @@ final class ProjectTests: XCTestCase {
         XCTAssertEqual(got[3], frameworkTests)
     }
 
-    func test_projectDefaultFileName() {
-        // Given
-        let framework = Target.test(name: "Framework", product: .framework)
-        let app = Target.test(name: "App", product: .app)
-        let appTests = Target.test(name: "AppTests", product: .unitTests)
-        let frameworkTests = Target.test(name: "FrameworkTests", product: .unitTests)
-
-        // When
-        let project = Project.test(name: "SomeProjectName", targets: [
-            framework, app, appTests, frameworkTests,
-        ])
-
-        // Then
-        XCTAssertEqual(project.fileName, "SomeProjectName")
-        XCTAssertEqual(project.name, "SomeProjectName")
-    }
-
     func test_defaultDebugBuildConfigurationName_when_defaultDebugConfigExists() {
         // Given
         let project = Project.test(settings: Settings.test())

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -354,14 +354,14 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
                                  entitlements: AbsolutePath("/Test.entitlements"),
                                  settings: Settings(base: ["Base": "Base"], configurations: configurations))
         let project = Project.test(path: dir,
+                                   sourceRootPath: dir,
+                                   xcodeProjPath: dir.appending(component: "Project.xcodeproj"),
                                    name: "Test",
                                    settings: .default,
                                    targets: [target])
+
         let fileElements = ProjectFileElements()
-        let groups = ProjectGroups.generate(project: project,
-                                            pbxproj: pbxproj,
-                                            xcodeprojPath: project.path.appending(component: "\(project.fileName).xcodeproj"),
-                                            sourceRootPath: dir)
+        let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
         let graph = Graph.test()
         try fileElements.generateProjectFiles(project: project,
                                               graph: graph,

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -366,8 +366,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         try fileElements.generateProjectFiles(project: project,
                                               graph: graph,
                                               groups: groups,
-                                              pbxproj: pbxproj,
-                                              sourceRootPath: project.path)
+                                              pbxproj: pbxproj)
         _ = try subject.generateTargetConfig(target,
                                              project: project,
                                              pbxTarget: pbxTarget,

--- a/Tests/TuistGeneratorTests/Generator/Mocks/MockProjectGenerator.swift
+++ b/Tests/TuistGeneratorTests/Generator/Mocks/MockProjectGenerator.swift
@@ -12,13 +12,13 @@ final class MockProjectGenerator: ProjectGenerating {
     }
 
     var generatedProjects: [Project] = []
-    var generateStub: ((Project, Graph, AbsolutePath?, AbsolutePath?) throws -> ProjectDescriptor)?
+    var generateStub: ((Project, Graph) throws -> ProjectDescriptor)?
 
-    func generate(project: Project, graph: Graph, sourceRootPath: AbsolutePath?, xcodeprojPath: AbsolutePath?) throws -> ProjectDescriptor {
+    func generate(project: Project, graph: Graph) throws -> ProjectDescriptor {
         guard let generateStub = generateStub else {
             throw MockError.stubNotImplemented
         }
         generatedProjects.append(project)
-        return try generateStub(project, graph, sourceRootPath, xcodeprojPath)
+        return try generateStub(project, graph)
     }
 }

--- a/Tests/TuistGeneratorTests/Generator/Mocks/MockTargetGenerator.swift
+++ b/Tests/TuistGeneratorTests/Generator/Mocks/MockTargetGenerator.swift
@@ -9,7 +9,7 @@ import XcodeProj
 class MockTargetGenerator: TargetGenerating {
     var generateTargetStub: (() -> PBXNativeTarget)?
 
-    func generateTarget(target: Target, project _: Project, pbxproj _: PBXProj, pbxProject _: PBXProject, projectSettings _: Settings, fileElements _: ProjectFileElements, path _: AbsolutePath, sourceRootPath _: AbsolutePath, graph _: Graph) throws -> PBXNativeTarget {
+    func generateTarget(target: Target, project _: Project, pbxproj _: PBXProj, pbxProject _: PBXProject, projectSettings _: Settings, fileElements _: ProjectFileElements, path _: AbsolutePath, graph _: Graph) throws -> PBXNativeTarget {
         generateTargetStub?() ?? PBXNativeTarget(name: target.name)
     }
 

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -342,8 +342,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         try subject.generateProjectFiles(project: project,
                                          graph: graph,
                                          groups: groups,
-                                         pbxproj: pbxproj,
-                                         sourceRootPath: project.path)
+                                         pbxproj: pbxproj)
 
         // Then
         XCTAssertEqual(groups.products.flattenedChildren, [
@@ -377,8 +376,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
             try subject.generateProjectFiles(project: project,
                                              graph: graph,
                                              groups: groups,
-                                             pbxproj: pbxproj,
-                                             sourceRootPath: project.path)
+                                             pbxproj: pbxproj)
 
             // Then
             XCTAssertEqual(groups.products.flattenedChildren, [
@@ -408,8 +406,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         try subject.generateProjectFiles(project: project,
                                          graph: graph,
                                          groups: groups,
-                                         pbxproj: pbxproj,
-                                         sourceRootPath: project.path)
+                                         pbxproj: pbxproj)
 
         // Then
         let fileReference = subject.product(target: "App")
@@ -673,8 +670,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         try subject.generateProjectFiles(project: project,
                                          graph: graph,
                                          groups: groups,
-                                         pbxproj: pbxproj,
-                                         sourceRootPath: project.path)
+                                         pbxproj: pbxproj)
 
         // Then
         let projectGroup = groups.sortedMain.group(named: "Project")

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -17,10 +17,8 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         super.setUp()
         playgrounds = MockPlaygrounds()
         pbxproj = PBXProj()
-        groups = ProjectGroups.generate(project: .test(),
+        groups = ProjectGroups.generate(project: .test(path: "/path", sourceRootPath: "/path", xcodeProjPath: "/path/Project.xcodeproj"),
                                         pbxproj: pbxproj,
-                                        xcodeprojPath: "/path/Project.xcodeproj",
-                                        sourceRootPath: "/path",
                                         playgrounds: MockPlaygrounds())
 
         subject = ProjectFileElements(playgrounds: playgrounds)
@@ -327,16 +325,13 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
     func test_generateProduct() throws {
         // Given
         let pbxproj = PBXProj()
-        let project = Project.test(targets: [
+        let project = Project.test(path: .root, sourceRootPath: .root, xcodeProjPath: AbsolutePath.root.appending(component: "Project.xcodeproj"), targets: [
             .test(name: "App", product: .app),
             .test(name: "Framework", product: .framework),
             .test(name: "Library", product: .staticLibrary),
         ])
         let graph = Graph.test()
-        let groups = ProjectGroups.generate(project: project,
-                                            pbxproj: pbxproj,
-                                            xcodeprojPath: project.path.appending(component: "\(project.fileName).xcodeproj"),
-                                            sourceRootPath: project.path)
+        let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
 
         // When
         try subject.generateProjectFiles(project: project,
@@ -365,12 +360,12 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
                 .test(name: "Library2", product: .staticLibrary),
             ].shuffled()
 
-            let project = Project.test(targets: targets)
+            let project = Project.test(path: .root,
+                                       sourceRootPath: .root,
+                                       xcodeProjPath: AbsolutePath.root.appending(component: "Project.xcodeproj"),
+                                       targets: targets)
             let graph = Graph.test()
-            let groups = ProjectGroups.generate(project: project,
-                                                pbxproj: pbxproj,
-                                                xcodeprojPath: project.path.appending(component: "\(project.fileName).xcodeproj"),
-                                                sourceRootPath: project.path)
+            let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
 
             // When
             try subject.generateProjectFiles(project: project,
@@ -393,14 +388,14 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
     func test_generateProduct_fileReferencesProperties() throws {
         // Given
         let pbxproj = PBXProj()
-        let project = Project.test(targets: [
-            .test(name: "App", product: .app),
-        ])
+        let project = Project.test(path: .root,
+                                   sourceRootPath: .root,
+                                   xcodeProjPath: AbsolutePath.root.appending(component: "Project.xcodeproj"),
+                                   targets: [
+                                       .test(name: "App", product: .app),
+                                   ])
         let graph = Graph.test()
-        let groups = ProjectGroups.generate(project: project,
-                                            pbxproj: pbxproj,
-                                            xcodeprojPath: project.path.appending(component: "\(project.fileName).xcodeproj"),
-                                            sourceRootPath: project.path)
+        let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
 
         // When
         try subject.generateProjectFiles(project: project,
@@ -419,11 +414,12 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         let target = Target.test()
         let projectGroupName = "Project"
         let projectGroup: ProjectGroup = .group(name: projectGroupName)
-        let project = Project.test(path: AbsolutePath("/"), filesGroup: projectGroup, targets: [target])
-        let groups = ProjectGroups.generate(project: project,
-                                            pbxproj: pbxproj,
-                                            xcodeprojPath: project.path.appending(component: "\(project.fileName).xcodeproj"),
-                                            sourceRootPath: sourceRootPath)
+        let project = Project.test(path: .root,
+                                   sourceRootPath: .root,
+                                   xcodeProjPath: AbsolutePath.root.appending(component: "Project.xcodeproj"),
+                                   filesGroup: projectGroup,
+                                   targets: [target])
+        let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
         var dependencies: Set<GraphDependencyReference> = Set()
         let precompiledNode = GraphDependencyReference.testFramework(path: project.path.appending(component: "waka.framework"))
         dependencies.insert(precompiledNode)
@@ -445,12 +441,12 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         let pbxproj = PBXProj()
         let path = AbsolutePath("/a/b/c/file.swift")
         let fileElement = GroupFileElement(path: path, group: .group(name: "SomeGroup"))
-        let project = Project.test(filesGroup: .group(name: "SomeGroup"))
+        let project = Project.test(path: .root,
+                                   sourceRootPath: .root,
+                                   xcodeProjPath: AbsolutePath.root.appending(component: "Project.xcodeproj"),
+                                   filesGroup: .group(name: "SomeGroup"))
         let sourceRootPath = AbsolutePath("/a/project/")
-        let groups = ProjectGroups.generate(project: project,
-                                            pbxproj: pbxproj,
-                                            xcodeprojPath: project.path.appending(component: "\(project.fileName).xcodeproj"),
-                                            sourceRootPath: sourceRootPath)
+        let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
 
         // When
         try subject.generate(fileElement: fileElement,
@@ -554,12 +550,10 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
             }
         }
 
-        let project = Project.test(path: temporaryPath)
-        let groups = ProjectGroups.generate(project: project,
-                                            pbxproj: pbxproj,
-                                            xcodeprojPath: project.path.appending(component: "\(project.fileName).xcodeproj"),
-                                            sourceRootPath: temporaryPath,
-                                            playgrounds: playgrounds)
+        let project = Project.test(path: temporaryPath,
+                                   sourceRootPath: temporaryPath,
+                                   xcodeProjPath: temporaryPath.appending(component: "Project.xcodeproj"))
+        let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj, playgrounds: playgrounds)
 
         subject.generatePlaygrounds(path: temporaryPath,
                                     groups: groups,
@@ -619,12 +613,9 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
     func test_generateDependencies_sdks() throws {
         // Given
         let pbxproj = PBXProj()
-        let project = Project.test()
         let sourceRootPath = AbsolutePath("/a/project/")
-        let groups = ProjectGroups.generate(project: project,
-                                            pbxproj: pbxproj,
-                                            xcodeprojPath: project.path.appending(component: "\(project.fileName).xcodeproj"),
-                                            sourceRootPath: sourceRootPath)
+        let project = Project.test(path: sourceRootPath, sourceRootPath: sourceRootPath, xcodeProjPath: sourceRootPath.appending(component: "Project.xcodeproj"))
+        let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
 
         let sdk = try SDKNode(name: "ARKit.framework",
                               platform: .iOS,
@@ -657,10 +648,8 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         let project = Project.empty(path: "/a/project",
                                     targets: [target],
                                     packages: [.remote(url: "url", requirement: .branch("master"))])
-        let groups = ProjectGroups.generate(project: .test(),
-                                            pbxproj: pbxproj,
-                                            xcodeprojPath: project.path.appending(component: "\(project.fileName).xcodeproj"),
-                                            sourceRootPath: project.path)
+        let groups = ProjectGroups.generate(project: .test(path: .root, sourceRootPath: .root, xcodeProjPath: AbsolutePath.root.appending(component: "Project.xcodeproj")),
+                                            pbxproj: pbxproj)
 
         let package = PackageProductNode(product: "A", path: "/packages/url")
 

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -198,7 +198,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
 
         // Then
         let projectGroup = groups.sortedMain.group(named: "Project")
-        XCTAssertEqual(projectGroup?.flattenedChildren, [
+        XCTAssertEqual(projectGroup?.flattenedChildren.sorted(), [
             "myfolder/resources/assets.scnassets",
             "myfolder/resources/assets.xcassets",
         ])

--- a/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
@@ -66,21 +66,6 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
         }, "Test target is missing from target attributes.")
     }
 
-    func test_generate_testUsingFileName() throws {
-        // Given
-        let project = Project.test(name: "Project",
-                                   fileName: "SomeAwesomeName",
-                                   targets: [])
-        let graph = Graph.create(project: project,
-                                 dependencies: [])
-
-        // When
-        let got = try subject.generate(project: project, graph: graph)
-
-        // Then
-        XCTAssertEqual(got.xcodeprojPath.basename, "SomeAwesomeName.xcodeproj")
-    }
-
     func test_objectVersion_when_xcode11_and_spm() throws {
         xcodeController.selectedVersionStub = .success(Version(11, 0, 0))
 
@@ -88,7 +73,6 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
         let temporaryPath = try self.temporaryPath()
         let project = Project.test(path: temporaryPath,
                                    name: "Project",
-                                   fileName: "SomeAwesomeName",
                                    targets: [.test(dependencies: [.package(product: "A")])],
                                    packages: [.remote(url: "A", requirement: .exact("0.1"))])
 
@@ -118,7 +102,6 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
         let temporaryPath = try self.temporaryPath()
         let project = Project.test(path: temporaryPath,
                                    name: "Project",
-                                   fileName: "SomeAwesomeName",
                                    targets: [])
         let graph = Graph.test(entryPath: temporaryPath)
 
@@ -138,7 +121,6 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
         let temporaryPath = try self.temporaryPath()
         let project = Project.test(path: temporaryPath,
                                    name: "Project",
-                                   fileName: "SomeAwesomeName",
                                    targets: [])
         let graph = Graph.test(entryPath: temporaryPath)
 

--- a/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
@@ -33,6 +33,7 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
                                platform: .iOS,
                                product: .unitTests)
         let project = Project.test(path: temporaryPath,
+                                   sourceRootPath: temporaryPath,
                                    name: "Project",
                                    targets: [app, test])
 

--- a/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
@@ -23,9 +23,9 @@ final class ProjectGroupsTests: XCTestCase {
         sourceRootPath = AbsolutePath("/test/")
         project = Project(path: path,
                           sourceRootPath: path,
+                          xcodeProjPath: path.appending(component: "Project.xcodeproj"),
                           name: "Project",
                           organizationName: nil,
-                          fileName: nil,
                           settings: .default,
                           filesGroup: .group(name: "Project"),
                           targets: [
@@ -58,8 +58,6 @@ final class ProjectGroupsTests: XCTestCase {
         }
         subject = ProjectGroups.generate(project: project,
                                          pbxproj: pbxproj,
-                                         xcodeprojPath: project.path.appending(component: "\(project.fileName).xcodeproj"),
-                                         sourceRootPath: sourceRootPath,
                                          playgrounds: playgrounds)
 
         let main = subject.sortedMain
@@ -98,8 +96,6 @@ final class ProjectGroupsTests: XCTestCase {
         }
         subject = ProjectGroups.generate(project: project,
                                          pbxproj: pbxproj,
-                                         xcodeprojPath: project.path.appending(component: "\(project.fileName).xcodeproj"),
-                                         sourceRootPath: sourceRootPath,
                                          playgrounds: playgrounds)
 
         XCTAssertNil(subject.playgrounds)
@@ -121,8 +117,6 @@ final class ProjectGroupsTests: XCTestCase {
         // When
         subject = ProjectGroups.generate(project: project,
                                          pbxproj: pbxproj,
-                                         xcodeprojPath: project.path.appending(component: "\(project.fileName).xcodeproj"),
-                                         sourceRootPath: sourceRootPath,
                                          playgrounds: playgrounds)
 
         // Then
@@ -141,8 +135,6 @@ final class ProjectGroupsTests: XCTestCase {
     func test_targetFrameworks() throws {
         subject = ProjectGroups.generate(project: project,
                                          pbxproj: pbxproj,
-                                         xcodeprojPath: project.path.appending(component: "\(project.fileName).xcodeproj"),
-                                         sourceRootPath: sourceRootPath,
                                          playgrounds: playgrounds)
 
         let got = try subject.targetFrameworks(target: "Test")
@@ -155,8 +147,6 @@ final class ProjectGroupsTests: XCTestCase {
         // Given
         subject = ProjectGroups.generate(project: project,
                                          pbxproj: pbxproj,
-                                         xcodeprojPath: project.path.appending(component: "\(project.fileName).xcodeproj"),
-                                         sourceRootPath: sourceRootPath,
                                          playgrounds: playgrounds)
 
         // When / Then
@@ -169,13 +159,14 @@ final class ProjectGroupsTests: XCTestCase {
         let target1 = Target.test(filesGroup: .group(name: "A"))
         let target2 = Target.test(filesGroup: .group(name: "B"))
         let target3 = Target.test(filesGroup: .group(name: "B"))
-        let project = Project.test(filesGroup: .group(name: "P"),
+        let project = Project.test(path: .root,
+                                   sourceRootPath: .root,
+                                   xcodeProjPath: AbsolutePath.root.appending(component: "Project.xcodeproj"),
+                                   filesGroup: .group(name: "P"),
                                    targets: [target1, target2, target3])
 
         subject = ProjectGroups.generate(project: project,
                                          pbxproj: pbxproj,
-                                         xcodeprojPath: project.path.appending(component: "\(project.fileName).xcodeproj"),
-                                         sourceRootPath: sourceRootPath,
                                          playgrounds: playgrounds)
 
         // When / Then

--- a/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
@@ -22,6 +22,7 @@ final class ProjectGroupsTests: XCTestCase {
         playgrounds = MockPlaygrounds()
         sourceRootPath = AbsolutePath("/test/")
         project = Project(path: path,
+                          sourceRootPath: path,
                           name: "Project",
                           organizationName: nil,
                           fileName: nil,

--- a/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
@@ -51,12 +51,13 @@ final class TargetGeneratorTests: XCTestCase {
                                                   inputFileListPaths: ["/tmp/b"],
                                                   outputFileListPaths: ["/tmp/d"]),
                                  ])
-        let project = Project.test(path: path, targets: [target])
+        let project = Project.test(path: path,
+                                   sourceRootPath: path,
+                                   xcodeProjPath: path.appending(component: "Test.xcodeproj"),
+                                   targets: [target])
         let graph = Graph.test()
         let groups = ProjectGroups.generate(project: project,
                                             pbxproj: pbxproj,
-                                            xcodeprojPath: project.path.appending(component: "\(project.fileName).xcodeproj"),
-                                            sourceRootPath: path,
                                             playgrounds: MockPlaygrounds())
         try fileElements.generateProjectFiles(project: project,
                                               graph: graph,
@@ -128,11 +129,9 @@ final class TargetGeneratorTests: XCTestCase {
                                      TargetAction(name: "post", order: .post, path: path.appending(component: "script.sh"), arguments: ["arg"]),
                                      TargetAction(name: "pre", order: .pre, path: path.appending(component: "script.sh"), arguments: ["arg"]),
                                  ])
-        let project = Project.test(path: path, sourceRootPath: path, targets: [target])
+        let project = Project.test(path: path, sourceRootPath: path, xcodeProjPath: path.appending(component: "Project.xcodeproj"), targets: [target])
         let groups = ProjectGroups.generate(project: project,
                                             pbxproj: pbxproj,
-                                            xcodeprojPath: project.path.appending(component: "\(project.fileName).xcodeproj"),
-                                            sourceRootPath: path,
                                             playgrounds: MockPlaygrounds())
         try fileElements.generateProjectFiles(project: project,
                                               graph: graph,

--- a/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
@@ -61,8 +61,7 @@ final class TargetGeneratorTests: XCTestCase {
         try fileElements.generateProjectFiles(project: project,
                                               graph: graph,
                                               groups: groups,
-                                              pbxproj: pbxproj,
-                                              sourceRootPath: path)
+                                              pbxproj: pbxproj)
 
         // When
         let generatedTarget = try subject.generateTarget(target: target,
@@ -72,7 +71,6 @@ final class TargetGeneratorTests: XCTestCase {
                                                          projectSettings: Settings.test(),
                                                          fileElements: fileElements,
                                                          path: path,
-                                                         sourceRootPath: path,
                                                          graph: graph)
 
         // Then
@@ -139,8 +137,7 @@ final class TargetGeneratorTests: XCTestCase {
         try fileElements.generateProjectFiles(project: project,
                                               graph: graph,
                                               groups: groups,
-                                              pbxproj: pbxproj,
-                                              sourceRootPath: path)
+                                              pbxproj: pbxproj)
 
         // When
         let pbxTarget = try subject.generateTarget(target: target,
@@ -150,7 +147,6 @@ final class TargetGeneratorTests: XCTestCase {
                                                    projectSettings: Settings.test(),
                                                    fileElements: fileElements,
                                                    path: path,
-                                                   sourceRootPath: path,
                                                    graph: graph)
 
         // Then

--- a/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
@@ -128,7 +128,7 @@ final class TargetGeneratorTests: XCTestCase {
                                      TargetAction(name: "post", order: .post, path: path.appending(component: "script.sh"), arguments: ["arg"]),
                                      TargetAction(name: "pre", order: .pre, path: path.appending(component: "script.sh"), arguments: ["arg"]),
                                  ])
-        let project = Project.test(path: path, targets: [target])
+        let project = Project.test(path: path, sourceRootPath: path, targets: [target])
         let groups = ProjectGroups.generate(project: project,
                                             pbxproj: pbxproj,
                                             xcodeprojPath: project.path.appending(component: "\(project.fileName).xcodeproj"),

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceGeneratorTests.swift
@@ -82,6 +82,7 @@ final class WorkspaceGeneratorTests: TuistUnitTestCase {
         let target = anyTarget()
         let project = Project.test(path: temporaryPath,
                                    sourceRootPath: temporaryPath,
+                                   xcodeProjPath: temporaryPath.appending(component: "Test.xcodeproj"),
                                    name: "Test",
                                    settings: .default,
                                    targets: [target])

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceGeneratorTests.swift
@@ -81,6 +81,7 @@ final class WorkspaceGeneratorTests: TuistUnitTestCase {
         let temporaryPath = try self.temporaryPath()
         let target = anyTarget()
         let project = Project.test(path: temporaryPath,
+                                   sourceRootPath: temporaryPath,
                                    name: "Test",
                                    settings: .default,
                                    targets: [target])

--- a/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -344,6 +344,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
 
     private func createProject(path: AbsolutePath, settings: Settings, targets: [Target], packages: [Package] = [], schemes: [Scheme]) -> Project {
         Project(path: path,
+                sourceRootPath: path,
                 name: "App",
                 organizationName: nil,
                 fileName: nil,

--- a/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -345,9 +345,9 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
     private func createProject(path: AbsolutePath, settings: Settings, targets: [Target], packages: [Package] = [], schemes: [Scheme]) -> Project {
         Project(path: path,
                 sourceRootPath: path,
+                xcodeProjPath: path.appending(component: "App.xcodeproj"),
                 name: "App",
                 organizationName: nil,
-                fileName: nil,
                 settings: settings,
                 filesGroup: .group(name: "Project"),
                 targets: targets,

--- a/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
@@ -158,6 +158,7 @@ final class StableXcodeProjIntegrationTests: TuistTestCase {
 
     private func createProject(path: AbsolutePath, settings: Settings, targets: [Target], packages: [Package] = [], schemes: [Scheme]) -> Project {
         Project(path: path,
+                sourceRootPath: path,
                 name: "App",
                 organizationName: nil,
                 fileName: nil,

--- a/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
@@ -159,9 +159,9 @@ final class StableXcodeProjIntegrationTests: TuistTestCase {
     private func createProject(path: AbsolutePath, settings: Settings, targets: [Target], packages: [Package] = [], schemes: [Scheme]) -> Project {
         Project(path: path,
                 sourceRootPath: path,
+                xcodeProjPath: path.appending(component: "App.xcodeproj"),
                 name: "App",
                 organizationName: nil,
-                fileName: nil,
                 settings: settings,
                 filesGroup: .group(name: "Project"),
                 targets: targets,

--- a/Tests/TuistKitTests/ProjectEditor/Mocks/MockProjectEditorMapper.swift
+++ b/Tests/TuistKitTests/ProjectEditor/Mocks/MockProjectEditorMapper.swift
@@ -10,6 +10,7 @@ final class MockProjectEditorMapper: ProjectEditorMapping {
     var mapArgs: [(
         tuistPath: AbsolutePath,
         sourceRootPath: AbsolutePath,
+        xcodeProjPath: AbsolutePath,
         manifests: [AbsolutePath],
         helpers: [AbsolutePath],
         templates: [AbsolutePath],
@@ -18,12 +19,14 @@ final class MockProjectEditorMapper: ProjectEditorMapping {
 
     func map(tuistPath: AbsolutePath,
              sourceRootPath: AbsolutePath,
+             xcodeProjPath: AbsolutePath,
              manifests: [AbsolutePath],
              helpers: [AbsolutePath],
              templates: [AbsolutePath],
              projectDescriptionPath: AbsolutePath) -> (Project, Graph) {
         mapArgs.append((tuistPath: tuistPath,
                         sourceRootPath: sourceRootPath,
+                        xcodeProjPath: xcodeProjPath,
                         manifests: manifests,
                         helpers: helpers,
                         templates: templates,

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
@@ -24,6 +24,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
     func test_edit_when_there_are_helpers() throws {
         // Given
         let sourceRootPath = try temporaryPath()
+        let xcodeProjPath = sourceRootPath.appending(component: "Project.xcodeproj")
         let manifestPaths = [sourceRootPath].map { $0.appending(component: "Project.swift") }
         let helperPaths = [sourceRootPath].map { $0.appending(component: "Project+Template.swift") }
         let templates = [sourceRootPath].map { $0.appending(component: "template") }
@@ -33,6 +34,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         // When
         let (project, graph) = try subject.map(tuistPath: tuistPath,
                                                sourceRootPath: sourceRootPath,
+                                               xcodeProjPath: xcodeProjPath,
                                                manifests: manifestPaths,
                                                helpers: helperPaths,
                                                templates: templates,
@@ -104,6 +106,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
     func test_edit_when_there_are_no_helpers() throws {
         // Given
         let sourceRootPath = try temporaryPath()
+        let xcodeProjPath = sourceRootPath.appending(component: "Project.xcodeproj")
         let manifestPaths = [sourceRootPath].map { $0.appending(component: "Project.swift") }
         let helperPaths: [AbsolutePath] = []
         let templates: [AbsolutePath] = []
@@ -113,6 +116,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         // When
         let (project, graph) = try subject.map(tuistPath: tuistPath,
                                                sourceRootPath: sourceRootPath,
+                                               xcodeProjPath: xcodeProjPath,
                                                manifests: manifestPaths,
                                                helpers: helperPaths,
                                                templates: templates,
@@ -160,6 +164,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
     func test_tuist_edit_with_more_than_one_manifest() throws {
         // Given
         let sourceRootPath = try temporaryPath()
+        let xcodeProjPath = sourceRootPath.appending(component: "Project.xcodeproj")
         let otherProjectPath = "Module"
         let manifestPaths = [
             sourceRootPath.appending(component: "Project.swift"),
@@ -173,6 +178,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         // When
         let (project, graph) = try subject.map(tuistPath: tuistPath,
                                                sourceRootPath: sourceRootPath,
+                                               xcodeProjPath: xcodeProjPath,
                                                manifests: manifestPaths,
                                                helpers: helperPaths,
                                                templates: templates,

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
@@ -92,7 +92,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
             return (project, [])
         }
         var generatedProject: Project?
-        generator.generateProjectWithConfigStub = { project, _, _ in
+        generator.generateProjectSub = { project, _ in
             generatedProject = project
             return .test(xcodeprojPath: directory.appending(component: "Edit.xcodeproj"))
         }

--- a/Tests/TuistLoaderTests/Loaders/GeneratorModelLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/GeneratorModelLoaderTests.swift
@@ -181,7 +181,7 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
         let model = try subject.loadProject(at: temporaryPath)
 
         // Then
-        XCTAssertEqual(model.fileName, "one SomeProject two")
+        XCTAssertEqual(model.xcodeProjPath.basenameWithoutExt, "one SomeProject two")
     }
 
     func test_loadProject_withCustomNameDuplicates() throws {
@@ -209,7 +209,7 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
         let model = try subject.loadProject(at: temporaryPath)
 
         // Then
-        XCTAssertEqual(model.fileName, "one SomeProject two")
+        XCTAssertEqual(model.xcodeProjPath.basenameWithoutExt, "one SomeProject two")
     }
 
     func test_loadProject_withCustomOrganizationName() throws {


### PR DESCRIPTION
# Short description 📝
Before this change, we used to pass down the `sourceRootPath` attribute to tell generators about the directory that contains the generated project. With the change in this PR that information is now part of the `Project` model.

### But why? 🧐
**This allows the mappers change the location where projects are generated.** For example, let's say that users are using the new cache feature with the `focus` command. In that case, we don't want to override the projects that contain the targets with the source code. Instead, we want to create a temporary directory that contains all the Xcode projects with the direct and transitive dependencies as .xcframeworks.