### PR TITLE
[fix-docs] link missing `test schemes` docs

### DIFF
--- a/website/markdown/docs/links.mdx
+++ b/website/markdown/docs/links.mdx
@@ -45,6 +45,7 @@ import {
 - [Focus on targets](/docs/commands/focus/)
 - [Sign your apps](/docs/commands/signing/)
 - [Build schemes](/docs/commands/build/)
+- [Test schemes](/docs/commands/test)
 - [Scaffold files](/docs/commands/scaffold/)
 - [Linting](/docs/commands/linting/)
 - [Project graph](/docs/commands/graph/)

--- a/website/markdown/docs/links.mdx
+++ b/website/markdown/docs/links.mdx
@@ -45,7 +45,7 @@ import {
 - [Focus on targets](/docs/commands/focus/)
 - [Sign your apps](/docs/commands/signing/)
 - [Build schemes](/docs/commands/build/)
-- [Test schemes](/docs/commands/test)
+- [Test schemes](/docs/commands/test/)
 - [Scaffold files](/docs/commands/scaffold/)
 - [Linting](/docs/commands/linting/)
 - [Project graph](/docs/commands/graph/)


### PR DESCRIPTION
Fix missing link to `Test schemes` documentation on the website. 
