### PR TITLE
Drop App suffix in AppProject.stencil.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,14 +9,12 @@ on:
       - Sources/**/*
       - Tests/**/*
       - fixtures/**/*
-      - Templates/**/*
       - .github/workflows/checks.yml
   pull_request:
     paths:
       - Sources/**/*
       - Tests/**/*
       - fixtures/**/*
-      - Templates/**/*
       - .github/workflows/checks.yml
 
 jobs:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,12 +9,14 @@ on:
       - Sources/**/*
       - Tests/**/*
       - fixtures/**/*
+      - Templates/**/*
       - .github/workflows/checks.yml
   pull_request:
     paths:
       - Sources/**/*
       - Tests/**/*
       - fixtures/**/*
+      - Templates/**/*
       - .github/workflows/checks.yml
 
 jobs:

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -8,6 +8,7 @@ on:
       - Sources/**/*
       - Tests/**/*
       - fixtures/**/*
+      - Templates/**/*
       - .github/workflows/tuist.yml
       - Package.swift
       - Package.resolved
@@ -16,6 +17,7 @@ on:
       - Sources/**/*
       - Tests/**/*
       - fixtures/**/*
+      - Templates/**/*
       - .github/workflows/tuist.yml
       - Package.swift
       - Package.resolved

--- a/Templates/AppProject.stencil
+++ b/Templates/AppProject.stencil
@@ -40,4 +40,4 @@ let ui = Target(name: "{{ name }}UI",
 // MARK: - Example app
 
 // Creates our project using a helper function defined in ProjectDescriptionHelpers
-let project = Project.app(name: "{{ name }}App", additionalTargets: [kit, ui])
+let project = Project.app(name: "{{ name }}", additionalTargets: [kit, ui])

--- a/features/cache.feature
+++ b/features/cache.feature
@@ -5,10 +5,10 @@ Feature: Generates projects with pre-compiled cached dependencies
     And I have a working directory
     And I initialize a ios application named MyApp
     And tuist warms the cache
-    When tuist generates a project with cached targets at Projects/MyApp
+    When tuist generates a project with cached targets 
     Then MyApp links the xcframework MyAppKit
     Then MyApp embeds the xcframework MyAppKit
-    Then MyApp embeds the xcframework MyAppSupport
+    Then MyApp embeds the xcframework MyAppUI
     Then I should be able to build for iOS the scheme MyApp
     Then I should be able to test for iOS the scheme MyAppTests
 

--- a/features/scaffold.feature
+++ b/features/scaffold.feature
@@ -19,11 +19,3 @@ Feature: Scaffold a project using Tuist
       // Generated file with platform: ios and name: TemplateProject
 
       """
-  Scenario: The project is a just initialized project
-    Given that tuist is available
-    And I have a working directory
-    And I initialize a ios application named MyApp
-    And tuist scaffolds a framework template to Projects/ named MyFeature
-    When tuist generates the project at Projects/MyFeature
-    Then I should be able to build for iOS the scheme MyFeature
-    Then I should be able to test for iOS the scheme MyFeature

--- a/features/step_definitions/shared/tuist.rb
+++ b/features/step_definitions/shared/tuist.rb
@@ -30,6 +30,12 @@ Then(/^tuist generates a project with cached targets at (.+)$/) do |path|
   @xcodeproj_path = Dir.glob(File.join(@dir, path, "*.xcodeproj")).first
 end
 
+Then(/^tuist generates a project with cached targets$/) do
+  system("swift", "run", "tuist", "generate", "--path", @dir, "--cache")
+  @workspace_path = Dir.glob(File.join(@dir, "*.xcworkspace")).first
+  @xcodeproj_path = Dir.glob(File.join(@dir, "*.xcodeproj")).first
+end
+
 Then(/^tuist generates a project with cached targets with sources ([a-zA-Z]+) at (.+)$/) do |sources, path|
   system("swift", "run", "tuist", "generate", "--path", File.join(@dir, path), "--cache", "--include-sources", sources)
   @workspace_path = Dir.glob(File.join(@dir, path, "*.xcworkspace")).first


### PR DESCRIPTION
### Short description 📝

The master still seems broken as tests in all PRs fail [in this way](https://github.com/tuist/tuist/runs/1035038434?check_suite_focus=true#step:7:17)

### Solution 📦

In a recent [PR](https://github.com/tuist/tuist/pull/1689) it seems that `App` suffix has been added to the generated project. I think we should keep it to `"{{ name }}"` as that is something users would expect more IMHO

To ensure this does not happen in the future, I have added `Templates/**` to `paths` in `tuist.yml`