### PR TITLE
Allow trailing line break in `.tuist_version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Fix calculation of Settings hash related to Cache commands [#1869](Fix calculation of Settings hash related to Cache commands) by [@natanrolnik](https://github.com/natanrolnik)
+- Fixed handling of `.tuist_version` file if the file had a trailing line break [#1900](Allow trailing line break in `.tuist_version`) by [@kalkwarf](https://github.com/kalkwarf)
 
 ## 1.20.0 - Heideberg
 

--- a/Sources/TuistEnvKit/Versions/VersionResolver.swift
+++ b/Sources/TuistEnvKit/Versions/VersionResolver.swift
@@ -86,7 +86,7 @@ class VersionResolver: VersionResolving {
     private func resolveVersionFile(path: AbsolutePath) throws -> ResolvedVersion {
         var value: String!
         do {
-            value = try String(contentsOf: URL(fileURLWithPath: path.pathString))
+            value = try String(contentsOf: URL(fileURLWithPath: path.pathString)).trimmingCharacters(in: .whitespacesAndNewlines)
         } catch {
             throw VersionResolverError.readError(path: path)
         }

--- a/Tests/TuistEnvKitTests/Versions/VersionResolverTests.swift
+++ b/Tests/TuistEnvKitTests/Versions/VersionResolverTests.swift
@@ -65,6 +65,19 @@ final class VersionResolverTests: XCTestCase {
         XCTAssertEqual(got, .versionFile(versionPath, "3.2.1"))
     }
 
+    func test_resolve_when_version_contains_trailing_whitespace() throws {
+        let tmp_dir = try TemporaryDirectory(removeTreeOnDeinit: true)
+        let versionPath = tmp_dir.path.appending(component: Constants.versionFileName)
+
+        // /tmp/dir/.tuist-version
+        try "3.2.1 \n".write(to: URL(fileURLWithPath: versionPath.pathString),
+                             atomically: true,
+                             encoding: .utf8)
+
+        let got = try subject.resolve(path: tmp_dir.path)
+        XCTAssertEqual(got, .versionFile(versionPath, "3.2.1"))
+    }
+
     func test_resolve_when_bin() throws {
         let tmp_dir = try TemporaryDirectory(removeTreeOnDeinit: true)
         let binPath = tmp_dir.path.appending(component: Constants.binFolderName)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY

### Short description 📝

If the `.tuist_version` file had a trailing line break (or spaces), the tuist update would fail:
```
Using version 1.21.0
 defined at /Users/me/my-project/.tuist-version
Version 1.21.0
 not found locally. Installing...
Pulling source code
Cloning into '/var/folders/f_/y6129x2j0jsdcp1q7tcb_3qh0000gn/T/TemporaryDirectory.opC1xa'...
Version 1.21.0
 not found
```
### Solution 📦

After reading the contents of the file, trim whitespace off the ends.

### Implementation 👩‍💻👨‍💻

Wrote a test that failed when the file contained training whitespace and line breaks

Wrote the code to trim the version

Verified the tests pass