### PR TITLE
Add analytics to the website

### DIFF
--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -227,5 +227,20 @@ module.exports = {
         // purgeOnly : ['components/', '/main.css', 'bootstrap/'], // Purge only these files/folders
       },
     },
+    {
+      resolve: `gatsby-plugin-google-analytics`,
+      options: {
+        trackingId: 'UA-125584790-6',
+        head: false,
+        anonymize: true,
+        respectDNT: true,
+        exclude: [],
+        pageTransitionDelay: 0,
+        defer: false,
+        sampleRate: 5,
+        siteSpeedSampleRate: 10,
+        cookieDomain: 'tuist.io',
+      },
+    },
   ],
 }

--- a/website/markdown/docs/scale/contract.mdx
+++ b/website/markdown/docs/scale/contract.mdx
@@ -11,7 +11,7 @@ the exposed API needs to conform with the contract described in this page.
 <Message
   info
   title="Base URL"
-  description={`In all the examples below, we are assuming that the project is pointing to a server with URL https://scale.tuist.io`}
+  description={`In all the examples below, we are assuming that the project is pointing to a server with URL https://cloud.test.io`}
 />
 
 ## Authentication

--- a/website/markdown/legal/cookies.mdx
+++ b/website/markdown/legal/cookies.mdx
@@ -1,6 +1,6 @@
-We use cookies to help improve your experience of [http://tuist.io](http://tuist.io) and [http://scale.tuist.io](http://scale.tuist.io). This cookie policy is part of Tuist' privacy policy, and covers the use of cookies between your device and our site. We also provide basic information on third-party services we may use, who may also use cookies as part of their service, though they are not covered by our policy.
+We use cookies to help improve your experience of [http://tuist.io](http://tuist.io). This cookie policy is part of Tuist' privacy policy, and covers the use of cookies between your device and our site. We also provide basic information on third-party services we may use, who may also use cookies as part of their service, though they are not covered by our policy.
 
-If you don’t wish to accept cookies from us, you should instruct your browser to refuse cookies from [http://tuist.io](http://tuist.io) and [http://scale.tuist.io](http://scale.tuist.io), with the understanding that we may be unable to provide you with some of your desired content and services.
+If you don’t wish to accept cookies from us, you should instruct your browser to refuse cookies from [http://tuist.io](http://tuist.io), with the understanding that we may be unable to provide you with some of your desired content and services.
 
 ### What is a cookie?
 

--- a/website/markdown/legal/privacy.mdx
+++ b/website/markdown/legal/privacy.mdx
@@ -1,4 +1,4 @@
-Your privacy is important to us. It is Tuist' policy to respect your privacy regarding any information we may collect from you across our website, [http://tuist.io](http://tuist.io) and [http://scale.tuist.io](http://scale.tuist.io), and other sites we own and operate.
+Your privacy is important to us. It is Tuist' policy to respect your privacy regarding any information we may collect from you across our website, [http://tuist.io](http://tuist.io), and other sites we own and operate.
 
 ### 1 - Information we collect
 

--- a/website/markdown/legal/terms.mdx
+++ b/website/markdown/legal/terms.mdx
@@ -1,6 +1,6 @@
 ### 1 - Terms
 
-By accessing the website at [http://tuist.io](http://tuist.io) and [http://scale.tuist.io](http://scale.tuist.io), you are agreeing to be bound by these terms of service, all applicable laws and regulations, and agree that you are responsible for compliance with any applicable local laws. If you do not agree with any of these terms, you are prohibited from using or accessing this site. The materials contained in this website are protected by applicable copyright and trademark law.
+By accessing the website at [http://tuist.io](http://tuist.io), you are agreeing to be bound by these terms of service, all applicable laws and regulations, and agree that you are responsible for compliance with any applicable local laws. If you do not agree with any of these terms, you are prohibited from using or accessing this site. The materials contained in this website are protected by applicable copyright and trademark law.
 
 ### 2 - Use License
 

--- a/website/package.json
+++ b/website/package.json
@@ -27,6 +27,7 @@
     "gatsby-image": "^2.4.13",
     "gatsby-plugin-favicon": "3.1.6",
     "gatsby-plugin-feed": "^2.5.4",
+    "gatsby-plugin-google-analytics": "^2.3.13",
     "gatsby-plugin-manifest": "2.4.18",
     "gatsby-plugin-mdx": "^1.2.32",
     "gatsby-plugin-meta-redirect": "^1.1.1",

--- a/website/src/components/cookie-banner.jsx
+++ b/website/src/components/cookie-banner.jsx
@@ -1,0 +1,65 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/core'
+import React from 'react'
+import { Link } from 'gatsby'
+import tw from 'twin.macro'
+import { useCookies } from 'react-cookie'
+
+const CookieBanner = () => {
+  const cookieName = 'cookie-banner'
+  const [cookies, setCookie] = useCookies([cookieName])
+
+  if (cookies[cookieName]) {
+    return <div />
+  } else {
+    return (
+      <div className="fixed bottom-0 inset-x-0 pb-2 sm:pb-5 z-10">
+        <div className="max-w-screen-xl mx-auto px-2 sm:px-6 lg:px-8">
+          <div className="p-2 rounded-lg bg-blue-600 shadow-lg sm:p-3">
+            <div className="flex items-center justify-between flex-wrap">
+              <div className="w-0 flex-1 flex items-center">
+                <p className="ml-3 font-medium text-white text-wrap">
+                  <span className="inline">
+                    By using this website, you agree to our{' '}
+                    <Link css={[tw`underline`, tw`text-white`]} to="/cookies">
+                      cookie policy
+                    </Link>
+                    .
+                  </span>
+                </p>
+              </div>
+              <div className="order-2 flex-shrink-0 sm:order-3 sm:ml-2">
+                <button
+                  type="button"
+                  className="-mr-1 flex p-2 rounded-md hover:bg-blue-500 focus:outline-none focus:bg-blue-500 transition ease-in-out duration-150"
+                  aria-label="Dismiss"
+                  onClick={() => {
+                    setCookie(cookieName, true, {
+                      maxAge: 60 * 60 * 24 * 31 /* 1 month */,
+                    })
+                  }}
+                >
+                  <svg
+                    className="h-6 w-6 text-white"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default CookieBanner

--- a/website/src/components/layout.jsx
+++ b/website/src/components/layout.jsx
@@ -6,6 +6,7 @@ import { Styled } from 'theme-ui'
 import GlobalStyle from './global-style'
 import Header from './header'
 import Footer from './footer'
+import CookieBanner from './cookie-banner'
 
 const Layout = ({ children, menuOpen, setMenuOpen, menuRef }) => {
   return (
@@ -13,6 +14,7 @@ const Layout = ({ children, menuOpen, setMenuOpen, menuRef }) => {
       <GlobalStyle />
       <Header menuOpen={menuOpen} setMenuOpen={setMenuOpen} menuRef={menuRef} />
       <main sx={{ mb: [3, 6] }}>{children}</main>
+      <CookieBanner />
       <Footer />
     </>
   )

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -7716,6 +7716,14 @@ gatsby-plugin-feed@^2.5.4:
     lodash.merge "^4.6.2"
     rss "^1.2.2"
 
+gatsby-plugin-google-analytics@^2.3.13:
+  version "2.3.13"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.3.13.tgz#46f78f4df11cc773d44e5909ea491c8f8c0e6774"
+  integrity sha512-K/6c9iByR8uDpFZuJrappjyMsVtWFwPyAkRlXFHhq2mmNtgZeRVKFf5XoGiOHCeMPEpBGE58LLana/F01LLteQ==
+  dependencies:
+    "@babel/runtime" "^7.10.3"
+    minimatch "3.0.4"
+
 gatsby-plugin-manifest@2.4.18:
   version "2.4.18"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.4.18.tgz#7853efc25dd86e7af760026d675ffb3fd6bac59e"
@@ -11218,7 +11226,7 @@ minimatch@3.0.3:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==


### PR DESCRIPTION
### Short description 📝
Without understanding how developers use the website, and in particular the documentation, it's hard to spot opportunities to improve the structure and the content of the website. For that reason I'm enabling **anonymous** Google Analytics on the website.

Note that the website has a privacy and cookies policy that users can read to know more about how we use the cookies.