### PR TITLE
Add support for --cache to the generate command

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -69,6 +69,7 @@ jobs:
             'scaffold',
             'up',
             'build',
+            'cache',
           ]
     steps:
       - uses: actions/checkout@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Disable SwiftLint in the generated synthesized interface for resources [#1574](https://github.com/tuist/tuist/pull/1574) by [@pepibumur](https://github.com/pepibumur).
 
+### Added
+
+- Support for `--cache` to the `tuist generate` command [#1576](https://github.com/tuist/tuist/pull/1576) by [@pepibumur](https://github.com/pepibumur).
+
 ## 1.13.1 - More Bella Vita
 
 ### Fixed

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -19,8 +19,12 @@ struct GenerateCommand: ParsableCommand {
     )
     var projectOnly: Bool
 
+    @Flag(help: "Generate a project replacing dependencies with pre-compiled assets.")
+    var cache: Bool
+
     func run() throws {
         try GenerateService().run(path: path,
-                                  projectOnly: projectOnly)
+                                  projectOnly: projectOnly,
+                                  cache: cache)
     }
 }

--- a/Sources/TuistKit/Services/FocusService.swift
+++ b/Sources/TuistKit/Services/FocusService.swift
@@ -8,11 +8,11 @@ import TuistGenerator
 import TuistLoader
 import TuistSupport
 
