### PR TITLE
Add benchmark rake task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ TODO
 TODO.md
 mkmf.log
 .rubocop-http---shopify-github-io-ruby-style-guide-rubocop-yml
+generated_fixtures
+.fixtures.generated.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Added
+
+- Add benchmark rake task [#1561](https://github.com/tuist/tuist/pull/1561) by [@kwridan](https://github.com/kwridan).
+
 ### Fixed
 
 - `UpHomebrew` (`Up.homebrew(packages:)`) in `Setup.swift` correctly checks package installation if the executable doesn't match the package name [#1544](https://github.com/tuist/tuist/pull/1544) by [@MatyasKriz](https://github.com/MatyasKriz).

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,7 @@ require "encrypted/environment"
 require 'colorize'
 require 'highline'
 require 'tmpdir'
+require 'json'
 
 Cucumber::Rake::Task.new(:features) do |t|
   t.cucumber_opts = "--format pretty"
@@ -69,6 +70,81 @@ end
 desc("Encrypt secret keys")
 task :encrypt_secrets do
   Encrypted::Environment.encrypt_ejson("secrets.ejson", private_key: ENV["SECRET_KEY"])
+end
+
+desc("Benchmarks tuist against a specified versiom")
+task :benchmark do
+
+  print_section("🛠 Building supporting tools")
+
+  # Build tuistbench
+  system(
+    "swift", "build", 
+    "-c", "release", 
+    "--package-path", "tools/tuistbench"
+  )
+
+  # Build fixturegen
+  system(
+    "swift", "build", 
+    "-c", "release", 
+    "--package-path", "tools/fixturegen"
+  )
+
+  # Generate large fixture
+  print_section("📁 Generating fixtures ...")
+  FileUtils.mkdir_p("generated_fixtures")
+
+  system(
+    "tools/fixturegen/.build/release/fixturegen",
+    "--path", "generated_fixtures/50_projects",
+    "--projects", "50",
+  )
+
+  system(
+    "tools/fixturegen/.build/release/fixturegen",
+    "--path", "generated_fixtures/2000_sources",
+    "--projects", "2",
+    "--sources", "2000",
+  )
+
+  # Generate fixture list
+  fixtures = {
+    "paths" => [
+      "generated_fixtures/50_projects",
+      "generated_fixtures/2000_sources",
+      "fixtures/ios_app_with_static_frameworks",
+      "fixtures/ios_app_with_framework_and_resources",
+      "fixtures/ios_app_with_transitive_framework",
+      "fixtures/ios_app_with_xcframeworks",
+    ]
+  }
+  File.open(".fixtures.generated.json","w") do |f|
+    f.write(fixtures.to_json)
+  end
+
+  # Build current version of tuist
+  print_section("🔨 Building release version of tuist ...")
+  system("swift", "build", "--product", "tuist", "--configuration", "release")
+  system("swift", "build", "--product", "tuistenv", "--configuration", "release")
+  system("swift", "build", "--product", "ProjectDescription", "--configuration", "release")
+
+  # Download latest tuist
+  print_section("⬇️ Downloading latest published version of tuist ...")
+
+  system(".build/release/tuistenv", "update")
+  puts("Reference tuist version:")
+  system(".build/release/tuistenv", "version")
+
+  print_section("⏱ Benchmarking ...")
+  system(
+    "tools/tuistbench/.build/release/tuistbench", 
+    "-b", ".build/release/tuist",
+    "-r", ".build/release/tuistenv",
+    "-l", ".fixtures.generated.json",
+    "--format", "markdown"
+  )
+
 end
 
 def decrypt_secrets

--- a/tools/fixturegen/Sources/FixtureGenerator/Commands/GenerateCommand.swift
+++ b/tools/fixturegen/Sources/FixtureGenerator/Commands/GenerateCommand.swift
@@ -56,7 +56,7 @@ final class GenerateCommand {
         }
 
         guard let path = arguments.get(pathArgument) else {
-            return currentPath
+            return currentPath.appending(component: "Fixture")
         }
         return AbsolutePath(path, relativeTo: currentPath)
     }

--- a/tools/fixturegen/Sources/FixtureGenerator/Generator/Generator.swift
+++ b/tools/fixturegen/Sources/FixtureGenerator/Generator/Generator.swift
@@ -16,7 +16,7 @@ class Generator {
     }
 
     func generate(at path: AbsolutePath) throws {
-        let rootPath = path.appending(component: "Fixture")
+        let rootPath = path
         let projects = (1 ... config.projects).map { "Project\($0)" }
 
         try fileSystem.createDirectory(rootPath)

--- a/website/markdown/docs/contribution/performance.mdx
+++ b/website/markdown/docs/contribution/performance.mdx
@@ -12,6 +12,16 @@ To test out generation speeds and to provide some utilities to aid profiling Tui
 
 Those tools are located within the [`tools/`](https://github.com/tuist/tuist/blob/master/tools) directory.
 
+## Benchmarking 
+
+As a convenience to automate the benchmarking process which entails leveraging several tools, a rake task is included with Tuist.
+
+```sh
+bundle exec rake benchmark
+```
+
+This benchmarks the current branch's version of Tuist against the latest published release using the tools described below.
+
 ## Fixture Generator (`fixturegen`)
 
 `fixturegen` allows generating large fixtures. For example it can generate a workspace with 10 projects, each project with 10 targets, and each target with 500 source files!


### PR DESCRIPTION
Part of #820 

### Short description 📝

Benchmarking tuist currently entails remembering and running several commands using different tools, this can add a barrier to benchmarking changes.

### Solution 📦

Automate the process of benchmarking against the latest release via introducing a new rake task.

### Implementation 👩‍💻👨‍💻

- [x] Add new `benchmark` rake task
  - Builds `fixturegen`
  - Builds `tuistbench`
  - Generates a few large fixtures in `generated_fixtures` _(Now included in `.gitignore`)_
  - Generates a list of fixtures to use for benchmarking
  - Builds release version of `tuist` and `tuistenv`
  - Downloads the latest release via `tuistenv`
  - Runs `tuistbench` where it benchmarks the `tuist` version on the current branch against the latest release
  
- [x] Update fixture generator to support specifying the paths without needing to create the corresponding directory
- [x] Update documentation
- [x] Update change log 

### Test Plan

- Run `rake benchmark`
- wait ... (it takes a while ...)
- Verify the benchmark results are displayed

### Notes 📝

There are some future enhancement we could do, but this is a good first step :)

- Update `tuistbench` to display incremental status of the benchmarking process as it take a long time and may appear stuck!
- Add a configuration file outside of the rake file to determine which fixtures to generate / use for benchmarking
