### PR TITLE
Add a mapper that adds a build phase to locate the built products directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 - Require the `Config.swift` file to be in the Tuist directory [#693](https://github.com/tuist/tuist/issues/693) by [@mollyIV](https://github.com/mollyIV).
+- Mapper for the caching logic to locate the built products directory [](https://github.com/tuist/tuist/pull/1929) by [@pepibumur](https://github.com/pepibumur).
 
 ## 1.22.0 - Heimat
 
@@ -17,7 +18,6 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 - Allow build phase scripts to disable dependency analysis [#1883](https://github.com/tuist/tuist/pull/1883) by [@bhuemer](https://github.com/bhuemer).
-
 - The default generated project does not include a LaunchScreen storyboard [#265](https://github.com/tuist/tuist/issues/265) by [@mollyIV](https://github.com/mollyIV).
 
 ## 1.21.0 - PBWerk

--- a/Sources/TuistCache/GraphMappers/CacheBuildPhaseProjectMapper.swift
+++ b/Sources/TuistCache/GraphMappers/CacheBuildPhaseProjectMapper.swift
@@ -1,0 +1,27 @@
+import Foundation
+import RxBlocking
+import RxSwift
+import TSCBasic
+import TuistCore
+import TuistSupport
+
+public class CacheBuildPhaseProjectMapper: ProjectMapping {
+    public func map(project: Project) throws -> (Project, [SideEffectDescriptor]) {
+        let project = project.with(targets: project.targets.map { target in
+            var target = target
+            if target.product.isFramework {
+                target.scripts.append(.init(name: "Create file to locate the built products dir", script: script(target: target)))
+            }
+            return target
+        })
+        return (project, [])
+    }
+
+    fileprivate func script(target: Target) -> String {
+        """
+        if [ -n "$\(target.targetLocatorBuildPhaseVariable)" ]; then
+            touch $BUILT_PRODUCTS_DIR/.$\(target.targetLocatorBuildPhaseVariable).tuist
+        fi
+        """
+    }
+}

--- a/Sources/TuistCore/Models/Target.swift
+++ b/Sources/TuistCore/Models/Target.swift
@@ -47,6 +47,7 @@ public struct Target: Equatable, Hashable, Comparable {
     public var environment: [String: String]
     public var launchArguments: [String: Bool]
     public var filesGroup: ProjectGroup
+    public var scripts: [TargetScript]
 
     // MARK: - Init
 
@@ -67,7 +68,8 @@ public struct Target: Equatable, Hashable, Comparable {
                 environment: [String: String] = [:],
                 launchArguments: [String: Bool] = [:],
                 filesGroup: ProjectGroup,
-                dependencies: [Dependency] = [])
+                dependencies: [Dependency] = [],
+                scripts: [TargetScript] = [])
     {
         self.name = name
         self.product = product
@@ -87,6 +89,7 @@ public struct Target: Equatable, Hashable, Comparable {
         self.launchArguments = launchArguments
         self.filesGroup = filesGroup
         self.dependencies = dependencies
+        self.scripts = scripts
     }
 
     /// Target can be included in the link phase of other targets
@@ -114,6 +117,17 @@ public struct Target: Equatable, Hashable, Comparable {
             .appExtension,
             .watch2Extension,
         ].contains(product)
+    }
+
+    /// It returns the name of the variable that should be used to create an empty file
+    /// in the $BUILT_PRODUCTS_DIR directory that is used after builds to reliably locate the
+    /// directories where the products have been exported into.
+    public var targetLocatorBuildPhaseVariable: String {
+        let upperCasedSnakeCasedProductName = productName
+            .camelCaseToSnakeCase()
+            .components(separatedBy: .whitespaces).joined(separator: "_")
+            .uppercased()
+        return "\(upperCasedSnakeCasedProductName)_LOCATE_HASH"
     }
 
     /// Returns the product name including the extension.

--- a/Sources/TuistCore/Models/TargetScript.swift
+++ b/Sources/TuistCore/Models/TargetScript.swift
@@ -1,0 +1,22 @@
+import Foundation
+import TSCBasic
+import TuistSupport
+
+/// It represents a target build phase.
+public struct TargetScript: Equatable {
+    /// The  name of the build phase.
+    public let name: String
+
+    /// Script.
+    public let script: String
+
+    /// Initializes the target script.
+    /// - Parameter name: The name of the build phase.
+    /// - Parameter script: Script.
+    public init(name: String,
+                script: String)
+    {
+        self.name = name
+        self.script = script
+    }
+}

--- a/Sources/TuistCoreTesting/Models/Target+TestData.swift
+++ b/Sources/TuistCoreTesting/Models/Target+TestData.swift
@@ -21,7 +21,8 @@ public extension Target {
                      actions: [TargetAction] = [],
                      environment: [String: String] = [:],
                      filesGroup: ProjectGroup = .group(name: "Project"),
-                     dependencies: [Dependency] = []) -> Target
+                     dependencies: [Dependency] = [],
+                     scripts: [TargetScript] = []) -> Target
     {
         Target(name: name,
                platform: platform,
@@ -39,7 +40,8 @@ public extension Target {
                actions: actions,
                environment: environment,
                filesGroup: filesGroup,
-               dependencies: dependencies)
+               dependencies: dependencies,
+               scripts: scripts)
     }
 
     /// Creates a bare bones Target with as little data as possible
@@ -59,7 +61,8 @@ public extension Target {
                       actions: [TargetAction] = [],
                       environment: [String: String] = [:],
                       filesGroup: ProjectGroup = .group(name: "Project"),
-                      dependencies: [Dependency] = []) -> Target
+                      dependencies: [Dependency] = [],
+                      scripts: [TargetScript] = []) -> Target
     {
         Target(name: name,
                platform: platform,
@@ -77,6 +80,7 @@ public extension Target {
                actions: actions,
                environment: environment,
                filesGroup: filesGroup,
-               dependencies: dependencies)
+               dependencies: dependencies,
+               scripts: scripts)
     }
 }

--- a/Sources/TuistCoreTesting/Models/TargetScript+TestData.swift
+++ b/Sources/TuistCoreTesting/Models/TargetScript+TestData.swift
@@ -1,0 +1,11 @@
+import Foundation
+import TSCBasic
+@testable import TuistCore
+
+public extension TargetScript {
+    static func test(name: String = "Test",
+                     script: String = "") -> TargetScript
+    {
+        TargetScript(name: name, script: script)
+    }
+}

--- a/Sources/TuistSupport/Extensions/String+Extras.swift
+++ b/Sources/TuistSupport/Extensions/String+Extras.swift
@@ -102,6 +102,19 @@ extension String {
 
         return ([first] + rest).joined(separator: "")
     }
+
+    public func camelCaseToSnakeCase() -> String {
+        let acronymPattern = "([A-Z]+)([A-Z][a-z]|[0-9])"
+        let normalPattern = "([a-z0-9])([A-Z])"
+        return processCamalCaseRegex(pattern: acronymPattern)?
+            .processCamalCaseRegex(pattern: normalPattern)?.lowercased() ?? lowercased()
+    }
+
+    fileprivate func processCamalCaseRegex(pattern: String) -> String? {
+        let regex = try? NSRegularExpression(pattern: pattern, options: [])
+        let range = NSRange(location: 0, length: count)
+        return regex?.stringByReplacingMatches(in: self, options: [], range: range, withTemplate: "$1_$2")
+    }
 }
 
 private func inShellWhitelist(_ codeUnit: UInt8) -> Bool {

--- a/Tests/TuistCacheTests/GraphMappers/CacheBuildPhaseProjectMapperTests.swift
+++ b/Tests/TuistCacheTests/GraphMappers/CacheBuildPhaseProjectMapperTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import RxBlocking
+import RxSwift
+import TuistCore
+import XCTest
+
+@testable import TuistCache
+@testable import TuistCacheTesting
+@testable import TuistCoreTesting
+@testable import TuistSupportTesting
+
+final class CacheBuildPhaseProjectMapperTests: TuistUnitTestCase {
+    var subject: CacheBuildPhaseProjectMapper!
+
+    override func setUp() {
+        subject = CacheBuildPhaseProjectMapper()
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        subject = nil
+    }
+
+    func test_map_when_the_target_is_a_framework() throws {
+        // When
+        let target = Target.test(product: .framework, productName: "Framework")
+        let project = Project.test(targets: [target])
+
+        // When
+        let (got, _) = try subject.map(project: project)
+
+        // Then
+        let script = try XCTUnwrap(got.targets.first?.scripts.first)
+        XCTAssertEqual(script.name, "Create file to locate the built products dir")
+        let expected = """
+        if [ -n "$\(target.targetLocatorBuildPhaseVariable)" ]; then
+            touch $BUILT_PRODUCTS_DIR/.$\(target.targetLocatorBuildPhaseVariable).tuist
+        fi
+        """
+        XCTAssertEqual(script.script, expected)
+    }
+
+    func test_map_when_the_target_is_not_a_framework() throws {
+        // When
+        let target = Target.test(product: .app, productName: "App")
+        let project = Project.test(targets: [target])
+
+        // When
+        let (got, _) = try subject.map(project: project)
+
+        // Then
+        XCTAssertEqual(got.targets.first?.scripts.count, 0)
+    }
+}

--- a/Tests/TuistCoreTests/Models/TargetTests.swift
+++ b/Tests/TuistCoreTests/Models/TargetTests.swift
@@ -59,6 +59,11 @@ final class TargetTests: TuistUnitTestCase {
         XCTAssertEqual(targets.apps, [app])
     }
 
+    func test_targetLocatorBuildPhaseVariable() {
+        XCTAssertEqual(Target.test(productName: "My Framework").targetLocatorBuildPhaseVariable, "MY_FRAMEWORK_LOCATE_HASH")
+        XCTAssertEqual(Target.test(productName: "Feature").targetLocatorBuildPhaseVariable, "FEATURE_LOCATE_HASH")
+    }
+
     func test_sources() throws {
         // Given
         let temporaryPath = try self.temporaryPath()


### PR DESCRIPTION
### Short description 📝
I'm adding a build phase that can be used by the caching logic to locate the built product directory where `xcodebuild` has exported the built artifacts. In a follow-up PR I'll extend the caching logic to use the mapper in the project generated for building the frameworks. 

Note that I've introduced a new internal model, `TargetScript`, that represents a more flexible scripts build phase. In a follow-up PR I'll extend the generation logic to account for the `target.scripts` attribute.