### PR TITLE
Fixed error message for command “migration list-targets” when xcodeproj path does not exists

### DIFF
--- a/Tests/TuistMigrationIntegrationTests/Utilities/TargetsExtractorIntegrationTests.swift
+++ b/Tests/TuistMigrationIntegrationTests/Utilities/TargetsExtractorIntegrationTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import TSCBasic
+import TuistSupport
+import XCTest
+
+@testable import TuistMigration
+@testable import TuistSupportTesting
+
+final class TargetsExtractorIntegrationTests: TuistTestCase {
+    var subject: TargetsExtractor!
+
+    override func setUp() {
+        super.setUp()
+        subject = TargetsExtractor()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        subject = nil
+    }
+
+    func test_when_the_xcodeproj_path_doesnt_exist() throws {
+        // Given
+        let xcodeprojPath = AbsolutePath("/invalid/path.xcodeproj")
+
+        // Then
+        XCTAssertThrowsSpecific(try subject.targetsSortedByDependencies(xcodeprojPath: xcodeprojPath), TargetsExtractorError.missingXcodeProj(xcodeprojPath))
+    }
+
+    func test_when_existing_xcodeproj_path_with_targets() throws {
+        // Given
+        let xcodeprojPath = fixturePath(path: RelativePath("Frameworks/Frameworks.xcodeproj"))
+
+        // Then
+        let result = try subject.targetsSortedByDependencies(xcodeprojPath: xcodeprojPath)
+        XCTAssertNotEmpty(result)
+    }
+}


### PR DESCRIPTION
### Short description 📝

As per title this should fix the error message for the command "migration list-targets" when passing a non existing file.
Also added some tests which were missing :)

Resolves https://github.com/tuist/tuist/issues/2295

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] A developer other than the author has verified that the changes work as expected.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
