### PR TITLE
tuist lint code with environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- Added `tuist lint code` support for custom .swiftlint.yml files. [1764](https://github.com/tuist/tuist/pull/1764) by [@facumenzella](https://github.com/facumenzella)
+
 ## 1.18.0 - Himalaya
 
 ### Fixed

--- a/Tests/TuistKitTests/Generator/Mocks/MockCodeLinter.swift
+++ b/Tests/TuistKitTests/Generator/Mocks/MockCodeLinter.swift
@@ -7,11 +7,11 @@ import TuistGenerator
 final class MockCodeLinter: CodeLinting {
     var invokedLint = false
     var invokedLintCount = 0
-    var invokedLintParameters: (sources: AbsolutePath, path: AbsolutePath)?
-    var invokedLintParametersList = [(sources: AbsolutePath, path: AbsolutePath)]()
+    var invokedLintParameters: (sources: [AbsolutePath], path: AbsolutePath)?
+    var invokedLintParametersList = [(sources: [AbsolutePath], path: AbsolutePath)]()
     var stubbedLintError: Error?
 
-    func lint(sources: AbsolutePath, path: AbsolutePath) throws {
+    func lint(sources: [AbsolutePath], path: AbsolutePath) throws {
         invokedLint = true
         invokedLintCount += 1
         invokedLintParameters = (sources, path)

--- a/Tests/TuistKitTests/Lint/CodeLinterTests.swift
+++ b/Tests/TuistKitTests/Lint/CodeLinterTests.swift
@@ -38,7 +38,12 @@ final class CodeLinterTests: TuistUnitTestCase {
     func test_lint_throws_an_error_when_binary_no_found() {
         // Given
         let fakeError = TestError("binaryNotFound")
-        let fakeSources = AbsolutePath("/xyz/abc")
+        let fakeSources = [
+            AbsolutePath("/xyz/abc"),
+            AbsolutePath("/xyz/def"),
+            AbsolutePath("/xyz/hij"),
+        ]
+
         let fakePath = AbsolutePath("/foo/bar")
         binaryLocator.stubbedSwiftLintPathError = fakeError
 
@@ -48,12 +53,16 @@ final class CodeLinterTests: TuistUnitTestCase {
 
     func test_lint_no_configuration() throws {
         // Given
-        let fakeSources = AbsolutePath("/xyz/abc")
+        let fakeSources = [
+            AbsolutePath("/xyz/abc"),
+            AbsolutePath("/xyz/def"),
+            AbsolutePath("/xyz/hij"),
+        ]
         let fakePath = AbsolutePath("/foo/bar")
         binaryLocator.stubbedSwiftLintPathResult = "/swiftlint"
         system.succeedCommand(binaryLocator.stubbedSwiftLintPathResult.pathString,
                               "lint",
-                              fakeSources.pathString)
+                              "--use-script-input-files")
 
         // When
         try subject.lint(sources: fakeSources, path: fakePath)
@@ -61,18 +70,29 @@ final class CodeLinterTests: TuistUnitTestCase {
 
     func test_lint_with_configuration_yml() throws {
         // Given
-        let fakeSources = AbsolutePath("/xyz/abc")
+        let fakeSources = [
+            AbsolutePath("/xyz/abc"),
+            AbsolutePath("/xyz/def"),
+            AbsolutePath("/xyz/hij"),
+        ]
         let fakePath = AbsolutePath("/foo/bar")
         let fakeRoot = AbsolutePath("/root")
         let fakeSwiftLintPath = AbsolutePath("/swiftlint")
-        let swiftLintConfigPath = fakeRoot.appending(RelativePath("\(Constants.tuistDirectoryName)/swiftlint.yml"))
+        let swiftLintConfigPath = fakeRoot.appending(RelativePath("\(Constants.tuistDirectoryName)/.swiftlint.yml"))
 
         rootDirectoryLocator.locateStub = fakeRoot
         binaryLocator.stubbedSwiftLintPathResult = fakeSwiftLintPath
         fileHandler.stubExists = { $0 == swiftLintConfigPath }
+
+        system.env = [
+            "SCRIPT_INPUT_FILE_COUNT": "3",
+            "SCRIPT_INPUT_FILE_0": fakeSources[0].pathString,
+            "SCRIPT_INPUT_FILE_1": fakeSources[1].pathString,
+            "SCRIPT_INPUT_FILE_2": fakeSources[2].pathString,
+        ]
         system.succeedCommand(binaryLocator.stubbedSwiftLintPathResult.pathString,
                               "lint",
-                              fakeSources.pathString,
+                              "--use-script-input-files",
                               "--config",
                               swiftLintConfigPath.pathString)
 
@@ -82,18 +102,22 @@ final class CodeLinterTests: TuistUnitTestCase {
 
     func test_lint_with_configuration_yaml() throws {
         // Given
-        let fakeSources = AbsolutePath("/xyz/abc")
+        let fakeSources = [
+            AbsolutePath("/xyz/abc"),
+            AbsolutePath("/xyz/def"),
+            AbsolutePath("/xyz/hij"),
+        ]
         let fakePath = AbsolutePath("/foo/bar")
         let fakeRoot = AbsolutePath("/root")
         let fakeSwiftLintPath = AbsolutePath("/swiftlint")
-        let swiftLintConfigPath = fakeRoot.appending(RelativePath("\(Constants.tuistDirectoryName)/swiftlint.yaml"))
+        let swiftLintConfigPath = fakeRoot.appending(RelativePath("\(Constants.tuistDirectoryName)/.swiftlint.yaml"))
 
         rootDirectoryLocator.locateStub = fakeRoot
         binaryLocator.stubbedSwiftLintPathResult = fakeSwiftLintPath
         fileHandler.stubExists = { $0 == swiftLintConfigPath }
         system.succeedCommand(binaryLocator.stubbedSwiftLintPathResult.pathString,
                               "lint",
-                              fakeSources.pathString,
+                              "--use-script-input-files",
                               "--config",
                               swiftLintConfigPath.pathString)
 

--- a/Tests/TuistKitTests/Services/Lint/LintCodeServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Lint/LintCodeServiceTests.swift
@@ -127,7 +127,14 @@ final class LintCodeServiceTests: TuistUnitTestCase {
         let invokedLintParameters = codeLinter.invokedLintParameters
 
         XCTAssertEqual(codeLinter.invokedLintCount, 1)
-        XCTAssertEqual(invokedLintParameters?.sources, "/rootPath")
+        XCTAssertEqual(invokedLintParameters?.sources, [
+            "/target01/file1.swift",
+            "/target01/file2.swift",
+            "/target02/file1.swift",
+            "/target02/file2.swift",
+            "/target02/file3.swift",
+            "/target03/file1.swift",
+        ])
         XCTAssertEqual(invokedLintParameters?.path, path)
 
         XCTAssertPrinterOutputContains("""
@@ -169,7 +176,14 @@ final class LintCodeServiceTests: TuistUnitTestCase {
         let invokedLintParameters = codeLinter.invokedLintParameters
 
         XCTAssertEqual(codeLinter.invokedLintCount, 1)
-        XCTAssertEqual(invokedLintParameters?.sources, "/rootPath")
+        XCTAssertEqual(invokedLintParameters?.sources, [
+            "/target01/file1.swift",
+            "/target01/file2.swift",
+            "/target02/file1.swift",
+            "/target02/file2.swift",
+            "/target02/file3.swift",
+            "/target03/file1.swift",
+        ])
         XCTAssertEqual(invokedLintParameters?.path, path)
 
         XCTAssertPrinterOutputContains("""
@@ -208,7 +222,10 @@ final class LintCodeServiceTests: TuistUnitTestCase {
         let invokedLintParameters = codeLinter.invokedLintParameters
 
         XCTAssertEqual(codeLinter.invokedLintCount, 1)
-        XCTAssertEqual(invokedLintParameters?.sources, "/target01")
+        XCTAssertEqual(invokedLintParameters?.sources, [
+            "/target01/file1.swift",
+            "/target01/file2.swift",
+        ])
         XCTAssertEqual(invokedLintParameters?.path, path)
 
         XCTAssertPrinterOutputContains("""


### PR DESCRIPTION
[Resolves](url) https://github.com/tuist/tuist/issues/1737

### Short description 📝

As @laxmorek describes, Swiftlint has an [issue](https://github.com/realm/SwiftLint/issues/3038) while linting multiple files with a custom configuration.
Fortunately, there's an approach that relies on environment variables that does the trick.

I've been using this approach at my last job, combining different swiftlint.yml based on different rules.

### Implementation 👩‍💻👨‍💻

- Set `SCRIPT_INPUT_FILE_COUNT`
- Set `SCRIPT_INPUT_FILE_COUNT_#{n}` for each file
- Use`--use-script-input-files`