### PR TITLE
Add `ValueGraphLoader`

### DIFF
--- a/Sources/TuistCore/Graph/GraphLoadingError.swift
+++ b/Sources/TuistCore/Graph/GraphLoadingError.swift
@@ -5,6 +5,7 @@ import TuistSupport
 enum GraphLoadingError: FatalError, Equatable {
     case missingFile(AbsolutePath)
     case targetNotFound(String, AbsolutePath)
+    case missingProject(AbsolutePath)
     case manifestNotFound(AbsolutePath)
     case circularDependency([GraphCircularDetectorNode])
     case unexpected(String)
@@ -15,6 +16,8 @@ enum GraphLoadingError: FatalError, Equatable {
             return lhsPath == rhsPath
         case let (.targetNotFound(lhsName, lhsPath), .targetNotFound(rhsName, rhsPath)):
             return lhsPath == rhsPath && lhsName == rhsName
+        case let (.missingProject(lhsPath), .missingProject(rhsPath)):
+            return lhsPath == rhsPath
         case let (.manifestNotFound(lhsPath), .manifestNotFound(rhsPath)):
             return lhsPath == rhsPath
         case let (.unexpected(lhsMessage), .unexpected(rhsMessage)):
@@ -36,6 +39,8 @@ enum GraphLoadingError: FatalError, Equatable {
             return "Couldn't find manifest at path: '\(path.pathString)'"
         case let .targetNotFound(targetName, path):
             return "Couldn't find target '\(targetName)' at '\(path.pathString)'"
+        case let .missingProject(path):
+            return "Could not locate project at path: \(path.pathString)"
         case let .missingFile(path):
             return "Couldn't find file at path '\(path.pathString)'"
         case let .unexpected(message):

--- a/Sources/TuistCore/MetadataProviders/FrameworkMetadataProvider.swift
+++ b/Sources/TuistCore/MetadataProviders/FrameworkMetadataProvider.swift
@@ -2,7 +2,25 @@ import Foundation
 import TSCBasic
 import TuistSupport
 
+// MARK: - Metadata
+
+public struct FrameworkMetadata: Equatable {
+    public var path: AbsolutePath
+    public var binaryPath: AbsolutePath
+    public var dsymPath: AbsolutePath?
+    public var bcsymbolmapPaths: [AbsolutePath]
+    public var linking: BinaryLinking
+    public var architectures: [BinaryArchitecture]
+    public var isCarthage: Bool
+}
+
+// MARK: - Provider
+
 public protocol FrameworkMetadataProviding: PrecompiledMetadataProviding {
+    /// Loads all the metadata associated with a framework at the specified path
+    /// - Note: This performs various shell calls and disk operations
+    func loadMetadata(at path: AbsolutePath) throws -> FrameworkMetadata
+
     /// Given the path to a framework, it returns the path to its dSYMs if they exist
     /// in the same framework directory.
     /// - Parameter frameworkPath: Path to the .framework directory.
@@ -18,7 +36,31 @@ public protocol FrameworkMetadataProviding: PrecompiledMetadataProviding {
     func product(frameworkPath: AbsolutePath) throws -> Product
 }
 
+// MARK: - Default Implementation
+
 public final class FrameworkMetadataProvider: PrecompiledMetadataProvider, FrameworkMetadataProviding {
+    public func loadMetadata(at path: AbsolutePath) throws -> FrameworkMetadata {
+        let fileHandler = FileHandler.shared
+        guard fileHandler.exists(path) else {
+            throw FrameworkMetadataProviderError.frameworkNotFound(path)
+        }
+        let binaryPath = self.binaryPath(frameworkPath: path)
+        let dsymPath = self.dsymPath(frameworkPath: path)
+        let bcsymbolmapPaths = try self.bcsymbolmapPaths(frameworkPath: path)
+        let linking = try self.linking(binaryPath: binaryPath)
+        let architectures = try self.architectures(binaryPath: binaryPath)
+        let isCarthage = path.pathString.contains("Carthage/Build")
+        return FrameworkMetadata(
+            path: path,
+            binaryPath: binaryPath,
+            dsymPath: dsymPath,
+            bcsymbolmapPaths: bcsymbolmapPaths,
+            linking: linking,
+            architectures: architectures,
+            isCarthage: isCarthage
+        )
+    }
+
     public func dsymPath(frameworkPath: AbsolutePath) -> AbsolutePath? {
         let path = AbsolutePath("\(frameworkPath.pathString).dSYM")
         if FileHandler.shared.exists(path) { return path }
@@ -26,7 +68,7 @@ public final class FrameworkMetadataProvider: PrecompiledMetadataProvider, Frame
     }
 
     public func bcsymbolmapPaths(frameworkPath: AbsolutePath) throws -> [AbsolutePath] {
-        let binaryPath = FrameworkNode.binaryPath(frameworkPath: frameworkPath)
+        let binaryPath = self.binaryPath(frameworkPath: frameworkPath)
         let uuids = try self.uuids(binaryPath: binaryPath)
         return uuids
             .map { frameworkPath.parentDirectory.appending(component: "\($0).bcsymbolmap") }
@@ -35,12 +77,38 @@ public final class FrameworkMetadataProvider: PrecompiledMetadataProvider, Frame
     }
 
     public func product(frameworkPath: AbsolutePath) throws -> Product {
-        let binaryPath = FrameworkNode.binaryPath(frameworkPath: frameworkPath)
+        let binaryPath = self.binaryPath(frameworkPath: frameworkPath)
         switch try linking(binaryPath: binaryPath) {
         case .dynamic:
             return .framework
         case .static:
             return .staticFramework
+        }
+    }
+
+    private func binaryPath(frameworkPath: AbsolutePath) -> AbsolutePath {
+        frameworkPath.appending(component: frameworkPath.basenameWithoutExt)
+    }
+}
+
+// MARK: - Error
+
+enum FrameworkMetadataProviderError: FatalError, Equatable {
+    case frameworkNotFound(AbsolutePath)
+
+    // MARK: - FatalError
+
+    var description: String {
+        switch self {
+        case let .frameworkNotFound(path):
+            return "Couldn't find framework at \(path.pathString)"
+        }
+    }
+
+    var type: ErrorType {
+        switch self {
+        case .frameworkNotFound:
+            return .abort
         }
     }
 }

--- a/Sources/TuistCore/MetadataProviders/LibraryMetadataProvider.swift
+++ b/Sources/TuistCore/MetadataProviders/LibraryMetadataProvider.swift
@@ -2,19 +2,82 @@ import Foundation
 import TSCBasic
 import TuistSupport
 
-protocol LibraryMetadataProviding: PrecompiledMetadataProviding {
-    /// Returns the product for the given library.
-    /// - Parameter library: Library instance.
-    func product(library: LibraryNode) throws -> Product
+// MARK: - Metadata
+
+public struct LibraryMetadata: Equatable {
+    public var path: AbsolutePath
+    public var publicHeaders: AbsolutePath
+    public var swiftModuleMap: AbsolutePath?
+    public var architectures: [BinaryArchitecture]
+    public var linking: BinaryLinking
 }
 
-final class LibraryMetadataProvider: PrecompiledMetadataProvider, LibraryMetadataProviding {
-    func product(library: LibraryNode) throws -> Product {
-        switch try linking(binaryPath: library.path) {
-        case .dynamic:
-            return .dynamicLibrary
-        case .static:
-            return .staticLibrary
+// MARK: - Provider
+
+public protocol LibraryMetadataProviding: PrecompiledMetadataProviding {
+    /// Loads all the metadata associated with a library (.a / .dylib) at the specified path
+    /// - Note: This performs various shell calls and disk operations
+    func loadMetadata(at path: AbsolutePath,
+                      publicHeaders: AbsolutePath,
+                      swiftModuleMap: AbsolutePath?) throws -> LibraryMetadata
+}
+
+// MARK: - Default Implementation
+
+public final class LibraryMetadataProvider: PrecompiledMetadataProvider, LibraryMetadataProviding {
+    public func loadMetadata(at path: AbsolutePath,
+                             publicHeaders: AbsolutePath,
+                             swiftModuleMap: AbsolutePath?) throws -> LibraryMetadata
+    {
+        let fileHandler = FileHandler.shared
+        guard fileHandler.exists(path) else {
+            throw LibraryMetadataProviderError.libraryNotFound(path)
+        }
+        guard fileHandler.exists(publicHeaders) else {
+            throw LibraryMetadataProviderError.publicHeadersNotFound(libraryPath: path, headersPath: publicHeaders)
+        }
+        if let swiftModuleMap = swiftModuleMap {
+            guard fileHandler.exists(swiftModuleMap) else {
+                throw LibraryMetadataProviderError.swiftModuleMapNotFound(libraryPath: path, moduleMapPath: swiftModuleMap)
+            }
+        }
+
+        let architectures = try self.architectures(binaryPath: path)
+        let linking = try self.linking(binaryPath: path)
+        return LibraryMetadata(
+            path: path,
+            publicHeaders: publicHeaders,
+            swiftModuleMap: swiftModuleMap,
+            architectures: architectures,
+            linking: linking
+        )
+    }
+}
+
+// MARK: - Error
+
+enum LibraryMetadataProviderError: FatalError, Equatable {
+    case libraryNotFound(AbsolutePath)
+    case publicHeadersNotFound(libraryPath: AbsolutePath, headersPath: AbsolutePath)
+    case swiftModuleMapNotFound(libraryPath: AbsolutePath, moduleMapPath: AbsolutePath)
+
+    // MARK: - FatalError
+
+    var description: String {
+        switch self {
+        case let .libraryNotFound(path):
+            return "Couldn't find library at \(path.pathString)"
+        case let .publicHeadersNotFound(libraryPath: libraryPath, headersPath: headersPath):
+            return "Couldn't find the public headers at \(headersPath.pathString) for library \(libraryPath.pathString)"
+        case let .swiftModuleMapNotFound(libraryPath: libraryPath, moduleMapPath: moduleMapPath):
+            return "Couldn't find the public headers at \(moduleMapPath.pathString) for library \(libraryPath.pathString)"
+        }
+    }
+
+    var type: ErrorType {
+        switch self {
+        case .libraryNotFound, .publicHeadersNotFound, .swiftModuleMapNotFound:
+            return .abort
         }
     }
 }

--- a/Sources/TuistCore/MetadataProviders/PrecompiledMetadataProvider.swift
+++ b/Sources/TuistCore/MetadataProviders/PrecompiledMetadataProvider.swift
@@ -47,8 +47,6 @@ public protocol PrecompiledMetadataProviding {
 }
 
 public class PrecompiledMetadataProvider: PrecompiledMetadataProviding {
-    public init() {}
-
     public func architectures(binaryPath: AbsolutePath) throws -> [BinaryArchitecture] {
         let result = try System.shared.capture("/usr/bin/lipo", "-info", binaryPath.pathString).spm_chuzzle() ?? ""
         let regexes = [

--- a/Sources/TuistCore/MetadataProviders/SystemFrameworksMetadataProvider.swift
+++ b/Sources/TuistCore/MetadataProviders/SystemFrameworksMetadataProvider.swift
@@ -1,0 +1,121 @@
+import Foundation
+import TSCBasic
+import TuistSupport
+
+// MARK: - Metadata
+
+public struct SystemFrameworkMetadata: Equatable {
+    var name: String
+    var path: AbsolutePath
+    var status: SDKStatus
+    var source: SDKSource
+}
+
+public enum SDKSource: Equatable {
+    case developer // Platforms/iPhoneOS.platform/Developer/Library
+    case system // Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library
+
+    /// Returns the framework search path that should be used in Xcode to locate the SDK.
+    public var frameworkSearchPath: String? {
+        switch self {
+        case .developer:
+            return "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+        case .system:
+            return nil
+        }
+    }
+}
+
+public enum SDKType: String, CaseIterable, Equatable {
+    case framework
+    case library = "tbd"
+
+    static var supportedTypesDescription: String {
+        let supportedTypes = allCases
+            .map { ".\($0.rawValue)" }
+            .joined(separator: ", ")
+        return "[\(supportedTypes)]"
+    }
+}
+
+// MARK: - Provider
+
+public protocol SystemFrameworkMetadataProviding {
+    func loadMetadata(sdkName: String, status: SDKStatus, platform: Platform, source: SDKSource) throws -> SystemFrameworkMetadata
+}
+
+extension SystemFrameworkMetadataProviding {
+    func loadXCTestMetadata(platform: Platform) throws -> SystemFrameworkMetadata {
+        try loadMetadata(sdkName: "XCTest.framework", status: .required, platform: platform, source: .developer)
+    }
+}
+
+// MARK: - Default Implementation
+
+public final class SystemFrameworkMetadataProvider: SystemFrameworkMetadataProviding {
+    public func loadMetadata(sdkName: String, status: SDKStatus, platform: Platform, source: SDKSource) throws -> SystemFrameworkMetadata {
+        let sdkNamePath = AbsolutePath("/\(sdkName)")
+        guard let sdkExtension = sdkNamePath.extension,
+            let sdkType = SDKType(rawValue: sdkExtension)
+        else {
+            throw SystemFrameworkMetadataProviderError.unsupportedSDK(name: sdkName)
+        }
+        let path = try sdkPath(name: sdkName, platform: platform, type: sdkType, source: source)
+        return SystemFrameworkMetadata(
+            name: sdkName,
+            path: path,
+            status: status,
+            source: source
+        )
+    }
+
+    private func sdkPath(name: String, platform: Platform, type: SDKType, source: SDKSource) throws -> AbsolutePath {
+        switch source {
+        case .developer:
+            guard let xcodeDeveloperSdkRootPath = platform.xcodeDeveloperSdkRootPath else {
+                throw SystemFrameworkMetadataProviderError.unsupportedSDKForPlatform(name: name, platform: platform)
+            }
+            let sdkRootPath = AbsolutePath("/\(xcodeDeveloperSdkRootPath)")
+            return sdkRootPath
+                .appending(RelativePath("Frameworks"))
+                .appending(component: name)
+
+        case .system:
+            let sdkRootPath = AbsolutePath("/\(platform.xcodeSdkRootPath)")
+            switch type {
+            case .framework:
+                return sdkRootPath
+                    .appending(RelativePath("System/Library/Frameworks"))
+                    .appending(component: name)
+            case .library:
+                return sdkRootPath
+                    .appending(RelativePath("usr/lib"))
+                    .appending(component: name)
+            }
+        }
+    }
+}
+
+// MARK: - Errors
+
+public enum SystemFrameworkMetadataProviderError: FatalError, Equatable {
+    case unsupportedSDK(name: String)
+    case unsupportedSDKForPlatform(name: String, platform: Platform)
+
+    public var description: String {
+        switch self {
+        case let .unsupportedSDK(sdk):
+            let supportedTypes = SDKType.supportedTypesDescription
+            return "The SDK type of \(sdk) is not currently supported - only \(supportedTypes) are supported."
+        case let .unsupportedSDKForPlatform(name: sdk, platform: platform):
+            return "The SDK \(sdk) is not currently supported on \(platform)."
+        }
+    }
+
+    public var type: ErrorType {
+        switch self {
+        case .unsupportedSDK, .unsupportedSDKForPlatform:
+            return .abort
+        }
+    }
+}

--- a/Sources/TuistCore/MetadataProviders/SystemFrameworksMetadataProvider.swift
+++ b/Sources/TuistCore/MetadataProviders/SystemFrameworksMetadataProvider.swift
@@ -2,39 +2,27 @@ import Foundation
 import TSCBasic
 import TuistSupport
 
-// MARK: - Metadata
+// MARK: - Provider Errors
 
-public struct SystemFrameworkMetadata: Equatable {
-    var name: String
-    var path: AbsolutePath
-    var status: SDKStatus
-    var source: SDKSource
-}
+public enum SystemFrameworkMetadataProviderError: FatalError, Equatable {
+    case unsupportedSDK(name: String)
+    case unsupportedSDKForPlatform(name: String, platform: Platform)
 
-public enum SDKSource: Equatable {
-    case developer // Platforms/iPhoneOS.platform/Developer/Library
-    case system // Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library
-
-    /// Returns the framework search path that should be used in Xcode to locate the SDK.
-    public var frameworkSearchPath: String? {
+    public var description: String {
         switch self {
-        case .developer:
-            return "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-        case .system:
-            return nil
+        case let .unsupportedSDK(sdk):
+            let supportedTypes = SDKType.supportedTypesDescription
+            return "The SDK type of \(sdk) is not currently supported - only \(supportedTypes) are supported."
+        case let .unsupportedSDKForPlatform(name: sdk, platform: platform):
+            return "The SDK \(sdk) is not currently supported on \(platform)."
         }
     }
-}
 
-public enum SDKType: String, CaseIterable, Equatable {
-    case framework
-    case library = "tbd"
-
-    static var supportedTypesDescription: String {
-        let supportedTypes = allCases
-            .map { ".\($0.rawValue)" }
-            .joined(separator: ", ")
-        return "[\(supportedTypes)]"
+    public var type: ErrorType {
+        switch self {
+        case .unsupportedSDK, .unsupportedSDKForPlatform:
+            return .abort
+        }
     }
 }
 
@@ -53,6 +41,8 @@ extension SystemFrameworkMetadataProviding {
 // MARK: - Default Implementation
 
 public final class SystemFrameworkMetadataProvider: SystemFrameworkMetadataProviding {
+    public init() {}
+
     public func loadMetadata(sdkName: String, status: SDKStatus, platform: Platform, source: SDKSource) throws -> SystemFrameworkMetadata {
         let sdkNamePath = AbsolutePath("/\(sdkName)")
         guard let sdkExtension = sdkNamePath.extension,
@@ -92,30 +82,6 @@ public final class SystemFrameworkMetadataProvider: SystemFrameworkMetadataProvi
                     .appending(RelativePath("usr/lib"))
                     .appending(component: name)
             }
-        }
-    }
-}
-
-// MARK: - Errors
-
-public enum SystemFrameworkMetadataProviderError: FatalError, Equatable {
-    case unsupportedSDK(name: String)
-    case unsupportedSDKForPlatform(name: String, platform: Platform)
-
-    public var description: String {
-        switch self {
-        case let .unsupportedSDK(sdk):
-            let supportedTypes = SDKType.supportedTypesDescription
-            return "The SDK type of \(sdk) is not currently supported - only \(supportedTypes) are supported."
-        case let .unsupportedSDKForPlatform(name: sdk, platform: platform):
-            return "The SDK \(sdk) is not currently supported on \(platform)."
-        }
-    }
-
-    public var type: ErrorType {
-        switch self {
-        case .unsupportedSDK, .unsupportedSDKForPlatform:
-            return .abort
         }
     }
 }

--- a/Sources/TuistCore/Models/Metadata/FrameworkMetadata.swift
+++ b/Sources/TuistCore/Models/Metadata/FrameworkMetadata.swift
@@ -1,0 +1,31 @@
+import Foundation
+import TSCBasic
+
+/// The metadata associated with a precompiled framework (.framework)
+public struct FrameworkMetadata: Equatable {
+    public var path: AbsolutePath
+    public var binaryPath: AbsolutePath
+    public var dsymPath: AbsolutePath?
+    public var bcsymbolmapPaths: [AbsolutePath]
+    public var linking: BinaryLinking
+    public var architectures: [BinaryArchitecture]
+    public var isCarthage: Bool
+
+    public init(
+        path: AbsolutePath,
+        binaryPath: AbsolutePath,
+        dsymPath: AbsolutePath?,
+        bcsymbolmapPaths: [AbsolutePath],
+        linking: BinaryLinking,
+        architectures: [BinaryArchitecture],
+        isCarthage: Bool
+    ) {
+        self.path = path
+        self.binaryPath = binaryPath
+        self.dsymPath = dsymPath
+        self.bcsymbolmapPaths = bcsymbolmapPaths
+        self.linking = linking
+        self.architectures = architectures
+        self.isCarthage = isCarthage
+    }
+}

--- a/Sources/TuistCore/Models/Metadata/LibraryMetadata.swift
+++ b/Sources/TuistCore/Models/Metadata/LibraryMetadata.swift
@@ -1,0 +1,25 @@
+import Foundation
+import TSCBasic
+
+/// The metadata associated with a precompiled library (.a / .dylib)
+public struct LibraryMetadata: Equatable {
+    public var path: AbsolutePath
+    public var publicHeaders: AbsolutePath
+    public var swiftModuleMap: AbsolutePath?
+    public var architectures: [BinaryArchitecture]
+    public var linking: BinaryLinking
+
+    public init(
+        path: AbsolutePath,
+        publicHeaders: AbsolutePath,
+        swiftModuleMap: AbsolutePath?,
+        architectures: [BinaryArchitecture],
+        linking: BinaryLinking
+    ) {
+        self.path = path
+        self.publicHeaders = publicHeaders
+        self.swiftModuleMap = swiftModuleMap
+        self.architectures = architectures
+        self.linking = linking
+    }
+}

--- a/Sources/TuistCore/Models/Metadata/SystemFrameworkMetadata.swift
+++ b/Sources/TuistCore/Models/Metadata/SystemFrameworkMetadata.swift
@@ -1,0 +1,22 @@
+import Foundation
+import TSCBasic
+
+/// The metadata associated with a system framework or library (e.g. UIKit.framework, libc++.tbd)
+public struct SystemFrameworkMetadata: Equatable {
+    var name: String
+    var path: AbsolutePath
+    var status: SDKStatus
+    var source: SDKSource
+
+    public init(
+        name: String,
+        path: AbsolutePath,
+        status: SDKStatus,
+        source: SDKSource
+    ) {
+        self.name = name
+        self.path = path
+        self.status = status
+        self.source = source
+    }
+}

--- a/Sources/TuistCore/Models/Metadata/XCFrameworkMetadata.swift
+++ b/Sources/TuistCore/Models/Metadata/XCFrameworkMetadata.swift
@@ -1,0 +1,22 @@
+import Foundation
+import TSCBasic
+
+/// The metadata associated with a precompiled xcframework
+public struct XCFrameworkMetadata: Equatable {
+    public var path: AbsolutePath
+    public var infoPlist: XCFrameworkInfoPlist
+    public var primaryBinaryPath: AbsolutePath
+    public var linking: BinaryLinking
+
+    public init(
+        path: AbsolutePath,
+        infoPlist: XCFrameworkInfoPlist,
+        primaryBinaryPath: AbsolutePath,
+        linking: BinaryLinking
+    ) {
+        self.path = path
+        self.infoPlist = infoPlist
+        self.primaryBinaryPath = primaryBinaryPath
+        self.linking = linking
+    }
+}

--- a/Sources/TuistCore/Models/SDKSource.swift
+++ b/Sources/TuistCore/Models/SDKSource.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+public enum SDKSource: Equatable {
+    case developer // Platforms/iPhoneOS.platform/Developer/Library
+    case system // Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library
+
+    /// Returns the framework search path that should be used in Xcode to locate the SDK.
+    public var frameworkSearchPath: String? {
+        switch self {
+        case .developer:
+            return "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+        case .system:
+            return nil
+        }
+    }
+}

--- a/Sources/TuistCore/Models/SDKType.swift
+++ b/Sources/TuistCore/Models/SDKType.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public enum SDKType: String, CaseIterable, Equatable {
+    case framework
+    case library = "tbd"
+
+    static var supportedTypesDescription: String {
+        let supportedTypes = allCases
+            .map { ".\($0.rawValue)" }
+            .joined(separator: ", ")
+        return "[\(supportedTypes)]"
+    }
+}

--- a/Sources/TuistCore/ValueGraph/ValueGraphLoader.swift
+++ b/Sources/TuistCore/ValueGraph/ValueGraphLoader.swift
@@ -24,7 +24,7 @@ public final class ValueGraphLoader: ValueGraphLoading {
         )
     }
 
-    init(
+    public init(
         frameworkMetadataProvider: FrameworkMetadataProviding,
         libraryMetadataProvider: LibraryMetadataProviding,
         xcframeworkMetadataProvider: XCFrameworkMetadataProviding,

--- a/Sources/TuistCore/ValueGraph/ValueGraphLoader.swift
+++ b/Sources/TuistCore/ValueGraph/ValueGraphLoader.swift
@@ -1,0 +1,365 @@
+import Foundation
+import TSCBasic
+import TuistSupport
+
+public protocol ValueGraphLoading {
+    func loadWorkspace(workspace: Workspace, projects: [Project]) throws -> ValueGraph
+    func loadProject(at path: AbsolutePath, projects: [Project]) throws -> (Project, ValueGraph)
+}
+
+// MARK: - ValueGraphLoader
+
+public final class ValueGraphLoader: ValueGraphLoading {
+    private let frameworkMetadataProvider: FrameworkMetadataProviding
+    private let libraryMetadataProvider: LibraryMetadataProviding
+    private let xcframeworkMetadataProvider: XCFrameworkMetadataProviding
+    private let systemFrameworkMetadataProvider: SystemFrameworkMetadataProviding
+
+    public convenience init() {
+        self.init(
+            frameworkMetadataProvider: FrameworkMetadataProvider(),
+            libraryMetadataProvider: LibraryMetadataProvider(),
+            xcframeworkMetadataProvider: XCFrameworkMetadataProvider(),
+            systemFrameworkMetadataProvider: SystemFrameworkMetadataProvider()
+        )
+    }
+
+    init(
+        frameworkMetadataProvider: FrameworkMetadataProviding,
+        libraryMetadataProvider: LibraryMetadataProviding,
+        xcframeworkMetadataProvider: XCFrameworkMetadataProviding,
+        systemFrameworkMetadataProvider: SystemFrameworkMetadataProviding
+    ) {
+        self.frameworkMetadataProvider = frameworkMetadataProvider
+        self.libraryMetadataProvider = libraryMetadataProvider
+        self.xcframeworkMetadataProvider = xcframeworkMetadataProvider
+        self.systemFrameworkMetadataProvider = systemFrameworkMetadataProvider
+    }
+
+    // MARK: - ValueGraphLoading
+
+    public func loadWorkspace(workspace: Workspace, projects: [Project]) throws -> ValueGraph {
+        let cache = Cache(projects: projects)
+        let cycleDetector = GraphCircularDetector()
+
+        try workspace.projects.forEach { project in
+            try loadProject(
+                path: project,
+                cache: cache,
+                cycleDetector: cycleDetector
+            )
+        }
+
+        let updatedWorkspace = workspace.replacing(projects: cache.loadedProjects.keys.sorted())
+        let graph = ValueGraph(
+            name: updatedWorkspace.name,
+            path: updatedWorkspace.path,
+            workspace: updatedWorkspace,
+            projects: cache.loadedProjects,
+            packages: cache.packages,
+            targets: cache.loadedTargets,
+            dependencies: cache.dependencies
+        )
+        return graph
+    }
+
+    public func loadProject(at path: AbsolutePath, projects: [Project]) throws -> (Project, ValueGraph) {
+        let cache = Cache(projects: projects)
+        guard let rootProject = cache.allProjects[path] else {
+            throw GraphLoadingError.missingProject(path)
+        }
+        let cycleDetector = GraphCircularDetector()
+        try loadProject(path: path, cache: cache, cycleDetector: cycleDetector)
+
+        let workspace = Workspace(
+            path: path,
+            name: rootProject.name,
+            projects: cache.loadedProjects.keys.sorted()
+        )
+        let graph = ValueGraph(
+            name: rootProject.name,
+            path: path,
+            workspace: workspace,
+            projects: cache.loadedProjects,
+            packages: cache.packages,
+            targets: cache.loadedTargets,
+            dependencies: cache.dependencies
+        )
+        return (rootProject, graph)
+    }
+
+    // MARK: - Private
+
+    private func loadProject(
+        path: AbsolutePath,
+        cache: Cache,
+        cycleDetector: GraphCircularDetector
+    ) throws {
+        guard !cache.projectLoaded(path: path) else {
+            return
+        }
+        guard let project = cache.allProjects[path] else {
+            throw GraphLoadingError.missingProject(path)
+        }
+        cache.add(project: project)
+
+        try project.targets.forEach {
+            try loadTarget(
+                path: path,
+                name: $0.name,
+                cache: cache,
+                cycleDetector: cycleDetector
+            )
+        }
+    }
+
+    private func loadTarget(
+        path: AbsolutePath,
+        name: String,
+        cache: Cache,
+        cycleDetector: GraphCircularDetector
+    ) throws {
+        guard !cache.targetLoaded(path: path, name: name) else {
+            return
+        }
+        guard let _ = cache.allProjects[path] else {
+            throw GraphLoadingError.missingProject(path)
+        }
+        guard let referencedTargetProject = cache.allTargets[path],
+            let target = referencedTargetProject[name]
+        else {
+            throw GraphLoadingError.targetNotFound(name, path)
+        }
+
+        cache.add(target: target, path: path)
+        let dependencies = try target.dependencies.map {
+            try loadDependency(
+                path: path,
+                fromTarget: target.name,
+                fromPlatform: target.platform,
+                dependency: $0,
+                cache: cache,
+                cycleDetector: cycleDetector
+            )
+        }
+
+        try cycleDetector.complete()
+
+        if !dependencies.isEmpty {
+            cache.dependencies[.target(name: name, path: path)] = Set(dependencies)
+        }
+    }
+
+    private func loadDependency(
+        path: AbsolutePath,
+        fromTarget: String,
+        fromPlatform: Platform,
+        dependency: Dependency,
+        cache: Cache,
+        cycleDetector: GraphCircularDetector
+    ) throws -> ValueGraphDependency {
+        switch dependency {
+        case let .target(toTarget):
+            // A target within the same project.
+            let circularFrom = GraphCircularDetectorNode(path: path, name: fromTarget)
+            let circularTo = GraphCircularDetectorNode(path: path, name: toTarget)
+            cycleDetector.start(from: circularFrom, to: circularTo)
+            try loadTarget(
+                path: path,
+                name: toTarget,
+                cache: cache,
+                cycleDetector: cycleDetector
+            )
+            return .target(name: toTarget, path: path)
+
+        case let .project(toTarget, projectPath):
+            // A target from another project
+            let circularFrom = GraphCircularDetectorNode(path: path, name: fromTarget)
+            let circularTo = GraphCircularDetectorNode(path: projectPath, name: toTarget)
+            cycleDetector.start(from: circularFrom, to: circularTo)
+            try loadProject(path: projectPath, cache: cache, cycleDetector: cycleDetector)
+            try loadTarget(
+                path: projectPath,
+                name: toTarget,
+                cache: cache,
+                cycleDetector: cycleDetector
+            )
+            return .target(name: toTarget, path: projectPath)
+
+        case let .framework(frameworkPath):
+            return try loadFramework(path: frameworkPath, cache: cache)
+
+        case let .library(libraryPath, publicHeaders, swiftModuleMap):
+            return try loadLibrary(
+                path: libraryPath,
+                publicHeaders: publicHeaders,
+                swiftModuleMap: swiftModuleMap,
+                cache: cache
+            )
+
+        case let .xcFramework(frameworkPath):
+            return try loadXCFramework(path: frameworkPath, cache: cache)
+
+        case let .sdk(name, status):
+            return try loadSDK(name: name, platform: fromPlatform, status: status, source: .system)
+
+        case let .cocoapods(podsPath):
+            return .cocoapods(path: podsPath)
+
+        case let .package(product):
+            return try loadPackage(fromPath: path, productName: product)
+
+        case .xctest:
+            return try loadXCTestSDK(platform: fromPlatform)
+        }
+    }
+
+    private func loadFramework(path: AbsolutePath, cache: Cache) throws -> ValueGraphDependency {
+        if let loaded = cache.frameworks[path] {
+            return loaded
+        }
+
+        let metadata = try frameworkMetadataProvider.loadMetadata(at: path)
+        let framework: ValueGraphDependency = .framework(
+            path: metadata.path,
+            binaryPath: metadata.binaryPath,
+            dsymPath: metadata.dsymPath,
+            bcsymbolmapPaths: metadata.bcsymbolmapPaths,
+            linking: metadata.linking,
+            architectures: metadata.architectures,
+            isCarthage: metadata.isCarthage
+        )
+        cache.add(framework: framework, at: path)
+        return framework
+    }
+
+    private func loadLibrary(
+        path: AbsolutePath,
+        publicHeaders: AbsolutePath,
+        swiftModuleMap: AbsolutePath?,
+        cache: Cache
+    ) throws -> ValueGraphDependency {
+        if let loaded = cache.libraries[path] {
+            return loaded
+        }
+
+        let metadata = try libraryMetadataProvider.loadMetadata(
+            at: path,
+            publicHeaders: publicHeaders,
+            swiftModuleMap: swiftModuleMap
+        )
+        let library: ValueGraphDependency = .library(
+            path: metadata.path,
+            publicHeaders: metadata.publicHeaders,
+            linking: metadata.linking,
+            architectures: metadata.architectures,
+            swiftModuleMap: metadata.swiftModuleMap
+        )
+        cache.add(library: library, at: path)
+        return library
+    }
+
+    private func loadXCFramework(path: AbsolutePath, cache: Cache) throws -> ValueGraphDependency {
+        if let loaded = cache.xcframeworks[path] {
+            return loaded
+        }
+
+        let metadata = try xcframeworkMetadataProvider.loadMetadata(at: path)
+        let xcframework: ValueGraphDependency = .xcframework(
+            path: metadata.path,
+            infoPlist: metadata.infoPlist,
+            primaryBinaryPath: metadata.primaryBinaryPath,
+            linking: metadata.linking
+        )
+        cache.add(xcframework: xcframework, at: path)
+        return xcframework
+    }
+
+    private func loadSDK(name: String,
+                         platform: Platform,
+                         status: SDKStatus,
+                         source: SDKSource) throws -> ValueGraphDependency
+    {
+        let metadata = try systemFrameworkMetadataProvider.loadMetadata(sdkName: name, status: status, platform: platform, source: source)
+        return .sdk(name: metadata.name, path: metadata.path, status: metadata.status, source: metadata.source)
+    }
+
+    private func loadXCTestSDK(platform: Platform) throws -> ValueGraphDependency {
+        let metadata = try systemFrameworkMetadataProvider.loadXCTestMetadata(platform: platform)
+        return .sdk(name: metadata.name, path: metadata.path, status: metadata.status, source: metadata.source)
+    }
+
+    private func loadPackage(fromPath: AbsolutePath, productName: String) throws -> ValueGraphDependency {
+        // TODO: `fromPath` isn't quite correct as it reflects the path where the dependency was declared
+        // and doesn't uniquely identify it. It's been copied from the previous implementation to maintain
+        // existing behaviour and should be fixed separately
+        .packageProduct(
+            path: fromPath,
+            product: productName
+        )
+    }
+
+    private final class Cache {
+        let allProjects: [AbsolutePath: Project]
+        let allTargets: [AbsolutePath: [String: Target]]
+
+        var loadedProjects: [AbsolutePath: Project] = [:]
+        var loadedTargets: [AbsolutePath: [String: Target]] = [:]
+        var dependencies: [ValueGraphDependency: Set<ValueGraphDependency>] = [:]
+        var frameworks: [AbsolutePath: ValueGraphDependency] = [:]
+        var libraries: [AbsolutePath: ValueGraphDependency] = [:]
+        var xcframeworks: [AbsolutePath: ValueGraphDependency] = [:]
+        var packages: [AbsolutePath: [String: Package]] = [:]
+
+        init(projects: [Project]) {
+            let allProjects = Dictionary(uniqueKeysWithValues: projects.map { ($0.path, $0) })
+            let allTargets = allProjects.mapValues {
+                Dictionary(uniqueKeysWithValues: $0.targets.map { ($0.name, $0) })
+            }
+            self.allProjects = allProjects
+            self.allTargets = allTargets
+        }
+
+        func add(project: Project) {
+            loadedProjects[project.path] = project
+            project.packages.forEach {
+                packages[project.path, default: [:]][$0.name] = $0
+            }
+        }
+
+        func add(target: Target, path: AbsolutePath) {
+            loadedTargets[path, default: [:]][target.name] = target
+        }
+
+        func add(framework: ValueGraphDependency, at path: AbsolutePath) {
+            frameworks[path] = framework
+        }
+
+        func add(xcframework: ValueGraphDependency, at path: AbsolutePath) {
+            xcframeworks[path] = xcframework
+        }
+
+        func add(library: ValueGraphDependency, at path: AbsolutePath) {
+            libraries[path] = library
+        }
+
+        func targetLoaded(path: AbsolutePath, name: String) -> Bool {
+            loadedTargets[path]?[name] != nil
+        }
+
+        func projectLoaded(path: AbsolutePath) -> Bool {
+            loadedProjects[path] != nil
+        }
+    }
+}
+
+private extension Package {
+    var name: String {
+        switch self {
+        case let .local(path: path):
+            return path.pathString
+        case let .remote(url: url, requirement: _):
+            return url
+        }
+    }
+}

--- a/Sources/TuistCoreTesting/MetadataProviders/MockFrameworkMetadataProvider.swift
+++ b/Sources/TuistCoreTesting/MetadataProviders/MockFrameworkMetadataProvider.swift
@@ -35,25 +35,3 @@ public final class MockFrameworkMetadataProvider: MockPrecompiledMetadataProvide
         }
     }
 }
-
-public extension FrameworkMetadata {
-    static func test(
-        path: AbsolutePath = "/Frameworks/TestFramework.xframework",
-        binaryPath: AbsolutePath = "/Frameworks/TestFramework.xframework/TestFramework",
-        dsymPath: AbsolutePath? = nil,
-        bcsymbolmapPaths: [AbsolutePath] = [],
-        linking: BinaryLinking = .dynamic,
-        architectures: [BinaryArchitecture] = [.arm64],
-        isCarthage: Bool = false
-    ) -> FrameworkMetadata {
-        FrameworkMetadata(
-            path: path,
-            binaryPath: binaryPath,
-            dsymPath: dsymPath,
-            bcsymbolmapPaths: bcsymbolmapPaths,
-            linking: linking,
-            architectures: architectures,
-            isCarthage: isCarthage
-        )
-    }
-}

--- a/Sources/TuistCoreTesting/MetadataProviders/MockFrameworkMetadataProvider.swift
+++ b/Sources/TuistCoreTesting/MetadataProviders/MockFrameworkMetadataProvider.swift
@@ -3,6 +3,15 @@ import TSCBasic
 @testable import TuistCore
 
 public final class MockFrameworkMetadataProvider: MockPrecompiledMetadataProvider, FrameworkMetadataProviding {
+    public var loadMetadataStub: ((AbsolutePath) throws -> FrameworkMetadata)?
+    public func loadMetadata(at path: AbsolutePath) throws -> FrameworkMetadata {
+        if let loadMetadataStub = loadMetadataStub {
+            return try loadMetadataStub(path)
+        } else {
+            return FrameworkMetadata.test(path: path)
+        }
+    }
+
     public var dsymPathStub: ((AbsolutePath) -> AbsolutePath?)?
     public func dsymPath(frameworkPath: AbsolutePath) -> AbsolutePath? {
         dsymPathStub?(frameworkPath) ?? nil
@@ -24,5 +33,27 @@ public final class MockFrameworkMetadataProvider: MockPrecompiledMetadataProvide
         } else {
             return .framework
         }
+    }
+}
+
+public extension FrameworkMetadata {
+    static func test(
+        path: AbsolutePath = "/Frameworks/TestFramework.xframework",
+        binaryPath: AbsolutePath = "/Frameworks/TestFramework.xframework/TestFramework",
+        dsymPath: AbsolutePath? = nil,
+        bcsymbolmapPaths: [AbsolutePath] = [],
+        linking: BinaryLinking = .dynamic,
+        architectures: [BinaryArchitecture] = [.arm64],
+        isCarthage: Bool = false
+    ) -> FrameworkMetadata {
+        FrameworkMetadata(
+            path: path,
+            binaryPath: binaryPath,
+            dsymPath: dsymPath,
+            bcsymbolmapPaths: bcsymbolmapPaths,
+            linking: linking,
+            architectures: architectures,
+            isCarthage: isCarthage
+        )
     }
 }

--- a/Sources/TuistCoreTesting/MetadataProviders/MockLibraryMetadataProvider.swift
+++ b/Sources/TuistCoreTesting/MetadataProviders/MockLibraryMetadataProvider.swift
@@ -19,21 +19,3 @@ public final class MockLibraryMetadataProvider: MockPrecompiledMetadataProvider,
         }
     }
 }
-
-public extension LibraryMetadata {
-    static func test(
-        path: AbsolutePath = "/Libraries/libTest/libTest.a",
-        publicHeaders: AbsolutePath = "/Libraries/libTest/include",
-        swiftModuleMap: AbsolutePath? = "/Libraries/libTest/libTest.swiftmodule",
-        architectures: [BinaryArchitecture] = [.arm64],
-        linking: BinaryLinking = .static
-    ) -> LibraryMetadata {
-        LibraryMetadata(
-            path: path,
-            publicHeaders: publicHeaders,
-            swiftModuleMap: swiftModuleMap,
-            architectures: architectures,
-            linking: linking
-        )
-    }
-}

--- a/Sources/TuistCoreTesting/MetadataProviders/MockLibraryMetadataProvider.swift
+++ b/Sources/TuistCoreTesting/MetadataProviders/MockLibraryMetadataProvider.swift
@@ -3,12 +3,37 @@ import TSCBasic
 @testable import TuistCore
 
 public final class MockLibraryMetadataProvider: MockPrecompiledMetadataProvider, LibraryMetadataProviding {
-    public var productStub: ((LibraryNode) throws -> Product)?
-    public func product(library: LibraryNode) throws -> Product {
-        if let productStub = productStub {
-            return try productStub(library)
+    public var loadMetadataStub: ((AbsolutePath, AbsolutePath, AbsolutePath?) throws -> LibraryMetadata)?
+    public func loadMetadata(at path: AbsolutePath,
+                             publicHeaders: AbsolutePath,
+                             swiftModuleMap: AbsolutePath?) throws -> LibraryMetadata
+    {
+        if let stub = loadMetadataStub {
+            return try stub(path, publicHeaders, swiftModuleMap)
         } else {
-            return .staticLibrary
+            return LibraryMetadata.test(
+                path: path,
+                publicHeaders: publicHeaders,
+                swiftModuleMap: swiftModuleMap
+            )
         }
+    }
+}
+
+public extension LibraryMetadata {
+    static func test(
+        path: AbsolutePath = "/Libraries/libTest/libTest.a",
+        publicHeaders: AbsolutePath = "/Libraries/libTest/include",
+        swiftModuleMap: AbsolutePath? = "/Libraries/libTest/libTest.swiftmodule",
+        architectures: [BinaryArchitecture] = [.arm64],
+        linking: BinaryLinking = .static
+    ) -> LibraryMetadata {
+        LibraryMetadata(
+            path: path,
+            publicHeaders: publicHeaders,
+            swiftModuleMap: swiftModuleMap,
+            architectures: architectures,
+            linking: linking
+        )
     }
 }

--- a/Sources/TuistCoreTesting/MetadataProviders/MockXCFrameworkMetadataProvider.swift
+++ b/Sources/TuistCoreTesting/MetadataProviders/MockXCFrameworkMetadataProvider.swift
@@ -33,19 +33,3 @@ public final class MockXCFrameworkMetadataProvider: MockPrecompiledMetadataProvi
         }
     }
 }
-
-public extension XCFrameworkMetadata {
-    static func test(
-        path: AbsolutePath = "/XCFrameworks/XCFramework.xcframework",
-        infoPlist: XCFrameworkInfoPlist = .test(),
-        primaryBinaryPath: AbsolutePath = "/XCFrameworks/XCFramework.xcframework/ios-arm64/XCFramework",
-        linking: BinaryLinking = .dynamic
-    ) -> XCFrameworkMetadata {
-        XCFrameworkMetadata(
-            path: path,
-            infoPlist: infoPlist,
-            primaryBinaryPath: primaryBinaryPath,
-            linking: linking
-        )
-    }
-}

--- a/Sources/TuistCoreTesting/MetadataProviders/MockXCFrameworkMetadataProvider.swift
+++ b/Sources/TuistCoreTesting/MetadataProviders/MockXCFrameworkMetadataProvider.swift
@@ -3,6 +3,18 @@ import TSCBasic
 @testable import TuistCore
 
 public final class MockXCFrameworkMetadataProvider: MockPrecompiledMetadataProvider, XCFrameworkMetadataProviding {
+    public var loadMetadataStub: ((AbsolutePath) throws -> XCFrameworkMetadata)?
+    public func loadMetadata(at path: AbsolutePath) throws -> XCFrameworkMetadata {
+        if let loadMetadataStub = loadMetadataStub {
+            return try loadMetadataStub(path)
+        } else {
+            return XCFrameworkMetadata.test(
+                path: path,
+                primaryBinaryPath: path.appending(RelativePath("ios-arm64/binary"))
+            )
+        }
+    }
+
     public var infoPlistStub: ((AbsolutePath) throws -> XCFrameworkInfoPlist)?
     public func infoPlist(xcframeworkPath: AbsolutePath) throws -> XCFrameworkInfoPlist {
         if let infoPlistStub = infoPlistStub {
@@ -19,5 +31,21 @@ public final class MockXCFrameworkMetadataProvider: MockPrecompiledMetadataProvi
         } else {
             return AbsolutePath.root
         }
+    }
+}
+
+public extension XCFrameworkMetadata {
+    static func test(
+        path: AbsolutePath = "/XCFrameworks/XCFramework.xcframework",
+        infoPlist: XCFrameworkInfoPlist = .test(),
+        primaryBinaryPath: AbsolutePath = "/XCFrameworks/XCFramework.xcframework/ios-arm64/XCFramework",
+        linking: BinaryLinking = .dynamic
+    ) -> XCFrameworkMetadata {
+        XCFrameworkMetadata(
+            path: path,
+            infoPlist: infoPlist,
+            primaryBinaryPath: primaryBinaryPath,
+            linking: linking
+        )
     }
 }

--- a/Sources/TuistCoreTesting/Models/Metadata/FrameworkMetadata+TestData.swift
+++ b/Sources/TuistCoreTesting/Models/Metadata/FrameworkMetadata+TestData.swift
@@ -1,0 +1,32 @@
+//
+//  File.swift
+//
+//
+//  Created by Kassem Wridan on 22/12/2020.
+//
+
+import Foundation
+import TSCBasic
+import TuistCore
+
+public extension FrameworkMetadata {
+    static func test(
+        path: AbsolutePath = "/Frameworks/TestFramework.xframework",
+        binaryPath: AbsolutePath = "/Frameworks/TestFramework.xframework/TestFramework",
+        dsymPath: AbsolutePath? = nil,
+        bcsymbolmapPaths: [AbsolutePath] = [],
+        linking: BinaryLinking = .dynamic,
+        architectures: [BinaryArchitecture] = [.arm64],
+        isCarthage: Bool = false
+    ) -> FrameworkMetadata {
+        FrameworkMetadata(
+            path: path,
+            binaryPath: binaryPath,
+            dsymPath: dsymPath,
+            bcsymbolmapPaths: bcsymbolmapPaths,
+            linking: linking,
+            architectures: architectures,
+            isCarthage: isCarthage
+        )
+    }
+}

--- a/Sources/TuistCoreTesting/Models/Metadata/LibraryMetadata+TestData.swift
+++ b/Sources/TuistCoreTesting/Models/Metadata/LibraryMetadata+TestData.swift
@@ -1,0 +1,28 @@
+//
+//  File.swift
+//
+//
+//  Created by Kassem Wridan on 22/12/2020.
+//
+
+import Foundation
+import TSCBasic
+import TuistCore
+
+public extension LibraryMetadata {
+    static func test(
+        path: AbsolutePath = "/Libraries/libTest/libTest.a",
+        publicHeaders: AbsolutePath = "/Libraries/libTest/include",
+        swiftModuleMap: AbsolutePath? = "/Libraries/libTest/libTest.swiftmodule",
+        architectures: [BinaryArchitecture] = [.arm64],
+        linking: BinaryLinking = .static
+    ) -> LibraryMetadata {
+        LibraryMetadata(
+            path: path,
+            publicHeaders: publicHeaders,
+            swiftModuleMap: swiftModuleMap,
+            architectures: architectures,
+            linking: linking
+        )
+    }
+}

--- a/Sources/TuistCoreTesting/Models/Metadata/XCFrameworkMetadata+TestData.swift
+++ b/Sources/TuistCoreTesting/Models/Metadata/XCFrameworkMetadata+TestData.swift
@@ -1,0 +1,19 @@
+import Foundation
+import TSCBasic
+import TuistCore
+
+public extension XCFrameworkMetadata {
+    static func test(
+        path: AbsolutePath = "/XCFrameworks/XCFramework.xcframework",
+        infoPlist: XCFrameworkInfoPlist = .test(),
+        primaryBinaryPath: AbsolutePath = "/XCFrameworks/XCFramework.xcframework/ios-arm64/XCFramework",
+        linking: BinaryLinking = .dynamic
+    ) -> XCFrameworkMetadata {
+        XCFrameworkMetadata(
+            path: path,
+            infoPlist: infoPlist,
+            primaryBinaryPath: primaryBinaryPath,
+            linking: linking
+        )
+    }
+}

--- a/Tests/TuistCoreTests/MetadataProviders/FrameworkMetadataProviderTests.swift
+++ b/Tests/TuistCoreTests/MetadataProviders/FrameworkMetadataProviderTests.swift
@@ -1,0 +1,40 @@
+import TSCBasic
+import XCTest
+
+@testable import TuistCore
+@testable import TuistSupportTesting
+
+final class FrameworkMetadataProviderTests: XCTestCase {
+    var subject: FrameworkMetadataProvider!
+
+    override func setUp() {
+        super.setUp()
+        subject = FrameworkMetadataProvider()
+    }
+
+    override func tearDown() {
+        subject = nil
+        super.tearDown()
+    }
+
+    func test_loadMetadata() throws {
+        // Given
+        let frameworkPath = fixturePath(path: RelativePath("xpm.framework"))
+
+        // When
+        let metadata = try subject.loadMetadata(at: frameworkPath)
+
+        // Then
+        let expectedBinaryPath = frameworkPath.appending(component: frameworkPath.basenameWithoutExt)
+        let expectedDsymPath = frameworkPath.parentDirectory.appending(component: "xpm.framework.dSYM")
+        XCTAssertEqual(metadata, FrameworkMetadata(
+            path: frameworkPath,
+            binaryPath: expectedBinaryPath,
+            dsymPath: expectedDsymPath,
+            bcsymbolmapPaths: [],
+            linking: .dynamic,
+            architectures: [.x8664, .arm64],
+            isCarthage: false
+        ))
+    }
+}

--- a/Tests/TuistCoreTests/MetadataProviders/LibraryMetadataProviderTests.swift
+++ b/Tests/TuistCoreTests/MetadataProviders/LibraryMetadataProviderTests.swift
@@ -1,0 +1,36 @@
+import TSCBasic
+import XCTest
+
+@testable import TuistCore
+@testable import TuistSupportTesting
+
+final class LibraryMetadataProviderTests: XCTestCase {
+    var subject: LibraryMetadataProvider!
+
+    override func setUp() {
+        super.setUp()
+        subject = LibraryMetadataProvider()
+    }
+
+    override func tearDown() {
+        subject = nil
+        super.tearDown()
+    }
+
+    func test_loadMetadata() throws {
+        // Given
+        let libraryPath = fixturePath(path: RelativePath("libStaticLibrary.a"))
+
+        // When
+        let metadata = try subject.loadMetadata(at: libraryPath, publicHeaders: libraryPath.parentDirectory, swiftModuleMap: nil)
+
+        // Then
+        XCTAssertEqual(metadata, LibraryMetadata(
+            path: libraryPath,
+            publicHeaders: libraryPath.parentDirectory,
+            swiftModuleMap: nil,
+            architectures: [.x8664],
+            linking: .static
+        ))
+    }
+}

--- a/Tests/TuistCoreTests/MetadataProviders/SystemFrameworkMetadataProviderTests.swift
+++ b/Tests/TuistCoreTests/MetadataProviders/SystemFrameworkMetadataProviderTests.swift
@@ -1,0 +1,93 @@
+import TSCBasic
+import XCTest
+
+@testable import TuistCore
+@testable import TuistSupportTesting
+
+final class SystemFrameworkMetadataProviderTests: XCTestCase {
+    var subject: SystemFrameworkMetadataProvider!
+
+    override func setUp() {
+        super.setUp()
+        subject = SystemFrameworkMetadataProvider()
+    }
+
+    override func tearDown() {
+        subject = nil
+        super.tearDown()
+    }
+
+    func test_loadMetadata_framework() throws {
+        // Given
+        let sdkName = "UIKit.framework"
+
+        // When
+        let metadata = try subject.loadMetadata(sdkName: sdkName, status: .required, platform: .iOS, source: .system)
+
+        // Then
+        XCTAssertEqual(metadata, SystemFrameworkMetadata(
+            name: sdkName,
+            path: "/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/UIKit.framework",
+            status: .required,
+            source: .system
+        ))
+    }
+
+    func test_loadMetadata_library() throws {
+        // Given
+        let sdkName = "libc++.tbd"
+
+        // When
+        let metadata = try subject.loadMetadata(sdkName: sdkName, status: .required, platform: .iOS, source: .system)
+
+        // Then
+        XCTAssertEqual(metadata, SystemFrameworkMetadata(
+            name: sdkName,
+            path: "/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib/libc++.tbd",
+            status: .required,
+            source: .system
+        ))
+    }
+
+    func test_loadMetadata_unsupportedType() throws {
+        // Given
+        let sdkName = "UIKit.xcframework"
+
+        // When / Then
+        XCTAssertThrowsSpecific(
+            try subject.loadMetadata(sdkName: sdkName, status: .required, platform: .iOS, source: .system),
+            SystemFrameworkMetadataProviderError.unsupportedSDK(name: "UIKit.xcframework")
+        )
+    }
+
+    func test_loadMetadata_developerSource_unsupportedPlatform() throws {
+        // Given
+        let sdkName = "XCTest.framework"
+        let source = SDKSource.developer
+        let platform = Platform.watchOS // watchOS doesn't support XCTest
+
+        // When / Then
+        XCTAssertThrowsSpecific(
+            try subject.loadMetadata(sdkName: sdkName, status: .required, platform: platform, source: source),
+            SystemFrameworkMetadataProviderError.unsupportedSDKForPlatform(name: "XCTest.framework", platform: .watchOS)
+        )
+    }
+
+    func test_loadMetadata_developerSource_supportedPlatform() throws {
+        // Given
+        let sdkName = "XCTest.framework"
+        let source = SDKSource.developer
+        let platform = Platform.iOS
+
+        // When
+        let metadata = try subject.loadMetadata(sdkName: sdkName, status: .required, platform: platform, source: source)
+
+        // Then
+        XCTAssertEqual(metadata, SystemFrameworkMetadata(
+            name: sdkName,
+            path: "/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework",
+            status: .required,
+            source: .developer
+        ))
+    }
+}

--- a/Tests/TuistCoreTests/MetadataProviders/XCFrameworkMetadataProviderTests.swift
+++ b/Tests/TuistCoreTests/MetadataProviders/XCFrameworkMetadataProviderTests.swift
@@ -74,4 +74,62 @@ final class XCFrameworkMetadataProviderTests: XCTestCase {
             frameworkPath.appending(RelativePath("ios-x86_64-simulator/libMyStaticLibrary.a"))
         )
     }
+
+    func test_loadMetadata_dynamicLibrary() throws {
+        // Given
+        let frameworkPath = fixturePath(path: RelativePath("MyFramework.xcframework"))
+
+        // When
+        let metadata = try subject.loadMetadata(at: frameworkPath)
+
+        // Then
+        let expectedInfoPlist = XCFrameworkInfoPlist(libraries: [
+            .init(
+                identifier: "ios-x86_64-simulator",
+                path: RelativePath("MyFramework.framework"),
+                architectures: [.x8664]
+            ),
+            .init(
+                identifier: "ios-arm64",
+                path: RelativePath("MyFramework.framework"),
+                architectures: [.arm64]
+            ),
+        ])
+        let expectedBinaryPath = frameworkPath.appending(RelativePath("ios-x86_64-simulator/MyFramework.framework/MyFramework"))
+        XCTAssertEqual(metadata, XCFrameworkMetadata(
+            path: frameworkPath,
+            infoPlist: expectedInfoPlist,
+            primaryBinaryPath: expectedBinaryPath,
+            linking: .dynamic
+        ))
+    }
+
+    func test_loadMetadata_staticLibrary() throws {
+        // Given
+        let frameworkPath = fixturePath(path: RelativePath("MyStaticLibrary.xcframework"))
+
+        // When
+        let metadata = try subject.loadMetadata(at: frameworkPath)
+
+        // Then
+        let expectedInfoPlist = XCFrameworkInfoPlist(libraries: [
+            .init(
+                identifier: "ios-x86_64-simulator",
+                path: RelativePath("libMyStaticLibrary.a"),
+                architectures: [.x8664]
+            ),
+            .init(
+                identifier: "ios-arm64",
+                path: RelativePath("libMyStaticLibrary.a"),
+                architectures: [.arm64]
+            ),
+        ])
+        let expectedBinaryPath = frameworkPath.appending(RelativePath("ios-x86_64-simulator/libMyStaticLibrary.a"))
+        XCTAssertEqual(metadata, XCFrameworkMetadata(
+            path: frameworkPath,
+            infoPlist: expectedInfoPlist,
+            primaryBinaryPath: expectedBinaryPath,
+            linking: .static
+        ))
+    }
 }

--- a/Tests/TuistCoreTests/ValueGraph/ValueGraphLoaderTests.swift
+++ b/Tests/TuistCoreTests/ValueGraph/ValueGraphLoaderTests.swift
@@ -1,0 +1,766 @@
+import Foundation
+import TSCBasic
+import TuistSupport
+import XCTest
+
+@testable import TuistCore
+@testable import TuistCoreTesting
+@testable import TuistSupportTesting
+
+final class ValueGraphLoaderTests: TuistUnitTestCase {
+    private var stubbedFrameworks = [AbsolutePath: PrecompiledMetadata]()
+    private var stubbedLibraries = [AbsolutePath: PrecompiledMetadata]()
+    private var stubbedXCFrameworks = [AbsolutePath: XCFrameworkMetadata]()
+    private var frameworkMetadataProvider: MockFrameworkMetadataProvider!
+    private var libraryMetadataProvider: MockLibraryMetadataProvider!
+    private var xcframeworkMetadataProvider: MockXCFrameworkMetadataProvider!
+
+    override func setUpWithError() throws {
+        frameworkMetadataProvider = makeFrameworkMetadataProvider()
+        libraryMetadataProvider = makeLibraryMetadataProvider()
+        xcframeworkMetadataProvider = makeXCFrameworkMetadataProvider()
+    }
+
+    // MARK: - Load Workspace
+
+    func test_loadWorkspace_unreferencedProjectsAreExcluded() throws {
+        // Given
+        let projectA = Project.test(path: "/A", name: "A", targets: [])
+        let projectB = Project.test(path: "/B", name: "B", targets: [])
+        let workspace = Workspace.test(path: "/", name: "Workspace", projects: ["/A"])
+        let subject = makeSubject()
+
+        // When
+        let graph = try subject.loadWorkspace(workspace: workspace, projects: [
+            projectA,
+            projectB,
+        ])
+
+        // Then
+        XCTAssertEqual(graph.workspace, workspace)
+        XCTAssertEqual(graph.projects, [
+            "/A": projectA,
+        ])
+        XCTAssertTrue(graph.targets.isEmpty)
+        XCTAssertTrue(graph.dependencies.isEmpty)
+    }
+
+    func test_loadWorkspace_unlinkedReferencedProjectsAreIncluded() throws {
+        // Given
+        let projectA = Project.test(path: "/A", name: "A", targets: [])
+        let projectB = Project.test(path: "/B", name: "B", targets: [])
+        let workspace = Workspace.test(path: "/", name: "Workspace", projects: ["/A", "/B"])
+        let subject = makeSubject()
+
+        // When
+        let graph = try subject.loadWorkspace(workspace: workspace, projects: [
+            projectA,
+            projectB,
+        ])
+
+        // Then
+        XCTAssertEqual(graph.workspace, workspace)
+        XCTAssertEqual(graph.projects, [
+            "/A": projectA,
+            "/B": projectB,
+        ])
+        XCTAssertTrue(graph.targets.isEmpty)
+        XCTAssertTrue(graph.dependencies.isEmpty)
+    }
+
+    func test_loadWorkspace_linkedReferencedProjectsAreIncluded() throws {
+        // Given
+        let targetA = Target.test(name: "A", dependencies: [.project(target: "B", path: "/B")])
+        let targetB = Target.test(name: "B", dependencies: [])
+        let projectA = Project.test(path: "/A", name: "A", targets: [targetA])
+        let projectB = Project.test(path: "/B", name: "B", targets: [targetB])
+        let workspace = Workspace.test(path: "/", name: "Workspace", projects: ["/A"])
+        let subject = makeSubject()
+
+        // When
+        let graph = try subject.loadWorkspace(workspace: workspace, projects: [
+            projectA,
+            projectB,
+        ])
+
+        // Then
+        XCTAssertEqual(graph.workspace, workspace.replacing(projects: ["/A", "/B"]))
+        XCTAssertEqual(graph.projects, [
+            "/A": projectA,
+            "/B": projectB,
+        ])
+        XCTAssertEqual(graph.targets, [
+            "/A": ["A": targetA],
+            "/B": ["B": targetB],
+        ])
+        XCTAssertEqual(graph.dependencies, [
+            .target(name: "A", path: "/A"): Set([
+                .target(name: "B", path: "/B"),
+            ]),
+        ])
+    }
+
+    // MARK: - Load Project
+
+    func test_loadProject_unlinkedProjectsAreExcluded() throws {
+        // Given
+        let projectA = Project.test(path: "/A", name: "A", targets: [])
+        let projectB = Project.test(path: "/B", name: "B", targets: [])
+        let subject = makeSubject()
+
+        // When
+        let (loadedProject, graph) = try subject.loadProject(at: "/A", projects: [
+            projectA,
+            projectB,
+        ])
+
+        // Then
+        XCTAssertEqual(loadedProject, projectA)
+        XCTAssertEqual(graph.projects, [
+            "/A": projectA,
+        ])
+        XCTAssertTrue(graph.targets.isEmpty)
+        XCTAssertTrue(graph.dependencies.isEmpty)
+    }
+
+    func test_loadProject_linkedProjectsAreIncluded() throws {
+        // Given
+        let targetA = Target.test(name: "A", dependencies: [.project(target: "B", path: "/B")])
+        let targetB = Target.test(name: "B", dependencies: [])
+        let projectA = Project.test(path: "/A", name: "A", targets: [targetA])
+        let projectB = Project.test(path: "/B", name: "B", targets: [targetB])
+        let subject = makeSubject()
+
+        // When
+        let (loadedProject, graph) = try subject.loadProject(at: "/A", projects: [
+            projectA,
+            projectB,
+        ])
+
+        // Then
+        XCTAssertEqual(loadedProject, projectA)
+        XCTAssertEqual(graph.projects, [
+            "/A": projectA,
+            "/B": projectB,
+        ])
+        XCTAssertEqual(graph.targets, [
+            "/A": ["A": targetA],
+            "/B": ["B": targetB],
+        ])
+        XCTAssertEqual(graph.dependencies, [
+            .target(name: "A", path: "/A"): Set([
+                .target(name: "B", path: "/B"),
+            ]),
+        ])
+    }
+
+    // MARK: - Frameworks
+
+    func test_loadWorkspace_frameworkDependency() throws {
+        // Given
+        let targetA = Target.test(name: "A", dependencies: [.framework(path: "/Frameworks/F1.framework")])
+        let targetB = Target.test(name: "B", dependencies: [.framework(path: "/Frameworks/F2.framework")])
+        let projectA = Project.test(path: "/A", name: "A", targets: [targetA])
+        let projectB = Project.test(path: "/B", name: "B", targets: [targetB])
+        let workspace = Workspace.test(path: "/", name: "Workspace", projects: ["/A", "/B"])
+
+        stubFramework(
+            metadata: .init(
+                path: "/Frameworks/F1.framework",
+                linkage: .dynamic,
+                architectures: [.arm64]
+            )
+        )
+        stubFramework(
+            metadata: .init(
+                path: "/Frameworks/F2.framework",
+                linkage: .static,
+                architectures: [.x8664]
+            )
+        )
+
+        let subject = makeSubject()
+
+        // When
+        let graph = try subject.loadWorkspace(workspace: workspace, projects: [
+            projectA,
+            projectB,
+        ])
+
+        // Then
+        XCTAssertEqual(graph.dependencies, [
+            .target(name: "A", path: "/A"): Set([
+                .framework(
+                    path: "/Frameworks/F1.framework",
+                    binaryPath: "/Frameworks/F1.framework/F1",
+                    dsymPath: nil,
+                    bcsymbolmapPaths: [],
+                    linking: .dynamic,
+                    architectures: [.arm64],
+                    isCarthage: false
+                ),
+            ]),
+            .target(name: "B", path: "/B"): Set([
+                .framework(
+                    path: "/Frameworks/F2.framework",
+                    binaryPath: "/Frameworks/F2.framework/F2",
+                    dsymPath: nil,
+                    bcsymbolmapPaths: [],
+                    linking: .static,
+                    architectures: [.x8664],
+                    isCarthage: false
+                ),
+            ]),
+        ])
+    }
+
+    func test_loadWorkspace_frameworkDependencyReferencedMultipleTimes() throws {
+        // Given
+        let targetA = Target.test(name: "A", dependencies: [.framework(path: "/Frameworks/F.framework")])
+        let targetB = Target.test(name: "B", dependencies: [.framework(path: "/Frameworks/F.framework")])
+        let projectA = Project.test(path: "/A", name: "A", targets: [targetA])
+        let projectB = Project.test(path: "/B", name: "B", targets: [targetB])
+        let workspace = Workspace.test(path: "/", name: "Workspace", projects: ["/A", "/B"])
+
+        stubFramework(
+            metadata: .init(
+                path: "/Frameworks/F.framework",
+                linkage: .dynamic,
+                architectures: [.arm64]
+            )
+        )
+
+        let subject = makeSubject()
+
+        // When
+        let graph = try subject.loadWorkspace(workspace: workspace, projects: [
+            projectA,
+            projectB,
+        ])
+
+        // Then
+        let frameworkDependency: ValueGraphDependency = .framework(
+            path: "/Frameworks/F.framework",
+            binaryPath: "/Frameworks/F.framework/F",
+            dsymPath: nil,
+            bcsymbolmapPaths: [],
+            linking: .dynamic,
+            architectures: [.arm64],
+            isCarthage: false
+        )
+        XCTAssertEqual(graph.dependencies, [
+            .target(name: "A", path: "/A"): Set([
+                frameworkDependency,
+            ]),
+            .target(name: "B", path: "/B"): Set([
+                frameworkDependency,
+            ]),
+        ])
+    }
+
+    // MARK: - Libraries
+
+    func test_loadWorkspace_libraryDependency() throws {
+        // Given
+        let targetA = Target.test(name: "A", dependencies: [
+            .library(path: "/libs/lib1/libL1.dylib", publicHeaders: "/libs/lib1/include", swiftModuleMap: nil),
+        ])
+        let targetB = Target.test(name: "B", dependencies: [
+            .library(
+                path: "/libs/lib2/libL2.a",
+                publicHeaders: "/libs/lib2/include",
+                swiftModuleMap: "/libs/lib2.swiftmodule"
+            ),
+        ])
+        let projectA = Project.test(path: "/A", name: "A", targets: [targetA])
+        let projectB = Project.test(path: "/B", name: "B", targets: [targetB])
+        let workspace = Workspace.test(path: "/", name: "Workspace", projects: ["/A", "/B"])
+
+        stubLibrary(
+            metadata: .init(
+                path: "/libs/lib1/libL1.dylib",
+                linkage: .dynamic,
+                architectures: [.arm64]
+            )
+        )
+        stubLibrary(
+            metadata: .init(
+                path: "/libs/lib2/libL2.a",
+                linkage: .static,
+                architectures: [.x8664]
+            )
+        )
+
+        let subject = makeSubject()
+
+        // When
+        let graph = try subject.loadWorkspace(workspace: workspace, projects: [
+            projectA,
+            projectB,
+        ])
+
+        // Then
+        XCTAssertEqual(graph.dependencies, [
+            .target(name: "A", path: "/A"): Set([
+                .library(
+                    path: "/libs/lib1/libL1.dylib",
+                    publicHeaders: "/libs/lib1/include",
+                    linking: .dynamic,
+                    architectures: [.arm64],
+                    swiftModuleMap: nil
+                ),
+            ]),
+            .target(name: "B", path: "/B"): Set([
+                .library(
+                    path: "/libs/lib2/libL2.a",
+                    publicHeaders: "/libs/lib2/include",
+                    linking: .static,
+                    architectures: [.x8664],
+                    swiftModuleMap: "/libs/lib2.swiftmodule"
+                ),
+            ]),
+        ])
+    }
+
+    // MARK: - XCFrameworks
+
+    func test_loadWorkspace_xcframeworkDependency() throws {
+        // Given
+        let targetA = Target.test(name: "A", dependencies: [.xcFramework(path: "/XCFrameworks/XF1.xcframework")])
+        let projectA = Project.test(path: "/A", name: "A", targets: [targetA])
+        let workspace = Workspace.test(path: "/", name: "Workspace", projects: ["/A"])
+
+        stubXCFramework(
+            metadata: .init(
+                path: "/XCFrameworks/XF1.xcframework",
+                infoPlist: .test(),
+                primaryBinaryPath: "/XCFrameworks/XF1.xcframework/ios-arm64/XF1",
+                linking: .dynamic
+            )
+        )
+
+        let subject = makeSubject()
+
+        // When
+        let graph = try subject.loadWorkspace(workspace: workspace, projects: [
+            projectA,
+        ])
+
+        // Then
+        XCTAssertEqual(graph.dependencies, [
+            .target(name: "A", path: "/A"): Set([
+                .xcframework(
+                    path: "/XCFrameworks/XF1.xcframework",
+                    infoPlist: .test(),
+                    primaryBinaryPath: "/XCFrameworks/XF1.xcframework/ios-arm64/XF1",
+                    linking: .dynamic
+                ),
+            ]),
+        ])
+    }
+
+    // MARK: - SDKs
+
+    func test_loadWorkspace_sdkDependency() throws {
+        // Given
+        let targetA = Target.test(name: "A", dependencies: [.sdk(name: "libc++.tbd", status: .required)])
+        let targetB = Target.test(name: "B", dependencies: [.sdk(name: "SwiftUI.framework", status: .optional)])
+        let targetC = Target.test(name: "C", dependencies: [.xctest])
+        let projectA = Project.test(path: "/A", name: "A", targets: [targetA, targetB, targetC])
+        let workspace = Workspace.test(path: "/", name: "Workspace", projects: ["/A"])
+        let subject = makeSubject()
+
+        // When
+        let graph = try subject.loadWorkspace(workspace: workspace, projects: [
+            projectA,
+        ])
+
+        // Then
+        XCTAssertEqual(graph.dependencies, [
+            .target(name: "A", path: "/A"): Set([
+                .sdk(
+                    name: "libc++.tbd",
+                    path: "/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib/libc++.tbd",
+                    status: .required,
+                    source: .system
+                ),
+            ]),
+            .target(name: "B", path: "/A"): Set([
+                .sdk(
+                    name: "SwiftUI.framework",
+                    path: "/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/SwiftUI.framework",
+                    status: .optional,
+                    source: .system
+                ),
+            ]),
+            .target(name: "C", path: "/A"): Set([
+                .sdk(
+                    name: "XCTest.framework",
+                    path: "/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework",
+                    status: .required,
+                    source: .developer
+                ),
+            ]),
+        ])
+    }
+
+    // MARK: - Packages
+
+    func test_loadWorkspace_packages() throws {
+        // Given
+        let targetA = Target.test(name: "A", dependencies: [
+            .package(product: "PackageLibraryA1"),
+        ])
+        let targetB = Target.test(name: "B", dependencies: [
+            .package(product: "PackageLibraryA2"),
+        ])
+        let targetC = Target.test(name: "C", dependencies: [
+            .package(product: "PackageLibraryB"),
+        ])
+        let projectA = Project.test(path: "/A", name: "A", targets: [targetA], packages: [
+            .local(path: "/Packages/PackageLibraryA"),
+        ])
+        let projectB = Project.test(path: "/B", name: "B", targets: [targetB], packages: [
+            .local(path: "/Packages/PackageLibraryA"),
+        ])
+        let projectC = Project.test(path: "/C", name: "C", targets: [targetC], packages: [
+            .remote(url: "https://example.com/package-library-b", requirement: .branch("testing")),
+        ])
+        let workspace = Workspace.test(path: "/", name: "Workspace", projects: ["/A", "/B", "/C"])
+
+        let subject = makeSubject()
+
+        // When
+        let graph = try subject.loadWorkspace(workspace: workspace, projects: [
+            projectA,
+            projectB,
+            projectC,
+        ])
+
+        // Then
+
+        // Note: the following is a reflection of the current implementation
+        // which has a few limitation / bugs when it comes to identifying the same
+        // package referenced by multiple projects/
+        XCTAssertEqual(graph.packages, [
+            "/A": ["/Packages/PackageLibraryA": .local(path: "/Packages/PackageLibraryA")],
+            "/B": ["/Packages/PackageLibraryA": .local(path: "/Packages/PackageLibraryA")],
+            "/C": ["https://example.com/package-library-b": .remote(url: "https://example.com/package-library-b", requirement: .branch("testing"))],
+        ])
+        XCTAssertEqual(graph.dependencies, [
+            .target(name: "A", path: "/A"): Set([
+                .packageProduct(path: "/A", product: "PackageLibraryA1"),
+            ]),
+            .target(name: "B", path: "/B"): Set([
+                .packageProduct(path: "/B", product: "PackageLibraryA2"),
+            ]),
+            .target(name: "C", path: "/C"): Set([
+                .packageProduct(path: "/C", product: "PackageLibraryB"),
+            ]),
+        ])
+    }
+
+    // MARK: - Dependency Cycle
+
+    func test_loadProject_localDependencyCycle() throws {
+        // Given
+        let targetA = Target.test(name: "A", dependencies: [.target(name: "B")])
+        let targetB = Target.test(name: "B", dependencies: [.target(name: "C")])
+        let targetC = Target.test(name: "C", dependencies: [.target(name: "A")])
+        let project = Project.test(path: "/A", name: "A", targets: [targetA, targetB, targetC])
+        let subject = makeSubject()
+
+        // When / Then
+        XCTAssertThrowsSpecific(
+            try subject.loadProject(at: "/A", projects: [
+                project,
+            ]),
+            GraphLoadingError.circularDependency([
+                .init(path: "/A", name: "A"),
+                .init(path: "/A", name: "B"),
+                .init(path: "/A", name: "C"),
+            ])
+        )
+    }
+
+    func test_loadProject_differentProjectDependencyCycle() throws {
+        // Given
+        let targetA = Target.test(name: "A", dependencies: [.project(target: "B", path: "/B")])
+        let targetB = Target.test(name: "B", dependencies: [.project(target: "C", path: "/C")])
+        let targetC = Target.test(name: "C", dependencies: [.project(target: "A", path: "/A")])
+        let projectA = Project.test(path: "/A", name: "A", targets: [targetA])
+        let projectB = Project.test(path: "/B", name: "B", targets: [targetB])
+        let projectC = Project.test(path: "/C", name: "C", targets: [targetC])
+        let subject = makeSubject()
+
+        // When / Then
+        XCTAssertThrowsSpecific(
+            try subject.loadProject(at: "/A", projects: [
+                projectA,
+                projectB,
+                projectC,
+            ]),
+            GraphLoadingError.circularDependency([
+                .init(path: "/A", name: "A"),
+                .init(path: "/B", name: "B"),
+                .init(path: "/C", name: "C"),
+            ])
+        )
+    }
+
+    func test_loadWorkspace_differentProjectDependencyCycle() throws {
+        // Given
+        let targetA = Target.test(name: "A", dependencies: [.project(target: "B", path: "/B")])
+        let targetB = Target.test(name: "B", dependencies: [.project(target: "C", path: "/C")])
+        let targetC = Target.test(name: "C", dependencies: [.project(target: "A", path: "/A")])
+        let projectA = Project.test(path: "/A", name: "A", targets: [targetA])
+        let projectB = Project.test(path: "/B", name: "B", targets: [targetB])
+        let projectC = Project.test(path: "/C", name: "C", targets: [targetC])
+        let workspace = Workspace.test(path: "/", name: "Workspace", projects: ["/A", "/B", "/C"])
+        let subject = makeSubject()
+
+        // When / Then
+        XCTAssertThrowsSpecific(
+            try subject.loadWorkspace(workspace: workspace, projects: [
+                projectA,
+                projectB,
+                projectC,
+            ]),
+            GraphLoadingError.circularDependency([
+                .init(path: "/A", name: "A"),
+                .init(path: "/B", name: "B"),
+                .init(path: "/C", name: "C"),
+            ])
+        )
+    }
+
+    func test_loadProject_crossProjectsReferenceWithNoDependencyCycle() throws {
+        // Given
+        let targetA1 = Target.test(name: "A1", dependencies: [.project(target: "B1", path: "/B")])
+        let targetA2 = Target.test(name: "A2", dependencies: [.project(target: "B2", path: "/B")])
+        let targetB1 = Target.test(name: "B1", dependencies: [.project(target: "C", path: "/C")])
+        let targetB2 = Target.test(name: "B2", dependencies: [])
+        let targetC = Target.test(name: "C", dependencies: [.project(target: "A2", path: "/A")])
+        let projectA = Project.test(path: "/A", name: "A", targets: [targetA1, targetA2])
+        let projectB = Project.test(path: "/B", name: "B", targets: [targetB1, targetB2])
+        let projectC = Project.test(path: "/C", name: "C", targets: [targetC])
+        let subject = makeSubject()
+
+        // When / Then
+        XCTAssertNoThrow(
+            try subject.loadProject(at: "/A", projects: [
+                projectA,
+                projectB,
+                projectC,
+            ])
+        )
+    }
+
+    func test_loadWorkspace_crossProjectsReferenceWithNoDependencyCycle() throws {
+        // Given
+        let targetA1 = Target.test(name: "A1", dependencies: [.project(target: "B1", path: "/B")])
+        let targetA2 = Target.test(name: "A2", dependencies: [.project(target: "B2", path: "/B")])
+        let targetB1 = Target.test(name: "B1", dependencies: [.project(target: "C", path: "/C")])
+        let targetB2 = Target.test(name: "B2", dependencies: [])
+        let targetC = Target.test(name: "C", dependencies: [.project(target: "A2", path: "/A")])
+        let projectA = Project.test(path: "/A", name: "A", targets: [targetA1, targetA2])
+        let projectB = Project.test(path: "/B", name: "B", targets: [targetB1, targetB2])
+        let projectC = Project.test(path: "/C", name: "C", targets: [targetC])
+        let workspace = Workspace.test(path: "/", name: "Workspace", projects: ["/A", "/B", "/C"])
+        let subject = makeSubject()
+
+        // When / Then
+        XCTAssertNoThrow(
+            try subject.loadWorkspace(workspace: workspace, projects: [
+                projectA,
+                projectB,
+                projectC,
+            ])
+        )
+    }
+
+    func test_loadWorkspace_crossProjectsReferenceWithDependencyCycle() throws {
+        // Given
+        let targetA1 = Target.test(name: "A1", dependencies: [.project(target: "B1", path: "/B")])
+        let targetA2 = Target.test(name: "A2", dependencies: [.project(target: "B2", path: "/B")])
+        let targetB1 = Target.test(name: "B1", dependencies: [.project(target: "C1", path: "/C")])
+        let targetB2 = Target.test(name: "B2", dependencies: [.project(target: "C2", path: "/C")])
+        let targetC1 = Target.test(name: "C1", dependencies: [.project(target: "A2", path: "/A")])
+        let targetC2 = Target.test(name: "C2", dependencies: [.project(target: "B1", path: "/B")])
+        let projectA = Project.test(path: "/A", name: "A", targets: [targetA1, targetA2])
+        let projectB = Project.test(path: "/B", name: "B", targets: [targetB1, targetB2])
+        let projectC = Project.test(path: "/C", name: "C", targets: [targetC1, targetC2])
+        let workspace = Workspace.test(path: "/", name: "Workspace", projects: ["/A", "/B", "/C"])
+        let subject = makeSubject()
+
+        // When / Then
+        XCTAssertThrowsError(
+            try subject.loadWorkspace(workspace: workspace, projects: [
+                projectA,
+                projectB,
+                projectC,
+            ])
+        ) { error in
+            // need to manually inspect the error as depending on traversal order may result in different nodes getting listed
+            let graphError = error as? GraphLoadingError
+            XCTAssertNotNil(graphError)
+            XCTAssertTrue(graphError?.isCycleError == true)
+        }
+    }
+
+    // MARK: - Error Cases
+
+    func test_loadWorkspace_missingProjectReferenceInWorkspace() throws {
+        // Given
+        let projectA = Project.test(path: "/A", name: "A", targets: [])
+        let workspace = Workspace.test(path: "/", name: "Workspace", projects: ["/A", "/Missing"])
+        let subject = makeSubject()
+
+        // When / Then
+        XCTAssertThrowsSpecific(
+            try subject.loadWorkspace(workspace: workspace, projects: [
+                projectA,
+            ]),
+            GraphLoadingError.missingProject("/Missing")
+        )
+    }
+
+    func test_loadWorkspace_missingProjectReferenceInDependency() throws {
+        // Given
+        let targetA = Target.test(name: "A", dependencies: [.project(target: "Missing", path: "/Missing")])
+        let projectA = Project.test(path: "/A", name: "A", targets: [targetA])
+        let workspace = Workspace.test(path: "/", name: "Workspace", projects: ["/A"])
+        let subject = makeSubject()
+
+        // When / Then
+        XCTAssertThrowsSpecific(
+            try subject.loadWorkspace(workspace: workspace, projects: [
+                projectA,
+            ]),
+            GraphLoadingError.missingProject("/Missing")
+        )
+    }
+
+    func test_loadWorkspace_missingTargetReferenceInLocalProject() throws {
+        // Given
+        let targetA = Target.test(name: "A", dependencies: [.target(name: "Missing")])
+        let projectA = Project.test(path: "/A", name: "A", targets: [targetA])
+        let workspace = Workspace.test(path: "/", name: "Workspace", projects: ["/A"])
+        let subject = makeSubject()
+
+        // When / Then
+        XCTAssertThrowsSpecific(
+            try subject.loadWorkspace(workspace: workspace, projects: [
+                projectA,
+            ]),
+            GraphLoadingError.targetNotFound("Missing", "/A")
+        )
+    }
+
+    func test_loadWorkspace_missingTargetReferenceInOtherProject() throws {
+        // Given
+        let targetA = Target.test(name: "A", dependencies: [.project(target: "Missing", path: "/B")])
+        let projectA = Project.test(path: "/A", name: "A", targets: [targetA])
+        let projectB = Project.test(path: "/B", name: "B", targets: [])
+        let workspace = Workspace.test(path: "/", name: "Workspace", projects: ["/A", "/B"])
+        let subject = makeSubject()
+
+        // When / Then
+        XCTAssertThrowsSpecific(
+            try subject.loadWorkspace(workspace: workspace, projects: [
+                projectA,
+                projectB,
+            ]),
+            GraphLoadingError.targetNotFound("Missing", "/B")
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func makeSubject() -> ValueGraphLoader {
+        ValueGraphLoader(
+            frameworkMetadataProvider: frameworkMetadataProvider,
+            libraryMetadataProvider: libraryMetadataProvider,
+            xcframeworkMetadataProvider: xcframeworkMetadataProvider,
+            systemFrameworkMetadataProvider: SystemFrameworkMetadataProvider()
+        )
+    }
+
+    private func makeFrameworkMetadataProvider() -> MockFrameworkMetadataProvider {
+        let provider = MockFrameworkMetadataProvider()
+        provider.loadMetadataStub = { [weak self] path in
+            guard let metadata = self?.stubbedFrameworks[path] else {
+                throw FrameworkMetadataProviderError.frameworkNotFound(path)
+            }
+            return FrameworkMetadata(
+                path: path,
+                binaryPath: path.appending(component: path.basenameWithoutExt),
+                dsymPath: nil,
+                bcsymbolmapPaths: [],
+                linking: metadata.linkage,
+                architectures: metadata.architectures,
+                isCarthage: false
+            )
+        }
+        return provider
+    }
+
+    private func makeLibraryMetadataProvider() -> MockLibraryMetadataProvider {
+        let provider = MockLibraryMetadataProvider()
+        provider.loadMetadataStub = { [weak self] path, publicHeaders, swiftModuleMap in
+            guard let metadata = self?.stubbedLibraries[path] else {
+                throw LibraryMetadataProviderError.libraryNotFound(path)
+            }
+            return LibraryMetadata(
+                path: path,
+                publicHeaders: publicHeaders,
+                swiftModuleMap: swiftModuleMap,
+                architectures: metadata.architectures,
+                linking: metadata.linkage
+            )
+        }
+        return provider
+    }
+
+    private func makeXCFrameworkMetadataProvider() -> MockXCFrameworkMetadataProvider {
+        let provider = MockXCFrameworkMetadataProvider()
+        provider.loadMetadataStub = { [weak self] path in
+            guard let metadata = self?.stubbedXCFrameworks[path] else {
+                throw XCFrameworkMetadataProviderError.xcframeworkNotFound(path)
+            }
+            return metadata
+        }
+        return provider
+    }
+
+    private func stubFramework(metadata: PrecompiledMetadata) {
+        stubbedFrameworks[metadata.path] = metadata
+    }
+
+    private func stubLibrary(metadata: PrecompiledMetadata) {
+        stubbedLibraries[metadata.path] = metadata
+    }
+
+    private func stubXCFramework(metadata: XCFrameworkMetadata) {
+        stubbedXCFrameworks[metadata.path] = metadata
+    }
+
+    // MARK: - Helper types
+
+    private struct PrecompiledMetadata {
+        var path: AbsolutePath
+        var linkage: BinaryLinking
+        var architectures: [BinaryArchitecture]
+    }
+}
+
+private extension GraphLoadingError {
+    var isCycleError: Bool {
+        switch self {
+        case .circularDependency:
+            return true
+        default:
+            return false
+        }
+    }
+}


### PR DESCRIPTION
### Short description 📝

@pepibumur has been working on replacing the reference graph (`Graph`) with value based graph (`ValueGraph`). As part of this effort, one of the components needed for this migration is a dedicated loader than can load and convert models to the `ValueGraph` directly.

### Solution 📦

- Add a new dedicated `ValueGraphLoader`

### Implementation 👩‍💻👨‍💻

- [x] Adding a new loader that can load and convert models to a `ValueGraph`
- [x] Update metadata loaders to allow loading metadata needed for external dependencies in one go (equivalent to the graph node loaders)
- [x] Add a new metadata provider for system frameworks (hosts the logic that used to be part of the deprecated SDKNode)

### Test Plan 🛠

- Verify unit tests pass

### Notes  📝

- To ease reviews, this PR only introduces the new component alongside its tests without integrating it, that will be done in a separate PR.
- The previous `GraphLoader` needed a separate component called a `ModelLoader` to load the individual models - this is no longer needed as the generation pipeline has evolved since that was first introduced. All models are now loaded concurrently upfront as such by the time we come to loading the graph we already have all the models available. (see [Generation Pipeline](https://tuist.io/docs/contribution/generation-pipeline/#pipeline) for reference)
