### PR TITLE
Feature/release automation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,19 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: master
+          fetch-depth: 0
+      - name: Create a new release
+        uses: fortmarek/tapestry-action@0.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,19 +2,9 @@
 
 This document describes the process of releasing new versions of tuist.
 
-1.  First make sure you are in master and the latest changes are pulled: `git pull origin master`
-2.  Ensure that the project is in a releasable state by running the tests: `swift test` and `bundle exec rake features`.
-3.  Determine the new version:
+1.  Determine the new version:
 
 - Major if there's been a breaking change.
 - Minor by default.
 - Patch if it's a hotfix release.
-
-4.  Update the version in the `Constants.swift` file.
-5.  Update the `CHANGELOG.md` to include the version section.
-6.  Commit the changes and tag the commit with the version `git tag x.y.z`.
-7.  Select the Xcode version 11.5 before building the binaries: `sudo xcode-select -s /Applications/Xcode_11.5.app`.
-8.  Package and upload the release to GCS by running `bundle exec rake release`.
-9.  Upload the installation scripts to GCS by running `bundle exec rake release_scripts`.
-10. Create a release on GitHub with the version as a title, the body from the CHANGELOG file, and attach the artifacts in the `build/` directory.
-11. Run `tuist update` and verify that the new version is installed and runs.
+2. Run `tapestry github-release version-number` (eg `tapestry github-release 1.1.0`) *(Install [tapestry](https://github.com/ackeecz/tapestry) and [tuist](https://github.com/tuist/tuist) if you don't have them installed already)*.

--- a/TapestryConfig.swift
+++ b/TapestryConfig.swift
@@ -1,0 +1,35 @@
+import TapestryDescription
+
+let config = TapestryConfig(
+    release: Release(
+        actions:
+        [
+            .pre(tool: "git", arguments: ["checkout", "master"]),
+            .pre(tool: "git", arguments: ["pull"]),
+            .pre(.dependenciesCompatibility([.spm(.all)])),
+            .pre(tool: "swift", arguments: ["test"]),
+            .pre(tool: "bundle", arguments: ["exec", "rake", "features"]),
+            .pre(.docsUpdate),
+            .pre(tool: "sudo", arguments: ["xcode-select", "-s", "/Applications/Xcode_11.5.app"]),
+            .post(tool: "bundle", arguments: ["exec", "rake", "release"]),
+            .post(tool: "bundle", arguments: ["exec", "rake", "release_scripts"]),
+            .post(
+                .githubRelease(
+                    owner: "tuist",
+                    repository: "xcodeproj",
+                    assetPaths: [
+                        "build/tuist.zip",
+                        "build/tuistenv.zip",
+                    ]
+                )
+            )
+        ],
+        add: [
+            "README.md",
+            "xcodeproj.podspec",
+            "CHANGELOG.md"
+        ],
+        commitMessage: "Version \(Argument.version)",
+        push: true
+    )
+)

--- a/TapestryConfig.swift
+++ b/TapestryConfig.swift
@@ -16,7 +16,7 @@ let config = TapestryConfig(
             .post(
                 .githubRelease(
                     owner: "tuist",
-                    repository: "xcodeproj",
+                    repository: "tuist",
                     assetPaths: [
                         "build/tuist.zip",
                         "build/tuistenv.zip",
@@ -25,8 +25,6 @@ let config = TapestryConfig(
             )
         ],
         add: [
-            "README.md",
-            "xcodeproj.podspec",
             "CHANGELOG.md"
         ],
         commitMessage: "Version \(Argument.version)",


### PR DESCRIPTION
### Short description 📝

Creating a release should be an automated process. Ideally, we should not even think about creating a new release and it should be done eg. every Friday.

### Solution 📦

For this task we can use [tapestry](https://github.com/ackeecz/tapestry) which now has a github action, too. As the first step, I'd run `tapestry` manually and once we validate it all works we can run the release automatically without us even doing anything.

