### PR TITLE
`GraphCommand.format` - standardize implementation and documentation 

### DIFF
--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -29,7 +29,7 @@ struct GraphCommand: ParsableCommand {
         name: [.customShort("f"), .long],
         help: "Available formats: dot, png"
     )
-    var format: GraphFormat = .dot
+    var format: GraphFormat = .png
 
     @Option(
         name: [.customShort("a"), .customLong("algorithm")],


### PR DESCRIPTION
### Short description 📝

I noticed that default value of graph's `format` generated by `tuist graph` does not match to documentation. I had have a quick conversation with @pepibumur about where we should make a fix, in the code or in the docs. We had agreed that in the code.

### Solution 📦 

I have fixed that by setting `.png` as default value of graph's `format`.
