### PR TITLE
Perform bootstrap instead of update within UpCarthage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+- **Breaking** UpCarthage should perform bootstrap instead of update by [@softmaxsg](https://github.com/softmaxsg)
+
 ## 1.17.0 - Luft
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
-- **Breaking** UpCarthage should perform bootstrap instead of update by [@softmaxsg](https://github.com/softmaxsg)
+- **Breaking** UpCarthage should perform bootstrap instead of update [#1744](https://github.com/tuist/tuist/pull/1744) by [@softmaxsg](https://github.com/softmaxsg)
 
 ## 1.17.0 - Luft
 

--- a/Sources/TuistLoader/Up/Carthage.swift
+++ b/Sources/TuistLoader/Up/Carthage.swift
@@ -12,14 +12,14 @@ struct CarthageVersionFile: Codable {
 
 /// Protocol that defines an interface to interact with a local Carthage setup.
 protocol Carthaging {
-    /// Updates the dependencies in the given directory.
+    /// Bootstraps the dependencies in the given directory.
     ///
     /// - Parameters:
     ///   - path: Directory where the Carthage dependencies are defined.
-    ///   - platforms: Platforms the dependencies will be updated for.
-    ///   - dependencies: Dependencies to update
-    /// - Throws: An error if the dependencies update fails.
-    func update(path: AbsolutePath, platforms: [Platform], dependencies: [String]) throws
+    ///   - platforms: Platforms the dependencies will be bootstraped for.
+    ///   - dependencies: Dependencies to bootstrap
+    /// - Throws: An error if the dependencies bootstrap fails.
+    func bootstrap(path: AbsolutePath, platforms: [Platform], dependencies: [String]) throws
 
     /// Returns the list of outdated dependencies in the given directory.
     ///
@@ -33,18 +33,18 @@ final class Carthage: Carthaging {
     // swiftlint:disable:next force_try
     static let resolvedLineRegex = try! NSRegularExpression(pattern: "(github|git|binary) \"([^\"]+)\" \"([^\"]+)\"", options: [])
 
-    /// Updates the dependencies in the given directory.
+    /// Bootstraps the dependencies in the given directory.
     ///
     /// - Parameters:
     ///   - path: Directory where the Carthage dependencies are defined.
-    ///   - platforms: Platforms the dependencies will be updated for.
-    ///   - dependencies: Dependencies to update
-    /// - Throws: An error if the dependencies update fails.
-    func update(path: AbsolutePath, platforms: [Platform], dependencies: [String]) throws {
+    ///   - platforms: Platforms the dependencies will be bootstraped for.
+    ///   - dependencies: Dependencies to bootstrap
+    /// - Throws: An error if the dependencies bootstrap fails.
+    func bootstrap(path: AbsolutePath, platforms: [Platform], dependencies: [String]) throws {
         let carthagePath = try System.shared.which("carthage")
 
         var command: [String] = [carthagePath]
-        command.append("update")
+        command.append("bootstrap")
         command.append("--project-directory")
         command.append(path.pathString)
 

--- a/Sources/TuistLoader/Up/UpCarthage.swift
+++ b/Sources/TuistLoader/Up/UpCarthage.swift
@@ -3,9 +3,9 @@ import TSCBasic
 import TuistCore
 import TuistSupport
 
-/// Up that updates outdated Carthage dependencies.
+/// Up that bootstraps outdated Carthage dependencies.
 class UpCarthage: Up, GraphInitiatable {
-    /// The platforms Carthage dependencies should be updated for.
+    /// The platforms Carthage dependencies should be bootstraped for.
     let platforms: [Platform]
 
     /// Up homebrew for installing Carthge.
@@ -17,7 +17,7 @@ class UpCarthage: Up, GraphInitiatable {
     /// Initializes the Carthage command.
     ///
     /// - Parameters:
-    ///   - platforms: The platforms Carthage dependencies should be updated for.
+    ///   - platforms: The platforms Carthage dependencies should be bootstraped for.
     ///   - upHomebrew: Up homebrew for installing Carthage.
     ///   - carthage: Carthage instace to interact with the project Carthage setup.
     init(platforms: [Platform],
@@ -27,7 +27,7 @@ class UpCarthage: Up, GraphInitiatable {
         self.platforms = platforms
         self.upHomebrew = upHomebrew
         self.carthage = carthage
-        super.init(name: "Carthage update")
+        super.init(name: "Carthage bootstrap")
     }
 
     /// Default constructor of entities that are part of the manifest.
@@ -69,9 +69,9 @@ class UpCarthage: Up, GraphInitiatable {
             try upHomebrew.meet(projectPath: projectPath)
         }
 
-        /// Updating Carthage dependencies.
+        /// Bootstraping Carthage dependencies.
         let oudated = try carthage.outdated(path: projectPath) ?? []
-        try carthage.update(path: projectPath, platforms: platforms, dependencies: oudated)
+        try carthage.bootstrap(path: projectPath, platforms: platforms, dependencies: oudated)
     }
 
     func whatever() {}

--- a/Tests/TuistLoaderTests/Up/CarthageTests.swift
+++ b/Tests/TuistLoaderTests/Up/CarthageTests.swift
@@ -19,7 +19,7 @@ final class CarthageTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_update() throws {
+    func test_bootstrap() throws {
         let temporaryPath = try self.temporaryPath()
         system.whichStub = { tool in
             if tool == "carthage" {
@@ -28,12 +28,12 @@ final class CarthageTests: TuistUnitTestCase {
                 throw NSError.test()
             }
         }
-        system.succeedCommand("/path/to/carthage", "update", "--project-directory", temporaryPath.pathString, "--platform", "iOS,macOS", "Alamofire",
+        system.succeedCommand("/path/to/carthage", "bootstrap", "--project-directory", temporaryPath.pathString, "--platform", "iOS,macOS", "Alamofire",
                               output: "")
 
-        try subject.update(path: temporaryPath,
-                           platforms: [.iOS, .macOS],
-                           dependencies: ["Alamofire"])
+        try subject.bootstrap(path: temporaryPath,
+                              platforms: [.iOS, .macOS],
+                              dependencies: ["Alamofire"])
     }
 
     func test_outdated() throws {

--- a/Tests/TuistLoaderTests/Up/Mocks/MockCarthage.swift
+++ b/Tests/TuistLoaderTests/Up/Mocks/MockCarthage.swift
@@ -7,16 +7,16 @@ import TuistCore
 final class MockCarthage: Carthaging {
     var outdatedStub: ((AbsolutePath) throws -> [String]?)?
     var outdatedCallCount: UInt = 0
-    var updateStub: ((AbsolutePath, [Platform], [String]) throws -> Void)?
-    var updateCallCount: UInt = 0
+    var bootstrapStub: ((AbsolutePath, [Platform], [String]) throws -> Void)?
+    var bootstrapCallCount: UInt = 0
 
     func outdated(path: AbsolutePath) throws -> [String]? {
         outdatedCallCount += 1
         return try outdatedStub?(path) ?? nil
     }
 
-    func update(path: AbsolutePath, platforms: [Platform], dependencies: [String]) throws {
-        updateCallCount += 1
-        try updateStub?(path, platforms, dependencies)
+    func bootstrap(path: AbsolutePath, platforms: [Platform], dependencies: [String]) throws {
+        bootstrapCallCount += 1
+        try bootstrapStub?(path, platforms, dependencies)
     }
 }

--- a/Tests/TuistLoaderTests/Up/UpCarthageTests.swift
+++ b/Tests/TuistLoaderTests/Up/UpCarthageTests.swift
@@ -94,7 +94,7 @@ final class UpCarthageTests: TuistUnitTestCase {
         carthage.outdatedStub = { _ in
             ["Dependency"]
         }
-        carthage.updateStub = { projectPath, platforms, dependencies in
+        carthage.bootstrapStub = { projectPath, platforms, dependencies in
             XCTAssertEqual(projectPath, temporaryPath)
             XCTAssertEqual(platforms, self.platforms)
             XCTAssertEqual(dependencies, ["Dependency"])
@@ -103,6 +103,6 @@ final class UpCarthageTests: TuistUnitTestCase {
         try subject.meet(projectPath: temporaryPath)
 
         XCTAssertEqual(upHomebrew.meetCallCount, 0)
-        XCTAssertEqual(carthage.updateCallCount, 1)
+        XCTAssertEqual(carthage.bootstrapCallCount, 1)
     }
 }

--- a/Tests/TuistLoaderTests/Up/UpTests.swift
+++ b/Tests/TuistLoaderTests/Up/UpTests.swift
@@ -61,7 +61,7 @@ final class UpTests: TuistUnitTestCase {
             "platforms": JSON.array([JSON.string("macos")]),
         ])
         let got = try Up.with(dictionary: dictionary, projectPath: temporaryPath) as? UpCarthage
-        XCTAssertEqual(got?.name, "Carthage update")
+        XCTAssertEqual(got?.name, "Carthage bootstrap")
         XCTAssertEqual(got?.platforms, [.macOS])
     }
 

--- a/website/markdown/docs/commands/up.mdx
+++ b/website/markdown/docs/commands/up.mdx
@@ -13,7 +13,7 @@ Most projects include a list of steps in the `README` file for developers to fol
 1. Clone the repository.
 2. Install Carthage if it's not already installed.
 3. Install `brew install swiftlint`.
-4. Run `carthage update`.
+4. Run `carthage bootstrap`.
 5. Open the project.
 ```
 
@@ -36,7 +36,7 @@ let setup = Setup([
 
 We have turned the markdown steps that we saw before into up commands in the setup manifest. When you run `tuist up`, Tuist translates those declarations into actual commands that are executed in your system.
 
-Moreover, it assesses whether those dependencies are already met in the environment, and if they are, it skips them. For instance, if the Carthage dependencies exist and are up to date, it doesn’t run the Carthage update command.
+Moreover, it assesses whether those dependencies are already met in the environment, and if they are, it skips them. For instance, if the Carthage dependencies exist and are up to date, it doesn’t run the Carthage bootstrap command.
 
 ```bash
 tuist up


### PR DESCRIPTION
Resolves #1634 

### Short description 📝

Currently `UpCarthage` performs `carthage update` which updates all dependencies and doesn't use the `Cartfile.resolved` file with resolved dependencies.

To be able to set the project up with the resolved dependencies it's necessary to perform `carthage bootstrap` instead of `carthage update`.

### Solution 📦

The solution is pretty straightforward - replace the `update` command with `bootstrap`.
