### PR TITLE
Update generators to use the traverser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Changed
 
 - Generate multiple `XXX-Project` schemes if there are multiple platforms [#2081](https://github.com/tuist/tuist/pull/2081) by [@fortmarek](https://github.com/fortmarek)
+- Generators to take in the graph as `GraphTraversing` instead of `Graph` [#2110](https://github.com/tuist/tuist/pull/2110) by [@pepibumur](https://github.com/pepibumur)
 
 ## 1.26.0 - New World
 

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -625,7 +625,7 @@ public class Graph: Encodable, Equatable {
     public func forEach(closure: (GraphNode) -> Void) {
         var stack = Stack<GraphNode>()
 
-        entryNodes.forEach { stack.push($0) }
+        targets.flatMap(\.value).forEach { stack.push($0) }
 
         var visited: Set<GraphNode> = .init()
 

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -91,4 +91,9 @@ public final class GraphTraverser: GraphTraversing {
         graph.hostTargetNodeFor(path: path, name: name)
             .map { ValueGraphTarget(path: $0.path, target: $0.target, project: $0.project) }
     }
+
+    public func allProjectDependencies(path: AbsolutePath) throws -> Set<GraphDependencyReference> {
+        guard let project = projects[path] else { return Set() }
+        return try Set(graph.allDependencyReferences(for: project))
+    }
 }

--- a/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
+++ b/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
@@ -112,4 +112,10 @@ public protocol GraphTraversing {
     ///     - path; Path to the directory where the project that defines the target
     ///     - name: Name of the target
     func hostTargetFor(path: AbsolutePath, name: String) -> ValueGraphTarget?
+
+    /// For the project at the given path, it returns all the dependencies that should
+    /// be referenced from the project. This method is intended to be used when generating
+    /// the groups.
+    /// - Parameter path: Path to the directory where the project is defined.
+    func allProjectDependencies(path: AbsolutePath) throws -> Set<GraphDependencyReference>
 }

--- a/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
+++ b/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
@@ -107,21 +107,6 @@ public class ValueGraphTraverser: GraphTraversing {
             .map { .product(target: $0.name, productName: $0.productNameWithExtension) } ?? [])
     }
 
-    /// It traverses the depdency graph and returns all the dependencies.
-    /// - Parameter path: Path to the project from where traverse the dependency tree.
-    public func allDependencies(path: AbsolutePath) -> Set<ValueGraphDependency> {
-        guard let targets = graph.targets[path]?.values else { return Set() }
-
-        var references = Set<ValueGraphDependency>()
-
-        targets.forEach { target in
-            let dependency = ValueGraphDependency.target(name: target.name, path: path)
-            references.formUnion(filterDependencies(from: dependency))
-        }
-
-        return references
-    }
-
     public func embeddableFrameworks(path: AbsolutePath, name: String) -> Set<GraphDependencyReference> {
         guard let target = self.target(path: path, name: name), canEmbedProducts(target: target.target) else { return Set() }
 
@@ -317,6 +302,20 @@ public class ValueGraphTraverser: GraphTraversing {
             let valueGraphTarget = ValueGraphTarget(path: path, target: target, project: project)
             return dependsOnTarget ? valueGraphTarget : nil
         }.first
+    }
+
+    public func allProjectDependencies(path: AbsolutePath) throws -> Set<GraphDependencyReference> {
+        let targets = self.targets(at: path)
+        if targets.isEmpty { return Set() }
+        var references: Set<GraphDependencyReference> = Set()
+
+        // Linkable dependencies
+        try targets.forEach { target in
+            try references.formUnion(self.linkableDependencies(path: path, name: target.target.name))
+            references.formUnion(self.embeddableFrameworks(path: path, name: target.target.name))
+            references.formUnion(self.copyProductDependencies(path: path, name: target.target.name))
+        }
+        return references
     }
 
     // MARK: - Internal

--- a/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
+++ b/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
@@ -280,4 +280,22 @@ final class MockGraphTraverser: GraphTraversing {
         invokedHostTargetForParametersList.append((path, name))
         return stubbedHostTargetForResult
     }
+
+    var invokedAllProjectDependencies = false
+    var invokedAllProjectDependenciesCount = 0
+    var invokedAllProjectDependenciesParameters: (path: AbsolutePath, Void)?
+    var invokedAllProjectDependenciesParametersList = [(path: AbsolutePath, Void)]()
+    var stubbedAllProjectDependenciesError: Error?
+    var stubbedAllProjectDependenciesResult: Set<GraphDependencyReference>! = []
+
+    func allProjectDependencies(path: AbsolutePath) throws -> Set<GraphDependencyReference> {
+        invokedAllProjectDependencies = true
+        invokedAllProjectDependenciesCount += 1
+        invokedAllProjectDependenciesParameters = (path, ())
+        invokedAllProjectDependenciesParametersList.append((path, ()))
+        if let error = stubbedAllProjectDependenciesError {
+            throw error
+        }
+        return stubbedAllProjectDependenciesResult
+    }
 }

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -405,7 +405,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
                                       fileElements: ProjectFileElements,
                                       pbxproj: PBXProj) throws
     {
-        let targetDependencies = graphTraverser.directTargetDependencies(path: path, name: target.name)
+        let targetDependencies = graphTraverser.directTargetDependencies(path: path, name: target.name).sorted()
         let watchApps = targetDependencies.filter { $0.target.product == .watch2App }
         guard !watchApps.isEmpty else { return }
 

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -224,7 +224,7 @@ final class ConfigGenerator: ConfigGenerating {
             return [:]
         }
 
-        let targetDependencies = graphTraverser.directTargetDependencies(path: projectPath, name: target.name)
+        let targetDependencies = graphTraverser.directTargetDependencies(path: projectPath, name: target.name).sorted()
         let appDependency = targetDependencies.first { $0.target.product.canHostTests() }
 
         guard let app = appDependency else {
@@ -286,7 +286,7 @@ final class ConfigGenerator: ConfigGenerating {
             return [:]
         }
 
-        let targetDependencies = graphTraverser.directTargetDependencies(path: projectPath, name: target.name)
+        let targetDependencies = graphTraverser.directTargetDependencies(path: projectPath, name: target.name).sorted()
         guard let watchExtension = targetDependencies.first(where: { $0.target.product == .watch2Extension }) else {
             return [:]
         }

--- a/Sources/TuistGenerator/Generator/DescriptorGenerator.swift
+++ b/Sources/TuistGenerator/Generator/DescriptorGenerator.swift
@@ -17,18 +17,18 @@ public protocol DescriptorGenerating {
     ///
     /// - Parameters:
     ///   - project: Project model
-    ///   - graph: Graph model
+    ///   - graphTraverser: Graph traverser.
     ///
     /// - Seealso: `GraphLoader`
-    func generateProject(project: Project, graph: Graph) throws -> ProjectDescriptor
+    func generateProject(project: Project, graphTraverser: GraphTraversing) throws -> ProjectDescriptor
 
     /// Generate a workspace descriptor
     ///
     /// - Parameters:
-    ///   - graph: Graph model
+    ///   - graphTraverser: Graph traverser.
     ///
     /// - Seealso: `GraphLoader`
-    func generateWorkspace(graph: Graph) throws -> WorkspaceDescriptor
+    func generateWorkspace(graphTraverser: GraphTraversing) throws -> WorkspaceDescriptor
 }
 
 // MARK: -
@@ -60,11 +60,11 @@ public final class DescriptorGenerator: DescriptorGenerating {
         self.projectDescriptorGenerator = projectDescriptorGenerator
     }
 
-    public func generateProject(project: Project, graph: Graph) throws -> ProjectDescriptor {
-        try projectDescriptorGenerator.generate(project: project, graph: graph)
+    public func generateProject(project: Project, graphTraverser: GraphTraversing) throws -> ProjectDescriptor {
+        try projectDescriptorGenerator.generate(project: project, graphTraverser: graphTraverser)
     }
 
-    public func generateWorkspace(graph: Graph) throws -> WorkspaceDescriptor {
-        try workspaceDescriptorGenerator.generate(graph: graph)
+    public func generateWorkspace(graphTraverser: GraphTraversing) throws -> WorkspaceDescriptor {
+        try workspaceDescriptorGenerator.generate(graphTraverser: graphTraverser)
     }
 }

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -45,7 +45,7 @@ class ProjectFileElements {
     }
 
     func generateProjectFiles(project: Project,
-                              graph: Graph,
+                              graphTraverser: GraphTraversing,
                               groups: ProjectGroups,
                               pbxproj: PBXProj) throws
     {
@@ -79,7 +79,7 @@ class ProjectFileElements {
         }
 
         // Dependencies
-        let dependencies = try graph.allDependencyReferences(for: project)
+        let dependencies = try graphTraverser.allProjectDependencies(path: project.path).sorted()
 
         try generate(dependencyReferences: Set(directProducts + dependencies),
                      groups: groups,

--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -12,11 +12,11 @@ protocol SchemeDescriptorsGenerating {
     ///   - workspace: Workspace model.
     ///   - xcworkspacePath: Path to the workspace.
     ///   - generatedProject: Generated Xcode project.
-    ///   - graph: Tuist graph.
+    ///   - graphTraverser: Graph traverser.
     /// - Throws: A FatalError if the generation of the schemes fails.
     func generateWorkspaceSchemes(workspace: Workspace,
                                   generatedProjects: [AbsolutePath: GeneratedProject],
-                                  graph: Graph) throws -> [SchemeDescriptor]
+                                  graphTraverser: GraphTraversing) throws -> [SchemeDescriptor]
 
     /// Generates the schemes for the project targets.
     ///
@@ -24,11 +24,11 @@ protocol SchemeDescriptorsGenerating {
     ///   - project: Project manifest.
     ///   - xcprojectPath: Path to the Xcode project.
     ///   - generatedProject: Generated Xcode project.
-    ///   - graph: Tuist graph.
+    ///   - graphTraverser: Graph traverser.
     /// - Throws: A FatalError if the generation of the schemes fails.
     func generateProjectSchemes(project: Project,
                                 generatedProject: GeneratedProject,
-                                graph: Graph) throws -> [SchemeDescriptor]
+                                graphTraverser: GraphTraversing) throws -> [SchemeDescriptor]
 }
 
 // swiftlint:disable:next type_body_length
@@ -64,12 +64,12 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
 
     func generateWorkspaceSchemes(workspace: Workspace,
                                   generatedProjects: [AbsolutePath: GeneratedProject],
-                                  graph: Graph) throws -> [SchemeDescriptor]
+                                  graphTraverser: GraphTraversing) throws -> [SchemeDescriptor]
     {
         let schemes = try workspace.schemes.map { scheme in
             try generateScheme(scheme: scheme,
                                path: workspace.path,
-                               graph: graph,
+                               graphTraverser: graphTraverser,
                                generatedProjects: generatedProjects)
         }
 
@@ -78,12 +78,12 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
 
     func generateProjectSchemes(project: Project,
                                 generatedProject: GeneratedProject,
-                                graph: Graph) throws -> [SchemeDescriptor]
+                                graphTraverser: GraphTraversing) throws -> [SchemeDescriptor]
     {
         try project.schemes.map { scheme in
             try generateScheme(scheme: scheme,
                                path: project.path,
-                               graph: graph,
+                               graphTraverser: graphTraverser,
                                generatedProjects: [project.path: generatedProject])
         }
     }
@@ -108,39 +108,39 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
     ///     - scheme: Project scheme.
     ///     - xcPath: Path to workspace's .xcworkspace or project's .xcodeproj.
     ///     - path: Path to workspace or project folder.
-    ///     - graph: Tuist graph.
+    ///     - graphTraverser: Graph traverser.
     ///     - generatedProjects: Project paths mapped to generated projects.
     private func generateScheme(scheme: Scheme,
                                 path: AbsolutePath,
-                                graph: Graph,
+                                graphTraverser: GraphTraversing,
                                 generatedProjects: [AbsolutePath: GeneratedProject]) throws -> SchemeDescriptor
     {
         let generatedBuildAction = try schemeBuildAction(scheme: scheme,
-                                                         graph: graph,
+                                                         graphTraverser: graphTraverser,
                                                          rootPath: path,
                                                          generatedProjects: generatedProjects)
         let generatedTestAction = try schemeTestAction(scheme: scheme,
-                                                       graph: graph,
+                                                       graphTraverser: graphTraverser,
                                                        rootPath: path,
                                                        generatedProjects: generatedProjects)
         let generatedLaunchAction = try schemeLaunchAction(scheme: scheme,
-                                                           graph: graph,
+                                                           graphTraverser: graphTraverser,
                                                            rootPath: path,
                                                            generatedProjects: generatedProjects)
         let generatedProfileAction = try schemeProfileAction(scheme: scheme,
-                                                             graph: graph,
+                                                             graphTraverser: graphTraverser,
                                                              rootPath: path,
                                                              generatedProjects: generatedProjects)
         let generatedAnalyzeAction = try schemeAnalyzeAction(scheme: scheme,
-                                                             graph: graph,
+                                                             graphTraverser: graphTraverser,
                                                              rootPath: path,
                                                              generatedProjects: generatedProjects)
         let generatedArchiveAction = try schemeArchiveAction(scheme: scheme,
-                                                             graph: graph,
+                                                             graphTraverser: graphTraverser,
                                                              rootPath: path,
                                                              generatedProjects: generatedProjects)
 
-        let wasCreatedForAppExtension = isSchemeForAppExtension(scheme: scheme, graph: graph)
+        let wasCreatedForAppExtension = isSchemeForAppExtension(scheme: scheme, graphTraverser: graphTraverser)
 
         let xcscheme = XCScheme(name: scheme.name,
                                 lastUpgradeVersion: Constants.defaultLastUpgradeVersion,
@@ -160,12 +160,12 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
     ///
     /// - Parameters:
     ///   - scheme: Scheme manifest.
-    ///   - graph: Tuist graph.
+    ///   - graphTraverser: Graph traverser.
     ///   - rootPath: Path to the project or workspace.
     ///   - generatedProjects: Project paths mapped to generated projects.
     /// - Returns: Scheme build action.
     func schemeBuildAction(scheme: Scheme,
-                           graph: Graph,
+                           graphTraverser: GraphTraversing,
                            rootPath: AbsolutePath,
                            generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.BuildAction?
     {
@@ -180,19 +180,20 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
         var postActions: [XCScheme.ExecutionAction] = []
 
         try buildAction.targets.forEach { buildActionTarget in
-            guard let buildableReference = try createBuildableReference(targetReference: buildActionTarget,
-                                                                        graph: graph,
+            guard let buildActionGraphTarget = graphTraverser.target(path: buildActionTarget.projectPath, name: buildActionTarget.name) else { return }
+            guard let buildableReference = try createBuildableReference(graphTarget: buildActionGraphTarget,
+                                                                        graphTraverser: graphTraverser,
                                                                         rootPath: rootPath,
                                                                         generatedProjects: generatedProjects) else { return }
             entries.append(XCScheme.BuildAction.Entry(buildableReference: buildableReference, buildFor: buildFor))
         }
 
         preActions = try buildAction.preActions.map {
-            try schemeExecutionAction(action: $0, graph: graph, generatedProjects: generatedProjects, rootPath: rootPath)
+            try schemeExecutionAction(action: $0, graphTraverser: graphTraverser, generatedProjects: generatedProjects, rootPath: rootPath)
         }
 
         postActions = try buildAction.postActions.map {
-            try schemeExecutionAction(action: $0, graph: graph, generatedProjects: generatedProjects, rootPath: rootPath)
+            try schemeExecutionAction(action: $0, graphTraverser: graphTraverser, generatedProjects: generatedProjects, rootPath: rootPath)
         }
 
         return XCScheme.BuildAction(buildActionEntries: entries,
@@ -206,13 +207,13 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
     ///
     /// - Parameters:
     ///   - scheme: Scheme manifest.
-    ///   - graph: Tuist graph.
+    ///   - graphTraverser: Graph traverser.
     ///   - rootPath: Root path to either project or workspace.
     ///   - generatedProjects: Project paths mapped to generated projects.
     /// - Returns: Scheme test action.
     // swiftlint:disable:next function_body_length
     func schemeTestAction(scheme: Scheme,
-                          graph: Graph,
+                          graphTraverser: GraphTraversing,
                           rootPath: AbsolutePath,
                           generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.TestAction?
     {
@@ -228,8 +229,9 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
         }
 
         try testAction.targets.forEach { testableTarget in
-            guard let reference = try createBuildableReference(targetReference: testableTarget.target,
-                                                               graph: graph,
+            guard let testableGraphTarget = graphTraverser.target(path: testableTarget.target.projectPath, name: testableTarget.target.name) else { return }
+            guard let reference = try createBuildableReference(graphTarget: testableGraphTarget,
+                                                               graphTraverser: graphTraverser,
                                                                rootPath: rootPath,
                                                                generatedProjects: generatedProjects) else { return }
             let testable = XCScheme.TestableReference(skipped: testableTarget.isSkipped,
@@ -240,11 +242,11 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
         }
 
         preActions = try testAction.preActions.map { try schemeExecutionAction(action: $0,
-                                                                               graph: graph,
+                                                                               graphTraverser: graphTraverser,
                                                                                generatedProjects: generatedProjects,
                                                                                rootPath: rootPath) }
         postActions = try testAction.postActions.map { try schemeExecutionAction(action: $0,
-                                                                                 graph: graph,
+                                                                                 graphTraverser: graphTraverser,
                                                                                  generatedProjects: generatedProjects,
                                                                                  rootPath: rootPath) }
 
@@ -256,11 +258,12 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
             environments = environmentVariables(arguments.environment)
         }
 
-        let codeCoverageTargets = try testAction.codeCoverageTargets.compactMap {
-            try testCoverageTargetReferences(target: $0,
-                                             graph: graph,
-                                             generatedProjects: generatedProjects,
-                                             rootPath: rootPath)
+        let codeCoverageTargets = try testAction.codeCoverageTargets.compactMap { (target: TargetReference) -> XCScheme.BuildableReference? in
+            guard let graphTarget = graphTraverser.target(path: target.projectPath, name: target.name) else { return nil }
+            return try testCoverageTargetReferences(graphTarget: graphTarget,
+                                                    graphTraverser: graphTraverser,
+                                                    generatedProjects: generatedProjects,
+                                                    rootPath: rootPath)
         }
 
         let onlyGenerateCoverageForSpecifiedTargets = codeCoverageTargets.count > 0 ? true : nil
@@ -291,12 +294,12 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
     ///
     /// - Parameters:
     ///   - scheme: Scheme manifest.
-    ///   - graph: Tuist graph.
+    ///   - graphTraverser: Graph traverser.
     ///   - rootPath: Root path to either project or workspace.
     ///   - generatedProjects: Project paths mapped to generated projects.
     /// - Returns: Scheme launch action.
     func schemeLaunchAction(scheme: Scheme,
-                            graph: Graph,
+                            graphTraverser: GraphTraversing,
                             rootPath: AbsolutePath,
                             generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.LaunchAction?
     {
@@ -312,14 +315,14 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
         if let filePath = scheme.runAction?.filePath {
             pathRunnable = XCScheme.PathRunnable(filePath: filePath.pathString)
         } else {
-            guard let targetNode = graph.target(path: target.projectPath, name: target.name) else { return nil }
-            defaultBuildConfiguration = targetNode.project.defaultDebugBuildConfigurationName
-            guard let buildableReference = try createBuildableReference(targetReference: target,
-                                                                        graph: graph,
+            guard let graphTarget = graphTraverser.target(path: target.projectPath, name: target.name) else { return nil }
+            defaultBuildConfiguration = graphTarget.project.defaultDebugBuildConfigurationName
+            guard let buildableReference = try createBuildableReference(graphTarget: graphTarget,
+                                                                        graphTraverser: graphTraverser,
                                                                         rootPath: rootPath,
                                                                         generatedProjects: generatedProjects) else { return nil }
 
-            if targetNode.target.product.runnable {
+            if graphTarget.target.product.runnable {
                 buildableProductRunnable = XCScheme.BuildableProductRunnable(buildableReference: buildableReference, runnableDebuggingMode: "0")
             } else {
                 macroExpansion = buildableReference
@@ -336,7 +339,7 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
 
         let buildConfiguration = scheme.runAction?.configurationName ?? defaultBuildConfiguration
         let disableMainThreadChecker = scheme.runAction?.diagnosticsOptions.contains(.mainThreadChecker) == false
-        let isSchemeForAppExtension = self.isSchemeForAppExtension(scheme: scheme, graph: graph)
+        let isSchemeForAppExtension = self.isSchemeForAppExtension(scheme: scheme, graphTraverser: graphTraverser)
         let launchActionConstants: Constants.LaunchAction = isSchemeForAppExtension == true ? .extension : .default
 
         return XCScheme.LaunchAction(runnable: buildableProductRunnable,
@@ -356,12 +359,12 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
     ///
     /// - Parameters:
     ///   - scheme: Target manifest.
-    ///   - graph: Tuist graph.
+    ///   - graphTraverser: Graph traverser.
     ///   - rootPath: Root path to either project or workspace.
     ///   - generatedProjects: Project paths mapped to generated projects.
     /// - Returns: Scheme profile action.
     func schemeProfileAction(scheme: Scheme,
-                             graph: Graph,
+                             graphTraverser: GraphTraversing,
                              rootPath: AbsolutePath,
                              generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.ProfileAction?
     {
@@ -385,22 +388,22 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
 
         let shouldUseLaunchSchemeArgsEnv: Bool = commandlineArguments == nil && environments == nil
 
-        guard let targetNode = graph.target(path: target.projectPath, name: target.name) else { return nil }
-        guard let buildableReference = try createBuildableReference(targetReference: target,
-                                                                    graph: graph,
+        guard let graphTarget = graphTraverser.target(path: target.projectPath, name: target.name) else { return nil }
+        guard let buildableReference = try createBuildableReference(graphTarget: graphTarget,
+                                                                    graphTraverser: graphTraverser,
                                                                     rootPath: rootPath,
                                                                     generatedProjects: generatedProjects) else { return nil }
 
         var buildableProductRunnable: XCScheme.BuildableProductRunnable?
         var macroExpansion: XCScheme.BuildableReference?
 
-        if targetNode.target.product.runnable {
+        if graphTarget.target.product.runnable {
             buildableProductRunnable = XCScheme.BuildableProductRunnable(buildableReference: buildableReference, runnableDebuggingMode: "0")
         } else {
             macroExpansion = buildableReference
         }
 
-        let buildConfiguration = scheme.profileAction?.configurationName ?? defaultReleaseBuildConfigurationName(in: targetNode.project)
+        let buildConfiguration = scheme.profileAction?.configurationName ?? defaultReleaseBuildConfigurationName(in: graphTarget.project)
         return XCScheme.ProfileAction(buildableProductRunnable: buildableProductRunnable,
                                       buildConfiguration: buildConfiguration,
                                       macroExpansion: macroExpansion,
@@ -413,19 +416,19 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
     ///
     /// - Parameters:
     ///     - scheme: Scheme manifest.
-    ///     - graph: Tuist graph.
+    ///     - graphTraverser: Graph traverser.
     ///     - rootPath: Root path to either project or workspace.
     ///     - generatedProjects: Project paths mapped to generated projects.
     /// - Returns: Scheme analyze action.
     func schemeAnalyzeAction(scheme: Scheme,
-                             graph: Graph,
+                             graphTraverser: GraphTraversing,
                              rootPath _: AbsolutePath,
                              generatedProjects _: [AbsolutePath: GeneratedProject]) throws -> XCScheme.AnalyzeAction?
     {
         guard let target = defaultTargetReference(scheme: scheme),
-            let targetNode = graph.target(path: target.projectPath, name: target.name) else { return nil }
+            let graphTarget = graphTraverser.target(path: target.projectPath, name: target.name) else { return nil }
 
-        let buildConfiguration = scheme.analyzeAction?.configurationName ?? targetNode.project.defaultDebugBuildConfigurationName
+        let buildConfiguration = scheme.analyzeAction?.configurationName ?? graphTarget.project.defaultDebugBuildConfigurationName
         return XCScheme.AnalyzeAction(buildConfiguration: buildConfiguration)
     }
 
@@ -433,28 +436,28 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
     ///
     /// - Parameters:
     ///     - scheme: Scheme manifest.
-    ///     - graph: Tuist graph.
+    ///     - graphTraverser: Graph traverser.
     ///     - rootPath: Root path to either project or workspace.
     ///     - generatedProjects: Project paths mapped to generated projects.
     /// - Returns: Scheme archive action.
     func schemeArchiveAction(scheme: Scheme,
-                             graph: Graph,
+                             graphTraverser: GraphTraversing,
                              rootPath: AbsolutePath,
                              generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.ArchiveAction?
     {
         guard let target = defaultTargetReference(scheme: scheme),
-            let targetNode = graph.target(path: target.projectPath, name: target.name) else { return nil }
+            let graphTarget = graphTraverser.target(path: target.projectPath, name: target.name) else { return nil }
 
         guard let archiveAction = scheme.archiveAction else {
-            return defaultSchemeArchiveAction(for: targetNode.project)
+            return defaultSchemeArchiveAction(for: graphTarget.project)
         }
 
         let preActions = try archiveAction.preActions.map {
-            try schemeExecutionAction(action: $0, graph: graph, generatedProjects: generatedProjects, rootPath: rootPath)
+            try schemeExecutionAction(action: $0, graphTraverser: graphTraverser, generatedProjects: generatedProjects, rootPath: rootPath)
         }
 
         let postActions = try archiveAction.postActions.map {
-            try schemeExecutionAction(action: $0, graph: graph, generatedProjects: generatedProjects, rootPath: rootPath)
+            try schemeExecutionAction(action: $0, graphTraverser: graphTraverser, generatedProjects: generatedProjects, rootPath: rootPath)
         }
 
         return XCScheme.ArchiveAction(buildConfiguration: archiveAction.configurationName,
@@ -465,18 +468,18 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
     }
 
     func schemeExecutionAction(action: ExecutionAction,
-                               graph: Graph,
+                               graphTraverser: GraphTraversing,
                                generatedProjects: [AbsolutePath: GeneratedProject],
                                rootPath _: AbsolutePath) throws -> XCScheme.ExecutionAction
     {
         guard let targetReference = action.target,
-            let targetNode = graph.target(path: targetReference.projectPath, name: targetReference.name),
+            let graphTarget = graphTraverser.target(path: targetReference.projectPath, name: targetReference.name),
             let generatedProject = generatedProjects[targetReference.projectPath]
         else {
             return schemeExecutionAction(action: action)
         }
         return schemeExecutionAction(action: action,
-                                     target: targetNode.target,
+                                     target: graphTarget.target,
                                      generatedProject: generatedProject)
     }
 
@@ -517,31 +520,31 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
 
     // MARK: - Helpers
 
-    private func resolveRelativeProjectPath(targetNode: TargetNode,
+    private func resolveRelativeProjectPath(graphTarget: ValueGraphTarget,
                                             generatedProject: GeneratedProject,
                                             rootPath: AbsolutePath) -> RelativePath
     {
-        let xcodeProjectPath = targetNode.path.appending(component: generatedProject.name)
+        let xcodeProjectPath = graphTarget.project.path.appending(component: generatedProject.name)
         return xcodeProjectPath.relative(to: rootPath)
     }
 
     /// Creates a target buildable refernece for a target
     ///
     /// - Parameters:
-    ///     - targetReference: The target reference.
+    ///     - graphTarget: The graph target.
     ///     - graph: Tuist graph.
     ///     - rootPath: Path to the project or workspace.
     ///     - generatedProjects: Project paths mapped to generated projects.
-    private func createBuildableReference(targetReference: TargetReference,
-                                          graph: Graph,
+    private func createBuildableReference(graphTarget: ValueGraphTarget,
+                                          graphTraverser: GraphTraversing,
                                           rootPath: AbsolutePath,
                                           generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.BuildableReference?
     {
-        let projectPath = targetReference.projectPath
-        guard let target = graph.target(path: projectPath, name: targetReference.name) else { return nil }
+        let projectPath = graphTarget.project.path
+        guard let target = graphTraverser.target(path: graphTarget.project.path, name: graphTarget.target.name) else { return nil }
         guard let generatedProject = generatedProjects[projectPath] else { return nil }
-        guard let pbxTarget = generatedProject.targets[targetReference.name] else { return nil }
-        let relativeXcodeProjectPath = resolveRelativeProjectPath(targetNode: target,
+        guard let pbxTarget = generatedProject.targets[graphTarget.target.name] else { return nil }
+        let relativeXcodeProjectPath = resolveRelativeProjectPath(graphTarget: graphTarget,
                                                                   generatedProject: generatedProject,
                                                                   rootPath: rootPath)
 
@@ -559,13 +562,13 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
     ///   - generatedProjects: Generated Xcode projects.
     ///   - rootPath: Root path to workspace or project.
     /// - Returns: Array of buildable references.
-    private func testCoverageTargetReferences(target: TargetReference,
-                                              graph: Graph,
+    private func testCoverageTargetReferences(graphTarget: ValueGraphTarget,
+                                              graphTraverser: GraphTraversing,
                                               generatedProjects: [AbsolutePath: GeneratedProject],
                                               rootPath: AbsolutePath) throws -> XCScheme.BuildableReference?
     {
-        try createBuildableReference(targetReference: target,
-                                     graph: graph,
+        try createBuildableReference(graphTarget: graphTarget,
+                                     graphTraverser: graphTraverser,
                                      rootPath: rootPath,
                                      generatedProjects: generatedProjects)
     }
@@ -655,14 +658,14 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
         scheme.buildAction?.targets.first
     }
 
-    private func isSchemeForAppExtension(scheme: Scheme, graph: Graph) -> Bool? {
+    private func isSchemeForAppExtension(scheme: Scheme, graphTraverser: GraphTraversing) -> Bool? {
         guard let defaultTarget = defaultTargetReference(scheme: scheme),
-            let targetNode = graph.target(path: defaultTarget.projectPath, name: defaultTarget.name)
+            let graphTarget = graphTraverser.target(path: defaultTarget.projectPath, name: defaultTarget.name)
         else {
             return nil
         }
 
-        switch targetNode.target.product {
+        switch graphTarget.target.product {
         case .appExtension, .messagesExtension:
             return true
         default:

--- a/Sources/TuistGenerator/Generator/WorkspaceDescriptorGenerator.swift
+++ b/Sources/TuistGenerator/Generator/WorkspaceDescriptorGenerator.swift
@@ -82,9 +82,11 @@ final class WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
         logger.notice("Generating workspace \(workspaceName)", metadata: .section)
 
         /// Projects
-        let projects = try Array(graphTraverser.projects.values).compactMap(context: config.projectGenerationContext) { project -> ProjectDescriptor? in
-            try projectDescriptorGenerator.generate(project: project, graphTraverser: graphTraverser)
-        }
+        let projects = try Array(graphTraverser.projects.values)
+            .sorted(by: { $0.path < $1.path })
+            .compactMap(context: config.projectGenerationContext) { project -> ProjectDescriptor? in
+                try projectDescriptorGenerator.generate(project: project, graphTraverser: graphTraverser)
+            }
 
         let generatedProjects: [AbsolutePath: GeneratedProject] = Dictionary(uniqueKeysWithValues: projects.map { project in
             let pbxproj = project.xcodeProj.pbxproj

--- a/Sources/TuistGenerator/Generator/WorkspaceDescriptorGenerator.swift
+++ b/Sources/TuistGenerator/Generator/WorkspaceDescriptorGenerator.swift
@@ -25,10 +25,10 @@ protocol WorkspaceDescriptorGenerating: AnyObject {
     /// Generates the given workspace.
     ///
     /// - Parameters:
-    ///   - graph: In-memory representation of the graph.
+    ///   - graphTraverser: Graph traverser.
     /// - Returns: Generated workspace descriptor
     /// - Throws: An error if the generation fails.
-    func generate(graph: Graph) throws -> WorkspaceDescriptor
+    func generate(graphTraverser: GraphTraversing) throws -> WorkspaceDescriptor
 }
 
 final class WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
@@ -76,14 +76,14 @@ final class WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
 
     // MARK: - WorkspaceGenerating
 
-    func generate(graph: Graph) throws -> WorkspaceDescriptor {
-        let workspaceName = "\(graph.name).xcworkspace"
+    func generate(graphTraverser: GraphTraversing) throws -> WorkspaceDescriptor {
+        let workspaceName = "\(graphTraverser.name).xcworkspace"
 
         logger.notice("Generating workspace \(workspaceName)", metadata: .section)
 
         /// Projects
-        let projects = try Array(graph.projects).compactMap(context: config.projectGenerationContext) { project -> ProjectDescriptor? in
-            try projectDescriptorGenerator.generate(project: project, graph: graph)
+        let projects = try Array(graphTraverser.projects.values).compactMap(context: config.projectGenerationContext) { project -> ProjectDescriptor? in
+            try projectDescriptorGenerator.generate(project: project, graphTraverser: graphTraverser)
         }
 
         let generatedProjects: [AbsolutePath: GeneratedProject] = Dictionary(uniqueKeysWithValues: projects.map { project in
@@ -99,26 +99,26 @@ final class WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
         })
 
         // Workspace structure
-        let structure = workspaceStructureGenerator.generateStructure(path: graph.entryPath,
-                                                                      workspace: graph.workspace,
+        let structure = workspaceStructureGenerator.generateStructure(path: graphTraverser.path,
+                                                                      workspace: graphTraverser.workspace,
                                                                       fileHandler: FileHandler.shared)
 
-        let workspacePath = graph.entryPath.appending(component: workspaceName)
+        let workspacePath = graphTraverser.path.appending(component: workspaceName)
         let workspaceData = XCWorkspaceData(children: [])
         let xcWorkspace = XCWorkspace(data: workspaceData)
         try workspaceData.children = structure.contents.map {
             try recursiveChildElement(generatedProjects: generatedProjects,
                                       element: $0,
-                                      path: graph.entryPath)
+                                      path: graphTraverser.path)
         }
 
         // Schemes
-        let schemes = try schemeDescriptorsGenerator.generateWorkspaceSchemes(workspace: graph.workspace,
+        let schemes = try schemeDescriptorsGenerator.generateWorkspaceSchemes(workspace: graphTraverser.workspace,
                                                                               generatedProjects: generatedProjects,
-                                                                              graph: graph)
+                                                                              graphTraverser: graphTraverser)
 
         return WorkspaceDescriptor(
-            path: graph.entryPath,
+            path: graphTraverser.path,
             xcworkspacePath: workspacePath,
             xcworkspace: xcWorkspace,
             projectDescriptors: projects,

--- a/Sources/TuistGeneratorTesting/Generator/MockDescriptorGenerator.swift
+++ b/Sources/TuistGeneratorTesting/Generator/MockDescriptorGenerator.swift
@@ -9,21 +9,21 @@ final class MockDescriptorGenerator: DescriptorGenerating {
         case stubNotImplemented
     }
 
-    var generateProjectSub: ((Project, Graph) throws -> ProjectDescriptor)?
-    func generateProject(project: Project, graph: Graph) throws -> ProjectDescriptor {
+    var generateProjectSub: ((Project, GraphTraversing) throws -> ProjectDescriptor)?
+    func generateProject(project: Project, graphTraverser: GraphTraversing) throws -> ProjectDescriptor {
         guard let generateProjectSub = generateProjectSub else {
             throw MockError.stubNotImplemented
         }
 
-        return try generateProjectSub(project, graph)
+        return try generateProjectSub(project, graphTraverser)
     }
 
-    var generateWorkspaceStub: ((Graph) throws -> WorkspaceDescriptor)?
-    func generateWorkspace(graph: Graph) throws -> WorkspaceDescriptor {
+    var generateWorkspaceStub: ((GraphTraversing) throws -> WorkspaceDescriptor)?
+    func generateWorkspace(graphTraverser: GraphTraversing) throws -> WorkspaceDescriptor {
         guard let generateWorkspaceStub = generateWorkspaceStub else {
             throw MockError.stubNotImplemented
         }
 
-        return try generateWorkspaceStub(graph)
+        return try generateWorkspaceStub(graphTraverser)
     }
 }

--- a/Sources/TuistKit/Generator/Generator.swift
+++ b/Sources/TuistKit/Generator/Generator.swift
@@ -132,7 +132,9 @@ class Generator: Generating {
         try lint(graph: graph)
 
         // Generate
-        let projectDescriptor = try generator.generateProject(project: project, graph: graph)
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
+        let projectDescriptor = try generator.generateProject(project: project, graphTraverser: graphTraverser)
 
         // Write
         try writer.write(project: projectDescriptor)
@@ -154,7 +156,9 @@ class Generator: Generating {
         try lint(graph: graph)
 
         // Generate
-        let workspaceDescriptor = try generator.generateWorkspace(graph: graph)
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
+        let workspaceDescriptor = try generator.generateWorkspace(graphTraverser: graphTraverser)
 
         // Write
         try writer.write(workspace: workspaceDescriptor)
@@ -176,7 +180,9 @@ class Generator: Generating {
         try lint(graph: graph)
 
         // Generate
-        let workspaceDescriptor = try generator.generateWorkspace(graph: graph)
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
+        let workspaceDescriptor = try generator.generateWorkspace(graphTraverser: graphTraverser)
 
         // Write
         try writer.write(workspace: workspaceDescriptor)

--- a/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
@@ -126,7 +126,9 @@ final class ProjectEditor: ProjectEditing {
 
         let (mappedProject, sideEffects) = try projectMapper.map(project: project)
         try sideEffectDescriptorExecutor.execute(sideEffects: sideEffects)
-        let descriptor = try generator.generateProject(project: mappedProject, graph: graph)
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
+        let descriptor = try generator.generateProject(project: mappedProject, graphTraverser: graphTraverser)
         try writer.write(project: descriptor)
         return descriptor.xcodeprojPath
     }

--- a/Tests/TuistCoreTests/ValueGraph/ValueGraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/ValueGraph/ValueGraphTraverserTests.swift
@@ -655,7 +655,7 @@ final class ValueGraphTraverserTests: TuistUnitTestCase {
         // App -> StaticLibrary -> Bundle
         let project = Project.test()
         let app = Target.test(name: "App", product: .app)
-        let staticLibrary = Target.test(name: "StaticLibrary", product: .staticLibrary)
+        let staticLibrary = Target.test(name: "StaticLibrary", product: .staticLibrary, productName: "StaticLibrary")
         let bundle = Target.test(name: "Bundle", product: .bundle)
 
         let dependencies: [ValueGraphDependency: Set<ValueGraphDependency>] = [
@@ -678,8 +678,8 @@ final class ValueGraphTraverserTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(Set(got), Set([
-            .testProduct(target: bundle.name, productName: bundle.productName),
-            .testProduct(target: staticLibrary.name, productName: staticLibrary.productName),
+            .testProduct(target: bundle.name, productName: bundle.productNameWithExtension),
+            .testProduct(target: staticLibrary.name, productName: staticLibrary.productNameWithExtension),
         ]))
     }
 

--- a/Tests/TuistCoreTests/ValueGraph/ValueGraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/ValueGraph/ValueGraphTraverserTests.swift
@@ -650,7 +650,7 @@ final class ValueGraphTraverserTests: TuistUnitTestCase {
         XCTAssertEqual(got?.target, app)
     }
 
-    func test_allDependencies() {
+    func test_allDependencies() throws {
         // Given
         // App -> StaticLibrary -> Bundle
         let project = Project.test()
@@ -674,12 +674,12 @@ final class ValueGraphTraverserTests: TuistUnitTestCase {
         let subject = ValueGraphTraverser(graph: valueGraph)
 
         // When
-        let got = subject.allDependencies(path: project.path)
+        let got = try subject.allProjectDependencies(path: project.path).sorted()
 
         // Then
         XCTAssertEqual(Set(got), Set([
-            .target(name: bundle.name, path: project.path),
-            .target(name: staticLibrary.name, path: project.path),
+            .testProduct(target: bundle.name, productName: bundle.productName),
+            .testProduct(target: staticLibrary.name, productName: staticLibrary.productName),
         ]))
     }
 

--- a/Tests/TuistGeneratorIntegrationTests/Generator/WorkspaceGeneratorIntegrationTests.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Generator/WorkspaceGeneratorIntegrationTests.swift
@@ -40,10 +40,12 @@ final class WorkspaceGeneratorIntegrationTests: TuistTestCase {
                                  })
         let workspace = Workspace.test(path: temporaryPath, projects: projects.map(\.path))
         graph = graph.with(workspace: workspace)
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When / Then
         try (0 ..< 50).forEach { _ in
-            _ = try subject.generate(graph: graph)
+            _ = try subject.generate(graphTraverser: graphTraverser)
         }
     }
 }

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -644,6 +644,8 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
         system.swiftVersionStub = { "5.2" }
         let fileElements = ProjectFileElements([:], playgrounds: MockPlaygrounds())
         let graph = Graph.test()
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
         let path = AbsolutePath("/test")
         let pbxproj = PBXProj()
         let pbxProject = createPbxProject(pbxproj: pbxproj)
@@ -658,7 +660,7 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
                                             pbxproj: pbxproj,
                                             playgrounds: MockPlaygrounds())
         try fileElements.generateProjectFiles(project: project,
-                                              graph: graph,
+                                              graphTraverser: graphTraverser,
                                               groups: groups,
                                               pbxproj: pbxproj)
 
@@ -670,7 +672,7 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
                                                              projectSettings: Settings.test(),
                                                              fileElements: fileElements,
                                                              path: path,
-                                                             graph: graph)
+                                                             graphTraverser: graphTraverser)
 
         // Then
         let preBuildPhase = try XCTUnwrap(pbxTarget.buildPhases.first as? PBXShellScriptBuildPhase)

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -489,7 +489,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         let fileElements = ProjectFileElements()
         let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
         try fileElements.generateProjectFiles(project: project,
-                                              graph: graph,
+                                              graphTraverser: graphTraverser,
                                               groups: groups,
                                               pbxproj: pbxproj)
         _ = try subject.generateTargetConfig(target,

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -515,13 +515,15 @@ final class LinkGeneratorTests: XCTestCase {
                                      (target: target, dependencies: [staticDependency]),
                                      (target: staticDependency, dependencies: []),
                                  ])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
         let fileElements = createProjectFileElements(for: [staticDependency])
         let xcodeProjElements = createXcodeprojElements()
 
         // When
         try subject.generateCopyProductsBuildPhase(path: path,
                                                    target: target,
-                                                   graph: graph,
+                                                   graphTraverser: graphTraverser,
                                                    pbxTarget: xcodeProjElements.pbxTarget,
                                                    pbxproj: xcodeProjElements.pbxproj,
                                                    fileElements: fileElements)
@@ -550,13 +552,15 @@ final class LinkGeneratorTests: XCTestCase {
                                      (target: target, dependencies: [staticDependency]),
                                      (target: staticDependency, dependencies: []),
                                  ])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
         let fileElements = createProjectFileElements(for: [staticDependency])
         let xcodeProjElements = createXcodeprojElements()
 
         // When
         try subject.generateCopyProductsBuildPhase(path: path,
                                                    target: target,
-                                                   graph: graph,
+                                                   graphTraverser: graphTraverser,
                                                    pbxTarget: xcodeProjElements.pbxTarget,
                                                    pbxproj: xcodeProjElements.pbxproj,
                                                    fileElements: fileElements)
@@ -582,11 +586,13 @@ final class LinkGeneratorTests: XCTestCase {
                                  ])
         let fileElements = createProjectFileElements(for: [resourceBundle])
         let xcodeProjElements = createXcodeprojElements()
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
         try subject.generateCopyProductsBuildPhase(path: path,
                                                    target: target,
-                                                   graph: graph,
+                                                   graphTraverser: graphTraverser,
                                                    pbxTarget: xcodeProjElements.pbxTarget,
                                                    pbxproj: xcodeProjElements.pbxproj,
                                                    fileElements: fileElements)

--- a/Tests/TuistGeneratorTests/Generator/Mocks/MockProjectDescriptorGenerator.swift
+++ b/Tests/TuistGeneratorTests/Generator/Mocks/MockProjectDescriptorGenerator.swift
@@ -12,13 +12,13 @@ final class MockProjectDescriptorGenerator: ProjectDescriptorGenerating {
     }
 
     var generatedProjects: [Project] = []
-    var generateStub: ((Project, Graph) throws -> ProjectDescriptor)?
+    var generateStub: ((Project, GraphTraversing) throws -> ProjectDescriptor)?
 
-    func generate(project: Project, graph: Graph) throws -> ProjectDescriptor {
+    func generate(project: Project, graphTraverser: GraphTraversing) throws -> ProjectDescriptor {
         guard let generateStub = generateStub else {
             throw MockError.stubNotImplemented
         }
         generatedProjects.append(project)
-        return try generateStub(project, graph)
+        return try generateStub(project, graphTraverser)
     }
 }

--- a/Tests/TuistGeneratorTests/Generator/Mocks/MockSchemeDescriptorsGenerator.swift
+++ b/Tests/TuistGeneratorTests/Generator/Mocks/MockSchemeDescriptorsGenerator.swift
@@ -5,11 +5,11 @@ import TuistCoreTesting
 @testable import TuistGenerator
 
 final class MockSchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
-    func generateProjectSchemes(project _: Project, generatedProject _: GeneratedProject, graph _: Graph) throws -> [SchemeDescriptor] {
+    func generateProjectSchemes(project _: Project, generatedProject _: GeneratedProject, graphTraverser _: GraphTraversing) throws -> [SchemeDescriptor] {
         []
     }
 
-    func generateWorkspaceSchemes(workspace _: Workspace, generatedProjects _: [AbsolutePath: GeneratedProject], graph _: Graph) throws -> [SchemeDescriptor] {
+    func generateWorkspaceSchemes(workspace _: Workspace, generatedProjects _: [AbsolutePath: GeneratedProject], graphTraverser _: GraphTraversing) throws -> [SchemeDescriptor] {
         []
     }
 }

--- a/Tests/TuistGeneratorTests/Generator/Mocks/MockTargetGenerator.swift
+++ b/Tests/TuistGeneratorTests/Generator/Mocks/MockTargetGenerator.swift
@@ -9,9 +9,9 @@ import XcodeProj
 class MockTargetGenerator: TargetGenerating {
     var generateTargetStub: (() -> PBXNativeTarget)?
 
-    func generateTarget(target: Target, project _: Project, pbxproj _: PBXProj, pbxProject _: PBXProject, projectSettings _: Settings, fileElements _: ProjectFileElements, path _: AbsolutePath, graph _: Graph) throws -> PBXNativeTarget {
+    func generateTarget(target: Target, project _: Project, pbxproj _: PBXProj, pbxProject _: PBXProject, projectSettings _: Settings, fileElements _: ProjectFileElements, path _: AbsolutePath, graphTraverser _: GraphTraversing) throws -> PBXNativeTarget {
         generateTargetStub?() ?? PBXNativeTarget(name: target.name)
     }
 
-    func generateTargetDependencies(path _: AbsolutePath, targets _: [Target], nativeTargets _: [String: PBXNativeTarget], graph _: Graph) throws {}
+    func generateTargetDependencies(path _: AbsolutePath, targets _: [Target], nativeTargets _: [String: PBXNativeTarget], graphTraverser _: GraphTraversing) throws {}
 }

--- a/Tests/TuistGeneratorTests/Generator/Mocks/MockWorkspaceDescriptorGenerator.swift
+++ b/Tests/TuistGeneratorTests/Generator/Mocks/MockWorkspaceDescriptorGenerator.swift
@@ -12,13 +12,13 @@ final class MockWorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
     }
 
     var generateWorkspaces: [Workspace] = []
-    var generateStub: ((Graph) throws -> WorkspaceDescriptor)?
+    var generateStub: ((GraphTraversing) throws -> WorkspaceDescriptor)?
 
-    func generate(graph: Graph) throws -> WorkspaceDescriptor {
+    func generate(graphTraverser: GraphTraversing) throws -> WorkspaceDescriptor {
         guard let generateStub = generateStub else {
             throw MockError.stubNotImplemented
         }
-        generateWorkspaces.append(graph.workspace)
-        return try generateStub(graph)
+        generateWorkspaces.append(graphTraverser.workspace)
+        return try generateStub(graphTraverser)
     }
 }

--- a/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
@@ -44,6 +44,7 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
 
         let graph = Graph.test(entryPath: temporaryPath,
                                entryNodes: [testTargetNode, appNode],
+                               projects: [project],
                                targets: [project.path: [testTargetNode, appNode]])
         let valueGraph = ValueGraph(graph: graph)
         let graphTraverser = ValueGraphTraverser(graph: valueGraph)

--- a/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
@@ -45,9 +45,11 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
         let graph = Graph.test(entryPath: temporaryPath,
                                entryNodes: [testTargetNode, appNode],
                                targets: [project.path: [testTargetNode, appNode]])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
-        let generatedProject = try subject.generate(project: project, graph: graph)
+        let generatedProject = try subject.generate(project: project, graphTraverser: graphTraverser)
 
         // Then
         let pbxproj = generatedProject.xcodeProj.pbxproj
@@ -86,9 +88,11 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
                                                        dependencies: [packageProductNode])],
                                projects: [project],
                                packages: [packageNode])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
-        let got = try subject.generate(project: project, graph: graph)
+        let got = try subject.generate(project: project, graphTraverser: graphTraverser)
 
         // Then
         let pbxproj = got.xcodeProj.pbxproj
@@ -105,9 +109,11 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
                                    name: "Project",
                                    targets: [])
         let graph = Graph.test(entryPath: temporaryPath)
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
-        let got = try subject.generate(project: project, graph: graph)
+        let got = try subject.generate(project: project, graphTraverser: graphTraverser)
 
         // Then
         let pbxproj = got.xcodeProj.pbxproj
@@ -124,9 +130,11 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
                                    name: "Project",
                                    targets: [])
         let graph = Graph.test(entryPath: temporaryPath)
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
-        let got = try subject.generate(project: project, graph: graph)
+        let got = try subject.generate(project: project, graphTraverser: graphTraverser)
 
         // Then
         let pbxproj = got.xcodeProj.pbxproj
@@ -138,6 +146,8 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
         // Given
         let path = try temporaryPath()
         let graph = Graph.test(entryPath: path)
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
         let resources = [
             "resources/en.lproj/App.strings",
             "resources/en.lproj/Extension.strings",
@@ -154,7 +164,7 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
                                    ])
 
         // When
-        let got = try subject.generate(project: project, graph: graph)
+        let got = try subject.generate(project: project, graphTraverser: graphTraverser)
 
         // Then
         let pbxProject = try XCTUnwrap(try got.xcodeProj.pbxproj.rootProject())
@@ -169,11 +179,13 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
         // Given
         let path = try temporaryPath()
         let graph = Graph.test(entryPath: path)
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
         let project = Project.test(path: path,
                                    targets: [])
 
         // When
-        let got = try subject.generate(project: project, graph: graph)
+        let got = try subject.generate(project: project, graphTraverser: graphTraverser)
 
         // Then
         let pbxProject = try XCTUnwrap(try got.xcodeProj.pbxproj.rootProject())
@@ -187,12 +199,14 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
         // Given
         let path = try temporaryPath()
         let graph = Graph.test(entryPath: path)
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
         let project = Project.test(path: path,
                                    organizationName: "tuist",
                                    targets: [])
 
         // When
-        let got = try subject.generate(project: project, graph: graph)
+        let got = try subject.generate(project: project, graphTraverser: graphTraverser)
 
         // Then
         let pbxProject = try XCTUnwrap(try got.xcodeProj.pbxproj.rootProject())
@@ -206,11 +220,13 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
         // Given
         let path = try temporaryPath()
         let graph = Graph.test(entryPath: path)
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
         let project = Project.test(path: path,
                                    targets: [])
 
         // When
-        let got = try subject.generate(project: project, graph: graph)
+        let got = try subject.generate(project: project, graphTraverser: graphTraverser)
 
         // Then
         let pbxProject = try XCTUnwrap(try got.xcodeProj.pbxproj.rootProject())
@@ -221,12 +237,14 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
         // Given
         let path = try temporaryPath()
         let graph = Graph.test(entryPath: path)
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
         let project = Project.test(path: path,
                                    developmentRegion: "de",
                                    targets: [])
 
         // When
-        let got = try subject.generate(project: project, graph: graph)
+        let got = try subject.generate(project: project, graphTraverser: graphTraverser)
 
         // Then
         let pbxProject = try XCTUnwrap(try got.xcodeProj.pbxproj.rootProject())
@@ -253,9 +271,11 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
                                                        dependencies: [packageProductNode])],
                                projects: [project],
                                packages: [packageNode])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
-        let got = try subject.generate(project: project, graph: graph)
+        let got = try subject.generate(project: project, graphTraverser: graphTraverser)
 
         // Then
         let pbxproj = got.xcodeProj.pbxproj

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -342,11 +342,13 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
             .test(name: "Library", product: .staticLibrary),
         ])
         let graph = Graph.test()
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
         let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
 
         // When
         try subject.generateProjectFiles(project: project,
-                                         graph: graph,
+                                         graphTraverser: graphTraverser,
                                          groups: groups,
                                          pbxproj: pbxproj)
 
@@ -376,11 +378,13 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
                                        xcodeProjPath: AbsolutePath.root.appending(component: "Project.xcodeproj"),
                                        targets: targets)
             let graph = Graph.test()
+            let valueGraph = ValueGraph(graph: graph)
+            let graphTraverser = ValueGraphTraverser(graph: valueGraph)
             let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
 
             // When
             try subject.generateProjectFiles(project: project,
-                                             graph: graph,
+                                             graphTraverser: graphTraverser,
                                              groups: groups,
                                              pbxproj: pbxproj)
 
@@ -406,11 +410,13 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
                                        .test(name: "App", product: .app),
                                    ])
         let graph = Graph.test()
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
         let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
 
         // When
         try subject.generateProjectFiles(project: project,
-                                         graph: graph,
+                                         graphTraverser: graphTraverser,
                                          groups: groups,
                                          pbxproj: pbxproj)
 
@@ -665,10 +671,12 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         let package = PackageProductNode(product: "A", path: "/packages/url")
 
         let graph = createGraph(project: project, target: target, dependencies: [package])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
         try subject.generateProjectFiles(project: project,
-                                         graph: graph,
+                                         graphTraverser: graphTraverser,
                                          groups: groups,
                                          pbxproj: pbxproj)
 

--- a/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -35,10 +35,12 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         let project = Project.test(path: projectPath)
         let graph = Graph.create(dependencies: [(project: project, target: app, dependencies: [])])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // Then
         let got = try subject.schemeBuildAction(scheme: scheme,
-                                                graph: graph,
+                                                graphTraverser: graphTraverser,
                                                 rootPath: AbsolutePath("/somepath/Workspace"),
                                                 generatedProjects: [projectPath:
                                                     generatedProject(targets: targets, projectPath: "\(projectPath)/project.xcodeproj")])
@@ -80,10 +82,12 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
             (project: projectA, target: frameworkA, dependencies: []),
             (project: projectB, target: frameworkB, dependencies: []),
         ])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // Then
         let got = try subject.schemeBuildAction(scheme: scheme,
-                                                graph: graph,
+                                                graphTraverser: graphTraverser,
                                                 rootPath: AbsolutePath("/somepath/Workspace"),
                                                 generatedProjects: [
                                                     projectAPath: generatedProject(targets: targets, projectPath: "\(projectAPath)/project.xcodeproj"),
@@ -130,10 +134,12 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let graph = Graph.create(dependencies: [
             (project: project, target: target, dependencies: []),
         ])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
         let got = try subject.schemeBuildAction(scheme: scheme,
-                                                graph: graph,
+                                                graphTraverser: graphTraverser,
                                                 rootPath: projectPath,
                                                 generatedProjects: createGeneratedProjects(projects: [project]))
 
@@ -177,9 +183,14 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: []),
                                                 (project: project, target: testTarget, dependencies: [target])])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
-        let got = try subject.schemeTestAction(scheme: scheme, graph: graph, rootPath: project.path, generatedProjects: generatedProjects)
+        let got = try subject.schemeTestAction(scheme: scheme,
+                                               graphTraverser: graphTraverser,
+                                               rootPath: project.path,
+                                               generatedProjects: generatedProjects)
 
         // Then
         let result = try XCTUnwrap(got)
@@ -213,9 +224,14 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let project = Project.test(path: projectPath, targets: [target, testTarget])
         let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: []),
                                                 (project: project, target: testTarget, dependencies: [target])])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
-        let got = try subject.schemeTestAction(scheme: scheme, graph: graph, rootPath: AbsolutePath("/somepath/Workspace"), generatedProjects: createGeneratedProjects(projects: [project]))
+        let got = try subject.schemeTestAction(scheme: scheme,
+                                               graphTraverser: graphTraverser,
+                                               rootPath: AbsolutePath("/somepath/Workspace"),
+                                               generatedProjects: createGeneratedProjects(projects: [project]))
 
         // Then
         let result = try XCTUnwrap(got)
@@ -232,9 +248,14 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let project = Project.test()
         let generatedProject = GeneratedProject.test()
         let graph = Graph.create(dependencies: [])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // Then
-        let got = try subject.schemeTestAction(scheme: scheme, graph: graph, rootPath: project.path, generatedProjects: [project.path: generatedProject])
+        let got = try subject.schemeTestAction(scheme: scheme,
+                                               graphTraverser: graphTraverser,
+                                               rootPath: project.path,
+                                               generatedProjects: [project.path: generatedProject])
 
         // When
         let result = try XCTUnwrap(got)
@@ -252,9 +273,14 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let scheme = Scheme.test(testAction: TestAction.test(testPlans: planList))
         let generatedProject = GeneratedProject.test()
         let graph = Graph.create(dependencies: [])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // Then
-        let got = try subject.schemeTestAction(scheme: scheme, graph: graph, rootPath: project.path, generatedProjects: [project.path: generatedProject])
+        let got = try subject.schemeTestAction(scheme: scheme,
+                                               graphTraverser: graphTraverser,
+                                               rootPath: project.path,
+                                               generatedProjects: [project.path: generatedProject])
 
         // When
         let result = try XCTUnwrap(got)
@@ -278,9 +304,14 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let scheme = Scheme.test(name: "AppTests", shared: true, buildAction: buildAction, testAction: testAction)
         let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: []),
                                                 (project: project, target: testTarget, dependencies: [testTarget])])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
-        let got = try subject.schemeTestAction(scheme: scheme, graph: graph, rootPath: project.path, generatedProjects: createGeneratedProjects(projects: [project]))
+        let got = try subject.schemeTestAction(scheme: scheme,
+                                               graphTraverser: graphTraverser,
+                                               rootPath: project.path,
+                                               generatedProjects: createGeneratedProjects(projects: [project]))
 
         // Then
         let testableTargetReference = got!.testables[0]
@@ -302,9 +333,14 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: []),
                                                 (project: project, target: testTarget, dependencies: [target])])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
-        let got = try subject.schemeTestAction(scheme: scheme, graph: graph, rootPath: project.path, generatedProjects: generatedProjects)
+        let got = try subject.schemeTestAction(scheme: scheme,
+                                               graphTraverser: graphTraverser,
+                                               rootPath: project.path,
+                                               generatedProjects: generatedProjects)
 
         // Then
         let result = try XCTUnwrap(got)
@@ -335,9 +371,14 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         let generatedProjects = createGeneratedProjects(projects: [project])
         let graph = Graph.create(dependencies: [(project: project, target: testTarget, dependencies: [])])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
-        let got = try subject.schemeTestAction(scheme: scheme, graph: graph, rootPath: project.path, generatedProjects: generatedProjects)
+        let got = try subject.schemeTestAction(scheme: scheme,
+                                               graphTraverser: graphTraverser,
+                                               rootPath: project.path,
+                                               generatedProjects: generatedProjects)
 
         // Then
         // Pre Action
@@ -390,10 +431,12 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         let project = Project.test(path: projectPath, targets: [app])
         let graph = Graph.create(dependencies: [(project: project, target: app, dependencies: [])])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
         let got = try subject.schemeLaunchAction(scheme: scheme,
-                                                 graph: graph,
+                                                 graphTraverser: graphTraverser,
                                                  rootPath: AbsolutePath("/somepath/Workspace"),
                                                  generatedProjects: createGeneratedProjects(projects: [project]))
 
@@ -446,10 +489,12 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         let project = Project.test(path: projectPath, targets: [app])
         let graph = Graph.create(dependencies: [(project: project, target: app, dependencies: [])])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
         let got = try subject.schemeLaunchAction(scheme: scheme,
-                                                 graph: graph,
+                                                 graphTraverser: graphTraverser,
                                                  rootPath: AbsolutePath("/somepath/Workspace"),
                                                  generatedProjects: createGeneratedProjects(projects: [project]))
 
@@ -478,10 +523,12 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let scheme = Scheme.test(name: "Library", buildAction: buildAction, runAction: launchAction)
         let project = Project.test(path: projectPath, targets: [target])
         let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: [])])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
         let got = try subject.schemeLaunchAction(scheme: scheme,
-                                                 graph: graph,
+                                                 graphTraverser: graphTraverser,
                                                  rootPath: projectPath,
                                                  generatedProjects: createGeneratedProjects(projects: [project]))
 
@@ -505,10 +552,12 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let scheme = Scheme.test(name: "Library", buildAction: buildAction, testAction: testAction, runAction: nil)
         let project = Project.test(path: projectPath, targets: [target])
         let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: [])])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
         let got = try subject.schemeLaunchAction(scheme: scheme,
-                                                 graph: graph,
+                                                 graphTraverser: graphTraverser,
                                                  rootPath: projectPath,
                                                  generatedProjects: createGeneratedProjects(projects: [project]))
 
@@ -534,10 +583,12 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let scheme = makeProfileActionScheme()
         let project = Project.test(path: projectPath, targets: [target])
         let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: [])])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
         let got = try subject.schemeProfileAction(scheme: scheme,
-                                                  graph: graph,
+                                                  graphTraverser: graphTraverser,
                                                   rootPath: projectPath,
                                                   generatedProjects: createGeneratedProjects(projects: [project]))
 
@@ -578,10 +629,12 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         let project = Project.test(path: projectPath, targets: [target])
         let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: [])])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
         let got = try subject.schemeProfileAction(scheme: scheme,
-                                                  graph: graph,
+                                                  graphTraverser: graphTraverser,
                                                   rootPath: projectPath,
                                                   generatedProjects: createGeneratedProjects(projects: [project]))
 
@@ -616,10 +669,12 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let scheme = makeProfileActionScheme(Arguments(launchArguments: [LaunchArgument(name: "something", isEnabled: true)]))
         let project = Project.test(path: projectPath, targets: [target])
         let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: [])])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
         let got = try subject.schemeProfileAction(scheme: scheme,
-                                                  graph: graph,
+                                                  graphTraverser: graphTraverser,
                                                   rootPath: projectPath,
                                                   generatedProjects: createGeneratedProjects(projects: [project]))
 
@@ -659,10 +714,12 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         let project = Project.test(path: projectPath, targets: [target])
         let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: [])])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
         let got = try subject.schemeAnalyzeAction(scheme: scheme,
-                                                  graph: graph,
+                                                  graphTraverser: graphTraverser,
                                                   rootPath: project.path,
                                                   generatedProjects: createGeneratedProjects(projects: [project]))
 
