### PR TITLE
Adjust the uFeatures guidelines

### DIFF
--- a/website/markdown/docs/building-at-scale/components/microfeatures.jsx
+++ b/website/markdown/docs/building-at-scale/components/microfeatures.jsx
@@ -15,49 +15,29 @@ const useBackgroundColor = () => {
   return theme.colors.background
 }
 
-const CrossPlatform = () => {
-  const textColor = useTextColor()
-  const backgroundColor = useBackgroundColor()
-  const width = useResponsiveValue(['100%', '600'])
-
-  return (
-    <Graphviz
-      options={{ width: width }}
-      dot={`digraph {
-        graph [bgcolor="${backgroundColor}"];
-        µSearchiOS [color="${textColor}", fontcolor="${textColor}"];
-        µSearchmacOS [color="${textColor}", fontcolor="${textColor}"];
-        µSearchwatchOS [color="${textColor}", fontcolor="${textColor}"];
-        µSearch [color="${textColor}", fontcolor="${textColor}"];
-        µSearchiOS -> µSearch [color="${textColor}"];
-        µSearchmacOS -> µSearch [color="${textColor}"];
-        µSearchwatchOS -> µSearch [color="${textColor}"];
-      }`}
-    />
-  )
-}
-
 const MicroFeature = () => {
   const textColor = useTextColor()
   const backgroundColor = useBackgroundColor()
-  const width = useResponsiveValue(['100%', '300'])
+  const width = useResponsiveValue(['100%', '400'])
 
   return (
-    <div sx={{ py: 2 }}>
+    <div sx={{ py: 0 }}>
       <Graphviz
         options={{ width: width }}
         dot={`digraph {
         graph [bgcolor="${backgroundColor}"];
-        Example [color="${textColor}", fontcolor="${textColor}"];
-        Source [color="${textColor}", fontcolor="${textColor}"];
-        Testing [color="${textColor}", fontcolor="${textColor}"];
-        Tests [color="${textColor}", fontcolor="${textColor}"];
+        FeatureExample [color="${textColor}", fontcolor="${textColor}"];
+        FeatureInterface [color="${textColor}", fontcolor="${textColor}"];
+        Feature [color="${textColor}", fontcolor="${textColor}"];
+        FeatureTesting [color="${textColor}", fontcolor="${textColor}"];
+        FeatureTests [color="${textColor}", fontcolor="${textColor}"];
 
-        Example -> Source [color="${textColor}"];
-        Example -> Testing [color="${textColor}"];
-        Tests -> Source [color="${textColor}"];
-        Tests -> Testing [color="${textColor}"];
-        Testing -> Source [color="${textColor}"];
+        FeatureExample -> Feature [color="${textColor}"];
+        FeatureExample -> FeatureTesting [color="${textColor}"];
+        FeatureTests -> Feature [color="${textColor}"];
+        FeatureTests -> FeatureTesting [color="${textColor}"];
+        FeatureTesting -> FeatureInterface [color="${textColor}"];
+        Feature -> FeatureInterface [color="${textColor}"];
       }`}
       />
     </div>
@@ -100,4 +80,4 @@ const Layers = () => {
   )
 }
 
-export { CrossPlatform, MicroFeature, Layers }
+export { MicroFeature, Layers }

--- a/website/markdown/docs/building-at-scale/microfeatures.mdx
+++ b/website/markdown/docs/building-at-scale/microfeatures.mdx
@@ -4,7 +4,7 @@ order: 1
 excerpt: 'This document describes an approach for architecting a modular Apple OS application to enable scalability, optimize build and test cycles, and ensure good practices.'
 ---
 
-import { CrossPlatform, MicroFeature, Layers } from './components/microfeatures'
+import { MicroFeature, Layers } from './components/microfeatures'
 
 # µFeatures Architecture
 
@@ -28,7 +28,7 @@ This is frequently a big source of frustration when it comes to work on those pr
 
 ## Motivation
 
-The µFeatures's main motivation is to support the scalability of large iOS codebases leveraging platform features and tools. There are other solutions out there that could be also be considered to overcome those issues. A very popular one nowadays is [React Native](https://facebook.github.io/react-native/) that leverages the Javascript dynamism to offer developers a pleasant experience working in the code base, but at the same time a native experience from the user point of view.
+The µFeatures's main motivation is to support the scalability of large Xcode codebases leveraging platform features and tools. There are other solutions out there that could be also be considered to overcome those issues. A very popular one nowadays is [React Native](https://facebook.github.io/react-native/) that leverages the Javascript dynamism to offer developers a pleasant experience working in the code base, but at the same time a native experience from the user point of view.
 
 **We believe that the usage of native tools and technologies can be optimized to overcome scalability challenges that sooner or later show up in our projects**
 
@@ -45,22 +45,28 @@ Developers should be able to **build, test and try** their features fast, with i
 
 ## What is a µFeature
 
-A µFeature represents an application feature and is a combination of the following 4 targets _(referring with target to a Xcode target)_:
+A µFeature represents an application feature and is a combination of the following five targets _(referring with target to a Xcode target)_:
 
 - **Source:** Contains the feature source code _(Swift, Objective-C, C++, React Native...)_ and its resources _(images, fonts, storyboards, xibs)_.
+- **Interface:** It's a companion target that contains the public interface and models of the feature.
 - **Tests:** Contains the feature unit and integration tests.
 - **Testing:** Provides testing data that can be used for the tests and from the example app. It also provides mocks for uFeature classes and protocols that can be used by other features as we'll see later.
 - **Example:** Contains an example app that developers can use to try out the feature under certain conditions _(different languages, screen sizes, settings)_.
 
-The diagram below shows the 4 targets and the dependencies between them:
+The diagram below shows the dependencies between the targets:
 
-<MicroFeature />
+- **Feature:** depends on `FeatureInterface` because it contains the models and the interfaces for which it provides implementations.
+- **FeatureTesting:** depends on `FeatureInterface` because it contains test data and mocks for the models and interfaces contained in it.
+- **FeatureTests:** depends on `Feature` because it contains the subjects under test and test data that can be used from the test classes.
+- **FeatureExample:** depends on `FeatureTesting` to have access to the test data, and `Feature` to instantiate the implementations and showcase them from the example app.
+
+  <MicroFeature />
 
 ## Why a µFeature
 
 ### Clear and concise APIs
 
-When all the app source code lives in the same target is very easy to build implicit dependencies in code, and end up with the so well-known spaghetti code. Everything is strongly coupled, the state is sometimes unpredictable, and introducing new changes become a nightmare. When we define features in independent targets we need to design public APIs as part of our feature implementation. We need to decide what should be public, how our feature should be consumed, what should remain private. We have more control over how we want our feature _"clients"_ to use the feature and we can enforce good practices by designing safe APIs.
+When all the app source code lives in the same target is very easy to build implicit dependencies in code, and end up with the so well-known spaghetti code. Everything is strongly coupled, the state is sometimes unpredictable, and introducing new changes become a nightmare. When we define features in independent targets we need to design public APIs as part of our feature implementation. We need to decide what should be public, how our feature should be consumed, what should remain private. We have more control over how we want our feature clients to use the feature and we can enforce good practices by designing safe APIs.
 
 ### Small modules
 
@@ -103,6 +109,15 @@ Product µFeatures contain features that the user can feel and interact with. Th
 />
 
 In practice, product µFeatures expose **views** and **services**. In the following sections we'll see how the app target uses those views and services to build up the app.
+
+## Dependencies between µFeatures
+
+When a µFeature depends on another µFeature, it declares a dependency against its interface target. The benefit of this is two-fold. It prevents the implementation of a µFeature to be coupled to the implementation of another µFeature, and it speeds up clean builds because they only have to compile the implementation of our feature, and the interfaces of direct and transitive dependencies. This approach is inspired by SwiftRock's idea of [Reducing iOS Build Times by using Interface Modules](https://swiftrocks.com/reducing-ios-build-times-by-using-interface-targets).
+
+Note that this approach comes at the cost of a bit of overhead doing dependency injection gluing all the µFeatures together.
+You can massage that cost by making an exception with the foundation µFeatures.
+Product µFeatures could have a direct dependency with the implementation of foundation µFeatures.
+That'd remove the need of an interface target for the core µFeatures.
 
 ## Hooking µFeatures
 
@@ -165,23 +180,6 @@ The example above shows how the home µFeature looks like. It gets initialized w
 You might have noticed that we pass a delegate when we instantiate the view controller. The delegate responds to actions that trigger a navigation to a different µFeature. It's up to the app to define the navigation between different µFeatures. A pattern that works very well here is the [Coordinator Pattern](https://vimeo.com/144116310) that allows you represent your navigation as a tree of coordinators. These coordinators would be in the app, responding to µFeatures actions, and triggering the navigation to other coordinators.
 
 Delegating the navigation to the app gives us the flexibility to change the navigation based on the product where we are consuming the µFeature from. Let's take an hypothetical search µFeature that exposes a search view controller. When we use that view controller from the app, we want to navigate to another µFeature when the user taps in one of the search results. However, if we use that view controller from an iMessage extension, we want the action to be different, and instead, share the search result with one of your contacts.
-
-## Layers
-
-We talked about µFeatures, types, and how to use them from the app, but we missed out a very important point, how to organize them to prevent ending up with a messy dependency graph or eventually with circular dependencies impossible to resolve for the compiler.
-
-It's recommended to organize the µFeatures in three layers below the product layer as shown in the image below.
-
-<Layers />
-
-- **Product µFeatures:** Contains all the product µFeatures.
-- **Dependency inversion:** Contains the product µFeatures public interfaces.
-- **Foundation µFeatures:** Contains all the foundation µFeatures.
-
-Product µFeatures don't depend on each other, instead we use the **dependency inversion principle** to expose their interfaces in a layer underneath them. There are a couple of advantages that support it:
-
-- It delegates to the app the decision about how different features are connected. We could decide in a product-basis.
-- It decouples the targets in the same layer, removing the need to compile all the dependencies when we try to compile a single product µFeature _(faster compilation)_.
 
 ## Dependencies
 
@@ -246,26 +244,22 @@ The example above shows how we can inject dependencies in a builder that builds 
   description="This is just an example of how we can simplify dependency injection. There are other alternatives out there. It's up to you to pick up the one that works best for your project and setup."
 />
 
-## Cross-platform µFeatures
+## Choosing the target product
 
-Your product might be available in different platforms or from different products. In that case it's very important that we reuse as much code as possible. `Foundation` APIs are very similar across plaftorms, with just some subtle differences, but UI frameworks like `UIKit` or `AppKit` are not. We could have multiplatform µFeatures by using [Swift macros](http://ericasadun.com/2014/06/06/swift-cross-platform-code/) that conditionally compile UI for each of the platforms. However, Xcode is very bad dealing with those macros and the syntax highlghting and the autocompletion don't work very well.
+When architecting a modular app,
+a question that arises often is whether targets should be frameworks or libraries, and whether they should be static or dynamic.
+In pre-Tuist era, there were many factor that influenced that decision:
 
-There is something we can do though to enable cross-platform µFeatures. Splitting business logic and UI in two different layers, one that contains the business layer and is cross-platform, and another one that contains the UI and that is platform/product specific.
+- Whether the target includes resources or not.
+- Whether the targeg depends on static targets that might lead to duplicated symbols issues upstream.
+- The number of dynamic targets that need to be linked at startup time and therfore might increase the time to launch the app.
 
-<CrossPlatform />
-
-The image above shows how the Search µFeature is split into the business logic target, `µSearch` and the platform specific ones `µSearchiOS` and `µSearchmacOS`. Both UI frameworks depend on `µSearch`. Each of those targets would have their corresponding tests target.
-
-<Message
-  info
-  title="Building cross-platform frameworks"
-  description="You can read more about how to setup frameworks to be cross-platform no the [following link](http://ilya.puchka.me/xcode-cross-platform-frameworks/)."
-/>
-
-## Example app
-
-You can check an example of the architecture on [this repository](https://github.com/tuist/microfeatures-example).
-Please, note that the project doesn't contain any code, it's just a definition of all the projects, targets, and the dependencies between them.
+Thanks to Tuist,
+the decision process has been notably simplified.
+Since Tuist supports defining resources in libraries,
+we recommend sticking to **static libraries**,
+unless you come across scenarios where a dynamic framework is more suitable.
+Bear in mind that Tuist makes changing the product a seamless process as long as you use the [standard interface](/docs/usage/resources/) for accessing resources.
 
 ## Frequently asked questions
 
@@ -277,13 +271,9 @@ If you are working with git branches, we recommend you to keep everything in the
 
 If µFeatures are part of the same repository, they are versioned with the app. If you have them in different repositories you can use Git Submodules, Carthage, or your own dependency resolver to fetch specific versions of your µFeatures to link from the app.
 
-#### External dependencies?
+#### How to add third-party dependencies?
 
-This architecture doesn't limit you from using external dependencies. There's one thing to keep in mind though: you won't be able to use [CocoaPods](https://cocoapods.org) dependencies with your µFeatures. CocoaPods is not able to analyze your dependencies tree, and setup all the targets in the stack accordingly. If you want to use an external dependency from a µFeature framework, we recommend you to use [Carthage](https://github.com/carthage) or the [Swift Package Manager](https://swift.org/package-manager/).
-
-#### Can I include resources?
-
-You can, but remember that you can only do it if your µFeature is a framework and not a library.
+This architecture doesn't limit you from using external dependencies. If you want to use an external dependency from a µFeature framework, we recommend you to use [Carthage](https://github.com/carthage) or the [Swift Package Manager](https://swift.org/package-manager/).
 
 ## Resources
 


### PR DESCRIPTION
### Short description 📝
It's been a long time since I wrote up the uFeatures guidelines. A lot has happened since then so it was calling for an update. In this PR, I'm introducing the following changes to the guidelines:
- Removed the idea of the features dependency-inversion layer in favor of [interface targets](https://swiftrocks.com/reducing-ios-build-times-by-using-interface-targets).
- Added a new section that documents how to define dependencies between features.
- Remove the layers section because it's no longer necessary after the introduction of interface targets.
- Added a section with some advice in regards to how to chose between framework or library, and static or dynamic.