### PR TITLE
Add support for `.xctest` dependency for tvOS targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Disable SwiftLint in the generated synthesized interface for resources [#1574](https://github.com/tuist/tuist/pull/1574) by [@pepibumur](https://github.com/pepibumur).
 - Synthesized accessors for framework targets not resolving the path [#1575](https://github.com/tuist/tuist/pull/1575) by [@pepibumur](https://github.com/pepibumur).
 - Read coredata version from /.xccurrentversion file [#1572](https://github.com/tuist/tuist/pull/1572) by [@matiasvillaverde](https://github.com/matiasvillaverde).
+- Add support for `.xctest` dependency for tvOS targets [#1597](https://github.com/tuist/tuist/pull/1597) by [@kwridan](https://github.com/kwridan).
 
 ### Added
 

--- a/Sources/TuistCore/Models/Platform.swift
+++ b/Sources/TuistCore/Models/Platform.swift
@@ -105,6 +105,8 @@ extension Platform {
             return "Platforms/iPhoneOS.platform/Developer/Library"
         case .macOS:
             return "Platforms/MacOSX.platform/Developer/Library"
+        case .tvOS:
+            return "Platforms/AppleTVOS.platform/Developer/Library"
         default: return nil
         }
     }

--- a/Tests/TuistCoreTests/Graph/Nodes/SDKNodeTests.swift
+++ b/Tests/TuistCoreTests/Graph/Nodes/SDKNodeTests.swift
@@ -70,8 +70,6 @@ final class SDKNodeTests: XCTestCase {
     }
 
     func test_xctest_sdk_framework_unsupported_platforms_path() throws {
-        XCTAssertThrowsSpecific(try SDKNode(name: "XCTest.framework", platform: .tvOS, status: .required, source: .developer),
-                                SDKNode.Error.unsupported(sdk: "XCTest.framework"))
         XCTAssertThrowsSpecific(try SDKNode(name: "XCTest.framework", platform: .watchOS, status: .required, source: .developer),
                                 SDKNode.Error.unsupported(sdk: "XCTest.framework"))
     }

--- a/Tests/TuistCoreTests/Graph/Nodes/SDKNodeTests.swift
+++ b/Tests/TuistCoreTests/Graph/Nodes/SDKNodeTests.swift
@@ -55,6 +55,7 @@ final class SDKNodeTests: XCTestCase {
         let libraries: [(name: String, platform: Platform)] = [
             ("XCTest.framework", .iOS),
             ("XCTest.framework", .macOS),
+            ("XCTest.framework", .tvOS),
         ]
 
         // When
@@ -64,6 +65,7 @@ final class SDKNodeTests: XCTestCase {
         XCTAssertEqual(nodes.map(\.path), [
             "/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework",
             "/Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework",
+            "/Platforms/AppleTVOS.platform/Developer/Library/Frameworks/XCTest.framework",
         ])
     }
 

--- a/fixtures/ios_app_with_sdk/Project.swift
+++ b/fixtures/ios_app_with_sdk/Project.swift
@@ -53,5 +53,6 @@ let project = Project(name: "Project",
                                  dependencies: [
                                     .sdk(name: "CloudKit.framework", status: .optional),
                                     .sdk(name: "libsqlite3.tbd"),
-                            ]),
+                                    .xctest
+                            ], settings: Settings(base: ["ENABLE_BITCODE": "NO"])),
 ])


### PR DESCRIPTION
### Short description 📝

@laxmorek reported an issue in his project where adding a `.xctest` dependency for a `.tvOS` framework fails generation with an error:

```
The SDK type of XCTest.framework is not currently supported - only [.framework, .tbd] are supported.
```

### Solution 📦

Looks like `.tvOS` developer directory wasn't specified causing this error to appear. Adding it and updating some of the fixtures and test should resolve this issue.

### Implementation 👩‍💻👨‍💻

- [x] Include developer paths for `tvOS` to support sdk dependencies
- [x] Update fixture and tests
- [x] Update change log

### Test Plan 🛠

- Run `swift run tuist generate` within `fixtures/ios_app_with_sdk`
- Verify it generates without errors 
