### PR TITLE
Fix framework search paths for SDK dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Generate multiple `XXX-Project` schemes if there are multiple platforms [#2081](https://github.com/tuist/tuist/pull/2081) by [@fortmarek](https://github.com/fortmarek)
 
+### Fixed
+
+- Fix framework search paths for SDK dependencies [#2097](https://github.com/tuist/tuist/pull/2097) by [@kwridan](https://github.com/kwridan)
+
 ## 1.26.0 - New World
 
 ### Added

--- a/Sources/TuistCore/Graph/GraphLoader.swift
+++ b/Sources/TuistCore/Graph/GraphLoader.swift
@@ -231,7 +231,7 @@ public class GraphLoader: GraphLoading {
 
         // System SDK
         case let .sdk(name, status):
-            return try SDKNode(name: name, platform: platform, status: status, source: .developer)
+            return try SDKNode(name: name, platform: platform, status: status, source: .system)
 
         // CocoaPods
         case let .cocoapods(podsPath):
@@ -243,7 +243,7 @@ public class GraphLoader: GraphLoading {
 
         // XCTest
         case .xctest:
-            return try SDKNode(name: SDKNode.xctestFrameworkName, platform: platform, status: .required, source: .system)
+            return try SDKNode(name: SDKNode.xctestFrameworkName, platform: platform, status: .required, source: .developer)
         }
     }
 

--- a/Sources/TuistCore/Graph/Nodes/SDKNode.swift
+++ b/Sources/TuistCore/Graph/Nodes/SDKNode.swift
@@ -7,12 +7,12 @@ public enum SDKSource {
     case system // Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library
 
     /// Returns the framewok search path that should be used in Xcode to locate the SDK.
-    public var frameworkSearchPath: String {
+    public var frameworkSearchPath: String? {
         switch self {
         case .developer:
-            return "$(DEVELOPER_FRAMEWORKS_DIR)"
-        case .system:
             return "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+        case .system:
+            return nil
         }
     }
 }

--- a/Sources/TuistCoreTesting/Graph/GraphDependencyReference+TestData.swift
+++ b/Sources/TuistCoreTesting/Graph/GraphDependencyReference+TestData.swift
@@ -50,7 +50,7 @@ public extension GraphDependencyReference {
 
     static func testSDK(path: AbsolutePath = "/path/CoreData.framework",
                         status: SDKStatus = .required,
-                        source: SDKSource = .developer) -> GraphDependencyReference
+                        source: SDKSource = .system) -> GraphDependencyReference
     {
         GraphDependencyReference.sdk(path: path,
                                      status: status,

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -241,7 +241,7 @@ final class LinkGenerator: LinkGenerating {
             .map { LinkGeneratorPath.absolutePath($0.removingLastComponent()) }
         let sdkPaths = dependencies.compactMap { (dependency: GraphDependencyReference) -> LinkGeneratorPath? in
             if case let GraphDependencyReference.sdk(_, _, source) = dependency {
-                return LinkGeneratorPath.string(source.frameworkSearchPath)
+                return source.frameworkSearchPath.map { LinkGeneratorPath.string($0) }
             } else {
                 return nil
             }

--- a/Tests/TuistCoreTests/Graph/Nodes/SDKNodeTests.swift
+++ b/Tests/TuistCoreTests/Graph/Nodes/SDKNodeTests.swift
@@ -7,8 +7,8 @@ import TuistSupportTesting
 
 final class SDKNodeTests: XCTestCase {
     func test_frameworkSearchPath() throws {
-        XCTAssertEqual(SDKSource.developer.frameworkSearchPath, "$(DEVELOPER_FRAMEWORKS_DIR)")
-        XCTAssertEqual(SDKSource.system.frameworkSearchPath, "$(PLATFORM_DIR)/Developer/Library/Frameworks")
+        XCTAssertEqual(SDKSource.developer.frameworkSearchPath, "$(PLATFORM_DIR)/Developer/Library/Frameworks")
+        XCTAssertNil(SDKSource.system.frameworkSearchPath)
     }
 
     func test_sdk_supportedTypes() throws {

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -15,7 +15,7 @@ final class LinkGeneratorPathTests: TuistUnitTestCase {
     }
 }
 
-final class LinkGeneratorErrorTests: XCTestCase {
+final class LinkGeneratorTests: XCTestCase {
     var embedScriptGenerator: MockEmbedScriptGenerator!
     var subject: LinkGenerator!
 
@@ -229,6 +229,7 @@ final class LinkGeneratorErrorTests: XCTestCase {
             GraphDependencyReference.testXCFramework(path: "/path/Dependencies/XCFrameworks/E.xcframework"),
             GraphDependencyReference.testSDK(path: "/libc++.tbd"),
             GraphDependencyReference.testSDK(path: "/CloudKit.framework"),
+            GraphDependencyReference.testSDK(path: "/XCTest.framework", source: .developer),
             GraphDependencyReference.testProduct(target: "Foo", productName: "Foo.framework"),
         ].shuffled()
         let sourceRootPath = AbsolutePath("/path")
@@ -243,8 +244,8 @@ final class LinkGeneratorErrorTests: XCTestCase {
         // Then
         let config = xcodeprojElements.config
         XCTAssertEqual(config.buildSettings["FRAMEWORK_SEARCH_PATHS"] as? [String], [
-            "$(DEVELOPER_FRAMEWORKS_DIR)",
             "$(inherited)",
+            "$(PLATFORM_DIR)/Developer/Library/Frameworks",
             "$(SRCROOT)/Dependencies/Frameworks",
             "$(SRCROOT)/Dependencies/Libraries",
             "$(SRCROOT)/Dependencies/XCFrameworks",


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/1937

### Short description 📝

Generated projects had the incorrect framework search paths set for system and developer SDK dependencies.

- System SDKs don't require any additional search paths
- XCTest requires `$(PLATFORM_DIR)/Developer/Library/Frameworks`

### Solution 📦

- Fix the paths used for SDK dependencies
- Omit framework search paths for system dependencies

### Implementation 👩‍💻👨‍💻

- [x] Fix Graph Loader logic
- [x] Correct SDK node search paths
- [x] Support optional framework search paths from SDK nodes
- [x] Update tests
- [x] Update change log

### Test Plan 🛠

- Run `swift build && swift run tuist generate --path fixtures/ios_app_with_sdk`
- Inspect the generated project
- Verify framework search paths are not added for system SDKs (e.g. in the App target)
- Verify framework search paths are still added (`$(PLATFORM_DIR)/Developer/Library/Frameworks`) for the XCTest SDK (e.g. in MyTestFramework)
- Verify `MyTestFramework` continues to build successfully
