### PR TITLE
Move the Project enrich logic to a mapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Support for `--cache` to the `tuist generate` command [#1576](https://github.com/tuist/tuist/pull/1576) by [@pepibumur](https://github.com/pepibumur).
 - Included that importing target name in the duplicate dependency warning message [#1573](https://github.com/tuist/tuist/pull/1573) by[ @thedavidharris](https://github.com/thedavidharris)
 
+### Changed
+
+- Change the project name and organization from a mapper [#1577](https://github.com/tuist/tuist/pull/1577) by [@pepibumur](https://github.com/pepibumur).
+
 ## 1.13.1 - More Bella Vita
 
 ### Fixed

--- a/Sources/TuistKit/GraphMappers/ProjectMapperProvider.swift
+++ b/Sources/TuistKit/GraphMappers/ProjectMapperProvider.swift
@@ -1,6 +1,7 @@
 import Foundation
 import TuistCore
 import TuistGenerator
+import TuistLoader
 import TuistSigning
 
 /// It defines an interface for providing the project mappers to be used for a specific configuration.
@@ -25,6 +26,9 @@ class ProjectMapperProvider: ProjectMapperProviding {
 
         // Support for resources in libraries
         mappers.append(ResourcesProjectMapper())
+
+        // Project name mapper
+        mappers.append(ProjectNameAndOrganizationMapper(config: config))
 
         // Signing
         mappers.append(SigningMapper())

--- a/Sources/TuistLoader/Mappers/ProjectNameAndOrganizationMapper.swift
+++ b/Sources/TuistLoader/Mappers/ProjectNameAndOrganizationMapper.swift
@@ -19,11 +19,9 @@ public class ProjectNameAndOrganizationMapper: ProjectMapping {
         var project = project
 
         // Xcode project file name
-        var xcodeProjPath: AbsolutePath = project.xcodeProjPath
         if let xcodeFileName = xcodeFileNameOverride(for: project) {
-            xcodeProjPath = project.xcodeProjPath.parentDirectory.appending(component: "\(xcodeFileName).xcodeproj")
+            project.xcodeProjPath = project.xcodeProjPath.parentDirectory.appending(component: "\(xcodeFileName).xcodeproj")
         }
-        project.xcodeProjPath = xcodeProjPath
 
         // Xcode project organization name
         if let organizationName = organizationNameOverride() {

--- a/Tests/TuistLoaderTests/Loaders/GeneratorModelLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/GeneratorModelLoaderTests.swift
@@ -157,61 +157,6 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
         XCTAssertEqual(model.additionalFiles, files.map { .folderReference(path: $0) })
     }
 
-    func test_loadProject_withCustomName() throws {
-        // Given
-        let temporaryPath = try self.temporaryPath()
-        try createFiles([
-            "TuistConfig.swift",
-        ])
-
-        let manifests = [
-            temporaryPath: ProjectManifest.test(name: "SomeProject",
-                                                additionalFiles: [
-                                                    .folderReference(path: "Stubs"),
-                                                ]),
-        ]
-        let configs = [
-            temporaryPath: ProjectDescription.TuistConfig.test(generationOptions: [.xcodeProjectName("one \(.projectName) two")]),
-        ]
-        let manifestLoader = createManifestLoader(with: manifests, configs: configs)
-        let subject = GeneratorModelLoader(manifestLoader: manifestLoader,
-                                           manifestLinter: manifestLinter)
-
-        // When
-        let model = try subject.loadProject(at: temporaryPath)
-
-        // Then
-        XCTAssertEqual(model.xcodeProjPath.basenameWithoutExt, "one SomeProject two")
-    }
-
-    func test_loadProject_withCustomNameDuplicates() throws {
-        // Given
-        let temporaryPath = try self.temporaryPath()
-        try createFiles([
-            "TuistConfig.swift",
-        ])
-
-        let manifests = [
-            temporaryPath: ProjectManifest.test(name: "SomeProject",
-                                                additionalFiles: [
-                                                    .folderReference(path: "Stubs"),
-                                                ]),
-        ]
-        let configs = [
-            temporaryPath: ProjectDescription.Config.test(generationOptions: [.xcodeProjectName("one \(.projectName) two"),
-                                                                              .xcodeProjectName("two \(.projectName) three")]),
-        ]
-        let manifestLoader = createManifestLoader(with: manifests, configs: configs)
-        let subject = GeneratorModelLoader(manifestLoader: manifestLoader,
-                                           manifestLinter: manifestLinter)
-
-        // When
-        let model = try subject.loadProject(at: temporaryPath)
-
-        // Then
-        XCTAssertEqual(model.xcodeProjPath.basenameWithoutExt, "one SomeProject two")
-    }
-
     func test_loadProject_withCustomOrganizationName() throws {
         // Given
         let temporaryPath = try self.temporaryPath()
@@ -238,34 +183,6 @@ class GeneratorModelLoaderTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(model.organizationName, "SomeOrganization")
-    }
-
-    func test_loadProject_withCustomOrganizationNameFromConfig() throws {
-        // Given
-        let temporaryPath = try self.temporaryPath()
-        try createFiles([
-            "TuistConfig.swift",
-        ])
-
-        let manifests = [
-            temporaryPath: ProjectManifest.test(name: "SomeProject",
-                                                organizationName: "SomeOrganization",
-                                                additionalFiles: [
-                                                    .folderReference(path: "Stubs"),
-                                                ]),
-        ]
-        let configs = [
-            temporaryPath: ProjectDescription.TuistConfig.test(generationOptions: [.organizationName("tuist")]),
-        ]
-        let manifestLoader = createManifestLoader(with: manifests, configs: configs)
-        let subject = GeneratorModelLoader(manifestLoader: manifestLoader,
-                                           manifestLinter: manifestLinter)
-
-        // When
-        let model = try subject.loadProject(at: temporaryPath)
-
-        // Then
-        XCTAssertEqual(model.organizationName, "tuist")
     }
 
     func test_loadWorkspace() throws {

--- a/Tests/TuistLoaderTests/Mappers/ProjectNameAndOrganizationMapperTests.swift
+++ b/Tests/TuistLoaderTests/Mappers/ProjectNameAndOrganizationMapperTests.swift
@@ -1,0 +1,51 @@
+import ProjectDescription
+import TuistCore
+import TuistSupport
+import XCTest
+
+@testable import TuistCoreTesting
+@testable import TuistLoader
+@testable import TuistSupportTesting
+
+class ProjectNameAndOrganizationMapperTests: TuistUnitTestCase {
+    var subject: ProjectNameAndOrganizationMapper!
+    var config: TuistCore.Config!
+
+    override func setUp() {
+        let nameTemplate: TemplateString = "Tuist-\(.projectName)"
+        config = TuistCore.Config.test(generationOptions: [
+            .xcodeProjectName(nameTemplate.description),
+            .organizationName("Tuist"),
+        ])
+        subject = ProjectNameAndOrganizationMapper(config: config)
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        subject = nil
+        config = nil
+    }
+
+    func test_map_changes_the_project_name() throws {
+        // Given
+        let project = Project.test(name: "Test")
+
+        // When
+        let (got, _) = try subject.map(project: project)
+
+        // Then
+        XCTAssertEqual(got.xcodeProjPath.basename, "Tuist-Test.xcodeproj")
+    }
+
+    func test_map_changes_the_organization() throws {
+        // Given
+        let project = Project.test(name: "Test", organizationName: nil)
+
+        // When
+        let (got, _) = try subject.map(project: project)
+
+        // Then
+        XCTAssertEqual(got.organizationName, "Tuist")
+    }
+}

--- a/Tests/TuistLoaderTests/Mappers/ProjectNameAndOrganizationMapperTests.swift
+++ b/Tests/TuistLoaderTests/Mappers/ProjectNameAndOrganizationMapperTests.swift
@@ -29,7 +29,7 @@ class ProjectNameAndOrganizationMapperTests: TuistUnitTestCase {
 
     func test_map_changes_the_project_name() throws {
         // Given
-        let project = Project.test(name: "Test")
+        let project = TuistCore.Project.test(name: "Test")
 
         // When
         let (got, _) = try subject.map(project: project)
@@ -40,7 +40,7 @@ class ProjectNameAndOrganizationMapperTests: TuistUnitTestCase {
 
     func test_map_changes_the_organization() throws {
         // Given
-        let project = Project.test(name: "Test", organizationName: nil)
+        let project = TuistCore.Project.test(name: "Test", organizationName: nil)
 
         // When
         let (got, _) = try subject.map(project: project)


### PR DESCRIPTION
### Short description 📝
There was some logic that was a good candidate to be part of a mapper. In particular, we have some logic ad generation time that changed the project name and organization based on some generation options.

### Implementation 👩‍💻👨‍💻
- Implement `ProjectNameAndOrganizationMapper`
- Test `ProjectNameAndOrganizationMapper`.
- Update the mappers provider to include it.