### PR TITLE
Chimera/spm models

### DIFF
--- a/Sources/ProjectDescription/Dependency.swift
+++ b/Sources/ProjectDescription/Dependency.swift
@@ -26,30 +26,10 @@ public enum Dependency: Codable, Equatable {
         case revision(String)
     }
 
-    /// Requirement for the Swift Package Manager dependency.
-    public enum SPMRequirement: Codable, Equatable {
-        /// Mimics `.exact("1.2.3")` from `Package.swift`.
-        case exact(Version)
-        /// Mimics `.upToNextMajor(from: "1.2.3")` from `Package.swift`.
-        case upToNextMajor(Version)
-        /// Mimics `.upToNextMinor(from: "1.2.3")` from `Package.swift`.
-        case upToNextMinor(Version)
-        /// Mimics `from: "1.2.3"` from `Package.swift`.
-        case atLeast(Version)
-        /// Mimics `"1.2.3"..<"1.2.6"` from `Package.swift`.
-        case range(Range<Version>)
-        /// Mimics `1.2.3"..."1.2.6` from `Package.swift`.`
-        case closedRange(ClosedRange<Version>)
-        /// Mimics `.branch("develop")` from `Package.swift`.
-        case branch(String)
-        /// Mimics `.revision("revision")` from `Package.swift`.
-        case revision(String)
-    }
-
     /// Contains the description of dependency that can by installed using Carthage. More: https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md
     case carthage(origin: CarthageOrigin, requirement: CarthageRequirement, platforms: Set<Platform>)
     /// Contains the description of dependency that can by installed using Swift Package Manager. More: https://docs.swift.org/package-manager/PackageDescription/index.html
-    case spm(url: String, requirement: SPMRequirement)
+    case swiftPackageManager(package: Package)
 }
 
 // MARK: - Dependency: Codable
@@ -57,7 +37,7 @@ public enum Dependency: Codable, Equatable {
 extension Dependency {
     private enum Kind: String, Codable {
         case carthage
-        case spm
+        case swiftPackageManager
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -65,8 +45,7 @@ extension Dependency {
         case origin
         case carthageRequirement
         case platforms
-        case url
-        case spmRequirement
+        case package
     }
 
     public init(from decoder: Decoder) throws {
@@ -78,10 +57,9 @@ extension Dependency {
             let requirement = try container.decode(CarthageRequirement.self, forKey: .carthageRequirement)
             let platforms = try container.decode(Set<Platform>.self, forKey: .platforms)
             self = .carthage(origin: origin, requirement: requirement, platforms: platforms)
-        case .spm:
-            let url = try container.decode(String.self, forKey: .url)
-            let requirement = try container.decode(SPMRequirement.self, forKey: .spmRequirement)
-            self = .spm(url: url, requirement: requirement)
+        case .swiftPackageManager:
+            let package = try container.decode(Package.self, forKey: .package)
+            self = .swiftPackageManager(package: package)
         }
     }
 
@@ -93,10 +71,9 @@ extension Dependency {
             try container.encode(origin, forKey: .origin)
             try container.encode(requirement, forKey: .carthageRequirement)
             try container.encode(platforms, forKey: .platforms)
-        case let .spm(url, requirement):
-            try container.encode(Kind.spm, forKey: .kind)
-            try container.encode(url, forKey: .url)
-            try container.encode(requirement, forKey: .spmRequirement)
+        case let .swiftPackageManager(package):
+            try container.encode(Kind.swiftPackageManager, forKey: .kind)
+            try container.encode(package, forKey: .package)
         }
     }
 }
@@ -205,91 +182,6 @@ extension Dependency.CarthageRequirement {
         case let .revision(revision):
             try container.encode(Kind.revision, forKey: .kind)
             try container.encode(revision, forKey: .revision)
-        }
-    }
-}
-
-// MARK: - Dependency.SPMRequirement: Codable
-
-extension Dependency.SPMRequirement {
-    private enum Kind: String, Codable {
-        case exact
-        case upToNextMajor
-        case upToNextMinor
-        case atLeast
-        case range
-        case closedRange
-        case revision
-        case branch
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case kind
-        case version
-        case range
-        case closedRange
-        case branch
-        case revision
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let kind = try container.decode(Kind.self, forKey: .kind)
-        switch kind {
-        case .exact:
-            let version = try container.decode(Version.self, forKey: .version)
-            self = .exact(version)
-        case .upToNextMajor:
-            let version = try container.decode(Version.self, forKey: .version)
-            self = .upToNextMajor(version)
-        case .upToNextMinor:
-            let version = try container.decode(Version.self, forKey: .version)
-            self = .upToNextMinor(version)
-        case .atLeast:
-            let version = try container.decode(Version.self, forKey: .version)
-            self = .atLeast(version)
-        case .range:
-            let range = try container.decode(Range<Version>.self, forKey: .range)
-            self = .range(range)
-        case .closedRange:
-            let closedRange = try container.decode(ClosedRange<Version>.self, forKey: .closedRange)
-            self = .closedRange(closedRange)
-        case .revision:
-            let revision = try container.decode(String.self, forKey: .revision)
-            self = .revision(revision)
-        case .branch:
-            let branch = try container.decode(String.self, forKey: .branch)
-            self = .branch(branch)
-        }
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        switch self {
-        case let .exact(version):
-            try container.encode(Kind.exact, forKey: .kind)
-            try container.encode(version, forKey: .version)
-        case let .upToNextMajor(version):
-            try container.encode(Kind.upToNextMajor, forKey: .kind)
-            try container.encode(version, forKey: .version)
-        case let .upToNextMinor(version):
-            try container.encode(Kind.upToNextMinor, forKey: .kind)
-            try container.encode(version, forKey: .version)
-        case let .atLeast(version):
-            try container.encode(Kind.atLeast, forKey: .kind)
-            try container.encode(version, forKey: .version)
-        case let .range(range):
-            try container.encode(Kind.range, forKey: .kind)
-            try container.encode(range, forKey: .range)
-        case let .closedRange(closedRange):
-            try container.encode(Kind.closedRange, forKey: .kind)
-            try container.encode(closedRange, forKey: .closedRange)
-        case let .revision(revision):
-            try container.encode(Kind.revision, forKey: .kind)
-            try container.encode(revision, forKey: .revision)
-        case let .branch(branch):
-            try container.encode(Kind.branch, forKey: .kind)
-            try container.encode(branch, forKey: .branch)
         }
     }
 }

