### PR TITLE
Add including target name to duplicate dependency warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 - Support for `--cache` to the `tuist generate` command [#1576](https://github.com/tuist/tuist/pull/1576) by [@pepibumur](https://github.com/pepibumur).
+- Included that importing target name in the duplicate dependency warning message [#1573](https://github.com/tuist/tuist/pull/1573) by[ @thedavidharris](https://github.com/thedavidharris)
 
 ## 1.13.1 - More Bella Vita
 

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -203,7 +203,7 @@ class TargetLinter: TargetLinting {
         target.dependencies.forEach { seen[$0, default: 0] += 1 }
         let duplicates = seen.enumerated().filter { $0.element.value > 1 }
         return duplicates.map {
-            .init(reason: "Target has duplicate '\($0.element.key)' dependency specified", severity: .warning)
+            .init(reason: "Target \(target.name) has duplicate '\($0.element.key)' dependency specified", severity: .warning)
         }
     }
 }

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -220,7 +220,7 @@ final class TargetLinterTests: TuistUnitTestCase {
 
         // Then
         XCTContainsLintingIssue(got, .init(
-            reason: "Target has duplicate '\(testDependency)' dependency specified",
+            reason: "Target \(target.name) has duplicate '\(testDependency)' dependency specified",
             severity: .warning
         ))
     }


### PR DESCRIPTION
### Short description 📝

Quick improvement on the error message here, noticed it tells you which target is duplicated, but not which target is actually consuming the duplicates

### Solution 📦

Add target name to the error message. This is inline with other lint messages.