### PR TITLE
Improve performance by removing unneeded Glob directory cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Changed
+
+- Improve performance of project generation by removing unneeded Glob directory cache [#2318](https://github.com/tuist/tuist/pull/2318) by [@adellibovi](https://github.com/adellibovi).
+
 ## 1.31.0 - Arctic
 
 ### Added

--- a/Sources/TuistSupport/Utils/Glob.swift
+++ b/Sources/TuistSupport/Utils/Glob.swift
@@ -67,8 +67,6 @@ public class Glob: Collection {
 
     public static var defaultBehavior = GlobBehaviorBashV4
 
-    private var isDirectoryCache = [String: Bool]()
-
     public let behavior: Behavior
     var paths = [String]()
     public var startIndex: Int { paths.startIndex }
@@ -103,8 +101,6 @@ public class Glob: Collection {
         paths = Array(Set(paths)).sorted { lhs, rhs in
             lhs.compare(rhs) != ComparisonResult.orderedDescending
         }
-
-        clearCaches()
     }
 
     // MARK: Private
@@ -162,10 +158,6 @@ public class Glob: Collection {
     }
 
     private func isDirectory(path: String) -> Bool {
-        if let isDirectory = isDirectoryCache[path] {
-            return isDirectory
-        }
-
         #if os(macOS)
             var isDirectoryBool = ObjCBool(false)
         #else
@@ -178,13 +170,7 @@ public class Glob: Collection {
             isDirectory = isDirectory && isDirectoryBool
         #endif
 
-        isDirectoryCache[path] = isDirectory
-
         return isDirectory
-    }
-
-    private func clearCaches() {
-        isDirectoryCache.removeAll()
     }
 
     private func populateFiles(gt: glob_t, includeFiles: Bool) {


### PR DESCRIPTION
### Short description 📝

Hi,
I didn't create a new issue for this PR, should I? Also, should this, if accepted, have an entry in the changelog?

The PR removes a cache that was used to prevent the check of isDirectory when listing files using glob. Unfortunately it seems the cache gets barely hit (actually I was not able to get any hit at all?)
This speeds things up to 65% from the time spent running the glob. Using the generated fixture "2000_sources" I've got almost 20% improvement! 😄

    Fixture       : 2000_sources
    Runs          : 5
    Result
        - cold : 14,50s  vs  17,71s (⬇︎ -3,21s -18,12%)
        - warm : 13,44s  vs  16,79s (⬇︎ -3,35s -19,97%)

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] A developer other than the author has verified that the changes work as expected.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
