### PR TITLE
Add support for embedded scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Added
+
+- Add support for embedded scripts in a TargetAction. [#2192](https://github.com/tuist/tuist/pull/2192) by [@jsorge](https://github.com/jsorge)
+
 ### Fixed
 
 - Fix import of multiple signing certificates [#2112](https://github.com/tuist/tuist/pull/2112) by [@rist](https://github.com/rist).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 - Fourier CLI tool to automate development tasks [#2196](https://github.com/tuist/tuist/pull/2196) by @pepibumur](https://github.com/pepibumur).
+- Add support for embedded scripts in a TargetAction. [#2192](https://github.com/tuist/tuist/pull/2192) by [@jsorge]
 - Support `.s` source files [#2199](https://github.com/tuist/tuist/pull/2199) by[ @dcvz](https://github.com/dcvz).
 
 ## 1.29.0 - Tutu

--- a/Sources/ProjectDescription/TargetAction.swift
+++ b/Sources/ProjectDescription/TargetAction.swift
@@ -85,7 +85,7 @@ public struct TargetAction: Codable, Equatable {
         self.tool = tool
         self.path = path
         self.arguments = arguments
-        self.embeddedScript = nil
+        embeddedScript = nil
         self.order = order
         self.inputPaths = inputPaths
         self.inputFileListPaths = inputFileListPaths
@@ -115,10 +115,10 @@ public struct TargetAction: Codable, Equatable {
          basedOnDependencyAnalysis: Bool? = nil)
     {
         self.name = name
-        self.embeddedScript = script
-        self.tool = nil
-        self.path = nil
-        self.arguments = []
+        embeddedScript = script
+        tool = nil
+        path = nil
+        arguments = []
         self.order = order
         self.inputPaths = inputPaths
         self.inputFileListPaths = inputFileListPaths
@@ -463,9 +463,9 @@ public struct TargetAction: Codable, Equatable {
         outputFileListPaths = try container.decodeIfPresent([Path].self, forKey: .outputFileListPaths) ?? []
         basedOnDependencyAnalysis = try container.decodeIfPresent(Bool.self, forKey: .basedOnDependencyAnalysis)
 
-        self.arguments = try container.decodeIfPresent([String].self, forKey: .arguments) ?? []
+        arguments = try container.decodeIfPresent([String].self, forKey: .arguments) ?? []
         if let script = try container.decodeIfPresent(String.self, forKey: .script) {
-            self.embeddedScript = script
+            embeddedScript = script
             tool = nil
             path = nil
         } else if let path = try container.decodeIfPresent(Path.self, forKey: .path) {
@@ -474,7 +474,7 @@ public struct TargetAction: Codable, Equatable {
             tool = nil
         } else {
             embeddedScript = nil
-            self.path = nil
+            path = nil
             tool = try container.decode(String.self, forKey: .tool)
         }
     }

--- a/Sources/TuistCore/Models/TargetAction.swift
+++ b/Sources/TuistCore/Models/TargetAction.swift
@@ -13,20 +13,62 @@ public struct TargetAction: Equatable {
         case post
     }
 
+    /// How to execute the target action
+    ///
+    /// - file: Executes the tool, calling the script at the path. Tuist will look up the tool on the environment's PATH
+    /// - text: Executes the entered script. This should be a short command.
+    private enum Script: Equatable {
+        case file(_ tool: String?, _ path: AbsolutePath?, _ args: [String])
+        case text(String)
+    }
+
     /// Name of the build phase when the project gets generated
     public let name: String
 
-    /// Name of the tool to execute. Tuist will look up the tool on the environment's PATH
-    public let tool: String?
+    /// The script to execute in the action
+    private let script: Script
+
+    public var isEmbeddedScript: Bool {
+        switch self.script {
+        case .file:
+            return false
+        case .text:
+            return true
+        }
+    }
+
+    /// Name of the tool to execute.
+    public var tool: String? {
+        switch script {
+        case .file(let tool, _, _):
+            return tool
+        case .text:
+            return nil
+        }
+    }
 
     /// Path to the script to execute
-    public let path: AbsolutePath?
+    public var path: AbsolutePath? {
+        switch script {
+        case .file(_, let path, _):
+            return path
+        case .text:
+            return nil
+        }
+    }
 
     /// Target action order
     public let order: Order
 
     /// Arguments that to be passed
-    public let arguments: [String]
+    public var arguments: [String] {
+        switch script {
+        case .file(_, _, let args):
+            return args
+        case .text:
+            return []
+        }
+    }
 
     /// List of input file paths
     public let inputPaths: [AbsolutePath]
@@ -74,9 +116,40 @@ public struct TargetAction: Equatable {
     {
         self.name = name
         self.order = order
-        self.tool = tool
-        self.path = path
-        self.arguments = arguments
+        self.script = .file(tool, path, arguments)
+        self.inputPaths = inputPaths
+        self.inputFileListPaths = inputFileListPaths
+        self.outputPaths = outputPaths
+        self.outputFileListPaths = outputFileListPaths
+        self.showEnvVarsInLog = showEnvVarsInLog
+        self.basedOnDependencyAnalysis = basedOnDependencyAnalysis
+    }
+
+    /// Initializes a new target action with its attributes.
+    ///
+    /// - Parameters:
+    ///   - name: Name of the build phase when the project gets generated
+    ///   - order: Target action order
+    ///   - script: The text of the script to run. This should be kept small.
+    ///   - inputPaths: List of input file paths
+    ///   - inputFileListPaths: List of input filelist paths
+    ///   - outputPaths: List of output file paths
+    ///   - outputFileListPaths: List of output filelist paths
+    ///   - showEnvVarsInLog: Show environment variables in the logs
+    ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+    public init(name: String,
+                order: Order,
+                script: String,
+                inputPaths: [AbsolutePath] = [],
+                inputFileListPaths: [AbsolutePath] = [],
+                outputPaths: [AbsolutePath] = [],
+                outputFileListPaths: [AbsolutePath] = [],
+                showEnvVarsInLog: Bool = true,
+                basedOnDependencyAnalysis: Bool? = nil)
+    {
+        self.name = name
+        self.order = order
+        self.script = .text(script)
         self.inputPaths = inputPaths
         self.inputFileListPaths = inputFileListPaths
         self.outputPaths = outputPaths
@@ -92,7 +165,9 @@ public struct TargetAction: Equatable {
     /// - Returns: Shell script that should be used in the target build phase.
     /// - Throws: An error if the tool absolute path cannot be obtained.
     public func shellScript(sourceRootPath: AbsolutePath) throws -> String {
-        if let path = path {
+        if case let Script.text(text) = script {
+            return text
+        } else if let path = path {
             return "\"${PROJECT_DIR}\"/\(path.relative(to: sourceRootPath).pathString) \(arguments.joined(separator: " "))"
         } else {
             return try "\(System.shared.which(tool!).spm_chomp().spm_chuzzle()!) \(arguments.joined(separator: " "))"

--- a/Sources/TuistCore/Models/TargetAction.swift
+++ b/Sources/TuistCore/Models/TargetAction.swift
@@ -30,7 +30,7 @@ public struct TargetAction: Equatable {
 
     /// The text of the embedded script
     public var embeddedScript: String? {
-        if case Script.embedded(let embeddedScript) = self.script {
+        if case let Script.embedded(embeddedScript) = script {
             return embeddedScript
         }
 
@@ -39,7 +39,7 @@ public struct TargetAction: Equatable {
 
     /// Name of the tool to execute. Tuist will look up the tool on the environment's PATH.
     public var tool: String? {
-        if case Script.externalFile(let tool, _, _) = self.script {
+        if case let Script.externalFile(tool, _, _) = script {
             return tool
         }
 
@@ -48,7 +48,7 @@ public struct TargetAction: Equatable {
 
     /// Path to the script to execute.
     public var path: AbsolutePath? {
-        if case Script.externalFile(_, let path, _) = self.script {
+        if case let Script.externalFile(_, path, _) = script {
             return path
         }
 
@@ -60,7 +60,7 @@ public struct TargetAction: Equatable {
 
     /// Arguments that to be passed
     public var arguments: [String] {
-        if case Script.externalFile(_, _, let args) = self.script {
+        if case let Script.externalFile(_, _, args) = script {
             return args
         }
 
@@ -113,7 +113,7 @@ public struct TargetAction: Equatable {
     {
         self.name = name
         self.order = order
-        self.script = .externalFile(tool, path, arguments)
+        script = .externalFile(tool, path, arguments)
         self.inputPaths = inputPaths
         self.inputFileListPaths = inputFileListPaths
         self.outputPaths = outputPaths
@@ -163,10 +163,10 @@ public struct TargetAction: Equatable {
     /// - Throws: An error if the tool absolute path cannot be obtained.
     public func shellScript(sourceRootPath: AbsolutePath) throws -> String {
         switch script {
-        case .embedded(let text):
+        case let .embedded(text):
             return text.spm_chomp().spm_chuzzle() ?? ""
 
-        case .externalFile(let tool, let path, let args):
+        case let .externalFile(tool, path, args):
             if let path = path {
                 return "\"${PROJECT_DIR}\"/\(path.relative(to: sourceRootPath).pathString) \(args.joined(separator: " "))"
             } else {

--- a/Sources/TuistGenerator/Linter/TargetActionLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetActionLinter.swift
@@ -13,8 +13,6 @@ protocol TargetActionLinting {
 
 class TargetActionLinter: TargetActionLinting {
     func lint(_ action: TargetAction) -> [LintingIssue] {
-        guard !action.isEmbeddedScript else { return [] }
-
         var issues: [LintingIssue] = []
         issues.append(contentsOf: lintToolExistence(action))
         issues.append(contentsOf: lintPathExistence(action))
@@ -25,9 +23,8 @@ class TargetActionLinter: TargetActionLinting {
     ///
     /// - Parameter action: Action to be linted.
     /// - Returns: Found linting issues.
-    func lintToolExistence(_ action: TargetAction) -> [LintingIssue] {
+    private func lintToolExistence(_ action: TargetAction) -> [LintingIssue] {
         guard
-            !action.isEmbeddedScript,
             let tool = action.tool
         else { return [] }
         do {
@@ -39,9 +36,8 @@ class TargetActionLinter: TargetActionLinting {
         }
     }
 
-    func lintPathExistence(_ action: TargetAction) -> [LintingIssue] {
+    private func lintPathExistence(_ action: TargetAction) -> [LintingIssue] {
         guard
-            !action.isEmbeddedScript,
             let path = action.path,
             !FileHandler.shared.exists(path)
         else { return [] }

--- a/Sources/TuistGenerator/Linter/TargetActionLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetActionLinter.swift
@@ -14,11 +14,22 @@ protocol TargetActionLinting {
 class TargetActionLinter: TargetActionLinting {
     func lint(_ action: TargetAction) -> [LintingIssue] {
         var issues: [LintingIssue] = []
+        issues.append(contentsOf: lintEmbeddedScriptNotEmpty(action))
         issues.append(contentsOf: lintToolExistence(action))
         issues.append(contentsOf: lintPathExistence(action))
         return issues
     }
 
+    private func lintEmbeddedScriptNotEmpty(_ action: TargetAction) -> [LintingIssue] {
+        guard let script = action.embeddedScript,
+              script.isEmpty
+        else { return [] }
+
+        return [
+            LintingIssue(reason: "The embedded script is empty", severity: .warning)
+        ]
+    }
+    
     /// Lints a target aciton.
     ///
     /// - Parameter action: Action to be linted.

--- a/Sources/TuistGenerator/Linter/TargetActionLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetActionLinter.swift
@@ -13,6 +13,8 @@ protocol TargetActionLinting {
 
 class TargetActionLinter: TargetActionLinting {
     func lint(_ action: TargetAction) -> [LintingIssue] {
+        guard !action.isEmbeddedScript else { return [] }
+
         var issues: [LintingIssue] = []
         issues.append(contentsOf: lintToolExistence(action))
         issues.append(contentsOf: lintPathExistence(action))
@@ -24,7 +26,10 @@ class TargetActionLinter: TargetActionLinting {
     /// - Parameter action: Action to be linted.
     /// - Returns: Found linting issues.
     func lintToolExistence(_ action: TargetAction) -> [LintingIssue] {
-        guard let tool = action.tool else { return [] }
+        guard
+            !action.isEmbeddedScript,
+            let tool = action.tool
+        else { return [] }
         do {
             _ = try System.shared.which(tool)
             return []
@@ -36,6 +41,7 @@ class TargetActionLinter: TargetActionLinting {
 
     func lintPathExistence(_ action: TargetAction) -> [LintingIssue] {
         guard
+            !action.isEmbeddedScript,
             let path = action.path,
             !FileHandler.shared.exists(path)
         else { return [] }

--- a/Sources/TuistGenerator/Linter/TargetActionLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetActionLinter.swift
@@ -22,14 +22,14 @@ class TargetActionLinter: TargetActionLinting {
 
     private func lintEmbeddedScriptNotEmpty(_ action: TargetAction) -> [LintingIssue] {
         guard let script = action.embeddedScript,
-              script.isEmpty
+            script.isEmpty
         else { return [] }
 
         return [
-            LintingIssue(reason: "The embedded script is empty", severity: .warning)
+            LintingIssue(reason: "The embedded script is empty", severity: .warning),
         ]
     }
-    
+
     /// Lints a target aciton.
     ///
     /// - Parameter action: Action to be linted.

--- a/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
@@ -11,37 +11,34 @@ extension TuistCore.TargetAction {
     ///   - generatorPaths: Generator paths.
     static func from(manifest: ProjectDescription.TargetAction, generatorPaths: GeneratorPaths) throws -> TuistCore.TargetAction {
         let name = manifest.name
-        let tool = manifest.tool
         let order = TuistCore.TargetAction.Order.from(manifest: manifest.order)
-        let arguments = manifest.arguments
         let inputPaths = try manifest.inputPaths.map { try generatorPaths.resolve(path: $0) }
         let inputFileListPaths = try manifest.inputFileListPaths.map { try generatorPaths.resolve(path: $0) }
         let outputPaths = try manifest.outputPaths.map { try generatorPaths.resolve(path: $0) }
         let outputFileListPaths = try manifest.outputFileListPaths.map { try generatorPaths.resolve(path: $0) }
         let basedOnDependencyAnalysis = manifest.basedOnDependencyAnalysis
-        let path = try manifest.path.map { try generatorPaths.resolve(path: $0) }
 
-        if let embeddedScript = manifest.embeddedScript {
-            return TargetAction(name: name,
-                                order: order,
-                                script: embeddedScript,
-                                inputPaths: inputPaths,
-                                inputFileListPaths: inputFileListPaths,
-                                outputPaths: outputPaths,
-                                outputFileListPaths: outputFileListPaths,
-                                basedOnDependencyAnalysis: basedOnDependencyAnalysis)
-        } else {
-            return TargetAction(name: name,
-                                order: order,
-                                tool: tool,
-                                path: path,
-                                arguments: arguments,
-                                inputPaths: inputPaths,
-                                inputFileListPaths: inputFileListPaths,
-                                outputPaths: outputPaths,
-                                outputFileListPaths: outputFileListPaths,
-                                basedOnDependencyAnalysis: basedOnDependencyAnalysis)
+        let script: TuistCore.TargetAction.Script
+        switch manifest.script {
+        case let .embedded(text):
+            script = .embedded(text)
+
+        case let .scriptPath(path, arguments):
+            let scriptPath = try generatorPaths.resolve(path: path)
+            script = .scriptPath(scriptPath, args: arguments)
+
+        case let .tool(tool, arguments):
+            script = .tool(tool, arguments)
         }
+
+        return TargetAction(name: name,
+                            order: order,
+                            script: script,
+                            inputPaths: inputPaths,
+                            inputFileListPaths: inputFileListPaths,
+                            outputPaths: outputPaths,
+                            outputFileListPaths: outputFileListPaths,
+                            basedOnDependencyAnalysis: basedOnDependencyAnalysis)
     }
 }
 

--- a/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
@@ -20,16 +20,28 @@ extension TuistCore.TargetAction {
         let outputFileListPaths = try manifest.outputFileListPaths.map { try generatorPaths.resolve(path: $0) }
         let basedOnDependencyAnalysis = manifest.basedOnDependencyAnalysis
         let path = try manifest.path.map { try generatorPaths.resolve(path: $0) }
-        return TargetAction(name: name,
-                            order: order,
-                            tool: tool,
-                            path: path,
-                            arguments: arguments,
-                            inputPaths: inputPaths,
-                            inputFileListPaths: inputFileListPaths,
-                            outputPaths: outputPaths,
-                            outputFileListPaths: outputFileListPaths,
-                            basedOnDependencyAnalysis: basedOnDependencyAnalysis)
+
+        if let embeddedScript = manifest.embeddedScript {
+            return TargetAction(name: name,
+                                order: order,
+                                script: embeddedScript,
+                                inputPaths: inputPaths,
+                                inputFileListPaths: inputFileListPaths,
+                                outputPaths: outputPaths,
+                                outputFileListPaths: outputFileListPaths,
+                                basedOnDependencyAnalysis: basedOnDependencyAnalysis)
+        } else {
+            return TargetAction(name: name,
+                                order: order,
+                                tool: tool,
+                                path: path,
+                                arguments: arguments,
+                                inputPaths: inputPaths,
+                                inputFileListPaths: inputFileListPaths,
+                                outputPaths: outputPaths,
+                                outputFileListPaths: outputFileListPaths,
+                                basedOnDependencyAnalysis: basedOnDependencyAnalysis)
+        }
     }
 }
 

--- a/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
+++ b/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
@@ -81,16 +81,13 @@ extension Target {
 
 extension TargetAction {
     public static func test(name: String = "Action",
-                            tool: String? = nil,
-                            path: Path? = nil,
+                            tool: String = "",
                             order: Order = .pre,
                             arguments: [String] = []) -> TargetAction
     {
         TargetAction(name: name,
-                     tool: tool,
-                     path: path,
-                     order: order,
-                     arguments: arguments)
+                     script: .tool(tool, arguments),
+                     order: order)
     }
 }
 

--- a/Tests/ProjectDescriptionTests/TargetActionTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetActionTests.swift
@@ -15,7 +15,7 @@ final class TargetActionTests: XCTestCase {
         XCTAssertCodable(subject)
     }
 
-    func test_embedded_script_functions() {
+    func test_embedded_script() {
         let script = """
         echo 'Hello World'
         wd=$(pwd)
@@ -23,7 +23,7 @@ final class TargetActionTests: XCTestCase {
         """
 
         let subject = TargetAction.pre(script: script, name: "name")
-        XCTAssertTrue(subject.isEmbeddedScript)
+        XCTAssertNotNil(subject.embeddedScript)
     }
 
     func test_toJSON_when_embedded() {

--- a/Tests/ProjectDescriptionTests/TargetActionTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetActionTests.swift
@@ -14,4 +14,26 @@ final class TargetActionTests: XCTestCase {
         let subject = TargetAction.post(tool: "tool", arguments: ["arg"], name: "name")
         XCTAssertCodable(subject)
     }
+
+    func test_embedded_script_functions() {
+        let script = """
+        echo 'Hello World'
+        wd=$(pwd)
+        echo "$wd"
+        """
+
+        let subject = TargetAction.pre(script: script, name: "name")
+        XCTAssertTrue(subject.isEmbeddedScript)
+    }
+
+    func test_toJSON_when_embedded() {
+        let script = """
+        echo 'Hello World'
+        wd=$(pwd)
+        echo "$wd"
+        """
+
+        let subject = TargetAction.pre(script: script, name: "name")
+        XCTAssertCodable(subject)
+    }
 }

--- a/Tests/ProjectDescriptionTests/TargetActionTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetActionTests.swift
@@ -23,7 +23,7 @@ final class TargetActionTests: XCTestCase {
         """
 
         let subject = TargetAction.pre(script: script, name: "name")
-        XCTAssertNotNil(subject.embeddedScript)
+        XCTAssertEqual(subject.script, .embedded(script))
     }
 
     func test_toJSON_when_embedded() {

--- a/Tests/TuistCacheTests/ContentHashing/TargetActionsContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/TargetActionsContentHasherTests.swift
@@ -35,7 +35,6 @@ final class TargetActionsContentHasherTests: TuistUnitTestCase {
     private func makeTargetAction(name: String = "1",
                                   order: TargetAction.Order = .pre,
                                   tool: String = "tool1",
-                                  path: AbsolutePath? = AbsolutePath("/path1"),
                                   arguments: [String] = ["arg1", "arg2"],
                                   inputPaths: [AbsolutePath] = [AbsolutePath("/inputPaths1")],
                                   inputFileListPaths: [AbsolutePath] = [AbsolutePath("/inputFileListPaths1")],
@@ -44,9 +43,7 @@ final class TargetActionsContentHasherTests: TuistUnitTestCase {
     {
         TargetAction(name: name,
                      order: order,
-                     tool: tool,
-                     path: path,
-                     arguments: arguments,
+                     script: .tool(tool, arguments),
                      inputPaths: inputPaths,
                      inputFileListPaths: inputFileListPaths,
                      outputPaths: outputPaths,
@@ -57,12 +54,10 @@ final class TargetActionsContentHasherTests: TuistUnitTestCase {
 
     func test_hash_targetAction_callsMockHasherWithExpectedStrings() throws {
         // Given
-        let file1hash = "file1-content-hash"
         let inputPaths1Hash = "inputPaths1-hash"
         let inputFileListPaths1 = "inputFileListPaths1-hash"
         let outputPaths1 = "outputPaths1-hash"
         let outputFileListPaths1 = "outputFileListPaths1-hash"
-        mockContentHasher.stubHashForPath[AbsolutePath("/path1")] = file1hash
         mockContentHasher.stubHashForPath[AbsolutePath("/inputPaths1")] = inputPaths1Hash
         mockContentHasher.stubHashForPath[AbsolutePath("/inputFileListPaths1")] = inputFileListPaths1
         mockContentHasher.stubHashForPath[AbsolutePath("/outputPaths1")] = outputPaths1
@@ -73,8 +68,7 @@ final class TargetActionsContentHasherTests: TuistUnitTestCase {
         _ = try subject.hash(targetActions: [targetAction])
 
         // Then
-        let expected = [file1hash,
-                        inputPaths1Hash,
+        let expected = [inputPaths1Hash,
                         inputFileListPaths1,
                         outputPaths1,
                         outputFileListPaths1,
@@ -96,7 +90,7 @@ final class TargetActionsContentHasherTests: TuistUnitTestCase {
         mockContentHasher.stubHashForPath[AbsolutePath("/inputFileListPaths1")] = inputFileListPaths1
         mockContentHasher.stubHashForPath[AbsolutePath("/outputPaths1")] = outputPaths1
         mockContentHasher.stubHashForPath[AbsolutePath("/outputFileListPaths1")] = outputFileListPaths1
-        let targetAction = makeTargetAction(path: nil)
+        let targetAction = makeTargetAction()
 
         // When
         _ = try subject.hash(targetActions: [targetAction])
@@ -118,12 +112,10 @@ final class TargetActionsContentHasherTests: TuistUnitTestCase {
 
     func test_hash_targetAction_valuesAreNotHarcoded() throws {
         // Given
-        let file2hash = "file2-content-hash"
         let inputPaths2Hash = "inputPaths2-hash"
         let inputFileListPaths2 = "inputFileListPaths2-hash"
         let outputPaths2 = "outputPaths2-hash"
         let outputFileListPaths2 = "outputFileListPaths2-hash"
-        mockContentHasher.stubHashForPath[AbsolutePath("/path2")] = file2hash
         mockContentHasher.stubHashForPath[AbsolutePath("/inputPaths2")] = inputPaths2Hash
         mockContentHasher.stubHashForPath[AbsolutePath("/inputFileListPaths2")] = inputFileListPaths2
         mockContentHasher.stubHashForPath[AbsolutePath("/outputPaths2")] = outputPaths2
@@ -131,7 +123,6 @@ final class TargetActionsContentHasherTests: TuistUnitTestCase {
         let targetAction = makeTargetAction(name: "2",
                                             order: .post,
                                             tool: "tool2",
-                                            path: AbsolutePath("/path2"),
                                             inputPaths: [AbsolutePath("/inputPaths2")],
                                             inputFileListPaths: [AbsolutePath("/inputFileListPaths2")],
                                             outputPaths: [AbsolutePath("/outputPaths2")],
@@ -141,8 +132,7 @@ final class TargetActionsContentHasherTests: TuistUnitTestCase {
         _ = try subject.hash(targetActions: [targetAction])
 
         // Then
-        let expected = [file2hash,
-                        inputPaths2Hash,
+        let expected = [inputPaths2Hash,
                         inputFileListPaths2,
                         outputPaths2,
                         outputFileListPaths2,

--- a/Tests/TuistCacheTests/Linters/CacheGraphLinterTests.swift
+++ b/Tests/TuistCacheTests/Linters/CacheGraphLinterTests.swift
@@ -16,7 +16,7 @@ final class CacheGraphLinterTests: TuistUnitTestCase {
     func test_lint() {
         // Given
         let target = Target.test(actions: [
-            .init(name: "test", order: .post),
+            .init(name: "test", order: .post, script: .embedded("echo 'Hello World'")),
         ])
         let targetNode = TargetNode.test(target: target)
         let graph = Graph.test(entryNodes: [targetNode],

--- a/Tests/TuistCoreTests/Models/TargetActionTests.swift
+++ b/Tests/TuistCoreTests/Models/TargetActionTests.swift
@@ -1,0 +1,20 @@
+import Foundation
+import TSCBasic
+import XCTest
+@testable import TuistCore
+
+private let script = """
+echo 'Hello World'
+wd=$(pwd)
+echo "$wd"
+"""
+
+final class TargetActionTests: XCTestCase {
+    func test_embedded_script_functions() throws {
+        let subject = TargetAction(name: "name", order: .pre, script: script)
+
+        let shellScript = try subject.shellScript(sourceRootPath: .root)
+        XCTAssertEqual(script, shellScript)
+        XCTAssertTrue(subject.isEmbeddedScript)
+    }
+}

--- a/Tests/TuistCoreTests/Models/TargetActionTests.swift
+++ b/Tests/TuistCoreTests/Models/TargetActionTests.swift
@@ -10,11 +10,11 @@ echo "$wd"
 """
 
 final class TargetActionTests: XCTestCase {
-    func test_embedded_script_functions() throws {
+    func test_embedded_script() throws {
         let subject = TargetAction(name: "name", order: .pre, script: script)
 
         let shellScript = try subject.shellScript(sourceRootPath: .root)
         XCTAssertEqual(script, shellScript)
-        XCTAssertTrue(subject.isEmbeddedScript)
+        XCTAssertNotNil(subject.embeddedScript)
     }
 }

--- a/Tests/TuistCoreTests/Models/TargetActionTests.swift
+++ b/Tests/TuistCoreTests/Models/TargetActionTests.swift
@@ -11,7 +11,7 @@ echo "$wd"
 
 final class TargetActionTests: XCTestCase {
     func test_embedded_script() throws {
-        let subject = TargetAction(name: "name", order: .pre, script: script)
+        let subject = TargetAction(name: "name", order: .pre, script: .embedded(script))
 
         let shellScript = try subject.shellScript(sourceRootPath: .root)
         XCTAssertEqual(script, shellScript)

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -652,8 +652,18 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
         let target = Target.test(sources: [],
                                  resources: [],
                                  actions: [
-                                     TargetAction(name: "post", order: .post, path: path.appending(component: "script.sh"), arguments: ["arg"], showEnvVarsInLog: false, basedOnDependencyAnalysis: false),
-                                     TargetAction(name: "pre", order: .pre, path: path.appending(component: "script.sh"), arguments: ["arg"]),
+                                     TargetAction(
+                                         name: "post",
+                                         order: .post,
+                                         script: .scriptPath(path.appending(component: "script.sh"), args: ["arg"]),
+                                         showEnvVarsInLog: false,
+                                         basedOnDependencyAnalysis: false
+                                     ),
+                                     TargetAction(
+                                         name: "pre",
+                                         order: .pre,
+                                         script: .scriptPath(path.appending(component: "script.sh"), args: ["arg"])
+                                     ),
                                  ])
         let project = Project.test(path: path, sourceRootPath: path, xcodeProjPath: path.appending(component: "Project.xcodeproj"), targets: [target])
         let groups = ProjectGroups.generate(project: project,

--- a/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
@@ -41,13 +41,10 @@ final class TargetGeneratorTests: XCTestCase {
                                  actions: [
                                      TargetAction(name: "pre",
                                                   order: .pre,
-                                                  tool: "echo",
-                                                  arguments: ["pre1", "pre2"]),
+                                                  script: .tool("echo", ["pre1", "pre2"])),
                                      TargetAction(name: "post",
                                                   order: .post,
-                                                  tool: "echo",
-                                                  path: "/tmp",
-                                                  arguments: ["post1", "post2"],
+                                                  script: .tool("echo", ["post1", "post2"]),
                                                   inputFileListPaths: ["/tmp/b"],
                                                   outputFileListPaths: ["/tmp/d"]),
                                  ])
@@ -132,8 +129,16 @@ final class TargetGeneratorTests: XCTestCase {
         let target = Target.test(sources: [],
                                  resources: [],
                                  actions: [
-                                     TargetAction(name: "post", order: .post, path: path.appending(component: "script.sh"), arguments: ["arg"]),
-                                     TargetAction(name: "pre", order: .pre, path: path.appending(component: "script.sh"), arguments: ["arg"]),
+                                     TargetAction(
+                                         name: "post",
+                                         order: .post,
+                                         script: .scriptPath(path.appending(component: "script.sh"), args: ["arg"])
+                                     ),
+                                     TargetAction(
+                                         name: "pre",
+                                         order: .pre,
+                                         script: .scriptPath(path.appending(component: "script.sh"), args: ["arg"])
+                                     ),
                                  ])
         let project = Project.test(path: path, sourceRootPath: path, xcodeProjPath: path.appending(component: "Project.xcodeproj"), targets: [target])
         let groups = ProjectGroups.generate(project: project,

--- a/Tests/TuistGeneratorTests/Linter/TargetActionLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetActionLinterTests.swift
@@ -52,4 +52,14 @@ final class TargetActionLinterTests: TuistUnitTestCase {
         let expected = [LintingIssue]()
         XCTAssertTrue(got.elementsEqual(expected))
     }
+
+    func test_lint_warns_when_embedded_script_empty() {
+        let action = TargetAction(name: "name",
+                                  order: .pre,
+                                  script: "")
+
+        let got = subject.lint(action)
+        let expected = LintingIssue(reason: "The embedded script is empty", severity: .warning)
+        XCTAssertTrue(got.contains(expected))
+    }
 }

--- a/Tests/TuistGeneratorTests/Linter/TargetActionLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetActionLinterTests.swift
@@ -23,7 +23,7 @@ final class TargetActionLinterTests: TuistUnitTestCase {
     func test_lint_whenTheToolDoesntExist() {
         let action = TargetAction(name: "name",
                                   order: .pre,
-                                  tool: "randomtool")
+                                  script: .tool("randomtool"))
         let got = subject.lint(action)
 
         let expected = LintingIssue(reason: "The action tool 'randomtool' was not found in the environment",
@@ -35,7 +35,7 @@ final class TargetActionLinterTests: TuistUnitTestCase {
         let temporaryPath = try self.temporaryPath()
         let action = TargetAction(name: "name",
                                   order: .pre,
-                                  path: temporaryPath.appending(component: "invalid.sh"))
+                                  script: .scriptPath(temporaryPath.appending(component: "invalid.sh")))
         let got = subject.lint(action)
 
         let expected = LintingIssue(reason: "The action path \(action.path!.pathString) doesn't exist",
@@ -46,7 +46,7 @@ final class TargetActionLinterTests: TuistUnitTestCase {
     func test_lint_succeeds_when_embedded() throws {
         let action = TargetAction(name: "name",
                                   order: .pre,
-                                  script: "echo 'Hello World'")
+                                  script: .embedded("echo 'Hello World'"))
 
         let got = subject.lint(action)
         let expected = [LintingIssue]()
@@ -56,7 +56,7 @@ final class TargetActionLinterTests: TuistUnitTestCase {
     func test_lint_warns_when_embedded_script_empty() {
         let action = TargetAction(name: "name",
                                   order: .pre,
-                                  script: "")
+                                  script: .embedded(""))
 
         let got = subject.lint(action)
         let expected = LintingIssue(reason: "The embedded script is empty", severity: .warning)

--- a/Tests/TuistGeneratorTests/Linter/TargetActionLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetActionLinterTests.swift
@@ -42,4 +42,14 @@ final class TargetActionLinterTests: TuistUnitTestCase {
                                     severity: .error)
         XCTAssertTrue(got.contains(expected))
     }
+
+    func test_lint_succeeds_when_text() throws {
+        let action = TargetAction(name: "name",
+                                  order: .pre,
+                                  script: "echo 'Hello World'")
+
+        let got = subject.lint(action)
+        let expected = [LintingIssue]()
+        XCTAssertTrue(got.elementsEqual(expected))
+    }
 }

--- a/Tests/TuistGeneratorTests/Linter/TargetActionLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetActionLinterTests.swift
@@ -43,7 +43,7 @@ final class TargetActionLinterTests: TuistUnitTestCase {
         XCTAssertTrue(got.contains(expected))
     }
 
-    func test_lint_succeeds_when_text() throws {
+    func test_lint_succeeds_when_embedded() throws {
         let action = TargetAction(name: "name",
                                   order: .pre,
                                   script: "echo 'Hello World'")

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/TargetAction+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/TargetAction+ManifestMapperTests.swift
@@ -15,7 +15,6 @@ final class TargetActionManifestMapperTests: TuistUnitTestCase {
         let generatorPaths = GeneratorPaths(manifestDirectory: temporaryPath)
         let manifest = ProjectDescription.TargetAction.test(name: "MyScript",
                                                             tool: "my_tool",
-                                                            path: "my/path",
                                                             order: .pre,
                                                             arguments: ["arg1", "arg2"])
         // When
@@ -23,9 +22,7 @@ final class TargetActionManifestMapperTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(model.name, "MyScript")
-        XCTAssertEqual(model.tool, "my_tool")
-        XCTAssertEqual(model.path, temporaryPath.appending(RelativePath("my/path")))
+        XCTAssertEqual(model.script, .tool("my_tool", ["arg1", "arg2"]))
         XCTAssertEqual(model.order, .pre)
-        XCTAssertEqual(model.arguments, ["arg1", "arg2"])
     }
 }

--- a/fixtures/ios_app_with_actions/App/Project.swift
+++ b/fixtures/ios_app_with_actions/App/Project.swift
@@ -11,6 +11,7 @@ let project = Project(name: "App",
                                actions: [
                                 .pre(tool: "/bin/echo", arguments: ["\"tuist\""], name: "Tuist"),
                                 .post(tool: "/bin/echo", arguments: ["rocks"], name: "Rocks"),
-                                .pre(path: "script.sh", name: "Run script")
+                                .pre(path: "script.sh", name: "Run script"),
+                                .pre(script: "echo 'Hello World'", name: "Embedded script"),
                               ]),
                       ])

--- a/website/markdown/docs/usage/project-description.mdx
+++ b/website/markdown/docs/usage/project-description.mdx
@@ -687,6 +687,12 @@ Target actions, represented as target script build phases, are useful to define 
         'Action executed before the target-specific build phases where path is the path to the tool to be executed.',
     },
     {
+    case:
+      '.pre(script: String, name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool)',
+    description:
+      'Action executed before the target-specific build phases where script is an embedded script to run. It is advised to keep embedded scripts as small as possible',
+    },
+    {
       case:
         '.post(tool: String, arguments: String..., name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool)',
       description:
@@ -697,6 +703,12 @@ Target actions, represented as target script build phases, are useful to define 
         '.post(path: Path, arguments: String..., name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool)',
       description:
         'Action executed after all the target-specific build phases where path is the path to the tool to be executed.',
+    },
+    {
+    case:
+      '.post(script: String, name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool)',
+    description:
+      'Action executed after all the target-specific build phases where script is an embedded script to run. It is advised to keep embedded scripts as small as possible',
     },
   ]}
 />


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/discussions/2157
Request for comments document (if applies):

### Short description 📝

Tuist's TargetAction type currently supports invoking a script, which definitely is preferred to keep up from making a big script inside of Xcode. However there are times where short scripts are preferred and Tuist does not support that currently. This PR adds support for embedded scripts.

I refactored the implementations of the `TargetAction` type in both ProjectDescription and TuistCore without making API breaking changes. The reasoning is that having Tuist put together the call to an external script (with the tool, script path, and arguments) is mutually exclusive to sending in an embedded script. The expectation is that the embedded script will be entirely self-contained.

This does alter the JSON transformation of the ProjectDescription.TargetAction type because there's a new possible key, `script`. If this key is present in decoding, then the `tool`, `path`, and `arguments` will not be part of the resulting object.

I did add a couple of tests and am happy to add any more that are requested.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] A developer other than the author has verified that the changes work as expected.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
