### PR TITLE
Fix Bool in plist generation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Ensure `DEVELOPER_DIR` is used in all `swiftc` calls [#1819](https://github.com/tuist/tuist/pull/1819) by [@kwridan](https://github.com/kwridan)
 - Fixed decoding bug on DefaultSettings [#1817](https://github.com/tuist/tuist/issues/1817) by [@jakeatoms](https://github.com/jakeatoms)
+- Bool compiler error when generating accessor for plists [#1827](https://github.com/tuist/tuist/pull/1827) by [@fortmarek](https://github.com/fortmarek)
 
 ### Added
 

--- a/Sources/TuistGenerator/Templates/PlistsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/PlistsTemplate.swift
@@ -60,6 +60,8 @@ extension SynthesizedResourceInterfaceTemplates {
         {% empty %}
           :
         {% endfor %}]
+      {% elif metadata.type == "Bool" %}
+        Bool(truncating: {{ value }})
       {% else %}
         {{ value }}
       {% endif %}

--- a/fixtures/ios_app_with_framework_and_resources/App/Resources/Environment.plist
+++ b/fixtures/ios_app_with_framework_and_resources/App/Resources/Environment.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>my_bool_key</key>
+	<false/>
 	<key>my_key</key>
 	<string>This is my secret key!</string>
 </dict>


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1784

### Short description 📝

There is a bug in Swiftgen `inline-swift5` template where `Bool` is not converted from `Int` representation. It seems to be a known [issue](https://github.com/SwiftGen/SwiftGen/issues/775) - I'll try to push the same fix there, too, but since we have the templates bundled in tuist, we can fix it right away.

### Solution 📦

Use `Boo.init(truncating:)` if the `metadata.type` is a Boolean

### Implementation 👩‍💻👨‍💻

- [x] Modify fixture to catch this bug
- [x] Fix it
