### PR TITLE
Improve some workflows

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,16 @@
+name: 'Close stale PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-message: "This PR has been marked as stale because it's been opened for more than 30 days. If no action is taken, it'll be closed in 5 days."
+          stale-pr-label: 'no-pr-activity'
+          days-before-stale: 30
+          days-before-close: 5

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,0 +1,16 @@
+version = 1
+
+[update]
+always = true
+require_automerge_label = false
+ignored_usernames = ["dependabot"]
+
+[approve]
+auto_approve_usernames = ["dependabot"]
+
+[merge]
+prioritize_ready_to_merge = true
+
+[merge.message]
+title = "pull_request_title"
+body = "pull_request_body"


### PR DESCRIPTION
### Short description 📝
This PR adds the following improvements to the repository workflows:
- I'm enabling [Kodiak](https://kodiakhq.com/#quickstart) to automerge dependabot PRs and PRs that been marked as ready to automerge and have got 2 approvals.
- I'm adding a new GitHub action that marks as stale PRs that have been opened for 30 days without activity, and closes them 5 days after if there's been no activity.