### PR TITLE
Adding platform support for Dependency.swift

### DIFF
--- a/Sources/ProjectDescription/Dependency.swift
+++ b/Sources/ProjectDescription/Dependency.swift
@@ -11,18 +11,27 @@ public struct Dependency: Codable, Equatable {
     /// Dependecy manager used to retrieve the dependecy
     public let manager: Dependency.Manager
 
-    public init(name: String, requirement: Dependency.Requirement, manager: Dependency.Manager) {
+    /// Set of platforms for  the given dependency
+    public let platforms: Set<Platform>
+
+    public init(name: String,
+                requirement: Dependency.Requirement,
+                manager: Dependency.Manager,
+                platforms: Set<Platform>) {
         self.name = name
         self.requirement = requirement
         self.manager = manager
+        self.platforms = platforms
     }
 
     /// Carthage dependency initailizer
     /// - Parameter name: Name of the dependency
     /// - Parameter requirement: Type of requirement for the given dependency
     /// - Returns Dependency
-    public static func carthage(name: String, requirement: Dependency.Requirement) -> Dependency {
-        Dependency(name: name, requirement: requirement, manager: .carthage)
+    public static func carthage(name: String,
+                                requirement: Dependency.Requirement,
+                                platforms: [Platform]) -> Dependency {
+        Dependency(name: name, requirement: requirement, manager: .carthage, platforms: Set(platforms))
     }
 
     public static func == (lhs: Dependency, rhs: Dependency) -> Bool {

--- a/Sources/ProjectDescription/Dependency.swift
+++ b/Sources/ProjectDescription/Dependency.swift
@@ -17,7 +17,8 @@ public struct Dependency: Codable, Equatable {
     public init(name: String,
                 requirement: Dependency.Requirement,
                 manager: Dependency.Manager,
-                platforms: [Platform]) {
+                platforms: [Platform])
+    {
         self.name = name
         self.requirement = requirement
         self.manager = manager
@@ -30,8 +31,9 @@ public struct Dependency: Codable, Equatable {
     /// - Returns Dependency
     public static func carthage(name: String,
                                 requirement: Dependency.Requirement,
-                                platforms: [Platform]) -> Dependency {
-        Dependency(name: name, requirement: requirement, manager: .carthage, platforms: Set(platforms))
+                                platforms: [Platform]) -> Dependency
+    {
+        Dependency(name: name, requirement: requirement, manager: .carthage, platforms: platforms)
     }
 
     public static func == (lhs: Dependency, rhs: Dependency) -> Bool {

--- a/Sources/ProjectDescription/Dependency.swift
+++ b/Sources/ProjectDescription/Dependency.swift
@@ -17,11 +17,11 @@ public struct Dependency: Codable, Equatable {
     public init(name: String,
                 requirement: Dependency.Requirement,
                 manager: Dependency.Manager,
-                platforms: Set<Platform>) {
+                platforms: [Platform]) {
         self.name = name
         self.requirement = requirement
         self.manager = manager
-        self.platforms = platforms
+        self.platforms = Set(platforms)
     }
 
     /// Carthage dependency initailizer

--- a/Sources/TuistCore/Models/CarthageDependency.swift
+++ b/Sources/TuistCore/Models/CarthageDependency.swift
@@ -7,4 +7,7 @@ struct CarthageDependency {
 
     /// Type of requirement for the given dependency
     let requirement: Requirement
+
+    /// Set of platforms for  the given dependency
+    let platoforms: Set<Platform>
 }

--- a/Sources/TuistCore/Models/CarthageDependency.swift
+++ b/Sources/TuistCore/Models/CarthageDependency.swift
@@ -9,5 +9,5 @@ struct CarthageDependency {
     let requirement: Requirement
 
     /// Set of platforms for  the given dependency
-    let platoforms: Set<Platform>
+    let platforms: Set<Platform>
 }

--- a/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
+++ b/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
@@ -167,6 +167,6 @@ extension Dependencies {
     public static func test(name: String = "Any Dependency",
                             requirement: Dependency.Requirement = .exact("1.4.0")) -> Dependencies
     {
-        Dependencies([.carthage(name: name, requirement: requirement)])
+        Dependencies([.carthage(name: name, requirement: requirement, platforms: [.iOS])])
     }
 }

--- a/fixtures/ios_app_with_helpers/Tuist/Dependencies.swift
+++ b/fixtures/ios_app_with_helpers/Tuist/Dependencies.swift
@@ -1,5 +1,5 @@
 import ProjectDescription
 
 let dependencies = Dependencies([
-    .carthage(name: "Alamofire", requirement: .exact("5.3.0")),
+    .carthage(name: "Alamofire", requirement: .exact("5.3.0"), platforms: [.iOS]),
 ])


### PR DESCRIPTION
### Short description 📝
We need our manifest to support platform-specific dependencies so we know what to fetch.

### Solution 📦

Adding support for that in our `Dependency.swift` model.
