### PR TITLE
Update CodeLinter to print all standard output and error

### DIFF
--- a/Sources/TuistKit/Lint/CodeLinter.swift
+++ b/Sources/TuistKit/Lint/CodeLinter.swift
@@ -36,7 +36,7 @@ final class CodeLinter: CodeLinting {
                                          verbose: false,
                                          environment: environment)
             .mapToString()
-            .printStandardError()
+            .print()
             .toBlocking()
             .last()
     }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1998

### Short description 📝

This updates `CodeLinter` to `print` instead of just `printStandardError`.

### Solution 📦

Looking at the default `swiftlint` output:

```bash
# in tuist/fixtures/ios_app_with_sdk
# swiftlint lint
Linting Swift files at paths
Linting 'AppDelegate.swift' (1/10)
Linting 'Config.swift' (2/10)
Linting 'Contents.swift' (3/10)
Linting 'AppTests.swift' (4/10)
Linting 'MyTestHelper.swift' (5/10)
Linting 'MyObjcppClassTests.swift' (6/10)
Linting 'Project.swift' (7/10)
Linting 'Framework/FrameworkClass.swift' (8/10)
Linting 'Modules/StaticFramework/Project.swift' (9/10)
Linting 'Modules/StaticFramework/Sources/FrameworkClass.swift' (10/10)
/Users/luis/Programming/tuist/fixtures/ios_app_with_sdk/Framework/FrameworkClass.swift:5:1: warning: Trailing Whitespace Violation: Lines should not have trailing whitespace. (trailing_whitespace)
/Users/luis/Programming/tuist/fixtures/ios_app_with_sdk/Framework/FrameworkClass.swift:6:1: warning: Trailing Whitespace Violation: Lines should not have trailing whitespace. (trailing_whitespace)
/Users/luis/Programming/tuist/fixtures/ios_app_with_sdk/App/AppDelegate.swift:7:1: warning: Line Length Violation: Line should be 120 characters or less: currently 121 characters (line_length)
/Users/luis/Programming/tuist/fixtures/ios_app_with_sdk/Modules/StaticFramework/Tests/MyObjcppClassTests.swift:10:1: warning: Trailing Newline Violation: Files should have a single trailing newline. (trailing_newline)
/Users/luis/Programming/tuist/fixtures/ios_app_with_sdk/Modules/StaticFramework/Sources/FrameworkClass.swift:1:23: warning: Opening Brace Spacing Violation: Opening braces should be preceded by a single space and on the same line as the declaration. (opening_brace)
/Users/luis/Programming/tuist/fixtures/ios_app_with_sdk/Modules/StaticFramework/Sources/FrameworkClass.swift:3:1: warning: Trailing Whitespace Violation: Lines should not have trailing whitespace. (trailing_whitespace)
/Users/luis/Programming/tuist/fixtures/ios_app_with_sdk/Modules/StaticFramework/Project.swift:13:61: warning: Trailing Comma Violation: Collection literals should not have trailing commas. (trailing_comma)
/Users/luis/Programming/tuist/fixtures/ios_app_with_sdk/Modules/StaticFramework/Project.swift:22:69: warning: Trailing Comma Violation: Collection literals should not have trailing commas. (trailing_comma)
/Users/luis/Programming/tuist/fixtures/ios_app_with_sdk/Project.swift:45:66: warning: Trailing Comma Violation: Collection literals should not have trailing commas. (trailing_comma)
/Users/luis/Programming/tuist/fixtures/ios_app_with_sdk/Project.swift:57:83: warning: Trailing Comma Violation: Collection literals should not have trailing commas. (trailing_comma)
Done linting! Found 10 violations, 0 serious in 10 files.
```

Looking at `tuist lint code` output (ignore difference in violations): 

```bash
# in tuist/fixtures/ios_app_with_sdk
# tuist lint code
Loading the dependency graph
Loading project at /Users/luis/Programming/tuist/fixtures/ios_app_with_sdk
Running code linting
Linting 'AppTests.swift' (1/7)
Linting 'Modules/StaticFramework/Sources/FrameworkClass.swift' (2/7)
Linting 'MyObjcppClassTests.swift' (3/7)
Linting 'MyTestHelper.swift' (4/7)
Linting 'Framework/FrameworkClass.swift' (5/7)
Linting 'AppDelegate.swift' (6/7)
Linting 'Framework/FrameworkClass.swift' (7/7)
Done linting! Found 8 violations, 0 serious in 7 files.
```

It looks like since we are only printing out the standard error, hence the actual swiftlint errors and warnings are filtered out of the output and as such not showing up in Xcode.

After the change:

```bash
# in tuist/fixtures/ios_app_with_sdk
# tuist lint code (debug build)
Loading the dependency graph
Loading project at /Users/luis/Programming/tuist/fixtures/ios_app_with_sdk
Running code linting
Linting 'MyTestHelper.swift' (1/7)
Linting 'AppTests.swift' (2/7)
Linting 'MyObjcppClassTests.swift' (3/7)

Linting 'AppDelegate.swift' (4/7)
Linting 'Framework/FrameworkClass.swift' (5/7)
Linting 'Framework/FrameworkClass.swift' (6/7)

Linting 'Modules/StaticFramework/Sources/FrameworkClass.swift' (7/7)

/Users/luis/Programming/tuist/fixtures/ios_app_with_sdk/Modules/StaticFramework/Tests/MyObjcppClassTests.swift:10:1: warning: Trailing Newline Violation: Files should have a single trailing newline. (trailing_newline)
/Users/luis/Programming/tuist/fixtures/ios_app_with_sdk/Framework/FrameworkClass.swift:5:1: warning: Trailing Whitespace Violation: Lines should not have trailing whitespace. (trailing_whitespace)
/Users/luis/Programming/tuist/fixtures/ios_app_with_sdk/Framework/FrameworkClass.swift:6:1: warning: Trailing Whitespace Violation: Lines should not have trailing whitespace. (trailing_whitespace)
/Users/luis/Programming/tuist/fixtures/ios_app_with_sdk/Modules/StaticFramework/Sources/FrameworkClass.swift:1:23: warning: Opening Brace Spacing Violation: Opening braces should be preceded by a single space and on the same line as the declaration. (opening_brace)
/Users/luis/Programming/tuist/fixtures/ios_app_with_sdk/Modules/StaticFramework/Sources/FrameworkClass.swift:3:1: warning: Trailing Whitespace Violation: Lines should not have trailing whitespace. (trailing_whitespace)
/Users/luis/Programming/tuist/fixtures/ios_app_with_sdk/Framework/FrameworkClass.swift:5:1: warning: Trailing Whitespace Violation: Lines should not have trailing whitespace. (trailing_whitespace)
/Users/luis/Programming/tuist/fixtures/ios_app_with_sdk/Framework/FrameworkClass.swift:6:1: warning: Trailing Whitespace Violation: Lines should not have trailing whitespace. (trailing_whitespace)
/Users/luis/Programming/tuist/fixtures/ios_app_with_sdk/App/AppDelegate.swift:7:1: warning: Line Length Violation: Line should be 120 characters or less: currently 121 characters (line_length)

Done linting! Found 8 violations, 0 serious in 7 files.
```

### Implementation 👩‍💻👨‍💻

One line change from `printStandardError` to `print`.

### Open questions

This may require more of a change than this. Would like some guidance here regarding where/how to write a test for this and figuring out why the output doesn't entirely match swiftlint.