### PR TITLE
fix: support arm64e architecture in xcframeworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Update failing trying to create the `swift-project` symbolic link [#2244](https://github.com/tuist/tuist/pull/2244)
+- Tuist now correctly parses arm64e architectures in xcframeworks [#2247](https://github.com/tuist/tuist/pull/2247) by [@thedavidharris](https://github.com/thedavidharris).
 
 ## 1.30.0 - 2021
 

--- a/Sources/TuistCore/Models/BinaryArchitecture.swift
+++ b/Sources/TuistCore/Models/BinaryArchitecture.swift
@@ -8,6 +8,7 @@ public enum BinaryArchitecture: String, Codable {
     case arm64
     case armv7k
     case arm6432 = "arm64_32"
+    case arm64e
 }
 
 public enum BinaryLinking: String, Codable {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY
Request for comments document (if applies):

### Short description 📝

Adds support so that arm64e architectures can be decoded when including xcframeworks. Previously, this error would appear:

```
We received an error that we couldn't handle:
    - Localized description: The data couldn't be read because it isn't in the correct format.
    - Error: dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "AvailableLibraries", intValue: nil), _PlistKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "SupportedArchitectures", intValue: nil), _PlistKey(stringValue: "Index 1", intValue: 1)], debugDescription: "Cannot initialize BinaryArchitecture from invalid String value arm64e", underlyingError: nil))"
```

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] A developer other than the author has verified that the changes work as expected.
- [ ] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
