### PR TITLE
Add support for running Tuist through 'swift project'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - **Breaking** Support for Xcode 11.3.x and Xcode 11.4.x [#1604](https://github.com/tuist/tuist/pull/1604) by [@fortmarek](https://github.com/fortmarek)
 
+### Added
+
+- Support for running Tuist through `swift project` [#1713](https://github.com/tuist/tuist/pull/1713) by [@pepibumur](https://github.com/pepibumur).
+
 ### Fixed
 
 - Generate the default `Info.plist` file for static frameworks that only contain resources [#1661](https://github.com/tuist/tuist/pull/1661) by [@Juanpe](https://github.com/juanpe)

--- a/Sources/TuistEnvKit/Updater/EnvUpdater.swift
+++ b/Sources/TuistEnvKit/Updater/EnvUpdater.swift
@@ -37,6 +37,7 @@ final class EnvUpdater: EnvUpdating {
 
             // Replace
             try System.shared.async(["/bin/cp", "-rf", binaryPath, "/usr/local/bin/tuist"])
+            try System.shared.async(["/bin/ln", "-s", "/usr/local/bin/tuist", "/usr/local/bin/swift-project"])
             try System.shared.async(["/bin/rm", binaryPath])
         }
     }

--- a/Tests/TuistEnvKitTests/Updater/EnvUpdaterTests.swift
+++ b/Tests/TuistEnvKitTests/Updater/EnvUpdaterTests.swift
@@ -33,6 +33,7 @@ final class EnvUpdaterTests: TuistUnitTestCase {
         system.succeedCommand(["/usr/bin/unzip", "-o", downloadPath.pathString, "-d", "/tmp/"])
         system.succeedCommand(["/bin/chmod", "+x", "/tmp/tuistenv"])
         system.succeedCommand(["/bin/cp", "-rf", "/tmp/tuistenv", "/usr/local/bin/tuist"])
+        system.succeedCommand(["/bin/ln", "-s", "/usr/local/bin/tuist", "/usr/local/bin/swift-project"])
         system.succeedCommand(["/bin/rm", "/tmp/tuistenv"])
 
         // When

--- a/script/install
+++ b/script/install
@@ -5,6 +5,7 @@ curl -LSs --output /tmp/tuistenv.zip https://storage.googleapis.com/tuist-releas
 echo "Installing Tuist"
 unzip -o /tmp/tuistenv.zip -d /tmp/tuistenv > /dev/null
 mv /tmp/tuistenv/tuistenv /usr/local/bin/tuist
+ln -s /usr/local/bin/tuist /usr/local/bin/swift-project
 
 chmod +x /usr/local/bin/tuist
 

--- a/website/markdown/docs/usage/getting-started.mdx
+++ b/website/markdown/docs/usage/getting-started.mdx
@@ -97,6 +97,17 @@ tuist generate --project-only
 
 This will generate an Xcode project for the local project only.
 
+### Swift project
+
+Tuist's installation creates a symbolic link at `/usr/local/bin/swift-project`.
+Thanks to that, the Swift CLI exposes the interface `swift project` for running Tuist:
+
+```bash
+swift project init # tuist init
+swift project build # tuist build
+swift project edit # tuist edit
+```
+
 ### Add a badge to your project's README
 
 [![Tuist badge](https://img.shields.io/badge/Powered%20by-Tuist-blue)](https://tuist.io)


### PR DESCRIPTION
### Short description 📝
There's an undocumented behavior of the Swift CLI that allows adding new commands by exposing executables that follow the naming convention `swift-xxx`.
This PR makes use of that behavior to allow users to use `swift project` for running Tuist:

```bash
swift project init # tuist init
swift project build # tuist build
``` 