@@ -689,10 +746,12 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         let project = Project.test(path: projectPath, targets: [target])
         let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: [])])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
         let got = try subject.schemeArchiveAction(scheme: scheme,
-                                                  graph: graph,
+                                                  graphTraverser: graphTraverser,
                                                   rootPath: project.path,
                                                   generatedProjects: createGeneratedProjects(projects: [project]))
 
@@ -721,11 +780,13 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
                 (target: uiTests, dependencies: [app]),
             ]
         )
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
         let result = try subject.generateProjectSchemes(project: project,
                                                         generatedProject: generatedProject(targets: project.targets),
-                                                        graph: graph)
+                                                        graphTraverser: graphTraverser)
 
         // Then
         let schemes = result.map(\.xcScheme.name)
@@ -757,11 +818,13 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
                 (target: appExtension, dependencies: []),
             ]
         )
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
         let result = try subject.generateProjectSchemes(project: project,
                                                         generatedProject: generatedProject(targets: project.targets),
-                                                        graph: graph)
+                                                        graphTraverser: graphTraverser)
 
         // Then
         let schemeForExtension = result.map(\.xcScheme.wasCreatedForAppExtension)
@@ -795,11 +858,13 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
                 (target: appExtension, dependencies: []),
             ]
         )
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
         let result = try subject.generateProjectSchemes(project: project,
                                                         generatedProject: generatedProject(targets: project.targets),
-                                                        graph: graph)
+                                                        graphTraverser: graphTraverser)
 
         // Then
         let scheme = try XCTUnwrap(result.first)

