### PR TITLE
Enable debugging Tuist in Xcode

### DIFF
--- a/Sources/TuistLoader/Utils/ProjectDescriptionPaths.swift
+++ b/Sources/TuistLoader/Utils/ProjectDescriptionPaths.swift
@@ -1,0 +1,92 @@
+import Foundation
+import TSCBasic
+
+/// Project Description Paths
+///
+/// A small utility that works out the various search paths needed
+/// for a given `ProjectDescription` library.
+struct ProjectDescriptionSearchPaths {
+    enum Style {
+        /// `libProjectDescription.dylib` library built via Swift PM in the command line
+        ///
+        /// `swift build`
+        ///
+        /// Example:
+        /// /path/to/tuist/.build/$CONFIGURATION/libProjectDescription.dylib
+        case commandLine
+
+        /// `ProjectDescription.framework` framework built via Xcode
+        ///
+        /// `swift package generate-xcodeproj`
+        ///
+        /// Example:
+        /// /path/to/DerivedData/Tuist/Build/Products/$CONFIGURATION/ProjectDescription.framework
+        case xcode
+
+        /// `ProjectDescription.framework` framework built via Swift Packages in Xcode
+        ///
+        /// `open Package.swift`
+        ///
+        ///  - Note: The `.framework` resides within `$BUILT_PRODUCTS_DIR/PackageFrameworks`, however
+        ///  the `.swiftmodule` remains within `$BUILT_PRODUCTS_DIR`.
+        ///
+        /// Example:
+        /// /path/to/DerivedData/Tuist/Build/Products/$CONFIGURATION/PackageFrameworks/ProjectDescription.framework
+        case swiftPackageInXcode
+    }
+
+    /// Path to the `ProjectDescription` framework or library
+    var path: AbsolutePath
+
+    /// The search path style to use for the library
+    var style: Style
+
+    var includeSearchPath: AbsolutePath {
+        switch style {
+        case .commandLine:
+            return path.parentDirectory
+        case .xcode:
+            return path.parentDirectory
+        case .swiftPackageInXcode:
+            return path.parentDirectory.parentDirectory
+        }
+    }
+
+    var librarySearchPath: AbsolutePath {
+        switch style {
+        case .commandLine:
+            return path.parentDirectory
+        case .xcode:
+            return path.parentDirectory
+        case .swiftPackageInXcode:
+            return path.parentDirectory.parentDirectory
+        }
+    }
+
+    var frameworkSearchPath: AbsolutePath {
+        switch style {
+        case .commandLine:
+            return path.parentDirectory
+        case .xcode:
+            return path.parentDirectory
+        case .swiftPackageInXcode:
+            return path.parentDirectory
+        }
+    }
+
+    /// Creates the `ProjectDescription` search paths based on the library path specified
+    static func paths(for libraryPath: AbsolutePath) -> ProjectDescriptionSearchPaths {
+        ProjectDescriptionSearchPaths(path: libraryPath,
+                                      style: pathStyle(for: libraryPath))
+    }
+
+    private static func pathStyle(for libraryPath: AbsolutePath) -> ProjectDescriptionSearchPaths.Style {
+        if libraryPath.extension == "framework" {
+            if libraryPath.parentDirectory.components.last == "PackageFrameworks" {
+                return .swiftPackageInXcode
+            }
+            return .xcode
+        }
+        return .commandLine
+    }
+}

