### PR TITLE
Change focus's behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Removed
 
 - **Breaking** Support for Xcode 11.3.x and Xcode 11.4.x [#1604](https://github.com/tuist/tuist/pull/1604) by [@fortmarek](https://github.com/fortmarek)
+- **Breaking** `--cache` & `--include-sources` arguments from `tuist generate` [#1712](https://github.com/tuist/tuist/pull/1712) by [@pepibumur](https://github.com/pepibumur).
+
+### Added
+
+- `--open` argument to the `tuist generate` command [#1712](https://github.com/tuist/tuist/pull/1712) by [@pepibumur](https://github.com/pepibumur).
+- `--no-open` argument to the `tuist focus` command to support disabling opening the project [#1712](https://github.com/tuist/tuist/pull/1712) by [@pepibumur](https://github.com/pepibumur).
 
 ### Fixed
 

--- a/Sources/TuistKit/Commands/FocusCommand.swift
+++ b/Sources/TuistKit/Commands/FocusCommand.swift
@@ -33,7 +33,16 @@ struct FocusCommand: ParsableCommand {
     )
     var path: String?
 
+    @Flag(
+        name: .shortAndLong,
+        help: "Don't open the project after generating it."
+    )
+    var noOpen: Bool = false
+
     func run() throws {
-        try FocusService().run(cache: cache, path: path, includeSources: Set(includeSources))
+        try FocusService().run(cache: cache,
+                               path: path,
+                               includeSources: Set(includeSources),
+                               noOpen: noOpen)
     }
 }

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -23,6 +23,11 @@ struct GenerateCommand: ParsableCommand {
     @Flag(help: "Generate a project replacing dependencies with pre-compiled assets.")
     var cache: Bool = false
 
+    @Flag(
+        help: "Open the project after generating it."
+    )
+    var open: Bool = false
+
     @Option(
         name: NameSpecification([.customShort("i"), .customLong("include-sources", withSingleDash: false)]),
         parsing: .singleValue,
@@ -34,6 +39,7 @@ struct GenerateCommand: ParsableCommand {
         try GenerateService().run(path: path,
                                   projectOnly: projectOnly,
                                   cache: cache,
-                                  cacheSources: Set(includeSources))
+                                  cacheSources: Set(includeSources),
+                                  open: open)
     }
 }

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -10,36 +10,26 @@ struct GenerateCommand: ParsableCommand {
 
     @Option(
         name: .shortAndLong,
-        help: "The path where the project will be generated.",
+        help: "The path to the directory that contains the definition of the project.",
         completion: .directory
     )
     var path: String?
 
     @Flag(
+        name: [.customShort("P"), .long],
         help: "Only generate the local project (without generating its dependencies)."
     )
     var projectOnly: Bool = false
 
-    @Flag(help: "Generate a project replacing dependencies with pre-compiled assets.")
-    var cache: Bool = false
-
     @Flag(
+        name: [.customShort("O"), .long],
         help: "Open the project after generating it."
     )
     var open: Bool = false
 
-    @Option(
-        name: NameSpecification([.customShort("i"), .customLong("include-sources", withSingleDash: false)]),
-        parsing: .singleValue,
-        help: "When used with --cache, it generates the given target (with the sources) even if it exists in the cache."
-    )
-    var includeSources: [String] = []
-
     func run() throws {
         try GenerateService().run(path: path,
                                   projectOnly: projectOnly,
-                                  cache: cache,
-                                  cacheSources: Set(includeSources),
                                   open: open)
     }
 }

--- a/Sources/TuistKit/Services/FocusService.swift
+++ b/Sources/TuistKit/Services/FocusService.swift
@@ -49,14 +49,16 @@ final class FocusService {
         self.projectGeneratorFactory = projectGeneratorFactory
     }
 
-    func run(cache: Bool, path: String?, includeSources: Set<String>) throws {
+    func run(cache: Bool, path: String?, includeSources: Set<String>, noOpen: Bool) throws {
         let path = self.path(path)
         if isWorkspace(path: path), cache {
             throw FocusServiceError.cacheWorkspaceNonSupported
         }
         let generator = projectGeneratorFactory.generator(cache: cache, includeSources: includeSources)
         let workspacePath = try generator.generate(path: path, projectOnly: false)
-        try opener.open(path: workspacePath)
+        if !noOpen {
+            try opener.open(path: workspacePath)
+        }
     }
 
     // MARK: - Helpers

--- a/Sources/TuistKit/Services/GenerateService.swift
+++ b/Sources/TuistKit/Services/GenerateService.swift
@@ -4,12 +4,12 @@ import TuistLoader
 import TuistSupport
 
 protocol GenerateServiceProjectGeneratorFactorying {
-    func generator(cache: Bool, includeSources: Set<String>) -> ProjectGenerating
+    func generator() -> ProjectGenerating
 }
 
 final class GenerateServiceProjectGeneratorFactory: GenerateServiceProjectGeneratorFactorying {
-    func generator(cache: Bool, includeSources: Set<String>) -> ProjectGenerating {
-        ProjectGenerator(graphMapperProvider: GraphMapperProvider(cache: cache, includeSources: includeSources))
+    func generator() -> ProjectGenerating {
+        ProjectGenerator(graphMapperProvider: GraphMapperProvider(cache: false, includeSources: Set()))
     }
 }
 
@@ -33,13 +33,11 @@ final class GenerateService {
 
     func run(path: String?,
              projectOnly: Bool,
-             cache: Bool,
-             cacheSources: Set<String>,
              open: Bool) throws
     {
         let timer = clock.startTimer()
         let path = self.path(path)
-        let generator = projectGeneratorFactory.generator(cache: cache, includeSources: cacheSources)
+        let generator = projectGeneratorFactory.generator()
 
         let generatedProjectPath = try generator.generate(path: path, projectOnly: projectOnly)
         if open {

--- a/Sources/TuistKit/Services/GenerateService.swift
+++ b/Sources/TuistKit/Services/GenerateService.swift
@@ -16,26 +16,35 @@ final class GenerateServiceProjectGeneratorFactory: GenerateServiceProjectGenera
 final class GenerateService {
     // MARK: - Attributes
 
+    private let opener: Opening
     private let clock: Clock
     private let projectGeneratorFactory: GenerateServiceProjectGeneratorFactorying
 
+    // MARK: - Init
+
     init(clock: Clock = WallClock(),
+         opener: Opening = Opener(),
          projectGeneratorFactory: GenerateServiceProjectGeneratorFactorying = GenerateServiceProjectGeneratorFactory())
     {
         self.clock = clock
+        self.opener = opener
         self.projectGeneratorFactory = projectGeneratorFactory
     }
 
     func run(path: String?,
              projectOnly: Bool,
              cache: Bool,
-             cacheSources: Set<String>) throws
+             cacheSources: Set<String>,
+             open: Bool) throws
     {
         let timer = clock.startTimer()
         let path = self.path(path)
         let generator = projectGeneratorFactory.generator(cache: cache, includeSources: cacheSources)
 
-        _ = try generator.generate(path: path, projectOnly: projectOnly)
+        let generatedProjectPath = try generator.generate(path: path, projectOnly: projectOnly)
+        if open {
+            try opener.open(path: generatedProjectPath, wait: false)
+        }
 
         let time = String(format: "%.3f", timer.stop())
 

--- a/Tests/TuistKitTests/Services/FocusServiceTests.swift
+++ b/Tests/TuistKitTests/Services/FocusServiceTests.swift
@@ -64,7 +64,7 @@ final class FocusServiceTests: TuistUnitTestCase {
             throw error
         }
 
-        XCTAssertThrowsError(try subject.run(cache: false, path: nil, includeSources: Set())) {
+        XCTAssertThrowsError(try subject.run(cache: false, path: nil, includeSources: Set(), noOpen: true)) {
             XCTAssertEqual($0 as NSError?, error)
         }
     }
@@ -76,7 +76,7 @@ final class FocusServiceTests: TuistUnitTestCase {
             workspacePath
         }
 
-        try subject.run(cache: false, path: nil, includeSources: Set())
+        try subject.run(cache: false, path: nil, includeSources: Set(), noOpen: false)
 
         XCTAssertEqual(opener.openArgs.last?.0, workspacePath.pathString)
     }

--- a/Tests/TuistKitTests/Services/GenerateServiceTests.swift
+++ b/Tests/TuistKitTests/Services/GenerateServiceTests.swift
@@ -13,15 +13,11 @@ import XCTest
 final class MockGenerateServiceProjectGeneratorFactory: GenerateServiceProjectGeneratorFactorying {
     var invokedGenerator = false
     var invokedGeneratorCount = 0
-    var invokedGeneratorParameters: (cache: Bool, includeSources: Set<String>)?
-    var invokedGeneratorParametersList = [(cache: Bool, includeSources: Set<String>)]()
     var stubbedGeneratorResult: ProjectGenerating!
 
-    func generator(cache: Bool, includeSources: Set<String>) -> ProjectGenerating {
+    func generator() -> ProjectGenerating {
         invokedGenerator = true
         invokedGeneratorCount += 1
-        invokedGeneratorParameters = (cache, includeSources)
-        invokedGeneratorParametersList.append((cache, includeSources))
         return stubbedGeneratorResult
     }
 }
@@ -169,13 +165,10 @@ final class GenerateServiceTests: TuistUnitTestCase {
 extension GenerateService {
     func testRun(path: String? = nil,
                  projectOnly: Bool = false,
-                 cache: Bool = false,
                  open: Bool = false) throws
     {
         try run(path: path,
                 projectOnly: projectOnly,
-                cache: cache,
-                cacheSources: Set(),
                 open: open)
     }
 }

--- a/Tests/TuistKitTests/Services/GenerateServiceTests.swift
+++ b/Tests/TuistKitTests/Services/GenerateServiceTests.swift
@@ -29,11 +29,13 @@ final class MockGenerateServiceProjectGeneratorFactory: GenerateServiceProjectGe
 final class GenerateServiceTests: TuistUnitTestCase {
     var subject: GenerateService!
     var generator: MockProjectGenerator!
+    var opener: MockOpener!
     var clock: StubClock!
     var projectGeneratorFactory: MockGenerateServiceProjectGeneratorFactory!
 
     override func setUp() {
         super.setUp()
+        opener = MockOpener()
         projectGeneratorFactory = MockGenerateServiceProjectGeneratorFactory()
         generator = MockProjectGenerator()
         projectGeneratorFactory.stubbedGeneratorResult = generator
@@ -43,6 +45,7 @@ final class GenerateServiceTests: TuistUnitTestCase {
         }
 
         subject = GenerateService(clock: clock,
+                                  opener: opener,
                                   projectGeneratorFactory: projectGeneratorFactory)
     }
 
@@ -51,6 +54,7 @@ final class GenerateServiceTests: TuistUnitTestCase {
         generator = nil
         clock = nil
         subject = nil
+        opener = nil
         super.tearDown()
     }
 
@@ -59,7 +63,16 @@ final class GenerateServiceTests: TuistUnitTestCase {
         try subject.testRun()
 
         // Then
+        XCTAssertEqual(opener.openCallCount, 0)
         XCTAssertPrinterOutputContains("Project generated.")
+    }
+
+    func test_run_opens_the_project_when_open_is_true() throws {
+        // When
+        try subject.testRun(open: true)
+
+        // Then
+        XCTAssertEqual(opener.openCallCount, 1)
     }
 
     func test_run_timeIsPrinted() throws {
@@ -156,11 +169,13 @@ final class GenerateServiceTests: TuistUnitTestCase {
 extension GenerateService {
     func testRun(path: String? = nil,
                  projectOnly: Bool = false,
-                 cache: Bool = false) throws
+                 cache: Bool = false,
+                 open: Bool = false) throws
     {
         try run(path: path,
                 projectOnly: projectOnly,
                 cache: cache,
-                cacheSources: Set())
+                cacheSources: Set(),
+                open: open)
     }
 }

--- a/features/cache.feature
+++ b/features/cache.feature
@@ -1,11 +1,11 @@
-Feature: Generates projects with pre-compiled cached dependencies
+Feature: Focuses projects with pre-compiled cached dependencies
 
   Scenario: The project is an application with templates (ios_app_with_templates)
     Given that tuist is available 
     And I have a working directory
     And I initialize a ios application named MyApp
     And tuist warms the cache
-    When tuist generates a project with cached targets 
+    When tuist focuses a project with cached targets 
     Then MyApp links the xcframework MyAppKit
     Then MyApp embeds the xcframework MyAppKit
     Then MyApp embeds the xcframework MyAppUI
@@ -17,7 +17,7 @@ Scenario: The project is an application (ios_workspace_with_microfeature_archite
     And I have a working directory
     Then I copy the fixture ios_workspace_with_microfeature_architecture into the working directory
     And tuist warms the cache
-    When tuist generates a project with cached targets at App
+    When tuist focuses a project with cached targets at App
     Then App embeds the xcframework Core
     Then App embeds the xcframework Data
     Then App embeds the xcframework FeatureContracts
@@ -31,7 +31,7 @@ Scenario: The project is an application and a target is modified after being cac
     Then I copy the fixture ios_workspace_with_microfeature_architecture into the working directory
     And tuist warms the cache
     And I add an empty line at the end of the file Frameworks/FeatureAFramework/Sources/FrameworkA.swift
-    When tuist generates a project with cached targets at App
+    When tuist focuses a project with cached targets at App
     Then App embeds the xcframework Core
     Then App embeds the xcframework Data
     Then App embeds the framework FrameworkA
@@ -46,7 +46,7 @@ Scenario: The project is an application and a target is generated as sources (io
     And I have a working directory
     Then I copy the fixture ios_workspace_with_microfeature_architecture into the working directory
     And tuist warms the cache
-    When tuist generates a project with cached targets with sources FrameworkA at App
+    When tuist focuses a project with cached targets with sources FrameworkA at App
     Then App embeds the xcframework Core
     Then App embeds the xcframework Data
     Then App embeds the framework FrameworkA
@@ -55,15 +55,3 @@ Scenario: The project is an application and a target is generated as sources (io
     Then App embeds the xcframework UIComponents
     Then I should be able to build for iOS the scheme App
     Then I should be able to test for iOS the scheme AppTests
-
-# TODO: We need to revisit the caching of static frameworks
-# Scenario: The project is an application with templates (ios_workspace_with_microfeature_architecture)
-#     Given that tuist is available 
-#     And I have a working directory
-#     Then I copy the fixture ios_workspace_with_microfeature_architecture into the working directory
-#     And tuist warms the cache
-#     When tuist generates a project with cached targets at StaticApp
-#     Then StaticApp links the xcframework FrameworkA
-#     Then StaticApp does not embed any xcframeworks
-#     Then I should be able to build for iOS the scheme StaticApp
-#     Then I should be able to test for iOS the scheme StaticAppTests

--- a/features/step_definitions/shared/tuist.rb
+++ b/features/step_definitions/shared/tuist.rb
@@ -24,20 +24,20 @@ Then(/^tuist generates the project at (.+)$/) do |path|
   @xcodeproj_path = Dir.glob(File.join(@dir, path, "*.xcodeproj")).first
 end
 
-Then(/^tuist generates a project with cached targets at (.+)$/) do |path|
-  system("swift", "run", "tuist", "generate", "--path", File.join(@dir, path), "--cache")
+Then(/^tuist focuses a project with cached targets at (.+)$/) do |path|
+  system("swift", "run", "tuist", "focus", "--no-open", "--path", File.join(@dir, path), "--cache")
   @workspace_path = Dir.glob(File.join(@dir, path, "*.xcworkspace")).first
   @xcodeproj_path = Dir.glob(File.join(@dir, path, "*.xcodeproj")).first
 end
 
-Then(/^tuist generates a project with cached targets$/) do
-  system("swift", "run", "tuist", "generate", "--path", @dir, "--cache")
+Then(/^tuist focuses a project with cached targets$/) do
+  system("swift", "run", "tuist", "focus", "--no-open", "--path", @dir, "--cache")
   @workspace_path = Dir.glob(File.join(@dir, "*.xcworkspace")).first
   @xcodeproj_path = Dir.glob(File.join(@dir, "*.xcodeproj")).first
 end
 
-Then(/^tuist generates a project with cached targets with sources ([a-zA-Z]+) at (.+)$/) do |sources, path|
-  system("swift", "run", "tuist", "generate", "--path", File.join(@dir, path), "--cache", "--include-sources", sources)
+Then(/^tuist focuses a project with cached targets with sources ([a-zA-Z]+) at (.+)$/) do |sources, path|
+  system("swift", "run", "tuist", "focus", "--no-open", "--path", File.join(@dir, path), "--cache", "--include-sources", sources)
   @workspace_path = Dir.glob(File.join(@dir, path, "*.xcworkspace")).first
   @xcodeproj_path = Dir.glob(File.join(@dir, path, "*.xcodeproj")).first
 end

--- a/fixtures/ios_app_with_extensions/Derived/Sources/Bundle+MessageExtension.swift
+++ b/fixtures/ios_app_with_extensions/Derived/Sources/Bundle+MessageExtension.swift
@@ -1,0 +1,23 @@
+// swiftlint:disable all
+import Foundation
+
+// MARK: - Swift Bundle Accessor
+
+private class BundleFinder {}
+
+extension Foundation.Bundle {
+    /// Since MessageExtension is a iMessage extension, the bundle containing the resources is copied into the final product.
+    static var module: Bundle = {
+        return Bundle(for: BundleFinder.self)
+    }()
+}
+
+// MARK: - Objective-C Bundle Accessor
+
+@objc
+public class MessageExtensionResources: NSObject {
+   @objc public class var bundle: Bundle {
+         return .module
+   }
+}
+// swiftlint:enable all

--- a/fixtures/ios_app_with_extensions/Derived/Sources/Bundle+WidgetExtension.swift
+++ b/fixtures/ios_app_with_extensions/Derived/Sources/Bundle+WidgetExtension.swift
@@ -1,0 +1,23 @@
+// swiftlint:disable all
+import Foundation
+
+// MARK: - Swift Bundle Accessor
+
+private class BundleFinder {}
+
+extension Foundation.Bundle {
+    /// Since WidgetExtension is a app extension, the bundle containing the resources is copied into the final product.
+    static var module: Bundle = {
+        return Bundle(for: BundleFinder.self)
+    }()
+}
+
+// MARK: - Objective-C Bundle Accessor
+
+@objc
+public class WidgetExtensionResources: NSObject {
+   @objc public class var bundle: Bundle {
+         return .module
+   }
+}
+// swiftlint:enable all

--- a/website/markdown/docs/commands/generate.mdx
+++ b/website/markdown/docs/commands/generate.mdx
@@ -22,3 +22,30 @@ tuist generate
 The command accepts the `--path` argument, which can be used to generate the project in a different directory.
 
 There might be situations when you are only interested in generating the project in a given directory, and not the projects it depends on. For that, you can pass the argument `--project-only`.
+
+### Arguments
+
+<ArgumentsTable
+  args={[
+    {
+      long: '`--path`',
+      short: '`-p`',
+      description:
+        'The path to the directory that contains the definition of the project.',
+      default: 'Current directory',
+    },
+    {
+      long: '`--project-only`',
+      short: '`-P`',
+      description:
+        'Only generate the local project (without generating its dependencies).',
+      default: '`false`',
+    },
+    {
+      long: '`--open`',
+      short: '`-o`',
+      description: 'Open the project after generating it.',
+      default: '`false`',
+    },
+  ]}
+/>


### PR DESCRIPTION
### Short description 📝
Traditionally, `tuist focus` has meant generating + opening. In this PR I'm moving that behavior to `tuist generate` by adding support for a new flag, `--open` that allows generating projects and opening them:

```
tuist generate --open
```

**What's the motivation for that?** I'd like to change `tuist focus` behavior to mean: *generate a project for me to focus on target X*. When users use the new behavior of the focus command they'll get a project that is optimized for what they need (i.e. work on a given target), and where direct and transitive dependencies have been replaced with pre-compiled versions.

For users that would like to continue using Tuist as just a project generator, they can continue using `tuist generate`. That command will translate manifests into Xcode projects and workspaces. For those who want to go further and let Tuist transform the project into something that is optimized for their intent, then they can use `tuist focus`.

In a follow-up PR I'll extend `tuist focus` to require an extra argument, the target they'd like to focus on:

```
tuist focus MyApp
```
As I explained [here](https://community.tuist.io/t/deprecate-workspace-swift/106/2), the command will only work when run a directory where there's a `Project.swift`. 