### PR TITLE
Update ConfigGenerator to use ValueGraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Changed
 
 - Change the project name and organization from a mapper [#1577](https://github.com/tuist/tuist/pull/1577) by [@pepibumur](https://github.com/pepibumur).
+- Update `ConfigGenerator` to use `ValueGraph` instead [#1583](https://github.com/tuist/tuist/pull/1583) by [@pepibumur](https://github.com/pepibumur).
 
 ## 1.13.1 - More Bella Vita
 

--- a/Sources/TuistCore/ValueGraph/ValueGraph.swift
+++ b/Sources/TuistCore/ValueGraph/ValueGraph.swift
@@ -109,9 +109,11 @@ public struct ValueGraph: Equatable {
                         path: node.path,
                         status: node.status,
                         source: node.source)
-        case let package as PackageProductNode:
-            return .packageProduct(path: package.path,
-                                   product: package.product)
+        case let node as PackageProductNode:
+            return .packageProduct(path: node.path,
+                                   product: node.product)
+        case let node as CocoaPodsNode:
+            return .cocoapods(path: node.path)
         default:
             fatalError("Unsupported dependency node type")
         }

--- a/Sources/TuistCore/ValueGraph/ValueGraph.swift
+++ b/Sources/TuistCore/ValueGraph/ValueGraph.swift
@@ -109,6 +109,9 @@ public struct ValueGraph: Equatable {
                         path: node.path,
                         status: node.status,
                         source: node.source)
+        case let package as PackageProductNode:
+            return .packageProduct(path: package.path,
+                                   product: package.product)
         default:
             fatalError("Unsupported dependency node type")
         }

--- a/Sources/TuistCore/ValueGraph/ValueGraphDependency.swift
+++ b/Sources/TuistCore/ValueGraph/ValueGraphDependency.swift
@@ -37,25 +37,37 @@ public enum ValueGraphDependency: Hashable {
     /// A dependency that represents an SDK
     case sdk(name: String, path: AbsolutePath, status: SDKStatus, source: SDKSource)
 
+    /// A dependency that represents a pod installlation.
+    case cocoapods(path: AbsolutePath)
+
     public func hash(into hasher: inout Hasher) {
         switch self {
         case let .xcframework(path, _, _, _):
+            hasher.combine("xcframework")
             hasher.combine(path)
         case let .framework(path, _, _, _, _):
+            hasher.combine("framework")
             hasher.combine(path)
         case let .library(path, _, _, _, _):
+            hasher.combine("library")
             hasher.combine(path)
         case let .packageProduct(path, product):
+            hasher.combine("package")
             hasher.combine(path)
             hasher.combine(product)
         case let .target(name, path):
+            hasher.combine("target")
             hasher.combine(name)
             hasher.combine(path)
         case let .sdk(name, path, status, source):
+            hasher.combine("sdk")
             hasher.combine(name)
             hasher.combine(path)
             hasher.combine(status)
             hasher.combine(source)
+        case let .cocoapods(path):
+            hasher.combine("pods")
+            hasher.combine(path)
         }
     }
 }

--- a/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
+++ b/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
@@ -1,0 +1,30 @@
+import Foundation
+import TSCBasic
+
+public protocol ValueGraphTraversing {
+    init(graph: ValueGraph)
+
+    /// Given a project directory and target name, it returns all its direct target dependencies.
+    /// - Parameters:
+    ///   - path: Path to the directory that contains the project.
+    ///   - name: Target name.
+    func directTargetDependencies(path: AbsolutePath, name: String) -> [Target]
+}
+
+public class ValueGraphTraverser: ValueGraphTraversing {
+    private let graph: ValueGraph
+
+    public required init(graph: ValueGraph) {
+        self.graph = graph
+    }
+
+    public func directTargetDependencies(path: AbsolutePath, name: String) -> [Target] {
+        guard let dependencies = graph.dependencies[.target(name: name, path: path)] else { return [] }
+        return dependencies.flatMap { (dependency) -> [Target] in
+            guard case let ValueGraphDependency.target(dependencyName, dependencyPath) = dependency else { return [] }
+            guard let projectDependencies = graph.targets[dependencyPath], let dependencyTarget = projectDependencies[dependencyName] else { return []
+            }
+            return [dependencyTarget]
+        }
+    }
+}

--- a/Sources/TuistGenerator/Generator/TargetGenerator.swift
+++ b/Sources/TuistGenerator/Generator/TargetGenerator.swift
@@ -51,6 +51,9 @@ final class TargetGenerator: TargetGenerating {
                         fileElements: ProjectFileElements,
                         path: AbsolutePath,
                         graph: Graph) throws -> PBXNativeTarget {
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
+
         /// Products reference.
         let productFileReference = fileElements.products[target.name]!
 
@@ -80,7 +83,7 @@ final class TargetGenerator: TargetGenerating {
                                                  pbxproj: pbxproj,
                                                  projectSettings: projectSettings,
                                                  fileElements: fileElements,
-                                                 graph: graph,
+                                                 graphTraverser: graphTraverser,
                                                  sourceRootPath: project.sourceRootPath)
 
         /// Build phases

--- a/Tests/TuistCoreTests/ValueGraph/ValueGraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/ValueGraph/ValueGraphTraverserTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import TSCBasic
+import TuistCore
+import TuistSupport
+import XCTest
+
+@testable import TuistCoreTesting
+@testable import TuistSupportTesting
+
+final class ValueGraphTraverserTests: TuistUnitTestCase {
+    func test_directTargetDependencies() {
+        // Given
+        // A -> B -> C
+        let project = Project.test()
+        let a = Target.test(name: "A")
+        let b = Target.test(name: "B")
+        let c = Target.test(name: "C")
+        let dependencies: [ValueGraphDependency: Set<ValueGraphDependency>] = [
+            .target(name: a.name, path: project.path): Set([.target(name: b.name, path: project.path)]),
+            .target(name: b.name, path: project.path): Set([.target(name: c.name, path: project.path)]),
+        ]
+        let targets: [AbsolutePath: [String: Target]] = [project.path: [
+            a.name: a,
+            b.name: b,
+            c.name: c,
+        ]]
+        let graph = ValueGraph.test(path: project.path,
+                                    projects: [project.path: project],
+                                    targets: targets,
+                                    dependencies: dependencies)
+        let subject = ValueGraphTraverser(graph: graph)
+
+        // When
+        let got = subject.directTargetDependencies(path: project.path, name: a.name)
+
+        // Then
+        XCTAssertEqual(got, [b])
+    }
+}

--- a/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGeneratorTests.swift
@@ -79,10 +79,11 @@ final class ProjectGeneratorTests: TuistUnitTestCase {
         let target = Target.test()
         let packageNode = PackageNode(package: .remote(url: "A", requirement: .exact("0.1")),
                                       path: temporaryPath)
+        let packageProductNode = PackageProductNode(product: "A", path: project.path)
         let graph = Graph.test(entryPath: temporaryPath,
                                entryNodes: [TargetNode(project: project,
                                                        target: target,
-                                                       dependencies: [packageNode])],
+                                                       dependencies: [packageProductNode])],
                                projects: [project],
                                packages: [packageNode])
 


### PR DESCRIPTION
### Short description 📝
Continuing with our effort of moving away from `Graph`, I started updating the `*Generator` components to use the `ValueGraph` instead. In this case, I'm updating the `ConfigGenerator` and I'll continue doing it backwards up to the `ProjectGenerator`.

Notice that instead of exposing accessors in the `ValueGraph` object, I created a class, `ValueGraphTraverser`, that provides those accessors. This is on purpose to be able to cache returned values and avoid unnecessary traverses.