### PR TITLE
Project Plugins: Add GitHandler Service

### DIFF
--- a/Sources/TuistSupport/Utils/GitHandler.swift
+++ b/Sources/TuistSupport/Utils/GitHandler.swift
@@ -32,7 +32,7 @@ public protocol GitHandling {
 }
 
 /// An implementation of `GitHandling`.
-/// Uses the system to execute git commands. 
+/// Uses the system to execute git commands.
 public final class GitHandler: GitHandling {
     private let system: Systeming
 

--- a/Sources/TuistSupport/Utils/GitHandler.swift
+++ b/Sources/TuistSupport/Utils/GitHandler.swift
@@ -1,0 +1,78 @@
+import Foundation
+import TSCBasic
+
+public protocol GitHandling {
+    /// Clones the given `url` **into** the given `path`.
+    /// `path` must point to a directory where a git repo can be cloned.
+    ///
+    /// - Parameters:
+    ///   - url: The `url` to the git repository to clone.
+    ///   - path: The `AbsolutePath` to clone the git repository.
+    func clone(url: String, into path: AbsolutePath) throws
+
+    /// Clones the given `url` **to** the given `path`.
+    /// `path` must point to a directory where a git repo can be cloned.
+    ///
+    /// - Parameters:
+    ///   - url: The `url` to the git repository to clone.
+    ///   - path: The `AbsolutePath` to clone the git repository.
+    func clone(url: String, to path: AbsolutePath?) throws
+
+    /// Checkout to some git `id` in the given `path`.
+    ///
+    /// The `id` must be something known to the `git checkout` command, which includes:
+    ///  - A branch, i.e. `main`.
+    ///  - A tag, i.e. `1.0.0`
+    ///  - A sha, i.e. `028c13b`
+    ///
+    /// - Parameters:
+    ///   - id: An identifier for the `git checkout` command.
+    ///   - path: The path to the git repository (location with `.git` directory) in which to perform the checkout.
+    func checkout(id: String, in path: AbsolutePath?) throws
+}
+
+/// An implementation of `GitHandling`.
+/// Uses the system to execute git commands. 
+public final class GitHandler: GitHandling {
+    private let system: Systeming
+
+    public init(
+        system: Systeming = System.shared
+    ) {
+        self.system = system
+    }
+
+    public func clone(url: String, into path: AbsolutePath) throws {
+        try system.runAndPrint("git", "-C", path.pathString, "clone", url)
+    }
+
+    public func clone(url: String, to path: AbsolutePath? = nil) throws {
+        if let path = path {
+            try system.runAndPrint("git", "clone", url, path.pathString)
+        } else {
+            try system.runAndPrint("git", "clone", url)
+        }
+    }
+
+    public func checkout(id: String, in path: AbsolutePath?) throws {
+        if let path = path {
+            try performCheckout(id: id, in: path)
+        } else {
+            try system.runAndPrint("git", "checkout", id)
+        }
+    }
+
+    private func performCheckout(id: String, in path: AbsolutePath) throws {
+        let gitDirectory = path.appending(.init(".git"))
+
+        try system.runAndPrint(
+            "git",
+            "--git-dir",
+            gitDirectory.pathString,
+            "--work-tree",
+            path.pathString,
+            "checkout",
+            id
+        )
+    }
+}

--- a/Sources/TuistSupport/Utils/GitHandler.swift
+++ b/Sources/TuistSupport/Utils/GitHandler.swift
@@ -63,7 +63,7 @@ public final class GitHandler: GitHandling {
     }
 
     private func performCheckout(id: String, in path: AbsolutePath) throws {
-        let gitDirectory = path.appending(.init(".git"))
+        let gitDirectory = path.appending(component: ".git")
 
         try system.runAndPrint(
             "git",

--- a/Sources/TuistSupportTesting/Utils/MockGitHandler.swift
+++ b/Sources/TuistSupportTesting/Utils/MockGitHandler.swift
@@ -1,0 +1,22 @@
+import TSCBasic
+import TuistSupport
+
+/// A mock implementation of `GitHandling`.
+public final class MockGitHandler: GitHandling {
+    public init() {}
+
+    public private(set) var cloneIntoStub: ((String, AbsolutePath) -> Void)?
+    public func clone(url: String, into path: AbsolutePath) throws {
+        cloneIntoStub?(url, path)
+    }
+
+    public private(set) var cloneToStub: ((String, AbsolutePath?) -> Void)?
+    public func clone(url: String, to path: AbsolutePath?) throws {
+        cloneToStub?(url, path)
+    }
+
+    public private(set) var checkoutStub: ((String, AbsolutePath?) -> Void)?
+    public func checkout(id: String, in path: AbsolutePath?) throws {
+        checkoutStub?(id, path)
+    }
+}

--- a/Sources/TuistSupportTesting/Utils/MockSystem.swift
+++ b/Sources/TuistSupportTesting/Utils/MockSystem.swift
@@ -7,7 +7,7 @@ import XCTest
 public final class MockSystem: Systeming {
     public var env: [String: String] = ProcessInfo.processInfo.environment
     // swiftlint:disable:next large_tuple
-    private var stubs: [String: (stderror: String?, stdout: String?, exitstatus: Int?)] = [:]
+    public var stubs: [String: (stderror: String?, stdout: String?, exitstatus: Int?)] = [:]
     private var calls: [String] = []
     var whichStub: ((String) throws -> String?)?
 
@@ -101,6 +101,7 @@ public final class MockSystem: Systeming {
             }
             throw TuistSupport.SystemError.terminated(command: arguments.first!, code: 1, standardError: Data())
         }
+        calls.append(arguments.joined(separator: " "))
     }
 
     public func observable(_ arguments: [String]) -> Observable<SystemEvent<Data>> {

--- a/Tests/TuistSupportTests/Utils/GitHandlerTests.swift
+++ b/Tests/TuistSupportTests/Utils/GitHandlerTests.swift
@@ -64,7 +64,7 @@ final class GitHandlerTests: TuistUnitTestCase {
             "--work-tree",
             path.pathString,
             "checkout",
-            id
+            id,
         ].joined(separator: " ")
 
         system.stubs[expectedCommand] = (stderror: nil, stdout: nil, exitstatus: 0)

--- a/Tests/TuistSupportTests/Utils/GitHandlerTests.swift
+++ b/Tests/TuistSupportTests/Utils/GitHandlerTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+
+@testable import TuistSupport
+@testable import TuistSupportTesting
+
+final class GitHandlerTests: TuistUnitTestCase {
+    private var subject: GitHandler!
+
+    override func setUp() {
+        super.setUp()
+        subject = GitHandler(system: system)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        subject = nil
+    }
+
+    func test_cloneInto() throws {
+        let url = "https://some/url/to/repo.git"
+        let path = try temporaryPath()
+
+        system.stubs["git -C \(path.pathString) clone \(url)"] = (stderror: nil, stdout: nil, exitstatus: 0)
+
+        XCTAssertNoThrow(try subject.clone(url: url, into: path))
+        XCTAssertTrue(system.called("git", "-C", path.pathString, "clone", url))
+    }
+
+    func test_cloneTo() throws {
+        let url = "https://some/url/to/repo.git"
+
+        system.stubs["git clone \(url)"] = (stderror: nil, stdout: nil, exitstatus: 0)
+
+        XCTAssertNoThrow(try subject.clone(url: url))
+        XCTAssertTrue(system.called("git", "clone", url))
+    }
+
+    func test_cloneTo_WITH_path() throws {
+        let url = "https://some/url/to/repo.git"
+        let path = try temporaryPath()
+
+        system.stubs["git clone \(url) \(path.pathString)"] = (stderror: nil, stdout: nil, exitstatus: 0)
+
+        XCTAssertNoThrow(try subject.clone(url: url, to: path))
+        XCTAssertTrue(system.called("git", "clone", url, path.pathString))
+    }
+
+    func test_checkout() throws {
+        let id = "main"
+
+        system.stubs["git checkout \(id)"] = (stderror: nil, stdout: nil, exitstatus: 0)
+
+        XCTAssertNoThrow(try subject.checkout(id: id, in: nil))
+    }
+
+    func test_checkout_WITH_path() throws {
+        let id = "main"
+        let path = try temporaryPath()
+
+        let expectedCommand = [
+            "git",
+            "--git-dir",
+            path.appending(.init(".git")).pathString,
+            "--work-tree",
+            path.pathString,
+            "checkout",
+            id
+        ].joined(separator: " ")
+
+        system.stubs[expectedCommand] = (stderror: nil, stdout: nil, exitstatus: 0)
+
+        XCTAssertNoThrow(try subject.checkout(id: id, in: path))
+        XCTAssertTrue(system.called(
+            "git",
+            "--git-dir",
+            path.appending(.init(".git")).pathString,
+            "--work-tree",
+            path.pathString,
+            "checkout",
+            id
+        ))
+    }
+}


### PR DESCRIPTION
### Short description 📝

Adds a `GitHandling`, `GitHandler` and `MockGitHandler`. Used for pulling plugins from remote repository.

### Solution 📦

As part of Project Plugins we need a way to pull plugins from a git repo, this service allows us to clone as well as checkout to specific sha, branch, or commit using `git`.

### Implementation 👩‍💻👨‍💻

The `GitHandler` is a simple "wrapper" around `Systeming` which forwards git commands to the system for the methods defined in the API.