### PR TITLE
Test without signing

### DIFF
--- a/Sources/TuistAutomation/Utilities/BuildGraphInspector.swift
+++ b/Sources/TuistAutomation/Utilities/BuildGraphInspector.swift
@@ -7,6 +7,7 @@ public protocol BuildGraphInspecting {
     /// Returns the build arguments to be used with the given target.
     /// - Parameter target: Target whose build arguments will be returned.
     /// - Parameter configuration: The configuration to be built. When nil, it defaults to the configuration specified in the scheme.
+    /// - Parameter skipSigning: Skip code signing during build that is not required to be signed (eg. build for testing on iOS Simulator)
     func buildArguments(target: Target, configuration: String?, skipSigning: Bool) -> [XcodeBuildArgument]
 
     /// Given a directory, it returns the first .xcworkspace found.

--- a/Sources/TuistAutomation/Utilities/BuildGraphInspector.swift
+++ b/Sources/TuistAutomation/Utilities/BuildGraphInspector.swift
@@ -70,7 +70,7 @@ public class BuildGraphInspector: BuildGraphInspecting {
                 .xcarg("CODE_SIGN_IDENTITY", ""),
                 .xcarg("CODE_SIGNING_REQUIRED", "NO"),
                 .xcarg("CODE_SIGN_ENTITLEMENTS", ""),
-                .xcarg("CODE_SIGNING_ALLOWED", "NO")
+                .xcarg("CODE_SIGNING_ALLOWED", "NO"),
             ]
         }
 

