### PR TITLE
Code style tooling improvements

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -15,6 +15,7 @@ disabled_rules:
   - file_length
   - todo
   - function_parameter_count
+  - opening_brace
 line_length:
   ignores_interpolated_strings: true
   ignores_comments: true


### PR DESCRIPTION
### Short description 📝

Improve `Swiftlint` and `swift-format` usage:
- removed `opening_brace` rule of `swiftlint` because it conflicts with `swiftformat` `wrapMultilineStatementBraces`
- added a `install-hooks.sh` script that installs tuist git hooks 
- created a `pre-commit` hook to run rake and format/lint the code

I thought about mentioning `script/install-hooks.sh` in the `Contributing` documentation, but I didn't find the right place. Any suggestions?