### PR TITLE
Fix throwing invalid glob component error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+## 1.12.2 - Waka Waka
+
+### Fixed
+
+- Fix a bug introduced in [#1523](https://github.com/tuist/tuist/pull/1523), when a valid source file would result in throwing an invalid glob error [#1566](https://github.com/tuist/tuist/pull/1566) by [@natanrolnik](https://github.com/natanrolnik)
+
 ## 1.12.1 - Waka
 
 ### Added

--- a/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
+++ b/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
@@ -43,12 +43,15 @@ extension AbsolutePath {
     /// - Returns: List of paths that match the given pattern.
     public func throwingGlob(_ pattern: String) throws -> [AbsolutePath] {
         let globPath = appending(RelativePath(pattern)).pathString
-        let pathUpToLastNonGlob = AbsolutePath(globPath).upToLastNonGlob
 
-        if !pathUpToLastNonGlob.isFolder {
-            let invalidGlob = InvalidGlob(pattern: globPath,
-                                          nonExistentPath: pathUpToLastNonGlob)
-            throw GlobError.nonExistentDirectory(invalidGlob)
+        if globPath.isGlobComponent {
+            let pathUpToLastNonGlob = AbsolutePath(globPath).upToLastNonGlob
+
+            if !pathUpToLastNonGlob.isFolder {
+                let invalidGlob = InvalidGlob(pattern: globPath,
+                                              nonExistentPath: pathUpToLastNonGlob)
+                throw GlobError.nonExistentDirectory(invalidGlob)
+            }
         }
 
         return glob(pattern)


### PR DESCRIPTION
Version 1.12.1 included #1523, which added throwing an error in case a glob used a non-existent directory.

This PR fixes the previous PR.

Even when a non-glob path was used, for a file for example, `isFolder` would return false and therefore the error would be thrown. Now, before checking if the last non glob pattern exists, we check if the path is a glob at all.