### PR TITLE
Implement value graph, project, and target mappers

### DIFF
--- a/Sources/TuistCore/ValueGraph/ValueGraph.swift
+++ b/Sources/TuistCore/ValueGraph/ValueGraph.swift
@@ -4,25 +4,25 @@ import TSCBasic
 /// An directed acyclic graph (DAG) that Tuist uses to represent the dependency tree.
 public struct ValueGraph: Equatable {
     /// The name of the graph
-    public let name: String
+    public var name: String
 
     /// The path where the graph has been loaded from.
-    public let path: AbsolutePath
+    public var path: AbsolutePath
 
     /// A dictionary where the keys are the paths to the directories where the projects are defined,
     /// and the values are the projects defined in the directories.
-    public let projects: [AbsolutePath: Project]
+    public var projects: [AbsolutePath: Project]
 
     /// A dictionary where the keys are paths to the directories where the projects that contain packages are defined,
     /// and the values are dictionaries where the key is the reference to the package, and the values are the packages.
-    public let packages: [AbsolutePath: [String: Package]]
+    public var packages: [AbsolutePath: [String: Package]]
 
     /// A dictionary where the keys are paths to the directories where the projects that contain targets are defined,
     /// and the values are dictionaries where the key is the name of the target, and the values are the targets.
-    public let targets: [AbsolutePath: [String: Target]]
+    public var targets: [AbsolutePath: [String: Target]]
 
     /// A dictionary that contains the one-to-many dependencies that represent the graph.
-    public let dependencies: [ValueGraphDependency: Set<ValueGraphDependency>]
+    public var dependencies: [ValueGraphDependency: Set<ValueGraphDependency>]
 
     public init(name: String,
                 path: AbsolutePath,

--- a/Sources/TuistCore/ValueGraph/ValueGraphMapper.swift
+++ b/Sources/TuistCore/ValueGraph/ValueGraphMapper.swift
@@ -1,0 +1,52 @@
+import Foundation
+import TSCBasic
+
+/// It defines the interface to map a value graph into another value graph.
+public protocol ValueGraphMapping {
+    /// Given a graph, it maps it into another graph and a list of side effects.
+    /// - Parameter graph: Graph to be mapped.
+    func map(graph: ValueGraph) throws -> (ValueGraph, [SideEffectDescriptor])
+}
+
+/// A value graph mapper that is initialized with the mapping function.
+public class AnyValueGraphMapper: ValueGraphMapping {
+    let mapper: (ValueGraph) throws -> (ValueGraph, [SideEffectDescriptor])
+
+    public init(mapper: @escaping (ValueGraph) throws -> (ValueGraph, [SideEffectDescriptor])) {
+        self.mapper = mapper
+    }
+
+    public func map(graph: ValueGraph) throws -> (ValueGraph, [SideEffectDescriptor]) {
+        try mapper(graph)
+    }
+}
+
+/// A type of value graph mapper that is initialized with a project mapper.
+public class ValueGraphProjectMapper: ValueGraphMapping {
+    /// Project mapper instance.
+    private let projectMapper: ValueProjectMapping
+
+    /// Initializes the value graph mapper with a project mapper.
+    /// - Parameter projectMapper: Project mapper instance.
+    public init(projectMapper: ValueProjectMapping) {
+        self.projectMapper = projectMapper
+    }
+
+    public func map(graph: ValueGraph) throws -> (ValueGraph, [SideEffectDescriptor]) {
+        var graph = graph
+        var sideEffects: [SideEffectDescriptor] = []
+        var mappedProjects: [AbsolutePath: Project] = [:]
+        var mappedTargets: [AbsolutePath: [String: Target]] = [:]
+
+        try graph.projects.forEach { path, project in
+            let (mappedProject, mappedProjectTargets, targetSideEffects) = try self.projectMapper.map(project: project, targets: graph.targets[path] ?? [:])
+            mappedProjects[path] = mappedProject
+            mappedTargets[path] = mappedProjectTargets
+            sideEffects.append(contentsOf: targetSideEffects)
+        }
+
+        graph.projects = mappedProjects
+        graph.targets = mappedTargets
+        return (graph, sideEffects)
+    }
+}

--- a/Sources/TuistCore/ValueGraph/ValueProjectMapper.swift
+++ b/Sources/TuistCore/ValueGraph/ValueProjectMapper.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// An interface to map projects.
+public protocol ValueProjectMapping {
+    /// Given a project and its targets, it maps them into another project and list of targets.
+    /// - Parameters:
+    ///   - project: Project to be mapped.
+    ///   - targets: List of project targets to be mapped
+    func map(project: Project, targets: [String: Target]) throws -> (project: Project, targets: [String: Target], sideEffects: [SideEffectDescriptor])
+}
+
+/// A project mapper that is initialized with the mapping function.
+public class AnyValueProjectMapper: ValueProjectMapping {
+    public typealias ValueProjectMap = (Project, [String: Target]) throws -> (Project, [String: Target], [SideEffectDescriptor])
+
+    /// Mapping function.
+    private let mapper: ValueProjectMap
+
+    /// It initializes the mapper with the mapping function.
+    /// - Parameter mapper: Mapping function.
+    public init(mapper: @escaping ValueProjectMap) {
+        self.mapper = mapper
+    }
+
+    public func map(project: Project, targets: [String: Target]) throws -> (project: Project, targets: [String: Target], sideEffects: [SideEffectDescriptor]) {
+        try mapper(project, targets)
+    }
+}
+
+/// A project mapper that is initialized with the target mapper.
+public class ValueProjectTargetMapper: ValueProjectMapping {
+    /// Target mapper.
+    private let targetMapper: ValueTargetMapping
+
+    /// Initializes the project mapper with a target mapper.
+    /// - Parameter targetMapper: Target mapper.
+    public init(targetMapper: ValueTargetMapping) {
+        self.targetMapper = targetMapper
+    }
+
+    public func map(project: Project, targets: [String: Target]) throws -> (project: Project, targets: [String: Target], sideEffects: [SideEffectDescriptor]) {
+        var sideEffects: [SideEffectDescriptor] = []
+        var targets: [String: Target] = [:]
+        try targets.forEach { _, target in
+            let (mappedTarget, targetSideEffects) = try self.targetMapper.map(target: target)
+            targets[mappedTarget.name] = mappedTarget
+            sideEffects.append(contentsOf: targetSideEffects)
+        }
+        return (project, [:], sideEffects)
+    }
+}

--- a/Sources/TuistCore/ValueGraph/ValueTargetMapper.swift
+++ b/Sources/TuistCore/ValueGraph/ValueTargetMapper.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Interface to map targets.
+public protocol ValueTargetMapping {
+    /// Given a target, it maps it into another target and a list of side effects to be executed.
+    /// - Parameter target: Target to be mapped.
+    func map(target: Target) throws -> (Target, [SideEffectDescriptor])
+}
+
+/// A target mapper that is initialized with the mapping function.
+class AnyValueTargetMapper: ValueTargetMapping {
+    typealias ValueTargetMap = (Target) throws -> (Target, [SideEffectDescriptor])
+
+    /// Mapping function.
+    private let mapper: ValueTargetMap
+
+    /// It initializes the mapper with a mapping function.
+    /// - Parameter mapper: Mapping function.
+    init(mapper: @escaping ValueTargetMap) {
+        self.mapper = mapper
+    }
+
+    func map(target: Target) throws -> (Target, [SideEffectDescriptor]) {
+        try mapper(target)
+    }
+}

--- a/Tests/TuistCoreTests/ValueGraph/ValueGraphMapperTests.swift
+++ b/Tests/TuistCoreTests/ValueGraph/ValueGraphMapperTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import TuistCore
+import TuistSupport
+import XCTest
+
+@testable import TuistCoreTesting
+@testable import TuistSupportTesting
+
+final class AnyValueGraphMapperTests: TuistUnitTestCase {
+    var subject: AnyValueGraphMapper!
+
+    override func tearDown() {
+        super.tearDown()
+        subject = nil
+    }
+
+    func test_map() throws {
+        // Given
+        let graph = ValueGraph.test(name: "graph", path: "/")
+        let sideEffect = SideEffectDescriptor.command(.init(command: ["test"]))
+        subject = AnyValueGraphMapper(mapper: { (graph) -> (ValueGraph, [SideEffectDescriptor]) in
+            var graph = graph
+            graph.name = "mapped"
+            return (graph, [sideEffect])
+        })
+
+        // When
+        let (gotGraph, gotSideEffects) = try subject.map(graph: graph)
+
+        // Then
+        XCTAssertEqual(gotGraph.name, "mapped")
+        XCTAssertEqual(gotSideEffects, [sideEffect])
+    }
+}
+
+final class ValueGraphProjectMapperTests: TuistUnitTestCase {
+    var subject: ValueGraphProjectMapper!
+
+    override func tearDown() {
+        super.tearDown()
+        subject = nil
+    }
+
+    func test_map() throws {
+        // Given
+        let project = Project.test(path: "/", name: "project")
+        let target = Target.test(name: "app", product: .app)
+        let sideEffect = SideEffectDescriptor.command(.init(command: ["test"]))
+        let graph = ValueGraph.test(name: "graph",
+                                    path: "/",
+                                    projects: [project.path: project],
+                                    targets: [project.path: [target.name: target]])
+        subject = ValueGraphProjectMapper(projectMapper: AnyValueProjectMapper(mapper: { (project, targets) -> (Project, [String: Target], [SideEffectDescriptor]) in
+            var project = project
+            project.name = "mapped-project"
+            let targets = targets.mapValues { (target) -> Target in
+                var target = target
+                target.name = "mapped-app"
+                return target
+            }
+            return (project, targets, [sideEffect])
+        }))
+
+        // Then
+        // When
+        let (gotGraph, gotSideEffects) = try subject.map(graph: graph)
+
+        // Then
+        XCTAssertEqual(gotGraph.projects.count, 1)
+        XCTAssertEqual(gotGraph.projects.values.first?.name, "mapped-project")
+        XCTAssertEqual(gotGraph.targets.count, 1)
+        XCTAssertEqual(gotGraph.targets.values.flatMap(\.values).first?.name, "mapped-app")
+        XCTAssertEqual(gotSideEffects, [sideEffect])
+    }
+}


### PR DESCRIPTION
### Short description 📝

A suggested by @kwridan [here](https://github.com/tuist/tuist/issues/1255), I'm doing a bit of prototyping on how the mappers could look with the new graph format. This PR introduces 3 mappers:
- Value graph mapper.
- Value project mapper.
- Value target mapper.

Bear in mind that with the new value graph model the attributes `project.targets` and `target.dependencies` go away. That means that `ValueGraph` the information about what targets belong to which projects, and what are the dependencies of a target live in the graph.

Although I added some tests, I refrained from adding more until we are all aligned with the way forward.