--- a/Sources/TuistLoader/Utils/ResourceLocator.swift
+++ b/Sources/TuistLoader/Utils/ResourceLocator.swift
@@ -48,14 +48,14 @@ public final class ResourceLocator: ResourceLocating {
     // MARK: - Fileprivate
 
     private func frameworkPath(_ name: String) throws -> AbsolutePath {
-        let frameworkNames = ["\(name).framework", "lib\(name).dylib"]
+        let frameworkNames = ["lib\(name).dylib", "\(name).framework", "PackageFrameworks/\(name).framework"]
         let bundlePath = AbsolutePath(Bundle(for: ManifestLoader.self).bundleURL.path)
         let paths = [
             bundlePath,
             bundlePath.parentDirectory,
         ]
         let candidates = paths.flatMap { path in
-            frameworkNames.map { path.appending(component: $0) }
+            frameworkNames.map { path.appending(RelativePath($0)) }
         }
         guard let frameworkPath = candidates.first(where: { FileHandler.shared.exists($0) }) else {
             throw ResourceLocatingError.notFound(name)

--- a/Sources/TuistSupport/Utils/Environment.swift
+++ b/Sources/TuistSupport/Utils/Environment.swift
@@ -26,6 +26,9 @@ public protocol Environmenting: AnyObject {
     /// Returns all the environment variables that are specific to Tuist (prefixed with TUIST_)
     var tuistVariables: [String: String] { get }
 
+    /// Returns all the environment variables that can be included during the manifest loading process
+    var manifestLoadingVariables: [String: String] { get }
+
     /// Returns true if Tuist is running with verbose mode enabled.
     var isVerbose: Bool { get }
 }
@@ -124,6 +127,17 @@ public class Environment: Environmenting {
     /// Returns all the environment variables that are specific to Tuist (prefixed with TUIST_)
     public var tuistVariables: [String: String] {
         ProcessInfo.processInfo.environment.filter { $0.key.hasPrefix("TUIST_") }
+    }
+
+    public var manifestLoadingVariables: [String: String] {
+        let allowedVariableKeys = [
+            "PATH",
+            "DEVELOPER_DIR",
+        ]
+        let allowedVariables = ProcessInfo.processInfo.environment.filter {
+            allowedVariableKeys.contains($0.key)
+        }
+        return tuistVariables.merging(allowedVariables, uniquingKeysWith: { $1 })
     }
 
     /// Settings path.

--- a/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
+++ b/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
@@ -21,6 +21,7 @@ public class MockEnvironment: Environmenting {
     public var shouldOutputBeColoured: Bool = false
     public var isStandardOutputInteractive: Bool = false
     public var tuistVariables: [String: String] = [:]
+    public var manifestLoadingVariables: [String: String] = [:]
 
     public var versionsDirectory: AbsolutePath {
         directory.path.appending(component: "Versions")

--- a/Tests/TuistLoaderTests/Utils/ProjectDescriptionSearchPathsTests.swift
+++ b/Tests/TuistLoaderTests/Utils/ProjectDescriptionSearchPathsTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import TSCBasic
+import XCTest
+
+@testable import TuistLoader
+@testable import TuistSupportTesting
+
+final class ProjectDescriptionSearchPathsTests: TuistUnitTestCase {
+    func test_paths_style() throws {
+        // Given
+        let libraryPaths: [AbsolutePath] = [
+            "/path/to/tuist/.build/debug/libProjectDescription.dylib",
+            "/path/to/DerivedData/Debug/ProjectDescription.framework",
+            "/path/to/DerivedData/Debug/PackageFrameworks/ProjectDescription.framework",
+        ]
+
+        // When
+        let searchPaths = libraryPaths.map { ProjectDescriptionSearchPaths.paths(for: $0) }
+
+        // Then
+        XCTAssertEqual(searchPaths.map(\.style), [
+            .commandLine,
+            .xcode,
+            .swiftPackageInXcode,
+        ])
+    }
+
+    func test_paths_includeSearchPath() throws {
+        // Given
+        let libraryPaths: [AbsolutePath] = [
+            "/path/to/tuist/.build/debug/libProjectDescription.dylib",
+            "/path/to/DerivedData/Debug/ProjectDescription.framework",
+            "/path/to/DerivedData/Debug/PackageFrameworks/ProjectDescription.framework",
+        ]
+
+        // When
+        let searchPaths = libraryPaths.map { ProjectDescriptionSearchPaths.paths(for: $0) }
+
+        // Then
+        XCTAssertEqual(searchPaths.map(\.includeSearchPath), [
+            "/path/to/tuist/.build/debug",
+            "/path/to/DerivedData/Debug",
+            "/path/to/DerivedData/Debug",
+        ])
+    }
+
+    func test_paths_librarySearchPath() throws {
+        // Given
+        let libraryPaths: [AbsolutePath] = [
+            "/path/to/tuist/.build/debug/libProjectDescription.dylib",
+            "/path/to/DerivedData/Debug/ProjectDescription.framework",
+            "/path/to/DerivedData/Debug/PackageFrameworks/ProjectDescription.framework",
+        ]
+
+        // When
+        let searchPaths = libraryPaths.map { ProjectDescriptionSearchPaths.paths(for: $0) }
+
+        // Then
+        XCTAssertEqual(searchPaths.map(\.librarySearchPath), [
+            "/path/to/tuist/.build/debug",
+            "/path/to/DerivedData/Debug",
+            "/path/to/DerivedData/Debug",
+        ])
+    }
+
+    func test_paths_frameworkSearchPath() throws {
+        // Given
+        let libraryPaths: [AbsolutePath] = [
+            "/path/to/tuist/.build/debug/libProjectDescription.dylib",
+            "/path/to/DerivedData/Debug/ProjectDescription.framework",
+            "/path/to/DerivedData/Debug/PackageFrameworks/ProjectDescription.framework",
+        ]
+
+        // When
+        let searchPaths = libraryPaths.map { ProjectDescriptionSearchPaths.paths(for: $0) }
+
+        // Then
+        XCTAssertEqual(searchPaths.map(\.frameworkSearchPath), [
+            "/path/to/tuist/.build/debug",
+            "/path/to/DerivedData/Debug",
+            "/path/to/DerivedData/Debug/PackageFrameworks",
+        ])
+    }
+}


### PR DESCRIPTION
# Short description 📝

When launching Tuist in Xcode via opening the `Package.swift` file, locating and using the `ProjectDescription` framework fails. This hinders the ability to locally debug Tuist in Xcode.

### Solution 📦

- This issue occurs due to a slightly different structure of where the built products are located when using Xcode and Swift Packages
- The built `.framework` resides in a subdirectory `PackageFrameworks`, while the `.swiftmodule` remains within built products directory

### Implementation 👩‍💻👨‍💻

- [x] Update search paths used for compiling manifests
- [x] Enable `DEVELOPER_DIR` and `PATH` variables to be propagated when compiling manifests
- [ ] Update the contributing docs

### Notes 📝

One aspect that doesn't work quite well is if you use an Xcode version that mismatches your `xcode-select -p` version, the loading process will fail due to mismatching compiler versions.

It seems, when Xcode is working with Swift Packages it no longer sets the `DEVELOPER_DIR` environment setting. I haven't managed to find a good mechanism to solve this yet :/ 

### Test Plan 🛠

- Open tuist in Xcode (via opening `Package.swift`)
- Build the `ProjectDescription` scheme first

![Screenshot 2020-09-18 at 12 57 37](https://user-images.githubusercontent.com/11914919/93594930-ab319300-f9ae-11ea-94f2-584d84c10737.png)

- Update the `tuist` scheme to include the launch arguments `tuist generate --path /path/to/some/fixture`
- Run the `tuist` scheme and verify generation works (note: repeat the test after delete `~/.tuist/Cache` to ensure manifest loading is taking place)
