### PR TITLE
feature: add DeploymentTarget cases for watchOS and tvOS

### DIFF
--- a/Sources/ProjectDescription/DeploymentTarget.swift
+++ b/Sources/ProjectDescription/DeploymentTarget.swift
@@ -5,11 +5,14 @@ import Foundation
 public enum DeploymentTarget: Codable, Equatable {
     case iOS(targetVersion: String, devices: DeploymentDevice)
     case macOS(targetVersion: String)
-    // TODO: 🙈 Add `watchOS` and `tvOS` support
+    case watchOS(targetVersion: String)
+    case tvOS(targetVersion: String)
 
     private enum Kind: String, Codable {
         case iOS
         case macOS
+        case watchOS
+        case tvOS
     }
 
     enum CodingKeys: String, CodingKey {
@@ -29,6 +32,12 @@ public enum DeploymentTarget: Codable, Equatable {
         case .macOS:
             let version = try container.decode(String.self, forKey: .version)
             self = .macOS(targetVersion: version)
+        case .watchOS:
+            let version = try container.decode(String.self, forKey: .version)
+            self = .watchOS(targetVersion: version)
+        case .tvOS:
+            let version = try container.decode(String.self, forKey: .version)
+            self = .tvOS(targetVersion: version)
         }
     }
 
@@ -41,6 +50,12 @@ public enum DeploymentTarget: Codable, Equatable {
             try container.encode(deploymentDevices, forKey: .deploymentDevices)
         case let .macOS(version):
             try container.encode(Kind.macOS.self, forKey: .kind)
+            try container.encode(version, forKey: .version)
+        case let .watchOS(version):
+            try container.encode(Kind.watchOS.self, forKey: .kind)
+            try container.encode(version, forKey: .version)
+        case let .tvOS(version):
+            try container.encode(Kind.tvOS.self, forKey: .kind)
             try container.encode(version, forKey: .version)
         }
     }

--- a/Sources/TuistCache/ContentHashing/DeploymentTargetContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/DeploymentTargetContentHasher.swift
@@ -25,6 +25,10 @@ public final class DeploymentTargetContentHasher: DeploymentTargetContentHashing
             stringToHash = "iOS-\(version)-\(device.rawValue)"
         case let .macOS(version):
             stringToHash = "macOS-\(version)"
+        case let .watchOS(version):
+            stringToHash = "watchOS-\(version)"
+        case let .tvOS(version):
+            stringToHash = "tvOS-\(version)"
         }
         return try contentHasher.hash(stringToHash)
     }

--- a/Sources/TuistCore/Models/DeploymentTarget.swift
+++ b/Sources/TuistCore/Models/DeploymentTarget.swift
@@ -5,12 +5,15 @@ import Foundation
 public enum DeploymentTarget {
     case iOS(String, DeploymentDevice)
     case macOS(String)
-    // TODO: 🙈 Add `watchOS` and `tvOS` support
+    case watchOS(String)
+    case tvOS(String)
 
     public var platform: String {
         switch self {
         case .iOS: return "iOS"
         case .macOS: return "macOS"
+        case .watchOS: return "watchOS"
+        case .tvOS: return "tvOS"
         }
     }
 
@@ -18,6 +21,8 @@ public enum DeploymentTarget {
         switch self {
         case let .iOS(version, _): return version
         case let .macOS(version): return version
+        case let .watchOS(version): return version
+        case let .tvOS(version): return version
         }
     }
 }

--- a/Sources/TuistCoreTesting/Extensions/TuistTestCase+LintingIssue.swift
+++ b/Sources/TuistCoreTesting/Extensions/TuistTestCase+LintingIssue.swift
@@ -13,7 +13,7 @@ public extension TuistTestCase {
     ///   - issue: Issue to be checked in the list. If it doesn't exist, the test will fail.
     func XCTContainsLintingIssue(_ issues: [LintingIssue], _ issue: LintingIssue, file: StaticString = #file, line: UInt = #line) {
         if !issues.contains(issue) {
-            XCTFail("The list doesn't contain the issue '\(issue)' and it shoud", file: file, line: line)
+            XCTFail("The list doesn't contain the issue '\(issue)' and it should", file: file, line: line)
         }
     }
 
@@ -23,7 +23,7 @@ public extension TuistTestCase {
     ///   - issue: Issue to be checked in the list. If it doesn't exist, the test will fail.
     func XCTDoesNotContainLintingIssue(_ issues: [LintingIssue], _ issue: LintingIssue, file: StaticString = #file, line: UInt = #line) {
         if issues.contains(issue) {
-            XCTFail("The list contains the issue '\(issue)' and it shoudn't", file: file, line: line)
+            XCTFail("The list contains the issue '\(issue)' and it shouldn't", file: file, line: line)
         }
     }
 }

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -269,6 +269,10 @@ final class ConfigGenerator: ConfigGenerating {
             }
         case let .macOS(version):
             settings["MACOSX_DEPLOYMENT_TARGET"] = .string(version)
+        case let .watchOS(version):
+            settings["WATCHOS_DEPLOYMENT_TARGET"] = .string(version)
+        case let .tvOS(version):
+            settings["TVOS_DEPLOYMENT_TARGET"] = .string(version)
         }
 
         return settings

