### PR TITLE
Fix `ValueGraphTraverser.directTargetDependencies` to return local targets only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Make watch targets runnable to fix schemes in Xcode 12 [#2096](https://github.com/tuist/tuist/pull/2096) by [@thedavidharris](https://github.com/thedavidharris)
 - Fix framework search paths for SDK dependencies [#2097](https://github.com/tuist/tuist/pull/2097) by [@kwridan](https://github.com/kwridan)
+- Fix `ValueGraphTraverser.directTargetDependencies` to return local targets only [#2111](https://github.com/tuist/tuist/pull/2111) by [@kwridan](https://github.com/kwridan)
+    - **Note:** This fixes an issue that previously allowed extension targets to be defined in a separate project (which isn't a supported dependency type)
 
 ### Changed
 

--- a/Sources/TuistCore/ValueGraph/ValueGraphDependency.swift
+++ b/Sources/TuistCore/ValueGraph/ValueGraphDependency.swift
@@ -96,4 +96,13 @@ public enum ValueGraphDependency: Hashable {
         case .cocoapods: return false
         }
     }
+
+    var targetDependency: (name: String, path: AbsolutePath)? {
+        switch self {
+        case let .target(name: name, path: path):
+            return (name, path)
+        default:
+            return nil
+        }
+    }
 }

--- a/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
+++ b/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
@@ -30,9 +30,14 @@ public class ValueGraphTraverser: GraphTraversing {
         guard let dependencies = graph.dependencies[.target(name: name, path: path)] else { return [] }
         guard let project = graph.projects[path] else { return Set() }
 
-        return Set(dependencies.flatMap { (dependency) -> [ValueGraphTarget] in
-            guard case let ValueGraphDependency.target(dependencyName, dependencyPath) = dependency else { return [] }
-            guard let projectDependencies = graph.targets[dependencyPath], let dependencyTarget = projectDependencies[dependencyName] else { return []
+        let localTargetDependencies = dependencies
+            .compactMap(\.targetDependency)
+            .filter { $0.path == path }
+        return Set(localTargetDependencies.flatMap { (dependencyName, dependencyPath) -> [ValueGraphTarget] in
+            guard let projectDependencies = graph.targets[dependencyPath],
+                let dependencyTarget = projectDependencies[dependencyName]
+            else {
+                return []
             }
             return [ValueGraphTarget(path: path, target: dependencyTarget, project: project)]
         })

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -519,37 +519,37 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
     func test_generateAppExtensionsBuildPhase() throws {
         // Given
         let path = try temporaryPath()
-        let appExtension = Target.test(name: "AppExtension", product: .appExtension)
         let projectA = Project.test(path: "/path/a")
+        let appExtension = Target.test(name: "AppExtension", product: .appExtension)
         let stickerPackExtension = Target.test(name: "StickerPackExtension", product: .stickerPackExtension)
-        let projectB = Project.test(path: "/path/b")
         let app = Target.test(name: "App", product: .app)
-        let projectC = Project.test(path: "/path/c")
         let pbxproj = PBXProj()
         let nativeTarget = PBXNativeTarget(name: "Test")
         let fileElements = createProductFileElements(for: [appExtension, stickerPackExtension])
 
         let targets: [AbsolutePath: [String: Target]] = [
-            projectA.path: [appExtension.name: appExtension],
-            projectB.path: [stickerPackExtension.name: stickerPackExtension],
-            projectC.path: [app.name: app],
+            projectA.path: [
+                appExtension.name: appExtension,
+                stickerPackExtension.name: stickerPackExtension,
+                app.name: app,
+            ],
         ]
         let dependencies: [ValueGraphDependency: Set<ValueGraphDependency>] = [
             .target(name: appExtension.name, path: projectA.path): Set(),
-            .target(name: stickerPackExtension.name, path: projectB.path): Set(),
-            .target(name: app.name, path: projectC.path): Set([.target(name: appExtension.name, path: projectA.path),
-                                                               .target(name: stickerPackExtension.name, path: projectB.path)]),
+            .target(name: stickerPackExtension.name, path: projectA.path): Set(),
+            .target(name: app.name, path: projectA.path): Set([
+                .target(name: appExtension.name, path: projectA.path),
+                .target(name: stickerPackExtension.name, path: projectA.path),
+            ]),
         ]
         let graph = ValueGraph.test(path: path,
-                                    projects: [projectA.path: projectA,
-                                               projectB.path: projectB,
-                                               projectC.path: projectC],
+                                    projects: [projectA.path: projectA],
                                     targets: targets,
                                     dependencies: dependencies)
         let graphTraverser = ValueGraphTraverser(graph: graph)
 
         // When
-        try subject.generateAppExtensionsBuildPhase(path: projectC.path,
+        try subject.generateAppExtensionsBuildPhase(path: projectA.path,
                                                     target: app,
                                                     graphTraverser: graphTraverser,
                                                     pbxTarget: nativeTarget,


### PR DESCRIPTION
Resolves test failure in #2110 

### Short description 📝

The value graph traverser was returning an incorrect set of direct target dependencies. In the previous implementation (reference graph), this would return local direct dependencies only.

### Solution 📦

Update the implementation to match that of the previous reference graph implementation.

### Implementation 👩‍💻👨‍💻

- [x] Return local targets only
- [x] Update test cases to cover scenarios with multiple projects

### Notes

- Perhaps we could rename this to `localTargetDependencies` to help clarify this?
- Once we switch to `ValueGraph` - extension targets defined in a separate project will no longer work _(this isn't a supported dependency type)_