--- a/Sources/ProjectDescription/Dependency.swift
+++ b/Sources/ProjectDescription/Dependency.swift
@@ -25,7 +25,7 @@ public enum Dependency: Codable, Equatable {
         /// Mimics `"revision"` from `Cartfile`.
         case revision(String)
     }
-    
+
     /// Requirement for the Swift Package Manager dependency.
     public enum SPMRequirement: Codable, Equatable {
         /// Mimics `.exact("1.2.3")` from `Package.swift`.
@@ -231,7 +231,7 @@ extension Dependency.SPMRequirement {
         case branch
         case revision
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(Kind.self, forKey: .kind)
@@ -262,7 +262,7 @@ extension Dependency.SPMRequirement {
             self = .branch(branch)
         }
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {

--- a/Sources/ProjectDescription/Dependency.swift
+++ b/Sources/ProjectDescription/Dependency.swift
@@ -12,7 +12,7 @@ public enum Dependency: Codable, Equatable {
         case binary(path: String)
     }
 
-    /// Requirement for the Carthage dependency
+    /// Requirement for the Carthage dependency.
     public enum CarthageRequirement: Codable, Equatable {
         /// Mimics `== 1.0` from `Cartfile`.
         case exact(Version)
@@ -25,9 +25,31 @@ public enum Dependency: Codable, Equatable {
         /// Mimics `"revision"` from `Cartfile`.
         case revision(String)
     }
+    
+    /// Requirement for the Swift Package Manager dependency.
+    public enum SPMRequirement: Codable, Equatable {
+        /// Mimics `.exact("1.2.3")` from `Package.swift`.
+        case exact(Version)
+        /// Mimics `.upToNextMajor(from: "1.2.3")` from `Package.swift`.
+        case upToNextMajor(Version)
+        /// Mimics `.upToNextMinor(from: "1.2.3")` from `Package.swift`.
+        case upToNextMinor(Version)
+        /// Mimics `from: "1.2.3"` from `Package.swift`.
+        case atLeast(Version)
+        /// Mimics `"1.2.3"..<"1.2.6"` from `Package.swift`.
+        case range(Range<Version>)
+        /// Mimics `1.2.3"..."1.2.6` from `Package.swift`.`
+        case closedRange(ClosedRange<Version>)
+        /// Mimics `.branch("develop")` from `Package.swift`.
+        case branch(String)
+        /// Mimics `.revision("revision")` from `Package.swift`.
+        case revision(String)
+    }
 
     /// Contains the description of dependency that can by installed using Carthage. More: https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md
     case carthage(origin: CarthageOrigin, requirement: CarthageRequirement, platforms: Set<Platform>)
+    /// Contains the description of dependency that can by installed using Swift Package Manager. More: https://docs.swift.org/package-manager/PackageDescription/index.html
+    case spm(url: String, requirement: SPMRequirement)
 }
 
 // MARK: - Dependency: Codable
@@ -35,13 +57,16 @@ public enum Dependency: Codable, Equatable {
 extension Dependency {
     private enum Kind: String, Codable {
         case carthage
+        case spm
     }
 
     private enum CodingKeys: String, CodingKey {
         case kind
         case origin
-        case requirement
+        case carthageRequirement
         case platforms
+        case url
+        case spmRequirement
     }
 
     public init(from decoder: Decoder) throws {
@@ -50,9 +75,13 @@ extension Dependency {
         switch kind {
         case .carthage:
             let origin = try container.decode(CarthageOrigin.self, forKey: .origin)
-            let requirement = try container.decode(CarthageRequirement.self, forKey: .requirement)
+            let requirement = try container.decode(CarthageRequirement.self, forKey: .carthageRequirement)
             let platforms = try container.decode(Set<Platform>.self, forKey: .platforms)
             self = .carthage(origin: origin, requirement: requirement, platforms: platforms)
+        case .spm:
+            let url = try container.decode(String.self, forKey: .url)
+            let requirement = try container.decode(SPMRequirement.self, forKey: .spmRequirement)
+            self = .spm(url: url, requirement: requirement)
         }
     }
 
@@ -62,8 +91,58 @@ extension Dependency {
         case let .carthage(origin, requirement, platforms):
             try container.encode(Kind.carthage, forKey: .kind)
             try container.encode(origin, forKey: .origin)
-            try container.encode(requirement, forKey: .requirement)
+            try container.encode(requirement, forKey: .carthageRequirement)
             try container.encode(platforms, forKey: .platforms)
+        case let .spm(url, requirement):
+            try container.encode(Kind.spm, forKey: .kind)
+            try container.encode(url, forKey: .url)
+            try container.encode(requirement, forKey: .spmRequirement)
+        }
+    }
+}
+
+// MARK: - Dependency.CarthageOrigin: Codable
+
+extension Dependency.CarthageOrigin {
+    private enum Kind: String, Codable {
+        case github
+        case git
+        case binary
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case path
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .github:
+            let path = try container.decode(String.self, forKey: .path)
+            self = .github(path: path)
+        case .git:
+            let path = try container.decode(String.self, forKey: .path)
+            self = .git(path: path)
+        case .binary:
+            let path = try container.decode(String.self, forKey: .path)
+            self = .binary(path: path)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .github(path):
+            try container.encode(Kind.github, forKey: .kind)
+            try container.encode(path, forKey: .path)
+        case let .git(path):
+            try container.encode(Kind.git, forKey: .kind)
+            try container.encode(path, forKey: .path)
+        case let .binary(path):
+            try container.encode(Kind.binary, forKey: .kind)
+            try container.encode(path, forKey: .path)
         }
     }
 }
@@ -130,48 +209,87 @@ extension Dependency.CarthageRequirement {
     }
 }
 
-// MARK: - Dependency.CarthageOrigin: Codable
+// MARK: - Dependency.SPMRequirement: Codable
 
-extension Dependency.CarthageOrigin {
+extension Dependency.SPMRequirement {
     private enum Kind: String, Codable {
-        case github
-        case git
-        case binary
+        case exact
+        case upToNextMajor
+        case upToNextMinor
+        case atLeast
+        case range
+        case closedRange
+        case revision
+        case branch
     }
 
     private enum CodingKeys: String, CodingKey {
         case kind
-        case path
+        case version
+        case range
+        case closedRange
+        case branch
+        case revision
     }
-
+    
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(Kind.self, forKey: .kind)
         switch kind {
-        case .github:
-            let path = try container.decode(String.self, forKey: .path)
-            self = .github(path: path)
-        case .git:
-            let path = try container.decode(String.self, forKey: .path)
-            self = .git(path: path)
-        case .binary:
-            let path = try container.decode(String.self, forKey: .path)
-            self = .binary(path: path)
+        case .exact:
+            let version = try container.decode(Version.self, forKey: .version)
+            self = .exact(version)
+        case .upToNextMajor:
+            let version = try container.decode(Version.self, forKey: .version)
+            self = .upToNextMajor(version)
+        case .upToNextMinor:
+            let version = try container.decode(Version.self, forKey: .version)
+            self = .upToNextMinor(version)
+        case .atLeast:
+            let version = try container.decode(Version.self, forKey: .version)
+            self = .atLeast(version)
+        case .range:
+            let range = try container.decode(Range<Version>.self, forKey: .range)
+            self = .range(range)
+        case .closedRange:
+            let closedRange = try container.decode(ClosedRange<Version>.self, forKey: .closedRange)
+            self = .closedRange(closedRange)
+        case .revision:
+            let revision = try container.decode(String.self, forKey: .revision)
+            self = .revision(revision)
+        case .branch:
+            let branch = try container.decode(String.self, forKey: .branch)
+            self = .branch(branch)
         }
     }
-
+    
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
-        case let .github(path):
-            try container.encode(Kind.github, forKey: .kind)
-            try container.encode(path, forKey: .path)
-        case let .git(path):
-            try container.encode(Kind.git, forKey: .kind)
-            try container.encode(path, forKey: .path)
-        case let .binary(path):
-            try container.encode(Kind.binary, forKey: .kind)
-            try container.encode(path, forKey: .path)
+        case let .exact(version):
+            try container.encode(Kind.exact, forKey: .kind)
+            try container.encode(version, forKey: .version)
+        case let .upToNextMajor(version):
+            try container.encode(Kind.upToNextMajor, forKey: .kind)
+            try container.encode(version, forKey: .version)
+        case let .upToNextMinor(version):
+            try container.encode(Kind.upToNextMinor, forKey: .kind)
+            try container.encode(version, forKey: .version)
+        case let .atLeast(version):
+            try container.encode(Kind.atLeast, forKey: .kind)
+            try container.encode(version, forKey: .version)
+        case let .range(range):
+            try container.encode(Kind.range, forKey: .kind)
+            try container.encode(range, forKey: .range)
+        case let .closedRange(closedRange):
+            try container.encode(Kind.closedRange, forKey: .kind)
+            try container.encode(closedRange, forKey: .closedRange)
+        case let .revision(revision):
+            try container.encode(Kind.revision, forKey: .kind)
+            try container.encode(revision, forKey: .revision)
+        case let .branch(branch):
+            try container.encode(Kind.branch, forKey: .kind)
+            try container.encode(branch, forKey: .branch)
         }
     }
 }

