### PR TITLE
Change the template to have a consistent directory structure

### DIFF
--- a/Templates/AppProject.stencil
+++ b/Templates/AppProject.stencil
@@ -17,27 +17,9 @@ import ProjectDescriptionHelpers
 
  */
 
-// MARK: - {{ name }} Kit Framework
-
-let kit = Target(name: "{{ name }}Kit",
-                platform: .{{ platform }},
-                product: .framework,
-                bundleId: "io.tuist.{{ name }}Kit",
-                infoPlist: .default,
-                sources: ["Targets/{{ name }}Kit/Sources/**"],
-                resources: [],
-                dependencies: [])
-
-let ui = Target(name: "{{ name }}UI",
-                platform: .{{ platform }},
-                product: .framework,
-                bundleId: "io.tuist.{{ name }}UI",
-                infoPlist: .default,
-                sources: ["Targets/{{ name }}UI/Sources/**"],
-                resources: [],
-                dependencies: [])
-
-// MARK: - Example app
+// MARK: - Project
 
 // Creates our project using a helper function defined in ProjectDescriptionHelpers
-let project = Project.app(name: "{{ name }}", additionalTargets: [kit, ui])
+let project = Project.app(name: "{{ name }}",
+                          platform: .{{ platform }},
+                          additionalTargets: ["{{name}}Kit", "{{name}}UI"])

--- a/Templates/KitTests.stencil
+++ b/Templates/KitTests.stencil
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+final class {{ name }}KitTests: XCTestCase {
+    func test_example() {
+        XCTAssertEqual("{{ name }}Kit", "{{ name }}Kit")
+    }
+}

