### PR TITLE
Add `DescriptorGenerator` performance test

### DIFF
--- a/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
@@ -11,41 +11,47 @@ import XCTest
 @testable import TuistSupportTesting
 
 final class StableXcodeProjIntegrationTests: TuistTestCase {
-    override func setUp() {
-        super.setUp()
-
-        do {
-            try setupTestProject()
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-    }
-
     func testXcodeProjStructureDoesNotChangeAfterRegeneration() throws {
         // Given
         let temporaryPath = try self.temporaryPath()
         var capturedProjects = [[XcodeProj]]()
-        var capturesWorkspaces = [XCWorkspace]()
+        var capturedWorkspaces = [XCWorkspace]()
         var capturedSharedSchemes = [[XCScheme]]()
         var capturedUserSchemes = [[XCScheme]]()
 
         // When
         try (0 ..< 10).forEach { _ in
-            let workspacePath = try generateWorkspace(path: temporaryPath)
+            let subject = DescriptorGenerator()
+            let writer = XcodeProjWriter()
+            let config = TestModelGenerator.WorkspaceConfig(projects: 4,
+                                                            testTargets: 10,
+                                                            frameworkTargets: 10,
+                                                            schemes: 10,
+                                                            sources: 200,
+                                                            resources: 100,
+                                                            headers: 100)
+            let modelGenerator = TestModelGenerator(rootPath: temporaryPath, config: config)
+            let (graph, workspace) = try modelGenerator.generate()
 
-            let workspace = try XCWorkspace(path: workspacePath.path)
-            let xcodeProjs = try findXcodeProjs(in: workspace)
-            let sharedSchemes = try findSharedSchemes(in: workspace)
-            let userSchemes = try findUserSchemes(in: workspace)
+            let workspaceDescriptor = try subject.generateWorkspace(workspace: workspace, graph: graph)
+
+            // Note: While we already have access to the `XcodeProj` models in `workspaceDescriptor`
+            // unfortunately they are not equtable, however once serialized & deserialized back they are
+            try writer.write(workspace: workspaceDescriptor)
+            let xcworkspace = try XCWorkspace(path: workspaceDescriptor.xcworkspacePath.path)
+            let xcodeProjs = try findXcodeProjs(in: xcworkspace)
+            let sharedSchemes = try findSharedSchemes(in: xcworkspace)
+            let userSchemes = try findUserSchemes(in: xcworkspace)
+
             capturedProjects.append(xcodeProjs)
-            capturesWorkspaces.append(workspace)
+            capturedWorkspaces.append(xcworkspace)
             capturedSharedSchemes.append(sharedSchemes)
             capturedUserSchemes.append(userSchemes)
         }
 
         // Then
         let unstableProjects = capturedProjects.dropFirst().filter { $0 != capturedProjects.first }
-        let unstableWorkspaces = capturesWorkspaces.dropFirst().filter { $0 != capturesWorkspaces.first }
+        let unstableWorkspaces = capturedWorkspaces.dropFirst().filter { $0 != capturedWorkspaces.first }
         let unstableSharedSchemes = capturedSharedSchemes.dropFirst().filter { $0 != capturedSharedSchemes.first }
         let unstableUserSchemes = capturedUserSchemes.dropFirst().filter { $0 != capturedUserSchemes.first }
 
@@ -56,27 +62,6 @@ final class StableXcodeProjIntegrationTests: TuistTestCase {
     }
 
     // MARK: - Helpers
-
-    private func generateWorkspace(path: AbsolutePath) throws -> AbsolutePath {
-        let subject = DescriptorGenerator()
-        let writer = XcodeProjWriter()
-        let linter = GraphLinter()
-        let frameworkNodeLoader = MockFrameworkNodeLoader()
-        let libraryNodeLoader = MockLibraryNodeLoader()
-        let xcframeworkNodeLoader = MockXCFrameworkNodeLoader()
-
-        let graphLoader = GraphLoader(modelLoader: try createModelLoader(),
-                                      frameworkNodeLoader: frameworkNodeLoader,
-                                      xcframeworkNodeLoader: xcframeworkNodeLoader,
-                                      libraryNodeLoader: libraryNodeLoader)
-
-        let (graph, workspace) = try graphLoader.loadWorkspace(path: path)
-        try linter.lint(graph: graph).printAndThrowIfNeeded()
-        let descriptor = try subject.generateWorkspace(workspace: workspace, graph: graph)
-        try writer.write(workspace: descriptor)
-
-        return descriptor.xcworkspacePath
-    }
 
     private func findXcodeProjs(in workspace: XCWorkspace) throws -> [XcodeProj] {
         let temporaryPath = try self.temporaryPath()
@@ -101,254 +86,6 @@ final class StableXcodeProjIntegrationTests: TuistTestCase {
             .flatMap { $0 }
             .map { try XCScheme(path: $0.path) }
         return schemes
-    }
-
-    private func setupTestProject() throws {
-        try createFolders(["App/Sources"])
-    }
-
-    private func createModelLoader() throws -> GeneratorModelLoading {
-        let temporaryPath = try self.temporaryPath()
-        let modelLoader = MockGeneratorModelLoader(basePath: temporaryPath)
-        let frameworksNames = (0 ..< 10).map { "Framework\($0)" }
-        let unitTestsTargetNames = (0 ..< 10).map { "TestAppTests\($0)" }
-        let targetSettings = Settings(base: ["A1": "A_VALUE",
-                                             "B1": "B_VALUE",
-                                             "C1": "C_VALUE"],
-                                      configurations: [.debug: nil,
-                                                       .release: nil,
-                                                       .debug("CustomDebug"): nil,
-                                                       .release("CustomRelease"): nil])
-        let projectSettings = Settings(base: ["A2": "A_VALUE",
-                                              "B2": "B_VALUE",
-                                              "C2": "C_VALUE"],
-                                       configurations: [.debug: nil,
-                                                        .release: nil,
-                                                        .debug("CustomDebug2"): nil,
-                                                        .release("CustomRelease2"): nil])
-        let projectPath = try pathTo("App")
-        let dependencies = try createDependencies(relativeTo: projectPath)
-        let frameworkTargets = try frameworksNames.map { try createFrameworkTarget(name: $0, depenendencies: dependencies) }
-        let appTarget = createTarget(name: "AppTarget", settings: targetSettings, dependencies: frameworksNames)
-        let appUnitTestsTargets = unitTestsTargetNames.map { createTarget(name: $0,
-                                                                          product: .unitTests,
-                                                                          settings: nil,
-                                                                          dependencies: [appTarget.name]) }
-        let schemes = try createSchemes(appTarget: appTarget, frameworkTargets: frameworkTargets)
-        let project = createProject(path: projectPath,
-                                    settings: projectSettings,
-                                    targets: [appTarget] + frameworkTargets + appUnitTestsTargets,
-                                    schemes: schemes)
-        let workspace = try createWorkspace(path: temporaryPath, projects: ["App"])
-        let config = createConfig()
-
-        modelLoader.mockProject("App") { _ in project }
-        modelLoader.mockWorkspace { _ in workspace }
-        modelLoader.mockConfig { _ in config }
-        return modelLoader
-    }
-
-    private func createConfig() -> Config {
-        Config(compatibleXcodeVersions: .all, cloud: nil, generationOptions: [])
-    }
-
-    private func createWorkspace(path: AbsolutePath, projects: [String]) throws -> Workspace {
-        Workspace(path: path, name: "Workspace", projects: try projects.map { try pathTo($0) })
-    }
-
-    private func createProject(path: AbsolutePath, settings: Settings, targets: [Target], packages: [Package] = [], schemes: [Scheme]) -> Project {
-        Project(path: path,
-                sourceRootPath: path,
-                xcodeProjPath: path.appending(component: "App.xcodeproj"),
-                name: "App",
-                organizationName: nil,
-                settings: settings,
-                filesGroup: .group(name: "Project"),
-                targets: targets,
-                packages: packages,
-                schemes: schemes,
-                additionalFiles: createAdditionalFiles())
-    }
-
-    private func createTarget(name: String, product: Product = .app, settings: Settings?, dependencies: [String]) -> Target {
-        Target(name: name,
-               platform: .iOS,
-               product: product,
-               productName: name,
-               bundleId: "test.bundle",
-               settings: settings,
-               sources: createSources(),
-               resources: createResources(),
-               headers: createHeaders(),
-               filesGroup: .group(name: "ProjectGroup"),
-               dependencies: dependencies.map { Dependency.target(name: $0) })
-    }
-
-    private func createSources() -> [Target.SourceFile] {
-        let sources: [Target.SourceFile] = (0 ..< 10)
-            .map { "/App/Sources/SourceFile\($0).swift" }
-            .map { (path: AbsolutePath($0), compilerFlags: nil) }
-            .shuffled()
-        return sources
-    }
-
-    private func createHeaders() -> Headers {
-        let publicHeaders = (0 ..< 10)
-            .map { "/App/Sources/PublicHeader\($0).h" }
-            .map { AbsolutePath($0) }
-            .shuffled()
-
-        let privateHeaders = (0 ..< 10)
-            .map { "/App/Sources/PrivateHeader\($0).h" }
-            .map { AbsolutePath($0) }
-            .shuffled()
-
-        let projectHeaders = (0 ..< 10)
-            .map { "/App/Sources/ProjectHeader\($0).h" }
-            .map { AbsolutePath($0) }
-            .shuffled()
-
-        return Headers(public: publicHeaders, private: privateHeaders, project: projectHeaders)
-    }
-
-    private func createResources() -> [FileElement] {
-        let files = (0 ..< 10)
-            .map { "/App/Resources/Resource\($0).png" }
-            .map { FileElement.file(path: AbsolutePath($0)) }
-
-        let folderReferences = (0 ..< 10)
-            .map { "/App/Resources/Folder\($0)" }
-            .map { FileElement.folderReference(path: AbsolutePath($0)) }
-
-        return (files + folderReferences).shuffled()
-    }
-
-    private func createAdditionalFiles() -> [FileElement] {
-        let files = (0 ..< 10)
-            .map { "/App/Files/File\($0).md" }
-            .map { FileElement.file(path: AbsolutePath($0)) }
-
-        // When using ** glob patterns (e.g. `Documentation/**`)
-        // the results will include the folders in addition to the files
-        //
-        // e.g.
-        //    Documentation
-        //    Documentation/a.md
-        //    Documentation/Subfolder
-        //    Documentation/Subfolder/a.md
-        let filesWithFolderPaths = files + [
-            .file(path: AbsolutePath("/App/Files")),
-        ]
-
-        let folderReferences = (0 ..< 10)
-            .map { "/App/Documentation\($0)" }
-            .map { FileElement.folderReference(path: AbsolutePath($0)) }
-
-        return (filesWithFolderPaths + folderReferences).shuffled()
-    }
-
-    private func createFrameworkTarget(name: String, depenendencies: [Dependency] = []) throws -> Target {
-        Target(name: name,
-               platform: .iOS,
-               product: .framework,
-               productName: name,
-               bundleId: "test.bundle.\(name)",
-               settings: nil,
-               sources: [],
-               filesGroup: .group(name: "ProjectGroup"),
-               dependencies: depenendencies)
-    }
-
-    private func createDependencies(relativeTo path: AbsolutePath) throws -> [Dependency] {
-        let prebuiltFrameworks = (0 ..< 10).map { "Frameworks/Framework\($0).framework" }
-        let frameworks = try createFiles(prebuiltFrameworks)
-            .map { Dependency.framework(path: $0) }
-
-        let libraries = try createLibraries(relativeTo: path)
-
-        return (frameworks + libraries).shuffled()
-    }
-
-    private func createLibraries(relativeTo _: AbsolutePath) throws -> [Dependency] {
-        var libraries = [Dependency]()
-
-        for i in 0 ..< 10 {
-            let libraryName = "Library\(i)"
-            let library = "Libraries/\(libraryName)/lib\(libraryName).a"
-            let headers = "Libraries/\(libraryName)/Headers"
-            let swiftModuleMap = "Libraries/\(libraryName)/\(libraryName).swiftmodule"
-
-            let files = try createFiles([
-                library,
-                headers,
-                swiftModuleMap,
-            ])
-
-            libraries.append(.library(path: files[0], publicHeaders: files[1], swiftModuleMap: files[2]))
-        }
-
-        return libraries
-    }
-
-    private func createSchemes(appTarget: Target, frameworkTargets: [Target]) throws -> [Scheme] {
-        let targets = try ([appTarget] + frameworkTargets).map(targetReference(from:))
-        return (0 ..< 10).map {
-            let boolStub = $0 % 2 == 0
-
-            return Scheme(
-                name: "Scheme \($0)",
-                shared: boolStub,
-                buildAction: BuildAction(targets: targets,
-                                         preActions: createExecutionActions(),
-                                         postActions: createExecutionActions()),
-                testAction: TestAction(targets: targets.map { TestableTarget(target: $0) },
-                                       arguments: createArguments(),
-                                       configurationName: "Debug",
-                                       coverage: boolStub,
-                                       codeCoverageTargets: targets,
-                                       preActions: createExecutionActions(),
-                                       postActions: createExecutionActions(),
-                                       diagnosticsOptions: Set()),
-                runAction: RunAction(configurationName: "Debug",
-                                     executable: nil,
-                                     filePath: nil,
-                                     arguments: createArguments(),
-                                     diagnosticsOptions: Set()),
-                archiveAction: ArchiveAction(configurationName: "Debug",
-                                             revealArchiveInOrganizer: boolStub,
-                                             preActions: createExecutionActions(),
-                                             postActions: createExecutionActions())
-            )
-        }
-    }
-
-    private func createArguments() -> Arguments {
-        let environment = (0 ..< 10).reduce([String: String]()) { acc, value in
-            var acc = acc
-            acc["Environment\(value)"] = "EnvironmentValue\(value)"
-            return acc
-        }
-        let launchArguments = (0 ..< 10).reduce([String: Bool]()) { acc, value in
-            var acc = acc
-            acc["Launch\(value)"] = value % 2 == 0
-            return acc
-        }
-        return Arguments(environment: environment, launchArguments: launchArguments)
-    }
-
-    private func createExecutionActions() -> [ExecutionAction] {
-        (0 ..< 10).map {
-            ExecutionAction(title: "ExecutionAction\($0)", scriptText: "ScripText\($0)", target: nil)
-        }
-    }
-
-    private func pathTo(_ relativePath: String) throws -> AbsolutePath {
-        let temporaryPath = try self.temporaryPath()
-        return temporaryPath.appending(RelativePath(relativePath))
-    }
-
-    private func targetReference(from target: Target) throws -> TargetReference {
-        TargetReference(projectPath: try pathTo("App"), name: target.name)
     }
 }
 

--- a/Tests/TuistIntegrationTests/Generator/TestModelGenerator.swift
+++ b/Tests/TuistIntegrationTests/Generator/TestModelGenerator.swift
@@ -1,0 +1,292 @@
+import Foundation
+import TSCBasic
+import TuistCore
+
+import TuistCoreTesting
+import TuistLoaderTesting
+@testable import TuistGenerator
+@testable import TuistSupport
+@testable import TuistSupportTesting
+
+final class TestModelGenerator {
+    struct WorkspaceConfig {
+        var projects: Int = 50
+        var testTargets: Int = 3
+        var frameworkTargets: Int = 3
+        var schemes: Int = 10
+        var sources: Int = 100
+        var resources: Int = 100
+        var headers: Int = 100
+    }
+
+    private let rootPath: AbsolutePath
+    private let config: WorkspaceConfig
+
+    init(rootPath: AbsolutePath, config: WorkspaceConfig) {
+        self.rootPath = rootPath
+        self.config = config
+    }
+
+    func generate() throws -> (Graph, Workspace) {
+        let frameworkNodeLoader = MockFrameworkNodeLoader()
+        let libraryNodeLoader = MockLibraryNodeLoader()
+        let xcframeworkNodeLoader = MockXCFrameworkNodeLoader()
+        let modelLoader = try createModelLoader()
+
+        let graphLoader = GraphLoader(modelLoader: modelLoader,
+                                      frameworkNodeLoader: frameworkNodeLoader,
+                                      xcframeworkNodeLoader: xcframeworkNodeLoader,
+                                      libraryNodeLoader: libraryNodeLoader)
+
+        return try graphLoader.loadWorkspace(path: rootPath)
+    }
+
+    private func createModelLoader() throws -> GeneratorModelLoading {
+        let modelLoader = MockGeneratorModelLoader(basePath: rootPath)
+
+        let projects = try (0 ..< config.projects).map { try createProjectWithDependencies(name: "App\($0)") }
+        let workspace = try createWorkspace(path: rootPath, projects: projects.map { $0.name })
+        projects.forEach { project in
+            modelLoader.mockProject(project.name) { _ in project }
+        }
+
+        modelLoader.mockWorkspace { _ in workspace }
+        return modelLoader
+    }
+
+    private func createProjectWithDependencies(name: String) throws -> Project {
+        let frameworksNames = (0 ..< config.frameworkTargets).map { "\(name)Framework\($0)" }
+        let unitTestsTargetNames = (0 ..< config.testTargets).map { "\(name)TestAppTests\($0)" }
+        let targetSettings = Settings(base: ["A1": "A_VALUE",
+                                             "B1": "B_VALUE",
+                                             "C1": "C_VALUE"],
+                                      configurations: [.debug: nil,
+                                                       .release: nil,
+                                                       .debug("CustomDebug"): nil,
+                                                       .release("CustomRelease"): nil])
+        let projectSettings = Settings(base: ["A2": "A_VALUE",
+                                              "B2": "B_VALUE",
+                                              "C2": "C_VALUE"],
+                                       configurations: [.debug: nil,
+                                                        .release: nil,
+                                                        .debug("CustomDebug2"): nil,
+                                                        .release("CustomRelease2"): nil])
+        let projectPath = pathTo(name)
+        let dependencies = try createDependencies(relativeTo: projectPath)
+        let frameworkTargets = try frameworksNames.map { try createFrameworkTarget(name: $0, depenendencies: dependencies) }
+        let appTarget = createTarget(path: projectPath, name: "\(name)AppTarget", settings: targetSettings, dependencies: frameworksNames)
+        let appUnitTestsTargets = unitTestsTargetNames.map { createTarget(path: projectPath,
+                                                                          name: $0,
+                                                                          product: .unitTests,
+                                                                          settings: nil,
+                                                                          dependencies: [appTarget.name]) }
+        let schemes = try createSchemes(projectName: name, appTarget: appTarget, frameworkTargets: frameworkTargets)
+        let project = createProject(path: projectPath,
+                                    name: name,
+                                    settings: projectSettings,
+                                    targets: [appTarget] + frameworkTargets + appUnitTestsTargets,
+                                    schemes: schemes)
+
+        return project
+    }
+
+    private func createWorkspace(path: AbsolutePath, projects: [String]) throws -> Workspace {
+        Workspace(path: path, name: "Workspace", projects: projects.map { pathTo($0) })
+    }
+
+    private func createProject(path: AbsolutePath, name: String, settings: Settings, targets: [Target], packages: [Package] = [], schemes: [Scheme]) -> Project {
+        Project(path: path,
+                sourceRootPath: path,
+                xcodeProjPath: path.appending(component: "App.xcodeproj"),
+                name: name,
+                organizationName: nil,
+                settings: settings,
+                filesGroup: .group(name: "Project"),
+                targets: targets,
+                packages: packages,
+                schemes: schemes,
+                additionalFiles: createAdditionalFiles(path: path))
+    }
+
+    private func createTarget(path: AbsolutePath, name: String, product: Product = .app, settings: Settings?, dependencies: [String]) -> Target {
+        Target(name: name,
+               platform: .iOS,
+               product: product,
+               productName: name,
+               bundleId: "test.bundle",
+               settings: settings,
+               sources: createSources(path: path),
+               resources: createResources(path: path),
+               headers: createHeaders(path: path),
+               filesGroup: .group(name: "ProjectGroup"),
+               dependencies: dependencies.map { Dependency.target(name: $0) })
+    }
+
+    private func createSources(path: AbsolutePath) -> [Target.SourceFile] {
+        let sources: [Target.SourceFile] = (0 ..< config.sources)
+            .map { "Sources/SourceFile\($0).swift" }
+            .map { (path: path.appending(RelativePath($0)), compilerFlags: nil) }
+            .shuffled()
+        return sources
+    }
+
+    private func createHeaders(path: AbsolutePath) -> Headers {
+        let publicHeaders = (0 ..< config.headers)
+            .map { "Sources/PublicHeader\($0).h" }
+            .map { path.appending(RelativePath($0)) }
+            .shuffled()
+
+        let privateHeaders = (0 ..< config.headers)
+            .map { "Sources/PrivateHeader\($0).h" }
+            .map { path.appending(RelativePath($0)) }
+            .shuffled()
+
+        let projectHeaders = (0 ..< config.headers)
+            .map { "Sources/ProjectHeader\($0).h" }
+            .map { path.appending(RelativePath($0)) }
+            .shuffled()
+
+        return Headers(public: publicHeaders, private: privateHeaders, project: projectHeaders)
+    }
+
+    private func createResources(path: AbsolutePath) -> [FileElement] {
+        let files = (0 ..< config.resources)
+            .map { "Resources/Resource\($0).png" }
+            .map { FileElement.file(path: path.appending(RelativePath($0))) }
+
+        let folderReferences = (0 ..< 10)
+            .map { "Resources/Folder\($0)" }
+            .map { FileElement.folderReference(path: path.appending(RelativePath($0))) }
+
+        return (files + folderReferences).shuffled()
+    }
+
+    private func createAdditionalFiles(path: AbsolutePath) -> [FileElement] {
+        let files = (0 ..< 10)
+            .map { "Files/File\($0).md" }
+            .map { FileElement.file(path: path.appending(RelativePath($0))) }
+
+        // When using ** glob patterns (e.g. `Documentation/**`)
+        // the results will include the folders in addition to the files
+        //
+        // e.g.
+        //    Documentation
+        //    Documentation/a.md
+        //    Documentation/Subfolder
+        //    Documentation/Subfolder/a.md
+        let filesWithFolderPaths = files + [
+            .file(path: path.appending(RelativePath("Files"))),
+        ]
+
+        let folderReferences = (0 ..< 10)
+            .map { "Documentation\($0)" }
+            .map { FileElement.folderReference(path: path.appending(RelativePath($0))) }
+
+        return (filesWithFolderPaths + folderReferences).shuffled()
+    }
+
+    private func createFrameworkTarget(name: String,
+                                       depenendencies: [Dependency] = []) throws -> Target
+    {
+        Target(name: name,
+               platform: .iOS,
+               product: .framework,
+               productName: name,
+               bundleId: "test.bundle.\(name)",
+               settings: nil,
+               sources: [],
+               filesGroup: .group(name: "ProjectGroup"),
+               dependencies: depenendencies)
+    }
+
+    private func createDependencies(relativeTo path: AbsolutePath) throws -> [Dependency] {
+        let frameworks = (0 ..< 10)
+            .map { "Frameworks/Framework\($0).framework" }
+            .map { Dependency.framework(path: path.appending(RelativePath($0))) }
+
+        let libraries = try createLibraries(relativeTo: path)
+
+        return (frameworks + libraries).shuffled()
+    }
+
+    private func createLibraries(relativeTo path: AbsolutePath) throws -> [Dependency] {
+        var libraries = [Dependency]()
+
+        for i in 0 ..< 10 {
+            let libraryName = "Library\(i)"
+            let library = "Libraries/\(libraryName)/lib\(libraryName).a"
+            let headers = "Libraries/\(libraryName)/Headers"
+            let swiftModuleMap = "Libraries/\(libraryName)/\(libraryName).swiftmodule"
+
+            libraries.append(
+                .library(
+                    path: path.appending(RelativePath(library)),
+                    publicHeaders: path.appending(RelativePath(headers)),
+                    swiftModuleMap: path.appending(RelativePath(swiftModuleMap))
+                )
+            )
+        }
+
+        return libraries
+    }
+
+    private func createSchemes(projectName: String, appTarget: Target, frameworkTargets: [Target]) throws -> [Scheme] {
+        let targets = ([appTarget] + frameworkTargets).map { targetReference(from: $0, projectName: projectName) }
+        return (0 ..< config.schemes).map {
+            let boolStub = $0 % 2 == 0
+
+            return Scheme(
+                name: "Scheme \($0)",
+                shared: boolStub,
+                buildAction: BuildAction(targets: targets,
+                                         preActions: createExecutionActions(),
+                                         postActions: createExecutionActions()),
+                testAction: TestAction(targets: targets.map { TestableTarget(target: $0) },
+                                       arguments: createArguments(),
+                                       configurationName: "Debug",
+                                       coverage: boolStub,
+                                       codeCoverageTargets: targets,
+                                       preActions: createExecutionActions(),
+                                       postActions: createExecutionActions(),
+                                       diagnosticsOptions: Set()),
+                runAction: RunAction(configurationName: "Debug",
+                                     executable: nil,
+                                     filePath: nil,
+                                     arguments: createArguments(),
+                                     diagnosticsOptions: Set()),
+                archiveAction: ArchiveAction(configurationName: "Debug",
+                                             revealArchiveInOrganizer: boolStub,
+                                             preActions: createExecutionActions(),
+                                             postActions: createExecutionActions())
+            )
+        }
+    }
+
+    private func createArguments() -> Arguments {
+        let environment = (0 ..< 10).reduce([String: String]()) { acc, value in
+            var acc = acc
+            acc["Environment\(value)"] = "EnvironmentValue\(value)"
+            return acc
+        }
+        let launch = (0 ..< 10).reduce([String: Bool]()) { acc, value in
+            var acc = acc
+            acc["Launch\(value)"] = value % 2 == 0
+            return acc
+        }
+        return Arguments(environment: environment, launch: launch)
+    }
+
+    private func createExecutionActions() -> [ExecutionAction] {
+        (0 ..< 10).map {
+            ExecutionAction(title: "ExecutionAction\($0)", scriptText: "ScripText\($0)", target: nil)
+        }
+    }
+
+    private func pathTo(_ relativePath: String) -> AbsolutePath {
+        rootPath.appending(RelativePath(relativePath))
+    }
+
+    private func targetReference(from target: Target, projectName: String) -> TargetReference {
+        TargetReference(projectPath: pathTo(projectName), name: target.name)
+    }
+}

--- a/Tests/TuistIntegrationTests/Generator/TestModelGenerator.swift
+++ b/Tests/TuistIntegrationTests/Generator/TestModelGenerator.swift
@@ -273,7 +273,7 @@ final class TestModelGenerator {
             acc["Launch\(value)"] = value % 2 == 0
             return acc
         }
-        return Arguments(environment: environment, launch: launch)
+        return Arguments(environment: environment, launchArguments: launch)
     }
 
     private func createExecutionActions() -> [ExecutionAction] {

--- a/Tests/TuistIntegrationTests/Generator/TuistGeneratorPerformanceTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/TuistGeneratorPerformanceTests.swift
@@ -18,6 +18,14 @@ final class TuistGeneratorPerformanceTests: TuistTestCase {
     // MARK: - Tests
 
     func test_generateWorkspace_performance() throws {
+        guard !isRunningInDebug() else {
+            // Performance tests need to be run in Release Mode for more realistic results
+            // Note: When we switch to Xcode11.5+ only on CI we can use `XCTSkipIf` instead of a guard statement
+            //
+            // XCTSkipIf(isRunningInDebug, "Performance tests need to be run in Release Mode for more realistic results")
+            return
+        }
+
         measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
             do {
                 // Given
@@ -42,5 +50,15 @@ final class TuistGeneratorPerformanceTests: TuistTestCase {
                 XCTFail("Failed to generate workspace: \(error)")
             }
         }
+    }
+
+    // MARK: - Helpers
+
+    private func isRunningInDebug() -> Bool {
+        #if DEBUG
+            return true
+        #else
+            return false
+        #endif
     }
 }

--- a/Tests/TuistIntegrationTests/Generator/TuistGeneratorPerformanceTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/TuistGeneratorPerformanceTests.swift
@@ -1,0 +1,46 @@
+import TSCBasic
+import TuistCore
+import TuistCoreTesting
+import TuistLoaderTesting
+import TuistSupport
+import XcodeProj
+import XCTest
+
+@testable import TuistGenerator
+@testable import TuistSupport
+@testable import TuistSupportTesting
+
+final class TuistGeneratorPerformanceTests: TuistTestCase {
+    override func setUp() {
+        super.setUp()
+    }
+
+    // MARK: - Tests
+
+    func test_generateWorkspace_performance() throws {
+        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
+            do {
+                // Given
+                let subject = DescriptorGenerator()
+                let config = TestModelGenerator.WorkspaceConfig(projects: 50,
+                                                                testTargets: 5,
+                                                                frameworkTargets: 5,
+                                                                schemes: 10,
+                                                                sources: 200,
+                                                                resources: 100,
+                                                                headers: 100)
+                let temporaryPath = try self.temporaryPath()
+                let modelGenerator = TestModelGenerator(rootPath: temporaryPath, config: config)
+                let (graph, workspace) = try modelGenerator.generate()
+
+                // When
+                startMeasuring()
+                _ = try subject.generateWorkspace(workspace: workspace, graph: graph)
+                stopMeasuring()
+
+            } catch {
+                XCTFail("Failed to generate workspace: \(error)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Part of #820 

### Short description 📝

Measuring performance of `tuist` as a whole can be achieved via `rake benchmark` however assessing / measuring performance of some of the components (e.g. `DescriptorGenerator`) can be hard to assess during refactors.

### Solution 📦

Add a performance `XCTest` for `DescriptorGenerator`.

### Implementation 👩‍💻👨‍💻

- [x] Add test model generator - to generate large graphs with test data
- [x] Write performance test
- [x] Leverage test model generator within `StableStructureIntegrationTests` as that too requires generating a large graph with test project, targets and dependencies 

### Test Plan 🛠

- Run `TuistGeneratorPerformanceTests`

### Note 📝

It appears there isn't a way to store baselines measurements for Swift PM projects - the feature is currently only available in Xcode - does anyone have any suggestions on how we can store baselines?
