### PR TITLE
Fix HTTP Redirect listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Skip synthesizing resource accessors when the file/folder is empty [#1829](https://github.com/tuist/tuist/pull/1829) by [@fortmarek](https://github.com/fortmarek)
+- The redirect after the cloud authentication is not being captured from the CLI [#1846](https://github.com/tuist/tuist/pull/1846) by [@pepibumur](https://github.com/pepibumur).
 
 ## 1.19.0 - Milano
 

--- a/Sources/TuistSupport/Utils/HTTPRedirectListener.swift
+++ b/Sources/TuistSupport/Utils/HTTPRedirectListener.swift
@@ -48,11 +48,6 @@ public final class HTTPRedirectListener: HTTPRedirectListening {
 
         runningSemaphore = DispatchSemaphore(value: 0)
         httpServer[path] = { request in
-
-            guard let fileRelativePath = request.params.first else {
-                return .notFound
-            }
-
             result = .success(request.queryParams.reduce(into: [String: String]()) { $0[$1.0] = $1.1 })
             DispatchQueue.global().async { runningSemaphore.signal() }
             return HttpResponse.ok(.html(self.html(logoURL: logoURL, redirectMessage: redirectMessage)))

--- a/TapestryConfig.swift
+++ b/TapestryConfig.swift
@@ -22,10 +22,10 @@ let config = TapestryConfig(
                         "build/tuistenv.zip",
                     ]
                 )
-            )
+            ),
         ],
         add: [
-            "CHANGELOG.md"
+            "CHANGELOG.md",
         ],
         commitMessage: "Version \(Argument.version)",
         push: true


### PR DESCRIPTION
### Short description 📝
While testing the cloud authentication I noticed it was not working because we have an unnecessary check in the HTTP Redirect listener utility. I've removed that check and the authentication works now.