### PR TITLE
Removed Rome isMet validation

### DIFF
--- a/Sources/TuistLoader/Up/Rome.swift
+++ b/Sources/TuistLoader/Up/Rome.swift
@@ -12,14 +12,6 @@ protocol Romeaging {
     ///   - cachePrefix: Cache Prefix to use when downloading dependencies
     /// - Throws: An error if the dependencies download fails.
     func download(platforms: [Platform], cachePrefix: String?) throws
-
-    /// Retrieves the list of dependencies that are missing
-    ///
-    /// - Parameters:
-    ///   - platforms: Platforms the dependencies will be updated for.
-    ///   - cachePrefix: Cache Prefix to use when downloading dependencies
-    /// - Throws: An error if the dependencies download fails.
-    func missing(platforms: [Platform], cachePrefix: String?) throws -> String?
 }
 
 final class Rome: Romeaging {
@@ -47,31 +39,5 @@ final class Rome: Romeaging {
         }
 
         try System.shared.run(command)
-    }
-
-    /// Retrieves the list of dependencies that are missing
-    ///
-    /// - Parameters:
-    ///   - platforms: Platforms the dependencies will be updated for.
-    ///   - cachePrefix: Cache Prefix to use when downloading dependencies
-    /// - Throws: An error if the dependencies download fails.
-    func missing(platforms: [Platform], cachePrefix: String?) throws -> String? {
-        let romePath = try System.shared.which("rome")
-
-        var command: [String] = [romePath]
-        command.append("list")
-        command.append("--missing")
-
-        if let cachePrefix = cachePrefix {
-            command.append("--cache-prefix")
-            command.append(cachePrefix)
-        }
-
-        if !platforms.isEmpty {
-            command.append("--platform")
-            command.append(platforms.map { $0.caseValue }.joined(separator: ","))
-        }
-
-        return try System.shared.capture(command)
     }
 }

--- a/Sources/TuistLoader/Up/UpRome.swift
+++ b/Sources/TuistLoader/Up/UpRome.swift
@@ -64,8 +64,8 @@ class UpRome: Up, GraphInitiatable {
     /// - Throws: An error if the check fails.
     override func isMet(projectPath: AbsolutePath) throws -> Bool {
         if try !upHomebrew.isMet(projectPath: projectPath) { return false }
-        guard let missing = try rome.missing(platforms: platforms, cachePrefix: cachePrefix) else { return false }
-        return missing.isEmpty
+
+        return false
     }
 
     /// When the command is not met, this method runs it.

--- a/Tests/TuistLoaderTests/Up/Mocks/MockRome.swift
+++ b/Tests/TuistLoaderTests/Up/Mocks/MockRome.swift
@@ -7,16 +7,9 @@ import TuistCore
 final class MockRome: Romeaging {
     var downloadStub: (([Platform], String?) throws -> Void)?
     var downloadCallCount: UInt = 0
-    var missingStub: (([Platform], String?) throws -> String?)?
-    var missingCallCount: UInt = 0
 
     func download(platforms: [Platform], cachePrefix: String?) throws {
         downloadCallCount += 1
         try downloadStub?(platforms, cachePrefix)
-    }
-
-    func missing(platforms: [Platform], cachePrefix: String?) throws -> String? {
-        missingCallCount += 1
-        return try missingStub?(platforms, cachePrefix)
     }
 }

--- a/Tests/TuistLoaderTests/Up/UpRomeTests.swift
+++ b/Tests/TuistLoaderTests/Up/UpRomeTests.swift
@@ -80,23 +80,20 @@ final class UpRomeTests: TuistUnitTestCase {
 
         upHomebrew.isMetStub = { _ in true }
         rome.downloadStub = { _, _ in }
-        /// Returns empty string to indicate that no frameworks are missing
-        rome.missingStub = { _, _ in "" }
 
         //  Then
         let result = try subject.isMet(projectPath: temporaryPath)
 
         //  When
-        XCTAssertTrue(result)
+        XCTAssertFalse(result)
     }
 
     func test_when_not_isMet() throws {
         //  Given
         let temporaryPath = try self.temporaryPath()
 
-        upHomebrew.isMetStub = { _ in true }
+        upHomebrew.isMetStub = { _ in false }
         rome.downloadStub = { _, _ in }
-        rome.missingStub = { _, _ in "MissingFramework ABC, Other framework missing" }
 
         //  Then
         let result = try subject.isMet(projectPath: temporaryPath)


### PR DESCRIPTION
### Short description 📝

Removes the isMet check for the Rome up command. This has been removed due to it being unreliable and never accurately indicating which dependencies are missing. It also does not work correctly when a cache-prefix is specified.

### Solution 📦

The isMet check now only validates that homebrew exists and no longer runs the `rome list --missing --platform ios --cache-prefix 5_2` command. 
