### PR TITLE
Fix missing ui test host applications for apps with "-" characters in their name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Allow to cache and warm static frameworks too (only dynamic frameworks were cached before) [#1590](https://github.com/tuist/tuist/pull/1590) by [@RomainBoulay](https://github.com/RomainBoulay)
 - Add support for `.xctest` dependency for tvOS targets [#1597](https://github.com/tuist/tuist/pull/1597) by [@kwridan](https://github.com/kwridan).
+- Fix missing ui test host applications for apps with "-" characters in their name [#1630](https://github.com/tuist/tuist/pull/1630) by [@kwridan](https://github.com/kwridan).
 
 ### Added
 

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -232,7 +232,7 @@ final class ConfigGenerator: ConfigGenerating {
         }
 
         var settings: SettingsDictionary = [:]
-        settings["TEST_TARGET_NAME"] = .string("\(app.productName)")
+        settings["TEST_TARGET_NAME"] = .string("\(app.name)")
         if target.product == .unitTests {
             settings["TEST_HOST"] = .string("$(BUILT_PRODUCTS_DIR)/\(app.productNameWithExtension)/\(app.productName)")
             settings["BUNDLE_LOADER"] = "$(TEST_HOST)"

--- a/fixtures/ios_app_with_tests/Project.swift
+++ b/fixtures/ios_app_with_tests/Project.swift
@@ -33,5 +33,28 @@ let project = Project(name: "App",
                                  sources: "UITests/**",
                                  dependencies: [
                                     .target(name: "App"),
-                                    ])
+                                    ]),
+
+
+                         Target(name: "App-dash",
+                                 platform: .iOS,
+                                 product: .app,
+                                 bundleId: "io.tuist.AppDash",
+                                 infoPlist: "Info.plist",
+                                 sources: .paths([.relativeToManifest("Sources/**")]),
+                                 dependencies: [
+                                     /* Target dependencies can be defined here */
+                                     /* .framework(path: "framework") */
+                                 ],
+                                 settings: Settings(base: ["CODE_SIGN_IDENTITY": "",
+                                                           "CODE_SIGNING_REQUIRED": "NO"])),
+                        Target(name: "App-dashUITests",
+                                 platform: .iOS,
+                                 product: .uiTests,
+                                 bundleId: "io.tuist.AppDashUITests",
+                                 infoPlist: "Tests.plist",
+                                 sources: "UITests/**",
+                                 dependencies: [
+                                    .target(name: "App-dash"),
+                                    ]),
 ])


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/1629

### Short description 📝

- UI test target had a missing target application in cases where the application had a name with "-" characters.

- This is caused due to target names with "-" automatically getting replaced with "_" resulting in the target having a `name` != `productName`.
- UI test targets have a `TEST_TARGET_NAME` build setting, this was incorrectly being set to the `productName` as opposed to the target `name`


### Solution 📦

Setting this to the target name ensures UI tests for applications with mismatching product names continue to be set correctly.

### Implementation 👩‍💻👨‍💻


- [x] Update `ConfigGenerator`
- [x] Update fixture
- [x] Update change log

### Test Plan 🛠

- Run `swift build && swift run tuist generate` within `fixtures/ios_app_with_tests`
- Verify the UI test target `App-dashUITests` has the target application "App-dash" set correctly
