### PR TITLE
Project Plugins: Add Plugin Service

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
         "state": {
           "branch": null,
-          "revision": "5669f222e46c8134fb1f399c745fa6882b43532e",
-          "version": "1.3.8"
+          "revision": "e2bc81be54d71d566a52ca17c3983d141c30aa70",
+          "version": "1.3.3"
         }
       },
       {
@@ -134,15 +134,6 @@
           "branch": null,
           "revision": "f717bbce0e19f0129fc001b2b6bed43b70fd8b87",
           "version": "0.9.1"
-        }
-      },
-      {
-        "package": "Stencil",
-        "repositoryURL": "https://github.com/stencilproject/Stencil.git",
-        "state": {
-          "branch": null,
-          "revision": "94197b3adbbf926348ad8765476a158aa4e54f8a",
-          "version": "0.14.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -134,6 +134,7 @@ let package = Package(
                 "TuistMigration",
                 "TuistAsyncQueue",
                 "TuistAnalytics",
+                "TuistPlugin",
             ]
         ),
         .testTarget(
@@ -638,6 +639,28 @@ let package = Package(
             name: "TuistAnalyticsTests",
             dependencies: [
                 "TuistSupportTesting",
+            ]
+        ),
+        .target(
+            name: "TuistPlugin",
+            dependencies: [
+                "TuistCore",
+                "TuistLoader",
+                "TuistSupport",
+                swiftToolsSupportDependency,
+            ]
+        ),
+        .testTarget(
+            name: "TuistPluginTests",
+            dependencies: [
+                "TuistCore",
+                "TuistLoader",
+                "TuistLoaderTesting",
+                "TuistPlugin",
+                "TuistSupport",
+                "TuistSupportTesting",
+                rxBlockingDependency,
+                swiftToolsSupportDependency,
             ]
         ),
     ]

--- a/Sources/TuistCore/Graph/Nodes/TargetNode.swift
+++ b/Sources/TuistCore/Graph/Nodes/TargetNode.swift
@@ -2,7 +2,7 @@ import Foundation
 import TSCBasic
 import TuistSupport
 
