### PR TITLE
Use the udid of an available device when building the frameworks for the cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Re-enable tests acceptance tests that were not running on CI [#1999](https://github.com/tuist/tuist/pull/1999) by [@pepibumur](https://github.com/pepibumur).
 - Block the process while editing the project and remove the project after the edition finishes [#1999](https://github.com/tuist/tuist/pull/1999) by [@pepibumur](https://github.com/pepibumur).
+- Use the simulator udid when building the frameworks for the cache instead of `os=latest` [#2016](https://github.com/tuist/tuist/pull/2016) by [@pepibumur](https://github.com/pepibumur).
 
 ## 1.23.0
 

--- a/Sources/TuistCache/Utilities/CacheFrameworkBuilder.swift
+++ b/Sources/TuistCache/Utilities/CacheFrameworkBuilder.swift
@@ -146,19 +146,9 @@ public final class CacheFrameworkBuilder: CacheArtifactBuilding {
         case .macOS: return .just("platform=OS X,arch=x86_64")
         }
 
-        return simulatorController.devicesAndRuntimes()
-            .map { (simulatorsAndRuntimes) -> [SimulatorDevice] in
-                simulatorsAndRuntimes
-                    .filter { $0.runtime.isAvailable && $0.runtime.name.contains(platform.caseValue) }
-                    .map { $0.device }
-            }
-            .flatMap { (devices) -> Single<String> in
-                if let device = devices.first {
-                    let destination = "platform=\(platform.caseValue) Simulator,name=\(device.name),OS=latest"
-                    return .just(destination)
-                } else {
-                    return .error(CacheFrameworkBuilderError.deviceNotFound(platform: target.platform.caseValue))
-                }
+        return simulatorController.findAvailableDevice(platform: target.platform)
+            .flatMap { (deviceAndRuntime) -> Single<String> in
+                .just("platform=\(platform.caseValue) Simulator,id=\(deviceAndRuntime.device.udid)")
             }
     }
 

--- a/Sources/TuistCache/Utilities/CacheFrameworkBuilder.swift
+++ b/Sources/TuistCache/Utilities/CacheFrameworkBuilder.swift
@@ -148,7 +148,7 @@ public final class CacheFrameworkBuilder: CacheArtifactBuilding {
 
         return simulatorController.findAvailableDevice(platform: target.platform)
             .flatMap { (deviceAndRuntime) -> Single<String> in
-                .just("platform=\(platform.caseValue) Simulator,id=\(deviceAndRuntime.device.udid)")
+                .just("id=\(deviceAndRuntime.device.udid)")
             }
     }
 

--- a/Sources/TuistCore/Simulator/SimulatorController.swift
+++ b/Sources/TuistCore/Simulator/SimulatorController.swift
@@ -130,10 +130,6 @@ public final class SimulatorController: SimulatorControlling {
             }
     }
 
-    public func findAvailableDevice(platform: Platform) -> Single<SimulatorDeviceAndRuntime> {
-        self.findAvailableDevice(platform: platform, version: nil, minVersion: nil, deviceName: nil)
-    }
-
     public func findAvailableDevice(
         platform: Platform,
         version: Version?,
@@ -164,5 +160,11 @@ public final class SimulatorController: SimulatorControlling {
 
                 return .just(device)
             }
+    }
+}
+
+public extension SimulatorControlling {
+    func findAvailableDevice(platform: Platform) -> Single<SimulatorDeviceAndRuntime> {
+        self.findAvailableDevice(platform: platform, version: nil, minVersion: nil, deviceName: nil)
     }
 }

--- a/Sources/TuistCore/Simulator/SimulatorController.swift
+++ b/Sources/TuistCore/Simulator/SimulatorController.swift
@@ -16,6 +16,12 @@ public protocol SimulatorControlling {
     /// - Returns: the list of simulator devices and runtimes.
     func devicesAndRuntimes() -> Single<[SimulatorDeviceAndRuntime]>
 
+    /// Find an available device for the given platform.
+    /// Available devices are sorted by their runtime version, meaning the ones with higher runtime
+    /// will be preferred over the ones with a lower runtime.
+    /// - Parameter platform: Platform.
+    func findAvailableDevice(platform: Platform) -> Single<SimulatorDeviceAndRuntime>
+
     /// Finds first available device defined by given parameters
     /// - Parameters:
     ///     - platform: Given platform
@@ -27,7 +33,7 @@ public protocol SimulatorControlling {
         version: Version?,
         minVersion: Version?,
         deviceName: String?
-    ) -> Single<SimulatorDevice>
+    ) -> Single<SimulatorDeviceAndRuntime>
 }
 
 public enum SimulatorControllerError: FatalError {
@@ -124,15 +130,20 @@ public final class SimulatorController: SimulatorControlling {
             }
     }
 
