### PR TITLE
Nit: Fix 'projct' typo in docs

### DIFF
--- a/website/markdown/docs/commands/linting.mdx
+++ b/website/markdown/docs/commands/linting.mdx
@@ -15,7 +15,7 @@ import {
 
 # Linting
 
-## Projct linting
+## Project linting
 
 One of the benefits of making the definition of projects explicit,
 is that we can run checks on them and uncover configuration issues that otherwise would be bubbled up by the build system later on.


### PR DESCRIPTION
### Short description 📝
Fixes a typo in the [Linting](https://tuist.io/docs/commands/linting/) docs page.