### PR TITLE
Update input files of embed precompiled frameworks build phase

### DIFF
--- a/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
+++ b/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
@@ -79,7 +79,9 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
             // Framework
             let relativeFrameworkPath = path.relative(to: sourceRootPath)
             script.append("install_framework \"\(relativeFrameworkPath.pathString)\"\n")
-            inputPaths.append(relativeFrameworkPath)
+
+            inputPaths.append(relativeFrameworkPath.appending(component: relativeFrameworkPath.basenameWithoutExt))
+            inputPaths.append(relativeFrameworkPath.appending(component: "Info.plist"))
             outputPaths.append("${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/\(relativeFrameworkPath.basename)")
 
             // .dSYM
@@ -246,4 +248,14 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
 
     // swiftlint:enable function_body_length
     // swiftlint:enable line_length
+}
+
+private extension RelativePath {
+    /// Returns the basename without the extension.
+    var basenameWithoutExt: String {
+        if let ext = self.extension {
+            return String(basename.dropLast(ext.count + 1))
+        }
+        return basename
+    }
 }

--- a/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
+++ b/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
@@ -80,6 +80,7 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
             let relativeFrameworkPath = path.relative(to: sourceRootPath)
             script.append("install_framework \"\(relativeFrameworkPath.pathString)\"\n")
 
+            inputPaths.append(relativeFrameworkPath)
             inputPaths.append(relativeFrameworkPath.appending(component: relativeFrameworkPath.basenameWithoutExt))
             inputPaths.append(relativeFrameworkPath.appending(component: "Info.plist"))
             outputPaths.append("${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/\(relativeFrameworkPath.basename)")

--- a/Tests/TuistGeneratorTests/Utils/EmbedScriptGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/EmbedScriptGeneratorTests.swift
@@ -34,6 +34,7 @@ final class EmbedScriptGeneratorTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(got.inputPaths, [
+            RelativePath("tuist.framework"),
             RelativePath("tuist.framework/tuist"),
             RelativePath("tuist.framework/Info.plist"),
         ])
@@ -60,6 +61,7 @@ final class EmbedScriptGeneratorTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(got.inputPaths, [
+            RelativePath("tuist.framework"),
             RelativePath("tuist.framework/tuist"),
             RelativePath("tuist.framework/Info.plist"),
         ])

--- a/Tests/TuistGeneratorTests/Utils/EmbedScriptGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/EmbedScriptGeneratorTests.swift
@@ -34,7 +34,8 @@ final class EmbedScriptGeneratorTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(got.inputPaths, [
-            RelativePath(path.basename),
+            RelativePath("tuist.framework/tuist"),
+            RelativePath("tuist.framework/Info.plist"),
         ])
         XCTAssertEqual(got.outputPaths, [
             "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/\(path.basename)",
@@ -59,7 +60,8 @@ final class EmbedScriptGeneratorTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(got.inputPaths, [
-            RelativePath(path.basename),
+            RelativePath("tuist.framework/tuist"),
+            RelativePath("tuist.framework/Info.plist"),
         ])
         XCTAssertEqual(got.outputPaths, [
             "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/\(path.basename)",


### PR DESCRIPTION
### Short description 📝

I've recently played with Kotlin Native in a dummy side project and had some troubles syncing the dynamic framework built by Gradle in incremental builds. The generated embed script phase has only path to `<MyFrameworkName.framework>` (bundle) in the input files, so the phase can be skipped by Xcode when the framework binary gets updated. 

Making the input file pointing to the binary triggers the script every time the binary gets updated what significantly improves the experience. Wonder if anyone else experienced similar issue.