--- a/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -34,7 +34,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let targets = [app]
 
         let project = Project.test(path: projectPath)
-        let graph = Graph.create(dependencies: [(project: project, target: app, dependencies: [])])
+        let graph = Graph.create(projects: [project], dependencies: [(project: project, target: app, dependencies: [])])
         let valueGraph = ValueGraph(graph: graph)
         let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
@@ -78,7 +78,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         let projectA = Project.test(path: projectAPath)
         let projectB = Project.test(path: projectBPath)
-        let graph = Graph.create(dependencies: [
+        let graph = Graph.create(projects: [projectA, projectB], dependencies: [
             (project: projectA, target: frameworkA, dependencies: []),
             (project: projectB, target: frameworkB, dependencies: []),
         ])
@@ -131,7 +131,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         let scheme = Scheme.test(name: "App", shared: true, buildAction: buildAction)
         let project = Project.test(path: projectPath, targets: [target])
-        let graph = Graph.create(dependencies: [
+        let graph = Graph.create(projects: [project], dependencies: [
             (project: project, target: target, dependencies: []),
         ])
         let valueGraph = ValueGraph(graph: graph)
@@ -181,8 +181,8 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let scheme = Scheme.test(name: "AppTests", testAction: testAction)
         let generatedProjects = createGeneratedProjects(projects: [project])
 
-        let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: []),
-                                                (project: project, target: testTarget, dependencies: [target])])
+        let graph = Graph.create(projects: [project], dependencies: [(project: project, target: target, dependencies: []),
+                                                                     (project: project, target: testTarget, dependencies: [target])])
         let valueGraph = ValueGraph(graph: graph)
         let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
@@ -222,8 +222,8 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let scheme = Scheme.test(name: "AppTests", shared: true, buildAction: buildAction, testAction: testAction)
 
         let project = Project.test(path: projectPath, targets: [target, testTarget])
-        let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: []),
-                                                (project: project, target: testTarget, dependencies: [target])])
+        let graph = Graph.create(projects: [project], dependencies: [(project: project, target: target, dependencies: []),
+                                                                     (project: project, target: testTarget, dependencies: [target])])
         let valueGraph = ValueGraph(graph: graph)
         let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
