### PR TITLE
Force the creation of the symbolic link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- Update failing trying to create the `swift-project` symbolic link [#2244](https://github.com/tuist/tuist/pull/2244)
+
 ## 1.30.0 - 2021
+
 ### Fixed
 
 - Fix import of multiple signing certificates [#2112](https://github.com/tuist/tuist/pull/2112) by [@rist](https://github.com/rist).
@@ -14,10 +19,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Add support for embedded scripts in a TargetAction. [#2192](https://github.com/tuist/tuist/pull/2192) by [@jsorge](https://github.com/jsorge)
 - Support for `Carthage` dependencies in `Dependencies.swift` [#2060](https://github.com/tuist/tuist/pull/2060) by [@laxmorek](https://github.com/laxmorek).
-- Fourier CLI tool to automate development tasks [#2196](https://github.com/tuist/tuist/pull/2196) by @pepibumur](https://github.com/pepibumur).
-- Add support for embedded scripts in a TargetAction. [#2192](https://github.com/tuist/tuist/pull/2192) by [@jsorge]
-- Support `.s` source files [#2199](https://github.com/tuist/tuist/pull/2199) by[ @dcvz](https://github.com/dcvz).
-- Support for printing from the manifest files [#2215](https://github.com/tuist/tuist/pull/2215) by @pepibumur](https://github.com/pepibumur).
+- Fourier CLI tool to automate development tasks [#2196](https://github.com/tuist/tuist/pull/2196) by [@pepibumur](https://github.com/pepibumur).
+- Add support for embedded scripts in a TargetAction. [#2192](https://github.com/tuist/tuist/pull/2192) by [@jsorge](https://github.com/jsorge)
+- Support `.s` source files [#2199](https://github.com/tuist/tuist/pull/2199) by [@dcvz](https://github.com/dcvz).
+- Support for printing from the manifest files [#2215](https://github.com/tuist/tuist/pull/2215) by [@pepibumur](https://github.com/pepibumur).
 
 ### Changed
 

--- a/Sources/TuistEnvKit/Updater/EnvUpdater.swift
+++ b/Sources/TuistEnvKit/Updater/EnvUpdater.swift
@@ -37,7 +37,7 @@ final class EnvUpdater: EnvUpdating {
 
             // Replace
             try System.shared.async(["/bin/cp", "-rf", binaryPath, "/usr/local/bin/tuist"])
-            try System.shared.async(["/bin/ln", "-s", "/usr/local/bin/tuist", "/usr/local/bin/swift-project"])
+            try System.shared.async(["/bin/ln", "-sf", "/usr/local/bin/tuist", "/usr/local/bin/swift-project"])
             try System.shared.async(["/bin/rm", binaryPath])
         }
     }

--- a/Tests/TuistEnvKitTests/Updater/EnvUpdaterTests.swift
+++ b/Tests/TuistEnvKitTests/Updater/EnvUpdaterTests.swift
@@ -32,7 +32,7 @@ final class EnvUpdaterTests: TuistUnitTestCase {
         system.succeedCommand(["/usr/bin/unzip", "-o", downloadPath.pathString, "-d", "/tmp/"])
         system.succeedCommand(["/bin/chmod", "+x", "/tmp/tuistenv"])
         system.succeedCommand(["/bin/cp", "-rf", "/tmp/tuistenv", "/usr/local/bin/tuist"])
-        system.succeedCommand(["/bin/ln", "-s", "/usr/local/bin/tuist", "/usr/local/bin/swift-project"])
+        system.succeedCommand(["/bin/ln", "-sf", "/usr/local/bin/tuist", "/usr/local/bin/swift-project"])
         system.succeedCommand(["/bin/rm", "/tmp/tuistenv"])
 
         // When


### PR DESCRIPTION
### Short description 📝
Updating Tuist with `tuist update` yields the following error:

```
git aln: /usr/local/bin/swift-project: File exists
```

It happens because we don't force the creation of the symbolic link and therefore it fails when a symbolic name at the same path already exists. I've extended the command that creates the symbolic link to use `-sf` instead of simply `-s`.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] A developer other than the author has verified that the changes work as expected.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
