### PR TITLE
WIP Bundle caching workaround

### DIFF
--- a/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
@@ -47,6 +47,11 @@ public final class GraphContentHasher: GraphContentHashing {
 
     fileprivate func isCacheable(_ target: TargetNode, visited: inout [TargetNode: Bool]) -> Bool {
         if let visitedValue = visited[target] { return visitedValue }
+        if target.target.product == .bundle {
+            visited[target] = true
+            return true
+        }
+        
         let isFramework = target.target.product == .framework || target.target.product == .staticFramework
         let noXCTestDependency = !target.dependsOnXCTest
         let allTargetDependenciesAreHasheable = target.targetDependencies.allSatisfy { isCacheable($0, visited: &visited) }
@@ -55,3 +60,6 @@ public final class GraphContentHasher: GraphContentHashing {
         return cacheable
     }
 }
+
+// return yes from isCachable for bundle targets (GraphContentHasher)
+// modify the graph to embed bundles directly in the app (CacheGraphMutator)

--- a/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
@@ -60,6 +60,3 @@ public final class GraphContentHasher: GraphContentHashing {
         return cacheable
     }
 }
-
-// return yes from isCachable for bundle targets (GraphContentHasher)
-// modify the graph to embed bundles directly in the app (CacheGraphMutator)

--- a/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
@@ -47,6 +47,7 @@ public final class GraphContentHasher: GraphContentHashing {
 
     fileprivate func isCacheable(_ target: TargetNode, visited: inout [TargetNode: Bool]) -> Bool {
         if let visitedValue = visited[target] { return visitedValue }
+        // Ignore bundle targets until they can be properly cached
         if target.target.product == .bundle {
             visited[target] = true
             return true

--- a/Sources/TuistCache/GraphMappers/CacheGraphMutator.swift
+++ b/Sources/TuistCache/GraphMappers/CacheGraphMutator.swift
@@ -46,6 +46,10 @@ class CacheGraphMutator: CacheGraphMutating {
         let userSpecifiedSourceTestTargets = userSpecifiedSourceTargets.flatMap { graph.testTargetsDependingOn(path: $0.path, name: $0.name) }
         var sourceTargets: Set<TargetNode> = Set(userSpecifiedSourceTargets)
 
+        // keep a record of runnable targets that have resources
+        // via transitive static dependencies
+        let runnableTargetsResources = runnableTargetsToResources(in: graph)
+        
         try (userSpecifiedSourceTargets + userSpecifiedSourceTestTargets)
             .forEach { try visit(targetNode: $0,
                                  precompiledFrameworks: precompiledFrameworks,
@@ -58,8 +62,27 @@ class CacheGraphMutator: CacheGraphMutating {
         graph.targets.flatMap(\.value).forEach {
             if !sourceTargets.contains($0) { $0.prune = true }
         }
+        
+        addResourceTargets(to: runnableTargetsResources)
 
         return graph
+    }
+    
+    fileprivate func runnableTargetsToResources(in graph: Graph) -> [TargetNode: [TargetNode]] {
+        let runnable = graph.targets.flatMap(\.value).filter { $0.target.product.runnable }
+        let runnableToResources: [TargetNode: [TargetNode]] = runnable.reduce([:]) { acc, target in
+            let resources = graph.resourceBundleDependencies(path: target.path, name: target.name)
+            var acc = acc
+            acc[target] = resources
+            return acc
+        }
+        return runnableToResources
+    }
+    
+    fileprivate func addResourceTargets(to runnableTargets: [TargetNode: [TargetNode]]) {
+        for (runnableTarget, resources) in runnableTargets {
+            runnableTarget.dependencies = runnableTarget.dependencies + resources
+        }
     }
 
     fileprivate func visit(targetNode: TargetNode,
@@ -70,7 +93,7 @@ class CacheGraphMutator: CacheGraphMutating {
                            loadedPrecompiledNodes: inout [AbsolutePath: PrecompiledNode]) throws
     {
         sourceTargets.formUnion([targetNode])
-        targetNode.dependencies = try mapDependencies(targetNode.dependencies,
+        targetNode.dependencies = try mapDependencies(targetNode,
                                                       precompiledFrameworks: precompiledFrameworks,
                                                       sources: sources,
                                                       sourceTargets: &sourceTargets,
@@ -79,7 +102,7 @@ class CacheGraphMutator: CacheGraphMutating {
     }
 
     // swiftlint:disable line_length
-    fileprivate func mapDependencies(_ dependencies: [GraphNode],
+    fileprivate func mapDependencies(_ targetNode: TargetNode,
                                      precompiledFrameworks: [TargetNode: AbsolutePath],
                                      sources: Set<String>,
                                      sourceTargets: inout Set<TargetNode>,
@@ -87,20 +110,22 @@ class CacheGraphMutator: CacheGraphMutating {
                                      loadedPrecompiledFrameworks: inout [AbsolutePath: PrecompiledNode]) throws -> [GraphNode]
     {
         var newDependencies: [GraphNode] = []
-        try dependencies.forEach { dependency in
+        try targetNode.dependencies.forEach { dependency in
             // If the dependency is not a target node we keep it.
             guard let targetDependency = dependency as? TargetNode else {
                 newDependencies.append(dependency)
                 return
             }
+            
+            let isBundleOfStaticTarget = targetDependency.target.product == .bundle && targetNode.target.product.isStatic
 
             // If the target cannot be replaced with its associated .(xc)framework we return
-            guard !sources.contains(targetDependency.target.name), let precompiledFrameworkPath = precompiledFrameworkPath(target: targetDependency,
+            guard !sources.contains(targetDependency.target.name), !isBundleOfStaticTarget, let precompiledFrameworkPath = precompiledFrameworkPath(target: targetDependency,
                                                                                                                            precompiledFrameworks: precompiledFrameworks,
                                                                                                                            visitedPrecompiledFrameworkPaths: &visitedPrecompiledFrameworkPaths)
             else {
                 sourceTargets.formUnion([targetDependency])
-                targetDependency.dependencies = try mapDependencies(targetDependency.dependencies,
+                targetDependency.dependencies = try mapDependencies(targetDependency,
                                                                     precompiledFrameworks: precompiledFrameworks,
                                                                     sources: sources,
                                                                     sourceTargets: &sourceTargets,
@@ -113,7 +138,7 @@ class CacheGraphMutator: CacheGraphMutating {
             // We load the .framework (or fallback on .xcframework)
             let precompiledFramework: PrecompiledNode = try loadPrecompiledFramework(path: precompiledFrameworkPath, loadedPrecompiledFrameworks: &loadedPrecompiledFrameworks)
 
-            try mapDependencies(targetDependency.dependencies,
+            try mapDependencies(targetDependency,
                                 precompiledFrameworks: precompiledFrameworks,
                                 sources: sources,
                                 sourceTargets: &sourceTargets,
@@ -160,9 +185,9 @@ class CacheGraphMutator: CacheGraphMutating {
         }
         // The target can be replaced
         else if let path = precompiledFrameworks[target],
-            target.targetDependencies.allSatisfy({ precompiledFrameworkPath(target: $0,
-                                                                            precompiledFrameworks: precompiledFrameworks,
-                                                                            visitedPrecompiledFrameworkPaths: &visitedPrecompiledFrameworkPaths) != nil })
+            target.targetDependencies.allSatisfy({ $0.target.product == .bundle || precompiledFrameworkPath(target: $0,
+                                                                                                            precompiledFrameworks: precompiledFrameworks,
+                                                                                                            visitedPrecompiledFrameworkPaths: &visitedPrecompiledFrameworkPaths) != nil })
         {
             visitedPrecompiledFrameworkPaths[target] = VisitedPrecompiledFramework(path: path)
             return path

--- a/Sources/TuistCache/GraphMappers/CacheGraphMutator.swift
+++ b/Sources/TuistCache/GraphMappers/CacheGraphMutator.swift
@@ -112,7 +112,7 @@ class CacheGraphMutator: CacheGraphMutating {
         targetNode.dependencies = try mapDependencies(targetNode,
                                                       precompiledFrameworks: precompiledFrameworks,
                                                       sources: sources,
-                                                      sourceTargets: &sourceTargets,
+                                                      ignoreTargets: &sourceTargets,
                                                       visitedPrecompiledFrameworkPaths: &visitedPrecompiledFrameworkPaths,
                                                       loadedPrecompiledFrameworks: &loadedPrecompiledNodes)
     }
@@ -121,7 +121,7 @@ class CacheGraphMutator: CacheGraphMutating {
     fileprivate func mapDependencies(_ targetNode: TargetNode,
                                      precompiledFrameworks: [TargetNode: AbsolutePath],
                                      sources: Set<String>,
-                                     sourceTargets: inout Set<TargetNode>,
+                                     ignoreTargets: inout Set<TargetNode>,
                                      visitedPrecompiledFrameworkPaths: inout [TargetNode: VisitedPrecompiledFramework?],
                                      loadedPrecompiledFrameworks: inout [AbsolutePath: PrecompiledNode]) throws -> [GraphNode]
     {
@@ -140,11 +140,11 @@ class CacheGraphMutator: CacheGraphMutating {
                                                                                                                            precompiledFrameworks: precompiledFrameworks,
                                                                                                                            visitedPrecompiledFrameworkPaths: &visitedPrecompiledFrameworkPaths)
             else {
-                sourceTargets.formUnion([targetDependency])
+                ignoreTargets.formUnion([targetDependency])
                 targetDependency.dependencies = try mapDependencies(targetDependency,
                                                                     precompiledFrameworks: precompiledFrameworks,
                                                                     sources: sources,
-                                                                    sourceTargets: &sourceTargets,
+                                                                    ignoreTargets: &ignoreTargets,
                                                                     visitedPrecompiledFrameworkPaths: &visitedPrecompiledFrameworkPaths,
                                                                     loadedPrecompiledFrameworks: &loadedPrecompiledFrameworks)
                 newDependencies.append(targetDependency)
@@ -157,7 +157,7 @@ class CacheGraphMutator: CacheGraphMutating {
             try mapDependencies(targetDependency,
                                 precompiledFrameworks: precompiledFrameworks,
                                 sources: sources,
-                                sourceTargets: &sourceTargets,
+                                ignoreTargets: &ignoreTargets,
                                 visitedPrecompiledFrameworkPaths: &visitedPrecompiledFrameworkPaths,
                                 loadedPrecompiledFrameworks: &loadedPrecompiledFrameworks).forEach { dependency in
                 if let frameworkDependency = dependency as? FrameworkNode {
@@ -191,6 +191,11 @@ class CacheGraphMutator: CacheGraphMutating {
                                               precompiledFrameworks: [TargetNode: AbsolutePath],
                                               visitedPrecompiledFrameworkPaths: inout [TargetNode: VisitedPrecompiledFramework?]) -> AbsolutePath?
     {
+        // Ignore bundle targets until they can be properly cached
+        let isBundleTarget: (TargetNode) -> Bool = {
+            $0.target.product == .bundle
+        }
+        
         // Already visited
         if let visited = visitedPrecompiledFrameworkPaths[target] { return visited?.path }
 
@@ -201,9 +206,9 @@ class CacheGraphMutator: CacheGraphMutating {
         }
         // The target can be replaced
         else if let path = precompiledFrameworks[target],
-            target.targetDependencies.allSatisfy({ $0.target.product == .bundle || precompiledFrameworkPath(target: $0,
-                                                                                                            precompiledFrameworks: precompiledFrameworks,
-                                                                                                            visitedPrecompiledFrameworkPaths: &visitedPrecompiledFrameworkPaths) != nil })
+            target.targetDependencies.allSatisfy({ isBundleTarget($0) || precompiledFrameworkPath(target: $0,
+                                                                                                  precompiledFrameworks: precompiledFrameworks,
+                                                                                                  visitedPrecompiledFrameworkPaths: &visitedPrecompiledFrameworkPaths) != nil })
         {
             visitedPrecompiledFrameworkPaths[target] = VisitedPrecompiledFramework(path: path)
             return path

--- a/Sources/TuistCache/GraphMappers/CacheGraphMutator.swift
+++ b/Sources/TuistCache/GraphMappers/CacheGraphMutator.swift
@@ -152,7 +152,14 @@ class CacheGraphMutator: CacheGraphMutating {
 
             // We load the .framework (or fallback on .xcframework)
             let precompiledFramework: PrecompiledNode = try loadPrecompiledFramework(path: precompiledFrameworkPath, loadedPrecompiledFrameworks: &loadedPrecompiledFrameworks)
-
+            
+            // Remove bundle dependencies for precompiled nodes since they get added
+            // directly into runnable targets that need them
+            targetDependency.dependencies = targetDependency.dependencies.filter { dep in
+                guard let dep = dep as? TargetNode else { return true }
+                return dep.target.product != .bundle
+            }
+            
             try mapDependencies(targetDependency,
                                 precompiledFrameworks: precompiledFrameworks,
                                 sources: sources,

--- a/Sources/TuistCache/GraphMappers/CacheGraphMutator.swift
+++ b/Sources/TuistCache/GraphMappers/CacheGraphMutator.swift
@@ -74,6 +74,7 @@ class CacheGraphMutator: CacheGraphMutating {
     }
         
     fileprivate func runnableTargetsToResources(in graph: Graph) -> [TargetNode: [TargetNode]] {
+        /// We only want to copy bundle resources that belong to static targets
         let runnableToStatic = runnableTargetsToStaticDependencies(in: graph)
         var runnableToResources: [TargetNode: [TargetNode]] = [:]
         for (runnable, staticDependencies) in runnableToStatic {
@@ -108,7 +109,7 @@ class CacheGraphMutator: CacheGraphMutating {
                            loadedPrecompiledNodes: inout [AbsolutePath: PrecompiledNode]) throws
     {
         sourceTargets.formUnion([targetNode])
-        targetNode.dependencies = try mapDependencies(targetNode,
+        targetNode.dependencies = try mapDependencies(of: targetNode,
                                                       precompiledFrameworks: precompiledFrameworks,
                                                       sources: sources,
                                                       ignoreTargets: &sourceTargets,
@@ -117,7 +118,7 @@ class CacheGraphMutator: CacheGraphMutating {
     }
 
     // swiftlint:disable line_length
-    fileprivate func mapDependencies(_ targetNode: TargetNode,
+    fileprivate func mapDependencies(of targetNode: TargetNode,
                                      precompiledFrameworks: [TargetNode: AbsolutePath],
                                      sources: Set<String>,
                                      ignoreTargets: inout Set<TargetNode>,
@@ -140,7 +141,7 @@ class CacheGraphMutator: CacheGraphMutating {
                                                                                                                            visitedPrecompiledFrameworkPaths: &visitedPrecompiledFrameworkPaths)
             else {
                 ignoreTargets.formUnion([targetDependency])
-                targetDependency.dependencies = try mapDependencies(targetDependency,
+                targetDependency.dependencies = try mapDependencies(of: targetDependency,
                                                                     precompiledFrameworks: precompiledFrameworks,
                                                                     sources: sources,
                                                                     ignoreTargets: &ignoreTargets,
@@ -160,7 +161,7 @@ class CacheGraphMutator: CacheGraphMutating {
                 return dep.target.product != .bundle
             }
             
-            try mapDependencies(targetDependency,
+            try mapDependencies(of: targetDependency,
                                 precompiledFrameworks: precompiledFrameworks,
                                 sources: sources,
                                 ignoreTargets: &ignoreTargets,

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -173,13 +173,18 @@ public class Graph: Encodable, Equatable {
             .filter(isStaticLibrary)
             .map(productDependencyReference)
     }
-
+    
     /// Returns the transitive resource bundle dependencies for the given target.
     /// - Parameters:
     ///   - path: Path to the directory where the project that defines the target is located.
     ///   - name: Name of the target.
-    public func resourceBundleDependencies(path: AbsolutePath, name: String) -> [TargetNode] {
+    ///   - allowNonSupportingTargets: Allow to search non-supporting targets.
+    public func resourceBundleDependencies(path: AbsolutePath, name: String, allowNonSupportingTargets: Bool = false) -> [TargetNode] {
         guard let targetNode = findTargetNode(path: path, name: name) else {
+            return []
+        }
+        
+        guard targetNode.target.supportsResources || allowNonSupportingTargets else {
             return []
         }
         

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -182,11 +182,7 @@ public class Graph: Encodable, Equatable {
         guard let targetNode = findTargetNode(path: path, name: name) else {
             return []
         }
-
-        guard targetNode.target.supportsResources else {
-            return []
-        }
-
+        
         let canHostResources: (TargetNode) -> Bool = {
             $0.target.supportsResources
         }

--- a/Sources/TuistCore/Graph/Nodes/TargetNode.swift
+++ b/Sources/TuistCore/Graph/Nodes/TargetNode.swift
@@ -56,6 +56,21 @@ public class TargetNode: GraphNode {
         return path == otherTagetNode.path
             && name == otherTagetNode.name
     }
+    
+    // MARK: - CustomDebugStringConvertible
+    
+    override public var debugDescription: String {
+        if dependencies.isEmpty {
+            return name
+        }
+        var dependenciesDescriptions: [String] = []
+        let uniqueDependencies = Set<GraphNode>(dependencies)
+        uniqueDependencies.forEach { dependency in
+            dependenciesDescriptions.append(dependency.debugDescription)
+        }
+
+        return "\(name) --> [\(dependenciesDescriptions.joined(separator: ", "))]"
+    }
 
     // MARK: - Encodable
 

--- a/Sources/TuistKit/Cache/CacheController.swift
+++ b/Sources/TuistKit/Cache/CacheController.swift
@@ -111,9 +111,8 @@ final class CacheController: CacheControlling {
         logger.notice("Building cacheable targets")
 
         try cacheableTargets.sorted(by: { $0.key.target.name < $1.key.target.name }).forEach { target, hash in
-            if target.target.product != .bundle {
-                try self.buildAndCacheFramework(path: path, target: target, hash: hash)
-            }
+            if target.target.product == .bundle { return }
+            try self.buildAndCacheFramework(path: path, target: target, hash: hash)
         }
 
         logger.notice("All cacheable targets have been cached successfully as \(artifactBuilder.cacheOutputType.description)s", metadata: .success)

--- a/Sources/TuistKit/Cache/CacheController.swift
+++ b/Sources/TuistKit/Cache/CacheController.swift
@@ -111,7 +111,9 @@ final class CacheController: CacheControlling {
         logger.notice("Building cacheable targets")
 
         try cacheableTargets.sorted(by: { $0.key.target.name < $1.key.target.name }).forEach { target, hash in
-            try self.buildAndCacheFramework(path: path, target: target, hash: hash)
+            if target.target.product != .bundle {
+                try self.buildAndCacheFramework(path: path, target: target, hash: hash)
+            }
         }
 
         logger.notice("All cacheable targets have been cached successfully as \(artifactBuilder.cacheOutputType.description)s", metadata: .success)

--- a/Tests/TuistCacheTests/Cache/CacheGraphMutatorTests.swift
+++ b/Tests/TuistCacheTests/Cache/CacheGraphMutatorTests.swift
@@ -624,6 +624,7 @@ final class CacheGraphMapperTests: TuistUnitTestCase {
         let app = try XCTUnwrap(got.entryNodes.first as? TargetNode)
         _ = try XCTUnwrap(app.dependencies.compactMap { $0 as? TargetNode }.first(where: { $0 == bFrameworkNode }))
         XCTAssertTrue(app.dependencies.contains(where: { $0 == cBundle }))
+        XCTAssertEqual(1, bFrameworkNode.dependencies.count)
     }
     
     // 11th scenario
@@ -675,6 +676,7 @@ final class CacheGraphMapperTests: TuistUnitTestCase {
         let app = try XCTUnwrap(got.entryNodes.first as? TargetNode)
         _ = try XCTUnwrap(app.dependencies.compactMap { $0 as? FrameworkNode }.first(where: { $0 == bCachedFramework }))
         XCTAssertTrue(app.dependencies.contains(where: { $0 == cBundle }))
+        XCTAssertEqual(0, bFrameworkNode.dependencies.count)
     }
 
     fileprivate func graphProjects(_ targets: [TargetNode]) -> [Project] {

--- a/Tests/TuistCacheTests/Cache/CacheGraphMutatorTests.swift
+++ b/Tests/TuistCacheTests/Cache/CacheGraphMutatorTests.swift
@@ -590,6 +590,92 @@ final class CacheGraphMapperTests: TuistUnitTestCase {
         XCTAssertTrue(b.dependencies.contains(where: { $0.path == dFrameworkPath }))
         XCTAssertTrue(c.dependencies.contains(where: { $0.path == eXCFrameworkPath }))
     }
+    
+    // 10th scenario
+    //       +---->B (Framework)
+    //       |
+    //    App|
+    //       |
+    //       +---->C (Bundle)
+    func test_map_when_tenth_scenario() throws {
+        let path = try temporaryPath()
+        
+        // Given nodes
+        
+        // Given: C
+        let cBundle = TargetNode.test(target: .test(product: .bundle))
+        
+        // Given: B
+        let bFramework = Target.test(name: "B", platform: .iOS, product: .staticFramework)
+        let bProject = Project.test(path: path.appending(component: "B"), name: "B", targets: [bFramework])
+        let bFrameworkNode = TargetNode.test(project: bProject, target: bFramework, dependencies: [cBundle])
+        
+        // Given: App
+        let appProject = Project.test(path: path.appending(component: "App"), name: "App")
+        let appTargetNode = TargetNode.test(project: appProject, target: Target.test(name: "App", platform: .iOS, product: .app), dependencies: [bFrameworkNode])
+        
+        let targetNodes = [bFrameworkNode, appTargetNode]
+        let graph = Graph.test(entryNodes: [appTargetNode], projects: graphProjects(targetNodes), targets: graphTargets(targetNodes))
+                        
+        // When
+        let got = try subject.map(graph: graph, precompiledFrameworks: [:], sources: Set(["App"]))
+        
+        // Then
+        let app = try XCTUnwrap(got.entryNodes.first as? TargetNode)
+        _ = try XCTUnwrap(app.dependencies.compactMap { $0 as? TargetNode }.first(where: { $0 == bFrameworkNode }))
+        XCTAssertTrue(app.dependencies.contains(where: { $0 == cBundle }))
+    }
+    
+    // 11th scenario
+    //       +---->B (Cached Framework)
+    //       |
+    //    App|
+    //       |
+    //       +---->C (Bundle)
+    func test_map_when_eleventh_scenario() throws {
+        let path = try temporaryPath()
+        
+        // Given nodes
+        
+        // Given: C
+        let cBundle = TargetNode.test(target: .test(product: .bundle))
+        
+        // Given: B
+        let bFramework = Target.test(name: "B", platform: .iOS, product: .staticFramework)
+        let bProject = Project.test(path: path.appending(component: "B"), name: "B", targets: [bFramework])
+        let bFrameworkNode = TargetNode.test(project: bProject, target: bFramework, dependencies: [cBundle])
+        
+        // Given: App
+        let appProject = Project.test(path: path.appending(component: "App"), name: "App")
+        let appTargetNode = TargetNode.test(project: appProject, target: Target.test(name: "App", platform: .iOS, product: .app), dependencies: [bFrameworkNode])
+        
+        let targetNodes = [bFrameworkNode, appTargetNode]
+        let graph = Graph.test(entryNodes: [appTargetNode], projects: graphProjects(targetNodes), targets: graphTargets(targetNodes))
+        
+        // Given xcframeworks
+        let bCachedFrameworkPath = path.appending(component: "B.xcframework")
+        let bCachedFramework = FrameworkNode.test(path: bCachedFrameworkPath)
+        let frameworks = [
+            bFrameworkNode: bCachedFrameworkPath,
+        ]
+        
+        frameworkLoader.loadStub = { path in
+            if path == bCachedFrameworkPath { return bCachedFramework }
+            else { fatalError("Unexpected load call") }
+        }
+        
+        xcframeworkLoader.loadStub = { _ in
+            throw "Can't find an .xcframework here"
+        }
+        
+        // When
+        let got = try subject.map(graph: graph, precompiledFrameworks: frameworks, sources: Set(["App"]))
+        
+        // Then
+        let app = try XCTUnwrap(got.entryNodes.first as? TargetNode)
+        _ = try XCTUnwrap(app.dependencies.compactMap { $0 as? FrameworkNode }.first(where: { $0 == bCachedFramework }))
+        XCTAssertTrue(app.dependencies.contains(where: { $0 == cBundle }))
+    }
 
     fileprivate func graphProjects(_ targets: [TargetNode]) -> [Project] {
         let projects = targets.reduce(into: Set<Project>()) { acc, target in


### PR DESCRIPTION
Partly resolves https://github.com/tuist/tuist/issues/1975 (caching of transitive bundles)

### Short description 📝

Opening this up for some feedback on the general approach before continuing...

The problem is that bundle targets cannot be cached. As a result anything that depends on the bundle cannot be cached either.

### Solution 📦

We agreed on a workaround as a first step

- Ignore bundle targets in the process of caching / swapping out cached targets
- Add any bundles, that are dependencies of static targets, to `runnable` targets that need them, e.g. app targets.

### Implementation 👩‍💻👨‍💻

> Detail in a checklist the steps that you took to implement the PR.

- [x] `isCacheable` == `true` for bundle types in `GraphContentHasher.swift`
- [x] Add resource targets, that are dependencies of static targets, to runnable targets that depend on these static targets.
- [x] Remove bundle dependencies of any nodes that are swapped out for their cached versions
