### PR TITLE
Include workspace in tree shaking process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Added
+
+- Extend the tree-shaking logic to include workspace projects and targets [#2056](https://github.com/tuist/tuist/pull/2056) by [@pepibumur](https://github.com/pepibumur).
+
 ### Changed
 
 - Change `launchArguments` of `Target` and `RunAction` to ordered array so order can be preserved [#2052](https://github.com/tuist/tuist/pull/2052) by [@olejnjak](https://github.com/olejnjak).

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
         "state": {
           "branch": null,
-          "revision": "04500de6c2d4f42dc6adcbb9aa54581219b32d5c",
-          "version": "1.3.5"
+          "revision": "e2bc81be54d71d566a52ca17c3983d141c30aa70",
+          "version": "1.3.3"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/tid-kijyun/Kanna.git",
         "state": {
           "branch": null,
-          "revision": "609367a2cd84827a33383cf7923cb4fe8f69ee0a",
-          "version": "5.2.2"
+          "revision": "4a80ebe93b6966d5083394fcaaaff57a2fcec935",
+          "version": "5.2.3"
         }
       },
       {
@@ -231,8 +231,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "88caa2e6fffdbef2e91c2022d038576062042907",
-          "version": "4.0.0"
+          "revision": "138cf1b701cf825233b92ceac919152d5aba8a3f",
+          "version": "4.0.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
         "state": {
           "branch": null,
-          "revision": "e2bc81be54d71d566a52ca17c3983d141c30aa70",
-          "version": "1.3.3"
+          "revision": "04500de6c2d4f42dc6adcbb9aa54581219b32d5c",
+          "version": "1.3.5"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/tid-kijyun/Kanna.git",
         "state": {
           "branch": null,
-          "revision": "4a80ebe93b6966d5083394fcaaaff57a2fcec935",
-          "version": "5.2.3"
+          "revision": "609367a2cd84827a33383cf7923cb4fe8f69ee0a",
+          "version": "5.2.2"
         }
       },
       {
@@ -231,8 +231,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "138cf1b701cf825233b92ceac919152d5aba8a3f",
-          "version": "4.0.1"
+          "revision": "88caa2e6fffdbef2e91c2022d038576062042907",
+          "version": "4.0.0"
         }
       },
       {

--- a/Sources/TuistCache/GraphMappers/CacheTreeShakingGraphMapper.swift
+++ b/Sources/TuistCache/GraphMappers/CacheTreeShakingGraphMapper.swift
@@ -27,9 +27,14 @@ public final class CacheTreeShakingGraphMapper: GraphMapping {
                 return project.with(targets: targets).with(schemes: schemes)
             }
         }
+        
+        let workspace = treeShake(workspace: graph.workspace,
+                                  projects: projects,
+                                  sourceTargets: sourceTargets)
 
         let graph = graph
             .with(projects: projects)
+            .with(workspace: workspace)
             .with(targets: sourceTargets.reduce(into: [AbsolutePath: [TargetNode]]()) { acc, targetReference in
                 var targets = acc[targetReference.projectPath, default: []]
                 if let target = graph.target(path: targetReference.projectPath, name: targetReference.name) {
@@ -39,6 +44,15 @@ public final class CacheTreeShakingGraphMapper: GraphMapping {
             })
 
         return (graph, [])
+    }
+    
+    fileprivate func treeShake(workspace: Workspace, projects: [Project], sourceTargets: Set<TargetReference>) -> Workspace {
+        let projects = workspace.projects.filter({ projects.map(\.path).contains($0) })
+        let schemes = treeShake(schemes: workspace.schemes, sourceTargets: sourceTargets)
+        var workspace = workspace
+        workspace.schemes = schemes
+        workspace.projects = projects
+        return workspace
     }
 
     fileprivate func treeShake(targets: [Target], path: AbsolutePath, graph: Graph, sourceTargets: Set<TargetReference>) -> [Target] {

--- a/Sources/TuistCache/GraphMappers/CacheTreeShakingGraphMapper.swift
+++ b/Sources/TuistCache/GraphMappers/CacheTreeShakingGraphMapper.swift
@@ -27,7 +27,7 @@ public final class CacheTreeShakingGraphMapper: GraphMapping {
                 return project.with(targets: targets).with(schemes: schemes)
             }
         }
-        
+
         let workspace = treeShake(workspace: graph.workspace,
                                   projects: projects,
                                   sourceTargets: sourceTargets)
@@ -45,9 +45,9 @@ public final class CacheTreeShakingGraphMapper: GraphMapping {
 
         return (graph, [])
     }
-    
+
     fileprivate func treeShake(workspace: Workspace, projects: [Project], sourceTargets: Set<TargetReference>) -> Workspace {
-        let projects = workspace.projects.filter({ projects.map(\.path).contains($0) })
+        let projects = workspace.projects.filter { projects.map(\.path).contains($0) }
         let schemes = treeShake(schemes: workspace.schemes, sourceTargets: sourceTargets)
         var workspace = workspace
         workspace.schemes = schemes


### PR DESCRIPTION
### Short description 📝
The current tree-shaking logic doesn't include the workspace. This PR extends it to remove the projects that are no longer part of the graph, and tree-shakes the workspace schemes too.
