### PR TITLE
Move methods to GraphTraversing

### DIFF
--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -186,7 +186,7 @@ public class Graph: Encodable, Equatable {
     /// - Parameters:
     ///   - path: Path to the directory where the project that defines the target is located.
     ///   - name: Name of the target.
-    public func linkableDependencies(path: AbsolutePath, name: String) throws -> [GraphDependencyReference] {
+    public func linkableDependencies(path: AbsolutePath, name: String) -> [GraphDependencyReference] {
         guard let targetNode = findTargetNode(path: path, name: name) else {
             return []
         }

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -26,4 +26,8 @@ public final class GraphTraverser: GraphTraversing {
     public func resourceBundleDependencies(path: AbsolutePath, name: String) -> [Target] {
         graph.resourceBundleDependencies(path: path, name: name).map { $0.target }
     }
+
+    public func testTargetsDependingOn(path: AbsolutePath, name: String) -> [Target] {
+        graph.testTargetsDependingOn(path: path, name: name).map(\.target)
+    }
 }

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -30,4 +30,8 @@ public final class GraphTraverser: GraphTraversing {
     public func testTargetsDependingOn(path: AbsolutePath, name: String) -> [Target] {
         graph.testTargetsDependingOn(path: path, name: name).map(\.target)
     }
+
+    public func directStaticDependencies(path: AbsolutePath, name: String) -> [GraphDependencyReference] {
+        graph.staticDependencies(path: path, name: name)
+    }
 }

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -1,7 +1,3 @@
-//
-// Created by kwridan on 7/29/20.
-//
-
 import Foundation
 import TSCBasic
 
@@ -9,6 +5,14 @@ public final class GraphTraverser: GraphTraversing {
     private let graph: Graph
     public init(graph: Graph) {
         self.graph = graph
+    }
+
+    public func target(path: AbsolutePath, name: String) -> Target? {
+        graph.target(path: path, name: name).map(\.target)
+    }
+
+    public func targets(at path: AbsolutePath) -> [Target] {
+        graph.targets(at: path).map(\.target)
     }
 
     public func directTargetDependencies(path: AbsolutePath, name: String) -> [Target] {

--- a/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
+++ b/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
@@ -35,4 +35,10 @@ public protocol GraphTraversing {
     ///   - path: Path to the directory that contains the project definition.
     ///   - name: Name of the target whose dependant test targets will be returned.
     func testTargetsDependingOn(path: AbsolutePath, name: String) -> [Target]
+
+    /// Returns all non-transitive target static dependencies for the given target.
+    /// - Parameters:
+    ///   - path: Path to the directory where the project that defines the target is located.
+    ///   - name: Name of the target.
+    func directStaticDependencies(path: AbsolutePath, name: String) -> [GraphDependencyReference]
 }

--- a/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
+++ b/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
@@ -29,4 +29,10 @@ public protocol GraphTraversing {
     ///   - path: Path to the directory where the project that defines the target is located.
     ///   - name: Name of the target.
     func resourceBundleDependencies(path: AbsolutePath, name: String) -> [Target]
+
+    /// Returns the list of test targets that depend on the one with the given name at the given path.
+    /// - Parameters:
+    ///   - path: Path to the directory that contains the project definition.
+    ///   - name: Name of the target whose dependant test targets will be returned.
+    func testTargetsDependingOn(path: AbsolutePath, name: String) -> [Target]
 }

--- a/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
+++ b/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
@@ -2,6 +2,16 @@ import Foundation
 import TSCBasic
 
 public protocol GraphTraversing {
+    /// It returns the target with the given name in the project that is defined in the given directory path.
+    /// - Parameters:
+    ///   - path: Path to the directory that contains the definition of the project with the target is defined.
+    ///   - name: Name of the target.
+    func target(path: AbsolutePath, name: String) -> Target?
+
+    /// It returns the targets of the project defined in the directory at the given path.
+    /// - Parameter path: Path to the directory that contains the definition of the project.
+    func targets(at path: AbsolutePath) -> [Target]
+
     /// Given a project directory and target name, it returns all its direct target dependencies.
     /// - Parameters:
     ///   - path: Path to the directory that contains the project.

--- a/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
+++ b/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
@@ -15,7 +15,7 @@ public class ValueGraphTraverser: GraphTraversing {
 
     public func targets(at path: AbsolutePath) -> [Target] {
         guard let targets = graph.targets[path] else { return [] }
-        return Array(targets.values)
+        return Array(targets.values).sorted()
     }
 
     public func directTargetDependencies(path: AbsolutePath, name: String) -> [Target] {
@@ -48,9 +48,13 @@ public class ValueGraphTraverser: GraphTraversing {
         return bundleTargets.sorted()
     }
 
-    /// Given a dependency, it returns the target if the dependency represents a target and the
-    /// target exists in the graph.
-    /// - Parameter from: Dependency.
+    public func testTargetsDependingOn(path: AbsolutePath, name: String) -> [Target] {
+        graph.targets[path]?.values
+            .filter { $0.product.testsBundle }
+            .filter { graph.dependencies[.target(name: $0.name, path: path)]?.contains(.target(name: name, path: path)) == true }
+            .sorted() ?? []
+    }
+
     public func target(from dependency: ValueGraphDependency) -> Target? {
         guard case let ValueGraphDependency.target(name, path) = dependency else {
             return nil

--- a/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
+++ b/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
@@ -81,7 +81,8 @@ public class ValueGraphTraverser: GraphTraversing {
             }
             .compactMap { graph.targets[$0.path]?[$0.name] }
             .filter { $0.product.isStatic }
-            .map { .product(target: $0.name, productName: $0.productNameWithExtension) } ?? []
+            .map { .product(target: $0.name, productName: $0.productNameWithExtension) }
+            .sorted() ?? []
     }
 
     /// It traverses the depdency graph and returns all the dependencies.

--- a/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
+++ b/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
@@ -9,6 +9,15 @@ public class ValueGraphTraverser: GraphTraversing {
         self.graph = graph
     }
 
+    public func target(path: AbsolutePath, name: String) -> Target? {
+        graph.targets[path]?[name]
+    }
+
+    public func targets(at path: AbsolutePath) -> [Target] {
+        guard let targets = graph.targets[path] else { return [] }
+        return Array(targets.values)
+    }
+
     public func directTargetDependencies(path: AbsolutePath, name: String) -> [Target] {
         guard let dependencies = graph.dependencies[.target(name: name, path: path)] else { return [] }
         return dependencies.flatMap { (dependency) -> [Target] in

--- a/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
+++ b/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
@@ -71,6 +71,19 @@ public class ValueGraphTraverser: GraphTraversing {
             .sorted()
     }
 
+    public func directStaticDependencies(path: AbsolutePath, name: String) -> [GraphDependencyReference] {
+        graph.dependencies[.target(name: name, path: path)]?
+            .compactMap { (dependency: ValueGraphDependency) -> (path: AbsolutePath, name: String)? in
+                guard case let ValueGraphDependency.target(name, path) = dependency else {
+                    return nil
+                }
+                return (path, name)
+            }
+            .compactMap { graph.targets[$0.path]?[$0.name] }
+            .filter { $0.product.isStatic }
+            .map { .product(target: $0.name, productName: $0.productNameWithExtension) } ?? []
+    }
+
     /// It traverses the depdency graph and returns all the dependencies.
     /// - Parameter path: Path to the project from where traverse the dependency tree.
     public func allDependencies(path: AbsolutePath) -> Set<ValueGraphDependency> {

--- a/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
+++ b/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
@@ -3,6 +3,34 @@ import TSCBasic
 @testable import TuistCore
 
 final class MockGraphTraverser: GraphTraversing {
+    var invokedTarget = false
+    var invokedTargetCount = 0
+    var invokedTargetParameters: (path: AbsolutePath, name: String)?
+    var invokedTargetParametersList = [(path: AbsolutePath, name: String)]()
+    var stubbedTargetResult: Target!
+
+    func target(path: AbsolutePath, name: String) -> Target? {
+        invokedTarget = true
+        invokedTargetCount += 1
+        invokedTargetParameters = (path, name)
+        invokedTargetParametersList.append((path, name))
+        return stubbedTargetResult
+    }
+
+    var invokedTargets = false
+    var invokedTargetsCount = 0
+    var invokedTargetsParameters: (path: AbsolutePath, Void)?
+    var invokedTargetsParametersList = [(path: AbsolutePath, Void)]()
+    var stubbedTargetsResult: [Target]! = []
+
+    func targets(at path: AbsolutePath) -> [Target] {
+        invokedTargets = true
+        invokedTargetsCount += 1
+        invokedTargetsParameters = (path, ())
+        invokedTargetsParametersList.append((path, ()))
+        return stubbedTargetsResult
+    }
+
     var invokedDirectTargetDependencies = false
     var invokedDirectTargetDependenciesCount = 0
     var invokedDirectTargetDependenciesParameters: (path: AbsolutePath, name: String)?

--- a/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
+++ b/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
@@ -86,4 +86,18 @@ final class MockGraphTraverser: GraphTraversing {
         invokedTestTargetsDependingOnParametersList.append((path, name))
         return stubbedTestTargetsDependingOnResult
     }
+
+    var invokedDirectStaticDependencies = false
+    var invokedDirectStaticDependenciesCount = 0
+    var invokedDirectStaticDependenciesParameters: (path: AbsolutePath, name: String)?
+    var invokedDirectStaticDependenciesParametersList = [(path: AbsolutePath, name: String)]()
+    var stubbedDirectStaticDependenciesResult: [GraphDependencyReference]! = []
+
+    func directStaticDependencies(path: AbsolutePath, name: String) -> [GraphDependencyReference] {
+        invokedDirectStaticDependencies = true
+        invokedDirectStaticDependenciesCount += 1
+        invokedDirectStaticDependenciesParameters = (path, name)
+        invokedDirectStaticDependenciesParametersList.append((path, name))
+        return stubbedDirectStaticDependenciesResult
+    }
 }

--- a/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
+++ b/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
@@ -72,4 +72,18 @@ final class MockGraphTraverser: GraphTraversing {
         invokedResourceBundleDependenciesParametersList.append((path, name))
         return stubbedResourceBundleDependenciesResult
     }
+
+    var invokedTestTargetsDependingOn = false
+    var invokedTestTargetsDependingOnCount = 0
+    var invokedTestTargetsDependingOnParameters: (path: AbsolutePath, name: String)?
+    var invokedTestTargetsDependingOnParametersList = [(path: AbsolutePath, name: String)]()
+    var stubbedTestTargetsDependingOnResult: [Target]! = []
+
+    func testTargetsDependingOn(path: AbsolutePath, name: String) -> [Target] {
+        invokedTestTargetsDependingOn = true
+        invokedTestTargetsDependingOnCount += 1
+        invokedTestTargetsDependingOnParameters = (path, name)
+        invokedTestTargetsDependingOnParametersList.append((path, name))
+        return stubbedTestTargetsDependingOnResult
+    }
 }

--- a/Tests/TuistCoreTests/ValueGraph/ValueGraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/ValueGraph/ValueGraphTraverserTests.swift
@@ -70,6 +70,30 @@ final class ValueGraphTraverserTests: TuistUnitTestCase {
         XCTAssertEqual(got, [uiTests, unitTests])
     }
 
+    func test_directStaticDependencies() {
+        // Given
+        let path = AbsolutePath.root
+        let framework = Target.test(name: "Framework", product: .framework)
+        let staticLibrary = Target.test(name: "StaticLibrary", product: .staticLibrary)
+        let targets: [AbsolutePath: [String: Target]] = [
+            path: [framework.name: framework,
+                   staticLibrary.name: staticLibrary],
+        ]
+        let dependencies: [ValueGraphDependency: Set<ValueGraphDependency>] = [
+            .target(name: framework.name, path: path): Set([.target(name: staticLibrary.name, path: path)]),
+        ]
+        let graph = ValueGraph.test(path: path,
+                                    targets: targets,
+                                    dependencies: dependencies)
+        let subject = ValueGraphTraverser(graph: graph)
+
+        // When
+        let got = subject.directStaticDependencies(path: path, name: framework.name)
+
+        // Then
+        XCTAssertEqual(got, [.product(target: staticLibrary.name, productName: staticLibrary.productNameWithExtension)])
+    }
+
     func test_directTargetDependencies() {
         // Given
         // A -> B -> C

--- a/Tests/TuistCoreTests/ValueGraph/ValueGraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/ValueGraph/ValueGraphTraverserTests.swift
@@ -8,6 +8,36 @@ import XCTest
 @testable import TuistSupportTesting
 
 final class ValueGraphTraverserTests: TuistUnitTestCase {
+    func test_target() {
+        // Given
+        let target = Target.test(name: "App", product: .app)
+        let graph = ValueGraph.test(path: "/", targets: [
+            "/": ["App": target],
+        ])
+        let subject = ValueGraphTraverser(graph: graph)
+
+        // When
+        let got = subject.target(path: "/", name: "App")
+
+        // Then
+        XCTAssertEqual(got, target)
+    }
+
+    func test_targets() {
+        // Given
+        let target = Target.test(name: "App", product: .app)
+        let graph = ValueGraph.test(path: "/", targets: [
+            "/": ["App": target],
+        ])
+        let subject = ValueGraphTraverser(graph: graph)
+
+        // When
+        let got = subject.targets(at: "/")
+
+        // Then
+        XCTAssertEqual(got, [target])
+    }
+
     func test_directTargetDependencies() {
         // Given
         // A -> B -> C
@@ -295,7 +325,7 @@ final class ValueGraphTraverserTests: TuistUnitTestCase {
         XCTAssertEqual(staticFramework2Results.map(\.name), [])
     }
 
-    func test_target() {
+    func test_target_from_dependency() {
         // Given
         let project = Project.test()
         let app = Target.test(name: "App", product: .app)


### PR DESCRIPTION
### Short description 📝
I'm moving the following methods from `Graph` to `GraphTraversing` and updating the classes/structs that conform the protocol to provide implementations for the methods. The methods are the following:

```swift
func target(path: AbsolutePath, name: String) -> Target?
func targets(at path: AbsolutePath) -> [Target]
func testTargetsDependingOn(path: AbsolutePath, name: String) -> [Target]
func directStaticDependencies(path: AbsolutePath, name: String) -> [GraphDependencyReference]
```

In follow-up PRs I'll continue migrating methods to the protocol.