### PR TITLE
Fix hashing of preaction when it has no path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
+- Fix hashing preaction with path to nil [#2074](https://github.com/tuist/tuist/pull/2074) by [@fortmarek](https://github.com/fortmarek)
 - Correct the `TEST_HOST` path for the macOS Platform [#2034](https://github.com/tuist/tuist/pull/2034) by [@ferologics](https://github.com/ferologics)
 
 ## 1.25.0 - Charles

--- a/Sources/TuistCache/ContentHashing/TargetActionsContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/TargetActionsContentHasher.swift
@@ -24,7 +24,8 @@ public final class TargetActionsContentHasher: TargetActionsContentHashing {
     public func hash(targetActions: [TargetAction]) throws -> String {
         var stringsToHash: [String] = []
         for targetAction in targetActions {
-            var pathsToHash: [AbsolutePath] = [targetAction.path ?? ""]
+            var pathsToHash: [AbsolutePath] = []
+            targetAction.path.map { pathsToHash.append($0) }
             pathsToHash.append(contentsOf: targetAction.inputPaths)
             pathsToHash.append(contentsOf: targetAction.inputFileListPaths)
             pathsToHash.append(contentsOf: targetAction.outputPaths)

--- a/Tests/TuistCacheTests/ContentHashing/TargetActionsContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/TargetActionsContentHasherTests.swift
@@ -35,7 +35,7 @@ final class TargetActionsContentHasherTests: TuistUnitTestCase {
     private func makeTargetAction(name: String = "1",
                                   order: TargetAction.Order = .pre,
                                   tool: String = "tool1",
-                                  path: AbsolutePath = AbsolutePath("/path1"),
+                                  path: AbsolutePath? = AbsolutePath("/path1"),
                                   arguments: [String] = ["arg1", "arg2"],
                                   inputPaths: [AbsolutePath] = [AbsolutePath("/inputPaths1")],
                                   inputFileListPaths: [AbsolutePath] = [AbsolutePath("/inputFileListPaths1")],
@@ -83,6 +83,36 @@ final class TargetActionsContentHasherTests: TuistUnitTestCase {
                         "pre",
                         "arg1",
                         "arg2"]
+        XCTAssertEqual(mockContentHasher.hashStringsSpy, expected)
+    }
+
+    func test_hash_targetAction_when_path_nil_callsMockHasherWithExpectedStrings() throws {
+        // Given
+        let inputPaths1Hash = "inputPaths1-hash"
+        let inputFileListPaths1 = "inputFileListPaths1-hash"
+        let outputPaths1 = "outputPaths1-hash"
+        let outputFileListPaths1 = "outputFileListPaths1-hash"
+        mockContentHasher.stubHashForPath[AbsolutePath("/inputPaths1")] = inputPaths1Hash
+        mockContentHasher.stubHashForPath[AbsolutePath("/inputFileListPaths1")] = inputFileListPaths1
+        mockContentHasher.stubHashForPath[AbsolutePath("/outputPaths1")] = outputPaths1
+        mockContentHasher.stubHashForPath[AbsolutePath("/outputFileListPaths1")] = outputFileListPaths1
+        let targetAction = makeTargetAction(path: nil)
+
+        // When
+        _ = try subject.hash(targetActions: [targetAction])
+
+        // Then
+        let expected = [
+            inputPaths1Hash,
+            inputFileListPaths1,
+            outputPaths1,
+            outputFileListPaths1,
+            "1",
+            "tool1",
+            "pre",
+            "arg1",
+            "arg2",
+        ]
         XCTAssertEqual(mockContentHasher.hashStringsSpy, expected)
     }
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/2054

### Short description 📝

Hashing would fail if a preaction did not have a path

### Solution 📦

Do not hash a path if it's nil

### Implementation 👩‍💻👨‍💻

- [x] Fix the bug
- [x] Tests
- [x] Edit changelog

cc @ferologics 