--- a/Sources/TuistCache/Utilities/CacheFrameworkBuilder.swift
+++ b/Sources/TuistCache/Utilities/CacheFrameworkBuilder.swift
@@ -124,7 +124,7 @@ public final class CacheFrameworkBuilder: CacheArtifactBuilding {
     }
 
     fileprivate func buildDirectory(for projectTarget: XcodeBuildTarget,
-                                    target: Target,
+                                    target _: Target,
                                     configuration: String,
                                     sdk: String) throws -> AbsolutePath
     {

--- a/Sources/TuistCache/Utilities/XcodeProjectPathHasher.swift
+++ b/Sources/TuistCache/Utilities/XcodeProjectPathHasher.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CryptoKit
+import Foundation
 
 // Thanks to https://pewpewthespells.com/blog/xcode_deriveddata_hashes.html for
 // the initial Objective-C implementation.
@@ -20,12 +20,13 @@ internal class XcodeProjectPathHasher {
 
         // Split 16 bytes into two chunks of 8 bytes each.
         let partitions = stride(from: 0, to: digest.count, by: 8).map {
-            Array(digest[$0..<Swift.min($0 + 8, digest.count)])
+            Array(digest[$0 ..< Swift.min($0 + 8, digest.count)])
         }
 
         guard
             let firstHalf = partitions.first,
-            let secondHalf = partitions.last else {
+            let secondHalf = partitions.last
+        else {
             throw HashingError.invalidPartitioning
         }
 

--- a/Sources/TuistLoader/Models+ManifestMappers/Dependencies+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Dependencies+ManifestMapper.swift
@@ -14,7 +14,7 @@ extension TuistGraph.Dependencies {
                 let requirement = try TuistGraph.CarthageDependency.Requirement.from(manifest: requirement)
                 let platforms = try platforms.map { try TuistGraph.Platform.from(manifest: $0) }
                 result.append(CarthageDependency(origin: origin, requirement: requirement, platforms: Set(platforms)))
-            case .spm:
+            case .swiftPackageManager:
                 #warning("IMPLEMENT ME")
             }
         }

--- a/Sources/TuistLoader/Models+ManifestMappers/Dependencies+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Dependencies+ManifestMapper.swift
@@ -14,6 +14,8 @@ extension TuistGraph.Dependencies {
                 let requirement = try TuistGraph.CarthageDependency.Requirement.from(manifest: requirement)
                 let platforms = try platforms.map { try TuistGraph.Platform.from(manifest: $0) }
                 result.append(CarthageDependency(origin: origin, requirement: requirement, platforms: Set(platforms)))
+            case .spm:
+                #warning("IMPLEMENT ME")
             }
         }
 

--- a/Sources/TuistSupport/System/System.swift
+++ b/Sources/TuistSupport/System/System.swift
@@ -504,9 +504,9 @@ public final class System: Systeming {
             var errorData: [UInt8] = []
             var processOne = System.process(arguments, environment: environment)
             var processTwo = System.process(secondArguments, environment: environment)
-            
+
             System.pipe(&processOne, &processTwo)
-            
+
             let pipes = System.pipeOutput(&processTwo)
 
             pipes.stdOut.fileHandleForReading.readabilityHandler = { fileHandle in
@@ -604,16 +604,17 @@ public final class System: Systeming {
     public func which(_ name: String) throws -> String {
         try capture("/usr/bin/env", "which", name).spm_chomp()
     }
-    
+
     // MARK: Helpers
-    
+
     /// Converts an array of arguments into a `Foundation.Process`
     /// - Parameters:
     ///   - arguments: Arguments for the process, first item being the executable URL.
     ///   - environment: Environment
     /// - Returns: A `Foundation.Process`
     static func process(_ arguments: [String],
-                        environment: [String: String]) -> Foundation.Process {
+                        environment: [String: String]) -> Foundation.Process
+    {
         let executablePath = arguments.first!
         let process = Foundation.Process()
         process.executableURL = URL(fileURLWithPath: executablePath)
@@ -621,7 +622,7 @@ public final class System: Systeming {
         process.environment = environment
         return process
     }
-    
+
     /// Pipe the output of one Process to another
     /// - Parameters:
     ///   - processOne: First Process
@@ -629,25 +630,26 @@ public final class System: Systeming {
     /// - Returns: The pipe
     @discardableResult
     static func pipe(_ processOne: inout Foundation.Process,
-                     _ processTwo: inout Foundation.Process) -> Pipe {
+                     _ processTwo: inout Foundation.Process) -> Pipe
+    {
         let processPipe = Pipe()
-        
+
         processOne.standardOutput = processPipe
         processTwo.standardInput = processPipe
         return processPipe
     }
-    
+
     /// PIpe the output of a process into separate output and error pipes
     /// - Parameter process: The process to pipe
     /// - Returns: Tuple that contains the output and error Pipe.
     static func pipeOutput(_ process: inout Foundation.Process) -> (stdOut: Pipe, stdErr: Pipe) {
         let stdOut: Pipe = Pipe()
         let stdErr: Pipe = Pipe()
-        
+
         // Redirect output of Process Two
         process.standardOutput = stdOut
         process.standardError = stdErr
-        
+
         return (stdOut, stdErr)
     }
 }

--- a/Tests/ProjectDescriptionTests/DependenciesTests.swift
+++ b/Tests/ProjectDescriptionTests/DependenciesTests.swift
@@ -8,6 +8,8 @@ final class DependenciesTests: XCTestCase {
         let subject = Dependencies([
             .carthage(origin: .github(path: "Dependency1/Dependency1"), requirement: .branch("BranchName"), platforms: [.iOS]),
             .carthage(origin: .git(path: "Dependency2/Dependency2"), requirement: .upToNext("1.2.3"), platforms: [.tvOS, .macOS]),
+            .spm(url: "Dependency3/Dependency3", requirement: .exact("4.5.6")),
+            .spm(url: "Dependency4/Dependency4", requirement: .range("1.1.1"..<"1.1.3")),
         ])
         XCTAssertCodable(subject)
     }

--- a/Tests/ProjectDescriptionTests/DependenciesTests.swift
+++ b/Tests/ProjectDescriptionTests/DependenciesTests.swift
@@ -8,8 +8,8 @@ final class DependenciesTests: XCTestCase {
         let subject = Dependencies([
             .carthage(origin: .github(path: "Dependency1/Dependency1"), requirement: .branch("BranchName"), platforms: [.iOS]),
             .carthage(origin: .git(path: "Dependency2/Dependency2"), requirement: .upToNext("1.2.3"), platforms: [.tvOS, .macOS]),
-            .spm(url: "Dependency3/Dependency3", requirement: .exact("4.5.6")),
-            .spm(url: "Dependency4/Dependency4", requirement: .range("1.1.1" ..< "1.1.3")),
+            .swiftPackageManager(package: .local(path: "Path/Path")),
+            .swiftPackageManager(package: .remote(url: "Dependency3/Dependency3", requirement: .exact("4.5.6"))),
         ])
         XCTAssertCodable(subject)
     }

--- a/Tests/ProjectDescriptionTests/DependenciesTests.swift
+++ b/Tests/ProjectDescriptionTests/DependenciesTests.swift
@@ -9,7 +9,7 @@ final class DependenciesTests: XCTestCase {
             .carthage(origin: .github(path: "Dependency1/Dependency1"), requirement: .branch("BranchName"), platforms: [.iOS]),
             .carthage(origin: .git(path: "Dependency2/Dependency2"), requirement: .upToNext("1.2.3"), platforms: [.tvOS, .macOS]),
             .spm(url: "Dependency3/Dependency3", requirement: .exact("4.5.6")),
-            .spm(url: "Dependency4/Dependency4", requirement: .range("1.1.1"..<"1.1.3")),
+            .spm(url: "Dependency4/Dependency4", requirement: .range("1.1.1" ..< "1.1.3")),
         ])
         XCTAssertCodable(subject)
     }

--- a/Tests/ProjectDescriptionTests/DependencyTests.swift
+++ b/Tests/ProjectDescriptionTests/DependencyTests.swift
@@ -8,7 +8,7 @@ final class DependencyTests: XCTestCase {
         let subject: Dependency = .carthage(origin: .github(path: "Dependency/Dependency"), requirement: .revision("xyz"), platforms: [.iOS, .macOS, .tvOS, .watchOS])
         XCTAssertCodable(subject)
     }
-    
+
     func test_dependency_spm_codable() {
         let subject: Dependency = .spm(url: "Path/Path", requirement: .exact("1.2.3"))
         XCTAssertCodable(subject)
@@ -57,44 +57,44 @@ final class DependencyTests: XCTestCase {
         let subject: Dependency.CarthageRequirement = .revision("revision")
         XCTAssertCodable(subject)
     }
-    
+
     // MARK: - SPM Requirement tests
-    
+
     func test_spmRequirement_exact_codable() {
         let subject: Dependency.SPMRequirement = .exact("1.2.3")
         XCTAssertCodable(subject)
     }
-    
+
     func test_spmRequirement_upToNextMajor_codable() {
         let subject: Dependency.SPMRequirement = .upToNextMajor("2.2.1")
         XCTAssertCodable(subject)
     }
-    
+
     func test_spmRequirement_upToNextMinor_codable() {
         let subject: Dependency.SPMRequirement = .upToNextMinor("4.4.1")
         XCTAssertCodable(subject)
     }
-    
+
     func test_spmRequirement_atLeast_codable() {
         let subject: Dependency.SPMRequirement = .atLeast("9.0.1")
         XCTAssertCodable(subject)
     }
-    
+
     func test_spmRequirement_range_codable() {
-        let subject: Dependency.SPMRequirement = .range("9.0.1"..<"10.1.0")
+        let subject: Dependency.SPMRequirement = .range("9.0.1" ..< "10.1.0")
         XCTAssertCodable(subject)
     }
-    
+
     func test_spmRequirement_closedRange_codable() {
-        let subject: Dependency.SPMRequirement = .closedRange("1.2.1"..."7.1.4")
+        let subject: Dependency.SPMRequirement = .closedRange("1.2.1" ... "7.1.4")
         XCTAssertCodable(subject)
     }
-    
+
     func test_spmRequirement_branch_codable() {
         let subject: Dependency.SPMRequirement = .branch("branch")
         XCTAssertCodable(subject)
     }
-    
+
     func test_spmRequirement_revision_codable() {
         let subject: Dependency.SPMRequirement = .revision("revision")
         XCTAssertCodable(subject)

--- a/Tests/ProjectDescriptionTests/DependencyTests.swift
+++ b/Tests/ProjectDescriptionTests/DependencyTests.swift
@@ -10,7 +10,7 @@ final class DependencyTests: XCTestCase {
     }
 
     func test_dependency_spm_codable() {
-        let subject: Dependency = .spm(url: "Path/Path", requirement: .exact("1.2.3"))
+        let subject: Dependency = .swiftPackageManager(package: .local(path: "Path/Path"))
         XCTAssertCodable(subject)
     }
 
@@ -55,48 +55,6 @@ final class DependencyTests: XCTestCase {
 
     func test_carthageRequirement_revision_codable() {
         let subject: Dependency.CarthageRequirement = .revision("revision")
-        XCTAssertCodable(subject)
-    }
-
-    // MARK: - SPM Requirement tests
-
-    func test_spmRequirement_exact_codable() {
-        let subject: Dependency.SPMRequirement = .exact("1.2.3")
-        XCTAssertCodable(subject)
-    }
-
-    func test_spmRequirement_upToNextMajor_codable() {
-        let subject: Dependency.SPMRequirement = .upToNextMajor("2.2.1")
-        XCTAssertCodable(subject)
-    }
-
-    func test_spmRequirement_upToNextMinor_codable() {
-        let subject: Dependency.SPMRequirement = .upToNextMinor("4.4.1")
-        XCTAssertCodable(subject)
-    }
-
-    func test_spmRequirement_atLeast_codable() {
-        let subject: Dependency.SPMRequirement = .atLeast("9.0.1")
-        XCTAssertCodable(subject)
-    }
-
-    func test_spmRequirement_range_codable() {
-        let subject: Dependency.SPMRequirement = .range("9.0.1" ..< "10.1.0")
-        XCTAssertCodable(subject)
-    }
-
-    func test_spmRequirement_closedRange_codable() {
-        let subject: Dependency.SPMRequirement = .closedRange("1.2.1" ... "7.1.4")
-        XCTAssertCodable(subject)
-    }
-
-    func test_spmRequirement_branch_codable() {
-        let subject: Dependency.SPMRequirement = .branch("branch")
-        XCTAssertCodable(subject)
-    }
-
-    func test_spmRequirement_revision_codable() {
-        let subject: Dependency.SPMRequirement = .revision("revision")
         XCTAssertCodable(subject)
     }
 }

--- a/Tests/ProjectDescriptionTests/DependencyTests.swift
+++ b/Tests/ProjectDescriptionTests/DependencyTests.swift
@@ -4,52 +4,99 @@ import XCTest
 @testable import ProjectDescription
 
 final class DependencyTests: XCTestCase {
-    func test_dependency_carthage_codable() throws {
+    func test_dependency_carthage_codable() {
         let subject: Dependency = .carthage(origin: .github(path: "Dependency/Dependency"), requirement: .revision("xyz"), platforms: [.iOS, .macOS, .tvOS, .watchOS])
+        XCTAssertCodable(subject)
+    }
+    
+    func test_dependency_spm_codable() {
+        let subject: Dependency = .spm(url: "Path/Path", requirement: .exact("1.2.3"))
         XCTAssertCodable(subject)
     }
 
     // MARK: - Carthage Origin tests
 
-    func test_carthageOrigin_github_codable() throws {
+    func test_carthageOrigin_github_codable() {
         let subject: Dependency.CarthageOrigin = .github(path: "Path/Path")
         XCTAssertCodable(subject)
     }
 
-    func test_carthageOrigin_git_codable() throws {
+    func test_carthageOrigin_git_codable() {
         let subject: Dependency.CarthageOrigin = .git(path: "Git/Git")
         XCTAssertCodable(subject)
     }
 
-    func test_carthageOrigin_binary_codable() throws {
+    func test_carthageOrigin_binary_codable() {
         let subject: Dependency.CarthageOrigin = .binary(path: "file:///some/Path/MyFramework.json")
         XCTAssertCodable(subject)
     }
 
     // MARK: - Carthage Requirement tests
 
-    func test_carthageRequirement_exact_codable() throws {
+    func test_carthageRequirement_exact_codable() {
         let subject: Dependency.CarthageRequirement = .exact("1.0.0")
         XCTAssertCodable(subject)
     }
 
-    func test_carthageRequirement_upToNext_codable() throws {
+    func test_carthageRequirement_upToNext_codable() {
         let subject: Dependency.CarthageRequirement = .upToNext("3.2.0")
         XCTAssertCodable(subject)
     }
 
-    func test_carthageRequirement_atLeast_codable() throws {
+    func test_carthageRequirement_atLeast_codable() {
         let subject: Dependency.CarthageRequirement = .atLeast("3.2.0")
         XCTAssertCodable(subject)
     }
 
-    func test_carthageRequirement_branch_codable() throws {
+    func test_carthageRequirement_branch_codable() {
         let subject: Dependency.CarthageRequirement = .branch("branch")
         XCTAssertCodable(subject)
     }
 
-    func test_carthageRequirement_revision_codable() throws {
+    func test_carthageRequirement_revision_codable() {
         let subject: Dependency.CarthageRequirement = .revision("revision")
+        XCTAssertCodable(subject)
+    }
+    
+    // MARK: - SPM Requirement tests
+    
+    func test_spmRequirement_exact_codable() {
+        let subject: Dependency.SPMRequirement = .exact("1.2.3")
+        XCTAssertCodable(subject)
+    }
+    
+    func test_spmRequirement_upToNextMajor_codable() {
+        let subject: Dependency.SPMRequirement = .upToNextMajor("2.2.1")
+        XCTAssertCodable(subject)
+    }
+    
+    func test_spmRequirement_upToNextMinor_codable() {
+        let subject: Dependency.SPMRequirement = .upToNextMinor("4.4.1")
+        XCTAssertCodable(subject)
+    }
+    
+    func test_spmRequirement_atLeast_codable() {
+        let subject: Dependency.SPMRequirement = .atLeast("9.0.1")
+        XCTAssertCodable(subject)
+    }
+    
+    func test_spmRequirement_range_codable() {
+        let subject: Dependency.SPMRequirement = .range("9.0.1"..<"10.1.0")
+        XCTAssertCodable(subject)
+    }
+    
+    func test_spmRequirement_closedRange_codable() {
+        let subject: Dependency.SPMRequirement = .closedRange("1.2.1"..."7.1.4")
+        XCTAssertCodable(subject)
+    }
+    
+    func test_spmRequirement_branch_codable() {
+        let subject: Dependency.SPMRequirement = .branch("branch")
+        XCTAssertCodable(subject)
+    }
+    
+    func test_spmRequirement_revision_codable() {
+        let subject: Dependency.SPMRequirement = .revision("revision")
         XCTAssertCodable(subject)
     }
 }


### PR DESCRIPTION
Working on #1674 

### Short description 📝

This PR adds possibility to define requirements for Swift Package Manager dependency in `Dependencies.swift` manifest.

### Implementation 👩‍💻👨‍💻

- `SPMRequirement` flats number of [methods](https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#package-dependency). 
- I do not add platforms argument. 

### Questions ❓

- What do you think about the name of `Dependency.spm`? I was also considering `Dependency.package` or `Dependency.swiftPackageManager`. 

