### PR TITLE
Carthage binary dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - **Breaking** Support for Xcode 11.3.x and Xcode 11.4.x [#1604](https://github.com/tuist/tuist/pull/1604) by [@fortmarek](https://github.com/fortmarek)
 - Support multiple rendering algorithms in Tuist Graph  [#1655]([1655](https://github.com/tuist/tuist/pull/1655/)) by [@andreacipriani][https://github.com/andreacipriani]
-- Fix Carthage support for binary dependencies by [@softmaxsg](https://github.com/softmaxsg) 
+- Fix Carthage support for binary dependencies [#1675](https://github.com/tuist/tuist/pull/1675) by [@softmaxsg](https://github.com/softmaxsg) 
 
 ## 1.15.0 - Riga
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - **Breaking** Support for Xcode 11.3.x and Xcode 11.4.x [#1604](https://github.com/tuist/tuist/pull/1604) by [@fortmarek](https://github.com/fortmarek)
 - Support multiple rendering algorithms in Tuist Graph  [#1655]([1655](https://github.com/tuist/tuist/pull/1655/)) by [@andreacipriani][https://github.com/andreacipriani]
+- Fix Carthage support for binary dependencies by [@softmaxsg](https://github.com/softmaxsg) 
 
 ## 1.15.0 - Riga
 

--- a/Sources/TuistLoader/Up/Carthage.swift
+++ b/Sources/TuistLoader/Up/Carthage.swift
@@ -112,9 +112,7 @@ final class Carthage: Carthaging {
 }
 
 extension Carthage {
-
     private enum DependencyType: String {
         case github, git, binary
     }
-
 }

--- a/Sources/TuistLoader/Up/Carthage.swift
+++ b/Sources/TuistLoader/Up/Carthage.swift
@@ -80,7 +80,13 @@ final class Carthage: Carthaging {
                                                range: NSRange(location: 0,
                                                               length: carfileResolved.count)).forEach { match in
             let dependencyNameRange = match.range(at: 2)
-            let dependencyName = String(carfileResolvedNSString.substring(with: dependencyNameRange).split(separator: "/").last!)
+            var dependencyName = String(carfileResolvedNSString.substring(with: dependencyNameRange).split(separator: "/").last!)
+
+            let dependencyTypeRange = match.range(at: 1)
+            let dependencyType = DependencyType(rawValue: carfileResolvedNSString.substring(with: dependencyTypeRange))
+            if dependencyType == .binary {
+                dependencyName = (dependencyName as NSString).deletingPathExtension
+            }
 
             let dependencyRevisionRange = match.range(at: 3)
             let dependencyRevision = carfileResolvedNSString.substring(with: dependencyRevisionRange)
@@ -103,4 +109,12 @@ final class Carthage: Carthaging {
 
         return outdated
     }
+}
+
+extension Carthage {
+
+    private enum DependencyType: String {
+        case github, git, binary
+    }
+
 }

--- a/Tests/TuistLoaderTests/Up/CarthageTests.swift
+++ b/Tests/TuistLoaderTests/Up/CarthageTests.swift
@@ -44,6 +44,8 @@ final class CarthageTests: TuistUnitTestCase {
         github "Tuist/DependencyA" "4.8.0"
         github "Tuist/DependencyB" "4.9.0"
         github "Tuist/DependencyC" "4.10.0"
+        binary "Tuist/DependencyD" "4.11.0"
+        binary "Tuist/DependencyE.json" "4.12.0"
         """
         let cartfileResolvedPath = temporaryPath.appending(component: "Cartfile.resolved")
         try cartfileResolved.write(to: cartfileResolvedPath.url,
@@ -58,6 +60,8 @@ final class CarthageTests: TuistUnitTestCase {
         // Dependency A: Outdated
         // Dependency B: Up to date
         // Dependency C: Missing version file
+        // Dependency D: Binary without extension, missing version file
+        // Dependency E: Binary with extension, missing version file
         let dependencyAVersionData = try jsonEncoder.encode(CarthageVersionFile(commitish: "4.7.0"))
         try dependencyAVersionData.write(to: buildPath.appending(component: ".DependencyA.version").url)
 
@@ -66,6 +70,6 @@ final class CarthageTests: TuistUnitTestCase {
 
         let got = try subject.outdated(path: temporaryPath)
 
-        XCTAssertEqual(got, ["DependencyA", "DependencyC"])
+        XCTAssertEqual(got, ["DependencyA", "DependencyC", "DependencyD", "DependencyE"])
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1232

### Short description 📝

Current implementation incorrectly parses the dependency name for binary dependencies.

### Solution 📦

The fix for the issue is very simple - just remove the file extension from the parsed dependency name.
