### PR TITLE
Version 1.21.0 and disable release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,21 +17,21 @@ jobs:
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: '2.x'
-      - name: Install Bundler 2.1.4
-        run: gem install bundler --version 2.1.4
-      - uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-      - name: Bundle install
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
-      - name: Select Xcode 11.5
-        run: sudo xcode-select -switch /Applications/Xcode_11.5.app
-      - name: Create a new release
-        uses: fortmarek/tapestry-action@0.1.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Install Bundler 2.1.4
+      #   run: gem install bundler --version 2.1.4
+      # - uses: actions/cache@v2
+      #   with:
+      #     path: vendor/bundle
+      #     key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-gems-
+      # - name: Bundle install
+      #   run: |
+      #     bundle config path vendor/bundle
+      #     bundle install --jobs 4 --retry 3
+      # - name: Select Xcode 11.5
+      #   run: sudo xcode-select -switch /Applications/Xcode_11.5.app
+      # - name: Create a new release
+      #   uses: fortmarek/tapestry-action@0.1.1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+## 1.21.0 - PBWerk
+
 ### Added
 
 - Allow ignoring cache when running tuist focus [#1879](https://github.com/tuist/tuist/pull/1879) by [@natanrolnik](https://github.com/natanrolnik).


### PR DESCRIPTION
### Short description 📝
I'm releasing a new version of Tuist, 1.21.0, and disabling the release pipeline for now because it's constantly marking the latest release on GitHub as a draft. I'll leave it disabled until we can investigate it further.