### PR TITLE
Use relative paths for Local Swift Packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- Use relative paths for Local Swift Packages [#1706](https://github.com/tuist/tuist/pull/1706) by [@kwridan](https://github.com/kwridan)
+
 ## 1.16.0 - Alhambra
 
 ### Removed

--- a/Sources/TuistGenerator/Generator/ProjectGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGenerator.swift
@@ -217,7 +217,7 @@ final class ProjectGenerator: ProjectGenerating {
                     sourceTree: .group,
                     name: path.components.last,
                     lastKnownFileType: "folder",
-                    path: path.pathString
+                    path: path.relative(to: project.sourceRootPath).pathString
                 )
 
                 pbxproj.add(object: reference)


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/1691

### Short description 📝

- Local Swift packages had absolute paths for their file elements within generated projects
- Generated projects should leverage relative paths for its elements to enable checking in the projects to source control if needed _(this is a common workflow with project generation)_

### Solution 📦

- Ensure relative paths are used for local packages

### Implementation 👩‍💻👨‍💻
- [x] Leverage a relative path to the project's source root for local swift packages
- [x] Update change log

### Test Plan 🛠

- Run `swift run tuist generate` within `fixtures/ios_app_with_local_swift_package`
- Inspect the generated pbxproj file (`App.xcodeproj/project.pbxproj`)
- Verify `PackageA` has a relative path