--- a/Sources/TuistAutomation/Utilities/BuildGraphInspector.swift
+++ b/Sources/TuistAutomation/Utilities/BuildGraphInspector.swift
@@ -65,14 +65,12 @@ public class BuildGraphInspector: BuildGraphInspecting {
 
         // Signing
         if skipSigning {
-            arguments.append(
-                contentsOf: [
-                    .xcarg("CODE_SIGN_IDENTITY", ""),
-                    .xcarg("CODE_SIGNING_REQUIRED", "NO"),
-                    .xcarg("CODE_SIGN_ENTITLEMENTS", ""),
-                    .xcarg("CODE_SIGNING_ALLOWED", "NO")
-                ]
-            )
+            arguments += [
+                .xcarg("CODE_SIGN_IDENTITY", ""),
+                .xcarg("CODE_SIGNING_REQUIRED", "NO"),
+                .xcarg("CODE_SIGN_ENTITLEMENTS", ""),
+                .xcarg("CODE_SIGNING_ALLOWED", "NO")
+            ]
         }
 
         return arguments

--- a/Sources/TuistAutomation/Utilities/BuildGraphInspector.swift
+++ b/Sources/TuistAutomation/Utilities/BuildGraphInspector.swift
@@ -7,7 +7,7 @@ public protocol BuildGraphInspecting {
     /// Returns the build arguments to be used with the given target.
     /// - Parameter target: Target whose build arguments will be returned.
     /// - Parameter configuration: The configuration to be built. When nil, it defaults to the configuration specified in the scheme.
-    func buildArguments(target: Target, configuration: String?) -> [XcodeBuildArgument]
+    func buildArguments(target: Target, configuration: String?, skipSigning: Bool) -> [XcodeBuildArgument]
 
     /// Given a directory, it returns the first .xcworkspace found.
     /// - Parameter path: Found .xcworkspace.
@@ -46,7 +46,7 @@ public protocol BuildGraphInspecting {
 public class BuildGraphInspector: BuildGraphInspecting {
     public init() {}
 
-    public func buildArguments(target: Target, configuration: String?) -> [XcodeBuildArgument] {
+    public func buildArguments(target: Target, configuration: String?, skipSigning: Bool) -> [XcodeBuildArgument] {
         var arguments: [XcodeBuildArgument]
         if target.platform == .macOS {
             arguments = [.sdk(target.platform.xcodeDeviceSDK)]
@@ -61,6 +61,18 @@ public class BuildGraphInspector: BuildGraphInspecting {
             } else {
                 logger.warning("The scheme's targets don't have the given configuration \(configuration). Defaulting to the scheme's default.")
             }
+        }
+
+        // Signing
+        if skipSigning {
+            arguments.append(
+                contentsOf: [
+                    .xcarg("CODE_SIGN_IDENTITY", ""),
+                    .xcarg("CODE_SIGNING_REQUIRED", "NO"),
+                    .xcarg("CODE_SIGN_ENTITLEMENTS", ""),
+                    .xcarg("CODE_SIGNING_ALLOWED", "NO")
+                ]
+            )
         }
 
         return arguments

--- a/Sources/TuistAutomationTesting/Utilities/MockBuildGraphInspector.swift
+++ b/Sources/TuistAutomationTesting/Utilities/MockBuildGraphInspector.swift
@@ -35,10 +35,10 @@ public final class MockBuildGraphInspector: BuildGraphInspecting {
         buildableEntrySchemesStub?(graph) ?? []
     }
 
-    public var buildArgumentsStub: ((Target, String?) -> [XcodeBuildArgument])?
-    public func buildArguments(target: Target, configuration: String?) -> [XcodeBuildArgument] {
+    public var buildArgumentsStub: ((Target, String?, Bool) -> [XcodeBuildArgument])?
+    public func buildArguments(target: Target, configuration: String?, skipSigning: Bool) -> [XcodeBuildArgument] {
         if let buildArgumentsStub = buildArgumentsStub {
-            return buildArgumentsStub(target, configuration)
+            return buildArgumentsStub(target, configuration, skipSigning)
         } else {
             return []
         }

--- a/Sources/TuistCache/Utilities/CacheFrameworkBuilder.swift
+++ b/Sources/TuistCache/Utilities/CacheFrameworkBuilder.swift
@@ -125,9 +125,9 @@ public final class CacheFrameworkBuilder: CacheArtifactBuilding {
                 [
                     .sdk(sdk),
                     .configuration(configuration),
-                    .buildSetting("DEBUG_INFORMATION_FORMAT", "dwarf-with-dsym"),
-                    .buildSetting("GCC_GENERATE_DEBUGGING_SYMBOLS", "YES"),
-                    .buildSetting(target.targetLocatorBuildPhaseVariable, builtProductsDirFingerprint),
+                    .xcarg("DEBUG_INFORMATION_FORMAT", "dwarf-with-dsym"),
+                    .xcarg("GCC_GENERATE_DEBUGGING_SYMBOLS", "YES"),
+                    .xcarg(target.targetLocatorBuildPhaseVariable, builtProductsDirFingerprint),
                     .destination(destination),
                 ]
             }

--- a/Sources/TuistCache/Utilities/CacheXCFrameworkBuilder.swift
+++ b/Sources/TuistCache/Utilities/CacheXCFrameworkBuilder.swift
@@ -113,8 +113,8 @@ public final class CacheXCFrameworkBuilder: CacheArtifactBuilding {
                                              archivePath: archivePath,
                                              arguments: [
                                                  .sdk(target.platform.xcodeDeviceSDK),
-                                                 .buildSetting("SKIP_INSTALL", "NO"),
-                                                 .buildSetting("BUILD_LIBRARY_FOR_DISTRIBUTION", "YES"),
+                                                 .xcarg("SKIP_INSTALL", "NO"),
+                                                 .xcarg("BUILD_LIBRARY_FOR_DISTRIBUTION", "YES"),
                                              ])
             .printFormattedOutput()
             .do(onSubscribed: {
@@ -137,8 +137,8 @@ public final class CacheXCFrameworkBuilder: CacheArtifactBuilding {
                                              archivePath: archivePath,
                                              arguments: [
                                                  .sdk(target.platform.xcodeSimulatorSDK!),
-                                                 .buildSetting("SKIP_INSTALL", "NO"),
-                                                 .buildSetting("BUILD_LIBRARY_FOR_DISTRIBUTION", "YES"),
+                                                 .xcarg("SKIP_INSTALL", "NO"),
+                                                 .xcarg("BUILD_LIBRARY_FOR_DISTRIBUTION", "YES"),
                                              ])
             .printFormattedOutput()
             .do(onSubscribed: {

--- a/Sources/TuistCore/Automation/XcodeBuildArgument.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildArgument.swift
@@ -18,6 +18,9 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
     /// To override build settings.
     case buildSetting(String, String)
 
+    /// To pass additional arguments
+    case xcarg(String, String)
+
     /// It returns the bash arguments that represent this xcodebuild argument.
     public var arguments: [String] {
         switch self {
@@ -30,6 +33,8 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
         case let .derivedDataPath(path):
             return ["-derivedDataPath", path.pathString]
         case let .buildSetting(key, value):
+            return ["\(key)=\(value.spm_shellEscaped())"]
+        case let .xcarg(key, value):
             return ["\(key)=\(value.spm_shellEscaped())"]
         }
     }
@@ -47,6 +52,8 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
             return "Xcodebuild's derivedDataPath argument: \(path.pathString)"
         case let .buildSetting(key, value):
             return "Xcodebuild's additional build setting: \(key)=\(value)"
+        case let .xcarg(key, value):
+            return "Xcodebuild's additional argument: \(key)=\(value)"
         }
     }
 }

--- a/Sources/TuistCore/Automation/XcodeBuildArgument.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildArgument.swift
@@ -15,9 +15,6 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
     /// Specifies the directory where build products and other derived data will go.
     case derivedDataPath(AbsolutePath)
 
-    /// To override build settings.
-    case buildSetting(String, String)
-
     /// To pass additional arguments
     case xcarg(String, String)
 
@@ -32,8 +29,6 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
             return ["-destination", "\(destination)"]
         case let .derivedDataPath(path):
             return ["-derivedDataPath", path.pathString]
-        case let .buildSetting(key, value):
-            return ["\(key)=\(value.spm_shellEscaped())"]
         case let .xcarg(key, value):
             return ["\(key)=\(value.spm_shellEscaped())"]
         }
@@ -50,8 +45,6 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
             return "Xcodebuild's destination argument: \(destination)"
         case let .derivedDataPath(path):
             return "Xcodebuild's derivedDataPath argument: \(path.pathString)"
-        case let .buildSetting(key, value):
-            return "Xcodebuild's additional build setting: \(key)=\(value)"
         case let .xcarg(key, value):
             return "Xcodebuild's additional argument: \(key)=\(value)"
         }

--- a/Sources/TuistKit/Services/BuildService.swift
+++ b/Sources/TuistKit/Services/BuildService.swift
@@ -97,7 +97,7 @@ final class BuildService {
         _ = try xcodebuildController.build(.workspace(workspacePath),
                                            scheme: scheme.name,
                                            clean: clean,
-                                           arguments: buildGraphInspector.buildArguments(target: buildableTarget, configuration: configuration))
+                                           arguments: buildGraphInspector.buildArguments(target: buildableTarget, configuration: configuration, skipSigning: false))
             .printFormattedOutput()
             .toBlocking()
             .last()

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -163,7 +163,7 @@ final class TestService {
             scheme: scheme.name,
             clean: clean,
             destination: destination,
-            arguments: buildGraphInspector.buildArguments(target: buildableTarget, configuration: configuration)
+            arguments: buildGraphInspector.buildArguments(target: buildableTarget, configuration: configuration, skipSigning: true)
         )
         .printFormattedOutput()
         .toBlocking()

--- a/Tests/TuistAutomationTests/Utilities/BuildGraphInspectorTests.swift
+++ b/Tests/TuistAutomationTests/Utilities/BuildGraphInspectorTests.swift
@@ -26,7 +26,7 @@ final class BuildGraphInspectorTests: TuistUnitTestCase {
         let target = Target.test(platform: .macOS)
 
         // When
-        let got = subject.buildArguments(target: target, configuration: nil)
+        let got = subject.buildArguments(target: target, configuration: nil, skipSigning: false)
 
         // Then
         XCTAssertEqual(got, [
@@ -39,7 +39,7 @@ final class BuildGraphInspectorTests: TuistUnitTestCase {
         let target = Target.test(platform: .iOS)
 
         // When
-        let got = subject.buildArguments(target: target, configuration: nil)
+        let got = subject.buildArguments(target: target, configuration: nil, skipSigning: false)
 
         // Then
         XCTAssertEqual(got, [
@@ -52,7 +52,7 @@ final class BuildGraphInspectorTests: TuistUnitTestCase {
         let target = Target.test(platform: .watchOS)
 
         // When
-        let got = subject.buildArguments(target: target, configuration: nil)
+        let got = subject.buildArguments(target: target, configuration: nil, skipSigning: false)
 
         // Then
         XCTAssertEqual(got, [
@@ -65,7 +65,7 @@ final class BuildGraphInspectorTests: TuistUnitTestCase {
         let target = Target.test(platform: .tvOS)
 
         // When
-        let got = subject.buildArguments(target: target, configuration: nil)
+        let got = subject.buildArguments(target: target, configuration: nil, skipSigning: false)
 
         // Then
         XCTAssertEqual(got, [
@@ -79,7 +79,7 @@ final class BuildGraphInspectorTests: TuistUnitTestCase {
         let target = Target.test(settings: settings)
 
         // When
-        let got = subject.buildArguments(target: target, configuration: "Release")
+        let got = subject.buildArguments(target: target, configuration: "Release", skipSigning: false)
 
         // Then
         XCTAssertTrue(got.contains(.configuration("Release")))
@@ -91,7 +91,7 @@ final class BuildGraphInspectorTests: TuistUnitTestCase {
         let target = Target.test(settings: settings)
 
         // When
-        let got = subject.buildArguments(target: target, configuration: "Release")
+        let got = subject.buildArguments(target: target, configuration: "Release", skipSigning: false)
 
         // Then
         XCTAssertFalse(got.contains(.configuration("Release")))

--- a/Tests/TuistAutomationTests/Utilities/BuildGraphInspectorTests.swift
+++ b/Tests/TuistAutomationTests/Utilities/BuildGraphInspectorTests.swift
@@ -37,52 +37,56 @@ final class BuildGraphInspectorTests: TuistUnitTestCase {
     func test_buildArguments_when_iOS() throws {
         // Given
         let target = Target.test(platform: .iOS)
+        let iosSimulatorSDK = try XCTUnwrap(Platform.iOS.xcodeSimulatorSDK)
 
         // When
         let got = subject.buildArguments(target: target, configuration: nil, skipSigning: false)
 
         // Then
         XCTAssertEqual(got, [
-            .sdk(Platform.iOS.xcodeSimulatorSDK!),
+            .sdk(iosSimulatorSDK),
         ])
     }
 
     func test_buildArguments_when_watchOS() throws {
         // Given
         let target = Target.test(platform: .watchOS)
+        let watchosSimulatorSDK = try XCTUnwrap(Platform.watchOS.xcodeSimulatorSDK)
 
         // When
         let got = subject.buildArguments(target: target, configuration: nil, skipSigning: false)
 
         // Then
         XCTAssertEqual(got, [
-            .sdk(Platform.watchOS.xcodeSimulatorSDK!),
+            .sdk(watchosSimulatorSDK),
         ])
     }
 
     func test_buildArguments_when_tvOS() throws {
         // Given
         let target = Target.test(platform: .tvOS)
+        let tvosSimulatorSDK = try XCTUnwrap(Platform.tvOS.xcodeSimulatorSDK)
 
         // When
         let got = subject.buildArguments(target: target, configuration: nil, skipSigning: false)
 
         // Then
         XCTAssertEqual(got, [
-            .sdk(Platform.tvOS.xcodeSimulatorSDK!),
+            .sdk(tvosSimulatorSDK),
         ])
     }
 
-    func test_buildArguments_when_skipSigning() {
+    func test_buildArguments_when_skipSigning() throws {
         // Given
         let target = Target.test(platform: .iOS)
+        let iosSimulatorSDK = try XCTUnwrap(Platform.iOS.xcodeSimulatorSDK)
 
         // When
         let got = subject.buildArguments(target: target, configuration: nil, skipSigning: true)
 
         // Then
         XCTAssertEqual(got, [
-            .sdk(Platform.iOS.xcodeSimulatorSDK!),
+            .sdk(iosSimulatorSDK),
             .xcarg("CODE_SIGN_IDENTITY", ""),
             .xcarg("CODE_SIGNING_REQUIRED", "NO"),
             .xcarg("CODE_SIGN_ENTITLEMENTS", ""),

--- a/Tests/TuistAutomationTests/Utilities/BuildGraphInspectorTests.swift
+++ b/Tests/TuistAutomationTests/Utilities/BuildGraphInspectorTests.swift
@@ -73,6 +73,23 @@ final class BuildGraphInspectorTests: TuistUnitTestCase {
         ])
     }
 
+    func test_buildArguments_when_skipSigning() {
+        // Given
+        let target = Target.test(platform: .iOS)
+
+        // When
+        let got = subject.buildArguments(target: target, configuration: nil, skipSigning: true)
+
+        // Then
+        XCTAssertEqual(got, [
+            .sdk(Platform.iOS.xcodeSimulatorSDK!),
+            .xcarg("CODE_SIGN_IDENTITY", ""),
+            .xcarg("CODE_SIGNING_REQUIRED", "NO"),
+            .xcarg("CODE_SIGN_ENTITLEMENTS", ""),
+            .xcarg("CODE_SIGNING_ALLOWED", "NO"),
+        ])
+    }
+
     func test_buildArguments_when_theGivenConfigurationExists() throws {
         // Given
         let settings = Settings.test(base: [:], debug: .test(), release: .test())

--- a/Tests/TuistCoreTests/Automation/XcodeBuildArgumentTests.swift
+++ b/Tests/TuistCoreTests/Automation/XcodeBuildArgumentTests.swift
@@ -39,9 +39,9 @@ final class XcodeBuildArgumentTests: TuistUnitTestCase {
         XCTAssertEqual(got, ["-derivedDataPath", path.pathString])
     }
 
-    func test_arguments_returns_the_right_value_when_buildSetting() {
+    func test_arguments_returns_the_right_value_when_xcarg() {
         // Given
-        let subject = XcodeBuildArgument.buildSetting("key", "value")
+        let subject = XcodeBuildArgument.xcarg("key", "value")
 
         // When
         let got = subject.arguments
@@ -50,9 +50,9 @@ final class XcodeBuildArgumentTests: TuistUnitTestCase {
         XCTAssertEqual(got, ["key=value"])
     }
 
-    func test_arguments_returns_the_right_value_when_buildSetting_with_spaces() {
+    func test_arguments_returns_the_right_value_when_xcarg_with_spaces() {
         // Given
-        let subject = XcodeBuildArgument.buildSetting("key", "value with spaces")
+        let subject = XcodeBuildArgument.xcarg("key", "value with spaces")
 
         // When
         let got = subject.arguments

--- a/Tests/TuistKitTests/Services/BuildServiceTests.swift
+++ b/Tests/TuistKitTests/Services/BuildServiceTests.swift
@@ -71,7 +71,7 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_path, path)
             return workspacePath
         }
-        buildgraphInspector.buildArgumentsStub = { _target, _ in
+        buildgraphInspector.buildArgumentsStub = { _target, _, _ in
             XCTAssertEqual(_target, target)
             return buildArguments
         }
@@ -114,7 +114,7 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_path, path)
             return workspacePath
         }
-        buildgraphInspector.buildArgumentsStub = { _target, _ in
+        buildgraphInspector.buildArgumentsStub = { _target, _, _ in
             XCTAssertEqual(_target, target)
             return buildArguments
         }
@@ -160,7 +160,7 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_path, path)
             return workspacePath
         }
-        buildgraphInspector.buildArgumentsStub = { _, _ in
+        buildgraphInspector.buildArgumentsStub = { _, _, _ in
             buildArguments
         }
         xcodebuildController.buildStub = { _target, _scheme, _clean, _arguments in
@@ -213,7 +213,7 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_path, path)
             return workspacePath
         }
-        buildgraphInspector.buildArgumentsStub = { _, _ in
+        buildgraphInspector.buildArgumentsStub = { _, _, _ in
             buildArguments
         }
         xcodebuildController.buildStub = { _target, _scheme, _clean, _arguments in

--- a/Tests/TuistKitTests/Services/BuildServiceTests.swift
+++ b/Tests/TuistKitTests/Services/BuildServiceTests.swift
@@ -56,7 +56,6 @@ final class BuildServiceTests: TuistUnitTestCase {
         let buildArguments: [XcodeBuildArgument] = [.sdk("iphoneos")]
         let skipSigning = false
 
-
         generator.generateWithGraphStub = { _path, _projectOnly in
             XCTAssertEqual(_path, path)
             XCTAssertFalse(_projectOnly)

--- a/Tests/TuistKitTests/Services/BuildServiceTests.swift
+++ b/Tests/TuistKitTests/Services/BuildServiceTests.swift
@@ -54,6 +54,8 @@ final class BuildServiceTests: TuistUnitTestCase {
         let scheme = Scheme.test()
         let target = Target.test()
         let buildArguments: [XcodeBuildArgument] = [.sdk("iphoneos")]
+        let skipSigning = false
+
 
         generator.generateWithGraphStub = { _path, _projectOnly in
             XCTAssertEqual(_path, path)
@@ -71,8 +73,9 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_path, path)
             return workspacePath
         }
-        buildgraphInspector.buildArgumentsStub = { _target, _, _ in
+        buildgraphInspector.buildArgumentsStub = { _target, _, _skipSigning in
             XCTAssertEqual(_target, target)
+            XCTAssertEqual(_skipSigning, skipSigning)
             return buildArguments
         }
         xcodebuildController.buildStub = { _target, _scheme, _clean, _arguments in
@@ -98,6 +101,7 @@ final class BuildServiceTests: TuistUnitTestCase {
         let scheme = Scheme.test()
         let target = Target.test()
         let buildArguments: [XcodeBuildArgument] = [.sdk("iphoneos")]
+        let skipSigning = false
 
         generator.loadStub = { _path in
             XCTAssertEqual(_path, path)
@@ -114,8 +118,9 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_path, path)
             return workspacePath
         }
-        buildgraphInspector.buildArgumentsStub = { _target, _, _ in
+        buildgraphInspector.buildArgumentsStub = { _target, _, _skipSigning in
             XCTAssertEqual(_target, target)
+            XCTAssertEqual(_skipSigning, skipSigning)
             return buildArguments
         }
         xcodebuildController.buildStub = { _target, _scheme, _clean, _arguments in
@@ -143,6 +148,7 @@ final class BuildServiceTests: TuistUnitTestCase {
         let targetA = Target.test(name: "A")
         let targetB = Target.test(name: "B")
         let buildArguments: [XcodeBuildArgument] = [.sdk("iphoneos")]
+        let skipSigning = false
 
         generator.loadStub = { _path in
             XCTAssertEqual(_path, path)
@@ -160,8 +166,9 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_path, path)
             return workspacePath
         }
-        buildgraphInspector.buildArgumentsStub = { _, _, _ in
-            buildArguments
+        buildgraphInspector.buildArgumentsStub = { _, _, _skipSigning in
+            XCTAssertEqual(_skipSigning, skipSigning)
+            return buildArguments
         }
         xcodebuildController.buildStub = { _target, _scheme, _clean, _arguments in
             XCTAssertEqual(_target, .workspace(workspacePath))
@@ -196,6 +203,7 @@ final class BuildServiceTests: TuistUnitTestCase {
         let targetA = Target.test(name: "A")
         let targetB = Target.test(name: "B")
         let buildArguments: [XcodeBuildArgument] = [.sdk("iphoneos")]
+        let skipSigning = false
 
         generator.loadStub = { _path in
             XCTAssertEqual(_path, path)
@@ -213,8 +221,9 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_path, path)
             return workspacePath
         }
-        buildgraphInspector.buildArgumentsStub = { _, _, _ in
-            buildArguments
+        buildgraphInspector.buildArgumentsStub = { _, _, _skipSigning in
+            XCTAssertEqual(_skipSigning, skipSigning)
+            return buildArguments
         }
         xcodebuildController.buildStub = { _target, _scheme, _clean, _arguments in
             XCTAssertEqual(_target, .workspace(workspacePath))

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -65,7 +65,7 @@ final class TestServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_path, path)
             return workspacePath
         }
-        buildGraphInspector.buildArgumentsStub = { _target, _ in
+        buildGraphInspector.buildArgumentsStub = { _target, _, _ in
             XCTAssertEqual(_target, target)
             return buildArguments
         }
@@ -118,7 +118,7 @@ final class TestServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_path, path)
             return workspacePath
         }
-        buildGraphInspector.buildArgumentsStub = { _, _ in
+        buildGraphInspector.buildArgumentsStub = { _, _, _ in
             buildArguments
         }
         xcodebuildController.testStub = { _target, _scheme, _clean, _, _arguments in

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -49,6 +49,7 @@ final class TestServiceTests: TuistUnitTestCase {
         let scheme = Scheme.test()
         let target = Target.test()
         let buildArguments: [XcodeBuildArgument] = [.sdk("iphoneos")]
+        let skipSigning = true
 
         generator.loadStub = { _path in
             XCTAssertEqual(_path, path)
@@ -65,8 +66,9 @@ final class TestServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_path, path)
             return workspacePath
         }
-        buildGraphInspector.buildArgumentsStub = { _target, _, _ in
+        buildGraphInspector.buildArgumentsStub = { _target, _, _skipSigning in
             XCTAssertEqual(_target, target)
+            XCTAssertEqual(_skipSigning, skipSigning)
             return buildArguments
         }
 
@@ -101,6 +103,7 @@ final class TestServiceTests: TuistUnitTestCase {
         let targetA = Target.test(name: "A")
         let targetB = Target.test(name: "B")
         let buildArguments: [XcodeBuildArgument] = [.sdk("iphoneos")]
+        let skipSigning = true
 
         generator.loadStub = { _path in
             XCTAssertEqual(_path, path)
@@ -118,8 +121,9 @@ final class TestServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_path, path)
             return workspacePath
         }
-        buildGraphInspector.buildArgumentsStub = { _, _, _ in
-            buildArguments
+        buildGraphInspector.buildArgumentsStub = { _, _, _skipSigning in
+            XCTAssertEqual(_skipSigning, skipSigning)
+            return buildArguments
         }
         xcodebuildController.testStub = { _target, _scheme, _clean, _, _arguments in
             XCTAssertEqual(_target, .workspace(workspacePath))


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1978

### Short description 📝

Disable signing when running `tuist test` command to save some time.

### Solution 📦

We can skip signing by passing additional arguments when running `xcodebuild` like it was described in original issue.

Some explanation and exact parameters that we should pass were found [here on SO](https://stackoverflow.com/questions/11034133/building-ios-applications-using-xcodebuild-without-codesign).

And same functionality already [implemented](https://github.com/fastlane/fastlane/blob/d4a761a2c3ac02766f5aeded92224220e6af8b7b/gym/lib/gym/generators/build_command_generator.rb#L61) in `fastlane gym` command with parameter `skip_codesigning`.

So I extended `XcodeBuildArgument` enum with `xcarg` case and extended `BuildGraphInspecting` `buildArgments(...)` method and implementation to add some skip signing logic.

- `xcarg` case looks very similar to `buildSetting` case, maybe we can refactor them in one case (xcarg?) or keep them both for clarity?
- Not sure if there any cases then implicit code sign disabling can lead to some compilation or other errors? maybe we should make it more implicit by introducing parameter for `this test` command like `tuist test -skipSigning`?

### Implementation 👩‍💻👨‍💻

- [X] Add `xcarg` case to `XcodeBuildArgument` to pass additional arguments
- [X] Add ability to skip signing when building build arguments
- [X] Add unit test for skip signing when building build arguments
- [x] Fix/update acceptance tests