### PR TITLE
Init dashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- Support initializing projects with dashes [#1766](https://github.com/tuist/tuist/pull/1766) by [@fortmarek](https://github.com/fortmarek)
+
 ### Added
 
 - Possibility to build schemes that are not part of any entry node [#1761](https://github.com/tuist/tuist/pull/1761) by [@fortmarek](htttps://github.com/fortmarek)

--- a/Package.swift
+++ b/Package.swift
@@ -159,7 +159,7 @@ let package = Package(
         ),
         .target(
             name: "TuistScaffold",
-            dependencies: ["SwiftToolsSupport-auto", "TuistCore", "TuistSupport", "Stencil"]
+            dependencies: ["SwiftToolsSupport-auto", "TuistCore", "TuistSupport", "StencilSwiftKit", "Stencil"]
         ),
         .target(
             name: "TuistScaffoldTesting",

--- a/Sources/TuistKit/Services/InitService.swift
+++ b/Sources/TuistKit/Services/InitService.swift
@@ -175,13 +175,15 @@ class InitService {
     }
 
     private func name(_ name: String?, path: AbsolutePath) throws -> String {
+        let initName: String
         if let name = name {
-            return name
+            initName = name
         } else if let name = path.components.last {
-            return name
+            initName = name
         } else {
             throw InitServiceError.ungettableProjectName(AbsolutePath.current)
         }
+        return initName.camelized.uppercasingFirst
     }
 
     private func path(_ path: String?) -> AbsolutePath {

--- a/Sources/TuistScaffold/TemplateGenerator.swift
+++ b/Sources/TuistScaffold/TemplateGenerator.swift
@@ -1,5 +1,5 @@
 import Foundation
-import struct Stencil.Environment
+import func StencilSwiftKit.stencilSwiftEnvironment
 import TSCBasic
 import TuistCore
 import TuistSupport
@@ -68,7 +68,7 @@ public final class TemplateGenerator: TemplateGenerating {
                                attributes: [String: String],
                                destinationPath: AbsolutePath) throws
     {
-        let environment = Environment()
+        let environment = stencilSwiftEnvironment()
         try renderedFiles.forEach {
             let renderedContents: String
             switch $0.contents {

--- a/Templates/AppProject.stencil
+++ b/Templates/AppProject.stencil
@@ -22,4 +22,4 @@ import ProjectDescriptionHelpers
 // Creates our project using a helper function defined in ProjectDescriptionHelpers
 let project = Project.app(name: "{{ name }}",
                           platform: .{{ platform }},
-                          additionalTargets: ["{{name }}Kit", "{{name}}UI"])
+                          additionalTargets: ["{{name}}Kit", "{{name}}UI"])

--- a/Templates/AppProject.stencil
+++ b/Templates/AppProject.stencil
@@ -22,4 +22,4 @@ import ProjectDescriptionHelpers
 // Creates our project using a helper function defined in ProjectDescriptionHelpers
 let project = Project.app(name: "{{ name }}",
                           platform: .{{ platform }},
-                          additionalTargets: ["{{name}}Kit", "{{name}}UI"])
+                          additionalTargets: ["{{name }}Kit", "{{name}}UI"])

--- a/Tests/TuistKitTests/Services/InitServiceTests.swift
+++ b/Tests/TuistKitTests/Services/InitServiceTests.swift
@@ -53,14 +53,14 @@ final class InitServiceTests: TuistUnitTestCase {
         templatesDirectoryLocator.templateDirectoriesStub = { _ in
             [defaultTemplatePath]
         }
-        let expectedAttributes = ["name": "name", "platform": "macOS"]
+        let expectedAttributes = ["name": "Name", "platform": "macOS"]
         var generatorAttributes: [String: String] = [:]
         templateGenerator.generateStub = { _, _, attributes in
             generatorAttributes = attributes
         }
 
         // When
-        try subject.testRun(name: "name", platform: "macos")
+        try subject.testRun(name: "Name", platform: "macos")
 
         // Then
         XCTAssertEqual(expectedAttributes, generatorAttributes)
@@ -72,14 +72,14 @@ final class InitServiceTests: TuistUnitTestCase {
         templatesDirectoryLocator.templateDirectoriesStub = { _ in
             [defaultTemplatePath]
         }
-        let expectedAttributes = ["name": "name", "platform": "iOS"]
+        let expectedAttributes = ["name": "Name", "platform": "iOS"]
         var generatorAttributes: [String: String] = [:]
         templateGenerator.generateStub = { _, _, attributes in
             generatorAttributes = attributes
         }
 
         // When
-        try subject.testRun(name: "name")
+        try subject.testRun(name: "Name")
 
         // Then
         XCTAssertEqual(expectedAttributes, generatorAttributes)

--- a/features/init.feature
+++ b/features/init.feature
@@ -10,7 +10,7 @@ Feature: Initialize a new project using Tuist
   Scenario: The project is a compilable iOS application
     Given that tuist is available
     And I have a working directory
-    When I initialize a ios application named MyApp
+    When I initialize a ios application named My-App
     Then tuist generates the project
     Then I should be able to build for iOS the scheme MyApp
 

--- a/website/markdown/docs/commands/scaffold.mdx
+++ b/website/markdown/docs/commands/scaffold.mdx
@@ -47,6 +47,6 @@ tuist scaffold name_of_template --name Name --platform macos
 
 Since platform is an optional argument, we can also call the command without the `--platform macos` argument.
 
-If `.string` and `.files` don't provide enough flexibility, you can leverage the [Stencil](https://github.com/stencilproject/Stencil) templating language via the `.file` case.
+If `.string` and `.files` don't provide enough flexibility, you can leverage the [Stencil](https://github.com/stencilproject/Stencil) templating language via the `.file` case. Besides that, you can also use additional filters defined [here](https://github.com/SwiftGen/StencilSwiftKit#filters)
 
 Templates can import [project description helpers](/docs/usage/helpers/). Just add `import ProjectDescriptionHelpers` at the top, and extract reusable logic into the helpers.


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1741

### Short description 📝

Target with dashes is unsupported, we should support them.

### Solution 📦

To fix it we are now camelizing the name of the initialized project with already-defined `camelized` function

### Implementation 👩‍💻👨‍💻

> Detail in a checklist the steps that you took to implement the PR.

- [x] Implement
- [x] Add acceptance test to catch this
- [x] Add changelog
