### PR TITLE
Use cache mapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Require the `Config.swift` file to be in the Tuist directory [#693](https://github.com/tuist/tuist/issues/693) by [@mollyIV](https://github.com/mollyIV).
 - Mapper for the caching logic to locate the built products directory [#1929](https://github.com/tuist/tuist/pull/1929) by [@pepibumur](https://github.com/pepibumur).
 - Extended `BuildPhaseGenerator` to generate script build phases [#1932](https://github.com/tuist/tuist/pull/1932) by [@pepibumur](https://github.com/pepibumur).
+- Extend the `TargetContentHasher` to account for the `Target.scripts` attribute [#1933](https://github.com/tuist/tuist/pull/1933) by [@pepibumur](https://github.com/pepibumur).
+- Extend the `CacheController` to generate projects with the build phase to locate the targets' built products directory [#1933](https://github.com/tuist/tuist/pull/1933) by [@pepibumur](https://github.com/pepibumur).
 
 ### Fixed
 

--- a/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
@@ -14,6 +14,7 @@ public final class TargetContentHasher: TargetContentHashing {
     private let coreDataModelsContentHasher: CoreDataModelsContentHashing
     private let sourceFilesContentHasher: SourceFilesContentHashing
     private let targetActionsContentHasher: TargetActionsContentHashing
+    private let targetScriptsContentHasher: TargetScriptsContentHashing
     private let resourcesContentHasher: ResourcesContentHashing
     private let headersContentHasher: HeadersContentHashing
     private let deploymentTargetContentHasher: DeploymentTargetContentHashing
@@ -28,6 +29,7 @@ public final class TargetContentHasher: TargetContentHashing {
             contentHasher: contentHasher,
             sourceFilesContentHasher: SourceFilesContentHasher(contentHasher: contentHasher),
             targetActionsContentHasher: TargetActionsContentHasher(contentHasher: contentHasher),
+            targetScriptsContentHasher: TargetScriptsContentHasher(contentHasher: contentHasher),
             coreDataModelsContentHasher: CoreDataModelsContentHasher(contentHasher: contentHasher),
             resourcesContentHasher: ResourcesContentHasher(contentHasher: contentHasher),
             headersContentHasher: HeadersContentHasher(contentHasher: contentHasher),
@@ -42,6 +44,7 @@ public final class TargetContentHasher: TargetContentHashing {
         contentHasher: ContentHashing,
         sourceFilesContentHasher: SourceFilesContentHashing,
         targetActionsContentHasher: TargetActionsContentHashing,
+        targetScriptsContentHasher: TargetScriptsContentHashing,
         coreDataModelsContentHasher: CoreDataModelsContentHashing,
         resourcesContentHasher: ResourcesContentHashing,
         headersContentHasher: HeadersContentHashing,
@@ -54,6 +57,7 @@ public final class TargetContentHasher: TargetContentHashing {
         self.sourceFilesContentHasher = sourceFilesContentHasher
         self.coreDataModelsContentHasher = coreDataModelsContentHasher
         self.targetActionsContentHasher = targetActionsContentHasher
+        self.targetScriptsContentHasher = targetScriptsContentHasher
         self.resourcesContentHasher = resourcesContentHasher
         self.headersContentHasher = headersContentHasher
         self.deploymentTargetContentHasher = deploymentTargetContentHasher
@@ -70,6 +74,7 @@ public final class TargetContentHasher: TargetContentHashing {
         let resourcesHash = try resourcesContentHasher.hash(resources: target.resources)
         let coreDataModelHash = try coreDataModelsContentHasher.hash(coreDataModels: target.coreDataModels)
         let targetActionsHash = try targetActionsContentHasher.hash(targetActions: target.actions)
+        let targetScriptsHash = try targetScriptsContentHasher.hash(targetScripts: target.scripts)
         let dependenciesHash = try dependenciesContentHasher.hash(dependencies: target.dependencies)
         let environmentHash = try contentHasher.hash(target.environment)
         var stringsToHash = [target.name,
@@ -82,6 +87,7 @@ public final class TargetContentHasher: TargetContentHashing {
                              resourcesHash,
                              coreDataModelHash,
                              targetActionsHash,
+                             targetScriptsHash,
                              environmentHash]
         if let headers = target.headers {
             let headersHash = try headersContentHasher.hash(headers: headers)

--- a/Sources/TuistCache/ContentHashing/TargetScriptsContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/TargetScriptsContentHasher.swift
@@ -1,0 +1,33 @@
+import Foundation
+import TSCBasic
+import TuistCore
+
+public protocol TargetScriptsContentHashing {
+    func hash(targetScripts: [TargetScript]) throws -> String
+}
+
+/// `TargetScriptsContentHasher`
+/// is responsible for computing a unique hash that identifies a list of target scripts
+public final class TargetScriptsContentHasher: TargetScriptsContentHashing {
+    private let contentHasher: ContentHashing
+
+    // MARK: - Init
+
+    public init(contentHasher: ContentHashing) {
+        self.contentHasher = contentHasher
+    }
+
+    // MARK: - TargetScriptsContentHashing
+
+    /// Returns the hash that uniquely identifies an array of target actions
+    /// The hash takes into consideration the content of the script to execute, the content of input/output files, the name of the tool to execute, the order, the arguments and its name
+    public func hash(targetScripts: [TargetScript]) throws -> String {
+        var stringsToHash: [String] = []
+        for targetScript in targetScripts {
+            stringsToHash.append(targetScript.name)
+            stringsToHash.append(targetScript.script)
+            stringsToHash.append("\(targetScript.showEnvVarsInLog)")
+        }
+        return try contentHasher.hash(stringsToHash)
+    }
+}

--- a/Sources/TuistCache/GraphMappers/CacheBuildPhaseProjectMapper.swift
+++ b/Sources/TuistCache/GraphMappers/CacheBuildPhaseProjectMapper.swift
@@ -6,6 +6,8 @@ import TuistCore
 import TuistSupport
 
 public class CacheBuildPhaseProjectMapper: ProjectMapping {
+    public init() {}
+
     public func map(project: Project) throws -> (Project, [SideEffectDescriptor]) {
         let project = project.with(targets: project.targets.map { target in
             var target = target

--- a/Tests/TuistCacheIntegrationTests/ContentHashing/ContentHashingIntegrationTests.swift
+++ b/Tests/TuistCacheIntegrationTests/ContentHashing/ContentHashingIntegrationTests.swift
@@ -107,8 +107,8 @@ final class ContentHashingIntegrationTests: TuistTestCase {
         let contentHash = try subject.contentHashes(for: graph, cacheOutputType: .framework)
 
         // Then
-        XCTAssertEqual(contentHash[framework1], "327b3a3ec1910300eac1519f2a6faed1")
-        XCTAssertEqual(contentHash[framework2], "8c1318407758ee46cb182af1c44373ac")
+        XCTAssertEqual(contentHash[framework1], "cb93cd96c5af9deb87fad78fd14b5664")
+        XCTAssertEqual(contentHash[framework2], "f224c9df7a44ce5c7849f10e58142718")
     }
 
     func test_contentHashes_hashChangesWithCacheOutputType() throws {

--- a/Tests/TuistCacheTests/ContentHashing/TargetScriptsContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/TargetScriptsContentHasherTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import TSCBasic
+import TuistCacheTesting
+import TuistCore
+import TuistCoreTesting
+import TuistSupport
+import XCTest
+@testable import TuistCache
+@testable import TuistSupportTesting
+
+final class TargetScriptsContentHasherTests: TuistUnitTestCase {
+    private var subject: TargetScriptsContentHasher!
+    private var mockContentHasher: MockContentHashing!
+
+    override func setUp() {
+        super.setUp()
+        mockContentHasher = MockContentHashing()
+        subject = TargetScriptsContentHasher(contentHasher: mockContentHasher)
+    }
+
+    override func tearDown() {
+        subject = nil
+        mockContentHasher = nil
+        super.tearDown()
+    }
+
+    // MARK: - Tests
+
+    func test_hash() throws {
+        // Given
+        let first = TargetScript(name: "First Test",
+                                 script: "echo 'first'",
+                                 showEnvVarsInLog: true)
+        let second = TargetScript(name: "Second test",
+                                  script: "echo 'second'",
+                                  showEnvVarsInLog: false)
+
+        // When
+        _ = try subject.hash(targetScripts: [first, second])
+
+        // Then
+        let expected = [
+            first.name, first.script, "\(first.showEnvVarsInLog)",
+            second.name, second.script, "\(second.showEnvVarsInLog)",
+        ]
+        XCTAssertEqual(mockContentHasher.hashStringsSpy, expected)
+    }
+}

--- a/Tests/TuistKitTests/Cache/CacheControllerTests.swift
+++ b/Tests/TuistKitTests/Cache/CacheControllerTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import TSCBasic
+import TuistCache
 import TuistCacheTesting
 import TuistCore
 import TuistCoreTesting
@@ -8,8 +9,29 @@ import TuistLoaderTesting
 import TuistSupport
 import XCTest
 
+@testable import TuistCore
 @testable import TuistKit
 @testable import TuistSupportTesting
+
+final class CacheControllerProjectMapperProviderTests: TuistUnitTestCase {
+    var subject: CacheControllerProjectMapperProvider!
+
+    override func setUp() {
+        subject = CacheControllerProjectMapperProvider()
+    }
+
+    func test_mapper_includes_the_cache_build_phase_project_mapper() throws {
+        // Given
+        let config = Config.test()
+
+        // When
+        let got = subject.mapper(config: config)
+
+        // Then
+        let sequentialMapper = try XCTUnwrap(got as? SequentialProjectMapper)
+        XCTAssertTrue(sequentialMapper.mappers.last is CacheBuildPhaseProjectMapper)
+    }
+}
 
 final class CacheControllerTests: TuistUnitTestCase {
     var generator: MockProjectGenerator!

--- a/Tests/TuistKitTests/Cache/CacheControllerTests.swift
+++ b/Tests/TuistKitTests/Cache/CacheControllerTests.swift
@@ -18,6 +18,7 @@ final class CacheControllerTests: TuistUnitTestCase {
     var manifestLoader: MockManifestLoader!
     var cache: MockCacheStorage!
     var subject: CacheController!
+    var projectGeneratorProvider: MockCacheControllerProjectGeneratorProvider!
     var config: Config!
 
     override func setUp() {
@@ -27,9 +28,11 @@ final class CacheControllerTests: TuistUnitTestCase {
         manifestLoader = MockManifestLoader()
         graphContentHasher = MockGraphContentHasher()
         config = .test()
+        projectGeneratorProvider = MockCacheControllerProjectGeneratorProvider()
+        projectGeneratorProvider.stubbedGeneratorResult = generator
         subject = CacheController(cache: cache,
                                   artifactBuilder: artifactBuilder,
-                                  generator: generator,
+                                  projectGeneratorProvider: projectGeneratorProvider,
                                   graphContentHasher: graphContentHasher)
 
         super.setUp()

--- a/Tests/TuistKitTests/Cache/Mocks/MockCacheControllerProjectGeneratorProvider.swift
+++ b/Tests/TuistKitTests/Cache/Mocks/MockCacheControllerProjectGeneratorProvider.swift
@@ -1,0 +1,14 @@
+import Foundation
+@testable import TuistKit
+
+final class MockCacheControllerProjectGeneratorProvider: CacheControllerProjectGeneratorProviding {
+    var invokedGenerator = false
+    var invokedGeneratorCount = 0
+    var stubbedGeneratorResult: ProjectGenerating!
+
+    func generator() -> ProjectGenerating {
+        invokedGenerator = true
+        invokedGeneratorCount += 1
+        return stubbedGeneratorResult
+    }
+}


### PR DESCRIPTION
# Short description 📝
I'm introducing a bunch if improvements that are required for fixing the issue that @natanrolnik came across in the caching functionality where we were sporting transitive dependencies and doing clean builds every time we built a target:

- I'm extending the `CacheController` to generate projects with the build phases that will be used to locate the targets' built products directory.
- I extended the `TargetContentHasher` to account for the new `Target.scripts` attribute.

In a follow-up PR I'll change the logic that builds the frameworks to use the file generated by the build phase to locate the built products.