--- a/Sources/TuistGenerator/Linter/SettingsLinter.swift
+++ b/Sources/TuistGenerator/Linter/SettingsLinter.swift
@@ -62,6 +62,8 @@ final class SettingsLinter: SettingsLinting {
         switch deploymentTarget {
         case .iOS: if platform != .iOS { return [issue] }
         case .macOS: if platform != .macOS { return [issue] }
+        case .watchOS: if platform != .watchOS { return [issue] }
+        case .tvOS: if platform != .tvOS { return [issue] }
         }
         return []
     }

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -176,10 +176,21 @@ class TargetLinter: TargetLinting {
             return []
         }
 
-        let issue = LintingIssue(reason: "The version of deployment target is incorrect", severity: .error)
+        let versionFormatIssue = LintingIssue(reason: "The version of deployment target is incorrect", severity: .error)
 
         let osVersionRegex = "\\b[0-9]+\\.[0-9]+(?:\\.[0-9]+)?\\b"
-        if !deploymentTarget.version.matches(pattern: osVersionRegex) { return [issue] }
+        if !deploymentTarget.version.matches(pattern: osVersionRegex) { return [versionFormatIssue] }
+
+        let platform = target.platform
+        let inconsistentPlatformIssue = LintingIssue(reason: "Found an inconsistency between a platform `\(platform.caseValue)` and deployment target `\(deploymentTarget.platform)`", severity: .error)
+
+        switch deploymentTarget {
+        case .iOS: if platform != .iOS { return [inconsistentPlatformIssue] }
+        case .macOS: if platform != .macOS { return [inconsistentPlatformIssue] }
+        case .watchOS: if platform != .watchOS { return [inconsistentPlatformIssue] }
+        case .tvOS: if platform != .tvOS { return [inconsistentPlatformIssue] }
+        }
+
         return []
     }
 

--- a/Sources/TuistLoader/Models+ManifestMappers/DeploymentTarget+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/DeploymentTarget+ManifestMapper.swift
@@ -13,6 +13,10 @@ extension TuistCore.DeploymentTarget {
             return .iOS(version, DeploymentDevice(rawValue: devices.rawValue))
         case let .macOS(version):
             return .macOS(version)
+        case let .watchOS(version):
+            return .watchOS(version)
+        case let .tvOS(version):
+            return .tvOS(version)
         }
     }
 }

--- a/Tests/ProjectDescriptionTests/DeploymentTargetTests.swift
+++ b/Tests/ProjectDescriptionTests/DeploymentTargetTests.swift
@@ -16,4 +16,16 @@ final class DeploymentTargetTests: XCTestCase {
         let expected = "{\"kind\":\"macOS\",\"version\":\"10.15\"}"
         XCTAssertCodableEqualToJson(subject, expected)
     }
+
+    func test_toJSON_whenWatchOS() {
+        let subject = DeploymentTarget.watchOS(targetVersion: "6.0")
+        let expected = "{\"kind\":\"watchOS\",\"version\":\"6.0\"}"
+        XCTAssertCodableEqualToJson(subject, expected)
+    }
+
+    func test_toJSON_whenTVOS() {
+        let subject = DeploymentTarget.tvOS(targetVersion: "14.2")
+        let expected = "{\"kind\":\"tvOS\",\"version\":\"14.2\"}"
+        XCTAssertCodableEqualToJson(subject, expected)
+    }
 }

--- a/Tests/TuistCacheTests/ContentHashing/DeploymentTargetContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/DeploymentTargetContentHasherTests.swift
@@ -53,4 +53,24 @@ final class DeploymentTargetContentHasherTests: TuistUnitTestCase {
         XCTAssertEqual(hash, "macOS-v2-hash")
         XCTAssertEqual(mockContentHasher.hashStringCallCount, 1)
     }
