### PR TITLE
fix: don't embed precompiled or locally built frameworks in unit tests

### DIFF
--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -357,7 +357,7 @@ public class Graph: Encodable, Equatable {
             if let hostApp = hostApplication(for: targetNode) {
                 references.subtract(try embeddableFrameworks(path: hostApp.path, name: hostApp.name))
             } else {
-                references.subtract(precompiledFrameworks)
+                references = []
             }
         }
 

--- a/Tests/TuistCoreTests/Graph/GraphTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTests.swift
@@ -730,8 +730,12 @@ final class GraphTests: TuistUnitTestCase {
         let precompiledNode = mockDynamicFrameworkNode(at: AbsolutePath("/test/test.framework"))
         let unitTests = Target.test(name: "AppUnitTests", product: .unitTests)
         let project = Project.test(path: "/path/a")
+        let target = Target.test(name: "LocallyBuiltFramework", product: .framework)
+        let targetNode = TargetNode(project: project,
+                                    target: target,
+                                    dependencies: [])
 
-        let unitTestsNode = TargetNode(project: project, target: unitTests, dependencies: [precompiledNode])
+        let unitTestsNode = TargetNode(project: project, target: unitTests, dependencies: [precompiledNode, targetNode])
 
         let cache = GraphLoaderCache()
         cache.add(project: project)


### PR DESCRIPTION
Extension of https://github.com/tuist/tuist/pull/1463

### Short description 📝

Just like precompiled frameworks shouldn't need to be embedded here, neither do locally compiled frameworks, which leaves test bundles without a test host with just an empty set of frameworks to embed.