### PR TITLE
[fix-unit-tests] change - replace `TuistTestCase` with `TuistUnitTest…

### DIFF
--- a/Tests/TuistCoreTests/Models/CarthageDependencyTests.swift
+++ b/Tests/TuistCoreTests/Models/CarthageDependencyTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import TuistCore
 @testable import TuistSupportTesting
 
-final class CarthageDependencyTests: TuistTestCase {
+final class CarthageDependencyTests: TuistUnitTestCase {
     func test_cartfileValue_github_exact() throws {
         // Given
         let dependency = CarthageDependency(origin: .github(path: "Alamofire/Alamofire"), requirement: .exact("1.2.3"), platforms: [.iOS])


### PR DESCRIPTION
Regard to @pepibumur comments:
- https://github.com/tuist/tuist/pull/2060#discussion_r549314323 - DONE
- https://github.com/tuist/tuist/pull/2060#discussion_r549314026 and https://github.com/tuist/tuist/pull/2060#discussion_r549314109 - I dig into `ProjectDescriptionTests` module and I found that every unit tests inherit from `XCTestCase` so I mimicked it for unit tests I added.