### PR TITLE
Fix Logger namespace collision on Xcode 12 and above

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        xcode: ['11.3.1', '11.5']
+        xcode: ["11.3.1", "11.5", "12_beta"]
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
@@ -41,7 +41,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        xcode: ['11.3.1', '11.4']
+        xcode: ["11.3.1", "11.4"]
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
@@ -55,21 +55,21 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        xcode: ['11.5']
+        xcode: ["11.5"]
         feature:
           [
-            'generate-1',
-            'generate-2',
-            'generate-3',
-            'generate-4',
-            'generate-5',
-            'generate-6',
-            'init',
-            'lint',
-            'scaffold',
-            'up',
-            'build',
-            'cache',
+            "generate-1",
+            "generate-2",
+            "generate-3",
+            "generate-4",
+            "generate-5",
+            "generate-6",
+            "init",
+            "lint",
+            "scaffold",
+            "up",
+            "build",
+            "cache",
           ]
     steps:
       - uses: actions/checkout@v1
@@ -77,7 +77,7 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: '2.x'
+          ruby-version: "2.x"
       - name: Install Bundler 2.0.2
         run: gem install bundler --version 2.0.2
       - name: Install Bundler dependencies
@@ -94,7 +94,7 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_11.5.app
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: '2.x'
+          ruby-version: "2.x"
       - name: Install Bundler 2.0.2
         run: gem install bundler --version 2.0.2
       - name: Install Bundler dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ playground.xcworkspace
 # Packages/
 # Package.pins
 .build/
+.swiftpm
 
 # CocoaPods - Refactored to standalone file
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Disable SwiftLint in the generated synthesized interface for resources [#1574](https://github.com/tuist/tuist/pull/1574) by [@pepibumur](https://github.com/pepibumur).
 - Synthesized accessors for framework targets not resolving the path [#1575](https://github.com/tuist/tuist/pull/1575) by [@pepibumur](https://github.com/pepibumur).
 
+
 ### Added
 
 - Support for `--cache` to the `tuist generate` command [#1576](https://github.com/tuist/tuist/pull/1576) by [@pepibumur](https://github.com/pepibumur).
 - Included that importing target name in the duplicate dependency warning message [#1573](https://github.com/tuist/tuist/pull/1573) by[ @thedavidharris](https://github.com/thedavidharris)
+- Support to build and run the project on Xcode 12 by fixing namespace collisions on Logger [#1579](https://github.com/tuist/tuist/pull/1579) by[ @thedavidharris](https://github.com/thedavidharris)
 
 ## 1.13.1 - More Bella Vita
 

--- a/Package.swift
+++ b/Package.swift
@@ -176,7 +176,7 @@ let package = Package(
         ),
         .testTarget(
             name: "TuistAutomationTests",
-            dependencies: ["TuistAutomation", "TuistSupportTesting", "TuistCoreTesting"]
+            dependencies: ["TuistAutomation", "TuistSupportTesting", "TuistCoreTesting", "RxBlocking"]
         ),
         .target(
             name: "TuistAutomationTesting",
@@ -184,7 +184,7 @@ let package = Package(
         ),
         .testTarget(
             name: "TuistAutomationIntegrationTests",
-            dependencies: ["TuistAutomation", "TuistSupportTesting"]
+            dependencies: ["TuistAutomation", "TuistSupportTesting", "RxBlocking"]
         ),
         .target(
             name: "TuistInsights",
@@ -224,11 +224,11 @@ let package = Package(
         ),
         .testTarget(
             name: "TuistLoaderTests",
-            dependencies: ["TuistLoader", "TuistSupportTesting", "TuistLoaderTesting", "TuistCoreTesting"]
+            dependencies: ["TuistLoader", "TuistSupportTesting", "TuistLoaderTesting", "TuistCoreTesting", "RxBlocking"]
         ),
         .testTarget(
             name: "TuistLoaderIntegrationTests",
-            dependencies: ["TuistLoader", "TuistSupportTesting", "ProjectDescription"]
+            dependencies: ["TuistLoader", "TuistSupportTesting", "ProjectDescription", "RxBlocking"]
         ),
         .testTarget(
             name: "TuistIntegrationTests",

--- a/Sources/TuistSupport/Logging/OSLogHandler.swift
+++ b/Sources/TuistSupport/Logging/OSLogHandler.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Logging
+import struct Logging.Logger
 import os
 
 public struct OSLogHandler: LogHandler {


### PR DESCRIPTION
### Short description 📝

Fixes namespace collisions on the new Logger type in Xcode 12 and above. Also adds some necessary RxBlocking dependencies so now opening the Package.swift directly in Xcode 12 builds correctly.