### PR TITLE
Support defining XCTest as a dependency of a tvOS target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Allow to cache and warm static frameworks too (only dynamic frameworks were cached before) [#1590](https://github.com/tuist/tuist/pull/1590) by [@RomainBoulay](https://github.com/RomainBoulay)
+- Support tvOS targets depending on XCTest [#1598](https://github.com/tuist/tuist/pull/1598) by [@pepibumur](https://github.com/pepibumur).
 
 ### Added
 

--- a/Sources/TuistCore/Models/Platform.swift
+++ b/Sources/TuistCore/Models/Platform.swift
@@ -103,9 +103,12 @@ extension Platform {
         switch self {
         case .iOS:
             return "Platforms/iPhoneOS.platform/Developer/Library"
+        case .tvOS:
+            return "Platforms/AppleTVOS.platform/Developer/Library"
+        case .watchOS:
+            return "Platforms/WatchOS.platform/Developer/Library"
         case .macOS:
             return "Platforms/MacOSX.platform/Developer/Library"
-        default: return nil
         }
     }
 }

--- a/Tests/TuistCoreTests/Models/PlatformTests.swift
+++ b/Tests/TuistCoreTests/Models/PlatformTests.swift
@@ -54,4 +54,25 @@ final class PlatformTests: XCTestCase {
             "Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk",
         ])
     }
+
+    func test_xcodeDeveloperSdkRootPath() {
+        // Given
+        let platforms: [Platform] = [
+            .iOS,
+            .tvOS,
+            .watchOS,
+            .macOS,
+        ]
+
+        // When
+        let paths = platforms.map(\.xcodeDeveloperSdkRootPath)
+
+        // Then
+        XCTAssertEqual(paths, [
+            "Platforms/iPhoneOS.platform/Developer/Library",
+            "Platforms/AppleTVOS.platform/Developer/Library",
+            "Platforms/WatchOS.platform/Developer/Library",
+            "Platforms/MacOSX.platform/Developer/Library",
+        ])
+    }
 }


### PR DESCRIPTION
### Short description 📝
When a `tvOS` target depends on `.xctest`, the generation of projects fail. I realised it happens because the `Platform. xcodeDeveloperSdkRootPath` attribute didn't include cases for all the platforms.