+
+    func test_hash_whenWatchOSV2_callsContentHasherWithExpectedStrings() throws {
+        // When
+        let deploymentTarget = DeploymentTarget.watchOS("v2")
+
+        // Then
+        let hash = try subject.hash(deploymentTarget: deploymentTarget)
+        XCTAssertEqual(hash, "watchOS-v2-hash")
+        XCTAssertEqual(mockContentHasher.hashStringCallCount, 1)
+    }
+
+    func test_hash_whentvOSV2_callsContentHasherWithExpectedStrings() throws {
+        // When
+        let deploymentTarget = DeploymentTarget.tvOS("v2")
+
+        // Then
+        let hash = try subject.hash(deploymentTarget: deploymentTarget)
+        XCTAssertEqual(hash, "tvOS-v2-hash")
+        XCTAssertEqual(mockContentHasher.hashStringCallCount, 1)
+    }
 }

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -282,6 +282,66 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         assert(config: releaseConfig, contains: expectedSettings)
     }
 
+    func test_generateTargetWithDeploymentTarget_whenWatch() throws {
+        // Given
+        let project = Project.test()
+        let target = Target.test(deploymentTarget: .watchOS("6.0"))
+        let graph = ValueGraph.test(path: project.path)
+        let graphTraverser = ValueGraphTraverser(graph: graph)
+
+        // When
+        try subject.generateTargetConfig(target,
+                                         project: project,
+                                         pbxTarget: pbxTarget,
+                                         pbxproj: pbxproj,
+                                         projectSettings: .default,
+                                         fileElements: ProjectFileElements(),
+                                         graphTraverser: graphTraverser,
+                                         sourceRootPath: AbsolutePath("/project"))
+
+        // Then
+        let configurationList = pbxTarget.buildConfigurationList
+        let debugConfig = configurationList?.configuration(name: "Debug")
+        let releaseConfig = configurationList?.configuration(name: "Release")
+
+        let expectedSettings = [
+            "WATCHOS_DEPLOYMENT_TARGET": "6.0",
+        ]
+
+        assert(config: debugConfig, contains: expectedSettings)
+        assert(config: releaseConfig, contains: expectedSettings)
+    }
+
+    func test_generateTargetWithDeploymentTarget_whenTV() throws {
+        // Given
+        let project = Project.test()
+        let target = Target.test(deploymentTarget: .tvOS("14.0"))
+        let graph = ValueGraph.test(path: project.path)
+        let graphTraverser = ValueGraphTraverser(graph: graph)
+
+        // When
+        try subject.generateTargetConfig(target,
+                                         project: project,
+                                         pbxTarget: pbxTarget,
+                                         pbxproj: pbxproj,
+                                         projectSettings: .default,
+                                         fileElements: ProjectFileElements(),
+                                         graphTraverser: graphTraverser,
+                                         sourceRootPath: AbsolutePath("/project"))
+
+        // Then
+        let configurationList = pbxTarget.buildConfigurationList
+        let debugConfig = configurationList?.configuration(name: "Debug")
+        let releaseConfig = configurationList?.configuration(name: "Release")
+
+        let expectedSettings = [
+            "TVOS_DEPLOYMENT_TARGET": "14.0",
+        ]
+
+        assert(config: debugConfig, contains: expectedSettings)
+        assert(config: releaseConfig, contains: expectedSettings)
+    }
+
     func test_generateProjectConfig_defaultConfigurationName() throws {
         // Given
         let settings = Settings(configurations: [

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -190,6 +190,23 @@ final class TargetLinterTests: TuistUnitTestCase {
         }
     }
 
+    func test_lint_when_target_platform_and_deployment_target_property_mismatch() throws {
+        let invalidCombinations: [(Platform, DeploymentTarget)] = [(.iOS, .macOS("10.0.0")),
+                                                                   (.watchOS, .macOS("10.0.0")),
+                                                                   (.macOS, .watchOS("10.0.0")),
+                                                                   (.tvOS, .macOS("10.0.0"))]
+        for combinations in invalidCombinations {
+            // Given
+            let target = Target.test(platform: combinations.0, deploymentTarget: combinations.1)
+
+            // When
+            let got = subject.lint(target: target)
+
+            // Then
+            XCTContainsLintingIssue(got, LintingIssue(reason: "Found an inconsistency between a platform `\(combinations.0.caseValue)` and deployment target `\(combinations.1.platform)`", severity: .error))
+        }
+    }
+
     func test_lint_invalidProductPlatformCombinations() throws {
         // Given
         let invalidTargets: [Target] = [


### PR DESCRIPTION
### Short description 📝

Adds DeploymentTarget struct for watchOS and tvOS targets

### Solution 📦

Adds cases for watchOS and tvOS to existing iOS and macOS target cases

### Implementation 👩‍💻👨‍💻

Generates appropriate `WATCHOS_DEPLOYMENT_TARGET` and `TVOS_DEPLOYMENT_TARGET` setting