### PR TITLE
Improve error message to have more actionable information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Changed
+
+- Improve error message to have more actionable information [#921](https://github.com/tuist/tuist/issues/921) by by [@mollyIV](https://github.com/mollyIV).
+
 ## 1.20.0 - Heideberg
 
 ### Changed

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -234,24 +234,24 @@ private extension Dependency {
             return "xctest"
         }
     }
-    
+
     var name: String {
         switch self {
-        case .target(let name):
+        case let .target(name):
             return name
-        case .project(let target, _):
+        case let .project(target, _):
             return target
-        case .framework(let path):
+        case let .framework(path):
             return path.basename
-        case .xcFramework(let path):
+        case let .xcFramework(path):
             return path.basename
-        case .library(let path, _, _):
+        case let .library(path, _, _):
             return path.basename
-        case .package(let product):
+        case let .package(product):
             return product
-        case .sdk(let name, _):
+        case let .sdk(name, _):
             return name
-        case .cocoapods(let path):
+        case let .cocoapods(path):
             return path.basename
         case .xctest:
             return "xctest"

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -206,7 +206,55 @@ class TargetLinter: TargetLinting {
         target.dependencies.forEach { seen[$0, default: 0] += 1 }
         let duplicates = seen.enumerated().filter { $0.element.value > 1 }
         return duplicates.map {
-            .init(reason: "Target \(target.name) has duplicate '\($0.element.key)' dependency specified", severity: .warning)
+            .init(reason: "Target '\(target.name)' has duplicate \($0.element.key.typeName) dependency specified: '\($0.element.key.name)'", severity: .warning)
+        }
+    }
+}
+
+private extension Dependency {
+    var typeName: String {
+        switch self {
+        case .target:
+            return "target"
+        case .project:
+            return "project"
+        case .framework:
+            return "framework"
+        case .library:
+            return "library"
+        case .package:
+            return "package"
+        case .sdk:
+            return "sdk"
+        case .cocoapods:
+            return "cocoapods"
+        case .xcFramework:
+            return "xcframework"
+        case .xctest:
+            return "xctest"
+        }
+    }
+    
+    var name: String {
+        switch self {
+        case .target(let name):
+            return name
+        case .project(let target, _):
+            return target
+        case .framework(let path):
+            return path.basename
+        case .xcFramework(let path):
+            return path.basename
+        case .library(let path, _, _):
+            return path.basename
+        case .package(let product):
+            return product
+        case .sdk(let name, _):
+            return name
+        case .cocoapods(let path):
+            return path.basename
+        case .xctest:
+            return "xctest"
         }
     }
 }

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -220,7 +220,7 @@ final class TargetLinterTests: TuistUnitTestCase {
 
         // Then
         XCTContainsLintingIssue(got, .init(
-            reason: "Target \(target.name) has duplicate '\(testDependency)' dependency specified",
+            reason: "Target '\(target.name)' has duplicate sdk dependency specified: 'libc++.tbd'",
             severity: .warning
         ))
     }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/921

### Short description 📝

The purpose of this pull request is to improve the error message when linting the project and facing the duplicated dependencies warning. 

### Implementation 👩‍💻👨‍💻

I modified the implementation of `TargetLinter` related to printing the warning when finding duplicated target dependencies. I didn't add new unit tests, only adjusted the existing one. Please let me know if you think it's worth adding more 🙇 

### Testing ⚙

- [x] Unit Tests
- [x] Manual Testing (the results below 👇 )

```bash
// Duplicated Swift Package target

Target 'App' has duplicate package dependency specified: 'XcodeProj'
Generating workspace App.xcworkspace
Generating project App
Resolving package dependencies using xcodebuild
Project generated.

// Duplicated SDK target

Target 'App' has duplicate sdk dependency specified: 'libc++.tbd'
Generating workspace App.xcworkspace
Generating project App
Project generated.

// Duplicated framework target (given path to the framework)

Target 'App' has duplicate framework dependency specified: 'framework.framework'
Generating workspace App.xcworkspace
Generating project App
Project generated.
```

🎊 🎊 