-@available(*, deprecated, message: "Target nodes are deprecated. Targets should be usted instead with the ValueGraph.")
+@available(*, deprecated, message: "Target nodes are deprecated. Targets should be used instead with the ValueGraph.")
 public class TargetNode: GraphNode {
     // MARK: - Attributes
 

--- a/Sources/TuistCore/Protocols/GeneratorModelLoading.swift
+++ b/Sources/TuistCore/Protocols/GeneratorModelLoading.swift
@@ -31,4 +31,11 @@ public protocol GeneratorModelLoading {
     /// - Returns: The config loaded from the specified path
     /// - Throws: Error encountered during the loading process (e.g. Missing Config file)
     func loadConfig(at path: AbsolutePath) throws -> Config
+
+    /// Load a Plugin model at the specified path
+    ///
+    /// - Parameter path: The absolute path for the Plugin model to load
+    /// - Returns: The Plugin loaded from the specified path
+    /// - Throws: Error encountered during the loading process (e.g. Missing Plugin file)
+    func loadPlugin(at path: AbsolutePath) throws -> Plugin
 }

--- a/Sources/TuistLoader/Loaders/CachedModelLoader.swift
+++ b/Sources/TuistLoader/Loaders/CachedModelLoader.swift
@@ -8,9 +8,12 @@ public class CachedModelLoader: GeneratorModelLoading {
     private let workspaces: [AbsolutePath: Workspace]
     private let projects: [AbsolutePath: Project]
     private let configs: [AbsolutePath: Config]
+    private let plugins: [AbsolutePath: Plugin]
+
     public init(workspace: [Workspace] = [],
                 projects: [Project] = [],
-                configs: [AbsolutePath: Config] = [:])
+                configs: [AbsolutePath: Config] = [:],
+                plugins: [AbsolutePath: Plugin] = [:])
     {
         workspaces = Dictionary(uniqueKeysWithValues: workspace.map {
             ($0.path, $0)
@@ -19,6 +22,7 @@ public class CachedModelLoader: GeneratorModelLoading {
             ($0.path, $0)
         })
         self.configs = configs
+        self.plugins = plugins
     }
 
     public func loadProject(at path: AbsolutePath) throws -> Project {
@@ -40,5 +44,12 @@ public class CachedModelLoader: GeneratorModelLoading {
             throw ManifestLoaderError.manifestNotFound(.config, path)
         }
         return config
+    }
+
+    public func loadPlugin(at path: AbsolutePath) throws -> Plugin {
+        guard let plugin = plugins[path] else {
+            throw ManifestLoaderError.manifestNotFound(.plugin, path)
+        }
+        return plugin
     }
 }

--- a/Sources/TuistLoader/Loaders/GeneratorModelLoader.swift
+++ b/Sources/TuistLoader/Loaders/GeneratorModelLoader.swift
@@ -71,6 +71,10 @@ extension GeneratorModelLoader: GeneratorModelLoading {
 
         return TuistCore.Config.default
     }
+
+    public func loadPlugin(at _: AbsolutePath) throws -> TuistCore.Plugin {
+        Plugin(name: "TODO")
+    }
 }
 
 extension GeneratorModelLoader: ManifestModelConverting {

--- a/Sources/TuistLoader/Models/Manifest.swift
+++ b/Sources/TuistLoader/Models/Manifest.swift
@@ -9,6 +9,7 @@ public enum Manifest: CaseIterable {
     case template
     case galaxy
     case dependencies
+    case plugin
 
     /// This was introduced to rename a file name without breaking existing projects.
     public var deprecatedFileName: String? {
@@ -41,6 +42,8 @@ public enum Manifest: CaseIterable {
             return "Galaxy.swift"
         case .dependencies:
             return "Dependencies.swift"
+        case .plugin:
+            return "Plugin.swift"
         }
     }
 }

--- a/Sources/TuistLoaderTesting/Loaders/Mocks/MockGeneratorModelLoader.swift
+++ b/Sources/TuistLoaderTesting/Loaders/Mocks/MockGeneratorModelLoader.swift
@@ -6,6 +6,7 @@ public class MockGeneratorModelLoader: GeneratorModelLoading {
     private var projects = [String: (AbsolutePath) throws -> Project]()
     private var workspaces = [String: (AbsolutePath) throws -> Workspace]()
     private var configs = [String: (AbsolutePath) throws -> Config]()
+    private var plugins = [String: (AbsolutePath) throws -> Plugin]()
 
     private let basePath: AbsolutePath
 
@@ -27,6 +28,10 @@ public class MockGeneratorModelLoader: GeneratorModelLoading {
         try configs[path.pathString]!(path)
     }
 
+    public func loadPlugin(at path: AbsolutePath) throws -> Plugin {
+        try plugins[path.pathString]!(path)
+    }
+
     // MARK: - Mock
 
     public func mockProject(_ path: String, loadClosure: @escaping (AbsolutePath) throws -> Project) {
@@ -39,5 +44,9 @@ public class MockGeneratorModelLoader: GeneratorModelLoading {
 
     public func mockConfig(_ path: String = "", loadClosure: @escaping (AbsolutePath) throws -> Config) {
         configs[basePath.appending(component: path).pathString] = loadClosure
+    }
+
+    public func mockPlugin(_ path: String = "", loadClosure: @escaping (AbsolutePath) throws -> Plugin) {
+        plugins[path] = loadClosure
     }
 }

--- a/Sources/TuistLoaderTesting/Utils/Mocks/MockManifestFilesLocator.swift
+++ b/Sources/TuistLoaderTesting/Utils/Mocks/MockManifestFilesLocator.swift
@@ -14,6 +14,8 @@ public final class MockManifestFilesLocator: ManifestFilesLocating {
     public var locateSetupStub: AbsolutePath?
     public var locateSetupArgs: [AbsolutePath] = []
 
+    public init() {}
+
     public func locateProjectManifests(at: AbsolutePath) -> [(Manifest, AbsolutePath)] {
         locateProjectManifestsArgs.append(at)
         return locateProjectManifestsStub ?? [(.project, at.appending(component: "Project.swift"))]

--- a/Sources/TuistPlugin/Logger.swift
+++ b/Sources/TuistPlugin/Logger.swift
@@ -1,0 +1,2 @@
+import TuistSupport
+let logger = Logger(label: "io.tuist.plugin")

--- a/Sources/TuistPlugin/PluginService.swift
+++ b/Sources/TuistPlugin/PluginService.swift
@@ -1,0 +1,89 @@
+import TSCBasic
+import TuistCore
+import TuistLoader
+import TuistSupport
+
+/// A default implementation of `PluginServicing` which loads `Plugins` using
+/// the `Config` description without it needing to be loaded. The  plugins are first fetched/copied into
+/// a cache and the loaded `Plugins` model is returned.
+public final class PluginService: PluginServicing {
+    private let modelLoader: GeneratorModelLoading
+    private let fileHandler: FileHandling
+    private let gitHandler: GitHandling
+    private let manifestFilesLocator: ManifestFilesLocating
+
+    /// Creates a `PluginService`.
+    /// - Parameters:
+    ///   - modelLoader: A model loader for loading plugins.
+    ///   - fileHandler: A file handler for creating plugin directories/related files.
+    ///   - gitHandler: A git handler for cloning and interacting with remote plugins.
+    ///   - manifestFilesLocator: A locator for manifest files, used to find location of `Config` manifest in order to load plugins.
+    public init(
+        modelLoader: GeneratorModelLoading = GeneratorModelLoader(manifestLoader: ManifestLoader(), manifestLinter: ManifestLinter()),
+        fileHandler: FileHandling = FileHandler.shared,
+        gitHandler: GitHandling = GitHandler(),
+        manifestFilesLocator: ManifestFilesLocating = ManifestFilesLocator()
+    ) {
+        self.modelLoader = modelLoader
+        self.fileHandler = fileHandler
+        self.gitHandler = gitHandler
+        self.manifestFilesLocator = manifestFilesLocator
+    }
+
+    public func loadPlugins(at path: AbsolutePath) throws -> Plugins {
+        guard let configPath = manifestFilesLocator.locateConfig(at: path) else {
+            throw PluginServiceError.configNotFound(path)
+        }
+
+        let config = try modelLoader.loadConfig(at: configPath)
+        return try loadPlugins(using: config)
+    }
+
+    public func loadPlugins(using config: Config) throws -> Plugins {
+        let pluginPaths = try fetchPlugins(config: config)
+        let pluginManifests = try pluginPaths.map(modelLoader.loadPlugin)
+        let projectDescriptionHelpers = zip(pluginManifests, pluginPaths)
+            .compactMap { plugin, path -> ProjectDescriptionHelpersPlugin? in
+                let helpersPath = path.appending(RelativePath(Constants.helpersDirectoryName))
+                guard fileHandler.exists(helpersPath) else { return nil }
+                return ProjectDescriptionHelpersPlugin(name: plugin.name, path: helpersPath)
+            }
+
+        return Plugins(projectDescriptionHelpers: projectDescriptionHelpers)
+    }
+
+    private func fetchPlugins(config: Config) throws -> [AbsolutePath] {
+        try config.plugins
+            .map { plugin in
+                switch plugin {
+                case let .local(path):
+                    logger.debug("Fetching \(plugin.description) at: \(path)")
+                    return AbsolutePath(path)
+                case let .gitWithBranch(url, id),
+                     let .gitWithTag(url, id),
+                     let .gitWithSha(url, id):
+                    logger.debug("Fetching \(plugin.description) at: \(url) @ \(id)")
+                    return try fetchGitPlugin(at: url, with: id)
+                }
+            }
+    }
+
+    /// fetches the git plugins from the remote server and caches them in
+    /// the Tuist cache with a unique fingerprint
+    private func fetchGitPlugin(at url: String, with gitId: String) throws -> AbsolutePath {
+        let fingerprint = "\(url)-\(gitId)".md5
+        let pluginDirectory = Environment.shared.cacheDirectory
+            .appending(RelativePath(Constants.PluginDirectory.name))
+            .appending(RelativePath(fingerprint))
+
+        guard !fileHandler.exists(pluginDirectory) else {
+            logger.debug("Using cached git plugin \(url)")
+            return pluginDirectory
+        }
+
+        try gitHandler.clone(url: url, to: pluginDirectory)
+        try gitHandler.checkout(id: gitId, in: pluginDirectory)
+
+        return pluginDirectory
+    }
+}

--- a/Sources/TuistPlugin/PluginServiceError.swift
+++ b/Sources/TuistPlugin/PluginServiceError.swift
@@ -1,0 +1,21 @@
+import TSCBasic
+import TuistSupport
+
+/// Errors thrown by `PluginService`.
+public enum PluginServiceError: FatalError {
+    case configNotFound(AbsolutePath)
+
+    public var description: String {
+        switch self {
+        case let .configNotFound(path):
+            return "Unable to load plugins, Config.swift manifest not located at \(path)"
+        }
+    }
+
+    public var type: ErrorType {
+        switch self {
+        case .configNotFound:
+            return .abort
+        }
+    }
+}

--- a/Sources/TuistPlugin/PluginServicing.swift
+++ b/Sources/TuistPlugin/PluginServicing.swift
@@ -1,0 +1,20 @@
+import Foundation
+import TSCBasic
+import TuistCore
+import TuistLoader
+import TuistSupport
+
+/// A protocol defining a service for interacting with plugins.
+public protocol PluginServicing {
+    /// Loads the `Plugins` and returns them as defined in given config.
+    /// Attempts to first locate and load the `Config` manifest.
+    /// The given path must be a valid location where a `Config` manifest may be found.
+    /// - Throws: An error if couldn't load a plugin.
+    /// - Returns: The loaded `Plugins` representation.
+    func loadPlugins(at path: AbsolutePath) throws -> Plugins
+
+    /// Loads the `Plugins` and returns them as defined in given config.
+    /// - Throws: An error if couldn't load a plugin.
+    /// - Returns: The loaded `Plugins` representation.
+    func loadPlugins(using config: Config) throws -> Plugins
+}

--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Constants {
+public enum Constants {
     public static let versionFileName = ".tuist-version"
     public static let binFolderName = ".tuist-bin"
     public static let binName = "tuist"
@@ -22,30 +22,30 @@ public struct Constants {
     public static let joinSlackURL: String = "https://slack.tuist.io/"
     public static let tuistGeneratedFileName = ".tuist-generated"
 
-    public struct Vendor {
+    public enum Vendor {
         public static let swiftLint = "swiftlint"
         public static let swiftDoc = "swift-doc"
     }
 
-    public struct DependenciesDirectory {
+    public enum DependenciesDirectory {
         public static let name = "Dependencies"
         public static let lockfilesDirectoryName = "Lockfiles"
         public static let cartfileResolvedName = "Cartfile.resolved"
         public static let carthageDirectoryName = "Carthage"
     }
 
-    public struct DerivedDirectory {
+    public enum DerivedDirectory {
         public static let name = "Derived"
         public static let infoPlists = "InfoPlists"
         public static let sources = "Sources"
         public static let signingKeychain = "signing.keychain"
     }
 
-    public struct AsyncQueue {
+    public enum AsyncQueue {
         public static let directoryName: String = "Queue"
     }
 
-    public struct EnvironmentVariables {
+    public enum EnvironmentVariables {
         public static let verbose = "TUIST_VERBOSE"
         public static let colouredOutput = "TUIST_COLOURED_OUTPUT"
         public static let versionsDirectory = "TUIST_VERSIONS_DIRECTORY"
@@ -55,7 +55,11 @@ public struct Constants {
         public static let cacheManifests = "TUIST_CACHE_MANIFESTS"
     }
 
-    public struct GoogleCloud {
+    public enum GoogleCloud {
         public static let relasesBucketURL = "https://storage.googleapis.com/tuist-releases/"
+    }
+
+    public enum PluginDirectory {
+        public static let name = "Plugins"
     }
 }

--- a/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
+++ b/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
@@ -48,7 +48,7 @@ public final class MockFileHandler: FileHandler {
     }
 }
 
-public class TuistTestCase: XCTestCase {
+open class TuistTestCase: XCTestCase {
     fileprivate var temporaryDirectory: TemporaryDirectory!
 
     override public static func setUp() {
@@ -61,7 +61,7 @@ public class TuistTestCase: XCTestCase {
     public var fileHandler: MockFileHandler!
     public var environment: MockEnvironment!
 
-    override public func setUp() {
+    override open func setUp() {
         super.setUp()
 
         do {
@@ -77,7 +77,7 @@ public class TuistTestCase: XCTestCase {
         FileHandler.shared = fileHandler
     }
 
-    override public func tearDown() {
+    override open func tearDown() {
         temporaryDirectory = nil
         super.tearDown()
     }

--- a/Tests/TuistPluginTests/PluginServiceTests.swift
+++ b/Tests/TuistPluginTests/PluginServiceTests.swift
@@ -1,0 +1,134 @@
+import TSCBasic
+import TuistCore
+import TuistLoader
+import TuistLoaderTesting
+import TuistSupport
+import TuistSupportTesting
+import XCTest
+
+@testable import TuistPlugin
+
+final class PluginServiceTests: TuistTestCase {
+    private var mockModelLoader: MockGeneratorModelLoader!
+    private var mockGitHandler: MockGitHandler!
+    private var mockManifestFilesLocator: MockManifestFilesLocator!
+    private var subject: PluginService!
+
+    override func setUp() {
+        super.setUp()
+        do {
+            let tuistPath = try temporaryPath().appending(RelativePath("Tuist"))
+            mockModelLoader = MockGeneratorModelLoader(basePath: tuistPath)
+            mockGitHandler = MockGitHandler()
+            mockManifestFilesLocator = MockManifestFilesLocator()
+            subject = PluginService(
+                modelLoader: mockModelLoader,
+                fileHandler: fileHandler,
+                gitHandler: mockGitHandler,
+                manifestFilesLocator: mockManifestFilesLocator
+            )
+        } catch {
+            XCTFail("Failed initializing PluginServiceTests")
+        }
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func test_loadPlugins_atPath_WHEN_localHelpers() throws {
+        let pluginPath = "/path/to/plugin"
+
+        mockModelLoader.mockConfig("Config.swift") { _ in
+            self.mockConfig(plugins: [.local(path: pluginPath)])
+        }
+        mockModelLoader.mockPlugin(pluginPath) { _ in
+            Plugin(name: "MockPlugin")
+        }
+        fileHandler.stubExists = { _ in
+            true
+        }
+
+        let plugins = try subject.loadPlugins(at: try temporaryPath())
+        let expectedPlugins = Plugins(projectDescriptionHelpers: [
+            .init(name: "MockPlugin", path: AbsolutePath(pluginPath).appending(component: Constants.helpersDirectoryName)),
+        ])
+
+        XCTAssertEqual(plugins, expectedPlugins)
+    }
+
+    func test_loadPlugins_usingConfig_WHEN_localHelpers() throws {
+        let pluginPath = "/path/to/plugin"
+        let config = mockConfig(plugins: [.local(path: pluginPath)])
+
+        mockModelLoader.mockPlugin(pluginPath) { _ in
+            Plugin(name: "MockPlugin")
+        }
+        fileHandler.stubExists = { _ in
+            true
+        }
+
+        let plugins = try subject.loadPlugins(using: config)
+        let expectedPlugins = Plugins(projectDescriptionHelpers: [
+            .init(name: "MockPlugin", path: AbsolutePath(pluginPath).appending(component: Constants.helpersDirectoryName)),
+        ])
+
+        XCTAssertEqual(plugins, expectedPlugins)
+    }
+
+    func test_loadPlugin_atPath_WHEN_gitHelpers() throws {
+        let pluginGitUrl = "https://url/to/repo.git"
+        let pluginGitId = "main"
+        let pluginFingerprint = "\(pluginGitUrl)-\(pluginGitId)".md5
+        let cachedPluginPath = environment.cacheDirectory.appending(components: Constants.PluginDirectory.name, pluginFingerprint)
+
+        mockModelLoader.mockConfig("Config.swift") { _ in
+            self.mockConfig(plugins: [.gitWithBranch(url: pluginGitUrl, branch: pluginGitId)])
+        }
+        mockModelLoader.mockPlugin(cachedPluginPath.pathString) { _ in
+            Plugin(name: "MockPlugin")
+        }
+        fileHandler.stubExists = { _ in
+            true
+        }
+
+        let plugins = try subject.loadPlugins(at: try temporaryPath())
+        let expectedPlugins = Plugins(projectDescriptionHelpers: [
+            .init(name: "MockPlugin", path: cachedPluginPath.appending(component: Constants.helpersDirectoryName)),
+        ])
+
+        XCTAssertEqual(plugins, expectedPlugins)
+    }
+
+    func test_loadPlugin_usingConfig_WHEN_gitHelpers() throws {
+        let pluginGitUrl = "https://url/to/repo.git"
+        let pluginGitId = "main"
+        let pluginFingerprint = "\(pluginGitUrl)-\(pluginGitId)".md5
+        let cachedPluginPath = environment.cacheDirectory.appending(components: Constants.PluginDirectory.name, pluginFingerprint)
+        let config = mockConfig(plugins: [.gitWithBranch(url: pluginGitUrl, branch: pluginGitId)])
+
+        mockModelLoader.mockPlugin(cachedPluginPath.pathString) { _ in
+            Plugin(name: "MockPlugin")
+        }
+        fileHandler.stubExists = { _ in
+            true
+        }
+
+        let plugins = try subject.loadPlugins(using: config)
+        let expectedPlugins = Plugins(projectDescriptionHelpers: [
+            .init(name: "MockPlugin", path: cachedPluginPath.appending(component: Constants.helpersDirectoryName)),
+        ])
+
+        XCTAssertEqual(plugins, expectedPlugins)
+    }
+
+    private func mockConfig(plugins: [PluginLocation]) -> Config {
+        Config(
+            compatibleXcodeVersions: .all,
+            cloud: nil,
+            plugins: plugins,
+            generationOptions: [],
+            path: nil
+        )
+    }
+}


### PR DESCRIPTION
### Short description 📝

This is another PR following up on work implemented in: #2095, #2103, #2107

#### New modules

In this PR we add two new modules: `TuistPlugin` and `TuistPluginTests`. 

The `TuistPlugin` module is intended to hold code related to tuist plugin feature. This includes the newly added `PluginService`. 

#### PluginService

With this PR we also add `PluginServicing` which is an interface for fetching and loading plugins. This service intends to allow developers to load `Plugin` manifests. In order to first load a plugin manifest we must determine where the manifest is located.
- For cases where the plugin is `local` we simply search in the specified path.
- For cases where the plugin is a "remote" plugin, i.e. a git plugin we use the `GitService` implemented in #2107. We fetch the plugin at the remote and store it into the tuist cache directory under the `/Plugins` directory. The fetched repository is then fingerprinted (using the remote URL and "git id"). With the plugin fetched we simply load the manifest using the loader.

#### Note

This PR does **not** add any actual functionality for loading a `Plugin` it simply adds the `PluginService` and any required changes to get this compiling. There will be a follow up PR for the logic required to load plugin manifests.