### PR TITLE
Add `--json` option to scaffold's output listing command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 - Add benchmark rake task [#1561](https://github.com/tuist/tuist/pull/1561) by [@kwridan](https://github.com/kwridan).
+- Add `--json` flag to `tuist scaffold list` command [#1589](https://github.com/tuist/tuist/issues/1589) by [@mollyIV](https://github.com/mollyIV).
 
 ### Fixed
 

--- a/Sources/TuistKit/Commands/ListCommand.swift
+++ b/Sources/TuistKit/Commands/ListCommand.swift
@@ -8,6 +8,11 @@ struct ListCommand: ParsableCommand {
                              subcommands: [])
     }
 
+    @Flag(
+        help: "The output in JSON format"
+    )
+    var json: Bool
+
     @Option(
         name: .shortAndLong,
         help: "The path where you want to list templates from"
@@ -15,6 +20,8 @@ struct ListCommand: ParsableCommand {
     var path: String?
 
     func run() throws {
-        try ListService().run(path: path)
+        let format: ListService.OutputFormat = json ? .json : .table
+        try ListService().run(path: path,
+                              outputFormat: format)
     }
 }

--- a/Sources/TuistKit/Commands/ScaffoldCommand.swift
+++ b/Sources/TuistKit/Commands/ScaffoldCommand.swift
@@ -63,7 +63,7 @@ struct ScaffoldCommand: ParsableCommand {
     func run() throws {
         // Currently, @Argument and subcommand clashes, so we need to handle that ourselves
         if template == ListCommand.configuration.commandName {
-            try ListService().run(path: path)
+            try ListService().run(path: path, outputFormat: .table)
         } else {
             try ScaffoldService().run(path: path,
                                       templateName: template,

--- a/Sources/TuistKit/Commands/ScaffoldCommand.swift
+++ b/Sources/TuistKit/Commands/ScaffoldCommand.swift
@@ -29,6 +29,11 @@ struct ScaffoldCommand: ParsableCommand {
                              subcommands: [ListCommand.self])
     }
 
+    @Flag(
+        help: "The output in JSON format"
+    )
+    var json: Bool
+
     @Option(
         name: .shortAndLong,
         help: "The path to the folder where the template will be generated (Default: Current directory)"
@@ -49,6 +54,7 @@ struct ScaffoldCommand: ParsableCommand {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         template = try container.decode(Argument<String>.self, forKey: .template).wrappedValue
+        json = try container.decodeIfPresent(Option<Bool>.self, forKey: .json)?.wrappedValue ?? false
         path = try container.decodeIfPresent(Option<String>.self, forKey: .path)?.wrappedValue
         try ScaffoldCommand.requiredTemplateOptions.forEach { option in
             requiredTemplateOptions[option.name] = try container.decode(Option<String>.self,
@@ -63,7 +69,8 @@ struct ScaffoldCommand: ParsableCommand {
     func run() throws {
         // Currently, @Argument and subcommand clashes, so we need to handle that ourselves
         if template == ListCommand.configuration.commandName {
-            try ListService().run(path: path, outputFormat: .table)
+            let format: ListService.OutputFormat = json ? .json : .table
+            try ListService().run(path: path, outputFormat: format)
         } else {
             try ScaffoldService().run(path: path,
                                       templateName: template,
@@ -87,13 +94,13 @@ extension ScaffoldCommand {
         else { throw ScaffoldCommandError.templateNotProvided }
         guard !configuration.subcommands.contains(where: { $0.configuration.commandName == arguments[1] }) else { return }
         // We want to parse only the name of template, not its arguments which will be dynamically added
-        // Plucking out path argument
+        // Plucking out json and path arguments
         let pairedArguments: [[String]] = stride(from: 2, to: arguments.count, by: 2).map {
             Array(arguments[$0 ..< min($0 + 2, arguments.count)])
         }
         let filteredArguments = pairedArguments
             .filter {
-                $0.first == "--path" || $0.first == "-p"
+                $0.first == "--path" || $0.first == "-p" || $0.first == "--json"
             }
             .flatMap { $0 }
 
@@ -116,6 +123,7 @@ extension ScaffoldCommand {
 extension ScaffoldCommand {
     enum CodingKeys: CodingKey {
         case template
+        case json
         case path
         case required(String)
         case optional(String)
@@ -124,6 +132,8 @@ extension ScaffoldCommand {
             switch self {
             case .template:
                 return "template"
+            case .json:
+                return "json"
             case .path:
                 return "path"
             case let .required(required):
@@ -137,6 +147,8 @@ extension ScaffoldCommand {
             switch stringValue {
             case "template":
                 self = .template
+            case "json":
+                self = .json
             case "path":
                 self = .path
             default:
@@ -166,6 +178,7 @@ extension ScaffoldCommand: CustomReflectable {
             .map { Mirror.Child(label: $0.name, value: $0.option) }
         let children = [
             Mirror.Child(label: "template", value: _template),
+            Mirror.Child(label: "json", value: _json),
             Mirror.Child(label: "path", value: _path),
         ].filter {
             // Prefer attributes defined in a template if it clashes with predefined ones

--- a/Sources/TuistKit/Services/ListService.swift
+++ b/Sources/TuistKit/Services/ListService.swift
@@ -5,6 +5,13 @@ import TuistScaffold
 import TuistSupport
 
 class ListService {
+    // MARK: - OutputFormat
+
+    enum OutputFormat {
+        case table
+        case json
+    }
+
     private let templatesDirectoryLocator: TemplatesDirectoryLocating
     private let templateLoader: TemplateLoading
 
@@ -51,13 +58,6 @@ class ListService {
             let json = try templates.toJSON()
             return json.toString(prettyPrint: true)
         }
-    }
-}
-
-extension ListService {
-    enum OutputFormat {
-        case table
-        case json
     }
 }
 

--- a/Tests/TuistKitTests/Services/ListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/ListServiceTests.swift
@@ -27,7 +27,7 @@ final class ListServiceTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_lists_available_templates() throws {
+    func test_lists_available_templates_table_format() throws {
         // Given
         let expectedTemplates = ["template", "customTemplate"]
         let expectedOutput = """
@@ -46,7 +46,38 @@ final class ListServiceTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.run(path: nil)
+        try subject.run(path: nil, outputFormat: .table)
+
+        // Then
+        XCTAssertPrinterContains(expectedOutput, at: .info, ==)
+    }
+
+    func test_lists_available_templates_json_format() throws {
+        // Given
+        let expectedTemplates = ["template", "customTemplate"]
+        let expectedOutput = """
+        [
+          {
+            "description": "description",
+            "name": "template"
+          },
+          {
+            "description": "description",
+            "name": "customTemplate"
+          }
+        ]
+        """
+
+        templatesDirectoryLocator.templateDirectoriesStub = { _ in
+            try expectedTemplates.map(self.temporaryPath().appending)
+        }
+
+        templateLoader.loadTemplateStub = { _ in
+            Template(description: "description")
+        }
+
+        // When
+        try subject.run(path: nil, outputFormat: .json)
 
         // Then
         XCTAssertPrinterContains(expectedOutput, at: .info, ==)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1589

### Short description 📝

The purpose of this pull request is to add a `--json` flag as output formatting option to `scaffold list` command.

### Testing

```
$ tuist scaffold list --json --path ~/Projects/demo/tuist-demo

[
  {
    "description": "Default template",
    "name": "default"
  },
  {
    "description": "SwiftUI template",
    "name": "swiftui"
  },
  {
    "description": "Default template",
    "name": "default"
  },
  {
    "description": "SwiftUI template",
    "name": "swiftui"
  }
]
```