### PR TITLE
Use .package.resolved from project's root.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- `tuist focus` creating new `.package.resolved` [#1569](https://github.com/tuist/tuist/pull/1569) by [@fortmarek](https://github.com/fortmarek)
+
 ## 1.12.2 - Waka Waka
 
 ### Fixed

--- a/Sources/TuistCoreTesting/Utils/MockRootDirectoryLocator.swift
+++ b/Sources/TuistCoreTesting/Utils/MockRootDirectoryLocator.swift
@@ -3,6 +3,8 @@ import TSCBasic
 @testable import TuistCore
 
 public final class MockRootDirectoryLocator: RootDirectoryLocating {
+    public init() {}
+
     public var locateArgs: [AbsolutePath] = []
     public var locateStub: AbsolutePath?
 

--- a/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
+++ b/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
@@ -4,24 +4,6 @@ import TSCBasic
 import TuistCore
 import TuistSupport
 
-enum SwiftPackageManagerInteractorError: FatalError, Equatable {
-    case rootDirectoryNotFound(AbsolutePath)
-
-    var type: ErrorType {
-        switch self {
-        case .rootDirectoryNotFound:
-            return .abort
-        }
-    }
-
-    var description: String {
-        switch self {
-        case let .rootDirectoryNotFound(path):
-            return "Couldn't locate the root directory from path \(path.pathString). The root directory is the closest directory that contains a Tuist or a .git directory."
-        }
-    }
-}
-
 /// Swift Package Manager Interactor
 ///
 /// This component is responsible for resolving
@@ -71,7 +53,7 @@ public class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting {
             return
         }
 
-        guard let rootDirectory = rootDirectoryLocator.locate(from: path) else { throw SwiftPackageManagerInteractorError.rootDirectoryNotFound(path) }
+        let rootDirectory = rootDirectoryLocator.locate(from: path) ?? path
         let rootPackageResolvedPath = rootDirectory.appending(component: ".package.resolved")
         let workspacePackageResolvedFolderPath = path.appending(RelativePath("\(workspaceName)/xcshareddata/swiftpm"))
         let workspacePackageResolvedPath = workspacePackageResolvedFolderPath.appending(component: "Package.resolved")


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1518

### Short description 📝

When running `tuist focus`, `tuist` was creating a new `.package.resolved`. We should be using the one that is located in the root of the project

### Solution 📦

Change path to point to root directory

### Implementation 👩‍💻👨‍💻

- [x] Implement
- [x] Add tests
