### PR TITLE
Add Acceptance Tests for a micro-feature kind of iOS application

### DIFF
--- a/features/cache.feature
+++ b/features/cache.feature
@@ -11,3 +11,16 @@ Feature: Generates projects with pre-compiled cached dependencies
     Then MyApp embeds the xcframework MyAppSupport
     Then I should be able to build for iOS the scheme MyApp
     Then I should be able to test for iOS the scheme MyAppTests
+
+Scenario: The project is an application with templates (ios_workspace_with_microfeature_architecture)
+    Given that tuist is available 
+    And I have a working directory
+    Then I copy the fixture ios_workspace_with_microfeature_architecture into the working directory
+    And tuist warms the cache
+    When tuist generates a project with cached targets at App
+    Then App embeds the xcframework Core
+    Then App embeds the xcframework Data
+    Then App embeds the xcframework FeatureContracts
+    Then App embeds the xcframework UIComponents
+    Then I should be able to build for iOS the scheme App
+    Then I should be able to test for iOS the scheme AppTests

--- a/fixtures/ios_workspace_with_microfeature_architecture/App/Info.plist
+++ b/fixtures/ios_workspace_with_microfeature_architecture/App/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/fixtures/ios_workspace_with_microfeature_architecture/App/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/App/Project.swift
@@ -1,0 +1,29 @@
+import ProjectDescription
+
+let project = Project(name: "App",
+                      targets: [
+                        Target(name: "App",
+                               platform: .iOS,
+                               product: .app,
+                               bundleId: "io.tuist.App",
+                               infoPlist: "Info.plist",
+                               sources: ["Sources/**"],
+                               resources: [
+                                       /* Path to resouces can be defined here */
+                                       // "Resources/**"
+                               ],
+                               dependencies: [
+                                    /* Target dependencies can be defined here */
+                                    // .framework(path: "Frameworks/MyFramework.framework")
+                                    .project(target: "FrameworkA", path: "../Frameworks/FeatureAFramework")
+                                ]),
+                        Target(name: "AppTests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               bundleId: "io.tuist.AppTests",
+                               infoPlist: "Tests.plist",
+                               sources: "Tests/**",
+                               dependencies: [
+                                    .target(name: "App")
+                               ])
+                      ])

--- a/fixtures/ios_workspace_with_microfeature_architecture/App/Sources/AppDelegate.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/App/Sources/AppDelegate.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
+    ) -> Bool {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        let viewController = UIViewController()
+        viewController.view.backgroundColor = .white
+        window?.rootViewController = viewController
+        window?.makeKeyAndVisible()
+        return true
+    }
+
+}