@@ -247,7 +247,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let scheme = Scheme.test()
         let project = Project.test()
         let generatedProject = GeneratedProject.test()
-        let graph = Graph.create(dependencies: [])
+        let graph = Graph.create(projects: [project], dependencies: [])
         let valueGraph = ValueGraph(graph: graph)
         let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
@@ -272,7 +272,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let planList = [TestPlan(path: planPath, isDefault: true)]
         let scheme = Scheme.test(testAction: TestAction.test(testPlans: planList))
         let generatedProject = GeneratedProject.test()
-        let graph = Graph.create(dependencies: [])
+        let graph = Graph.create(projects: [project], dependencies: [])
         let valueGraph = ValueGraph(graph: graph)
         let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
@@ -302,8 +302,8 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let buildAction = BuildAction.test(targets: [TargetReference(projectPath: project.path, name: "App")])
 
         let scheme = Scheme.test(name: "AppTests", shared: true, buildAction: buildAction, testAction: testAction)
-        let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: []),
-                                                (project: project, target: testTarget, dependencies: [testTarget])])
+        let graph = Graph.create(projects: [project], dependencies: [(project: project, target: target, dependencies: []),
+                                                                     (project: project, target: testTarget, dependencies: [testTarget])])
         let valueGraph = ValueGraph(graph: graph)
         let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
