### PR TITLE
Some visual fixes on the documentation website

### DIFF
--- a/website/markdown/docs/components/enum.jsx
+++ b/website/markdown/docs/components/enum.jsx
@@ -1,48 +1,43 @@
-/** @jsx jsx */
-import { jsx, Styled } from 'theme-ui'
+import React from 'react'
+import { Styled } from 'theme-ui'
 import ReactMarkdown from 'react-markdown'
+import tw from 'twin.macro'
 
 const EnumTable = ({ cases }) => {
-  const borderStyle = {
-    border: theme => `1px solid ${theme.colors.gray}`,
-    borderCollapse: 'collapse',
-  }
-  const cellStyle = {
-    ...borderStyle,
-    p: 2,
-  }
-  return (
-    <table sx={{ ...borderStyle, tableLayout: 'fixed', my: 3 }}>
-      <thead sx={{ display: ['none', 'table-header-group'] }}>
-        <tr sx={{ bg: 'muted' }}>
-          <th sx={{ ...cellStyle }}>Case</th>
-          <th sx={{ ...cellStyle }}>Description</th>
-        </tr>
-      </thead>
+  const headerStyle = tw`px-6 py-3 bg-gray-100 text-left text-xs leading-4 font-medium text-gray-600 uppercase tracking-wider`
+  const cellStyle = tw`px-6 py-4 whitespace-normal leading-5 font-normal text-sm text-gray-900`
 
-      <tbody>
-        {cases.map((prop, index) => {
-          return (
-            <tr key={index}>
-              <td sx={{ ...cellStyle }}>
-                <Styled.code>{prop.case}</Styled.code>
-                <div sx={{ display: ['block', 'none'] }}>
-                  <ReactMarkdown source={prop.description} />
-                </div>
-              </td>
-              <td
-                sx={{
-                  ...cellStyle,
-                  display: ['none', 'table-cell'],
-                }}
-              >
-                <ReactMarkdown source={prop.description} />
-              </td>
+  return (
+    <div className="my-2 py-2 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
+      <div className="align-middle inline-block min-w-full shadow sm:rounded-lg border-b border-gray-200">
+        <table css={[tw`min-w-full divide-y divide-gray-200`]}>
+          <thead css={[tw`hidden md:table-header-group`]}>
+            <tr>
+              <th css={[headerStyle, tw`hidden md:table-cell`]}>Case</th>
+              <th css={[headerStyle, tw`hidden md:table-cell`]}>Description</th>
             </tr>
-          )
-        })}
-      </tbody>
-    </table>
+          </thead>
+
+          <tbody>
+            {cases.map((prop, index) => {
+              return (
+                <tr key={index}>
+                  <td css={[cellStyle]}>
+                    <Styled.inlineCode>{prop.case}</Styled.inlineCode>
+                    <div css={[tw`block mt-2 md:mt-0 md:hidden`]}>
+                      <ReactMarkdown source={prop.description} />
+                    </div>
+                  </td>
+                  <td css={[cellStyle, tw`hidden md:table-cell`]}>
+                    <ReactMarkdown source={prop.description} />
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
   )
 }
 

--- a/website/markdown/docs/components/message.jsx
+++ b/website/markdown/docs/components/message.jsx
@@ -1,25 +1,66 @@
 /** @jsx jsx */
 import { jsx, Styled } from 'theme-ui'
 import React from 'react'
-import { Message as SemanticMessage } from 'semantic-ui-react'
 import ReactMarkdown from 'react-markdown'
-import { Message as ThemeUIMessage } from 'theme-ui'
+import tw from 'twin.macro'
 
-const Message = ({ title, description }) => {
+const Message = ({ title, description, info, warning }) => {
+  let backgroundColor
+  let iconColor
+  let titleColor
+  let textColor
+  if (info) {
+    backgroundColor = tw`bg-blue-100`
+    iconColor = tw`text-blue-400`
+    titleColor = tw`text-blue-800`
+    textColor = tw`text-blue-700`
+  }
+  if (warning) {
+    backgroundColor = tw`bg-yellow-100`
+    iconColor = tw`text-yellow-400`
+    titleColor = tw`text-yellow-800`
+    textColor = tw`text-yellow-700`
+  }
+
   return (
-    <ThemeUIMessage sx={{ bg: 'muted', my: 3 }}>
-      <div sx={{ fontWeight: 'heading', fontSize: 2 }}>
-        <span>{title}</span>
+    <div className="my-3">
+      <div className="rounded-md p-4" css={[backgroundColor]}>
+        <div className="flex">
+          <div className="flex-shrink-0">
+            <svg
+              css={[iconColor, tw`h-5 w-5`, warning ? tw`block` : tw`hidden`]}
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+                clip-rule="evenodd"
+              />
+            </svg>
+            <svg
+              css={[iconColor, tw`h-5 w-5`, info ? tw`block` : tw`hidden`]}
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </div>
+          <div className="ml-3">
+            <h3 className="text-sm leading-5 font-medium" css={[titleColor]}>
+              {title}
+            </h3>
+            <div className="mt-2 text-sm leading-5" css={[textColor]}>
+              <ReactMarkdown source={description} />
+            </div>
+          </div>
+        </div>
       </div>
-      <ReactMarkdown source={description} sx={{
-        "a:-webkit-any-link": {
-          color: "primary",
-          ":hover,:focus,:visited": {
-            color: "secondary",
-          },
-        },
-      }} />
-    </ThemeUIMessage>
+    </div>
   )
 }
 

--- a/website/markdown/docs/components/properties-table.jsx
+++ b/website/markdown/docs/components/properties-table.jsx
@@ -1,87 +1,83 @@
-/** @jsx jsx */
 import { jsx, Styled } from 'theme-ui'
-
+import tw from 'twin.macro'
 import React from 'react'
 import ReactMarkdown from 'react-markdown'
 
 const PropertiesTable = ({ properties }) => {
-  const borderStyle = {
-    border: theme => `1px solid ${theme.colors.gray}`,
-    borderCollapse: 'collapse',
-  }
-  const cellStyle = {
-    ...borderStyle,
-    p: 2,
-  }
+  const headerStyle = tw`px-6 py-3 bg-gray-100 text-left text-xs leading-4 font-medium text-gray-600 uppercase tracking-wider`
+  const cellStyle = tw`px-6 py-4 whitespace-normal leading-5 font-normal text-sm text-gray-900`
+
   return (
-    <table
-      sx={{
-        ...borderStyle,
-        my: 3,
-      }}
-    >
-      <thead>
-        <tr sx={{ bg: 'muted', ...borderStyle, display: ['none', 'table-row'] }}>
-          <th sx={{ ...cellStyle }}>Property</th>
-          <th sx={{ ...cellStyle }}>Description</th>
-          <th sx={{ ...cellStyle }}>Type</th>
-          <th sx={{ ...cellStyle }}>Optional</th>
-          <th sx={{ ...cellStyle }}>Default</th>
-        </tr>
-      </thead>
-
-      <tbody>
-        {properties.map((prop, index) => {
-          let type
-          if (prop.typeLink) {
-            type = <Styled.a href={prop.typeLink}>{prop.type}</Styled.a>
-          } else {
-            type = <span>{prop.type}</span>
-          }
-
-          const optionalValue = prop.optional ? 'Yes' : 'No'
-
-          return (
-            <tr key={index} sx={{ ...borderStyle }}>
-              <td sx={{ ...cellStyle }}>
-                <div sx={{ fontWeight: ['bold', 'body'] }}>{prop.name}</div>
-                <div sx={{ display: ['block', 'none'] }}>
-                  <ReactMarkdown source={prop.description} />
-                </div>
-                <div sx={{ display: ['block', 'none'], mt: 3 }}>
-                  <span sx={{ fontWeight: 'bold' }}>Type: </span>{' '}
-                  <Styled.code>{type}</Styled.code>
-                </div>
-                <div sx={{ display: ['block', 'none'] }}>
-                  <span sx={{ fontWeight: 'bold' }}>Optional: </span>{' '}
-                  {optionalValue}
-                </div>
-                <div sx={{ display: ['block', 'none'] }}>
-                  <span sx={{ fontWeight: 'bold' }}>Default value: </span>{' '}
-                  {prop.default != '' && (
-                    <Styled.code>{prop.default}</Styled.code>
-                  )}
-                </div>
-              </td>
-              <td sx={{ ...cellStyle, display: ['none', 'table-cell'] }}>
-                <ReactMarkdown source={prop.description} />
-              </td>
-              <td sx={{ ...cellStyle, display: ['none', 'table-cell'] }}>
-                <Styled.code>{type}</Styled.code>
-              </td>
-              <td sx={{ ...cellStyle, display: ['none', 'table-cell'] }}>
-                {optionalValue}
-              </td>
-              <td sx={{ ...cellStyle, display: ['none', 'table-cell'] }}>
-                {prop.default != '' && (
-                  <Styled.code>{prop.default}</Styled.code>
-                )}
-              </td>
+    <div className="my-2 py-2 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
+      <div className="align-middle inline-block min-w-full shadow sm:rounded-lg border-b border-gray-200">
+        <table css={[tw`min-w-full divide-y divide-gray-200`]}>
+          <thead>
+            <tr>
+              <th css={[headerStyle, tw`hidden md:table-cell`]}>Property</th>
+              <th css={[headerStyle, tw`hidden md:table-cell`]}>Description</th>
+              <th css={[headerStyle, tw`hidden md:table-cell`]}>Type</th>
+              <th css={[headerStyle, tw`hidden md:table-cell`]}>Optional</th>
+              <th css={[headerStyle, tw`hidden md:table-cell`]}>Default</th>
             </tr>
-          )
-        })}
-      </tbody>
-    </table>
+          </thead>
+
+          <tbody>
+            {properties.map((prop, index) => {
+              let type
+              if (prop.typeLink) {
+                type = <Styled.a href={prop.typeLink}>{prop.type}</Styled.a>
+              } else {
+                type = <span>{prop.type}</span>
+              }
+
+              const optionalValue = prop.optional ? 'Yes' : 'No'
+
+              return (
+                <tr
+                  key={index}
+                  css={[index % 2 == 0 ? tw`bg-white` : tw`bg-gray-100`]}
+                >
+                  <td css={[cellStyle]}>
+                    <div css={[tw`font-bold md:font-normal`]}>{prop.name}</div>
+                    <div css={[tw`block md:hidden`]}>
+                      <ReactMarkdown source={prop.description} />
+                    </div>
+                    <div css={[tw`block md:hidden mt-3`]}>
+                      <span css={[tw`font-medium`]}>Type: </span>{' '}
+                      <Styled.inlineCode>{type}</Styled.inlineCode>
+                    </div>
+                    <div css={[tw`block md:hidden`]}>
+                      <span css={[tw`font-medium`]}>Optional: </span>{' '}
+                      {optionalValue}
+                    </div>
+                    <div css={[tw`block md:hidden`]}>
+                      <span css={[tw`font-medium`]}>Default value: </span>{' '}
+                      {prop.default != '' && (
+                        <Styled.inlineCode>{prop.default}</Styled.inlineCode>
+                      )}
+                    </div>
+                  </td>
+                  <td css={[cellStyle, tw`hidden md:table-cell`]}>
+                    <ReactMarkdown source={prop.description} />
+                  </td>
+                  <td css={[cellStyle, tw`hidden md:table-cell`]}>
+                    <Styled.inlineCode>{type}</Styled.inlineCode>
+                  </td>
+                  <td css={[cellStyle, tw`hidden md:table-cell`]}>
+                    {optionalValue}
+                  </td>
+                  <td css={[cellStyle, tw`hidden md:table-cell`]}>
+                    {prop.default != '' && (
+                      <Styled.inlineCode>{prop.default}</Styled.inlineCode>
+                    )}
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
   )
 }
 

--- a/website/markdown/docs/components/settingsdictionary-table.jsx
+++ b/website/markdown/docs/components/settingsdictionary-table.jsx
@@ -1,51 +1,48 @@
-/** @jsx jsx */
-import { jsx, Styled } from 'theme-ui'
+import { Styled } from 'theme-ui'
+import tw from 'twin.macro'
 
 import React from 'react'
 import ReactMarkdown from 'react-markdown'
 
 const SettingsDictionaryTable = ({ methods }) => {
-  const borderStyle = {
-    border: theme => `1px solid ${theme.colors.gray}`,
-    borderCollapse: 'collapse',
-  }
-  const cellStyle = {
-    ...borderStyle,
-    p: 2,
-  }
-  return (
-    <table
-      sx={{
-        ...borderStyle,
-        my: 3,
-      }}
-    >
-      <thead>
-        <tr sx={{ bg: 'muted', ...borderStyle, display: ['none', 'table-row'] }}>
-          <th sx={{ ...cellStyle }}>Subject</th>
-          <th sx={{ ...cellStyle }}>Function Signature</th>
-          <th sx={{ ...cellStyle }}>Description</th>
-        </tr>
-      </thead>
+  const headerStyle = tw`px-6 py-3 bg-gray-100 text-left text-xs leading-4 font-medium text-gray-600 uppercase tracking-wider`
+  const cellStyle = tw`px-6 py-4 whitespace-normal leading-5 font-normal text-sm text-gray-900`
 
-      <tbody>
-        {methods.map((method, index) => {
-          return (
-            <tr key={index} sx={{ ...borderStyle }}>
-              <td sx={{ ...cellStyle, display: ['none', 'table-cell'] }}>
-                {method.subject}
-              </td>
-              <td sx={{ ...cellStyle, display: ['none', 'table-cell'] }}>
-                <Styled.code>{method.signature}</Styled.code>
-              </td>
-              <td sx={{ ...cellStyle, display: ['none', 'table-cell'], mt: 6 }}>
-                <ReactMarkdown source={method.description} />
-              </td>
+  return (
+    <div className="my-2 py-2 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
+      <div className="align-middle inline-block min-w-full shadow sm:rounded-lg border-b border-gray-200">
+        <table css={[tw`min-w-full divide-y divide-gray-200`]}>
+          <thead>
+            <tr css={[tw`hidden md:table-row`]}>
+              <th css={[headerStyle]}>Subject</th>
+              <th css={[headerStyle]}>Function Signature</th>
+              <th css={[headerStyle]}>Description</th>
             </tr>
-          )
-        })}
-      </tbody>
-    </table>
+          </thead>
+
+          <tbody>
+            {methods.map((method, index) => {
+              return (
+                <tr
+                  key={index}
+                  css={[index % 2 == 0 ? tw`bg-white` : tw`bg-gray-100`]}
+                >
+                  <td css={[cellStyle, tw`hidden md:table-cell`]}>
+                    {method.subject}
+                  </td>
+                  <td css={[cellStyle, tw`hidden md:table-cell`]}>
+                    <Styled.inlineCode>{method.signature}</Styled.inlineCode>
+                  </td>
+                  <td css={[cellStyle, tw`hidden md:table-cell`]}>
+                    <ReactMarkdown source={method.description} />
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
   )
 }
 

--- a/website/markdown/docs/usage/project-description.mdx
+++ b/website/markdown/docs/usage/project-description.mdx
@@ -625,7 +625,7 @@ description: 'It represents an array value.',
 <Message
   info
   title="ExpressiveByLiteral"
-  description="InfoPlist.Value conforms to the ExpressiveByLiteral protocols and therefore, it can be initialized with an instance of the primitive type that they encapsulate."
+  description="`InfoPlist.Value` conforms to the `ExpressiveByLiteral` protocols and therefore, it can be initialized with an instance of the primitive type that they encapsulate."
 />
 
 ## Target Action

--- a/website/markdown/docs/usage/resources.mdx
+++ b/website/markdown/docs/usage/resources.mdx
@@ -8,7 +8,7 @@ excerpt: 'In this page documents how Tuist synthesizes accessors for resources t
 Depending on the target product (e.g. app, framework), resources are accessed differently.
 For example, if we are trying to get an image that is part of an app target, we get the image from the `Bundle.main`.
 Conversely, if the image is part of a framework, we access it from the `Bundle` that represents the framework, `Bundle(for: FrameworkClass.self).resourceURL`.
-Having an **inconsistent interface** for accessing resources complicates moving code a resources around.
+Having an **inconsistent interface** for accessing resources complicates moving code and resources around.
 
 Moreover,
 as you might know,

--- a/website/src/gatsby-plugin-theme-ui/index.js
+++ b/website/src/gatsby-plugin-theme-ui/index.js
@@ -38,7 +38,7 @@ fontSizes.display = fontSizes[5]
 
 // Colors
 const colors = {
-  text: '#000',
+  text: '#2d3748', // text-gray-800
   background: '#ffffff',
   primary: '#046abd',
   secondary: '#6F52DA',
@@ -77,6 +77,7 @@ const styles = {
     fontSize: [5, 6],
   },
   h2: {
+    color: 'text',
     mt: 5,
     variant: 'text.heading',
     fontSize: 5,
@@ -131,7 +132,7 @@ const styles = {
   inlineCode: {
     fontSize: 1,
     fontFamily: 'monospace',
-    color: 'secondary',
+    color: 'primary',
   },
   hr: {
     border: 0,


### PR DESCRIPTION
### Short description 📝

I've been noticing some tiny inconsistencies on the design of the documentaion that I've been meaning to fix for a while and I finally found some time to do so. Below are some screenshots of the result:

**Cleaner and more beautiful table design**
<img width="1312" alt="image" src="https://user-images.githubusercontent.com/663605/90271023-75533900-de5b-11ea-9cfe-9557fe0f1650.png">

**New design for information banners**
<img width="1266" alt="image" src="https://user-images.githubusercontent.com/663605/90271052-7f753780-de5b-11ea-980f-14f61d85ac4b.png">
<img width="1268" alt="image" src="https://user-images.githubusercontent.com/663605/90271067-88660900-de5b-11ea-9e4d-316efe7634c4.png">

In a follow-up PR I plan to improve the side menu to allow expanding and collapsing sections as needed. This will make the menu more navigateable and thus more user-friendly.