### PR TITLE
Allowing build-phase scripts to disable dependency analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Added
+
+- Allow build phase scripts to disable dependency analysis [#1883](https://github.com/tuist/tuist/pull/1883) by [@bhuemer](https://github.com/bhuemer).
+
 ## 1.21.0 - PBWerk
 
 ### Added

--- a/Package.resolved
+++ b/Package.resolved
@@ -204,8 +204,8 @@
         "repositoryURL": "https://github.com/tuist/XcodeProj",
         "state": {
           "branch": null,
-          "revision": "81bb2bb333eafa68f8ecd8187a4bb56d51e78e97",
-          "version": "7.14.0"
+          "revision": "3038221d72c7202a7b72fb971495dc6257bc3835",
+          "version": "7.15.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
                  targets: ["TuistGenerator"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tuist/XcodeProj", .upToNextMajor(from: "7.11.0")),
+        .package(url: "https://github.com/tuist/XcodeProj", .upToNextMajor(from: "7.15.0")),
         .package(url: "https://github.com/IBM-Swift/BlueSignals", .upToNextMajor(from: "1.0.21")),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.1")),
         .package(url: "https://github.com/rnine/Checksum.git", .upToNextMajor(from: "1.0.2")),

--- a/Sources/ProjectDescription/TargetAction.swift
+++ b/Sources/ProjectDescription/TargetAction.swift
@@ -36,6 +36,9 @@ public struct TargetAction: Codable, Equatable {
 
     /// List of output filelist paths
     public let outputFileListPaths: [Path]
+    
+    /// Whether to skip running this script in incremental builds, if nothing has changed
+    public let basedOnDependencyAnalysis: Bool?
 
     public enum CodingKeys: String, CodingKey {
         case name
@@ -47,6 +50,7 @@ public struct TargetAction: Codable, Equatable {
         case inputFileListPaths
         case outputPaths
         case outputFileListPaths
+        case basedOnDependencyAnalysis
     }
 
     /// Initializes the target action with its attributes.
@@ -61,6 +65,7 @@ public struct TargetAction: Codable, Equatable {
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
+    ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
     init(name: String,
          tool: String?,
          path: Path?,
@@ -69,7 +74,8 @@ public struct TargetAction: Codable, Equatable {
          inputPaths: [Path] = [],
          inputFileListPaths: [Path] = [],
          outputPaths: [Path] = [],
-         outputFileListPaths: [Path] = [])
+         outputFileListPaths: [Path] = [],
+         basedOnDependencyAnalysis: Bool? = nil)
     {
         self.name = name
         self.path = path
@@ -80,6 +86,7 @@ public struct TargetAction: Codable, Equatable {
         self.inputFileListPaths = inputFileListPaths
         self.outputPaths = outputPaths
         self.outputFileListPaths = outputFileListPaths
+        self.basedOnDependencyAnalysis = basedOnDependencyAnalysis
     }
 
     /// Returns a target action that gets executed before the sources and resources build phase.
@@ -92,6 +99,7 @@ public struct TargetAction: Codable, Equatable {
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
+    ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
     /// - Returns: Target action.
     public static func pre(tool: String,
                            arguments: String...,
@@ -99,7 +107,8 @@ public struct TargetAction: Codable, Equatable {
                            inputPaths: [Path] = [],
                            inputFileListPaths: [Path] = [],
                            outputPaths: [Path] = [],
-                           outputFileListPaths: [Path] = []) -> TargetAction
+                           outputFileListPaths: [Path] = [],
+                           basedOnDependencyAnalysis: Bool? = nil) -> TargetAction
     {
         TargetAction(name: name,
                      tool: tool,
@@ -109,7 +118,8 @@ public struct TargetAction: Codable, Equatable {
                      inputPaths: inputPaths,
                      inputFileListPaths: inputFileListPaths,
                      outputPaths: outputPaths,
-                     outputFileListPaths: outputFileListPaths)
+                     outputFileListPaths: outputFileListPaths,
+                     basedOnDependencyAnalysis: basedOnDependencyAnalysis)
     }
 
     /// Returns a target action that gets executed before the sources and resources build phase.
@@ -122,6 +132,7 @@ public struct TargetAction: Codable, Equatable {
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
+    ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
     /// - Returns: Target action.
     public static func pre(tool: String,
                            arguments: [String],
@@ -129,7 +140,8 @@ public struct TargetAction: Codable, Equatable {
                            inputPaths: [Path] = [],
                            inputFileListPaths: [Path] = [],
                            outputPaths: [Path] = [],
-                           outputFileListPaths: [Path] = []) -> TargetAction
+                           outputFileListPaths: [Path] = [],
+                           basedOnDependencyAnalysis: Bool? = nil) -> TargetAction
     {
         TargetAction(name: name,
                      tool: tool,
@@ -139,7 +151,8 @@ public struct TargetAction: Codable, Equatable {
                      inputPaths: inputPaths,
                      inputFileListPaths: inputFileListPaths,
                      outputPaths: outputPaths,
-                     outputFileListPaths: outputFileListPaths)
+                     outputFileListPaths: outputFileListPaths,
+                     basedOnDependencyAnalysis: basedOnDependencyAnalysis)
     }
 
     /// Returns a target action that gets executed before the sources and resources build phase.
@@ -152,6 +165,7 @@ public struct TargetAction: Codable, Equatable {
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
+    ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
     /// - Returns: Target action.
     public static func pre(path: Path,
                            arguments: String...,
@@ -159,7 +173,8 @@ public struct TargetAction: Codable, Equatable {
                            inputPaths: [Path] = [],
                            inputFileListPaths: [Path] = [],
                            outputPaths: [Path] = [],
-                           outputFileListPaths: [Path] = []) -> TargetAction
+                           outputFileListPaths: [Path] = [],
+                           basedOnDependencyAnalysis: Bool? = nil) -> TargetAction
     {
         TargetAction(name: name,
                      tool: nil,
@@ -169,7 +184,8 @@ public struct TargetAction: Codable, Equatable {
                      inputPaths: inputPaths,
                      inputFileListPaths: inputFileListPaths,
                      outputPaths: outputPaths,
-                     outputFileListPaths: outputFileListPaths)
+                     outputFileListPaths: outputFileListPaths,
+                     basedOnDependencyAnalysis: basedOnDependencyAnalysis)
     }
 
     /// Returns a target action that gets executed before the sources and resources build phase.
@@ -182,6 +198,7 @@ public struct TargetAction: Codable, Equatable {
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
+    ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
     /// - Returns: Target action.
     public static func pre(path: Path,
                            arguments: [String],
@@ -189,7 +206,8 @@ public struct TargetAction: Codable, Equatable {
                            inputPaths: [Path] = [],
                            inputFileListPaths: [Path] = [],
                            outputPaths: [Path] = [],
-                           outputFileListPaths: [Path] = []) -> TargetAction
+                           outputFileListPaths: [Path] = [],
+                           basedOnDependencyAnalysis: Bool? = nil) -> TargetAction
     {
         TargetAction(name: name,
                      tool: nil,
@@ -199,7 +217,8 @@ public struct TargetAction: Codable, Equatable {
                      inputPaths: inputPaths,
                      inputFileListPaths: inputFileListPaths,
                      outputPaths: outputPaths,
-                     outputFileListPaths: outputFileListPaths)
+                     outputFileListPaths: outputFileListPaths,
+                     basedOnDependencyAnalysis: basedOnDependencyAnalysis)
     }
 
     /// Returns a target action that gets executed after the sources and resources build phase.
@@ -212,6 +231,7 @@ public struct TargetAction: Codable, Equatable {
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
+    ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
     /// - Returns: Target action.
     public static func post(tool: String,
                             arguments: String...,
@@ -219,7 +239,8 @@ public struct TargetAction: Codable, Equatable {
                             inputPaths: [Path] = [],
                             inputFileListPaths: [Path] = [],
                             outputPaths: [Path] = [],
-                            outputFileListPaths: [Path] = []) -> TargetAction
+                            outputFileListPaths: [Path] = [],
+                            basedOnDependencyAnalysis: Bool? = nil) -> TargetAction
     {
         TargetAction(name: name,
                      tool: tool,
@@ -229,7 +250,8 @@ public struct TargetAction: Codable, Equatable {
                      inputPaths: inputPaths,
                      inputFileListPaths: inputFileListPaths,
                      outputPaths: outputPaths,
-                     outputFileListPaths: outputFileListPaths)
+                     outputFileListPaths: outputFileListPaths,
+                     basedOnDependencyAnalysis: basedOnDependencyAnalysis)
     }
 
     /// Returns a target action that gets executed after the sources and resources build phase.
@@ -242,6 +264,7 @@ public struct TargetAction: Codable, Equatable {
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
+    ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
     /// - Returns: Target action.
     public static func post(tool: String,
                             arguments: [String],
@@ -249,7 +272,8 @@ public struct TargetAction: Codable, Equatable {
                             inputPaths: [Path] = [],
                             inputFileListPaths: [Path] = [],
                             outputPaths: [Path] = [],
-                            outputFileListPaths: [Path] = []) -> TargetAction
+                            outputFileListPaths: [Path] = [],
+                            basedOnDependencyAnalysis: Bool? = nil) -> TargetAction
     {
         TargetAction(name: name,
                      tool: tool,
@@ -259,7 +283,8 @@ public struct TargetAction: Codable, Equatable {
                      inputPaths: inputPaths,
                      inputFileListPaths: inputFileListPaths,
                      outputPaths: outputPaths,
-                     outputFileListPaths: outputFileListPaths)
+                     outputFileListPaths: outputFileListPaths,
+                     basedOnDependencyAnalysis: basedOnDependencyAnalysis)
     }
 
     /// Returns a target action that gets executed after the sources and resources build phase.
@@ -272,6 +297,7 @@ public struct TargetAction: Codable, Equatable {
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
+    ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
     /// - Returns: Target action.
     public static func post(path: Path,
                             arguments: String...,
@@ -279,7 +305,8 @@ public struct TargetAction: Codable, Equatable {
                             inputPaths: [Path] = [],
                             inputFileListPaths: [Path] = [],
                             outputPaths: [Path] = [],
-                            outputFileListPaths: [Path] = []) -> TargetAction
+                            outputFileListPaths: [Path] = [],
+                            basedOnDependencyAnalysis: Bool? = nil) -> TargetAction
     {
         TargetAction(name: name,
                      tool: nil,
@@ -289,7 +316,8 @@ public struct TargetAction: Codable, Equatable {
                      inputPaths: inputPaths,
                      inputFileListPaths: inputFileListPaths,
                      outputPaths: outputPaths,
-                     outputFileListPaths: outputFileListPaths)
+                     outputFileListPaths: outputFileListPaths,
+                     basedOnDependencyAnalysis: basedOnDependencyAnalysis)
     }
 
     /// Returns a target action that gets executed after the sources and resources build phase.
@@ -302,6 +330,7 @@ public struct TargetAction: Codable, Equatable {
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
+    ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
     /// - Returns: Target action.
     public static func post(path: Path,
                             arguments: [String],
@@ -309,7 +338,8 @@ public struct TargetAction: Codable, Equatable {
                             inputPaths: [Path] = [],
                             inputFileListPaths: [Path] = [],
                             outputPaths: [Path] = [],
-                            outputFileListPaths: [Path] = []) -> TargetAction
+                            outputFileListPaths: [Path] = [],
+                            basedOnDependencyAnalysis: Bool? = nil) -> TargetAction
     {
         TargetAction(name: name,
                      tool: nil,
@@ -319,7 +349,8 @@ public struct TargetAction: Codable, Equatable {
                      inputPaths: inputPaths,
                      inputFileListPaths: inputFileListPaths,
                      outputPaths: outputPaths,
-                     outputFileListPaths: outputFileListPaths)
+                     outputFileListPaths: outputFileListPaths,
+                     basedOnDependencyAnalysis: basedOnDependencyAnalysis)
     }
 
     // MARK: - Codable
@@ -333,6 +364,7 @@ public struct TargetAction: Codable, Equatable {
         inputFileListPaths = try container.decodeIfPresent([Path].self, forKey: .inputFileListPaths) ?? []
         outputPaths = try container.decodeIfPresent([Path].self, forKey: .outputPaths) ?? []
         outputFileListPaths = try container.decodeIfPresent([Path].self, forKey: .outputFileListPaths) ?? []
+        basedOnDependencyAnalysis = try container.decodeIfPresent(Bool.self, forKey: .basedOnDependencyAnalysis)
         if let path = try container.decodeIfPresent(Path.self, forKey: .path) {
             self.path = path
             tool = nil
@@ -352,6 +384,7 @@ public struct TargetAction: Codable, Equatable {
         try container.encode(inputFileListPaths, forKey: .inputFileListPaths)
         try container.encode(outputPaths, forKey: .outputPaths)
         try container.encode(outputFileListPaths, forKey: .outputFileListPaths)
+        try container.encode(basedOnDependencyAnalysis, forKey: .basedOnDependencyAnalysis)
 
         if let tool = tool {
             try container.encode(tool, forKey: .tool)

--- a/Sources/ProjectDescription/TargetAction.swift
+++ b/Sources/ProjectDescription/TargetAction.swift
@@ -36,7 +36,7 @@ public struct TargetAction: Codable, Equatable {
 
     /// List of output filelist paths
     public let outputFileListPaths: [Path]
-    
+
     /// Whether to skip running this script in incremental builds, if nothing has changed
     public let basedOnDependencyAnalysis: Bool?
 

--- a/Sources/TuistCore/Models/TargetAction.swift
+++ b/Sources/TuistCore/Models/TargetAction.swift
@@ -42,7 +42,7 @@ public struct TargetAction: Equatable {
 
     /// Show environment variables in the logs
     public var showEnvVarsInLog: Bool
-    
+
     /// Whether to skip running this script in incremental builds, if nothing has changed
     public let basedOnDependencyAnalysis: Bool?
 

--- a/Sources/TuistCore/Models/TargetAction.swift
+++ b/Sources/TuistCore/Models/TargetAction.swift
@@ -42,6 +42,9 @@ public struct TargetAction: Equatable {
 
     /// Show environment variables in the logs
     public var showEnvVarsInLog: Bool
+    
+    /// Whether to skip running this script in incremental builds, if nothing has changed
+    public let basedOnDependencyAnalysis: Bool?
 
     /// Initializes a new target action with its attributes.
     ///
@@ -55,6 +58,8 @@ public struct TargetAction: Equatable {
     ///   - inputFileListPaths: List of input filelist paths
     ///   - outputPaths: List of output file paths
     ///   - outputFileListPaths: List of output filelist paths
+    ///   - showEnvVarsInLog: Show environment variables in the logs
+    ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
     public init(name: String,
                 order: Order,
                 tool: String? = nil,
@@ -64,7 +69,8 @@ public struct TargetAction: Equatable {
                 inputFileListPaths: [AbsolutePath] = [],
                 outputPaths: [AbsolutePath] = [],
                 outputFileListPaths: [AbsolutePath] = [],
-                showEnvVarsInLog: Bool = true)
+                showEnvVarsInLog: Bool = true,
+                basedOnDependencyAnalysis: Bool? = nil)
     {
         self.name = name
         self.order = order
@@ -76,6 +82,7 @@ public struct TargetAction: Equatable {
         self.outputPaths = outputPaths
         self.outputFileListPaths = outputFileListPaths
         self.showEnvVarsInLog = showEnvVarsInLog
+        self.basedOnDependencyAnalysis = basedOnDependencyAnalysis
     }
 
     /// Returns the shell script that should be used in the target build phase.

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -114,6 +114,13 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
                                                           shellPath: "/bin/sh",
                                                           shellScript: action.shellScript(sourceRootPath: sourceRootPath),
                                                           showEnvVarsInLog: action.showEnvVarsInLog)
+            if let basedOnDependencyAnalysis = action.basedOnDependencyAnalysis {
+                // Force the script to run in all incremental builds, if we
+                // are NOT running it based on dependency analysis. Otherwise
+                // leave it at the default value.
+                buildPhase.alwaysOutOfDate = !basedOnDependencyAnalysis
+            }
+
             pbxproj.add(object: buildPhase)
             pbxTarget.buildPhases.append(buildPhase)
         }

--- a/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
@@ -18,6 +18,7 @@ extension TuistCore.TargetAction {
         let inputFileListPaths = try manifest.inputFileListPaths.map { try generatorPaths.resolve(path: $0) }
         let outputPaths = try manifest.outputPaths.map { try generatorPaths.resolve(path: $0) }
         let outputFileListPaths = try manifest.outputFileListPaths.map { try generatorPaths.resolve(path: $0) }
+        let basedOnDependencyAnalysis = manifest.basedOnDependencyAnalysis
         let path = try manifest.path.map { try generatorPaths.resolve(path: $0) }
         return TargetAction(name: name,
                             order: order,
@@ -27,7 +28,8 @@ extension TuistCore.TargetAction {
                             inputPaths: inputPaths,
                             inputFileListPaths: inputFileListPaths,
                             outputPaths: outputPaths,
-                            outputFileListPaths: outputFileListPaths)
+                            outputFileListPaths: outputFileListPaths,
+                            basedOnDependencyAnalysis: basedOnDependencyAnalysis)
     }
 }
 

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -546,7 +546,7 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
         let target = Target.test(sources: [],
                                  resources: [],
                                  actions: [
-                                     TargetAction(name: "post", order: .post, path: path.appending(component: "script.sh"), arguments: ["arg"], showEnvVarsInLog: false),
+                                     TargetAction(name: "post", order: .post, path: path.appending(component: "script.sh"), arguments: ["arg"], showEnvVarsInLog: false, basedOnDependencyAnalysis: false),
                                      TargetAction(name: "pre", order: .pre, path: path.appending(component: "script.sh"), arguments: ["arg"]),
                                  ])
         let project = Project.test(path: path, sourceRootPath: path, xcodeProjPath: path.appending(component: "Project.xcodeproj"), targets: [target])
@@ -580,6 +580,7 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
         XCTAssertEqual(postBuildPhase.shellPath, "/bin/sh")
         XCTAssertEqual(postBuildPhase.shellScript, "\"${PROJECT_DIR}\"/script.sh arg")
         XCTAssertFalse(postBuildPhase.showEnvVarsInLog)
+        XCTAssertTrue(postBuildPhase.alwaysOutOfDate)
     }
 
     // MARK: - Helpers

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -574,6 +574,7 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
         XCTAssertEqual(preBuildPhase.shellPath, "/bin/sh")
         XCTAssertEqual(preBuildPhase.shellScript, "\"${PROJECT_DIR}\"/script.sh arg")
         XCTAssertTrue(preBuildPhase.showEnvVarsInLog)
+        XCTAssertFalse(preBuildPhase.alwaysOutOfDate)
 
         let postBuildPhase = try XCTUnwrap(pbxTarget.buildPhases.last as? PBXShellScriptBuildPhase)
         XCTAssertEqual(postBuildPhase.name, "post")

--- a/website/markdown/docs/usage/project-description.mdx
+++ b/website/markdown/docs/usage/project-description.mdx
@@ -636,25 +636,25 @@ Target actions, represented as target script build phases, are useful to define 
   cases={[
     {
       case:
-        '.pre(tool: String, arguments: String..., name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path])',
+        '.pre(tool: String, arguments: String..., name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool)',
       description:
         'Action executed before the target-specific build phases where tool is the name of the tool to be executed.',
     },
     {
       case:
-        '.pre(path: Path, arguments: String..., name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path])',
+        '.pre(path: Path, arguments: String..., name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool)',
       description:
         'Action executed before the target-specific build phases where path is the path to the tool to be executed.',
     },
     {
       case:
-        '.post(tool: String, arguments: String..., name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path])',
+        '.post(tool: String, arguments: String..., name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool)',
       description:
         'Action executed after all the target-specific build phases where tool is the name of the tool to be executed.',
     },
     {
       case:
-        '.post(path: Path, arguments: String..., name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path])',
+        '.post(path: Path, arguments: String..., name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool)',
       description:
         'Action executed after all the target-specific build phases where path is the path to the tool to be executed.',
     },
@@ -671,6 +671,12 @@ The following example shows the definition of an action that runs the `my_custom
 
 ```swift
 .pre(path: "my_custom_script.sh", name: "My Custom Script Phase", inputFileListPaths: [ "Data/Cars.raw.json", "Data/Drivers.raw.json" ], outputFileListPaths: [ "Data/Cars.swift", "Data/Drivers.swift" ])
+```
+
+The following example shows the definition of an action that runs the `my_custom_script.sh` on all incremental builds, regardless of whether or not something has changed:
+
+```swift
+.pre(path: "my_custom_script.sh", name: "My Custom Script Phase", basedOnDependencyAnalysis: false)
 ```
 
 ## Preset Build Configuration


### PR DESCRIPTION
Resolves https://community.tuist.io/t/git-commit-hashes-in-info-plists/139/3

### Short description 📝

This PR allows Tuist projects to configure build-phase scripts to run in incremental builds regardless of whether or not something has changed according to Xcode's build dependency analysis. One use-case for this is to allow these scripts to update the Git commit hash in the Info plist.

### Solution 📦

The `XcodeProj` model already allowed you to specify an `alwaysOutOfDate` flag to suppress that build dependency analysis. This PR merely exposes that flag through Tuist's project description model, i.e. it adds a flag in the model `TargetAction` called `basedOnDependencyAnalysis` and passes it through accordingly.

### Implementation 👩‍💻👨‍💻

- Added the flag in both `ProjectDescription.TargetAction` and `TuistCore.Models.TargetAction`
- Made sure that it's passed through correctly in the mapping between those two models, and in the `BuildPhaseGenerator`
- Added a unit test for this
- Ran `tuist generate` locally using [the Getting Started instructions](https://tuist.io/docs/contribution/getting-started/) and made sure that the script runs always in my project.

<img width="877" alt="" src="https://user-images.githubusercontent.com/1212480/95727786-53bbd580-0c83-11eb-87e4-dc941aa4bba9.png">
<img width="350" alt="" src="https://user-images.githubusercontent.com/1212480/95727777-50c0e500-0c83-11eb-96ff-d4c71bdd4ec4.png">