@@ -331,8 +331,8 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let scheme = Scheme.test(name: "AppTests", testAction: testAction)
         let generatedProjects = createGeneratedProjects(projects: [project])
 
-        let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: []),
-                                                (project: project, target: testTarget, dependencies: [target])])
+        let graph = Graph.create(projects: [project], dependencies: [(project: project, target: target, dependencies: []),
+                                                                     (project: project, target: testTarget, dependencies: [target])])
         let valueGraph = ValueGraph(graph: graph)
         let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
@@ -370,7 +370,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let project = Project.test(path: projectPath, targets: [testTarget])
 
         let generatedProjects = createGeneratedProjects(projects: [project])
-        let graph = Graph.create(dependencies: [(project: project, target: testTarget, dependencies: [])])
+        let graph = Graph.create(projects: [project], dependencies: [(project: project, target: testTarget, dependencies: [])])
         let valueGraph = ValueGraph(graph: graph)
         let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
@@ -430,7 +430,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let app = Target.test(name: "App", product: .app, environment: environment)
 
         let project = Project.test(path: projectPath, targets: [app])
-        let graph = Graph.create(dependencies: [(project: project, target: app, dependencies: [])])
+        let graph = Graph.create(projects: [project], dependencies: [(project: project, target: app, dependencies: [])])
         let valueGraph = ValueGraph(graph: graph)
         let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
