### PR TITLE
Don't install Bundler dependencies at vendor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,13 @@ jobs:
         run: gem install bundler --version 2.1.4
       - uses: actions/cache@v2
         with:
-          path: vendor/bundle
+          path: gems/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-gems-
       - name: Bundle install
         run: |
-          bundle config path vendor/bundle
+          bundle config path gems/bundle
           bundle install --jobs 4 --retry 3
       - name: Select Xcode 11.5
         run: sudo xcode-select -switch /Applications/Xcode_11.5.app


### PR DESCRIPTION
### Short description 📝
Some users reported that the most recent Tuist versions contained a directory with Gem dependencies. It turns out that since we are installing `Bundler` dependencies at the `vendor` directory, which is included in the release `.tar`, the Gems end up being part of the tar too.

I've changed the pipeline to install Bundler dependencies at the `gems` directory.