### PR TITLE
Allow ignoring cache when running tuist focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Added
+
+- Allow ignoring cache when running tuist focus [#1879](https://github.com/tuist/tuist/pull/1879) by [@natanrolnik](https://github.com/natanrolnik).
+
 ### Changed
 
-- Improve error message to have more actionable information [#921](https://github.com/tuist/tuist/issues/921) by by [@mollyIV](https://github.com/mollyIV).
+- Improve error message to have more actionable information [#921](https://github.com/tuist/tuist/issues/921) by [@mollyIV](https://github.com/mollyIV).
 
 ## 1.20.0 - Heideberg
 

--- a/Sources/TuistKit/Commands/FocusCommand.swift
+++ b/Sources/TuistKit/Commands/FocusCommand.swift
@@ -56,6 +56,12 @@ struct FocusCommand: ParsableCommand {
     )
     var xcframeworks: Bool = false
 
+    @Flag(
+        name: [.customLong("no-cache")],
+        help: "Ignore cached targets, and use their sources instead."
+    )
+    var ignoreCache: Bool = false
+
     func run() throws {
         if sources.isEmpty {
             throw FocusCommandError.noSources
@@ -63,6 +69,7 @@ struct FocusCommand: ParsableCommand {
         try FocusService().run(path: path,
                                sources: Set(sources),
                                noOpen: noOpen,
-                               xcframeworks: xcframeworks)
+                               xcframeworks: xcframeworks,
+                               ignoreCache: ignoreCache)
     }
 }

--- a/Sources/TuistKit/Services/FocusService.swift
+++ b/Sources/TuistKit/Services/FocusService.swift
@@ -9,13 +9,15 @@ import TuistLoader
 import TuistSupport
 
 protocol FocusServiceProjectGeneratorFactorying {
-    func generator(sources: Set<String>, xcframeworks: Bool) -> ProjectGenerating
+    func generator(sources: Set<String>, xcframeworks: Bool, ignoreCache: Bool) -> ProjectGenerating
 }
 
 final class FocusServiceProjectGeneratorFactory: FocusServiceProjectGeneratorFactorying {
-    func generator(sources: Set<String>, xcframeworks: Bool) -> ProjectGenerating {
+    func generator(sources: Set<String>, xcframeworks: Bool, ignoreCache: Bool) -> ProjectGenerating {
         let cacheOutputType: CacheOutputType = xcframeworks ? .xcframework : .framework
-        let cacheConfig = CacheConfig.withCaching(cacheOutputType: cacheOutputType)
+        let cacheConfig: CacheConfig = ignoreCache
+            ? .withoutCaching()
+            : .withCaching(cacheOutputType: cacheOutputType)
         return ProjectGenerator(graphMapperProvider: GraphMapperProvider(cacheConfig: cacheConfig, sources: sources))
     }
 }
@@ -51,12 +53,14 @@ final class FocusService {
         self.projectGeneratorFactory = projectGeneratorFactory
     }
 
-    func run(path: String?, sources: Set<String>, noOpen: Bool, xcframeworks: Bool) throws {
+    func run(path: String?, sources: Set<String>, noOpen: Bool, xcframeworks: Bool, ignoreCache: Bool) throws {
         let path = self.path(path)
         if isWorkspace(path: path) {
             throw FocusServiceError.cacheWorkspaceNonSupported
         }
-        let generator = projectGeneratorFactory.generator(sources: sources, xcframeworks: xcframeworks)
+        let generator = projectGeneratorFactory.generator(sources: sources,
+                                                          xcframeworks: xcframeworks,
+                                                          ignoreCache: ignoreCache)
         let workspacePath = try generator.generate(path: path, projectOnly: false)
         if !noOpen {
             try opener.open(path: workspacePath)

--- a/Tests/TuistKitTests/Services/FocusServiceTests.swift
+++ b/Tests/TuistKitTests/Services/FocusServiceTests.swift
@@ -9,18 +9,20 @@ import XCTest
 @testable import TuistLoaderTesting
 @testable import TuistSupportTesting
 
+private typealias GeneratorParameters = (sources: Set<String>, xcframeworks: Bool, ignoreCache: Bool)
+
 final class MockFocusServiceProjectGeneratorFactory: FocusServiceProjectGeneratorFactorying {
     var invokedGenerator = false
     var invokedGeneratorCount = 0
-    var invokedGeneratorParameters: (sources: Set<String>, xcframeworks: Bool)?
-    var invokedGeneratorParametersList = [(sources: Set<String>, xcframeworks: Bool)]()
+    fileprivate var invokedGeneratorParameters: GeneratorParameters?
+    fileprivate var invokedGeneratorParametersList = [GeneratorParameters]()
     var stubbedGeneratorResult: ProjectGenerating!
 
-    func generator(sources: Set<String>, xcframeworks: Bool) -> ProjectGenerating {
+    func generator(sources: Set<String>, xcframeworks: Bool, ignoreCache: Bool) -> ProjectGenerating {
         invokedGenerator = true
         invokedGeneratorCount += 1
-        invokedGeneratorParameters = (sources, xcframeworks)
-        invokedGeneratorParametersList.append((sources, xcframeworks))
+        invokedGeneratorParameters = (sources, xcframeworks, ignoreCache)
+        invokedGeneratorParametersList.append((sources, xcframeworks, ignoreCache))
         return stubbedGeneratorResult
     }
 }
@@ -64,7 +66,7 @@ final class FocusServiceTests: TuistUnitTestCase {
             throw error
         }
 
-        XCTAssertThrowsError(try subject.run(path: nil, sources: Set(), noOpen: true, xcframeworks: false)) {
+        XCTAssertThrowsError(try subject.run(path: nil, sources: Set(), noOpen: true, xcframeworks: false, ignoreCache: false)) {
             XCTAssertEqual($0 as NSError?, error)
         }
     }
@@ -76,7 +78,7 @@ final class FocusServiceTests: TuistUnitTestCase {
             workspacePath
         }
 
-        try subject.run(path: nil, sources: Set(), noOpen: false, xcframeworks: false)
+        try subject.run(path: nil, sources: Set(), noOpen: false, xcframeworks: false, ignoreCache: false)
 
         XCTAssertEqual(opener.openArgs.last?.0, workspacePath.pathString)
     }


### PR DESCRIPTION
When using the `focus` command, Tuist by default chooses cached targets if they're available. When the user wants to use only sources, and ignore caches, they would need to pass all the targets names.

This PR enables the `--no-cache` flag, to use only sources when focusing on a target.
