### PR TITLE
Ensure `DEVELOPER_DIR` is used in all `swiftc` calls

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -61,6 +61,11 @@ task :style_ruby_correct do
   system("bundle", "exec", "rubocop", "-a")
 end
 
+desc("Builds and archive a release version of tuist and tuistenv for local testing.")
+task :local_package do
+  package
+end
+
 desc("Builds, archives, and publishes tuist and tuistenv for release")
 task :release do
   decrypt_secrets

--- a/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -155,7 +155,7 @@ public class CachedManifestLoader: ManifestLoading {
     }
 
     private func calculateEnvironmentHash() -> String? {
-        let tuistEnvVariables = environment.tuistVariables.map { "\($0.key)=\($0.value)" }.sorted()
+        let tuistEnvVariables = environment.manifestLoadingVariables.map { "\($0.key)=\($0.value)" }.sorted()
         guard !tuistEnvVariables.isEmpty else {
             return nil
         }

--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -189,7 +189,7 @@ public class ManifestLoader: ManifestLoading {
         ]
 
         // Helpers
-        let projectDesciptionHelpersModulePath = try projectDescriptionHelpersBuilder.build(at: path, projectDescriptionPath: projectDescriptionPath)
+        let projectDesciptionHelpersModulePath = try projectDescriptionHelpersBuilder.build(at: path, projectDescriptionSearchPaths: searchPaths)
         if let projectDesciptionHelpersModulePath = projectDesciptionHelpersModulePath {
             arguments.append(contentsOf: [
                 "-I", projectDesciptionHelpersModulePath.parentDirectory.pathString,

--- a/Sources/TuistLoader/ProjectDEscriptionHelpers/ProjectDescriptionHelpersBuilder.swift
+++ b/Sources/TuistLoader/ProjectDEscriptionHelpers/ProjectDescriptionHelpersBuilder.swift
@@ -10,7 +10,7 @@ protocol ProjectDescriptionHelpersBuilding: AnyObject {
     /// - Parameters:
     ///   - at: Path to the directory that contains the manifest being loaded.
     ///   - projectDescriptionPath: Path to the project description module.
-    func build(at: AbsolutePath, projectDescriptionPath: AbsolutePath) throws -> AbsolutePath?
+    func build(at: AbsolutePath, projectDescriptionSearchPaths: ProjectDescriptionSearchPaths) throws -> AbsolutePath?
 }
 
 final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding {
@@ -41,7 +41,7 @@ final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding 
         self.helpersDirectoryLocator = helpersDirectoryLocator
     }
 
-    func build(at: AbsolutePath, projectDescriptionPath: AbsolutePath) throws -> AbsolutePath? {
+    func build(at: AbsolutePath, projectDescriptionSearchPaths: ProjectDescriptionSearchPaths) throws -> AbsolutePath? {
         guard let helpersDirectory = helpersDirectoryLocator.locate(at: at) else { return nil }
         if let cachedPath = builtHelpers[helpersDirectory] { return cachedPath }
 
@@ -69,8 +69,8 @@ final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding 
 
         let command = self.command(outputDirectory: helpersModuleCachePath,
                                    helpersDirectory: helpersDirectory,
-                                   projectDescriptionPath: projectDescriptionPath)
-        try System.shared.runAndPrint(command, verbose: false, environment: Environment.shared.tuistVariables)
+                                   projectDescriptionSearchPaths: projectDescriptionSearchPaths)
+        try System.shared.runAndPrint(command, verbose: false, environment: Environment.shared.manifestLoadingVariables)
 
         return modulePath
     }
@@ -79,7 +79,7 @@ final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding 
 
     fileprivate func command(outputDirectory: AbsolutePath,
                              helpersDirectory: AbsolutePath,
-                             projectDescriptionPath: AbsolutePath) -> [String]
+                             projectDescriptionSearchPaths: ProjectDescriptionSearchPaths) -> [String]
     {
         let files = FileHandler.shared.glob(helpersDirectory, glob: "**/*.swift")
         var command: [String] = [
@@ -90,12 +90,12 @@ final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBuilding 
             "-parse-as-library",
             "-emit-library",
             "-suppress-warnings",
-            "-I", projectDescriptionPath.parentDirectory.pathString,
-            "-L", projectDescriptionPath.parentDirectory.pathString,
-            "-F", projectDescriptionPath.parentDirectory.pathString,
+            "-I", projectDescriptionSearchPaths.includeSearchPath.pathString,
+            "-L", projectDescriptionSearchPaths.librarySearchPath.pathString,
+            "-F", projectDescriptionSearchPaths.frameworkSearchPath.pathString,
             "-working-directory", outputDirectory.pathString,
         ]
-        if projectDescriptionPath.extension == "dylib" {
+        if projectDescriptionSearchPaths.path.extension == "dylib" {
             command.append(contentsOf: ["-lProjectDescription"])
         } else {
             command.append(contentsOf: ["-framework", "ProjectDescription"])

--- a/Sources/TuistLoader/ProjectDEscriptionHelpers/ProjectDescriptionHelpersHasher.swift
+++ b/Sources/TuistLoader/ProjectDEscriptionHelpers/ProjectDescriptionHelpersHasher.swift
@@ -30,7 +30,7 @@ final class ProjectDescriptionHelpersHasher: ProjectDescriptionHelpersHashing {
             .sorted()
             .compactMap { $0.sha256() }
             .compactMap { $0.compactMap { byte in String(format: "%02x", byte) }.joined() }
-        let tuistEnvVariables = Environment.shared.tuistVariables.map { "\($0.key)=\($0.value)" }.sorted()
+        let tuistEnvVariables = Environment.shared.manifestLoadingVariables.map { "\($0.key)=\($0.value)" }.sorted()
         let swiftVersion = try System.shared.swiftVersion()
 
         let identifiers = [swiftVersion, tuistVersion] + fileHashes + tuistEnvVariables

--- a/Sources/TuistSupport/Utils/Environment.swift
+++ b/Sources/TuistSupport/Utils/Environment.swift
@@ -131,7 +131,6 @@ public class Environment: Environmenting {
 
     public var manifestLoadingVariables: [String: String] {
         let allowedVariableKeys = [
-            "PATH",
             "DEVELOPER_DIR",
         ]
         let allowedVariables = ProcessInfo.processInfo.environment.filter {

--- a/Tests/TuistLoaderIntegrationTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilderIntegrationTests.swift
+++ b/Tests/TuistLoaderIntegrationTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilderIntegrationTests.swift
@@ -35,10 +35,10 @@ final class ProjectDescriptionHelpersBuilderIntegrationTests: TuistTestCase {
         try FileHandler.shared.createFolder(helpersPath)
         try FileHandler.shared.write("import Foundation; class Test {}", path: helpersPath.appending(component: "Helper.swift"), atomically: true)
         let projectDescriptionPath = try resourceLocator.projectDescription()
-        print(helpersPath)
+        let searchPaths = ProjectDescriptionSearchPaths.paths(for: projectDescriptionPath)
 
         // When
-        let paths = try (0 ..< 3).map { _ in try subject.build(at: path, projectDescriptionPath: projectDescriptionPath) }
+        let paths = try (0 ..< 3).map { _ in try subject.build(at: path, projectDescriptionSearchPaths: searchPaths) }
 
         // Then
         XCTAssertEqual(Set(paths).count, 1)

--- a/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
@@ -128,7 +128,7 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
         let path = try temporaryPath().appending(component: "App")
         let project = Project.test(name: "App")
         try stub(manifest: project, at: path)
-        environment.tuistVariables = ["NAME": "A"]
+        environment.manifestLoadingVariables = ["NAME": "A"]
 
         // When
         _ = try subject.loadProject(at: path)
@@ -146,11 +146,11 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
         let path = try temporaryPath().appending(component: "App")
         let project = Project.test(name: "App")
         try stub(manifest: project, at: path)
-        environment.tuistVariables = ["NAME": "A"]
+        environment.manifestLoadingVariables = ["NAME": "A"]
         _ = try subject.loadProject(at: path)
 
         // When
-        environment.tuistVariables = ["NAME": "B"]
+        environment.manifestLoadingVariables = ["NAME": "B"]
         _ = try subject.loadProject(at: path)
 
         // Then

--- a/Tests/TuistLoaderTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasherTests.swift
+++ b/Tests/TuistLoaderTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasherTests.swift
@@ -27,7 +27,7 @@ class ProjectDescriptionHelpersHasherTests: TuistUnitTestCase {
         let temporaryDir = try temporaryPath()
         let helperPath = temporaryDir.appending(component: "Project+Templates.swift")
         try FileHandler.shared.write("import ProjectDescription", path: helperPath, atomically: true)
-        environment.tuistVariables = ["TUIST_VARIABLE": "TEST"]
+        environment.manifestLoadingVariables = ["TUIST_VARIABLE": "TEST"]
 
         // Then
         for _ in 0 ..< 20 {


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/1816

### Short description 📝

In the event `xcode-select -p` mismatches the environment variable `DEVELOPER_DIR` `tuist generate` would fail to for projects with `ProjectDescriptionHelpers`.

This was happening due to`ProjectDescriptionHelpers` getting compiled with the default version Xcode ignoring the `DEVELOPER_DIR` environment variable, whereas the manifests were respecting the environment variable causing a mismatch in Swift versions used during the loading process.


### Solution 📦

Ensure all manifest loading operations (all calls to `swiftc`) respect the `DEVELOPER_DIR` environment variable.

### Implementation 👩‍💻👨‍💻

- [x] Update allowed environment variables (`PATH` was not required, removed to minimise changes)
- [x] Leverage `manifestLoadingVariables` for all manifest loading operations (to ensure consistent version of Swift is used)
- [x] Leverage `manifestLoadingVariables` for all manifest hashing operations (to ensure cache is invalidated in case of switch Xcode versions)


### Test Plan 🛠

- Set your default Xcode to 11.5 (e.g. `sudo xcode-select -s /Applications/Xcode11.5.app/Contents/Developer`)
- Create a local release package of `tuist` using `bundle exec rake local_package`
- Unzip `build/tuist`
- Clear the tuist cache via `rm ~/.tuist/Cache`
- Run `build/tuist/tuist generate --path fixtures/ios_app_with_helpers`
- Set the developer dir environment to Xcode 12 (e.g. `export DEVELOPER_DIR=/Applications/Xcode12.app/Contents/Developer`)
- Clear the tuist cache via `rm ~/.tuist/Cache`
- Run `build/tuist/tuist generate --path fixtures/ios_app_with_helpers`
- Verify project generation succeeds

