### PR TITLE
Adds a --withDevice flag to exclude simulator builds by default when running `cache warm`

### DIFF
--- a/Sources/TuistCache/Utilities/XCFrameworkBuilder.swift
+++ b/Sources/TuistCache/Utilities/XCFrameworkBuilder.swift
@@ -157,7 +157,8 @@ public final class XCFrameworkBuilder: XCFrameworkBuilding {
             var frameworkpaths: [AbsolutePath] = [AbsolutePath]()
             if let simulatorArchivePath = simulatorArchivePath {
                 frameworkpaths.append(frameworkPath(fromArchivePath: simulatorArchivePath, productName: target.productName))
-            } else if withDevice {
+            }
+            if withDevice {
                 frameworkpaths.append(frameworkPath(fromArchivePath: deviceArchivePath, productName: target.productName))
             }
 

--- a/Sources/TuistCache/Utilities/XCFrameworkBuilder.swift
+++ b/Sources/TuistCache/Utilities/XCFrameworkBuilder.swift
@@ -30,8 +30,9 @@ public protocol XCFrameworkBuilding {
     /// - Parameters:
     ///   - workspacePath: Path to the generated .xcworkspace that contains the given target.
     ///   - target: Target whose .xcframework will be generated.
+    ///   - withDevice: Define whether the .xcframework will also contain the target built for devices (it only contains the target built for simulators by default).
     /// - Returns: Path to the compiled .xcframework.
-    func build(workspacePath: AbsolutePath, target: Target) throws -> Observable<AbsolutePath>
+    func build(workspacePath: AbsolutePath, target: Target, withDevice: Bool) throws -> Observable<AbsolutePath>
 
     /// Returns an observable to build an xcframework for the given target.
     /// The target must have framework as product.
@@ -39,8 +40,9 @@ public protocol XCFrameworkBuilding {
     /// - Parameters:
     ///   - projectPath: Path to the generated .xcodeproj that contains the given target.
     ///   - target: Target whose .xcframework will be generated.
+    ///   - withDevice: Define whether the .xcframework will also contain the target built for devices (it only contains the target built for simulators by default).
     /// - Returns: Path to the compiled .xcframework.
-    func build(projectPath: AbsolutePath, target: Target) throws -> Observable<AbsolutePath>
+    func build(projectPath: AbsolutePath, target: Target, withDevice: Bool) throws -> Observable<AbsolutePath>
 }
 
 public final class XCFrameworkBuilder: XCFrameworkBuilding {
@@ -59,18 +61,60 @@ public final class XCFrameworkBuilder: XCFrameworkBuilding {
 
     // MARK: - XCFrameworkBuilding
 
-    public func build(workspacePath: AbsolutePath, target: Target) throws -> Observable<AbsolutePath> {
-        try build(.workspace(workspacePath), target: target)
+    public func build(workspacePath: AbsolutePath, target: Target, withDevice: Bool) throws -> Observable<AbsolutePath> {
+        try build(.workspace(workspacePath), target: target, withDevice: withDevice)
     }
 
-    public func build(projectPath: AbsolutePath, target: Target) throws -> Observable<AbsolutePath> {
-        try build(.project(projectPath), target: target)
+    public func build(projectPath: AbsolutePath, target: Target, withDevice: Bool) throws -> Observable<AbsolutePath> {
+        try build(.project(projectPath), target: target, withDevice: withDevice)
     }
 
     // MARK: - Fileprivate
 
+    fileprivate func deviceBuild(projectTarget: XcodeBuildTarget,
+                                 scheme: String,
+                                 target: Target,
+                                 deviceArchivePath: AbsolutePath) -> Observable<SystemEvent<XcodeBuildOutput>>
+    {
+        // Without the BUILD_LIBRARY_FOR_DISTRIBUTION argument xcodebuild doesn't generate the .swiftinterface file
+        xcodeBuildController.archive(projectTarget,
+                                     scheme: scheme,
+                                     clean: false,
+                                     archivePath: deviceArchivePath,
+                                     arguments: [
+                                         .sdk(target.platform.xcodeDeviceSDK),
+                                         .buildSetting("SKIP_INSTALL", "NO"),
+                                         .buildSetting("BUILD_LIBRARY_FOR_DISTRIBUTION", "YES"),
+                                     ])
+            .printFormattedOutput()
+            .do(onSubscribed: {
+                logger.notice("Building \(target.name) for device...", metadata: .subsection)
+            })
+    }
+
+    fileprivate func simulatorBuild(projectTarget: XcodeBuildTarget,
+                                    scheme: String,
+                                    target: Target,
+                                    simulatorArchivePath: AbsolutePath) -> Observable<SystemEvent<XcodeBuildOutput>>
+    {
+        // Without the BUILD_LIBRARY_FOR_DISTRIBUTION argument xcodebuild doesn't generate the .swiftinterface file
+        xcodeBuildController.archive(projectTarget,
+                                     scheme: scheme,
+                                     clean: false,
+                                     archivePath: simulatorArchivePath,
+                                     arguments: [
+                                         .sdk(target.platform.xcodeSimulatorSDK!),
+                                         .buildSetting("SKIP_INSTALL", "NO"),
+                                         .buildSetting("BUILD_LIBRARY_FOR_DISTRIBUTION", "YES"),
+                                     ])
+            .printFormattedOutput()
+            .do(onSubscribed: {
+                logger.notice("Building \(target.name) for simulator...", metadata: .subsection)
+            })
+    }
+
     // swiftlint:disable:next function_body_length
-    fileprivate func build(_ projectTarget: XcodeBuildTarget, target: Target) throws -> Observable<AbsolutePath> {
+    fileprivate func build(_ projectTarget: XcodeBuildTarget, target: Target, withDevice: Bool) throws -> Observable<AbsolutePath> {
         guard target.product.isFramework else {
             throw XCFrameworkBuilderError.nonFrameworkTarget(target.name)
         }
@@ -78,53 +122,45 @@ public final class XCFrameworkBuilder: XCFrameworkBuilding {
 
         // Create temporary directories
         return try withTemporaryDirectories { outputDirectory, temporaryPath in
-
             logger.notice("Building .xcframework for \(target.name)...", metadata: .section)
 
-            // Build for the device
-            // Without the BUILD_LIBRARY_FOR_DISTRIBUTION argument xcodebuild doesn't generate the .swiftinterface file
-            let deviceArchivePath = temporaryPath.appending(component: "device.xcarchive")
-            let deviceArchiveObservable = xcodeBuildController.archive(projectTarget,
-                                                                       scheme: scheme,
-                                                                       clean: false,
-                                                                       archivePath: deviceArchivePath,
-                                                                       arguments: [
-                                                                           .sdk(target.platform.xcodeDeviceSDK),
-                                                                           .derivedDataPath(temporaryPath),
-                                                                           .buildSetting("SKIP_INSTALL", "NO"),
-                                                                           .buildSetting("BUILD_LIBRARY_FOR_DISTRIBUTION", "YES"),
-                                                                       ])
-                .printFormattedOutput()
-                .do(onSubscribed: {
-                    logger.notice("Building \(target.name) for device...", metadata: .subsection)
-                })
-
             // Build for the simulator
-            var simulatorArchiveObservable: Observable<SystemEvent<XcodeBuildOutput>>?
+            var simulatorArchiveObservable: Observable<SystemEvent<XcodeBuildOutput>>
             var simulatorArchivePath: AbsolutePath?
             if target.platform.hasSimulators {
                 simulatorArchivePath = temporaryPath.appending(component: "simulator.xcarchive")
-                simulatorArchiveObservable = xcodeBuildController.archive(projectTarget,
-                                                                          scheme: scheme,
-                                                                          clean: false,
-                                                                          archivePath: simulatorArchivePath!,
-                                                                          arguments: [
-                                                                              .sdk(target.platform.xcodeSimulatorSDK!),
-                                                                              .derivedDataPath(temporaryPath),
-                                                                              .buildSetting("SKIP_INSTALL", "NO"),
-                                                                              .buildSetting("BUILD_LIBRARY_FOR_DISTRIBUTION", "YES"),
-                                                                          ])
-                    .printFormattedOutput()
-                    .do(onSubscribed: {
-                        logger.notice("Building \(target.name) for simulator", metadata: .subsection)
-                    })
+                simulatorArchiveObservable = simulatorBuild(
+                    projectTarget: projectTarget,
+                    scheme: scheme,
+                    target: target,
+                    simulatorArchivePath: simulatorArchivePath!
+                )
+            } else {
+                simulatorArchiveObservable = Observable.empty()
+            }
+
+            // Build for the device - if required
+            let deviceArchivePath = temporaryPath.appending(component: "device.xcarchive")
+            var deviceArchiveObservable: Observable<SystemEvent<XcodeBuildOutput>>
+            if withDevice {
+                deviceArchiveObservable = deviceBuild(
+                    projectTarget: projectTarget,
+                    scheme: scheme,
+                    target: target,
+                    deviceArchivePath: deviceArchivePath
+                )
+            } else {
+                deviceArchiveObservable = Observable.empty()
             }
 
             // Build the xcframework
-            var frameworkpaths = [frameworkPath(fromArchivePath: deviceArchivePath, productName: target.productName)]
+            var frameworkpaths: [AbsolutePath] = [AbsolutePath]()
             if let simulatorArchivePath = simulatorArchivePath {
                 frameworkpaths.append(frameworkPath(fromArchivePath: simulatorArchivePath, productName: target.productName))
+            } else if withDevice {
+                frameworkpaths.append(frameworkPath(fromArchivePath: deviceArchivePath, productName: target.productName))
             }
+
             let xcframeworkPath = outputDirectory.appending(component: "\(target.productName).xcframework")
             let xcframeworkObservable = xcodeBuildController.createXCFramework(frameworks: frameworkpaths, output: xcframeworkPath)
                 .do(onSubscribed: {
@@ -132,7 +168,7 @@ public final class XCFrameworkBuilder: XCFrameworkBuilding {
                 })
 
             return deviceArchiveObservable
-                .concat(simulatorArchiveObservable ?? Observable.empty())
+                .concat(simulatorArchiveObservable)
                 .concat(xcframeworkObservable)
                 .ignoreElements()
                 .andThen(Observable.just(xcframeworkPath))

--- a/Sources/TuistCache/Utilities/XCFrameworkBuilder.swift
+++ b/Sources/TuistCache/Utilities/XCFrameworkBuilder.swift
@@ -30,9 +30,9 @@ public protocol XCFrameworkBuilding {
     /// - Parameters:
     ///   - workspacePath: Path to the generated .xcworkspace that contains the given target.
     ///   - target: Target whose .xcframework will be generated.
-    ///   - withDevice: Define whether the .xcframework will also contain the target built for devices (it only contains the target built for simulators by default).
+    ///   - includeDeviceArch: Define whether the .xcframework will also contain the target built for devices (it only contains the target built for simulators by default).
     /// - Returns: Path to the compiled .xcframework.
-    func build(workspacePath: AbsolutePath, target: Target, withDevice: Bool) throws -> Observable<AbsolutePath>
+    func build(workspacePath: AbsolutePath, target: Target, includeDeviceArch: Bool) throws -> Observable<AbsolutePath>
 
     /// Returns an observable to build an xcframework for the given target.
     /// The target must have framework as product.
@@ -40,9 +40,9 @@ public protocol XCFrameworkBuilding {
     /// - Parameters:
     ///   - projectPath: Path to the generated .xcodeproj that contains the given target.
     ///   - target: Target whose .xcframework will be generated.
-    ///   - withDevice: Define whether the .xcframework will also contain the target built for devices (it only contains the target built for simulators by default).
+    ///   - includeDeviceArch: Define whether the .xcframework will also contain the target built for devices (it only contains the target built for simulators by default).
     /// - Returns: Path to the compiled .xcframework.
-    func build(projectPath: AbsolutePath, target: Target, withDevice: Bool) throws -> Observable<AbsolutePath>
+    func build(projectPath: AbsolutePath, target: Target, includeDeviceArch: Bool) throws -> Observable<AbsolutePath>
 }
 
 public final class XCFrameworkBuilder: XCFrameworkBuilding {
@@ -61,12 +61,12 @@ public final class XCFrameworkBuilder: XCFrameworkBuilding {
 
     // MARK: - XCFrameworkBuilding
 
-    public func build(workspacePath: AbsolutePath, target: Target, withDevice: Bool) throws -> Observable<AbsolutePath> {
-        try build(.workspace(workspacePath), target: target, withDevice: withDevice)
+    public func build(workspacePath: AbsolutePath, target: Target, includeDeviceArch: Bool) throws -> Observable<AbsolutePath> {
+        try build(.workspace(workspacePath), target: target, includeDeviceArch: includeDeviceArch)
     }
 
-    public func build(projectPath: AbsolutePath, target: Target, withDevice: Bool) throws -> Observable<AbsolutePath> {
-        try build(.project(projectPath), target: target, withDevice: withDevice)
+    public func build(projectPath: AbsolutePath, target: Target, includeDeviceArch: Bool) throws -> Observable<AbsolutePath> {
+        try build(.project(projectPath), target: target, includeDeviceArch: includeDeviceArch)
     }
 
     // MARK: - Fileprivate
@@ -114,7 +114,7 @@ public final class XCFrameworkBuilder: XCFrameworkBuilding {
     }
 
     // swiftlint:disable:next function_body_length
-    fileprivate func build(_ projectTarget: XcodeBuildTarget, target: Target, withDevice: Bool) throws -> Observable<AbsolutePath> {
+    fileprivate func build(_ projectTarget: XcodeBuildTarget, target: Target, includeDeviceArch: Bool) throws -> Observable<AbsolutePath> {
         guard target.product.isFramework else {
             throw XCFrameworkBuilderError.nonFrameworkTarget(target.name)
         }
@@ -142,7 +142,7 @@ public final class XCFrameworkBuilder: XCFrameworkBuilding {
             // Build for the device - if required
             let deviceArchivePath = temporaryPath.appending(component: "device.xcarchive")
             var deviceArchiveObservable: Observable<SystemEvent<XcodeBuildOutput>>
-            if withDevice {
+            if includeDeviceArch {
                 deviceArchiveObservable = deviceBuild(
                     projectTarget: projectTarget,
                     scheme: scheme,
@@ -158,7 +158,7 @@ public final class XCFrameworkBuilder: XCFrameworkBuilding {
             if let simulatorArchivePath = simulatorArchivePath {
                 frameworkpaths.append(frameworkPath(fromArchivePath: simulatorArchivePath, productName: target.productName))
             }
-            if withDevice {
+            if includeDeviceArch {
                 frameworkpaths.append(frameworkPath(fromArchivePath: deviceArchivePath, productName: target.productName))
             }
 

--- a/Sources/TuistCacheTesting/Cache/Mocks/MockXCFrameworkBuilder.swift
+++ b/Sources/TuistCacheTesting/Cache/Mocks/MockXCFrameworkBuilder.swift
@@ -5,15 +5,15 @@ import TuistCache
 import TuistCore
 
 public final class MockXCFrameworkBuilder: XCFrameworkBuilding {
-    public var buildProjectArgs: [(projectPath: AbsolutePath, target: Target)] = []
-    public var buildWorkspaceArgs: [(workspacePath: AbsolutePath, target: Target)] = []
+    public var buildProjectArgs: [(projectPath: AbsolutePath, target: Target, withDevice: Bool)] = []
+    public var buildWorkspaceArgs: [(workspacePath: AbsolutePath, target: Target, withDevice: Bool)] = []
     public var buildProjectStub: ((AbsolutePath, Target) -> Result<AbsolutePath, Error>)?
     public var buildWorkspaceStub: ((AbsolutePath, Target) -> Result<AbsolutePath, Error>)?
 
     public init() {}
 
-    public func build(projectPath: AbsolutePath, target: Target) throws -> Observable<AbsolutePath> {
-        buildProjectArgs.append((projectPath: projectPath, target: target))
+    public func build(projectPath: AbsolutePath, target: Target, withDevice: Bool) throws -> Observable<AbsolutePath> {
+        buildProjectArgs.append((projectPath: projectPath, target: target, withDevice: withDevice))
         if let buildProjectStub = buildProjectStub {
             switch buildProjectStub(projectPath, target) {
             case let .failure(error):
@@ -26,8 +26,8 @@ public final class MockXCFrameworkBuilder: XCFrameworkBuilding {
         }
     }
 
-    public func build(workspacePath: AbsolutePath, target: Target) throws -> Observable<AbsolutePath> {
-        buildWorkspaceArgs.append((workspacePath: workspacePath, target: target))
+    public func build(workspacePath: AbsolutePath, target: Target, withDevice: Bool) throws -> Observable<AbsolutePath> {
+        buildWorkspaceArgs.append((workspacePath: workspacePath, target: target, withDevice: withDevice))
         if let buildWorkspaceStub = buildWorkspaceStub {
             switch buildWorkspaceStub(workspacePath, target) {
             case let .failure(error):

--- a/Sources/TuistCacheTesting/Cache/Mocks/MockXCFrameworkBuilder.swift
+++ b/Sources/TuistCacheTesting/Cache/Mocks/MockXCFrameworkBuilder.swift
@@ -5,15 +5,15 @@ import TuistCache
 import TuistCore
 
 public final class MockXCFrameworkBuilder: XCFrameworkBuilding {
-    public var buildProjectArgs: [(projectPath: AbsolutePath, target: Target, withDevice: Bool)] = []
-    public var buildWorkspaceArgs: [(workspacePath: AbsolutePath, target: Target, withDevice: Bool)] = []
+    public var buildProjectArgs: [(projectPath: AbsolutePath, target: Target, includeDeviceArch: Bool)] = []
+    public var buildWorkspaceArgs: [(workspacePath: AbsolutePath, target: Target, includeDeviceArch: Bool)] = []
     public var buildProjectStub: ((AbsolutePath, Target) -> Result<AbsolutePath, Error>)?
     public var buildWorkspaceStub: ((AbsolutePath, Target) -> Result<AbsolutePath, Error>)?
 
     public init() {}
 
-    public func build(projectPath: AbsolutePath, target: Target, withDevice: Bool) throws -> Observable<AbsolutePath> {
-        buildProjectArgs.append((projectPath: projectPath, target: target, withDevice: withDevice))
+    public func build(projectPath: AbsolutePath, target: Target, includeDeviceArch: Bool) throws -> Observable<AbsolutePath> {
+        buildProjectArgs.append((projectPath: projectPath, target: target, includeDeviceArch: includeDeviceArch))
         if let buildProjectStub = buildProjectStub {
             switch buildProjectStub(projectPath, target) {
             case let .failure(error):
@@ -26,8 +26,8 @@ public final class MockXCFrameworkBuilder: XCFrameworkBuilding {
         }
     }
 
-    public func build(workspacePath: AbsolutePath, target: Target, withDevice: Bool) throws -> Observable<AbsolutePath> {
-        buildWorkspaceArgs.append((workspacePath: workspacePath, target: target, withDevice: withDevice))
+    public func build(workspacePath: AbsolutePath, target: Target, includeDeviceArch: Bool) throws -> Observable<AbsolutePath> {
+        buildWorkspaceArgs.append((workspacePath: workspacePath, target: target, includeDeviceArch: includeDeviceArch))
         if let buildWorkspaceStub = buildWorkspaceStub {
             switch buildWorkspaceStub(workspacePath, target) {
             case let .failure(error):

--- a/Sources/TuistKit/Commands/Cache/CacheWarmCommand.swift
+++ b/Sources/TuistKit/Commands/Cache/CacheWarmCommand.swift
@@ -12,13 +12,13 @@ struct CacheWarmCommand: ParsableCommand {
 
     @Option(
         name: .shortAndLong,
-        help: "The path to the directory that contains the project whose frameworks will be cached",
+        help: "The path to the directory that contains the project whose targets will be cached",
         completion: .directory
     )
     var path: String?
 
     @Flag(
-        help: "Cache frameworks built for devices (only frameworks built for simulator are cached by default)"
+        help: "When passed it caches the targets also for device (only targets built for simulator are cached by default)"
     )
     var withDevice: Bool = false
 

--- a/Sources/TuistKit/Commands/Cache/CacheWarmCommand.swift
+++ b/Sources/TuistKit/Commands/Cache/CacheWarmCommand.swift
@@ -17,7 +17,12 @@ struct CacheWarmCommand: ParsableCommand {
     )
     var path: String?
 
+    @Flag(
+        help: "Cache frameworks built for devices (only frameworks built for simulator are cached by default)"
+    )
+    var withDevice: Bool = false
+
     func run() throws {
-        try CacheWarmService().run(path: path)
+        try CacheWarmService().run(path: path, withDevice: withDevice)
     }
 }

--- a/Sources/TuistKit/Commands/Cache/CacheWarmCommand.swift
+++ b/Sources/TuistKit/Commands/Cache/CacheWarmCommand.swift
@@ -18,6 +18,7 @@ struct CacheWarmCommand: ParsableCommand {
     var path: String?
 
     @Flag(
+        name: [.customShort("d"), .long],
         help: "When passed it caches the targets also for device (only targets built for simulator are cached by default)"
     )
     var withDevice: Bool = false

--- a/Sources/TuistKit/Commands/Cache/CacheWarmCommand.swift
+++ b/Sources/TuistKit/Commands/Cache/CacheWarmCommand.swift
@@ -21,9 +21,9 @@ struct CacheWarmCommand: ParsableCommand {
         name: [.customShort("d"), .long],
         help: "When passed it caches the targets also for device (only targets built for simulator are cached by default)"
     )
-    var withDevice: Bool = false
+    var includeDeviceArch: Bool = false
 
     func run() throws {
-        try CacheWarmService().run(path: path, withDevice: withDevice)
+        try CacheWarmService().run(path: path, includeDeviceArch: includeDeviceArch)
     }
 }

--- a/Sources/TuistKit/Services/Cache/CacheWarmService.swift
+++ b/Sources/TuistKit/Services/Cache/CacheWarmService.swift
@@ -16,12 +16,12 @@ final class CacheWarmService {
                                                     manifestLinter: manifestLinter)
     }
 
-    func run(path: String?) throws {
+    func run(path: String?, withDevice: Bool) throws {
         let path = self.path(path)
         let config = try generatorModelLoader.loadConfig(at: currentPath)
         let cache = Cache(storageProvider: CacheStorageProvider(config: config))
         let cacheController = CacheController(cache: cache)
-        try cacheController.cache(path: path)
+        try cacheController.cache(path: path, withDevice: withDevice)
     }
 
     // MARK: - Helpers

--- a/Sources/TuistKit/Services/Cache/CacheWarmService.swift
+++ b/Sources/TuistKit/Services/Cache/CacheWarmService.swift
@@ -16,12 +16,12 @@ final class CacheWarmService {
                                                     manifestLinter: manifestLinter)
     }
 
-    func run(path: String?, withDevice: Bool) throws {
+    func run(path: String?, includeDeviceArch: Bool) throws {
         let path = self.path(path)
         let config = try generatorModelLoader.loadConfig(at: currentPath)
         let cache = Cache(storageProvider: CacheStorageProvider(config: config))
         let cacheController = CacheController(cache: cache)
-        try cacheController.cache(path: path, withDevice: withDevice)
+        try cacheController.cache(path: path, includeDeviceArch: includeDeviceArch)
     }
 
     // MARK: - Helpers

--- a/Tests/TuistKitIntegrationTests/Automation/XCFrameworkBuilderIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Automation/XCFrameworkBuilderIntegrationTests.swift
@@ -32,7 +32,7 @@ final class XCFrameworkBuilderIntegrationTests: TuistTestCase {
         let target = Target.test(name: "iOS", platform: .iOS, product: .framework, productName: "iOS")
 
         // When
-        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target).toBlocking().single()
+        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target, withDevice: true).toBlocking().single()
         let infoPlist = try self.infoPlist(xcframeworkPath: xcframeworkPath)
 
         // Then
@@ -50,7 +50,7 @@ final class XCFrameworkBuilderIntegrationTests: TuistTestCase {
         let target = Target.test(name: "macOS", platform: .macOS, product: .framework, productName: "macOS")
 
         // When
-        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target).toBlocking().single()
+        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target, withDevice: true).toBlocking().single()
         let infoPlist = try self.infoPlist(xcframeworkPath: xcframeworkPath)
 
         // Then
@@ -67,7 +67,7 @@ final class XCFrameworkBuilderIntegrationTests: TuistTestCase {
         let target = Target.test(name: "tvOS", platform: .tvOS, product: .framework, productName: "tvOS")
 
         // When
-        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target).toBlocking().single()
+        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target, withDevice: true).toBlocking().single()
         let infoPlist = try self.infoPlist(xcframeworkPath: xcframeworkPath)
 
         // Then
@@ -85,7 +85,7 @@ final class XCFrameworkBuilderIntegrationTests: TuistTestCase {
         let target = Target.test(name: "watchOS", platform: .watchOS, product: .framework, productName: "watchOS")
 
         // When
-        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target).toBlocking().single()
+        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target, withDevice: true).toBlocking().single()
         let infoPlist = try self.infoPlist(xcframeworkPath: xcframeworkPath)
 
         // Then

--- a/Tests/TuistKitIntegrationTests/Automation/XCFrameworkBuilderIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Automation/XCFrameworkBuilderIntegrationTests.swift
@@ -32,7 +32,7 @@ final class XCFrameworkBuilderIntegrationTests: TuistTestCase {
         let target = Target.test(name: "iOS", platform: .iOS, product: .framework, productName: "iOS")
 
         // When
-        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target, withDevice: true).toBlocking().single()
+        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target, includeDeviceArch: true).toBlocking().single()
         let infoPlist = try self.infoPlist(xcframeworkPath: xcframeworkPath)
 
         // Then
@@ -50,7 +50,7 @@ final class XCFrameworkBuilderIntegrationTests: TuistTestCase {
         let target = Target.test(name: "macOS", platform: .macOS, product: .framework, productName: "macOS")
 
         // When
-        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target, withDevice: true).toBlocking().single()
+        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target, includeDeviceArch: true).toBlocking().single()
         let infoPlist = try self.infoPlist(xcframeworkPath: xcframeworkPath)
 
         // Then
@@ -67,7 +67,7 @@ final class XCFrameworkBuilderIntegrationTests: TuistTestCase {
         let target = Target.test(name: "tvOS", platform: .tvOS, product: .framework, productName: "tvOS")
 
         // When
-        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target, withDevice: true).toBlocking().single()
+        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target, includeDeviceArch: true).toBlocking().single()
         let infoPlist = try self.infoPlist(xcframeworkPath: xcframeworkPath)
 
         // Then
@@ -85,7 +85,7 @@ final class XCFrameworkBuilderIntegrationTests: TuistTestCase {
         let target = Target.test(name: "watchOS", platform: .watchOS, product: .framework, productName: "watchOS")
 
         // When
-        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target, withDevice: true).toBlocking().single()
+        let xcframeworkPath = try subject.build(projectPath: projectPath, target: target, includeDeviceArch: true).toBlocking().single()
         let infoPlist = try self.infoPlist(xcframeworkPath: xcframeworkPath)
 
         // Then

--- a/Tests/TuistKitTests/Cache/CacheControllerTests.swift
+++ b/Tests/TuistKitTests/Cache/CacheControllerTests.swift
@@ -83,7 +83,7 @@ final class CacheControllerTests: TuistUnitTestCase {
             }
         }
 
-        try subject.cache(path: path)
+        try subject.cache(path: path, withDevice: true)
 
         // Then
         XCTAssertPrinterOutputContains("""

--- a/Tests/TuistKitTests/Cache/CacheControllerTests.swift
+++ b/Tests/TuistKitTests/Cache/CacheControllerTests.swift
@@ -83,7 +83,7 @@ final class CacheControllerTests: TuistUnitTestCase {
             }
         }
 
-        try subject.cache(path: path, withDevice: true)
+        try subject.cache(path: path, includeDeviceArch: true)
 
         // Then
         XCTAssertPrinterOutputContains("""

--- a/features/generate-1.feature
+++ b/features/generate-1.feature
@@ -21,7 +21,7 @@ Feature: Generate a new project using Tuist (suite 1)
     Then I should be able to build for macOS the scheme Framework2-macOS
     Then I should be able to test for iOS the scheme Framework2Tests
     Then I should be able to build for iOS the scheme Framework1
-    Then the product 'Framework1.framework' with destination 'Debug-iphoneos' contains the Info.plist key 'Test'
+    Then the product 'Framework1.framework' with destination 'Debug-iphonesimulator' contains the Info.plist key 'Test'
 
   Scenario: The project is an iOS application with headers (ios_app_with_headers)
     Given that tuist is available

--- a/features/generate-2.feature
+++ b/features/generate-2.feature
@@ -38,11 +38,11 @@ Scenario: The project is an iOS application with a target dependency and transit
     Then I copy the fixture ios_app_with_transitive_framework into the working directory
     Then tuist generates the project
     Then I should be able to build for iOS the scheme App
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains the framework 'Framework1' with architecture 'arm64'
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains the framework 'Framework2' without architecture 'x86_64'
-    Then the product 'App.app' with destination 'Debug-iphoneos' does not contain headers
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains the framework 'Framework1' with architecture 'x86_64'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains the framework 'Framework2' without architecture 'arm64'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' does not contain headers
     Then I should be able to build for iOS the scheme AppUITests
-    Then the product 'AppUITests-Runner.app' with destination 'Debug-iphoneos' does not contain the framework 'Framework2'
+    Then the product 'AppUITests-Runner.app' with destination 'Debug-iphonesimulator' does not contain the framework 'Framework2'
     Then I should be able to build for iOS the scheme Framework1-iOS
     Then I should be able to build for iOS the scheme Framework1-macOS
     Then I should be able to build for iOS the scheme Framework1Tests-iOS
@@ -54,23 +54,23 @@ Scenario: The project is an iOS application that has resources (ios_app_with_fra
     Then I copy the fixture ios_app_with_framework_and_resources into the working directory
     Then tuist generates the project
     Then I should be able to build for iOS the scheme App
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'tuist.png'
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'Examples/item.json'
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'Examples/list.json'
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'Assets.car'
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'resource.txt'
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'en.lproj/App.strings'
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'en.lproj/Greetings.strings'
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'fr.lproj/App.strings'
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'fr.lproj/Greetings.strings'
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'resource_without_extension'
-    Then the product 'App.app' with destination 'Debug-iphoneos' does not contain resource 'do_not_include.dat'
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'StaticFrameworkResources.bundle'
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'StaticFramework2Resources.bundle'
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'StaticFramework3Resources.bundle'
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'StaticFramework4Resources.bundle'
-    Then the product 'App.app' with destination 'Debug-iphoneos' does not contain headers
-    Then the product 'StaticFrameworkResources.bundle' with destination 'Debug-iphoneos' contains resource 'tuist-bundle.png'
-    Then the product 'StaticFramework2Resources.bundle' with destination 'Debug-iphoneos' contains resource 'StaticFramework2Resources-tuist.png'
-    Then the product 'StaticFramework3Resources.bundle' with destination 'Debug-iphoneos' contains resource 'StaticFramework3Resources-tuist.png'
-    Then the product 'StaticFramework4Resources.bundle' with destination 'Debug-iphoneos' contains resource 'StaticFramework4Resources-tuist.png'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'tuist.png'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'Examples/item.json'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'Examples/list.json'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'Assets.car'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'resource.txt'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'en.lproj/App.strings'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'en.lproj/Greetings.strings'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'fr.lproj/App.strings'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'fr.lproj/Greetings.strings'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'resource_without_extension'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' does not contain resource 'do_not_include.dat'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'StaticFrameworkResources.bundle'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'StaticFramework2Resources.bundle'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'StaticFramework3Resources.bundle'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'StaticFramework4Resources.bundle'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' does not contain headers
+    Then the product 'StaticFrameworkResources.bundle' with destination 'Debug-iphonesimulator' contains resource 'tuist-bundle.png'
+    Then the product 'StaticFramework2Resources.bundle' with destination 'Debug-iphonesimulator' contains resource 'StaticFramework2Resources-tuist.png'
+    Then the product 'StaticFramework3Resources.bundle' with destination 'Debug-iphonesimulator' contains resource 'StaticFramework3Resources-tuist.png'
+    Then the product 'StaticFramework4Resources.bundle' with destination 'Debug-iphonesimulator' contains resource 'StaticFramework4Resources-tuist.png'

--- a/features/generate-3.feature
+++ b/features/generate-3.feature
@@ -6,11 +6,11 @@ Scenario: The project is an iOS application with frameworks and tests (ios_app_w
     Then I copy the fixture ios_app_with_framework_linking_static_framework into the working directory
     Then tuist generates the project
     Then I should be able to build for iOS the scheme App
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'Frameworks/Framework1.framework/Framework1'
-    Then the product 'App.app' with destination 'Debug-iphoneos' does not contain resource 'Frameworks/Framework2.framework/Framework2'
-    Then the product 'App.app' with destination 'Debug-iphoneos' does not contain resource 'Frameworks/Framework3.framework/Framework3'
-    Then the product 'App.app' with destination 'Debug-iphoneos' does not contain resource 'Frameworks/Framework4.framework/Framework4'
-    Then the product 'App.app' with destination 'Debug-iphoneos' does not contain headers
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'Frameworks/Framework1.framework/Framework1'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' does not contain resource 'Frameworks/Framework2.framework/Framework2'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' does not contain resource 'Frameworks/Framework3.framework/Framework3'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' does not contain resource 'Frameworks/Framework4.framework/Framework4'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' does not contain headers
     Then I should be able to test for iOS the scheme AppTests
     Then I should be able to build for iOS the scheme Framework1
     Then I should be able to test for iOS the scheme Framework1Tests

--- a/features/generate-4.feature
+++ b/features/generate-4.feature
@@ -31,9 +31,9 @@ Scenario: The project is an iOS application with Carthage frameworks (ios_app_wi
     Then I copy the fixture ios_app_with_carthage_frameworks into the working directory
     Then tuist generates the project
     Then I should be able to build for iOS the scheme AllTargets
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains the framework 'RxSwift' without architecture 'armv7'
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains the framework 'RxSwift' with architecture 'arm64'
-    Then the product 'App.app' with destination 'Debug-iphoneos' does not contain headers
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains the framework 'RxSwift' without architecture 'armv7'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains the framework 'RxSwift' with architecture 'x86_64'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' does not contain headers
 
 Scenario: The project is an iOS application with extensions (ios_app_with_extensions)
     Given that tuist is available
@@ -41,7 +41,7 @@ Scenario: The project is an iOS application with extensions (ios_app_with_extens
     Then I copy the fixture ios_app_with_extensions into the working directory
     Then tuist generates the project
     Then I should be able to build for iOS the scheme App
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains extension 'StickersPackExtension'
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains extension 'NotificationServiceExtension'
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains extension 'NotificationServiceExtension'
-    Then the product 'App.app' with destination 'Debug-iphoneos' does not contain headers
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains extension 'StickersPackExtension'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains extension 'NotificationServiceExtension'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains extension 'NotificationServiceExtension'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' does not contain headers

--- a/features/generate-5.feature
+++ b/features/generate-5.feature
@@ -6,9 +6,9 @@ Scenario: The project is an iOS application with watch app (ios_app_with_watchap
     Then I copy the fixture ios_app_with_watchapp2 into the working directory
     Then tuist generates the project
     Then I should be able to build for watchOS the scheme App
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'Watch/WatchApp.app'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'Watch/WatchApp.app'
     Then the product 'WatchApp.app' with destination 'Debug-watchos' contains extension 'WatchAppExtension'
-    Then the product 'App.app' with destination 'Debug-iphoneos' does not contain headers
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' does not contain headers
     Then the product 'WatchApp.app' with destination 'Debug-watchos' does not contain headers
 
 Scenario: The project is an iOS application with xcframeworks (ios_app_with_xcframeworks)
@@ -17,8 +17,8 @@ Scenario: The project is an iOS application with xcframeworks (ios_app_with_xcfr
     Then I copy the fixture ios_app_with_xcframeworks into the working directory
     Then tuist generates the project
     Then I should be able to build for iOS the scheme App
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains the framework 'MyFramework' with architecture 'arm64'
-    Then the product 'App.app' with destination 'Debug-iphoneos' does not contain headers
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains the framework 'MyFramework' with architecture 'x86_64'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' does not contain headers
 
 
 Scenario: The project is an iOS application with a deprecated configuration name (app_with_old_config_name)

--- a/features/generate-5.feature
+++ b/features/generate-5.feature
@@ -6,9 +6,9 @@ Scenario: The project is an iOS application with watch app (ios_app_with_watchap
     Then I copy the fixture ios_app_with_watchapp2 into the working directory
     Then tuist generates the project
     Then I should be able to build for watchOS the scheme App
-    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'Watch/WatchApp.app'
+    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'Watch/WatchApp.app'
     Then the product 'WatchApp.app' with destination 'Debug-watchos' contains extension 'WatchAppExtension'
-    Then the product 'App.app' with destination 'Debug-iphonesimulator' does not contain headers
+    Then the product 'App.app' with destination 'Debug-iphoneos' does not contain headers
     Then the product 'WatchApp.app' with destination 'Debug-watchos' does not contain headers
 
 Scenario: The project is an iOS application with xcframeworks (ios_app_with_xcframeworks)

--- a/features/generate-6.feature
+++ b/features/generate-6.feature
@@ -15,5 +15,5 @@ Scenario: The project is an iOS application with core data models (ios_app_with_
     Then I copy the fixture ios_app_with_coredata into the working directory
     Then tuist generates the project
     Then I should be able to build for iOS the scheme App
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource 'Users.momd'
-    Then the product 'App.app' with destination 'Debug-iphoneos' contains resource '1_2.cdm'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'Users.momd'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource '1_2.cdm'

--- a/features/step_definitions/shared/xcode.rb
+++ b/features/step_definitions/shared/xcode.rb
@@ -21,7 +21,7 @@ Then(/I should be able to (.+) for (iOS|macOS|tvOS|watchOS) the scheme (.+)/) do
   end
 
   if action == "build" && platform == "iOS"
-    args << "-sdk\ iphoneos"
+    args << "-sdk\ iphonesimulator"
   end
 
   args << "clean"

--- a/features/step_definitions/shared/xcode.rb
+++ b/features/step_definitions/shared/xcode.rb
@@ -23,6 +23,12 @@ Then(/I should be able to (.+) for (iOS|macOS|tvOS|watchOS) the scheme (.+)/) do
   if action == "build" && platform == "iOS"
     args << "-sdk\ iphonesimulator"
   end
+  if action == "build" && platform == "watchOS"
+    args << "-sdk\ watchsimulator"
+  end
+  if action == "build" && platform == "tvOS"
+    args << "-sdk\ appletvsimulator"
+  end
 
   args << "clean"
   args << action
@@ -32,6 +38,7 @@ Then(/I should be able to (.+) for (iOS|macOS|tvOS|watchOS) the scheme (.+)/) do
   args << "CODE_SIGN_ENTITLEMENTS=\"\""
 
   xcodebuild(*args)
+  
 end
 
 Then(/the scheme (.+) has a build setting (.+) with value (.+) for the configuration (.+)/) do |scheme, key, value, config| # rubocop:disable Metrics/LineLength

--- a/website/markdown/docs/usage/caching.mdx
+++ b/website/markdown/docs/usage/caching.mdx
@@ -23,6 +23,20 @@ We recommend setting up a continuous integration pipeline that runs on every mas
 tuist cache warm
 ```
 
+### Arguments
+
+<ArgumentsTable
+  args={[
+    {
+      long: '`--with-device`',
+      short: '`-d`',
+      description:
+        'When passed, it includes the architecture for device when caching the targets.',
+      default: '`false`',
+    },
+  ]}
+/>
+
 ## Focusing on a project
 
 Once the cache has been warmed with the pre-compiled targets,

--- a/website/markdown/docs/usage/caching.mdx
+++ b/website/markdown/docs/usage/caching.mdx
@@ -28,7 +28,7 @@ tuist cache warm
 <ArgumentsTable
   args={[
     {
-      long: '`--with-device`',
+      long: '`--include-device-arch`',
       short: '`-d`',
       description:
         'When passed, it includes the architecture for device when caching the targets.',


### PR DESCRIPTION
### Short description 📝

> This PR will speed up the `cache warm` command, by default.

### Solution 📦

Previously, running `cache warm` would take quite some times on large projects because every target would be compiled for simulator and device.
It seems that the main use case of this command is to be able to speed up local builds, hence probably builds targeting simulators.

It is still possible to build for device with the added `--withDevice` flag.