@@ -488,7 +488,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let app = Target.test(name: "App", product: .app)
 
         let project = Project.test(path: projectPath, targets: [app])
-        let graph = Graph.create(dependencies: [(project: project, target: app, dependencies: [])])
+        let graph = Graph.create(projects: [project], dependencies: [(project: project, target: app, dependencies: [])])
         let valueGraph = ValueGraph(graph: graph)
         let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
@@ -522,7 +522,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         let scheme = Scheme.test(name: "Library", buildAction: buildAction, runAction: launchAction)
         let project = Project.test(path: projectPath, targets: [target])
-        let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: [])])
+        let graph = Graph.create(projects: [project], dependencies: [(project: project, target: target, dependencies: [])])
         let valueGraph = ValueGraph(graph: graph)
         let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
@@ -551,7 +551,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         let scheme = Scheme.test(name: "Library", buildAction: buildAction, testAction: testAction, runAction: nil)
         let project = Project.test(path: projectPath, targets: [target])
-        let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: [])])
+        let graph = Graph.create(projects: [project], dependencies: [(project: project, target: target, dependencies: [])])
         let valueGraph = ValueGraph(graph: graph)
         let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
@@ -582,7 +582,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         let scheme = makeProfileActionScheme()
         let project = Project.test(path: projectPath, targets: [target])
