### PR TITLE
Change the behaviour of the focus command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Changed
+
+- **Breaking** `tuist focus` only works with `Project.swift` [#1739](https://github.com/tuist/tuist/pull/1739) by [@pepibumur](https://github.com/pepibumur).
+- **Breaking** a target or a list of targets is required for `tuist focus` [#1739](https://github.com/tuist/tuist/pull/1739) by [@pepibumur](https://github.com/pepibumur).
+- **Breaking** cache is enabled by default in `tuist focus` [#1739](https://github.com/tuist/tuist/pull/1739) by [@pepibumur](https://github.com/pepibumur).
+
 ## 1.16.0 - Alhambra
 
 ### Removed

--- a/Sources/TuistCache/GraphMappers/CacheGraphMutator.swift
+++ b/Sources/TuistCache/GraphMappers/CacheGraphMutator.swift
@@ -19,27 +19,27 @@ class CacheGraphMutator: CacheGraphMutating {
     struct VisitedXCFramework {
         let path: AbsolutePath?
     }
-    
+
     // MARK: - Attributes
-    
+
     /// Utility to parse an .xcframework from the filesystem and load it into memory.
     private let xcframeworkLoader: XCFrameworkNodeLoading
-    
+
     /// Initializes the graph mapper with its attributes.
     /// - Parameter xcframeworkLoader: Utility to parse an .xcframework from the filesystem and load it into memory.
     init(xcframeworkLoader: XCFrameworkNodeLoading = XCFrameworkNodeLoader()) {
         self.xcframeworkLoader = xcframeworkLoader
     }
-    
+
     // MARK: - CacheGraphMapping
-    
+
     public func map(graph: Graph, xcframeworks: [TargetNode: AbsolutePath], sources: Set<String>) throws -> Graph {
         var visitedXCFrameworkPaths: [TargetNode: VisitedXCFramework?] = [:]
         var loadedXCFrameworks: [AbsolutePath: XCFrameworkNode] = [:]
-        let userSpecifiedSourceTargets = graph.targets.flatMap({ $0.value }).filter({ sources.contains($0.target.name )})
-        let userSpecifiedSourceTestTargets = userSpecifiedSourceTargets.flatMap({ graph.testTargetsDependingOn(path: $0.path, name: $0.name)})
+        let userSpecifiedSourceTargets = graph.targets.flatMap { $0.value }.filter { sources.contains($0.target.name) }
+        let userSpecifiedSourceTestTargets = userSpecifiedSourceTargets.flatMap { graph.testTargetsDependingOn(path: $0.path, name: $0.name) }
         var sourceTargets: Set<TargetNode> = Set(userSpecifiedSourceTargets)
-        
+
         try (userSpecifiedSourceTargets + userSpecifiedSourceTestTargets)
             .forEach { try visit(targetNode: $0,
                                  xcframeworks: xcframeworks,
@@ -47,10 +47,10 @@ class CacheGraphMutator: CacheGraphMutating {
                                  sourceTargets: &sourceTargets,
                                  visitedXCFrameworkPaths: &visitedXCFrameworkPaths,
                                  loadedXCFrameworks: &loadedXCFrameworks) }
-        
+
         return treeShake(graph: graph, sourceTargets: sourceTargets)
     }
-    
+
     fileprivate func visit(targetNode: TargetNode,
                            xcframeworks: [TargetNode: AbsolutePath],
                            sources: Set<String>,
@@ -66,7 +66,7 @@ class CacheGraphMutator: CacheGraphMutating {
                                                       visitedXCFrameworkPaths: &visitedXCFrameworkPaths,
                                                       loadedXCFrameworks: &loadedXCFrameworks)
     }
-    
+
     fileprivate func mapDependencies(_ dependencies: [GraphNode],
                                      xcframeworks: [TargetNode: AbsolutePath],
                                      sources: Set<String>,
@@ -81,23 +81,23 @@ class CacheGraphMutator: CacheGraphMutating {
                 newDependencies.append(dependency)
                 return
             }
-            
+
             // If the target cannot be replaced with its associated .xcframework we return
             guard !sources.contains(targetDependency.target.name), let xcframeworkPath = xcframeworkPath(target: targetDependency,
                                                                                                          xcframeworks: xcframeworks,
                                                                                                          visitedXCFrameworkPaths: &visitedXCFrameworkPaths)
-                else {
-                    sourceTargets.formUnion([targetDependency])
-                    targetDependency.dependencies = try mapDependencies(targetDependency.dependencies,
-                                                                        xcframeworks: xcframeworks,
-                                                                        sources: sources,
-                                                                        sourceTargets: &sourceTargets,
-                                                                        visitedXCFrameworkPaths: &visitedXCFrameworkPaths,
-                                                                        loadedXCFrameworks: &loadedXCFrameworks)
-                    newDependencies.append(targetDependency)
-                    return
+            else {
+                sourceTargets.formUnion([targetDependency])
+                targetDependency.dependencies = try mapDependencies(targetDependency.dependencies,
+                                                                    xcframeworks: xcframeworks,
+                                                                    sources: sources,
+                                                                    sourceTargets: &sourceTargets,
+                                                                    visitedXCFrameworkPaths: &visitedXCFrameworkPaths,
+                                                                    loadedXCFrameworks: &loadedXCFrameworks)
+                newDependencies.append(targetDependency)
+                return
             }
-            
+
             // We load the xcframework
             let xcframework = try self.loadXCFramework(path: xcframeworkPath, loadedXCFrameworks: &loadedXCFrameworks)
             try mapDependencies(targetDependency.dependencies,
@@ -106,23 +106,23 @@ class CacheGraphMutator: CacheGraphMutating {
                                 sourceTargets: &sourceTargets,
                                 visitedXCFrameworkPaths: &visitedXCFrameworkPaths,
                                 loadedXCFrameworks: &loadedXCFrameworks).forEach { dependency in
-                                    if let frameworkDependency = dependency as? FrameworkNode {
-                                        xcframework.add(dependency: XCFrameworkNode.Dependency.framework(frameworkDependency))
-                                    } else if let xcframeworkDependency = dependency as? XCFrameworkNode {
-                                        xcframework.add(dependency: XCFrameworkNode.Dependency.xcframework(xcframeworkDependency))
-                                    } else {
-                                        // Static dependencies fall into this case.
-                                        // Those are now part of the precompiled xcframework and therefore we don't have to link against them.
-                                    }
+                if let frameworkDependency = dependency as? FrameworkNode {
+                    xcframework.add(dependency: XCFrameworkNode.Dependency.framework(frameworkDependency))
+                } else if let xcframeworkDependency = dependency as? XCFrameworkNode {
+                    xcframework.add(dependency: XCFrameworkNode.Dependency.xcframework(xcframeworkDependency))
+                } else {
+                    // Static dependencies fall into this case.
+                    // Those are now part of the precompiled xcframework and therefore we don't have to link against them.
+                }
             }
             newDependencies.append(xcframework)
         }
         return newDependencies
     }
-    
+
     func treeShake(graph: Graph, sourceTargets: Set<TargetNode>) -> Graph {
         let targetReferences = Set(sourceTargets.map { TargetReference(projectPath: $0.path, name: $0.name) })
-        
+
         let projects = graph.projects.compactMap { (project) -> Project? in
             let targets: [Target] = project.targets.compactMap { (target) -> Target? in
                 guard let targetNode = graph.target(path: project.path, name: target.name) else { return nil }
@@ -134,10 +134,10 @@ class CacheGraphMutator: CacheGraphMutating {
             } else {
                 let schemes: [Scheme] = project.schemes.compactMap { scheme -> Scheme? in
                     let buildActionTargets = scheme.buildAction?.targets.filter { targetReferences.contains($0) } ?? []
-                    
+
                     // The scheme contains no buildable targets so we don't include it.
                     if buildActionTargets.isEmpty { return nil }
-                    
+
                     let testActionTargets = scheme.testAction?.targets.filter { targetReferences.contains($0.target) } ?? []
                     var scheme = scheme
                     var buildAction = scheme.buildAction
@@ -146,13 +146,13 @@ class CacheGraphMutator: CacheGraphMutating {
                     testAction?.targets = testActionTargets
                     scheme.buildAction = buildAction
                     scheme.testAction = testAction
-                    
+
                     return scheme
                 }
                 return project.with(targets: targets).with(schemes: schemes)
             }
         }
-        
+
         return graph
             .with(projects: projects)
             .with(targets: sourceTargets.reduce(into: [AbsolutePath: [TargetNode]]()) { acc, target in
@@ -161,27 +161,27 @@ class CacheGraphMutator: CacheGraphMutating {
                 acc[target.path] = targets
             })
     }
-    
+
     fileprivate func loadXCFramework(path: AbsolutePath, loadedXCFrameworks: inout [AbsolutePath: XCFrameworkNode]) throws -> XCFrameworkNode {
         if let cachedXCFramework = loadedXCFrameworks[path] { return cachedXCFramework }
         let xcframework = try xcframeworkLoader.load(path: path)
         loadedXCFrameworks[path] = xcframework
         return xcframework
     }
-    
+
     fileprivate func xcframeworkPath(target: TargetNode,
                                      xcframeworks: [TargetNode: AbsolutePath],
                                      visitedXCFrameworkPaths: inout [TargetNode: VisitedXCFramework?]) -> AbsolutePath?
     {
         // Already visited
         if let visited = visitedXCFrameworkPaths[target] { return visited?.path }
-        
+
         // The target doesn't have a cached xcframework
         if xcframeworks[target] == nil {
             visitedXCFrameworkPaths[target] = VisitedXCFramework(path: nil)
             return nil
         }
-            // The target can be replaced
+        // The target can be replaced
         else if let path = xcframeworks[target],
             target.targetDependencies.allSatisfy({ xcframeworkPath(target: $0, xcframeworks: xcframeworks,
                                                                    visitedXCFrameworkPaths: &visitedXCFrameworkPaths) != nil })

--- a/Sources/TuistKit/Commands/FocusCommand.swift
+++ b/Sources/TuistKit/Commands/FocusCommand.swift
@@ -9,6 +9,24 @@ import TuistGenerator
 import TuistLoader
 import TuistSupport
 
+enum FocusCommandError: FatalError {
+    case noSources
+    
+    var description: String {
+        switch self {
+        case .noSources:
+            return "A list of targets is required: tuist focus MyTarget."
+        }
+    }
+    
+    var type: ErrorType {
+        switch self {
+        case .noSources:
+            return .abort
+        }
+    }
+}
+
 /// The focus command generates the Xcode workspace and launches it on Xcode.
 struct FocusCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
@@ -16,22 +34,15 @@ struct FocusCommand: ParsableCommand {
                              abstract: "Opens Xcode ready to focus on the project in the current directory")
     }
 
-    @Flag(help: "Generate a project replacing dependencies with pre-compiled assets.")
-    var cache: Bool = false
-
-    @Option(
-        name: NameSpecification([.customShort("i"), .customLong("include-sources", withSingleDash: false)]),
-        parsing: .singleValue,
-        help: "When used with --cache, it generates the given target (with the sources) even if it exists in the cache."
-    )
-    var includeSources: [String] = []
-
     @Option(
         name: .shortAndLong,
         help: "The path to the directory containing the project you plan to focus on.",
         completion: .directory
     )
     var path: String?
+    
+    @Argument(help: "A list of targets in which you'd like to focus. Those and their dependant targets will be generated as sources.")
+    var sources: [String] = []
 
     @Flag(
         name: .shortAndLong,
@@ -40,9 +51,11 @@ struct FocusCommand: ParsableCommand {
     var noOpen: Bool = false
 
     func run() throws {
-        try FocusService().run(cache: cache,
-                               path: path,
-                               includeSources: Set(includeSources),
+        if sources.isEmpty {
+            throw FocusCommandError.noSources
+        }
+        try FocusService().run(path: path,
+                               sources: Set(sources),
                                noOpen: noOpen)
     }
 }

--- a/Sources/TuistKit/Commands/FocusCommand.swift
+++ b/Sources/TuistKit/Commands/FocusCommand.swift
@@ -11,14 +11,14 @@ import TuistSupport
 
 enum FocusCommandError: FatalError {
     case noSources
-    
+
     var description: String {
         switch self {
         case .noSources:
             return "A list of targets is required: tuist focus MyTarget."
         }
     }
-    
+
     var type: ErrorType {
         switch self {
         case .noSources:
@@ -40,7 +40,7 @@ struct FocusCommand: ParsableCommand {
         completion: .directory
     )
     var path: String?
-    
+
     @Argument(help: "A list of targets in which you'd like to focus. Those and their dependant targets will be generated as sources.")
     var sources: [String] = []
 

--- a/Sources/TuistKit/GraphMappers/GraphMapperProvider.swift
+++ b/Sources/TuistKit/GraphMappers/GraphMapperProvider.swift
@@ -14,11 +14,11 @@ protocol GraphMapperProviding {
 
 final class GraphMapperProvider: GraphMapperProviding {
     fileprivate let cache: Bool
-    fileprivate let includeSources: Set<String>
+    fileprivate let sources: Set<String>
 
-    init(cache: Bool = false, includeSources: Set<String> = Set()) {
+    init(cache: Bool = false, sources: Set<String> = Set()) {
         self.cache = cache
-        self.includeSources = includeSources
+        self.sources = sources
     }
 
     func mapper(config: Config) -> GraphMapping {
@@ -32,7 +32,7 @@ final class GraphMapperProvider: GraphMapperProviding {
         if cache {
             let cacheMapper = CacheMapper(config: config,
                                           cacheStorageProvider: CacheStorageProvider(config: config),
-                                          sources: includeSources)
+                                          sources: sources)
             mappers.append(cacheMapper)
         }
 

--- a/Sources/TuistKit/Services/FocusService.swift
+++ b/Sources/TuistKit/Services/FocusService.swift
@@ -9,12 +9,12 @@ import TuistLoader
 import TuistSupport
 
 protocol FocusServiceProjectGeneratorFactorying {
-    func generator(cache: Bool, includeSources: Set<String>) -> ProjectGenerating
+    func generator(sources: Set<String>) -> ProjectGenerating
 }
 
 final class FocusServiceProjectGeneratorFactory: FocusServiceProjectGeneratorFactorying {
-    func generator(cache: Bool, includeSources: Set<String>) -> ProjectGenerating {
-        ProjectGenerator(graphMapperProvider: GraphMapperProvider(cache: cache, includeSources: includeSources))
+    func generator(sources: Set<String>) -> ProjectGenerating {
+        ProjectGenerator(graphMapperProvider: GraphMapperProvider(cache: true, sources: sources))
     }
 }
 
@@ -49,12 +49,12 @@ final class FocusService {
         self.projectGeneratorFactory = projectGeneratorFactory
     }
 
-    func run(cache: Bool, path: String?, includeSources: Set<String>, noOpen: Bool) throws {
+    func run(path: String?, sources: Set<String>, noOpen: Bool) throws {
         let path = self.path(path)
-        if isWorkspace(path: path), cache {
+        if isWorkspace(path: path) {
             throw FocusServiceError.cacheWorkspaceNonSupported
         }
-        let generator = projectGeneratorFactory.generator(cache: cache, includeSources: includeSources)
+        let generator = projectGeneratorFactory.generator(sources: sources)
         let workspacePath = try generator.generate(path: path, projectOnly: false)
         if !noOpen {
             try opener.open(path: workspacePath)

--- a/Sources/TuistKit/Services/FocusService.swift
+++ b/Sources/TuistKit/Services/FocusService.swift
@@ -51,7 +51,7 @@ final class FocusService {
 
     func run(path: String?, sources: Set<String>, noOpen: Bool) throws {
         let path = self.path(path)
-        if !isProject(path: path) {
+        if isWorkspace(path: path) {
             throw FocusServiceError.cacheWorkspaceNonSupported
         }
         let generator = projectGeneratorFactory.generator(sources: sources)
@@ -71,7 +71,7 @@ final class FocusService {
         }
     }
 
-    private func isProject(path: AbsolutePath) -> Bool {
-        manifestLoader.manifests(at: path).contains(.project)
+    private func isWorkspace(path: AbsolutePath) -> Bool {
+        manifestLoader.manifests(at: path).contains(.workspace)
     }
 }

--- a/Sources/TuistKit/Services/FocusService.swift
+++ b/Sources/TuistKit/Services/FocusService.swift
@@ -51,7 +51,7 @@ final class FocusService {
 
     func run(path: String?, sources: Set<String>, noOpen: Bool) throws {
         let path = self.path(path)
-        if isWorkspace(path: path) {
+        if !isProject(path: path) {
             throw FocusServiceError.cacheWorkspaceNonSupported
         }
         let generator = projectGeneratorFactory.generator(sources: sources)
@@ -71,7 +71,7 @@ final class FocusService {
         }
     }
 
-    private func isWorkspace(path: AbsolutePath) -> Bool {
-        manifestLoader.manifests(at: path).contains(.workspace)
+    private func isProject(path: AbsolutePath) -> Bool {
+        manifestLoader.manifests(at: path).contains(.project)
     }
 }

--- a/Sources/TuistKit/Services/GenerateService.swift
+++ b/Sources/TuistKit/Services/GenerateService.swift
@@ -9,7 +9,7 @@ protocol GenerateServiceProjectGeneratorFactorying {
 
 final class GenerateServiceProjectGeneratorFactory: GenerateServiceProjectGeneratorFactorying {
     func generator() -> ProjectGenerating {
-        ProjectGenerator(graphMapperProvider: GraphMapperProvider(cache: false, includeSources: Set()))
+        ProjectGenerator(graphMapperProvider: GraphMapperProvider(cache: false, sources: Set()))
     }
 }
 

--- a/Templates/Project+Templates.stencil
+++ b/Templates/Project+Templates.stencil
@@ -36,7 +36,7 @@ extension Project {
                 infoPlist: .default,
                 sources: ["Targets/\(name)/Tests/**"],
                 resources: [],
-                dependencies: [])
+                dependencies: [.target(name: name)])
         return [sources, tests]
     }
 

--- a/Tests/TuistCacheTests/Cache/CacheGraphMutatorTests.swift
+++ b/Tests/TuistCacheTests/Cache/CacheGraphMutatorTests.swift
@@ -77,7 +77,7 @@ final class CacheGraphMapperTests: TuistUnitTestCase {
         }
 
         // When
-        let got = try subject.map(graph: graph, xcframeworks: xcframeworks, sources: Set())
+        let got = try subject.map(graph: graph, xcframeworks: xcframeworks, sources: Set(["App"]))
 
         // Then
         let appNode = try XCTUnwrap(got.entryNodes.first as? TargetNode)
@@ -145,7 +145,7 @@ final class CacheGraphMapperTests: TuistUnitTestCase {
         }
 
         // When
-        let got = try subject.map(graph: graph, xcframeworks: xcframeworks, sources: Set())
+        let got = try subject.map(graph: graph, xcframeworks: xcframeworks, sources: Set(["App"]))
 
         // Then
         let app = try XCTUnwrap(got.entryNodes.first as? TargetNode)
@@ -217,7 +217,7 @@ final class CacheGraphMapperTests: TuistUnitTestCase {
         }
 
         // When
-        let got = try subject.map(graph: graph, xcframeworks: xcframeworks, sources: Set())
+        let got = try subject.map(graph: graph, xcframeworks: xcframeworks, sources: Set(["App"]))
 
         // Then
         let app = try XCTUnwrap(got.entryNodes.first as? TargetNode)
@@ -285,7 +285,7 @@ final class CacheGraphMapperTests: TuistUnitTestCase {
         }
 
         // When
-        let got = try subject.map(graph: graph, xcframeworks: xcframeworks, sources: Set())
+        let got = try subject.map(graph: graph, xcframeworks: xcframeworks, sources: Set(["App"]))
 
         // Then
         let app = try XCTUnwrap(got.entryNodes.first as? TargetNode)
@@ -328,7 +328,7 @@ final class CacheGraphMapperTests: TuistUnitTestCase {
         let graph = Graph.test(entryNodes: [appTargetNode], projects: graphProjects(targetNodes), targets: graphTargets(targetNodes))
 
         // When
-        let got = try subject.map(graph: graph, xcframeworks: [:], sources: Set())
+        let got = try subject.map(graph: graph, xcframeworks: [:], sources: Set(["App"]))
 
         // Then
         let app = try XCTUnwrap(got.entryNodes.first as? TargetNode)

--- a/Tests/TuistKitTests/Services/FocusServiceTests.swift
+++ b/Tests/TuistKitTests/Services/FocusServiceTests.swift
@@ -12,15 +12,15 @@ import XCTest
 final class MockFocusServiceProjectGeneratorFactory: FocusServiceProjectGeneratorFactorying {
     var invokedGenerator = false
     var invokedGeneratorCount = 0
-    var invokedGeneratorParameters: (cache: Bool, includeSources: Set<String>)?
-    var invokedGeneratorParametersList = [(cache: Bool, includeSources: Set<String>)]()
+    var invokedGeneratorParameters: (sources: Set<String>, Void)?
+    var invokedGeneratorParametersList = [(sources: Set<String>, Void)]()
     var stubbedGeneratorResult: ProjectGenerating!
 
-    func generator(cache: Bool, includeSources: Set<String>) -> ProjectGenerating {
+    func generator(sources: Set<String>) -> ProjectGenerating {
         invokedGenerator = true
         invokedGeneratorCount += 1
-        invokedGeneratorParameters = (cache, includeSources)
-        invokedGeneratorParametersList.append((cache, includeSources))
+        invokedGeneratorParameters = (sources, ())
+        invokedGeneratorParametersList.append((sources, ()))
         return stubbedGeneratorResult
     }
 }
@@ -64,7 +64,7 @@ final class FocusServiceTests: TuistUnitTestCase {
             throw error
         }
 
-        XCTAssertThrowsError(try subject.run(cache: false, path: nil, includeSources: Set(), noOpen: true)) {
+        XCTAssertThrowsError(try subject.run(path: nil, sources: Set(), noOpen: true)) {
             XCTAssertEqual($0 as NSError?, error)
         }
     }
@@ -76,7 +76,7 @@ final class FocusServiceTests: TuistUnitTestCase {
             workspacePath
         }
 
-        try subject.run(cache: false, path: nil, includeSources: Set(), noOpen: false)
+        try subject.run(path: nil, sources: Set(), noOpen: false)
 
         XCTAssertEqual(opener.openArgs.last?.0, workspacePath.pathString)
     }

--- a/features/cache.feature
+++ b/features/cache.feature
@@ -5,7 +5,7 @@ Feature: Focuses projects with pre-compiled cached dependencies
     And I have a working directory
     And I initialize a ios application named MyApp
     And tuist warms the cache
-    When tuist focuses a project with cached targets 
+    When tuist focuses the target MyApp
     Then MyApp links the xcframework MyAppKit
     Then MyApp embeds the xcframework MyAppKit
     Then MyApp embeds the xcframework MyAppUI
@@ -17,7 +17,7 @@ Scenario: The project is an application (ios_workspace_with_microfeature_archite
     And I have a working directory
     Then I copy the fixture ios_workspace_with_microfeature_architecture into the working directory
     And tuist warms the cache
-    When tuist focuses a project with cached targets at App
+    When tuist focuses the target App at App
     Then App embeds the xcframework Core
     Then App embeds the xcframework Data
     Then App embeds the xcframework FeatureContracts
@@ -31,7 +31,7 @@ Scenario: The project is an application and a target is modified after being cac
     Then I copy the fixture ios_workspace_with_microfeature_architecture into the working directory
     And tuist warms the cache
     And I add an empty line at the end of the file Frameworks/FeatureAFramework/Sources/FrameworkA.swift
-    When tuist focuses a project with cached targets at App
+    When tuist focuses the target App at App
     Then App embeds the xcframework Core
     Then App embeds the xcframework Data
     Then App embeds the framework FrameworkA
@@ -46,7 +46,7 @@ Scenario: The project is an application and a target is generated as sources (io
     And I have a working directory
     Then I copy the fixture ios_workspace_with_microfeature_architecture into the working directory
     And tuist warms the cache
-    When tuist focuses a project with cached targets with sources FrameworkA at App
+    When tuist focuses the targets App,FrameworkA at App
     Then App embeds the xcframework Core
     Then App embeds the xcframework Data
     Then App embeds the framework FrameworkA

--- a/features/step_definitions/shared/tuist.rb
+++ b/features/step_definitions/shared/tuist.rb
@@ -24,20 +24,20 @@ Then(/^tuist generates the project at (.+)$/) do |path|
   @xcodeproj_path = Dir.glob(File.join(@dir, path, "*.xcodeproj")).first
 end
 
-Then(/^tuist focuses a project with cached targets at (.+)$/) do |path|
-  system("swift", "run", "tuist", "focus", "--no-open", "--path", File.join(@dir, path), "--cache")
-  @workspace_path = Dir.glob(File.join(@dir, path, "*.xcworkspace")).first
-  @xcodeproj_path = Dir.glob(File.join(@dir, path, "*.xcodeproj")).first
-end
-
-Then(/^tuist focuses a project with cached targets$/) do
-  system("swift", "run", "tuist", "focus", "--no-open", "--path", @dir, "--cache")
+Then(/^tuist focuses the target ([a-zA-Z]+)$/) do |target|
+  system("swift", "run", "tuist", "focus", "--no-open", "--path", @dir, target)
   @workspace_path = Dir.glob(File.join(@dir, "*.xcworkspace")).first
   @xcodeproj_path = Dir.glob(File.join(@dir, "*.xcodeproj")).first
 end
 
-Then(/^tuist focuses a project with cached targets with sources ([a-zA-Z]+) at (.+)$/) do |sources, path|
-  system("swift", "run", "tuist", "focus", "--no-open", "--path", File.join(@dir, path), "--cache", "--include-sources", sources)
+Then(/^tuist focuses the target ([a-zA-Z]+) at (.+)$/) do |target, path|
+  system("swift", "run", "tuist", "focus", "--no-open", "--path", File.join(@dir, path), target)
+  @workspace_path = Dir.glob(File.join(@dir, path, "*.xcworkspace")).first
+  @xcodeproj_path = Dir.glob(File.join(@dir, path, "*.xcodeproj")).first
+end
+
+Then(/^tuist focuses the targets ([a-zA-Z,]+) at (.+)$/) do |targets, path|
+  system("swift", "run", "tuist", "focus", "--no-open", "--path", File.join(@dir, path), *targets.split(","))
   @workspace_path = Dir.glob(File.join(@dir, path, "*.xcworkspace")).first
   @xcodeproj_path = Dir.glob(File.join(@dir, path, "*.xcodeproj")).first
 end

--- a/website/markdown/docs/commands/focus.mdx
+++ b/website/markdown/docs/commands/focus.mdx
@@ -1,0 +1,25 @@
+---
+name: Focus on targets
+excerpt: 'Learn how to generate projects with the focus on specific targets removing the unnecessary targets and schemes, and replacing direct and transitive dependencies with pre-compiled targets from the cache.'
+---
+
+# Focus on targets
+
+In large Xcode projects that contain many targets and schemes, Xcode can be slow indexing the project.
+Moreover, the build system, which needs to resolve implicit dependencies, might take longer to do so because there are more Xcode objects to analyze.
+This is **not ideal for developers' productivity** and for that reason Tuist includes a command that allows users to focus on a specific target or set of targets.
+
+```bash
+tuist focus MyApp
+```
+
+The command generates and opens an Xcode workspace where the targets and schemes that are not directly related to `MyApp` are removed.
+Moreover, if the direct and transitive dependencies exist in the [cache](/docs/usage/caching/),
+Tuist replaces them with their pre-compiled version.
+Thanks to that developers can safely clean their Xcode environment because they'll only be building the target they are focusing on.
+
+<Message
+  info
+  title="Only compatible with Project.swift"
+  description="Since Tuist generates a workspace that is optimized for the user's intent, Tuist needs to own the structure of the workspace. For that reason this command only works with directories that contain a `Project.swift` and not a `Workspace.swift`."
+/>

--- a/website/markdown/docs/links.mdx
+++ b/website/markdown/docs/links.mdx
@@ -30,6 +30,7 @@ import DocTitle from './components/doc-title'
 
 - [Edit your projects](/docs/commands/edit/)
 - [Generate projects](/docs/commands/generate/)
+- [Focus on targets](/docs/commands/focus/)
 - [Sign your apps](/docs/commands/signing/)
 - [Build schemes](/docs/commands/build/)
 - [Scaffold files](/docs/commands/scaffold/)

--- a/website/markdown/docs/usage/best-practices.mdx
+++ b/website/markdown/docs/usage/best-practices.mdx
@@ -39,3 +39,12 @@ Adding `tuist` to your project will require you to have installed it in your CI 
 - Bundle it: `tuist bundle`
 - Commit the added files into git
 - Run `tuist` using `.tuist-bin/tuist generate` in your CI
+
+## Workspace.swift vs Project.swift
+
+Even though we support aggregating multiple projects into a workspace using the `Workspace.swift` manifest.
+We recommend **one project with multiple targets** over one workspace with multiple projects.
+Having an Xcode workspace is useful when projects are part of the Git repository because it helps reduce the likelihood of conflicts.
+However, that's not an issue in Tuist because projects don't need to be part of the repository.
+
+Moreover, having a single project allows using the [focus](/docs/commands/focus/) feature to generate optimized projects with dependencies from the cache.


### PR DESCRIPTION
### Short description 📝
I'm changing the behavior of the focus command to:
```
tuist focus MyTarget
```
- The cache is **enabled by default**
- The list of targets is **required** to indicate the target
- It only works in a directory that has a `Project.swift`.

As part of this PR I also added a new page to the documentation explaining what the "focus" command is for.