### PR TITLE
Fixes on hashing

### DIFF
--- a/Sources/TuistCache/ContentHashing/CacheContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/CacheContentHasher.swift
@@ -25,11 +25,11 @@ public final class CacheContentHasher: ContentHashing {
         try contentHasher.hash(dictionary)
     }
 
-    public func hash(fileAtPath filePath: AbsolutePath) throws -> String {
+    public func hash(path filePath: AbsolutePath) throws -> String {
         if let cachedHash = hashesCache[filePath] {
             return cachedHash
         }
-        let hash = try contentHasher.hash(fileAtPath: filePath)
+        let hash = try contentHasher.hash(path: filePath)
         hashesCache[filePath] = hash
         return hash
     }

--- a/Sources/TuistCache/ContentHashing/ContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/ContentHasher.swift
@@ -52,6 +52,10 @@ public final class ContentHasher: ContentHashing {
     }
 
     public func hash(fileAtPath filePath: AbsolutePath) throws -> String {
+        if fileHandler.isFolder(filePath) {
+            let paths = try fileHandler.contentsOfDirectory(filePath)
+            return try paths.map { try hash(fileAtPath: $0) }.joined(separator: "-")
+        }
         guard fileHandler.exists(filePath) else {
             throw FileHandlerError.fileNotFound(filePath)
         }

--- a/Sources/TuistCache/ContentHashing/ContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/ContentHasher.swift
@@ -4,7 +4,7 @@ import TuistCore
 import TuistSupport
 
 public protocol FileContentHashing {
-    func hash(fileAtPath: AbsolutePath) throws -> String
+    func hash(path: AbsolutePath) throws -> String
 }
 
 public protocol ContentHashing: FileContentHashing {
@@ -51,10 +51,10 @@ public final class ContentHasher: ContentHashing {
         return try hash(dictString)
     }
 
-    public func hash(fileAtPath filePath: AbsolutePath) throws -> String {
+    public func hash(path filePath: AbsolutePath) throws -> String {
         if fileHandler.isFolder(filePath) {
             let paths = try fileHandler.contentsOfDirectory(filePath)
-            return try paths.map { try hash(fileAtPath: $0) }.joined(separator: "-")
+            return try paths.map { try hash(path: $0) }.joined(separator: "-")
         }
         guard fileHandler.exists(filePath) else {
             throw FileHandlerError.fileNotFound(filePath)

--- a/Sources/TuistCache/ContentHashing/ContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/ContentHasher.swift
@@ -54,7 +54,8 @@ public final class ContentHasher: ContentHashing {
     public func hash(path filePath: AbsolutePath) throws -> String {
         if fileHandler.isFolder(filePath) {
             let paths = try fileHandler.contentsOfDirectory(filePath)
-            return try paths.map { try hash(path: $0) }.joined(separator: "-")
+            let sortedPaths = paths.sorted(by: { $0 < $1 })
+            return try sortedPaths.map { try hash(path: $0) }.joined(separator: "-")
         }
         guard fileHandler.exists(filePath) else {
             throw FileHandlerError.fileNotFound(filePath)

--- a/Sources/TuistCache/ContentHashing/ContentHashingError.swift
+++ b/Sources/TuistCache/ContentHashing/ContentHashingError.swift
@@ -17,9 +17,9 @@ enum ContentHashingError: FatalError, Equatable {
     var description: String {
         switch self {
         case let .failedToReadFile(path):
-            return "Couldn't find file at path \(path.pathString) while hashing the target for caching."
+            return "Couldn't find file to calculate hash at path \(path.pathString)"
         case let .fileHashingFailed(path):
-            return "Couldn't calculate hash of file at path \(path.pathString) for caching."
+            return "Couldn't calculate hash of file at path \(path.pathString)"
         case let .stringHashingFailed(string):
             return "Couldn't calculate hash of string \(string) for caching."
         }

--- a/Sources/TuistCache/ContentHashing/CoreDataModelsContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/CoreDataModelsContentHasher.swift
@@ -21,7 +21,7 @@ public final class CoreDataModelsContentHasher: CoreDataModelsContentHashing {
     public func hash(coreDataModels: [CoreDataModel]) throws -> String {
         var stringsToHash: [String] = []
         for cdModel in coreDataModels {
-            let contentHash = try contentHasher.hash(fileAtPath: cdModel.path)
+            let contentHash = try contentHasher.hash(path: cdModel.path)
             let currentVersionHash = try contentHasher.hash([cdModel.currentVersion])
             let cdModelHash = try contentHasher.hash([contentHash, currentVersionHash])
             let versionsHash = try contentHasher.hash(cdModel.versions.map { $0.pathString })

--- a/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
@@ -28,7 +28,9 @@ public final class GraphContentHasher: GraphContentHashing {
         var visitedNodes: [TargetNode: Bool] = [:]
         let hashableTargets = graph.targets.values.flatMap { (targets: [TargetNode]) -> [TargetNode] in
             targets.compactMap { target in
-                if self.isCacheable(target, visited: &visitedNodes) { return target }
+                if self.isCacheable(target, visited: &visitedNodes) {
+                    return target
+                }
                 return nil
             }
         }
@@ -42,7 +44,7 @@ public final class GraphContentHasher: GraphContentHashing {
 
     fileprivate func isCacheable(_ target: TargetNode, visited: inout [TargetNode: Bool]) -> Bool {
         if let visitedValue = visited[target] { return visitedValue }
-        let isFramework = target.target.product == .framework
+        let isFramework = target.target.product == .framework || target.target.product == .staticFramework
         let noXCTestDependency = !target.dependsOnXCTest
         let allTargetDependenciesAreHasheable = target.targetDependencies.allSatisfy { isCacheable($0, visited: &visited) }
         let cacheable = isFramework && noXCTestDependency && allTargetDependenciesAreHasheable

--- a/Sources/TuistCache/ContentHashing/HeadersContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/HeadersContentHasher.swift
@@ -20,7 +20,7 @@ public final class HeadersContentHasher: HeadersContentHashing {
 
     public func hash(headers: Headers) throws -> String {
         let allHeaders = headers.public + headers.private + headers.project
-        let headersContent = try allHeaders.map { try contentHasher.hash(fileAtPath: $0) }
+        let headersContent = try allHeaders.map { try contentHasher.hash(path: $0) }
         return try contentHasher.hash(headersContent)
     }
 }

--- a/Sources/TuistCache/ContentHashing/InfoPlistContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/InfoPlistContentHasher.swift
@@ -21,7 +21,7 @@ public final class InfoPlistContentHasher: InfoPlistContentHashing {
     public func hash(plist: InfoPlist) throws -> String {
         switch plist {
         case let .file(path):
-            return try contentHasher.hash(fileAtPath: path)
+            return try contentHasher.hash(path: path)
         case let .dictionary(dictionary), let .extendingDefault(dictionary):
             var dictionaryString: String = ""
             for key in dictionary.keys.sorted() {
@@ -30,7 +30,7 @@ public final class InfoPlistContentHasher: InfoPlistContentHashing {
             }
             return try contentHasher.hash(dictionaryString)
         case let .generatedFile(path):
-            return try contentHasher.hash(fileAtPath: path)
+            return try contentHasher.hash(path: path)
         }
     }
 }

--- a/Sources/TuistCache/ContentHashing/ResourcesContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/ResourcesContentHasher.swift
@@ -17,7 +17,7 @@ public final class ResourcesContentHasher: ResourcesContentHashing {
     }
 
     public func hash(resources: [FileElement]) throws -> String {
-        let hashes = try resources.map { try contentHasher.hash(fileAtPath: $0.path) }
+        let hashes = try resources.map { try contentHasher.hash(path: $0.path) }
         return try contentHasher.hash(hashes)
     }
 }

--- a/Sources/TuistCache/ContentHashing/SettingsContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/SettingsContentHasher.swift
@@ -46,7 +46,7 @@ public final class SettingsContentHasher: SettingsContentHashing {
     private func hash(_ configuration: Configuration) throws -> String {
         var configurationHash = hash(configuration.settings)
         if let xcconfigPath = configuration.xcconfig {
-            let xcconfigHash = try contentHasher.hash(fileAtPath: xcconfigPath)
+            let xcconfigHash = try contentHasher.hash(path: xcconfigPath)
             configurationHash += xcconfigHash
         }
         return configurationHash

--- a/Sources/TuistCache/ContentHashing/SourceFilesContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/SourceFilesContentHasher.swift
@@ -23,7 +23,7 @@ public final class SourceFilesContentHasher: SourceFilesContentHashing {
     /// Then it hashes again all partial hashes to get a unique identifier that represents a group of source files together with their compiler flags
     public func hash(sources: [Target.SourceFile]) throws -> String {
         var stringsToHash: [String] = []
-        for source in sources.sorted(by: { $0.path.pathString < $1.path.pathString }) {
+        for source in sources.sorted(by: { $0.path < $1.path }) {
             var sourceHash = try contentHasher.hash(path: source.path)
             if let compilerFlags = source.compilerFlags {
                 sourceHash += try contentHasher.hash(compilerFlags)

--- a/Sources/TuistCache/ContentHashing/SourceFilesContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/SourceFilesContentHasher.swift
@@ -23,8 +23,8 @@ public final class SourceFilesContentHasher: SourceFilesContentHashing {
     /// Then it hashes again all partial hashes to get a unique identifier that represents a group of source files together with their compiler flags
     public func hash(sources: [Target.SourceFile]) throws -> String {
         var stringsToHash: [String] = []
-        for source in sources {
-            var sourceHash = try contentHasher.hash(fileAtPath: source.path)
+        for source in sources.sorted(by: { $0.path.pathString < $1.path.pathString }) {
+            var sourceHash = try contentHasher.hash(path: source.path)
             if let compilerFlags = source.compilerFlags {
                 sourceHash += try contentHasher.hash(compilerFlags)
             }

--- a/Sources/TuistCache/ContentHashing/TargetActionsContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/TargetActionsContentHasher.swift
@@ -29,7 +29,7 @@ public final class TargetActionsContentHasher: TargetActionsContentHashing {
             pathsToHash.append(contentsOf: targetAction.inputFileListPaths)
             pathsToHash.append(contentsOf: targetAction.outputPaths)
             pathsToHash.append(contentsOf: targetAction.outputFileListPaths)
-            let fileHashes = try pathsToHash.map { try contentHasher.hash(fileAtPath: $0) }
+            let fileHashes = try pathsToHash.map { try contentHasher.hash(path: $0) }
             stringsToHash.append(contentsOf: fileHashes +
                 [targetAction.name,
                  targetAction.tool ?? "", // TODO: don't default to ""

--- a/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
@@ -96,7 +96,7 @@ public final class TargetContentHasher: TargetContentHashing {
             stringsToHash.append(infoPlistHash)
         }
         if let entitlements = target.entitlements {
-            let entitlementsHash = try contentHasher.hash(fileAtPath: entitlements)
+            let entitlementsHash = try contentHasher.hash(path: entitlements)
             stringsToHash.append(entitlementsHash)
         }
         if let settings = target.settings {

--- a/Sources/TuistCacheTesting/ContentHashing/Mocks/MockContentHashing.swift
+++ b/Sources/TuistCacheTesting/ContentHashing/Mocks/MockContentHashing.swift
@@ -22,9 +22,9 @@ public class MockContentHashing: ContentHashing {
     }
 
     public var stubHashForPath: [AbsolutePath: String] = [:]
-    public var hashFileAtPathCallCount = 0
-    public func hash(fileAtPath filePath: AbsolutePath) throws -> String {
-        hashFileAtPathCallCount += 1
+    public var hashPathCallCount = 0
+    public func hash(path filePath: AbsolutePath) throws -> String {
+        hashPathCallCount += 1
         return stubHashForPath[filePath] ?? ""
     }
 

--- a/Sources/TuistKit/Commands/Cloud/CloudPrintHashesCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudPrintHashesCommand.swift
@@ -6,7 +6,7 @@ import TuistSupport
 struct CloudPrintHashesCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(commandName: "print-hashes",
-                             abstract: "Print the hashes of the frameworks used by the given project.")
+                             abstract: "Print the hashes of the cacheable frameworks in the given project.")
     }
 
     @Option(

--- a/Sources/TuistKit/Services/Cloud/CloudPrintHashesService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudPrintHashesService.swift
@@ -20,18 +20,21 @@ final class CloudPrintHashesService {
         self.clock = clock
     }
 
-    func run(path: AbsolutePath) throws -> TimeInterval {
+    func run(path: AbsolutePath) throws {
         let timer = clock.startTimer()
 
         let graph = try projectGenerator.load(path: path)
         let hashes = try graphContentHasher.contentHashes(for: graph)
         let duration = timer.stop()
         let time = String(format: "%.3f", duration)
-
-        for (target, hash) in hashes {
+        guard hashes.count > 0 else {
+            logger.notice("No cacheable targets were found")
+            return
+        }
+        let sortedHashes = hashes.sorted { $0.key.name < $1.key.name }
+        for (target, hash) in sortedHashes {
             logger.info("\(target.name) - \(hash)")
         }
         logger.notice("Total time taken: \(time)s")
-        return duration
     }
 }

--- a/Tests/TuistCacheIntegrationTests/ContentHashing/ContentHashingIntegrationTests.swift
+++ b/Tests/TuistCacheIntegrationTests/ContentHashing/ContentHashingIntegrationTests.swift
@@ -66,7 +66,7 @@ final class ContentHashingIntegrationTests: TuistTestCase {
         // Given
         let temporaryDirectoryPath = try temporaryPath()
         let framework1 = makeFramework(named: "f1", sources: [source1, source2])
-        let framework2 = makeFramework(named: "f2", sources: [source1, source2])
+        let framework2 = makeFramework(named: "f2", sources: [source2, source1])
         let graph = Graph.test(targets: [
             temporaryDirectoryPath: [framework1, framework2],
         ])

--- a/Tests/TuistCacheTests/ContentHashing/CacheContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/CacheContentHasherTests.swift
@@ -41,30 +41,30 @@ final class CacheContentHasherTests: TuistUnitTestCase {
         XCTAssertEqual(mockContentHashing.hashStringsSpy, ["foo", "bar"])
     }
 
-    func test_hashFileAtPath_callsContentHasherWithExpectedPath() throws {
+    func test_hashpath_callsContentHasherWithExpectedPath() throws {
         // Given
         let path = AbsolutePath("/foo")
         mockContentHashing.stubHashForPath[path] = "foo-hash"
 
         // When
-        _ = try subject.hash(fileAtPath: path)
+        _ = try subject.hash(path: path)
 
         // Then
-        XCTAssertEqual(mockContentHashing.hashFileAtPathCallCount, 1)
+        XCTAssertEqual(mockContentHashing.hashPathCallCount, 1)
         XCTAssertEqual(mockContentHashing.stubHashForPath[path], "foo-hash")
     }
 
-    func test_hashFileAtPath_secondTime_doesntCallContentHasher() throws {
+    func test_hashpath_secondTime_doesntCallContentHasher() throws {
         // Given
         let path = AbsolutePath("/foo")
         mockContentHashing.stubHashForPath[path] = "foo-hash"
 
         // When
-        let hash = try subject.hash(fileAtPath: path)
-        let cachedHash = try subject.hash(fileAtPath: path)
+        let hash = try subject.hash(path: path)
+        let cachedHash = try subject.hash(path: path)
 
         // Then
-        XCTAssertEqual(mockContentHashing.hashFileAtPathCallCount, 1)
+        XCTAssertEqual(mockContentHashing.hashPathCallCount, 1)
         XCTAssertEqual(mockContentHashing.stubHashForPath[path], "foo-hash")
         XCTAssertEqual(hash, cachedHash)
     }

--- a/Tests/TuistCacheTests/ContentHashing/ContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/ContentHasherTests.swift
@@ -59,7 +59,7 @@ final class ContentHasherTests: TuistUnitTestCase {
         let path = try writeToTemporaryPath(content: "foo")
 
         // When
-        let hash = try subject.hash(fileAtPath: path)
+        let hash = try subject.hash(path: path)
 
         // Then
         XCTAssertEqual(hash, "acbd18db4cc2f85cedef654fccc4a4d8") // This is the md5 of "foo"
@@ -70,7 +70,7 @@ final class ContentHasherTests: TuistUnitTestCase {
         let path = try writeToTemporaryPath(content: "bar")
 
         // When
-        let hash = try subject.hash(fileAtPath: path)
+        let hash = try subject.hash(path: path)
 
         // Then
         XCTAssertEqual(hash, "37b51d194a7513e45b56f6524f2d51f2") // This is the md5 of "bar"
@@ -81,7 +81,7 @@ final class ContentHasherTests: TuistUnitTestCase {
         let wrongPath = AbsolutePath("/shakirashakira")
 
         // Then
-        XCTAssertThrowsError(try subject.hash(fileAtPath: wrongPath)) { error in
+        XCTAssertThrowsError(try subject.hash(path: wrongPath)) { error in
             XCTAssertEqual(error as? FileHandlerError, FileHandlerError.fileNotFound(wrongPath))
         }
     }

--- a/Tests/TuistCacheTests/ContentHashing/GraphContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/GraphContentHasherTests.swift
@@ -48,7 +48,7 @@ final class GraphContentHasherTests: TuistUnitTestCase {
                                precompiled: [],
                                targets: [path: [frameworkTarget, secondFrameworkTarget, appTarget, dynamicLibraryTarget, staticFrameworkTarget]])
 
-        let expectedCachableTargets = [frameworkTarget, secondFrameworkTarget].sorted(by: { $0.target.name < $1.target.name })
+        let expectedCachableTargets = [frameworkTarget, secondFrameworkTarget, staticFrameworkTarget].sorted(by: { $0.target.name < $1.target.name })
 
         // When
         let hashes = try subject.contentHashes(for: graph)

--- a/Tests/TuistCacheTests/ContentHashing/HeadersContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/HeadersContentHasherTests.swift
@@ -47,6 +47,6 @@ final class HeadersContentHasherTests: TuistUnitTestCase {
         // Then
         let hash = try subject.hash(headers: headers)
         XCTAssertEqual(hash, "1;2;3;4;5;6")
-        XCTAssertEqual(mockContentHasher.hashFileAtPathCallCount, 6)
+        XCTAssertEqual(mockContentHasher.hashPathCallCount, 6)
     }
 }

--- a/Tests/TuistCacheTests/ContentHashing/InfoPlistContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/InfoPlistContentHasherTests.swift
@@ -34,7 +34,7 @@ final class InfoPlistContentHasherTests: TuistUnitTestCase {
         let hash = try subject.hash(plist: infoPlist)
 
         // Then
-        XCTAssertEqual(mockContentHasher.hashFileAtPathCallCount, 1)
+        XCTAssertEqual(mockContentHasher.hashPathCallCount, 1)
         XCTAssertEqual(hash, "stubHash")
     }
 
@@ -47,7 +47,7 @@ final class InfoPlistContentHasherTests: TuistUnitTestCase {
         let hash = try subject.hash(plist: infoPlist)
 
         // Then
-        XCTAssertEqual(mockContentHasher.hashFileAtPathCallCount, 1)
+        XCTAssertEqual(mockContentHasher.hashPathCallCount, 1)
         XCTAssertEqual(hash, "stubHash")
     }
 

--- a/Tests/TuistCacheTests/ContentHashing/ResourcesContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/ResourcesContentHasherTests.swift
@@ -39,7 +39,7 @@ final class ResourcesContentHasherTests: TuistUnitTestCase {
         let hash = try subject.hash(resources: [file1, file2])
 
         // Then
-        XCTAssertEqual(mockContentHasher.hashFileAtPathCallCount, 2)
+        XCTAssertEqual(mockContentHasher.hashPathCallCount, 2)
         XCTAssertEqual(hash, "1;2")
     }
 
@@ -54,7 +54,7 @@ final class ResourcesContentHasherTests: TuistUnitTestCase {
         let hash = try subject.hash(resources: [file1, file2])
 
         // Then
-        XCTAssertEqual(mockContentHasher.hashFileAtPathCallCount, 2)
+        XCTAssertEqual(mockContentHasher.hashPathCallCount, 2)
         XCTAssertEqual(hash, "1;2")
     }
 }


### PR DESCRIPTION
### Short description 📝

While debugging `tuist cloud print-hashes` targeting a big project, I found some issues that I addressed in this PR:

1) static frameworks were not considered cacheable but they should be
2) `sources` were not sorted when hashing, resulting into inconsistent hashes 
3) Hashing a `path` pointing to a folder resulted in an error because we expected a file

Plus: renamed some commands/error to improve the DX

### Solution 📦

- Sort `sources`
- Include `staticFramework` as a valid cacheable target 
- Hash directory recursively on all its files/sub-directories