### PR TITLE
Code style improvements 

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,6 +7,13 @@ excluded:
   - .build
   - tools/fixturegen/.build
   - tools/tuistbench/.build
+  - bin
+  - design
+  - next
+  - generated_fixtures
+  - website
+  - script
+  - vendor
 disabled_rules:
   - trailing_whitespace
   - trailing_comma

--- a/Rakefile
+++ b/Rakefile
@@ -84,7 +84,7 @@ desc("Install git hooks")
 task :install_git_hooks do
   system("cp hooks/pre-commit .git/hooks/pre-commit")
   system("chmod 777 .git/hooks/pre-commit")
-  puts("pre-commit hooks installed on .git/hooks/")
+  puts("pre-commit hook installed on .git/hooks/")
 end
 
 desc("Formats the code style")

--- a/Rakefile
+++ b/Rakefile
@@ -80,10 +80,16 @@ task :swift_lint_update do
   File.write(File.join(root_dir, "vendor/.swiftlint.version"), SWIFTLINT_VERSION)
 end
 
+desc("Install git hooks")
+task :install_git_hooks do
+  system("cp hooks/pre-commit .git/hooks/pre-commit")
+  system("chmod 777 .git/hooks/pre-commit")
+  puts("pre-commit hooks installed on .git/hooks/")
+end
+
 desc("Formats the code style")
 task :style_correct do
-  system(swiftlint_path, "autocorrect")
-  system(swiftformat_path, ".")
+  system(code_style_path)
 end
 
 desc("Swift format check")
@@ -207,6 +213,10 @@ end
 
 def swiftlint_path
   File.expand_path("bin/swiftlint", __dir__)
+end
+
+def code_style_path
+  File.expand_path("script/code_style.sh", __dir__)
 end
 
 def decrypt_secrets

--- a/Rakefile
+++ b/Rakefile
@@ -83,7 +83,7 @@ end
 desc("Install git hooks")
 task :install_git_hooks do
   system("cp hooks/pre-commit .git/hooks/pre-commit")
-  system("chmod 777 .git/hooks/pre-commit")
+  system("chmod u+x .git/hooks/pre-commit")
   puts("pre-commit hook installed on .git/hooks/")
 end
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+script/code_style.sh

--- a/script/code_style.sh
+++ b/script/code_style.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+echo "Running SwiftFormat..."
+bin/swiftformat . --quiet
+if [ $? -ne 0 ] 
+then
+    echo "Swiftformat detected issues, please add changes and commit again"
+    exit 1
+else
+    echo "Running Swiftlint...";
+    bin/swiftlint lint --quiet
+    if [ $? -ne 0 ]
+    then
+        bin/swiftlint autocorrect --quiet
+        echo "Swiftlint detected issues, please add changes and commit again"
+    else
+        echo "Code is formatted and linted correctly. Proceeding with commit..."
+        exit 0
+    fi
+fi

--- a/website/markdown/docs/contribution/getting-started.mdx
+++ b/website/markdown/docs/contribution/getting-started.mdx
@@ -41,6 +41,7 @@ With it you'll also get familiar with the most used elements from the Foundation
 To start working on the project, we can follow the steps below:
 
 - Clone the repository by running: `git clone git@github.com:tuist/tuist.git`
+- Run `rake install_git_hooks` to automatically format the code following Tuist's conventions
 - Open `Package.swift` using Xcode
 
 <Message


### PR DESCRIPTION
Follow up of [this PR](https://github.com/tuist/tuist/pull/2254)

### Short description 📝

- Improve `Swiftlint` and `swift-format` usage:
- Added a `rake install_git_hooks` script that installs Tuist git hooks, for now only a `pre-commit`
- Created a `pre-commit` hook to format and lint the code. I had to write it in bash because when invoking `swiftlint` from ruby it was terminating the process on a failure.
- Updated documentation