### PR TITLE
Fix DefaultSettings decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- Fixed decoding bug on DefaultSettings [#1817](https://github.com/tuist/tuist/issues/1817) by [@jakeatoms](https://github.com/jakeatoms)
+
 ### Added
 
 - Add Workspace Mappers [#1767](https://github.com/tuist/tuist/pull/1767) by [@kwridan](https://github.com/kwridan)

--- a/Sources/ProjectDescription/Settings.swift
+++ b/Sources/ProjectDescription/Settings.swift
@@ -148,7 +148,7 @@ public enum DefaultSettings: Codable, Equatable {
             var nestedContainer = try container.nestedUnkeyedContainer(forKey: .essential)
             let excludedKeys = try nestedContainer.decode(Set<String>.self)
             self = .essential(excluding: excludedKeys)
-        case .none:
+        case .none?:
             self = .none
         default:
             throw DecodingError.dataCorrupted(

--- a/Tests/ProjectDescriptionTests/DefaultSettingsTests.swift
+++ b/Tests/ProjectDescriptionTests/DefaultSettingsTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import ProjectDescription
+
+final class DefaultSettingsTests: XCTestCase {
+    func test_recommended_toJSON() {
+        let subject = DefaultSettings.recommended(excluding: ["exclude"])
+        XCTAssertCodable(subject)
+    }
+
+    func test_essential_toJSON() {
+        let subject = DefaultSettings.essential(excluding: ["exclude"])
+        XCTAssertCodable(subject)
+    }
+
+    func test_none_toJSON() {
+        let subject = DefaultSettings.none
+        XCTAssertCodable(subject)
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1817

### Short description 📝

This PR resolves an issue decoding `DefaultSettings.none` from JSON.

### Solution 📦

The solution is to use the optional unwrap character to tell Swift that we're matching on `DefaultSettings.none` and not `Optional.none`.  
Other solutions could include:

1. Unwrapping the `key` itself, but then we're left throwing another error.
2. Accessing the first key with `container.allKeys[0]`, but the risk of introducing a crash is non-zero.
3. Change `DefaultSettings.none` to a different value, but that would break the API.
4. Doing a `rawValue` dance with the coding keys and comparing against string values, but we lose the compiler benefits of the `switch` statement.

### Implementation 👩‍💻👨‍💻

> Detail in a checklist the steps that you took to implement the PR.

- [x] The first commit includes the test in its failing state.
- [x] The 2nd commit simply applies the fix.
