### PR TITLE
Add support for .s source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 - Fourier CLI tool to automate development tasks [#2196](https://github.com/tuist/tuist/pull/2196) by @pepibumur](https://github.com/pepibumur).
+- Support `.s` source files [#2199](https://github.com/tuist/tuist/pull/2199) by[ @dcvz](https://github.com/dcvz).
 
 ## 1.29.0 - Tutu
 

--- a/Sources/TuistCore/Models/Target.swift
+++ b/Sources/TuistCore/Models/Target.swift
@@ -18,7 +18,7 @@ public enum TargetError: FatalError, Equatable {
 public struct Target: Equatable, Hashable, Comparable {
     // MARK: - Static
 
-    public static let validSourceExtensions: [String] = ["m", "swift", "mm", "cpp", "c", "d", "intentdefinition", "xcmappingmodel", "metal"]
+    public static let validSourceExtensions: [String] = ["m", "swift", "mm", "cpp", "c", "d", "s", "intentdefinition", "xcmappingmodel", "metal"]
     public static let validFolderExtensions: [String] = ["framework", "bundle", "app", "xcassets", "appiconset", "scnassets"]
 
     // MARK: - Attributes

--- a/Tests/TuistCoreTests/Models/TargetTests.swift
+++ b/Tests/TuistCoreTests/Models/TargetTests.swift
@@ -20,7 +20,7 @@ final class TargetErrorTests: TuistUnitTestCase {
 
 final class TargetTests: TuistUnitTestCase {
     func test_validSourceExtensions() {
-        XCTAssertEqual(Target.validSourceExtensions, ["m", "swift", "mm", "cpp", "c", "d", "intentdefinition", "xcmappingmodel", "metal"])
+        XCTAssertEqual(Target.validSourceExtensions, ["m", "swift", "mm", "cpp", "c", "d", "s", "intentdefinition", "xcmappingmodel", "metal"])
     }
 
     func test_productName_when_staticLibrary() {
@@ -87,6 +87,7 @@ final class TargetTests: TuistUnitTestCase {
             "sources/c.mm",
             "sources/d.c",
             "sources/e.cpp",
+            "sources/f.s",
             "sources/k.kt",
             "sources/n.metal",
         ])
@@ -105,6 +106,7 @@ final class TargetTests: TuistUnitTestCase {
             "sources/b.m",
             "sources/c.mm",
             "sources/d.c",
+            "sources/f.s",
             "sources/e.cpp",
             "sources/n.metal",
         ]))


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY
Request for comments document (if applies):

### Short description 📝

While migrating a large Swift/Objective-C++ codebase to use Tuist - I came across the need to use `.s` (assembly) files as sources. This PR will add it to the whitelisted extensions.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] A developer other than the author has verified that the changes work as expected.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