-protocol FocusServiceProjectGeneratorProviding {
+protocol FocusServiceProjectGeneratorFactorying {
     func generator(cache: Bool) -> ProjectGenerating
 }
 
-final class FocusServiceProjectGeneratorProvider: FocusServiceProjectGeneratorProviding {
+final class FocusServiceProjectGeneratorFactory: FocusServiceProjectGeneratorFactorying {
     func generator(cache: Bool) -> ProjectGenerating {
         ProjectGenerator(graphMapperProvider: GraphMapperProvider(cache: cache))
     }
@@ -37,15 +37,15 @@ enum FocusServiceError: FatalError {
 
 final class FocusService {
     private let opener: Opening
-    private let generatorProvider: FocusServiceProjectGeneratorProviding
+    private let projectGeneratorFactory: FocusServiceProjectGeneratorFactorying
     private let manifestLoader: ManifestLoading
 
     init(manifestLoader: ManifestLoading = ManifestLoader(),
          opener: Opening = Opener(),
-         generatorProvider: FocusServiceProjectGeneratorProviding = FocusServiceProjectGeneratorProvider()) {
+         projectGeneratorFactory: FocusServiceProjectGeneratorFactorying = FocusServiceProjectGeneratorFactory()) {
         self.manifestLoader = manifestLoader
         self.opener = opener
-        self.generatorProvider = generatorProvider
+        self.projectGeneratorFactory = projectGeneratorFactory
     }
 
     func run(cache: Bool, path: String?) throws {
@@ -53,7 +53,7 @@ final class FocusService {
         if isWorkspace(path: path), cache {
             throw FocusServiceError.cacheWorkspaceNonSupported
         }
-        let generator = generatorProvider.generator(cache: cache)
+        let generator = projectGeneratorFactory.generator(cache: cache)
         let workspacePath = try generator.generate(path: path, projectOnly: false)
         try opener.open(path: workspacePath)
     }

--- a/Sources/TuistKit/Services/GenerateService.swift
+++ b/Sources/TuistKit/Services/GenerateService.swift
@@ -3,22 +3,34 @@ import TuistGenerator
 import TuistLoader
 import TuistSupport
 
+protocol GenerateServiceProjectGeneratorFactorying {
+    func generator(cache: Bool) -> ProjectGenerating
+}
+
+final class GenerateServiceProjectGeneratorFactory: GenerateServiceProjectGeneratorFactorying {
+    func generator(cache: Bool) -> ProjectGenerating {
+        ProjectGenerator(graphMapperProvider: GraphMapperProvider(cache: cache))
+    }
+}
+
 final class GenerateService {
     // MARK: - Attributes
 
     private let clock: Clock
-    private let generator: ProjectGenerating
+    private let projectGeneratorFactory: GenerateServiceProjectGeneratorFactorying
 
-    init(generator: ProjectGenerating = ProjectGenerator(),
-         clock: Clock = WallClock()) {
-        self.generator = generator
+    init(clock: Clock = WallClock(),
+         projectGeneratorFactory: GenerateServiceProjectGeneratorFactorying = GenerateServiceProjectGeneratorFactory()) {
         self.clock = clock
+        self.projectGeneratorFactory = projectGeneratorFactory
     }
 
     func run(path: String?,
-             projectOnly: Bool) throws {
+             projectOnly: Bool,
+             cache: Bool) throws {
         let timer = clock.startTimer()
         let path = self.path(path)
+        let generator = projectGeneratorFactory.generator(cache: cache)
 
         _ = try generator.generate(path: path, projectOnly: projectOnly)
 

--- a/Tests/TuistKitTests/Services/FocusServiceTests.swift
+++ b/Tests/TuistKitTests/Services/FocusServiceTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import TuistLoaderTesting
 @testable import TuistSupportTesting
 
-final class MockFocusServiceProjectGeneratorProvider: FocusServiceProjectGeneratorProviding {
+final class MockFocusServiceProjectGeneratorFactory: FocusServiceProjectGeneratorFactorying {
     var invokedGenerator = false
     var invokedGeneratorCount = 0
     var invokedGeneratorParameters: (cache: Bool, Void)?
@@ -39,22 +39,22 @@ final class FocusServiceTests: TuistUnitTestCase {
     var subject: FocusService!
     var opener: MockOpener!
     var generator: MockProjectGenerator!
-    var generatorProvider: MockFocusServiceProjectGeneratorProvider!
+    var projectGeneratorFactory: MockFocusServiceProjectGeneratorFactory!
 
     override func setUp() {
         super.setUp()
         opener = MockOpener()
         generator = MockProjectGenerator()
-        generatorProvider = MockFocusServiceProjectGeneratorProvider()
-        generatorProvider.stubbedGeneratorResult = generator
-        subject = FocusService(opener: opener, generatorProvider: generatorProvider)
+        projectGeneratorFactory = MockFocusServiceProjectGeneratorFactory()
+        projectGeneratorFactory.stubbedGeneratorResult = generator
+        subject = FocusService(opener: opener, projectGeneratorFactory: projectGeneratorFactory)
     }
 
     override func tearDown() {
         opener = nil
         generator = nil
         subject = nil
-        generatorProvider = nil
+        projectGeneratorFactory = nil
         super.tearDown()
     }
 

--- a/features/cache.feature
+++ b/features/cache.feature
@@ -1,0 +1,10 @@
+Feature: Generates projects with pre-compiled cached dependencies
+
+  Scenario: The project is an application with templates (ios_app_with_templates)
+    Given that tuist is available 
+    And I have a working directory
+    And I initialize a ios application named MyApp
+    And tuist warms the cache
+    When tuist generates a project with cached targets at Projects/MyApp
+    Then I should be able to build for iOS the scheme MyApp
+    Then I should be able to test for iOS the scheme MyAppTests

--- a/features/step_definitions/cache.rb
+++ b/features/step_definitions/cache.rb
@@ -1,0 +1,3 @@
+Then(/^tuist warms the cache$/) do
+  system("swift", "run", "tuist", "cache", "warm", "--path", @dir)
+end

--- a/features/step_definitions/shared/tuist.rb
+++ b/features/step_definitions/shared/tuist.rb
@@ -24,6 +24,12 @@ Then(/^tuist generates the project at (.+)$/) do |path|
   @xcodeproj_path = Dir.glob(File.join(@dir, path, "*.xcodeproj")).first
 end
 
+Then(/^tuist generates a project with cached targets at (.+)$/) do |path|
+  system("swift", "run", "tuist", "generate", "--path", File.join(@dir, path), "--cache")
+  @workspace_path = Dir.glob(File.join(@dir, path, "*.xcworkspace")).first
+  @xcodeproj_path = Dir.glob(File.join(@dir, path, "*.xcodeproj")).first
+end
+
 Then(/tuist lints the project and fails/) do
   _, _, status = Open3.capture3("swift", "run", "tuist", "lint", "--path", @dir)
   refute(status.success?, "Expected 'tuist lint' to fail but it didn't")

--- a/features/step_definitions/shared/workspace.rb
+++ b/features/step_definitions/shared/workspace.rb
@@ -5,8 +5,11 @@ require 'fileutils'
 
 And(/I have a working directory/) do
   @dir = Dir.mktmpdir
+  @cache_dir = Dir.mktmpdir
+  ENV["TUIST_CACHE_DIRECTORY"] = @cache_dir
 end
 
 After do |_scenario|
   FileUtils.rm_r(@dir) unless @dir.nil?
+  FileUtils.rm_r(@cache_dir) unless @cache_dir.nil?
 end


### PR DESCRIPTION
### Short description 📝
I'm planning to add a new group of acceptance tests to test the cache feature and make sure it handles all different scenarios gracefully. To allow that, I'm extending the `tuist generate` command to support the `--cache` argument. These are the steps that I plan to run for every acceptance test:

1. Warm the cache
2. Generate the project with: `tuist generate --cache`.
3. Make sure it compiles.