--- a/fixtures/ios_workspace_with_microfeature_architecture/App/Tests.plist
+++ b/fixtures/ios_workspace_with_microfeature_architecture/App/Tests.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_workspace_with_microfeature_architecture/App/Tests/AppTests.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/App/Tests/AppTests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+@testable import App
+
+final class AppTests: XCTestCase {
+
+}

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/CoreFramework/Info.plist
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/CoreFramework/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/CoreFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/CoreFramework/Project.swift
@@ -1,0 +1,24 @@
+import ProjectDescription
+
+let project = Project(name: "Core",
+                      targets: [
+                        Target(name: "Core",
+                               platform: .iOS,
+                               product: .framework,
+                               bundleId: "io.tuist.Core",
+                               infoPlist: "Info.plist",
+                               sources: ["Sources/**"],
+                               resources: [
+                                       /* Path to resouces can be defined here */
+                                       // "Resources/**"
+                               ]),
+                        Target(name: "CoreTests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               bundleId: "io.tuist.CoreTests",
+                               infoPlist: "Tests.plist",
+                               sources: "Tests/**",
+                               dependencies: [
+                                    .target(name: "Core")
+                               ])
+                      ])

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/CoreFramework/Sources/CoreClass.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/CoreFramework/Sources/CoreClass.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public class CoreClass {
+    public init() {}
+}

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/CoreFramework/Tests.plist
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/CoreFramework/Tests.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/CoreFramework/Tests/CoreClassTests.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/CoreFramework/Tests/CoreClassTests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+@testable import Core
+
+final class CoreClassTests: XCTestCase {
+
+}

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/DataFramework/Info.plist
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/DataFramework/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/DataFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/DataFramework/Project.swift
@@ -1,0 +1,29 @@
+import ProjectDescription
+
+let project = Project(name: "Data",
+                      targets: [
+                        Target(name: "Data",
+                               platform: .iOS,
+                               product: .framework,
+                               bundleId: "io.tuist.Data",
+                               infoPlist: "Info.plist",
+                               sources: ["Sources/**"],
+                               resources: [
+                                       /* Path to resouces can be defined here */
+                                       // "Resources/**"
+                               ],
+                               dependencies: [
+                                    /* Target dependencies can be defined here */
+                                    // .framework(path: "Frameworks/MyFramework.framework")
+                                    .project(target: "Core", path: "../CoreFramework")
+                                ]),
+                        Target(name: "DataTests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               bundleId: "io.tuist.DataFrameworkTests",
+                               infoPlist: "Tests.plist",
+                               sources: "Tests/**",
+                               dependencies: [
+                                    .target(name: "Data")
+                               ])
+                      ])

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/DataFramework/Sources/DataClass.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/DataFramework/Sources/DataClass.swift
@@ -1,0 +1,8 @@
+import Foundation
+import Core
+
+public class DataClass {
+    let core = CoreClass()
+    
+    public init() {}
+}

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/DataFramework/Tests.plist
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/DataFramework/Tests.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/DataFramework/Tests/FrameworkATests.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/DataFramework/Tests/FrameworkATests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+@testable import Data
+
+final class DataClassTests: XCTestCase {
+
+}

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureAFramework/Info.plist
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureAFramework/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureAFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureAFramework/Project.swift
@@ -1,0 +1,32 @@
+import ProjectDescription
+
+let project = Project(name: "FrameworkA",
+                      targets: [
+                        Target(name: "FrameworkA",
+                               platform: .iOS,
+                               product: .framework,
+                               bundleId: "io.tuist.FrameworkA",
+                               infoPlist: "Info.plist",
+                               sources: ["Sources/**"],
+                               resources: [
+                                       /* Path to resouces can be defined here */
+                                       // "Resources/**"
+                               ],
+                               dependencies: [
+                                    /* Target dependencies can be defined here */
+                                    // .framework(path: "Frameworks/MyFramework.framework")
+                                    .project(target: "FeatureContracts", path: "../FeatureContracts"),
+                                    .project(target: "Core", path: "../CoreFramework"),
+                                    .project(target: "Data", path: "../DataFramework"),
+                                    .project(target: "UIComponents", path: "../UIComponentsFramework")
+                                ]),
+                        Target(name: "FrameworkATests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               bundleId: "io.tuist.FrameworkATests",
+                               infoPlist: "Tests.plist",
+                               sources: "Tests/**",
+                               dependencies: [
+                                    .target(name: "FrameworkA")
+                               ])
+                      ])

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureAFramework/Sources/FrameworkA.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureAFramework/Sources/FrameworkA.swift
@@ -1,0 +1,10 @@
+import Foundation
+import FeatureContracts
+
+class FrameworkA {
+	func run(featureB: FeatureBContract) {
+		featureB.run()
+        let a = featureB.expose()
+        print(a)
+	}
+}

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureAFramework/Tests.plist
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureAFramework/Tests.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureAFramework/Tests/FrameworkATests.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureAFramework/Tests/FrameworkATests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+@testable import FrameworkA
+
+final class FrameworkATests: XCTestCase {
+
+}

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureContracts/Info.plist
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureContracts/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureContracts/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureContracts/Project.swift
@@ -1,0 +1,30 @@
+import ProjectDescription
+
+let project = Project(name: "FeatureContracts",
+                      targets: [
+                        Target(name: "FeatureContracts",
+                               platform: .iOS,
+                               product: .framework,
+                               bundleId: "io.tuist.FeatureContracts",
+                               infoPlist: "Info.plist",
+                               sources: ["Sources/**"],
+                               resources: [
+                                       /* Path to resouces can be defined here */
+                                       // "Resources/**"
+                               ],
+                               dependencies: [
+                                    /* Target dependencies can be defined here */
+                                    // .framework(path: "Frameworks/MyFramework.framework")
+                                    .project(target: "Data", path: "../DataFramework"),
+                                    .project(target: "Core", path: "../CoreFramework")
+                                ]),
+                        Target(name: "FeatureContractsTests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               bundleId: "io.tuist.FeatureContractsTests",
+                               infoPlist: "Tests.plist",
+                               sources: "Tests/**",
+                               dependencies: [
+                                    .target(name: "FeatureContracts")
+                               ])
+                      ])

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureContracts/Sources/FeatureAContract.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureContracts/Sources/FeatureAContract.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol FeatureAContract {
+	func run()
+}

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureContracts/Sources/FeatureBContract.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureContracts/Sources/FeatureBContract.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Core
 public protocol FeatureBContract {
-	func run()
+    func run()
     func expose() -> CoreClass
 }

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureContracts/Sources/FeatureBContract.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureContracts/Sources/FeatureBContract.swift
@@ -1,0 +1,6 @@
+import Foundation
+import Core
+public protocol FeatureBContract {
+	func run()
+    func expose() -> CoreClass
+}

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureContracts/Tests.plist
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureContracts/Tests.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureContracts/Tests/FrameworkAContractTests.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureContracts/Tests/FrameworkAContractTests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+@testable import FrameworkA
+
+final class FrameworkAContractTests: XCTestCase {
+
+}

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/UIComponentsFramework/Info.plist
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/UIComponentsFramework/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/UIComponentsFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/UIComponentsFramework/Project.swift
@@ -1,0 +1,29 @@
+import ProjectDescription
+
+let project = Project(name: "UIComponents",
+                      targets: [
+                        Target(name: "UIComponents",
+                               platform: .iOS,
+                               product: .framework,
+                               bundleId: "io.tuist.UIComponents",
+                               infoPlist: "Info.plist",
+                               sources: ["Sources/**"],
+                               resources: [
+                                       /* Path to resouces can be defined here */
+                                       // "Resources/**"
+                               ],
+                               dependencies: [
+                                    /* Target dependencies can be defined here */
+                                    // .framework(path: "Frameworks/MyFramework.framework")
+                                    .project(target: "FeatureContracts", path: "../FeatureContracts")
+                                ]),
+                        Target(name: "UIComponentsTests",
+                               platform: .iOS,
+                               product: .unitTests,
+                               bundleId: "io.tuist.UIComponentsTests",
+                               infoPlist: "Tests.plist",
+                               sources: "Tests/**",
+                               dependencies: [
+                                    .target(name: "UIComponents")
+                               ])
+                      ])

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/UIComponentsFramework/Sources/UIComponentA.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/UIComponentsFramework/Sources/UIComponentA.swift
@@ -1,0 +1,7 @@
+import Foundation
+import UIKit
+import Data
+
+class UIComponentA: UIView {
+	let data = DataClass()
+}

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/UIComponentsFramework/Tests.plist
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/UIComponentsFramework/Tests.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright ©. All rights reserved.</string>
+</dict>
+</plist>

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/UIComponentsFramework/Tests/UIComponentATests.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/UIComponentsFramework/Tests/UIComponentATests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+@testable import UIComponents
+
+final class UIComponentATests: XCTestCase {
+
+}

--- a/fixtures/ios_workspace_with_microfeature_architecture/Workspace.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Workspace.swift
@@ -1,0 +1,7 @@
+import ProjectDescription
+
+let workspace = Workspace(name: "Workspace",
+                          projects: [
+                              "App", 
+                              "Frameworks/**", 
+                            ])


### PR DESCRIPTION
### Short description 📝

Add more acceptance testing around the warm cache command.

### Solution 📦

As part of the cache acceptance tests suite, I added a scenario that warms the cache for a micro-feature architected kind of application - every single target being a dynamic framework here.