-        let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: [])])
+        let graph = Graph.create(projects: [project], dependencies: [(project: project, target: target, dependencies: [])])
         let valueGraph = ValueGraph(graph: graph)
         let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
@@ -628,7 +628,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let scheme = Scheme.test(name: "Library", buildAction: buildAction, testAction: testAction, runAction: nil, profileAction: profileAction)
 
         let project = Project.test(path: projectPath, targets: [target])
-        let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: [])])
+        let graph = Graph.create(projects: [project], dependencies: [(project: project, target: target, dependencies: [])])
         let valueGraph = ValueGraph(graph: graph)
         let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
@@ -668,7 +668,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         let scheme = makeProfileActionScheme(Arguments(launchArguments: [LaunchArgument(name: "something", isEnabled: true)]))
         let project = Project.test(path: projectPath, targets: [target])
-        let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: [])])
+        let graph = Graph.create(projects: [project], dependencies: [(project: project, target: target, dependencies: [])])
         let valueGraph = ValueGraph(graph: graph)
         let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
@@ -713,7 +713,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let scheme = Scheme.test(buildAction: buildAction, analyzeAction: analyzeAction)
 
         let project = Project.test(path: projectPath, targets: [target])
-        let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: [])])
+        let graph = Graph.create(projects: [project], dependencies: [(project: project, target: target, dependencies: [])])
         let valueGraph = ValueGraph(graph: graph)
         let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
