### PR TITLE
Disable SwiftLint in the generated synthesized interface for resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- Disable SwiftLint in the generated synthesized interface for resources [#1574](https://github.com/tuist/tuist/pull/1574) by [@pepibumur](https://github.com/pepibumur).
+
 ## 1.13.1 - More Bella Vita
 
 ### Fixed

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -63,6 +63,7 @@ public class ResourcesProjectMapper: ProjectMapping {
 
     static func fileContent(targetName: String, bundleName: String) -> String {
         """
+        // swiftlint:disable all
         import Foundation
 
         // MARK: - Swift Bundle Accessor
@@ -103,6 +104,7 @@ public class ResourcesProjectMapper: ProjectMapping {
                  return .module
            }
         }
+        // swiftlint:enable all
         """
     }
 }

--- a/website/markdown/posts/2020-07-20-version-1.13.0/post.mdx
+++ b/website/markdown/posts/2020-07-20-version-1.13.0/post.mdx
@@ -58,7 +58,7 @@ After warming the cache, developers can run `tuist focus --cache` which reads as
 <Message
   info
   title="Your feedback is important"
-  description="The biggest challenge for this feature is to be able to handle all project scenarios gracefully. For that reason, any feedback you can provide from your projects is precious. It's possible that the first time you try to warm the cache it fails to compile xcframeworks. If that's the case, we'd love to know why and help you get it working."
+  description="The biggest challenge for this feature is to be able to handle all project scenarios gracefully. For that reason, any feedback you can provide from your projects is precious. It's possible that the first time you try to warm the cache, it fails to compile xcframeworks. If that's the case, we'd love to know why and help you get it working."
 />
 
 ## Minor improvements


### PR DESCRIPTION
### Short description 📝
It was pointed out on Slack that SwiftLint is failing in some projects because the synthesized accessors for resources don't meet the styling conventions of the project.

This PR adds an annotation to disable SwiftLint in the generated file.