### PR TITLE
Init `TuistDependencies` targets.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -243,7 +243,7 @@ let package = Package(
         ),
         .testTarget(
             name: "TuistDependenciesIntegrationTests",
-            dependencies: ["TuistDependencies",  "TuistDependenciesTesting", "TuistCoreTesting", "TuistSupportTesting"]
+            dependencies: ["TuistDependencies", "TuistDependenciesTesting", "TuistCoreTesting", "TuistSupportTesting"]
         ),
         .target(
             name: "TuistMigration",

--- a/Package.swift
+++ b/Package.swift
@@ -230,6 +230,22 @@ let package = Package(
             dependencies: ["TuistSigning", "TuistSupportTesting", "TuistCoreTesting", "TuistSigningTesting"]
         ),
         .target(
+            name: "TuistDependencies",
+            dependencies: ["TuistCore", "TuistSupport"]
+        ),
+        .target(
+            name: "TuistDependenciesTesting",
+            dependencies: ["TuistDependencies"]
+        ),
+        .testTarget(
+            name: "TuistDependenciesTests",
+            dependencies: ["TuistDependencies", "TuistDependenciesTesting", "TuistCoreTesting", "TuistSupportTesting"]
+        ),
+        .testTarget(
+            name: "TuistDependenciesIntegrationTests",
+            dependencies: ["TuistDependencies",  "TuistDependenciesTesting", "TuistCoreTesting", "TuistSupportTesting"]
+        ),
+        .target(
             name: "TuistMigration",
             dependencies: ["TuistCore", "TuistSupport", "XcodeProj", "SwiftToolsSupport-auto"]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -75,11 +75,11 @@ let package = Package(
         ),
         .target(
             name: "TuistKit",
-            dependencies: ["XcodeProj", "SwiftToolsSupport-auto", "ArgumentParser", "TuistSupport", "TuistGenerator", "TuistCache", "TuistAutomation", "ProjectDescription", "Signals", "RxSwift", "RxBlocking", "Checksum", "TuistLoader", "TuistInsights", "TuistScaffold", "TuistSigning", "TuistCloud", "TuistDoc", "GraphViz", "TuistMigration"]
+            dependencies: ["XcodeProj", "SwiftToolsSupport-auto", "ArgumentParser", "TuistSupport", "TuistGenerator", "TuistCache", "TuistAutomation", "ProjectDescription", "Signals", "RxSwift", "RxBlocking", "Checksum", "TuistLoader", "TuistInsights", "TuistScaffold", "TuistSigning", "TuistDependencies", "TuistCloud", "TuistDoc", "GraphViz", "TuistMigration"]
         ),
         .testTarget(
             name: "TuistKitTests",
-            dependencies: ["TuistKit", "TuistAutomation", "TuistSupportTesting", "TuistCoreTesting", "ProjectDescription", "RxBlocking", "TuistLoaderTesting", "TuistCacheTesting", "TuistGeneratorTesting", "TuistScaffoldTesting", "TuistCloudTesting", "TuistAutomationTesting", "TuistSigningTesting", "TuistMigrationTesting", "TuistDocTesting"]
+            dependencies: ["TuistKit", "TuistAutomation", "TuistSupportTesting", "TuistCoreTesting", "ProjectDescription", "RxBlocking", "TuistLoaderTesting", "TuistCacheTesting", "TuistGeneratorTesting", "TuistScaffoldTesting", "TuistCloudTesting", "TuistAutomationTesting", "TuistSigningTesting", "TuistDependenciesTesting", "TuistMigrationTesting", "TuistDocTesting"]
         ),
         .testTarget(
             name: "TuistKitIntegrationTests",

--- a/Sources/TuistDependencies/Empty.swift
+++ b/Sources/TuistDependencies/Empty.swift
@@ -1,3 +1,5 @@
 import Foundation
 import TuistCore
 import TuistSupport
+
+#warning("Remove this file when you will start adding files to this target.")

--- a/Sources/TuistDependencies/Empty.swift
+++ b/Sources/TuistDependencies/Empty.swift
@@ -1,0 +1,3 @@
+import Foundation
+import TuistCore
+import TuistSupport

--- a/Sources/TuistDependenciesTesting/Empty.swift
+++ b/Sources/TuistDependenciesTesting/Empty.swift
@@ -1,3 +1,5 @@
 import Foundation
 import TuistCore
 import TuistSupport
+
+#warning("Remove this file when you will start adding files to this target.")

--- a/Sources/TuistDependenciesTesting/Empty.swift
+++ b/Sources/TuistDependenciesTesting/Empty.swift
@@ -1,0 +1,3 @@
+import Foundation
+import TuistCore
+import TuistSupport

--- a/Tests/TuistDependenciesIntegrationTests/EmptyTests.swift
+++ b/Tests/TuistDependenciesIntegrationTests/EmptyTests.swift
@@ -1,0 +1,16 @@
+import Foundation
+import XCTest
+
+@testable import TuistDependencies
+@testable import TuistSupportTesting
+
+final class EmptyTests: TuistUnitTestCase {
+    func test_empty() {
+        // Given
+        
+        // When
+        
+        // Then
+        XCTAssertTrue(true)
+    }
+}

--- a/Tests/TuistDependenciesIntegrationTests/EmptyTests.swift
+++ b/Tests/TuistDependenciesIntegrationTests/EmptyTests.swift
@@ -14,3 +14,5 @@ final class EmptyTests: TuistUnitTestCase {
         XCTAssertTrue(true)
     }
 }
+
+#warning("Remove this file when you will start adding files to this target.")

--- a/Tests/TuistDependenciesIntegrationTests/EmptyTests.swift
+++ b/Tests/TuistDependenciesIntegrationTests/EmptyTests.swift
@@ -7,9 +7,9 @@ import XCTest
 final class EmptyTests: TuistUnitTestCase {
     func test_empty() {
         // Given
-        
+
         // When
-        
+
         // Then
         XCTAssertTrue(true)
     }

--- a/Tests/TuistDependenciesTests/EmptyTests.swift
+++ b/Tests/TuistDependenciesTests/EmptyTests.swift
@@ -1,0 +1,16 @@
+import Foundation
+import XCTest
+
+@testable import TuistDependencies
+@testable import TuistSupportTesting
+
+final class EmptyTests: TuistUnitTestCase {
+    func test_empty() {
+        // Given
+        
+        // When
+        
+        // Then
+        XCTAssertTrue(true)
+    }
+}

--- a/Tests/TuistDependenciesTests/EmptyTests.swift
+++ b/Tests/TuistDependenciesTests/EmptyTests.swift
@@ -14,3 +14,5 @@ final class EmptyTests: TuistUnitTestCase {
         XCTAssertTrue(true)
     }
 }
+
+#warning("Remove this file when you will start adding files to this target.")

--- a/Tests/TuistDependenciesTests/EmptyTests.swift
+++ b/Tests/TuistDependenciesTests/EmptyTests.swift
@@ -7,9 +7,9 @@ import XCTest
 final class EmptyTests: TuistUnitTestCase {
     func test_empty() {
         // Given
-        
+
         // When
-        
+
         // Then
         XCTAssertTrue(true)
     }


### PR DESCRIPTION
### Short description 📝

Initiates new targets for future implementation of Project Chimera. I'm adding it as a separate PR because me and @facumenzella will need it and I want to avoid any conflicts. If this PR merges into master then we will be able to work on these new targets in parallel.

### Implementation 👩‍💻👨‍💻

I have added four new targets:
- TuistDependencies
- TuistDependenciesTesting 
- TuistDependenciesTests
- TuistDependenciesIntegrationTests

I have been inspiring on already existing targets and https://tuist.io/docs/contribution/architecture/

I have added one `Empty.swift` file per target to check if imports work and tests run. 

The added files are temporary and contain `warning` messages that will remind us to remove them later.  