### PR TITLE
Add app extension documentation

### DIFF
--- a/website/markdown/docs/links.mdx
+++ b/website/markdown/docs/links.mdx
@@ -15,6 +15,7 @@ import DocTitle from './components/doc-title'
 - [Project description](/docs/usage/project-description/)
 - [Project description helpers](/docs/usage/helpers/)
 - [Dependencies](/docs/usage/dependencies/)
+- [App Extensions](/docs/usage/app-extensions/)
 - [Accessing resources](/docs/usage/resources/)
 - [Third-party dependencies](/docs/usage/third-party-dependencies/)
 - [Caching dependencies](/docs/usage/caching/)

--- a/website/markdown/docs/usage/app-extensions.mdx
+++ b/website/markdown/docs/usage/app-extensions.mdx
@@ -59,7 +59,7 @@ For example, here is a list of some of the extension types and their correspondi
 | Notification Service                   | `com.apple.usernotifications.service`        |
 | Widgets Extension                      | `com.apple.widgetkit-extension`              |
 
-Knowing the different key/value requirements may be needed when leveraging the auto-generated `Info.plist` file _(see [Info Plist](/docs/usage/project-description/#info-plist))_.
+Knowing the different key/value requirements may be needed when leveraging the auto-generated `Info.plist` file _(see [Info Plist](/docs/usage/project-description/#infoplist))_.
 
 To find out what the identifier for an extension type is or any other required key, you can examine the values within an existing `Info.plist` file _(if one exists)_, 
 or create a new sample project using the Xcode UI with the desired app extension target and examine the `Info.plist` file created by Xcode.

--- a/website/markdown/docs/usage/app-extensions.mdx
+++ b/website/markdown/docs/usage/app-extensions.mdx
@@ -1,0 +1,89 @@
+---
+name: App Extensions
+excerpt: 'This page documents how to declare and use App Extension targets.'
+---
+
+import Message from '../components/message'
+
+# App Extensions
+
+## Product Types
+
+iOS applications have a wide range of app extension types _(Notification Service, Intents, Widgets, etc...)_.
+
+Some of those extensions have dedicated product types (e.g. `.messagesExtension`), while others may be represented
+using the generic `.appExtension` product type.
+
+For example, this is how a Notification Service Extension can be declared:
+
+```swift
+let project = Project(name: "App",
+                      targets: [
+                        Target(name: "App",
+                               platform: .iOS,
+                               product: .app,
+                               bundleId: "io.tuist.App",
+                               infoPlist: "Info.plist",
+                               sources: ["Sources/**"],
+                               dependencies: [
+                                    .target(name: "NotificationServiceExtension"),
+                                ]),
+                        Target(name: "NotificationServiceExtension",
+                               platform: .iOS,
+                               product: .appExtension,
+                               bundleId: "io.tuist.App.NotificationServiceExtension",
+                               infoPlist: .extendingDefault(with: [
+                                       "CFBundleDisplayName": "$(PRODUCT_NAME)",
+                                       "NSExtension": [
+                                               "NSExtensionPointIdentifier": "com.apple.usernotifications.service", 
+                                               "NSExtensionPrincipalClass": "$(PRODUCT_MODULE_NAME).NotificationService"
+                                       ]
+                               ]),
+                               sources: "NotificationServiceExtension/**",
+                               dependencies: [
+                                   
+                               ]),
+                      ])
+```
+
+## Info Plist Keys
+
+Different app extensions have a different set of `Info.plist` key requirements, one of the main ones is the `NSExtensionPointIdentifier` key that identifies the extension type.
+
+For example, here is a list of some of the extension types and their corresponding identifier value:
+
+| Extension                              | `NSExtensionPointIdentifier`                 | 
+| -------------------------------------- | -------------------------------------------- |
+| Intents Extension                      | `com.apple.intents-service`                  |
+| Intents UI Extension                   | `com.apple.intents-ui-service`               |
+| Notification Service                   | `com.apple.usernotifications.service`        |
+| Widgets Extension                      | `com.apple.widgetkit-extension`              |
+
+Knowing the different key/value requirements may be needed when leveraging the auto-generated `Info.plist` file _(see [Info Plist](/docs/usage/project-description/#info-plist))_.
+
+To find out what the identifier for an extension type is or any other required key, you can examine the values within an existing `Info.plist` file _(if one exists)_, 
+or create a new sample project using the Xcode UI with the desired app extension target and examine the `Info.plist` file created by Xcode.
+
+## Associating Extensions With Applications
+
+To associate or include extensions within an application, the application target needs to declare a dependency on the corresponding extension targets.
+
+For example:
+
+```swift
+let project = Project(name: "App",
+                      targets: [
+                        Target(name: "App",
+                               platform: .iOS,
+                               product: .app,
+                               bundleId: "io.tuist.App",
+                               infoPlist: "Info.plist",
+                               sources: ["Sources/**"],
+                               dependencies: [
+                                    .target(name: "NotificationServiceExtension"),
+                                    .target(name: "WidgetExtension"),
+                                    // ...
+                                ]),
+                        // ...
+                      ])
+```

--- a/website/markdown/docs/usage/project-description.mdx
+++ b/website/markdown/docs/usage/project-description.mdx
@@ -568,62 +568,6 @@ The type of build product this target will output. It can be any of the followin
   ]}
 />
 
-<Message
-  info
-  title="Extensions"
-  description="Application targets need to declare a dependency on any Extension targets they wish to bundle."
-/>
-
-### App Extensions
-
-The `.appExtension` product type actually covers a wide range of different app extensions types (e.g. Notification Service, Intents, Widgets, etc...).
-Xcode treats them all as the same product type, however each have a different set of `Info.plist` keys and values.
-
-For example, this is how a Notification Service Extension can be declared:
-
-```swift
-let project = Project(name: "App",
-                      targets: [
-                        Target(name: "App",
-                               platform: .iOS,
-                               product: .app,
-                               bundleId: "io.tuist.App",
-                               infoPlist: "Info.plist",
-                               sources: ["Sources/**"],
-                               dependencies: [
-                                    .target(name: "NotificationServiceExtension"),
-                                ]),
-                        Target(name: "NotificationServiceExtension",
-                               platform: .iOS,
-                               product: .appExtension,
-                               bundleId: "io.tuist.App.NotificationServiceExtension",
-                               infoPlist: .extendingDefault(with: [
-                                       "CFBundleDisplayName": "$(PRODUCT_NAME)",
-                                       "NSExtension": [
-                                               "NSExtensionPointIdentifier": "com.apple.usernotifications.service", 
-                                               "NSExtensionPrincipalClass": "$(PRODUCT_MODULE_NAME).NotificationService"
-                                       ]
-                               ]),
-                               sources: "NotificationServiceExtension/**",
-                               dependencies: [
-                                   
-                               ]),
-```
-
-One of the key differences lies within the `NSExtensionPointIdentifier` value.
-
-For example, here is a list of some of the extensions and their corresponding identifier:
-
-| Extension                              | `NSExtensionPointIdentifier`                 | 
-| -------------------------------------- | -------------------------------------------- |
-| Intents Extension                      | `com.apple.intents-service`                  |
-| Intents UI Extension                   | `com.apple.intents-ui-service`               |
-| Notification Service                   | `com.apple.usernotifications.service`        |
-| Widgets Extension                      | `com.apple.widgetkit-extension`              |
-
-To find out what the identifier for an extension type that isn't listed, you can examine the `NSExtensionPointIdentifier` value within an existing `Info.plist` file if one exists, 
-or create a new sample project using the Xcode UI with the desired app extension target and examine the `Info.plist` file created by Xcode.
-
 ## InfoPlist
 
 The `InfoPlist` model represents a target `Info.plist` file. It can have any of the following values:<EnumTable

--- a/website/markdown/docs/usage/project-description.mdx
+++ b/website/markdown/docs/usage/project-description.mdx
@@ -568,6 +568,62 @@ The type of build product this target will output. It can be any of the followin
   ]}
 />
 
+<Message
+  info
+  title="Extensions"
+  description="Application targets need to declare a dependency on any Extension targets they wish to bundle."
+/>
+
+### App Extensions
+
+The `.appExtension` product type actually covers a wide range of different app extensions types (e.g. Notification Service, Intents, Widgets, etc...).
+Xcode treats them all as the same product type, however each have a different set of `Info.plist` keys and values.
+
+For example, this is how a Notification Service Extension can be declared:
+
+```swift
+let project = Project(name: "App",
+                      targets: [
+                        Target(name: "App",
+                               platform: .iOS,
+                               product: .app,
+                               bundleId: "io.tuist.App",
+                               infoPlist: "Info.plist",
+                               sources: ["Sources/**"],
+                               dependencies: [
+                                    .target(name: "NotificationServiceExtension"),
+                                ]),
+                        Target(name: "NotificationServiceExtension",
+                               platform: .iOS,
+                               product: .appExtension,
+                               bundleId: "io.tuist.App.NotificationServiceExtension",
+                               infoPlist: .extendingDefault(with: [
+                                       "CFBundleDisplayName": "$(PRODUCT_NAME)",
+                                       "NSExtension": [
+                                               "NSExtensionPointIdentifier": "com.apple.usernotifications.service", 
+                                               "NSExtensionPrincipalClass": "$(PRODUCT_MODULE_NAME).NotificationService"
+                                       ]
+                               ]),
+                               sources: "NotificationServiceExtension/**",
+                               dependencies: [
+                                   
+                               ]),
+```
+
+One of the key differences lies within the `NSExtensionPointIdentifier` value.
+
+For example, here is a list of some of the extensions and their corresponding identifier:
+
+| Extension                              | `NSExtensionPointIdentifier`                 | 
+| -------------------------------------- | -------------------------------------------- |
+| Intents Extension                      | `com.apple.intents-service`                  |
+| Intents UI Extension                   | `com.apple.intents-ui-service`               |
+| Notification Service                   | `com.apple.usernotifications.service`        |
+| Widgets Extension                      | `com.apple.widgetkit-extension`              |
+
+To find out what the identifier for an extension type that isn't listed, you can examine the `NSExtensionPointIdentifier` value within an existing `Info.plist` file if one exists, 
+or create a new sample project using the Xcode UI with the desired app extension target and examine the `Info.plist` file created by Xcode.
+
 ## InfoPlist
 
 The `InfoPlist` model represents a target `Info.plist` file. It can have any of the following values:<EnumTable


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1676

### Short description 📝

Working with app extensions can be a bit confusing as different app extension types are all represented using the same product type. Having some guidance in the documentation can help new users when needing to generate projects with extensions.

### Solution 📦

There is room for improvement to have explicit product types for all the different app extensions and generate the appropriate keys, however in the interim adding documentation could be a good first step.

### Implementation 👩‍💻👨‍💻

- [x] Adding notes on how different app extensions share the same product type
- [x] Adding notes on application targets needing to declare dependencies on any extension targets they wish to bundle


### Additional Context

I was taking a look at the feasibility of having dedicated product types, sadly there's a few caveats hence why I went with the documentation option as a first step while we figure out if it's worth investing in anything more involved.

In theory, it should be straight forward, add new product types (e.g. `.notificationExtension`) and map it to `.appExtension` + add the appropriate `Info.plist` keys.

However some of those keys need to be user defined, 

e.g. The principle class name

```swift
[ "NSExtensionPrincipalClass": "$(PRODUCT_MODULE_NAME).MyNotificationServiceClass" ]
```

In the Intents case there's also an additional `IntentsSupported` which requires user customization:

```swift
"NSExtensionAttributes": [
        "IntentsSupported": [
                "INSendMessageIntent",
                "INSearchForMessagesIntent",
                "INSetMessageAttributeIntent"
        ]
],
```

For Intents UI:

```swift
["NSExtensionMainStoryboard": "MyMainInterface"]
```

etc... 