### PR TITLE
Extend dependsOnXCTest to take into account test bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,19 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Removed
+
 - **Breaking** Support for Xcode 11.3.x and Xcode 11.4.x [#1604](https://github.com/tuist/tuist/pull/1604) by [@fortmarek](https://github.com/fortmarek)
-- Support multiple rendering algorithms in Tuist Graph  [#1655]([1655](https://github.com/tuist/tuist/pull/1655/)) by [@andreacipriani][https://github.com/andreacipriani]
-- Fix Carthage support for binary dependencies [#1675](https://github.com/tuist/tuist/pull/1675) by [@softmaxsg](https://github.com/softmaxsg) 
 
 ### Fixed
-  
+
 - Generate the default `Info.plist` file for static frameworks that only contain resources [#1661](https://github.com/tuist/tuist/pull/1661) by [@Juanpe](https://github.com/juanpe)
+- Fix Carthage support for binary dependencies [#1675](https://github.com/tuist/tuist/pull/1675) by [@softmaxsg](https://github.com/softmaxsg)
+
+### Changed
+
+- `Target.dependsOnXCTest` returns true if the target is a test bundle [#1679](https://github.com/tuist/tuist/pull/1679) by [@pepibumur](https://github.com/pepibumur)
+- Support multiple rendering algorithms in Tuist Graph [#1655](<[1655](https://github.com/tuist/tuist/pull/1655/)>) by [@andreacipriani][https://github.com/andreacipriani]
 
 ## 1.15.0 - Riga
 

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -387,7 +387,7 @@ public class Graph: Encodable, Equatable {
     /// - Parameter project: Project whose dependency references will be returned.
     public func allDependencyReferences(for project: Project) throws -> [GraphDependencyReference] {
         let linkableDependencies = try project.targets.flatMap {
-            try self.linkableDependencies(path: project.path, name: $0.name)
+            self.linkableDependencies(path: project.path, name: $0.name)
         }
 
         let embeddableDependencies = try project.targets.flatMap {

--- a/Sources/TuistCore/Graph/Nodes/TargetNode.swift
+++ b/Sources/TuistCore/Graph/Nodes/TargetNode.swift
@@ -105,6 +105,6 @@ public class TargetNode: GraphNode {
 
     /// Returns true if the target depends on XCTest
     public var dependsOnXCTest: Bool {
-        sdkDependencies.contains(where: { $0.name == "XCTest" })
+        sdkDependencies.contains(where: { $0.name == "XCTest" }) || target.product.testsBundle
     }
 }

--- a/Sources/TuistEnvKit/Commands/InstallCommand.swift
+++ b/Sources/TuistEnvKit/Commands/InstallCommand.swift
@@ -17,7 +17,7 @@ struct InstallCommand: ParsableCommand {
         name: .shortAndLong,
         help: "Re-installs the version compiling it from the source"
     )
-    var force: Bool
+    var force: Bool = false
 
     func run() throws {
         try InstallService().run(version: version,

--- a/Sources/TuistEnvKit/Commands/UpdateCommand.swift
+++ b/Sources/TuistEnvKit/Commands/UpdateCommand.swift
@@ -14,7 +14,7 @@ struct UpdateCommand: ParsableCommand {
         name: .shortAndLong,
         help: "Re-installs the latest version compiling it from the source"
     )
-    var force: Bool
+    var force: Bool = false
 
     func run() throws {
         try UpdateService().run(force: force)

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -98,7 +98,7 @@ final class LinkGenerator: LinkGenerating {
                        graph: Graph) throws
     {
         let embeddableFrameworks = try graph.embeddableFrameworks(path: path, name: target.name)
-        let linkableModules = try graph.linkableDependencies(path: path, name: target.name)
+        let linkableModules = graph.linkableDependencies(path: path, name: target.name)
 
         try setupSearchAndIncludePaths(target: target,
                                        pbxTarget: pbxTarget,

--- a/Sources/TuistKit/Commands/FocusCommand.swift
+++ b/Sources/TuistKit/Commands/FocusCommand.swift
@@ -24,7 +24,7 @@ struct FocusCommand: ParsableCommand {
         parsing: .singleValue,
         help: "When used with --cache, it generates the given target (with the sources) even if it exists in the cache."
     )
-    var includeSources: [String]
+    var includeSources: [String] = []
 
     @Option(
         name: .shortAndLong,

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -28,7 +28,7 @@ struct GenerateCommand: ParsableCommand {
         parsing: .singleValue,
         help: "When used with --cache, it generates the given target (with the sources) even if it exists in the cache."
     )
-    var includeSources: [String]
+    var includeSources: [String] = []
 
     func run() throws {
         try GenerateService().run(path: path,

--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -14,26 +14,28 @@ struct GraphCommand: ParsableCommand {
     }
 
     @Flag(
+        name: [.customShort("t"), .long],
         help: "Skip Test targets during graph rendering."
     )
     var skipTestTargets: Bool = false
 
     @Flag(
+        name: [.customShort("d"), .long],
         help: "Skip external dependencies."
     )
     var skipExternalDependencies: Bool = false
 
     @Option(
-        default: .dot,
+        name: [.customShort("f"), .long],
         help: "Available formats: dot, png"
     )
-    var format: GraphFormat
+    var format: GraphFormat = .dot
 
     @Option(
-        default: .dot,
+        name: [.customShort("a"), .customLong("algorithm")],
         help: "Available formats: dot, neato, twopi, circo, fdp, sfddp, patchwork"
     )
-    var layoutAlgorithm: GraphViz.LayoutAlgorithm
+    var layoutAlgorithm: GraphViz.LayoutAlgorithm = .dot
 
     @Option(
         name: .shortAndLong,

--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -33,7 +33,7 @@ public struct TuistCommand: ParsableCommand {
         name: [.customLong("help-env")],
         help: "Display subcommands to manage the environment tuist versions."
     )
-    var isTuistEnvHelp: Bool
+    var isTuistEnvHelp: Bool = false
 
     public static func main(_ arguments: [String]? = nil) -> Never {
         let errorHandler = ErrorHandler()

--- a/Tests/TuistCoreTests/Graph/GraphTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTests.swift
@@ -81,7 +81,7 @@ final class GraphTests: TuistUnitTestCase {
                                     dependencies: [precompiledNode])
         let graph = Graph.test(targets: [targetNode.path: [targetNode]])
 
-        let got = try graph.linkableDependencies(path: project.path, name: target.name)
+        let got = graph.linkableDependencies(path: project.path, name: target.name)
         XCTAssertEqual(got.first, GraphDependencyReference(precompiledNode: precompiledNode))
     }
 
@@ -99,7 +99,7 @@ final class GraphTests: TuistUnitTestCase {
             project.path: [dependencyNode, targetNode],
         ])
 
-        let got = try graph.linkableDependencies(path: project.path, name: target.name)
+        let got = graph.linkableDependencies(path: project.path, name: target.name)
         XCTAssertEqual(got.first, .product(target: "Dependency", productName: "libDependency.a"))
     }
 
@@ -120,12 +120,12 @@ final class GraphTests: TuistUnitTestCase {
                                     dependencies: [dependencyNode])
 
         let graph = Graph.test(projects: [project], targets: [project.path: [targetNode, dependencyNode, staticDependencyNode]])
-        let got = try graph.linkableDependencies(path: project.path,
-                                                 name: target.name)
+        let got = graph.linkableDependencies(path: project.path,
+                                             name: target.name)
         XCTAssertEqual(got.count, 1)
         XCTAssertEqual(got.first, .product(target: "Dependency", productName: "Dependency.framework"))
 
-        let frameworkGot = try graph.linkableDependencies(path: project.path, name: dependency.name)
+        let frameworkGot = graph.linkableDependencies(path: project.path, name: dependency.name)
 
         XCTAssertEqual(frameworkGot.count, 1)
         XCTAssertTrue(frameworkGot.contains(.product(target: "StaticDependency", productName: "libStaticDependency.a")))
@@ -152,7 +152,7 @@ final class GraphTests: TuistUnitTestCase {
                                  ])
 
         // When
-        let result = try graph.linkableDependencies(path: projectA.path, name: app.name)
+        let result = graph.linkableDependencies(path: projectA.path, name: app.name)
 
         // Then
         XCTAssertEqual(result, [GraphDependencyReference.product(target: "DynamicFramework", productName: "DynamicFramework.framework"),
@@ -188,8 +188,8 @@ final class GraphTests: TuistUnitTestCase {
                                  ])
 
         // When
-        let appResult = try graph.linkableDependencies(path: projectA.path, name: app.name)
-        let dynamicFramework1Result = try graph.linkableDependencies(path: projectA.path, name: dynamicFramework1.name)
+        let appResult = graph.linkableDependencies(path: projectA.path, name: app.name)
+        let dynamicFramework1Result = graph.linkableDependencies(path: projectA.path, name: dynamicFramework1.name)
 
         // Then
         XCTAssertEqual(appResult, [
@@ -235,7 +235,7 @@ final class GraphTests: TuistUnitTestCase {
                                  ])
 
         // When
-        let dynamicFramework1Result = try graph.linkableDependencies(path: projectA.path, name: dynamicFramework1.name)
+        let dynamicFramework1Result = graph.linkableDependencies(path: projectA.path, name: dynamicFramework1.name)
 
         // Then
         XCTAssertEqual(dynamicFramework1Result, [GraphDependencyReference.product(target: "DynamicFramework2", productName: "DynamicFramework2.framework")])
@@ -262,7 +262,7 @@ final class GraphTests: TuistUnitTestCase {
                                  ])
 
         // When
-        let result = try graph.linkableDependencies(path: projectA.path, name: app.name)
+        let result = graph.linkableDependencies(path: projectA.path, name: app.name)
 
         // Then
         XCTAssertEqual(result.compactMap(sdkDependency), [
@@ -291,8 +291,8 @@ final class GraphTests: TuistUnitTestCase {
                                  ])
 
         // When
-        let appResult = try graph.linkableDependencies(path: projectA.path, name: app.name)
-        let dynamicResult = try graph.linkableDependencies(path: projectA.path, name: dynamicFramework.name)
+        let appResult = graph.linkableDependencies(path: projectA.path, name: app.name)
+        let dynamicResult = graph.linkableDependencies(path: projectA.path, name: dynamicFramework.name)
 
         // Then
         XCTAssertEqual(appResult.compactMap(sdkDependency), [])
@@ -318,7 +318,7 @@ final class GraphTests: TuistUnitTestCase {
                                  ])
 
         // When
-        let result = try graph.linkableDependencies(path: projectA.path, name: app.name)
+        let result = graph.linkableDependencies(path: projectA.path, name: app.name)
 
         // Then
         XCTAssertEqual(result.compactMap(sdkDependency), [SDKPathAndStatus(name: "some.framework", status: .optional)])
@@ -339,7 +339,7 @@ final class GraphTests: TuistUnitTestCase {
                                  ])
 
         // When
-        let result = try graph.linkableDependencies(path: projectA.path, name: staticFramework.name)
+        let result = graph.linkableDependencies(path: projectA.path, name: staticFramework.name)
 
         // Then
         XCTAssertEqual(result.compactMap(sdkDependency),
@@ -365,7 +365,7 @@ final class GraphTests: TuistUnitTestCase {
                                  ])
 
         // When
-        let result = try graph.linkableDependencies(path: projectA.path, name: staticFrameworkA.name)
+        let result = graph.linkableDependencies(path: projectA.path, name: staticFrameworkA.name)
 
         // Then
         XCTAssertEqual(result.compactMap(sdkDependency),
@@ -387,7 +387,7 @@ final class GraphTests: TuistUnitTestCase {
                                  ])
 
         // When
-        let result = try graph.linkableDependencies(path: project.path, name: watchExtension.name)
+        let result = graph.linkableDependencies(path: project.path, name: watchExtension.name)
 
         // Then
         XCTAssertEqual(result, [
@@ -410,7 +410,7 @@ final class GraphTests: TuistUnitTestCase {
                                  ])
 
         // When
-        let result = try graph.linkableDependencies(path: project.path, name: watchExtension.name)
+        let result = graph.linkableDependencies(path: project.path, name: watchExtension.name)
 
         // Then
         XCTAssertEqual(result, [
@@ -436,7 +436,7 @@ final class GraphTests: TuistUnitTestCase {
                                  ])
 
         // When
-        let result = try graph.linkableDependencies(path: projectA.path, name: tests.name)
+        let result = graph.linkableDependencies(path: projectA.path, name: tests.name)
 
         // Then
         XCTAssertTrue(result.isEmpty)
@@ -459,7 +459,7 @@ final class GraphTests: TuistUnitTestCase {
                                  ])
 
         // When
-        let result = try graph.linkableDependencies(path: projectA.path, name: tests.name)
+        let result = graph.linkableDependencies(path: projectA.path, name: tests.name)
 
         // Then
         XCTAssertEqual(result, [
@@ -484,7 +484,7 @@ final class GraphTests: TuistUnitTestCase {
                                  ])
 
         // When
-        let result = try graph.linkableDependencies(path: projectA.path, name: tests.name)
+        let result = graph.linkableDependencies(path: projectA.path, name: tests.name)
 
         // Then
         XCTAssertTrue(result.isEmpty)

--- a/Tests/TuistCoreTests/Graph/Nodes/TargetNodeTests.swift
+++ b/Tests/TuistCoreTests/Graph/Nodes/TargetNodeTests.swift
@@ -91,4 +91,13 @@ final class TargetNodeTests: XCTestCase {
         // Then
         XCTAssertTrue(subject.dependsOnXCTest)
     }
+
+    func test_dependsOnXCTest_when_testBundle() {
+        // When
+        let target = Target.test(product: .uiTests)
+        let subject = TargetNode.test(target: target)
+
+        // Then
+        XCTAssertTrue(subject.dependsOnXCTest)
+    }
 }

--- a/website/markdown/docs/components/arguments-table.jsx
+++ b/website/markdown/docs/components/arguments-table.jsx
@@ -34,23 +34,31 @@ const ArgumentsTable = ({ args }) => {
                     <div css={[tw`font-bold md:font-normal`]}>
                       <ReactMarkdown source={arg.long} />
                     </div>
-                    <div css={[tw`block md:hidden`]}>
+                    <div css={[tw`block md:hidden font-bold`]}>
                       <ReactMarkdown source={arg.short} />
                     </div>
-                    {/* <div css={[tw`block md:hidden mt-3`]}>
-                      <span css={[tw`font-medium`]}>Type: </span>{' '}
-                      <Styled.inlineCode>{type}</Styled.inlineCode>
-                    </div> */}
                     <div css={[tw`block md:hidden`]}>
-                      <span css={[tw`font-medium`]}>Optional: </span>{' '}
-                      {optionalValue}
+                      <span css={[tw`font-semibold mt-3 uppercase`]}>
+                        Description:{' '}
+                      </span>{' '}
+                      <ReactMarkdown source={arg.description} />
                     </div>
-                    <div css={[tw`block md:hidden`]}>
-                      <span css={[tw`font-medium`]}>Default value: </span>{' '}
-                      {arg.default != '' && (
-                        <Styled.inlineCode>{arg.default}</Styled.inlineCode>
-                      )}
-                    </div>
+                    {arg.values && (
+                      <div css={[tw`block md:hidden mt-3`]}>
+                        <span css={[tw`font-semibold uppercase`]}>
+                          Values:{' '}
+                        </span>{' '}
+                        <ReactMarkdown source={arg.values.join(', ')} />
+                      </div>
+                    )}
+                    {arg.default && (
+                      <div css={[tw`block md:hidden mt-3`]}>
+                        <span css={[tw`font-semibold uppercase`]}>
+                          Default:{' '}
+                        </span>{' '}
+                        <ReactMarkdown source={arg.default} />
+                      </div>
+                    )}
                   </td>
                   <td css={[cellStyle, tw`hidden md:table-cell`]}>
                     <ReactMarkdown source={arg.short} />


### PR DESCRIPTION
### Short description 📝
I'm extending the `dependsOnXCTest` logic to return true if the target is a test bundle. Those targets implicitly depends on XCTest so they don't need to declare the dependency explicitly.