### PR TITLE
Speed up cache warm by using precompiled cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Changed
 
+- Improve the cache warm command significantly by avoiding to recompile already in-cache dependency targets [#2377](https://github.com/tuist/tuist/pull/2377) by [@adellibovi](https://github.com/adellibovi).
 - Improve the cache warm command significantly (around 20-45 seconds per framework) by using `XcodeProjectPathHasher` instead of `CacheBuildPhaseProjectMapper` [#2356](https://github.com/tuist/tuist/pull/2318) by [@natanrolnik](https://github.com/natanrolnik).
 - Improve performance of project generation by removing unneeded Glob directory cache [#2318](https://github.com/tuist/tuist/pull/2318) by [@adellibovi](https://github.com/adellibovi).
 - Extracted graph models into `TuistGraph` [#2324](https://github.com/tuist/tuist/pull/2324) by [@pepibumur](https://github.com/pepibumur).

--- a/Sources/TuistSupport/Utils/Glob.swift
+++ b/Sources/TuistSupport/Utils/Glob.swift
@@ -133,7 +133,6 @@ public class Glob: Collection {
             }
         } catch {
             directories = []
-            print("Error parsing file system item: \(error)")
         }
 
         if behavior.includesFilesFromRootOfGlobstar {

--- a/Tests/TuistKitTests/Cache/CacheControllerTests.swift
+++ b/Tests/TuistKitTests/Cache/CacheControllerTests.swift
@@ -25,6 +25,7 @@ final class CacheControllerTests: TuistUnitTestCase {
     var projectGeneratorProvider: MockCacheControllerProjectGeneratorProvider!
     var config: Config!
     var cacheGraphLinter: MockCacheGraphLinter!
+    var focusServiceProjectGeneratorFactory: MockFocusServiceProjectGeneratorFactory!
 
     override func setUp() {
         generator = MockGenerator()
@@ -36,11 +37,14 @@ final class CacheControllerTests: TuistUnitTestCase {
         projectGeneratorProvider = MockCacheControllerProjectGeneratorProvider()
         projectGeneratorProvider.stubbedGeneratorResult = generator
         cacheGraphLinter = MockCacheGraphLinter()
+        focusServiceProjectGeneratorFactory = MockFocusServiceProjectGeneratorFactory()
+        focusServiceProjectGeneratorFactory.stubbedGeneratorResult = generator
         subject = CacheController(cache: cache,
                                   artifactBuilder: artifactBuilder,
                                   projectGeneratorProvider: projectGeneratorProvider,
                                   graphContentHasher: graphContentHasher,
-                                  cacheGraphLinter: cacheGraphLinter)
+                                  cacheGraphLinter: cacheGraphLinter,
+                                  focusServiceProjectGeneratorFactory: focusServiceProjectGeneratorFactory)
 
         super.setUp()
     }
@@ -54,6 +58,7 @@ final class CacheControllerTests: TuistUnitTestCase {
         cache = nil
         subject = nil
         config = nil
+        focusServiceProjectGeneratorFactory = nil
     }
 
     func test_cache_builds_and_caches_the_frameworks() throws {
@@ -61,16 +66,24 @@ final class CacheControllerTests: TuistUnitTestCase {
         let path = try temporaryPath()
         let xcworkspacePath = path.appending(component: "Project.xcworkspace")
         let project = Project.test(path: path, name: "Cache")
-        let aTarget = Target.test(name: "A")
-        let bTarget = Target.test(name: "B")
-        let aFrameworkPath = path.appending(component: "A.framework")
-        let bFrameworkPath = path.appending(component: "B.framework")
+        let targetNames = ["foo", "bar", "baz"].shuffled()
+        let aTarget = Target.test(name: targetNames[0])
+        let bTarget = Target.test(name: targetNames[1])
+        let cTarget = Target.test(name: targetNames[2])
+        let aFrameworkPath = path.appending(component: "\(aTarget.name).framework")
+        let bFrameworkPath = path.appending(component: "\(bTarget.name).framework")
+        let cFrameworkPath = path.appending(component: "\(cTarget.name).framework")
         try FileHandler.shared.createFolder(aFrameworkPath)
         try FileHandler.shared.createFolder(bFrameworkPath)
+        try FileHandler.shared.createFolder(cFrameworkPath)
 
+        let aTargetNode = TargetNode.test(project: project, target: aTarget)
+        let bTargetNode = TargetNode.test(project: project, target: bTarget, dependencies: [aTargetNode])
+        let cTargetNode = TargetNode.test(project: project, target: cTarget, dependencies: [bTargetNode])
         let nodeWithHashes = [
-            TargetNode.test(project: project, target: aTarget): "A_HASH",
-            TargetNode.test(project: project, target: bTarget): "B_HASH",
+            aTargetNode: "\(aTarget.name)_HASH",
+            bTargetNode: "\(bTarget.name)_HASH",
+            cTargetNode: "\(cTarget.name)_HASH",
         ]
         let graph = Graph.test(projects: [project],
                                targets: nodeWithHashes.keys.reduce(into: [project.path: [TargetNode]()]) { $0[project.path]?.append($1) })
@@ -83,6 +96,10 @@ final class CacheControllerTests: TuistUnitTestCase {
             XCTAssertEqual(loadPath, path)
             return (xcworkspacePath, graph)
         }
+        generator.generateStub = { (loadPath, _) -> AbsolutePath in
+            XCTAssertEqual(loadPath, path)
+            return xcworkspacePath
+        }
         graphContentHasher.stubbedContentHashesResult = nodeWithHashes
         artifactBuilder.stubbedCacheOutputType = .xcframework
 
@@ -92,10 +109,17 @@ final class CacheControllerTests: TuistUnitTestCase {
         XCTAssertPrinterOutputContains("""
         Hashing cacheable targets
         Building cacheable targets
+        Building cacheable targets: \(aTarget.name), 1 out of 3
+        Focusing cacheable targets: \(aTarget.name)
+        Building cacheable targets: \(bTarget.name), 2 out of 3
+        Focusing cacheable targets: \(bTarget.name)
+        Building cacheable targets: \(cTarget.name), 3 out of 3
+        Focusing cacheable targets: \(cTarget.name)
         All cacheable targets have been cached successfully as xcframeworks
         """)
         XCTAssertEqual(cacheGraphLinter.invokedLintCount, 1)
-        XCTAssertEqual(artifactBuilder.invokedBuildWorkspacePathParametersList.first?.target, aTarget)
-        XCTAssertEqual(artifactBuilder.invokedBuildWorkspacePathParametersList.last?.target, bTarget)
+        XCTAssertEqual(artifactBuilder.invokedBuildWorkspacePathParametersList[0].target, aTarget)
+        XCTAssertEqual(artifactBuilder.invokedBuildWorkspacePathParametersList[1].target, bTarget)
+        XCTAssertEqual(artifactBuilder.invokedBuildWorkspacePathParametersList[2].target, cTarget)
     }
 }


### PR DESCRIPTION
### Short description 📝

Hi, I was experimenting with the idea of dog fooding the command "cache warm" with its own cache, in order to avoid recompiling what has been already compiled 😄 

What this PR does is: 
* sort the targets into a topological orders, so we get to build the targets in the correct order so we can fulfil dependencies of  following targets.
* reuse the focus project generation to regenerate the project so that previous precompiled targets are used instead

From my benchmark, to complete `tuist cache warm` we went from few **hours** to **minutes**,  quite an improvement! 🚀
Empirically many targets may have shared dependencies (think about a "project foundation" target or a "project design system" target), or when having a login/ui modules too (as in tuist's default project generation).

This is still a draft, I am missing tests, didn't inject some objects and probably the sorting logic should not be there (and maybe to skip project regeneration when not needed), yet I wanted to open it already to gather early feedback. 🙏
What do you think? Maybe I missing something of why it should not be done? Almost too good to be true.

Update: it seems that there is a leak during the execution of the command, which lead to a giga of memory just after 10 targets 😞  Did anyone notice something similar already?
Update 2: I found one in the `observable(_ arguments: [String],  environment: [String: String], pipeTo secondArguments: [String])` the file handler was not reset to nil which was leaking 128MB each `xcbeautify` execution. Probably this behaviour exists in main branch already. Happy to do a separated PR if needed. It seems that it was introduced in #2297. @fortmarek if you were planning to do a release maybe worth to include this fix?

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] A developer other than the author has verified that the changes work as expected.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
