### PR TITLE
Fix an issue that caused the generation to fail when the resources glob includes a bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Fix "Embed Frameworks" build phase parameters [#2156](https://github.com/tuist/tuist/pull/2156) by [@kwridan](https://github.com/kwridan).
 - Adjust the project generated for editing to not build for the arm64 architecture [#2154](https://github.com/tuist/tuist/pull/2154) by [@pepibumur](https://github.com/pepibumur).
+- Project generation failing when the resources glob includes a bundle [#2183](https://github.com/tuist/tuist/pull/2183) by [@pepibumur](https://github.com/pepibumur).
 
 ### Added
 

--- a/Sources/TuistCore/Models/FileElement.swift
+++ b/Sources/TuistCore/Models/FileElement.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public enum FileElement: Equatable {
+public enum FileElement: Equatable, Hashable {
     case file(path: AbsolutePath)
     case folderReference(path: AbsolutePath)
 

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
@@ -189,7 +189,8 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         // Generated Project
         XCTAssertEqual(project.path, sourceRootPath)
         XCTAssertEqual(project.name, "Manifests")
-        XCTAssertEqual(project.settings, Settings(base: [:],
+        XCTAssertEqual(project.settings, Settings(base: ["ONLY_ACTIVE_ARCH": "NO",
+                                                         "EXCLUDED_ARCHS": "arm64"],
                                                   configurations: Settings.default.configurations,
                                                   defaultSettings: .recommended))
         XCTAssertEqual(project.filesGroup, .group(name: "Manifests"))
@@ -295,7 +296,8 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         // Generated Project
         XCTAssertEqual(project.path, sourceRootPath)
         XCTAssertEqual(project.name, "Manifests")
-        XCTAssertEqual(project.settings, Settings(base: [:],
+        XCTAssertEqual(project.settings, Settings(base: ["ONLY_ACTIVE_ARCH": "NO",
+                                                         "EXCLUDED_ARCHS": "arm64"],
                                                   configurations: Settings.default.configurations,
                                                   defaultSettings: .recommended))
         XCTAssertEqual(project.filesGroup, .group(name: "Manifests"))


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/539

### Short description 📝

As @asalom reported [here](https://github.com/tuist/tuist/issues/539) andn @jsorge confirmed recently, when a resources glob includes a bundle, the generation of projects fails. That's because we try to add the files that are part of the bundle, to the resources build phase of the target. That's not right because we should add the bundle instead.

### Solution 📦
Like we recently did with Playgrounds, I'm filtering out the files contained inside a `.bundle` when mapping the `Target. 