### PR TITLE
Bugfix/empty resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- Skip synthesizing resource accessors when the file/folder is empty [#1829](https://github.com/tuist/tuist/pull/1829) by [@fortmarek](https://github.com/fortmarek)
+
 ## 1.19.0 - Milano
 
 ### Fixed

--- a/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
@@ -201,7 +201,7 @@ public final class SynthesizedResourceInterfaceProjectMapper: ProjectMapping {
         if FileHandler.shared.isFolder(path) {
             if try !FileHandler.shared.contentsOfDirectory(path).isEmpty { return true }
         } else {
-            if try !FileHandler.shared.readTextFile(path).isEmpty { return true }
+            if try !FileHandler.shared.readFile(path).isEmpty { return true }
         }
         logger.log(
             level: .warning,

--- a/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
@@ -90,7 +90,8 @@ public final class SynthesizedResourceInterfaceProjectMapper: ProjectMapping {
             .appending(component: Constants.DerivedDirectory.name)
             .appending(component: Constants.DerivedDirectory.sources)
 
-        let paths = self.paths(for: synthesizedResourceInterfaceType, target: target)
+        let paths = try self.paths(for: synthesizedResourceInterfaceType, target: target)
+            .filter(isResourceEmpty)
 
         let renderedInterfaces: [(String, String)]
 
@@ -194,5 +195,18 @@ public final class SynthesizedResourceInterfaceProjectMapper: ProjectMapping {
             return resourcesPaths
                 .filter { $0.extension.map(fontExtensions.contains) ?? false }
         }
+    }
+
+    private func isResourceEmpty(_ path: AbsolutePath) throws -> Bool {
+        if FileHandler.shared.isFolder(path) {
+            if try !FileHandler.shared.contentsOfDirectory(path).isEmpty { return true }
+        } else {
+            if try !FileHandler.shared.readTextFile(path).isEmpty { return true }
+        }
+        logger.log(
+            level: .notice,
+            "Skipping synthesizing accessors for \(path.pathString) because it's contents are empty."
+        )
+        return false
     }
 }

--- a/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
@@ -204,7 +204,7 @@ public final class SynthesizedResourceInterfaceProjectMapper: ProjectMapping {
             if try !FileHandler.shared.readTextFile(path).isEmpty { return true }
         }
         logger.log(
-            level: .notice,
+            level: .warning,
             "Skipping synthesizing accessors for \(path.pathString) because it's contents are empty."
         )
         return false

--- a/Tests/TuistGeneratorTests/Mappers/SynthesizedResourceInterfaceProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/Mappers/SynthesizedResourceInterfaceProjectMapperTests.swift
@@ -36,20 +36,26 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
         let projectPath = try temporaryPath()
         let targetAPath = projectPath.appending(component: "TargetA")
         let aAssets = targetAPath.appending(component: "a.xcassets")
+        let aAsset = aAssets.appending(component: "asset")
         let frenchStrings = targetAPath.appending(components: "fr.lproj", "aStrings.strings")
         let englishStrings = targetAPath.appending(components: "en.lproj", "aStrings.strings")
         let environmentPlist = targetAPath.appending(component: "Environment.plist")
+        let emptyPlist = targetAPath.appending(component: "Empty.plist")
         let ttfFont = targetAPath.appending(component: "ttfFont.ttf")
         let otfFont = targetAPath.appending(component: "otfFont.otf")
         let ttcFont = targetAPath.appending(component: "ttcFont.ttc")
 
         try fileHandler.createFolder(aAssets)
+        try fileHandler.touch(aAsset)
         try fileHandler.touch(frenchStrings)
         try fileHandler.touch(englishStrings)
-        try fileHandler.touch(environmentPlist)
-        try fileHandler.touch(ttfFont)
-        try fileHandler.touch(otfFont)
-        try fileHandler.touch(ttcFont)
+        try fileHandler.write("a", path: frenchStrings, atomically: true)
+        try fileHandler.write("a", path: englishStrings, atomically: true)
+        try fileHandler.touch(emptyPlist)
+        try fileHandler.write("a", path: environmentPlist, atomically: true)
+        try fileHandler.write("a", path: ttfFont, atomically: true)
+        try fileHandler.write("a", path: otfFont, atomically: true)
+        try fileHandler.write("a", path: ttcFont, atomically: true)
 
         let targetA = Target.test(
             name: "TargetA",
@@ -57,6 +63,7 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
                 .folderReference(path: aAssets),
                 .file(path: frenchStrings),
                 .file(path: englishStrings),
+                .file(path: emptyPlist),
                 .file(path: environmentPlist),
                 .file(path: ttfFont),
                 .file(path: otfFont),
@@ -134,6 +141,12 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
                     ),
                 ]
             )
+        )
+        
+        XCTAssertPrinterContains(
+            "Skipping synthesizing accessors for \(emptyPlist.pathString) because it's contents are empty.",
+            at: .notice,
+            ==
         )
     }
 }

--- a/Tests/TuistGeneratorTests/Mappers/SynthesizedResourceInterfaceProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/Mappers/SynthesizedResourceInterfaceProjectMapperTests.swift
@@ -145,7 +145,7 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
 
         XCTAssertPrinterContains(
             "Skipping synthesizing accessors for \(emptyPlist.pathString) because it's contents are empty.",
-            at: .notice,
+            at: .warning,
             ==
         )
     }

--- a/Tests/TuistGeneratorTests/Mappers/SynthesizedResourceInterfaceProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/Mappers/SynthesizedResourceInterfaceProjectMapperTests.swift
@@ -142,7 +142,7 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
                 ]
             )
         )
-        
+
         XCTAssertPrinterContains(
             "Skipping synthesizing accessors for \(emptyPlist.pathString) because it's contents are empty.",
             at: .notice,

--- a/website/markdown/docs/usage/config.mdx
+++ b/website/markdown/docs/usage/config.mdx
@@ -113,6 +113,11 @@ Generation options allow customizing the generation of Xcode projects.
       description:
         'Suppress logging of environment in Run Script build phases',
     },
+    {
+      case: '.disableSynthesizedResourceAccessors',
+      description:
+        'Do not automatically synthesize resource accessors (assets, localized strings, etc.)',
+    },
   ]}
 />
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1813

### Short description 📝

- Output `.warning` when resource file/folder is empty and do not run swiftgen on it, as that fails
- Add documentation for `disableSynthesizedResourceAccessors`

### Implementation 👩‍💻👨‍💻

- [x] Add tests
- [x] Skip and warn about empty files/folders
- [x] Add changelog