### PR TITLE
[fix-graph-docs] fix graph documentation

### DIFF
--- a/website/markdown/docs/commands/graph.mdx
+++ b/website/markdown/docs/commands/graph.mdx
@@ -29,13 +29,13 @@ tuist graph --format dot
   args={[
     {
       long: '`--skip-test-targets`',
-      short: '`-s`',
+      short: '`-t`',
       description: 'Excludes test targets from the generated graph.',
     },
     {
       long: '`--skip-external-dependencies`',
-      short: '`-s`',
-      description: 'Excludes test targets from the generated graph.',
+      short: '`-d`',
+      description: 'Excludes external dependencies from the generated graph.',
     },
     {
       long: '`--format`',
@@ -45,8 +45,8 @@ tuist graph --format dot
       default: '`png`',
     },
     {
-      long: '`--layout-algorithm`',
-      short: '`-l`',
+      long: '`--algorithm`',
+      short: '`-a`',
       description:
         "The algorithm used for drawing the graph. For large graphs, it's recommended to use `fdp`.",
       default: '`dot`',


### PR DESCRIPTION
Fixes graph command's documentation.

I checked for correct values in `GraphCommand.swift`

Now documentation should coincide with implementation