@@ -745,7 +745,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let scheme = Scheme.test(buildAction: buildAction, archiveAction: archiveAction)
 
         let project = Project.test(path: projectPath, targets: [target])
-        let graph = Graph.create(dependencies: [(project: project, target: target, dependencies: [])])
+        let graph = Graph.create(projects: [project], dependencies: [(project: project, target: target, dependencies: [])])
         let valueGraph = ValueGraph(graph: graph)
         let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 

--- a/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
@@ -56,11 +56,13 @@ final class TargetGeneratorTests: XCTestCase {
                                    xcodeProjPath: path.appending(component: "Test.xcodeproj"),
                                    targets: [target])
         let graph = Graph.test()
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
         let groups = ProjectGroups.generate(project: project,
                                             pbxproj: pbxproj,
                                             playgrounds: MockPlaygrounds())
         try fileElements.generateProjectFiles(project: project,
-                                              graph: graph,
+                                              graphTraverser: graphTraverser,
                                               groups: groups,
                                               pbxproj: pbxproj)
 
@@ -72,7 +74,7 @@ final class TargetGeneratorTests: XCTestCase {
                                                          projectSettings: Settings.test(),
                                                          fileElements: fileElements,
                                                          path: path,
-                                                         graph: graph)
+                                                         graphTraverser: graphTraverser)
 
         // Then
         XCTAssertEqual(generatedTarget.productName, "MyFramework")
@@ -105,6 +107,8 @@ final class TargetGeneratorTests: XCTestCase {
                                     (target: targetA, dependencies: [targetB]),
                                     (target: targetB, dependencies: []),
                                 ])
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
         try subject.generateTargetDependencies(path: path,
@@ -113,7 +117,7 @@ final class TargetGeneratorTests: XCTestCase {
                                                    "TargetA": nativeTargetA,
                                                    "TargetB": nativeTargetB,
                                                ],
-                                               graph: graph)
+                                               graphTraverser: graphTraverser)
 
         // Then
         XCTAssertEqual(nativeTargetA.dependencies.map(\.name), [
@@ -124,6 +128,8 @@ final class TargetGeneratorTests: XCTestCase {
     func test_generateTarget_actions() throws {
         // Given
         let graph = Graph.test()
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
         let target = Target.test(sources: [],
                                  resources: [],
                                  actions: [
@@ -135,7 +141,7 @@ final class TargetGeneratorTests: XCTestCase {
                                             pbxproj: pbxproj,
                                             playgrounds: MockPlaygrounds())
         try fileElements.generateProjectFiles(project: project,
-                                              graph: graph,
+                                              graphTraverser: graphTraverser,
                                               groups: groups,
                                               pbxproj: pbxproj)
 
@@ -147,7 +153,7 @@ final class TargetGeneratorTests: XCTestCase {
                                                    projectSettings: Settings.test(),
                                                    fileElements: fileElements,
                                                    path: path,
-                                                   graph: graph)
+                                                   graphTraverser: graphTraverser)
 
         // Then
         let preBuildPhase = pbxTarget.buildPhases.first as? PBXShellScriptBuildPhase

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceDescriptorGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceDescriptorGeneratorTests.swift
@@ -44,7 +44,9 @@ final class WorkspaceDescriptorGeneratorTests: TuistUnitTestCase {
         let graph = Graph.test(entryPath: temporaryPath, workspace: workspace)
 
         // When
-        let result = try subject.generate(graph: graph)
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
+        let result = try subject.generate(graphTraverser: graphTraverser)
 
         // Then
         let xcworkspace = result.xcworkspace
@@ -64,10 +66,12 @@ final class WorkspaceDescriptorGeneratorTests: TuistUnitTestCase {
         try FileHandler.shared.createFolder(temporaryPath.appending(component: "\(name).xcworkspace"))
         let workspace = Workspace.test(name: name)
         let graph = Graph.test(entryPath: temporaryPath, workspace: workspace)
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
         XCTAssertNoThrow(
-            try subject.generate(graph: graph)
+            try subject.generate(graphTraverser: graphTraverser)
         )
     }
 
@@ -85,9 +89,11 @@ final class WorkspaceDescriptorGeneratorTests: TuistUnitTestCase {
         let workspace = Workspace.test(projects: [project.path])
         let graph = Graph.create(project: project,
                                  dependencies: [(target, [])])
+        let valueGraph = ValueGraph(graph: graph.with(workspace: workspace))
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         // When
-        let result = try subject.generate(graph: graph.with(workspace: workspace))
+        let result = try subject.generate(graphTraverser: graphTraverser)
 
         // Then
         let xcworkspace = result.xcworkspace

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -135,7 +135,7 @@ final class GraphLinterTests: TuistUnitTestCase {
                                       name: "projectStaticFramework",
                                       targets: [staticFrameworkA, staticFrameworkB, staticLibrary])
 
-        let graph = Graph.create(dependencies: [
+        let graph = Graph.create(projects: [frameworks], dependencies: [
             (project: app, target: appTarget, dependencies: [staticFrameworkA, staticFrameworkB, staticLibrary]),
             (project: frameworks, target: staticFrameworkA, dependencies: [staticFrameworkB]),
             (project: frameworks, target: staticFrameworkB, dependencies: [staticLibrary]),
@@ -161,7 +161,7 @@ final class GraphLinterTests: TuistUnitTestCase {
                                       name: "projectStaticFramework",
                                       targets: [staticLibraryA, staticLibraryB, staticFramework])
 
-        let graph = Graph.create(dependencies: [
+        let graph = Graph.create(projects: [frameworks], dependencies: [
             (project: app, target: appTarget, dependencies: [staticLibraryA, staticLibraryB, staticFramework]),
             (project: frameworks, target: staticLibraryA, dependencies: [staticLibraryB]),
             (project: frameworks, target: staticLibraryB, dependencies: [staticFramework]),

--- a/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -302,7 +302,9 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
 
         let graph = try graphLoader.loadWorkspace(path: temporaryPath)
         try linter.lint(graph: graph).printAndThrowIfNeeded()
-        let descriptor = try subject.generateWorkspace(graph: graph)
+        let valueGraph = ValueGraph(graph: graph)
+        let graphTraverser = ValueGraphTraverser(graph: valueGraph)
+        let descriptor = try subject.generateWorkspace(graphTraverser: graphTraverser)
         try writer.write(workspace: descriptor)
     }
 

--- a/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/StableStructureIntegrationTests.swift
@@ -32,8 +32,10 @@ final class StableXcodeProjIntegrationTests: TuistTestCase {
                                                             headers: 100)
             let modelGenerator = TestModelGenerator(rootPath: temporaryPath, config: config)
             let graph = try modelGenerator.generate()
+            let valueGraph = ValueGraph(graph: graph)
+            let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
-            let workspaceDescriptor = try subject.generateWorkspace(graph: graph)
+            let workspaceDescriptor = try subject.generateWorkspace(graphTraverser: graphTraverser)
 
             // Note: While we already have access to the `XcodeProj` models in `workspaceDescriptor`
             // unfortunately they are not equtable, however once serialized & deserialized back they are

--- a/Tests/TuistIntegrationTests/Generator/TuistGeneratorPerformanceTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/TuistGeneratorPerformanceTests.swift
@@ -43,7 +43,9 @@ final class TuistGeneratorPerformanceTests: TuistTestCase {
 
                 // When
                 startMeasuring()
-                _ = try subject.generateWorkspace(graph: graph)
+                let valueGraph = ValueGraph(graph: graph)
+                let graphTraverser = ValueGraphTraverser(graph: valueGraph)
+                _ = try subject.generateWorkspace(graphTraverser: graphTraverser)
                 stopMeasuring()
 
             } catch {


### PR DESCRIPTION
### Short description 📝
Continuing with the migration to `ValueGraph`, I'm updating all the components that are involved in the generation of the Xcode project to take a `GraphTraversing` instead of a `Graph` instance.

Note that the loading and the mapping loads a `Graph`, and we turn it into a `ValueGraph` that we use then to initialize the `ValueGraphTraverser`. Also, I have accommodated the tests to the change, but they still depend on `Graph`. In a follow-up PR I plan to update them to initialize a `ValueGraph` directly, instead of creating a `Graph` and then turning it into a `ValueGraph`.