### PR TITLE
Fix synthesized accessors for resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Disable SwiftLint in the generated synthesized interface for resources [#1574](https://github.com/tuist/tuist/pull/1574) by [@pepibumur](https://github.com/pepibumur).
+- Synthesized accessors for framework targets not resolving the path [#1575](https://github.com/tuist/tuist/pull/1575) by [@pepibumur](https://github.com/pepibumur).
 
 ### Added
 

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -73,7 +73,7 @@ public class ResourcesProjectMapper: ProjectMapping {
             private class BundleFinder {}
 
             extension Foundation.Bundle {
-                /// Since \(targetName) is a library, the bundle containing the resources is copied into the final product (app).
+                /// Since \(targetName) is a \(target.product), the bundle for classes within this module can be used directly.
                 static var module: Bundle = {
                     let bundleName = "\(bundleName)"
 
@@ -113,7 +113,7 @@ public class ResourcesProjectMapper: ProjectMapping {
             private class BundleFinder {}
 
             extension Foundation.Bundle {
-                /// Since \(targetName) is a framework, the bundle represents a framework.
+                /// Since \(targetName) is a \(target.product), the bundle containing the resources is copied into the final product.
                 static var module: Bundle = {
                     return Bundle(for: BundleFinder.self)
                 }()

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -58,12 +58,12 @@ public class ResourcesProjectMapper: ProjectMapping {
 
         let content: String = ResourcesProjectMapper.fileContent(targetName: target.name,
                                                                  bundleName: bundleName,
-                                                                 product: target.product)
+                                                                 target: target)
         return (filePath, [.file(.init(path: filePath, contents: content.data(using: .utf8), state: .present))])
     }
 
-    static func fileContent(targetName: String, bundleName: String, product: Product) -> String {
-        if product == .staticLibrary || product == .dynamicLibrary {
+    static func fileContent(targetName: String, bundleName: String, target: Target) -> String {
+        if !target.supportsResources {
             return """
             // swiftlint:disable all
             import Foundation

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -57,54 +57,78 @@ public class ResourcesProjectMapper: ProjectMapping {
             .appending(component: "Bundle+\(target.name).swift")
 
         let content: String = ResourcesProjectMapper.fileContent(targetName: target.name,
-                                                                 bundleName: bundleName)
+                                                                 bundleName: bundleName,
+                                                                 product: target.product)
         return (filePath, [.file(.init(path: filePath, contents: content.data(using: .utf8), state: .present))])
     }
 
-    static func fileContent(targetName: String, bundleName: String) -> String {
-        """
-        // swiftlint:disable all
-        import Foundation
+    static func fileContent(targetName: String, bundleName: String, product: Product) -> String {
+        if product == .staticLibrary || product == .dynamicLibrary {
+            return """
+            // swiftlint:disable all
+            import Foundation
 
-        // MARK: - Swift Bundle Accessor
+            // MARK: - Swift Bundle Accessor
 
-        private class BundleFinder {}
+            private class BundleFinder {}
 
-        extension Foundation.Bundle {
-            /// Returns the resource bundle associated with the current Swift module.
-            static var module: Bundle = {
-                let bundleName = "\(bundleName)"
+            extension Foundation.Bundle {
+                /// Since \(targetName) is a library, the bundle containing the resources is copied into the final product (app).
+                static var module: Bundle = {
+                    let bundleName = "\(bundleName)"
 
-                let candidates = [
-                    // Bundle should be present here when the package is linked into an App.
-                    Bundle.main.resourceURL,
+                    let candidates = [
+                        Bundle.main.resourceURL,
+                        Bundle(for: BundleFinder.self).resourceURL,
+                        Bundle.main.bundleURL,
+                    ]
 
-                    // Bundle should be present here when the package is linked into a framework.
-                    Bundle(for: BundleFinder.self).resourceURL,
-
-                    // For command-line tools.
-                    Bundle.main.bundleURL,
-                ]
-
-                for candidate in candidates {
-                    let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")
-                    if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
-                        return bundle
+                    for candidate in candidates {
+                        let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")
+                        if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
+                            return bundle
+                        }
                     }
-                }
-                fatalError("unable to find bundle named \(bundleName)")
-            }()
-        }
+                    fatalError("unable to find bundle named \(bundleName)")
+                }()
+            }
 
-        // MARK: - Objective-C Bundle Accessor
+            // MARK: - Objective-C Bundle Accessor
 
-        @objc
-        public class \(targetName.camelized.uppercasingFirst)Resources: NSObject {
-           @objc public class var bundle: Bundle {
-                 return .module
-           }
+            @objc
+            public class \(targetName.camelized.uppercasingFirst)Resources: NSObject {
+               @objc public class var bundle: Bundle {
+                     return .module
+               }
+            }
+            // swiftlint:enable all
+            """
+        } else {
+            return """
+            // swiftlint:disable all
+            import Foundation
+
+            // MARK: - Swift Bundle Accessor
+
+            private class BundleFinder {}
+
+            extension Foundation.Bundle {
+                /// Since \(targetName) is a framework, the bundle represents a framework.
+                static var module: Bundle = {
+                    return Bundle(for: BundleFinder.self)
+                }()
+            }
+
+            // MARK: - Objective-C Bundle Accessor
+
+            @objc
+            public class \(targetName.camelized.uppercasingFirst)Resources: NSObject {
+               @objc public class var bundle: Bundle {
+                     return .module
+               }
+            }
+            // swiftlint:enable all
+            """
         }
-        // swiftlint:enable all
-        """
     }
 }

--- a/Tests/TuistCoreTests/Models/LintingIssueTests.swift
+++ b/Tests/TuistCoreTests/Models/LintingIssueTests.swift
@@ -17,12 +17,12 @@ final class LintingIssueTests: TuistUnitTestCase {
         XCTAssertThrowsError(try [first, second].printAndThrowIfNeeded())
 
         XCTAssertPrinterOutputContains("""
-        warning
-        """
+            warning
+            """
         )
         XCTAssertPrinterErrorContains("""
-        error
-        """
+            error
+            """
         )
     }
 
@@ -32,8 +32,8 @@ final class LintingIssueTests: TuistUnitTestCase {
         XCTAssertThrowsError(try [first].printAndThrowIfNeeded())
 
         XCTAssertPrinterErrorContains("""
-        error
-        """
+            error
+            """
         )
     }
 }

--- a/Tests/TuistGeneratorIntegrationTests/Generator/WorkspaceGeneratorIntegrationTests.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Generator/WorkspaceGeneratorIntegrationTests.swift
@@ -37,7 +37,7 @@ final class WorkspaceGeneratorIntegrationTests: TuistTestCase {
                                      project.targets.map { target in
                                          (project: project, target: target, dependencies: [])
                                      }
-        })
+                                 })
         let workspace = Workspace.test(path: temporaryPath, projects: projects.map(\.path))
 
         // When / Then

--- a/Tests/TuistGeneratorTests/GraphMappers/ResourcesProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/GraphMappers/ResourcesProjectMapperTests.swift
@@ -43,7 +43,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
             .appending(component: Constants.DerivedDirectory.sources)
             .appending(component: "Bundle+\(target.name).swift")
         let expectedContents = ResourcesProjectMapper
-            .fileContent(targetName: target.name, bundleName: "\(target.name)Resources", product: target.product)
+            .fileContent(targetName: target.name, bundleName: "\(target.name)Resources", target: target)
         XCTAssertEqual(file.path, expectedPath)
         XCTAssertEqual(file.contents, expectedContents.data(using: .utf8))
 
@@ -88,7 +88,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
             .appending(component: Constants.DerivedDirectory.sources)
             .appending(component: "Bundle+\(target.name).swift")
         let expectedContents = ResourcesProjectMapper
-            .fileContent(targetName: target.name, bundleName: "\(target.name)Resources", product: target.product)
+            .fileContent(targetName: target.name, bundleName: "\(target.name)Resources", target: target)
         XCTAssertEqual(file.path, expectedPath)
         XCTAssertEqual(file.contents, expectedContents.data(using: .utf8))
 

--- a/Tests/TuistGeneratorTests/GraphMappers/ResourcesProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/GraphMappers/ResourcesProjectMapperTests.swift
@@ -43,7 +43,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
             .appending(component: Constants.DerivedDirectory.sources)
             .appending(component: "Bundle+\(target.name).swift")
         let expectedContents = ResourcesProjectMapper
-            .fileContent(targetName: target.name, bundleName: "\(target.name)Resources")
+            .fileContent(targetName: target.name, bundleName: "\(target.name)Resources", product: target.product)
         XCTAssertEqual(file.path, expectedPath)
         XCTAssertEqual(file.contents, expectedContents.data(using: .utf8))
 
@@ -88,7 +88,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
             .appending(component: Constants.DerivedDirectory.sources)
             .appending(component: "Bundle+\(target.name).swift")
         let expectedContents = ResourcesProjectMapper
-            .fileContent(targetName: target.name, bundleName: "\(target.name)Resources")
+            .fileContent(targetName: target.name, bundleName: "\(target.name)Resources", product: target.product)
         XCTAssertEqual(file.path, expectedPath)
         XCTAssertEqual(file.contents, expectedContents.data(using: .utf8))
 


### PR DESCRIPTION
### Short description 📝
While testing the new `Bundle.module` accessor with @natanrolnik, we realized that the synthesized accessor doesn't resolve correctly when it's generated for a framework.

### Solution 📦
When we are synthesizing the accessor for a target that is a framework, just use `Bundle(for: BundleFinder.self)`.