### PR TITLE
Feature: Pre/Post Target Generation Actions

### DIFF
--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -56,6 +56,9 @@ public struct Target: Codable, Equatable {
     /// Launch argument to be exposed to the target.
     public let launchArguments: [String: Bool]
 
+    /// Target generation actions.
+    public let targetGenerationActions: [TargetGenerationAction]
+
     public enum CodingKeys: String, CodingKey {
         case name
         case platform
@@ -74,6 +77,7 @@ public struct Target: Codable, Equatable {
         case environment
         case launchArguments
         case deploymentTarget
+        case targetGenerationActions = "target_generation_action"
     }
 
     /// Initializes the target.
@@ -109,7 +113,8 @@ public struct Target: Codable, Equatable {
                 settings: Settings? = nil,
                 coreDataModels: [CoreDataModel] = [],
                 environment: [String: String] = [:],
-                launchArguments: [String: Bool] = [:])
+                launchArguments: [String: Bool] = [:],
+                targetGenerationActions: [TargetGenerationAction] = [])
     {
         self.name = name
         self.platform = platform
@@ -128,5 +133,6 @@ public struct Target: Codable, Equatable {
         self.environment = environment
         self.launchArguments = launchArguments
         self.deploymentTarget = deploymentTarget
+        self.targetGenerationActions = targetGenerationActions
     }
 }

--- a/Sources/ProjectDescription/TargetGenerationAction.swift
+++ b/Sources/ProjectDescription/TargetGenerationAction.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+public struct TargetGenerationAction: Codable, Equatable {
+    /// Order when the target generation action gets called.
+    ///
+    /// - pre: Before the target is generated.
+    /// - post: After the target is generated.
+    public enum Order: String, Codable, Equatable {
+        case pre
+        case post
+    }
+
+    /// Name of the tool to execute. Tuist will look up the tool on the environment's PATH.
+    public let tool: String?
+
+    /// Path to the script to execute.
+    public let path: Path?
+
+    /// Target generation action order.
+    public let order: Order
+
+    /// Arguments that to be passed.
+    public let arguments: [String]
+
+    public enum CodingKeys: String, CodingKey {
+        case name
+        case tool
+        case path
+        case order
+        case arguments
+    }
+
+    /// Initializes the target action with its attributes.
+    ///
+    /// - Parameters:
+    ///   - tool: Name of the tool to execute. Tuist will look up the tool on the environment's PATH.
+    ///   - path: Path to the script to execute.
+    ///   - order: Target generation action order.
+    init(tool: String?, path: Path?, order: Order, arguments: [String]) {
+        self.path = path
+        self.tool = tool
+        self.order = order
+        self.arguments = arguments
+    }
+
+    /// Returns a target generation action that gets executed before the project is generated.
+    ///
+    /// - Parameters:
+    ///   - tool: Name of the tool to execute. Tuist will look up the tool on the environment's PATH.
+    ///   - arguments: Arguments that to be passed.
+    /// - Returns: Target generation action.
+    public static func pre(tool: String, arguments: String...) -> TargetGenerationAction {
+        return TargetGenerationAction(tool: tool, path: nil, order: .pre, arguments: arguments)
+    }
+
+    /// Returns a target generation action that gets executed before the project is generated.
+    ///
+    /// - Parameters:
+    ///   - tool: Name of the tool to execute. Tuist will look up the tool on the environment's PATH.
+    ///   - arguments: Arguments that to be passed.
+    /// - Returns: Target generation action.
+    public static func pre(tool: String, arguments: [String]) -> TargetGenerationAction {
+        return TargetGenerationAction(tool: tool, path: nil, order: .pre, arguments: arguments)
+    }
+
+    /// Returns a target generation action that gets executed before the project is generated.
+    ///
+    /// - Parameters:
+    ///   - path: Path to the script to execute.
+    ///   - arguments: Arguments that to be passed.
+    /// - Returns: Target generation action.
+    public static func pre(path: Path, arguments: String...) -> TargetGenerationAction {
+        return TargetGenerationAction(tool: nil, path: path, order: .pre, arguments: arguments)
+    }
+
+    /// Returns a target generation action that gets executed before the project is generated.
+    ///
+    /// - Parameters:
+    ///   - path: Path to the script to execute.
+    ///   - arguments: Arguments that to be passed.
+    /// - Returns: Target generation action.
+    public static func pre(path: Path, arguments: [String]) -> TargetGenerationAction {
+        return TargetGenerationAction(tool: nil, path: path, order: .pre, arguments: arguments)
+    }
+
+    /// Returns a target generation action that gets executed after the project is generated.
+    ///
+    /// - Parameters:
+    ///   - tool: Name of the tool to execute. Tuist will look up the tool on the environment's PATH.
+    ///   - arguments: Arguments that to be passed.
+    /// - Returns: Target generation action.
+    public static func post(tool: String, arguments: String...) -> TargetGenerationAction {
+        return TargetGenerationAction(tool: tool, path: nil, order: .post, arguments: arguments)
+    }
+
+    /// Returns a target generation action that gets executed after the project is generated.
+    ///
+    /// - Parameters:
+    ///   - tool: Name of the tool to execute. Tuist will look up the tool on the environment's PATH.
+    ///   - arguments: Arguments that to be passed.
+    /// - Returns: Target generation action.
+    public static func post(tool: String, arguments: [String]) -> TargetGenerationAction {
+        return TargetGenerationAction(tool: tool, path: nil, order: .post, arguments: arguments)
+    }
+
+    /// Returns a target generation action that gets executed after the project is generated.
+    ///
+    /// - Parameters:
+    ///   - path: Path to the script to execute.
+    ///   - arguments: Arguments that to be passed.
+    /// - Returns: Target generation action.
+    public static func post(path: Path, arguments: String...) -> TargetGenerationAction {
+        return TargetGenerationAction(tool: nil, path: path, order: .post, arguments: arguments)
+    }
+
+    /// Returns a target generation action that gets executed after the project is generated.
+    ///
+    /// - Parameters:
+    ///   - path: Path to the script to execute.
+    ///   - arguments: Arguments that to be passed.
+    /// - Returns: Target generation action.
+    public static func post(path: Path, arguments: [String]) -> TargetGenerationAction {
+        return TargetGenerationAction(tool: nil, path: path, order: .post, arguments: arguments)
+    }
+
+    // MARK: - Codable
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        order = try container.decode(Order.self, forKey: .order)
+        arguments = try container.decode([String].self, forKey: .arguments)
+        if let path = try container.decodeIfPresent(Path.self, forKey: .path) {
+            self.path = path
+            tool = nil
+        } else {
+            path = nil
+            tool = try container.decode(String.self, forKey: .tool)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(order, forKey: .order)
+        try container.encode(arguments, forKey: .arguments)
+
+        if let tool = tool {
+            try container.encode(tool, forKey: .tool)
+        }
+        if let path = path {
+            try container.encode(path, forKey: .path)
+        }
+    }
+}

--- a/Sources/TuistCore/Models/Target.swift
+++ b/Sources/TuistCore/Models/Target.swift
@@ -47,6 +47,7 @@ public struct Target: Equatable, Hashable, Comparable {
     public var environment: [String: String]
     public var launchArguments: [String: Bool]
     public var filesGroup: ProjectGroup
+    public var targetGenerationActions: [TargetGenerationAction]
 
     // MARK: - Init
 
@@ -67,7 +68,8 @@ public struct Target: Equatable, Hashable, Comparable {
                 environment: [String: String] = [:],
                 launchArguments: [String: Bool] = [:],
                 filesGroup: ProjectGroup,
-                dependencies: [Dependency] = [])
+                dependencies: [Dependency] = [],
+                targetGenerationActions: [TargetGenerationAction] = [])
     {
         self.name = name
         self.product = product
@@ -87,6 +89,7 @@ public struct Target: Equatable, Hashable, Comparable {
         self.launchArguments = launchArguments
         self.filesGroup = filesGroup
         self.dependencies = dependencies
+        self.targetGenerationActions = targetGenerationActions
     }
 
     /// Target can be included in the link phase of other targets
@@ -102,6 +105,16 @@ public struct Target: Equatable, Hashable, Comparable {
     /// Returns target's post actions.
     public var postActions: [TargetAction] {
         actions.filter { $0.order == .post }
+    }
+
+    /// Returns pre generation actions.
+    public var preGenerationActions: [TargetGenerationAction] {
+        targetGenerationActions.filter { $0.order == .pre }
+    }
+
+    /// Returns post generation actions.
+    public var postGenerationActions: [TargetGenerationAction] {
+        targetGenerationActions.filter { $0.order == .post }
     }
 
     /// Target can link static products (e.g. an app can link a staticLibrary)

--- a/Sources/TuistCore/Models/TargetGenerationAction.swift
+++ b/Sources/TuistCore/Models/TargetGenerationAction.swift
@@ -1,0 +1,69 @@
+import Foundation
+import TSCBasic
+import TuistSupport
+
+/// It represents an action to be called at a determined point in the generation
+public struct TargetGenerationAction: Codable, Equatable {
+    /// Order when the project generation action gets called.
+    ///
+    /// - pre: Before the target is generated.
+    /// - post: After the target is generated.
+    public enum Order: String, Codable, Equatable {
+        case pre
+        case post
+    }
+
+    /// Name of the tool to execute. Tuist will look up the tool on the environment's PATH
+    public let tool: String?
+
+    /// Path to the script to execute
+    public let path: AbsolutePath?
+
+    /// Target generation action order.
+    public let order: Order
+
+    /// Arguments that to be passed
+    public let arguments: [String]
+
+    /// Initializes a new target action with its attributes.
+    ///
+    /// - Parameters:
+    ///   - order: Target generation action order.
+    ///   - tool: Name of the tool to execute. Tuist will look up the tool on the environment's PATH
+    ///   - path: Path to the script to execute
+    ///   - arguments: Arguments that to be passed
+    public init(order: Order,
+                tool: String? = nil,
+                path: AbsolutePath? = nil,
+                arguments: [String] = [])
+    {
+        self.order = order
+        self.tool = tool
+        self.path = path
+        self.arguments = arguments
+    }
+
+    /// Returns the shell script that should be used in the target build phase.
+    ///
+    /// - Parameters:
+    ///   - sourceRootPath: Path to the directory where the Xcode project is generated.
+    /// - Returns: Shell script that should be used in the target build phase.
+    /// - Throws: An error if the tool absolute path cannot be obtained.
+    public func shellScript(sourceRootPath: AbsolutePath) throws -> String {
+        if let path = path {
+            return "\"${PROJECT_DIR}\"/\(path.relative(to: sourceRootPath).pathString) \(arguments.joined(separator: " "))"
+        } else {
+            return try "\(System.shared.which(tool!).spm_chomp().spm_chuzzle()!) \(arguments.joined(separator: " "))"
+        }
+    }
+}
+
+extension Array where Element == TargetGenerationAction {
+    public var preActions: [TargetGenerationAction] {
+        filter { $0.order == .pre }
+    }
+
+    public var postActions: [TargetGenerationAction] {
+        filter { $0.order == .post }
+    }
+}

--- a/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
@@ -75,6 +75,10 @@ extension TuistCore.Target {
             try TuistCore.TargetAction.from(manifest: $0, generatorPaths: generatorPaths)
         }
 
+        let targetGenerationActions = try manifest.targetGenerationActions.map {
+            try TuistCore.TargetGenerationAction.from(manifest: $0, generatorPaths: generatorPaths)
+        }
+
         let environment = manifest.environment
         let launchArguments = manifest.launchArguments
 
@@ -95,6 +99,7 @@ extension TuistCore.Target {
                                 environment: environment,
                                 launchArguments: launchArguments,
                                 filesGroup: .group(name: "Project"),
-                                dependencies: dependencies)
+                                dependencies: dependencies,
+                                targetGenerationActions: targetGenerationActions)
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/TargetGenerationAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetGenerationAction+ManifestMapper.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+import ProjectDescription
+import TSCBasic
+import TuistCore
+import TuistSupport
+
+extension TuistCore.TargetGenerationAction {
+    /// Maps a ProjectDescription.TargetGenerationAction instance into a TuistCore.TargetGenerationAction model.
+    /// - Parameters:
+    ///   - manifest: Manifest representation of target action.
+    ///   - generatorPaths: Generator paths.
+    static func from(manifest: ProjectDescription.TargetGenerationAction, generatorPaths: GeneratorPaths) throws -> TuistCore.TargetGenerationAction {
+        let tool = manifest.tool
+        let order = TuistCore.TargetGenerationAction.Order.from(manifest: manifest.order)
+        let arguments = manifest.arguments
+        let path = try manifest.path.map { try generatorPaths.resolve(path: $0) }
+        return TargetGenerationAction(order: order, tool: tool, path: path, arguments: arguments)
+    }
+}
+
+extension TuistCore.TargetGenerationAction.Order {
+    /// Maps a ProjectDescription.TargetGenerationAction.Order instance into a TuistCore.TargetGenerationAction.Order model.
+    /// - Parameters:
+    ///   - manifest: Manifest representation of target action order.
+    ///   - generatorPaths: Generator paths.
+    static func from(manifest: ProjectDescription.TargetGenerationAction.Order) -> TuistCore.TargetGenerationAction.Order {
+        switch manifest {
+        case .pre:
+            return .pre
+        case .post:
+            return .post
+        }
+    }
+}


### PR DESCRIPTION
### Short description 📝

Adding a hook pre and post project generation allowing you to run custom steps before and after the project generation.

### Implementation 👩‍💻👨‍💻

- [x] Add TargetGenerationAction
- [ ] Map actions to SideEffects?
- [ ] Run actions at the appropriate place in ProjectGenerator
