### PR TITLE
[Prototype] Performance Tests on CI

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,37 @@
+name: Performance Tests
+
+on:  
+  pull_request:
+    paths:
+      - Sources/**/*
+      - Tests/**/*
+      - .github/workflows/performance.yml
+
+jobs:
+  performance_tests:
+    name: Performance tests
+    runs-on: macOS-latest
+    strategy:
+      matrix:
+        xcode: ["12.1"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          path: reference_branch
+          ref: main
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+      - name: Record baseline measurements
+        run: |
+            cd reference_branch
+            TEST_RECORD_BASELINES=1 swift test -c release --filter "PerformanceTests" -Xswiftc -enable-testing
+      - name: Copy baselines measurements
+        id: copy_baselines
+        continue-on-error: true
+        run: |
+            cp -r reference_branch/performance_tests_baselines performance_tests_baselines
+      - name: Run performance tests
+        if: steps.copy_baselines.outcome == 'success'
+        run: |
+          TEST_FAIL_MISSING_BASELINES=1 swift test -c release --filter "PerformanceTests" -Xswiftc -enable-testing

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ mkmf.log
 .rubocop-http---shopify-github-io-ruby-style-guide-rubocop-yml
 generated_fixtures
 .fixtures.generated.json
+performance_tests_baselines

--- a/Tests/TuistIntegrationTests/Generator/TestModelGenerator.swift
+++ b/Tests/TuistIntegrationTests/Generator/TestModelGenerator.swift
@@ -17,6 +17,7 @@ final class TestModelGenerator {
         var sources: Int = 100
         var resources: Int = 100
         var headers: Int = 100
+        var shuffle: Bool = true
     }
 
     private let rootPath: AbsolutePath
@@ -127,7 +128,7 @@ final class TestModelGenerator {
         let sources: [SourceFile] = (0 ..< config.sources)
             .map { "Sources/SourceFile\($0).swift" }
             .map { SourceFile(path: path.appending(RelativePath($0))) }
-            .shuffled()
+            .shuffled(config.shuffle)
         return sources
     }
 
@@ -135,17 +136,17 @@ final class TestModelGenerator {
         let publicHeaders = (0 ..< config.headers)
             .map { "Sources/PublicHeader\($0).h" }
             .map { path.appending(RelativePath($0)) }
-            .shuffled()
+            .shuffled(config.shuffle)
 
         let privateHeaders = (0 ..< config.headers)
             .map { "Sources/PrivateHeader\($0).h" }
             .map { path.appending(RelativePath($0)) }
-            .shuffled()
+            .shuffled(config.shuffle)
 
         let projectHeaders = (0 ..< config.headers)
             .map { "Sources/ProjectHeader\($0).h" }
             .map { path.appending(RelativePath($0)) }
-            .shuffled()
+            .shuffled(config.shuffle)
 
         return Headers(public: publicHeaders, private: privateHeaders, project: projectHeaders)
     }
@@ -159,7 +160,7 @@ final class TestModelGenerator {
             .map { "Resources/Folder\($0)" }
             .map { FileElement.folderReference(path: path.appending(RelativePath($0))) }
 
-        return (files + folderReferences).shuffled()
+        return (files + folderReferences).shuffled(config.shuffle)
     }
 
     private func createAdditionalFiles(path: AbsolutePath) -> [FileElement] {
@@ -183,7 +184,7 @@ final class TestModelGenerator {
             .map { "Documentation\($0)" }
             .map { FileElement.folderReference(path: path.appending(RelativePath($0))) }
 
-        return (filesWithFolderPaths + folderReferences).shuffled()
+        return (filesWithFolderPaths + folderReferences).shuffled(config.shuffle)
     }
 
     private func createFrameworkTarget(name: String,
@@ -207,7 +208,7 @@ final class TestModelGenerator {
 
         let libraries = try createLibraries(relativeTo: path)
 
-        return (frameworks + libraries).shuffled()
+        return (frameworks + libraries).shuffled(config.shuffle)
     }
 
     private func createLibraries(relativeTo path: AbsolutePath) throws -> [Dependency] {
@@ -289,5 +290,14 @@ final class TestModelGenerator {
 
     private func targetReference(from target: Target, projectName: String) -> TargetReference {
         TargetReference(projectPath: pathTo(projectName), name: target.name)
+    }
+}
+
+private extension Array {
+    func shuffled(_ shuffle: Bool) -> Self {
+        if shuffle {
+            return shuffled()
+        }
+        return self
     }
 }

--- a/Tests/TuistIntegrationTests/Generator/TuistGeneratorPerformanceTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/TuistGeneratorPerformanceTests.swift
@@ -11,45 +11,58 @@ import XCTest
 @testable import TuistSupportTesting
 
 final class TuistGeneratorPerformanceTests: TuistTestCase {
-    override func setUp() {
-        super.setUp()
+    private let manualTimer = ManualTestTimer()
+
+    override func setUpWithError() throws {
+        try XCTSkipIf(
+            isRunningInDebug(),
+            "Performance tests need to be run in Release Mode for more realistic results"
+        )
     }
 
     // MARK: - Tests
 
     func test_generateWorkspace_performance() throws {
-        guard !isRunningInDebug() else {
-            // Performance tests need to be run in Release Mode for more realistic results
-            // Note: When we switch to Xcode11.5+ only on CI we can use `XCTSkipIf` instead of a guard statement
-            //
-            // XCTSkipIf(isRunningInDebug, "Performance tests need to be run in Release Mode for more realistic results")
-            return
-        }
+        // Given
+        let subject = DescriptorGenerator()
+        let config = TestModelGenerator.WorkspaceConfig(projects: 50,
+                                                        testTargets: 5,
+                                                        frameworkTargets: 5,
+                                                        schemes: 10,
+                                                        sources: 200,
+                                                        resources: 100,
+                                                        headers: 100,
+                                                        shuffle: false)
+        let temporaryPath = try self.temporaryPath()
+        let modelGenerator = TestModelGenerator(rootPath: temporaryPath, config: config)
+        let graph = try modelGenerator.generate()
 
-        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
+        // When
+        measure {
             do {
-                // Given
-                let subject = DescriptorGenerator()
-                let config = TestModelGenerator.WorkspaceConfig(projects: 50,
-                                                                testTargets: 5,
-                                                                frameworkTargets: 5,
-                                                                schemes: 10,
-                                                                sources: 200,
-                                                                resources: 100,
-                                                                headers: 100)
-                let temporaryPath = try self.temporaryPath()
-                let modelGenerator = TestModelGenerator(rootPath: temporaryPath, config: config)
-                let graph = try modelGenerator.generate()
-
-                // When
-                startMeasuring()
                 _ = try subject.generateWorkspace(graph: graph)
-                stopMeasuring()
-
             } catch {
                 XCTFail("Failed to generate workspace: \(error)")
             }
         }
+
+        // Then
+
+        // Currently Swift PM doesn't support setting baselines, as such we'll need to
+        // manually assert measurements are within an expected value and tolerance
+        try assertMeasurement(tolerancePercentage: 0.1)
+    }
+
+    // MARK: - Overrides
+
+    override func startMeasuring() {
+        super.startMeasuring()
+        manualTimer.start()
+    }
+
+    override func stopMeasuring() {
+        super.stopMeasuring()
+        manualTimer.stop()
     }
 
     // MARK: - Helpers
@@ -60,5 +73,107 @@ final class TuistGeneratorPerformanceTests: TuistTestCase {
         #else
             return false
         #endif
+    }
+
+    private func assertMeasurement(tolerancePercentage: Double,
+                                   file: StaticString = #file,
+                                   line: UInt = #line) throws
+    {
+        if shouldRecordBaselines() {
+            try save(baseline: Baseline(measurements: manualTimer.measurements))
+        } else {
+            guard let baseline = try loadBaseline() else {
+                if shouldFailForMissingBaselines() {
+                    XCTFail("Baseline measurements were not found.")
+                } else {
+                    print("Skipping assertion, baseline measurements were not found.")
+                }
+                return
+            }
+            let expectedDuration = baseline.measurements.average()
+            let average = manualTimer.measurements.average()
+            let accuracy = expectedDuration * tolerancePercentage
+            let percentageString = String(format: "%.2f", tolerancePercentage * 100)
+            XCTAssertEqual(average,
+                           expectedDuration,
+                           accuracy: accuracy,
+                           "The measurement \(average) wasn't within expected range ~(\(expectedDuration) ±\(percentageString)%)",
+                           file: file,
+                           line: line)
+        }
+    }
+
+    private func shouldRecordBaselines() -> Bool {
+        ProcessInfo.processInfo.environment["TEST_RECORD_BASELINES"] == "1"
+    }
+
+    private func shouldFailForMissingBaselines() -> Bool {
+        ProcessInfo.processInfo.environment["TEST_FAIL_MISSING_BASELINES"] == "1"
+    }
+
+    private func currentTestBaselineFilePath() -> AbsolutePath {
+        let currentTestIdentifier = name
+            .replacingOccurrences(of: "-", with: "")
+            .replacingOccurrences(of: "[", with: "")
+            .replacingOccurrences(of: "]", with: "")
+            .replacingOccurrences(of: " ", with: ".")
+        return AbsolutePath(#file)
+            .parentDirectory
+            .parentDirectory
+            .parentDirectory
+            .parentDirectory
+            .appending(component: "performance_tests_baselines")
+            .appending(component: currentTestIdentifier)
+    }
+
+    private func loadBaseline() throws -> Baseline? {
+        let fileHandler = FileHandler()
+        let baselineFile = currentTestBaselineFilePath()
+        guard fileHandler.exists(baselineFile) else {
+            return nil
+        }
+        let data = try fileHandler.readFile(baselineFile)
+        return try JSONDecoder().decode(Baseline.self, from: data)
+    }
+
+    private func save(baseline: Baseline) throws {
+        let fileHandler = FileHandler()
+        let baselineFile = currentTestBaselineFilePath()
+        if fileHandler.exists(baselineFile) {
+            try fileHandler.delete(baselineFile)
+        }
+        try fileHandler.createFolder(baselineFile.parentDirectory)
+        let data = try JSONEncoder().encode(baseline)
+        try data.write(to: baselineFile.asURL)
+    }
+
+    // MARK: - Helper Classes
+
+    struct Baseline: Codable {
+        var measurements: [TimeInterval]
+    }
+
+    private final class ManualTestTimer {
+        private let clock = WallClock()
+        private(set) var measurements: [TimeInterval] = []
+        private var currentTimer: ClockTimer?
+
+        func start() {
+            currentTimer = clock.startTimer()
+        }
+
+        func stop() {
+            guard let elapsedTime = currentTimer?.stop() else {
+                return
+            }
+            measurements.append(elapsedTime)
+            currentTimer = nil
+        }
+    }
+}
+
+private extension Array where Element == Double {
+    func average() -> Double {
+        reduce(0, +) / Double(count)
     }
 }


### PR DESCRIPTION
Continuation of #1593 
Part of #820 

### Short description 📝

Swift PM doesn't currently have a way of setting baselines measurements for performance tests making it a bit challenging to get any feedback from performance tests should any regressions occur.

### Solution 📦

Test out manually setting baselines and asserting on them within the test.

### Implementation 👩‍💻👨‍💻

- [x] Add a new workflow step dedicate to performance tests 
  - Runs tests in Release mode
  - Runs tests with _"PerformanceTests"_ in the name
- [x] Add mechanism to manually set baselines and assert on performance tests
- [ ] Examine stability on #1740 after a few runs
- [ ] Create `TuistPerformanceTestCase` to allow addition of more performance tests
- [ ] Update docs
 