### PR TITLE
Fixed a typo

### DIFF
--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -113,11 +113,11 @@ final class LinkGenerator: LinkGenerating {
                                  fileElements: fileElements)
 
         try generateCopyProductsBuildPhase(path: path,
-                                            target: target,
-                                            graph: graph,
-                                            pbxTarget: pbxTarget,
-                                            pbxproj: pbxproj,
-                                            fileElements: fileElements)
+                                           target: target,
+                                           graph: graph,
+                                           pbxTarget: pbxTarget,
+                                           pbxproj: pbxproj,
+                                           fileElements: fileElements)
 
         try generatePackages(target: target,
                              pbxTarget: pbxTarget,
@@ -362,11 +362,11 @@ final class LinkGenerator: LinkGenerating {
     }
 
     func generateCopyProductsBuildPhase(path: AbsolutePath,
-                                         target: Target,
-                                         graph: Graph,
-                                         pbxTarget: PBXTarget,
-                                         pbxproj: PBXProj,
-                                         fileElements: ProjectFileElements) throws
+                                        target: Target,
+                                        graph: Graph,
+                                        pbxTarget: PBXTarget,
+                                        pbxproj: PBXProj,
+                                        fileElements: ProjectFileElements) throws
     {
         // If the current target, which is non-shared (e.g., static lib), depends on other focused targets which
         // include Swift code, we must ensure those are treated as dependencies so that Xcode builds the targets

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -112,7 +112,7 @@ final class LinkGenerator: LinkGenerating {
                                  pbxproj: pbxproj,
                                  fileElements: fileElements)
 
-        try generateCopyProductsdBuildPhase(path: path,
+        try generateCopyProductsBuildPhase(path: path,
                                             target: target,
                                             graph: graph,
                                             pbxTarget: pbxTarget,
@@ -361,7 +361,7 @@ final class LinkGenerator: LinkGenerating {
             }
     }
 
-    func generateCopyProductsdBuildPhase(path: AbsolutePath,
+    func generateCopyProductsBuildPhase(path: AbsolutePath,
                                          target: Target,
                                          graph: Graph,
                                          pbxTarget: PBXTarget,

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -504,7 +504,7 @@ final class LinkGeneratorErrorTests: XCTestCase {
         ])
     }
 
-    func test_generateCopyProductsdBuildPhase_staticTargetDependsOnStaticProducts() throws {
+    func test_generateCopyProductsBuildPhase_staticTargetDependsOnStaticProducts() throws {
         // Given
         let path = AbsolutePath("/path/")
         let staticDependency = Target.test(name: "StaticDependency", product: .staticLibrary)
@@ -518,7 +518,7 @@ final class LinkGeneratorErrorTests: XCTestCase {
         let xcodeProjElements = createXcodeprojElements()
 
         // When
-        try subject.generateCopyProductsdBuildPhase(path: path,
+        try subject.generateCopyProductsBuildPhase(path: path,
                                                     target: target,
                                                     graph: graph,
                                                     pbxTarget: xcodeProjElements.pbxTarget,
@@ -539,7 +539,7 @@ final class LinkGeneratorErrorTests: XCTestCase {
         ])
     }
 
-    func test_generateCopyProductsdBuildPhase_dynamicTargetDependsOnStaticProducts() throws {
+    func test_generateCopyProductsBuildPhase_dynamicTargetDependsOnStaticProducts() throws {
         // Given
         let path = AbsolutePath("/path/")
         let staticDependency = Target.test(name: "StaticDependency", product: .staticLibrary)
@@ -553,7 +553,7 @@ final class LinkGeneratorErrorTests: XCTestCase {
         let xcodeProjElements = createXcodeprojElements()
 
         // When
-        try subject.generateCopyProductsdBuildPhase(path: path,
+        try subject.generateCopyProductsBuildPhase(path: path,
                                                     target: target,
                                                     graph: graph,
                                                     pbxTarget: xcodeProjElements.pbxTarget,
@@ -569,7 +569,7 @@ final class LinkGeneratorErrorTests: XCTestCase {
         XCTAssertNil(copyProductsPhase)
     }
 
-    func test_generateCopyProductsdBuildPhase_resourceBundles() throws {
+    func test_generateCopyProductsBuildPhase_resourceBundles() throws {
         // Given
         let path = AbsolutePath("/path/")
         let resourceBundle = Target.test(name: "ResourceBundle", product: .bundle)
@@ -583,7 +583,7 @@ final class LinkGeneratorErrorTests: XCTestCase {
         let xcodeProjElements = createXcodeprojElements()
 
         // When
-        try subject.generateCopyProductsdBuildPhase(path: path,
+        try subject.generateCopyProductsBuildPhase(path: path,
                                                     target: target,
                                                     graph: graph,
                                                     pbxTarget: xcodeProjElements.pbxTarget,

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -519,11 +519,11 @@ final class LinkGeneratorErrorTests: XCTestCase {
 
         // When
         try subject.generateCopyProductsBuildPhase(path: path,
-                                                    target: target,
-                                                    graph: graph,
-                                                    pbxTarget: xcodeProjElements.pbxTarget,
-                                                    pbxproj: xcodeProjElements.pbxproj,
-                                                    fileElements: fileElements)
+                                                   target: target,
+                                                   graph: graph,
+                                                   pbxTarget: xcodeProjElements.pbxTarget,
+                                                   pbxproj: xcodeProjElements.pbxproj,
+                                                   fileElements: fileElements)
 
         // Then
         let copyProductsPhase = xcodeProjElements
@@ -554,11 +554,11 @@ final class LinkGeneratorErrorTests: XCTestCase {
 
         // When
         try subject.generateCopyProductsBuildPhase(path: path,
-                                                    target: target,
-                                                    graph: graph,
-                                                    pbxTarget: xcodeProjElements.pbxTarget,
-                                                    pbxproj: xcodeProjElements.pbxproj,
-                                                    fileElements: fileElements)
+                                                   target: target,
+                                                   graph: graph,
+                                                   pbxTarget: xcodeProjElements.pbxTarget,
+                                                   pbxproj: xcodeProjElements.pbxproj,
+                                                   fileElements: fileElements)
 
         // Then
         let copyProductsPhase = xcodeProjElements
@@ -584,11 +584,11 @@ final class LinkGeneratorErrorTests: XCTestCase {
 
         // When
         try subject.generateCopyProductsBuildPhase(path: path,
-                                                    target: target,
-                                                    graph: graph,
-                                                    pbxTarget: xcodeProjElements.pbxTarget,
-                                                    pbxproj: xcodeProjElements.pbxproj,
-                                                    fileElements: fileElements)
+                                                   target: target,
+                                                   graph: graph,
+                                                   pbxTarget: xcodeProjElements.pbxTarget,
+                                                   pbxproj: xcodeProjElements.pbxproj,
+                                                   fileElements: fileElements)
 
         // Then
         let copyProductsPhase = xcodeProjElements


### PR DESCRIPTION
### Short description 📝

While looking at a bug, I came across what is almost certainly a typo: `generateCopyProductsdBuildPhase`

### Solution 📦

I fixed it. :-)

### Implementation 👩‍💻👨‍💻

Found all instances of `generateCopyProductsdBuildPhase` and replaced them with `generateCopyProductsBuildPhase`