--- a/Templates/Project+Templates.stencil
+++ b/Templates/Project+Templates.stencil
@@ -7,17 +7,42 @@ import ProjectDescription
 
 extension Project {
     /// Helper function to create the Project for this ExampleApp
-    public static func app(name: String, additionalTargets: [Target]) -> Project {
-        var targets = makeAppTargets(name: name, dependencies: additionalTargets.map { TargetDependency.target(name: $0.name) })
-        targets += additionalTargets
+    public static func app(name: String, platform: Platform, additionalTargets: [String]) -> Project {
+        var targets = makeAppTargets(name: name,
+                                     platform: platform,
+                                     dependencies: additionalTargets.map { TargetDependency.target(name: $0) })
+        targets += additionalTargets.flatMap({ makeFrameworkTargets(name: $0, platform: platform) })
         return Project(name: name,
                        organizationName: "tuist.io",
                        targets: targets)
     }
 
-    /// Helper function to create the application target and the unit test target for the ExampleApp
-    private static func makeAppTargets(name: String, dependencies: [TargetDependency]) -> [Target] {
-        let platform: Platform = .{{ platform }}
+    // MARK: - Private
+
+    /// Helper function to create a framework target and an associated unit test target
+    private static func makeFrameworkTargets(name: String, platform: Platform) -> [Target] {
+        let sources = Target(name: name,
+                platform: platform,
+                product: .framework,
+                bundleId: "io.tuist.\(name)",
+                infoPlist: .default,
+                sources: ["Targets/\(name)/Sources/**"],
+                resources: [],
+                dependencies: [])
+        let tests = Target(name: "\(name)Tests",
+                platform: platform,
+                product: .unitTests,
+                bundleId: "io.tuist.\(name)Tests",
+                infoPlist: .default,
+                sources: ["Targets/\(name)/Tests/**"],
+                resources: [],
+                dependencies: [])
+        return [sources, tests]
+    }
+
+    /// Helper function to create the application target and the unit test target.
+    private static func makeAppTargets(name: String, platform: Platform, dependencies: [TargetDependency]) -> [Target] {
+        let platform: Platform = platform
         let infoPlist: [String: InfoPlist.Value] = [
             "CFBundleShortVersionString": "1.0",
             "CFBundleVersion": "1",

--- a/Templates/Project+Templates.stencil
+++ b/Templates/Project+Templates.stencil
@@ -30,7 +30,7 @@ extension Project {
             product: .app,
             bundleId: "io.tuist.\(name)",
             infoPlist: .extendingDefault(with: infoPlist),
-            sources: ["Sources/**"],
+            sources: ["Targets/\(name)/Sources/**"],
             resources: [],
             dependencies: dependencies
         )
@@ -41,7 +41,7 @@ extension Project {
             product: .unitTests,
             bundleId: "io.tuist.\(name)Tests",
             infoPlist: .default,
-            sources: "Tests/**",
+            sources: ["Targets/\(name)/Tests/**"],
             dependencies: [
                 .target(name: "\(name)")
         ])

--- a/Templates/UITests.stencil
+++ b/Templates/UITests.stencil
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+final class {{ name }}UITests: XCTestCase {
+    func test_example() {
+        XCTAssertEqual("{{ name }}UI", "{{ name }}UI")
+    }
+}

--- a/Templates/default/Template.swift
+++ b/Templates/default/Template.swift
@@ -28,8 +28,12 @@ let template = Template(
               templatePath: templatePath("AppTests.stencil")),
         .file(path: kitFrameworkPath + "/Sources/\(nameAttribute)Kit.swift",
               templatePath: templatePath("/KitSource.stencil")),
+        .file(path: kitFrameworkPath + "/Tests/\(nameAttribute)KitTests.swift",
+              templatePath: templatePath("/KitTests.stencil")),
         .file(path: uiFrameworkPath + "/Sources/\(nameAttribute)UI.swift",
               templatePath: templatePath("/UISource.stencil")),
+        .file(path: uiFrameworkPath + "/Tests/\(nameAttribute)UITests.swift",
+              templatePath: templatePath("/UITests.stencil")),
         .file(path: ".gitignore",
               templatePath: templatePath("Gitignore.stencil")),
     ]

--- a/Templates/default/Template.swift
+++ b/Templates/default/Template.swift
@@ -3,6 +3,7 @@ import ProjectDescription
 let nameAttribute: Template.Attribute = .required("name")
 let platformAttribute: Template.Attribute = .optional("platform", default: "iOS")
 let projectPath = "."
+let appPath = "Targets/\(nameAttribute)"
 let kitFrameworkPath = "Targets/\(nameAttribute)Kit"
 let uiFrameworkPath = "Targets/\(nameAttribute)UI"
 
@@ -21,9 +22,9 @@ let template = Template(
               templatePath: templatePath("Project+Templates.stencil")),
         .file(path: projectPath + "/Project.swift",
               templatePath: templatePath("AppProject.stencil")),
-        .file(path: projectPath + "/Sources/AppDelegate.swift",
+        .file(path: appPath + "/Sources/AppDelegate.swift",
               templatePath: "AppDelegate.stencil"),
-        .file(path: projectPath + "/Tests/AppTests.swift",
+        .file(path: appPath + "/Tests/AppTests.swift",
               templatePath: templatePath("AppTests.stencil")),
         .file(path: kitFrameworkPath + "/Sources/\(nameAttribute)Kit.swift",
               templatePath: templatePath("/KitSource.stencil")),

--- a/Templates/swiftui/Template.swift
+++ b/Templates/swiftui/Template.swift
@@ -3,6 +3,7 @@ import ProjectDescription
 let nameAttribute: Template.Attribute = .required("name")
 let platformAttribute: Template.Attribute = .optional("platform", default: "iOS")
 let projectPath = "."
+let appPath = "Targets/\(nameAttribute)"
 let kitFrameworkPath = "Targets/\(nameAttribute)Kit"
 let uiFrameworkPath = "Targets/\(nameAttribute)UI"
 
@@ -21,20 +22,24 @@ let template = Template(
               templatePath: templatePath("Project+Templates.stencil")),
         .file(path: projectPath + "/Project.swift",
               templatePath: templatePath("AppProject.stencil")),
-        .file(path: projectPath + "/Sources/AppDelegate.swift",
+        .file(path: appPath + "/Sources/AppDelegate.swift",
               templatePath: "AppDelegate.stencil"),
-        .file(path: projectPath + "/Sources/SceneDelegate.swift",
+        .file(path: appPath + "/Sources/SceneDelegate.swift",
               templatePath: "SceneDelegate.stencil"),
-        .file(path: projectPath + "/Sources/main.swift",
+        .file(path: appPath + "/Sources/main.swift",
               templatePath: "main.stencil"),
-        .file(path: projectPath + "/Sources/ContentView.swift",
+        .file(path: appPath + "/Sources/ContentView.swift",
               templatePath: "ContentView.stencil"),
-        .file(path: projectPath + "/Tests/AppTests.swift",
+        .file(path: appPath + "/Tests/AppTests.swift",
               templatePath: templatePath("AppTests.stencil")),
         .file(path: kitFrameworkPath + "/Sources/\(nameAttribute)Kit.swift",
               templatePath: templatePath("KitSource.stencil")),
+        .file(path: kitFrameworkPath + "/Tests/\(nameAttribute)KitTests.swift",
+              templatePath: templatePath("/KitTests.stencil")),
         .file(path: uiFrameworkPath + "/Sources/\(nameAttribute)UI.swift",
               templatePath: templatePath("UISource.stencil")),
+        .file(path: uiFrameworkPath + "/Tests/\(nameAttribute)UITests.swift",
+              templatePath: templatePath("/UITests.stencil")),
         .file(path: ".gitignore",
               templatePath: templatePath("Gitignore.stencil")),
     ]


### PR DESCRIPTION
### Short description 📝
Using the recent template changes I realized we don't have a consistent directory structure:

```
Sources/
Tests
Targets/
  XXKit/
    Sources
  XXUI/
    Sources
```

### Solution 📦

I'm moving the root `Sources/` and `Tests/` into `Targets/XXX` to be consistent with the other targets. I've also taken the opportunity to add a tests target to the frameworks.