+    public func findAvailableDevice(platform: Platform) -> Single<SimulatorDeviceAndRuntime> {
+        self.findAvailableDevice(platform: platform, version: nil, minVersion: nil, deviceName: nil)
+    }
+
     public func findAvailableDevice(
         platform: Platform,
         version: Version?,
         minVersion: Version?,
         deviceName: String?
-    ) -> Single<SimulatorDevice> {
+    ) -> Single<SimulatorDeviceAndRuntime> {
         devicesAndRuntimes()
             .flatMap { devicesAndRuntimes in
                 let availableDevices = devicesAndRuntimes
+                    .sorted(by: { $0.runtime.version >= $1.runtime.version })
                     .filter { simulatorDeviceAndRuntime in
                         let nameComponents = simulatorDeviceAndRuntime.runtime.name.components(separatedBy: " ")
                         guard nameComponents.first == platform.caseValue else { return false }
@@ -147,9 +158,8 @@ public final class SimulatorController: SimulatorControlling {
                         }
                         return true
                     }
-                    .map(\.device)
                 guard
-                    let device = availableDevices.first(where: { !$0.isShutdown }) ?? availableDevices.first
+                    let device = availableDevices.first(where: { !$0.device.isShutdown }) ?? availableDevices.first
                 else { return .error(SimulatorControllerError.deviceNotFound(platform, version, deviceName, devicesAndRuntimes)) }
 
                 return .just(device)

--- a/Sources/TuistCoreTesting/Simulator/MockSimulatorController.swift
+++ b/Sources/TuistCoreTesting/Simulator/MockSimulatorController.swift
@@ -46,8 +46,15 @@ public final class MockSimulatorController: SimulatorControlling {
         }
     }
 
-    public var findAvailableDeviceStub: ((Platform, Version?, Version?, String?) -> Single<SimulatorDevice>)?
-    public func findAvailableDevice(platform: Platform, version: Version?, minVersion: Version?, deviceName: String?) -> Single<SimulatorDevice> {
-        findAvailableDeviceStub?(platform, version, minVersion, deviceName) ?? .just(SimulatorDevice.test())
+    public func findAvailableDevice(platform: Platform) -> Single<SimulatorDeviceAndRuntime> {
+        self.findAvailableDevice(platform: platform,
+                                 version: nil,
+                                 minVersion: nil,
+                                 deviceName: nil)
+    }
+
+    public var findAvailableDeviceStub: ((Platform, Version?, Version?, String?) -> Single<SimulatorDeviceAndRuntime>)?
+    public func findAvailableDevice(platform: Platform, version: Version?, minVersion: Version?, deviceName: String?) -> Single<SimulatorDeviceAndRuntime> {
+        findAvailableDeviceStub?(platform, version, minVersion, deviceName) ?? .just(SimulatorDeviceAndRuntime.test())
     }
 }

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -144,7 +144,7 @@ final class TestService {
                     .sorted()
                     .first
             }
-            let device = try simulatorController.findAvailableDevice(
+            let deviceAndRuntime = try simulatorController.findAvailableDevice(
                 platform: buildableTarget.platform,
                 version: version,
                 minVersion: minVersion,
@@ -152,7 +152,7 @@ final class TestService {
             )
             .toBlocking()
             .single()
-            destination = .device(device.udid)
+            destination = .device(deviceAndRuntime.device.udid)
         case .macOS:
             destination = .mac
         }

--- a/Tests/TuistAutomationIntegrationTests/Simulator/SimulatorControllerIntegrationTests.swift
+++ b/Tests/TuistAutomationIntegrationTests/Simulator/SimulatorControllerIntegrationTests.swift
@@ -61,6 +61,16 @@ final class SimulatorControllerIntegrationTests: TuistTestCase {
         .single()
 
         // Then
-        XCTAssertTrue(got.isAvailable)
+        XCTAssertTrue(got.device.isAvailable)
+    }
+
+    func test_findAvailableDeviceForPlatform() throws {
+        // When
+        let got = try subject.findAvailableDevice(platform: .iOS)
+            .toBlocking()
+            .single()
+
+        // Then
+        XCTAssertTrue(got.device.isAvailable)
     }
 }

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -70,16 +70,16 @@ final class TestServiceTests: TuistUnitTestCase {
             return buildArguments
         }
 
-        let availableDevice: SimulatorDevice = .test()
+        let availableDeviceAndRuntime: SimulatorDeviceAndRuntime = .test()
         simulatorController.findAvailableDeviceStub = { _, _, _, _ in
-            .just(availableDevice)
+            .just(availableDeviceAndRuntime)
         }
         xcodebuildController.testStub = { _target, _scheme, _clean, _destination, _arguments in
             XCTAssertEqual(_target, .workspace(workspacePath))
             XCTAssertEqual(_scheme, scheme.name)
             XCTAssertTrue(_clean)
             XCTAssertEqual(_arguments, buildArguments)
-            XCTAssertEqual(_destination, .device(availableDevice.udid))
+            XCTAssertEqual(_destination, .device(availableDeviceAndRuntime.device.udid))
             return Observable.just(.standardOutput(.init(raw: "success", formatted: nil)))
         }
 


### PR DESCRIPTION
Related https://github.com/tuist/tuist/issues/1975

### Short description 📝
@RomainBoulay reported that cache warming might fail if developers use custom simulators. In that scenario, the `os=latest` doesn't resolve well. 

### Solution 📦
I've extended the logic in the framework builder to get an available simulator for the target's platform and use its udid instead. 