### PR TITLE
Fix missing profile scheme arguments when specified in manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Fixed non-framework/library targets having a header build phase [#367](https://github.com/tuist/tuist/issues/367) by [@eito](https://github.com/eito).
+- Fixed missing profile scheme arguments when specified in manifest [#1543](https://github.com/tuist/tuist/issues/1543) by [@lakpa](https://github.com/lakpa).
 
 ## 1.22.0 - Heimat
 

--- a/Sources/TuistGenerator/Generator/SchemesGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemesGenerator.swift
@@ -377,6 +377,8 @@ final class SchemesGenerator: SchemesGenerating {
             }
         }
 
+        let shouldUseLaunchSchemeArgsEnv: Bool = commandlineArguments == nil && environments == nil
+
         guard let targetNode = graph.target(path: target.projectPath, name: target.name) else { return nil }
         guard let buildableReference = try createBuildableReference(targetReference: target,
                                                                     graph: graph,
@@ -396,6 +398,7 @@ final class SchemesGenerator: SchemesGenerating {
         return XCScheme.ProfileAction(buildableProductRunnable: buildableProductRunnable,
                                       buildConfiguration: buildConfiguration,
                                       macroExpansion: macroExpansion,
+                                      shouldUseLaunchSchemeArgsEnv: shouldUseLaunchSchemeArgsEnv,
                                       commandlineArguments: commandlineArguments,
                                       environmentVariables: environments)
     }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1543

### Short description 📝

This PR resolves missing profile scheme command line arguments when specified in manifest .

### Solution 📦

Command line arguments and environments appears to be not taken account of when setting **shouldUseLaunchSchemeArgsEnv** property of **LaunchAction** which translated to **Use the Run action's argument and environment variables** and that is use to toggle **command line arguments visibility and setting**, please refer to following screenshot for more context.

<img width="899" alt="Screenshot 2020-10-22 at 22 13 19" src="https://user-images.githubusercontent.com/389328/96930830-4210d400-14b4-11eb-8bef-423e6e822615.png">

