### PR TITLE
Add dependency loaders

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/tid-kijyun/Kanna.git",
         "state": {
           "branch": null,
-          "revision": "4a80ebe93b6966d5083394fcaaaff57a2fcec935",
-          "version": "5.2.3"
+          "revision": "609367a2cd84827a33383cf7923cb4fe8f69ee0a",
+          "version": "5.2.2"
         }
       },
       {
@@ -195,8 +195,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "138cf1b701cf825233b92ceac919152d5aba8a3f",
-          "version": "4.0.1"
+          "revision": "88caa2e6fffdbef2e91c2022d038576062042907",
+          "version": "4.0.0"
         }
       },
       {

--- a/Sources/TuistCache/Utilities/CacheFrameworkBuilder.swift
+++ b/Sources/TuistCache/Utilities/CacheFrameworkBuilder.swift
@@ -124,7 +124,7 @@ public final class CacheFrameworkBuilder: CacheArtifactBuilding {
     }
 
     fileprivate func buildDirectory(for projectTarget: XcodeBuildTarget,
-                                    target: Target,
+                                    target _: Target,
                                     configuration: String,
                                     sdk: String) throws -> AbsolutePath
     {

--- a/Sources/TuistCache/Utilities/XcodeProjectPathHasher.swift
+++ b/Sources/TuistCache/Utilities/XcodeProjectPathHasher.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CryptoKit
+import Foundation
 
 // Thanks to https://pewpewthespells.com/blog/xcode_deriveddata_hashes.html for
 // the initial Objective-C implementation.
@@ -20,12 +20,13 @@ internal class XcodeProjectPathHasher {
 
         // Split 16 bytes into two chunks of 8 bytes each.
         let partitions = stride(from: 0, to: digest.count, by: 8).map {
-            Array(digest[$0..<Swift.min($0 + 8, digest.count)])
+            Array(digest[$0 ..< Swift.min($0 + 8, digest.count)])
         }
 
         guard
             let firstHalf = partitions.first,
-            let secondHalf = partitions.last else {
+            let secondHalf = partitions.last
+        else {
             throw HashingError.invalidPartitioning
         }
 

--- a/Sources/TuistCore/DependencyLoaders/FrameworkDependencyLoader.swift
+++ b/Sources/TuistCore/DependencyLoaders/FrameworkDependencyLoader.swift
@@ -1,0 +1,62 @@
+import Foundation
+import TSCBasic
+import TuistGraph
+import TuistSupport
+
+enum FrameworkDependencyLoaderError: FatalError, Equatable {
+    case frameworkNotFound(AbsolutePath)
+
+    /// Error type.
+    var type: ErrorType {
+        switch self {
+        case .frameworkNotFound:
+            return .abort
+        }
+    }
+
+    /// Error description
+    var description: String {
+        switch self {
+        case let .frameworkNotFound(path):
+            return "Couldn't find framework at \(path.pathString)."
+        }
+    }
+}
+
+public protocol FrameworkDependencyLoading {
+    /// Reads an existing framework and returns its in-memory representation, FrameworkNode.
+    /// - Parameter path: Path to the .framework.
+    func load(path: AbsolutePath) throws -> ValueGraphDependency
+}
+
+public final class FrameworkDependencyLoader: FrameworkDependencyLoading {
+    /// Framework metadata provider.
+    fileprivate let frameworkMetadataProvider: FrameworkMetadataProviding
+
+    /// Initializes the loader with its attributes.
+    /// - Parameter frameworkMetadataProvider: Framework metadata provider.
+    public init(frameworkMetadataProvider: FrameworkMetadataProviding = FrameworkMetadataProvider()) {
+        self.frameworkMetadataProvider = frameworkMetadataProvider
+    }
+
+    public func load(path: AbsolutePath) throws -> ValueGraphDependency {
+        guard FileHandler.shared.exists(path) else {
+            throw FrameworkDependencyLoaderError.frameworkNotFound(path)
+        }
+
+        let frameworkName = path.basename.replacingOccurrences(of: ".framework", with: "")
+        let binaryPath = path.appending(component: frameworkName)
+        let dsymsPath = frameworkMetadataProvider.dsymPath(frameworkPath: path)
+        let bcsymbolmapPaths = try frameworkMetadataProvider.bcsymbolmapPaths(frameworkPath: path)
+        let linking = try frameworkMetadataProvider.linking(binaryPath: binaryPath)
+        let architectures = try frameworkMetadataProvider.architectures(binaryPath: binaryPath)
+
+        return ValueGraphDependency.framework(path: path,
+                                              binaryPath: binaryPath,
+                                              dsymPath: dsymsPath,
+                                              bcsymbolmapPaths: bcsymbolmapPaths,
+                                              linking: linking,
+                                              architectures: architectures,
+                                              isCarthage: path.pathString.contains("Carthage/Build"))
+    }
+}

--- a/Sources/TuistCore/DependencyLoaders/LibraryDependencyLoader.swift
+++ b/Sources/TuistCore/DependencyLoaders/LibraryDependencyLoader.swift
@@ -1,0 +1,79 @@
+import Foundation
+import TSCBasic
+import TuistGraph
+import TuistSupport
+
+enum LibraryDependencyLoaderError: FatalError, Equatable {
+    case libraryNotFound(AbsolutePath)
+    case publicHeadersNotFound(AbsolutePath)
+    case swiftModuleMapNotFound(AbsolutePath)
+
+    /// Error type.
+    var type: ErrorType {
+        switch self {
+        case .libraryNotFound: return .abort
+        case .publicHeadersNotFound: return .abort
+        case .swiftModuleMapNotFound: return .abort
+        }
+    }
+
+    /// Error description
+    var description: String {
+        switch self {
+        case let .libraryNotFound(path):
+            return "The library \(path.pathString) does not exist."
+        case let .publicHeadersNotFound(path):
+            return "The public headers directory \(path.pathString) does not exist."
+        case let .swiftModuleMapNotFound(path):
+            return "The Swift modulemap file \(path.pathString) does not exist."
+        }
+    }
+}
+
+public protocol LibraryDependencyLoading {
+    /// Reads an existing library and returns its in-memory representation, LibraryNode.
+    /// - Parameters:
+    ///   - path: Path to the library.
+    ///   - publicHeaders: Path to the directorythat contains the public headers.
+    ///   - swiftModuleMap: Path to the Swift modulemap file.
+    func load(path: AbsolutePath,
+              publicHeaders: AbsolutePath,
+              swiftModuleMap: AbsolutePath?) throws -> ValueGraphDependency
+}
+
+final class LibraryDependencyLoader: LibraryDependencyLoading {
+    /// Library metadata provider.
+    fileprivate let libraryMetadataProvider: LibraryMetadataProviding
+
+    /// Initializes the loader with its attributes.
+    /// - Parameter libraryMetadataProvider: Library metadata provider.
+    init(libraryMetadataProvider: LibraryMetadataProviding = LibraryMetadataProvider()) {
+        self.libraryMetadataProvider = libraryMetadataProvider
+    }
+
+    func load(path: AbsolutePath,
+              publicHeaders: AbsolutePath,
+              swiftModuleMap: AbsolutePath?) throws -> ValueGraphDependency
+    {
+        if !FileHandler.shared.exists(path) {
+            throw LibraryDependencyLoaderError.libraryNotFound(path)
+        }
+        if !FileHandler.shared.exists(publicHeaders) {
+            throw LibraryDependencyLoaderError.publicHeadersNotFound(publicHeaders)
+        }
+
+        if let swiftModuleMap = swiftModuleMap {
+            if !FileHandler.shared.exists(swiftModuleMap) {
+                throw LibraryDependencyLoaderError.swiftModuleMapNotFound(swiftModuleMap)
+            }
+        }
+        let architectures = try libraryMetadataProvider.architectures(binaryPath: path)
+        let linking = try libraryMetadataProvider.linking(binaryPath: path)
+
+        return .library(path: path,
+                        publicHeaders: publicHeaders,
+                        linking: linking,
+                        architectures: architectures,
+                        swiftModuleMap: swiftModuleMap)
+    }
+}

--- a/Sources/TuistCore/DependencyLoaders/XCFrameworkDependencyLoader.swift
+++ b/Sources/TuistCore/DependencyLoaders/XCFrameworkDependencyLoader.swift
@@ -1,0 +1,59 @@
+import Foundation
+import TSCBasic
+import TuistGraph
+import TuistSupport
+
+enum XCFrameworkDependencyLoaderError: FatalError, Equatable {
+    case xcframeworkNotFound(AbsolutePath)
+
+    /// Error type.
+    var type: ErrorType {
+        switch self {
+        case .xcframeworkNotFound:
+            return .abort
+        }
+    }
+
+    /// Error description
+    var description: String {
+        switch self {
+        case let .xcframeworkNotFound(path):
+            return "Couldn't find xcframework at \(path.pathString)"
+        }
+    }
+}
+
+public protocol XCFrameworkDependencyLoading {
+    /// Reads an existing xcframework and returns its in-memory representation, XCFrameworkNode..
+    /// - Parameter path: Path to the .xcframework.
+    func load(path: AbsolutePath) throws -> ValueGraphDependency
+}
+
+public final class XCFrameworkDependencyLoader: XCFrameworkDependencyLoading {
+    /// xcframework metadata provider.
+    fileprivate let xcframeworkMetadataProvider: XCFrameworkMetadataProviding
+
+    public convenience init() {
+        self.init(xcframeworkMetadataProvider: XCFrameworkMetadataProvider())
+    }
+
+    /// Initializes the loader with its attributes.
+    /// - Parameter xcframeworkMetadataProvider: xcframework metadata provider.
+    init(xcframeworkMetadataProvider: XCFrameworkMetadataProviding) {
+        self.xcframeworkMetadataProvider = xcframeworkMetadataProvider
+    }
+
+    public func load(path: AbsolutePath) throws -> ValueGraphDependency {
+        guard FileHandler.shared.exists(path) else {
+            throw XCFrameworkDependencyLoaderError.xcframeworkNotFound(path)
+        }
+        let infoPlist = try xcframeworkMetadataProvider.infoPlist(xcframeworkPath: path)
+        let primaryBinaryPath = try xcframeworkMetadataProvider.binaryPath(xcframeworkPath: path,
+                                                                           libraries: infoPlist.libraries)
+        let linking = try xcframeworkMetadataProvider.linking(binaryPath: primaryBinaryPath)
+        return .xcframework(path: path,
+                            infoPlist: infoPlist,
+                            primaryBinaryPath: primaryBinaryPath,
+                            linking: linking)
+    }
+}

--- a/Sources/TuistSupport/System/System.swift
+++ b/Sources/TuistSupport/System/System.swift
@@ -504,9 +504,9 @@ public final class System: Systeming {
             var errorData: [UInt8] = []
             var processOne = System.process(arguments, environment: environment)
             var processTwo = System.process(secondArguments, environment: environment)
-            
+
             System.pipe(&processOne, &processTwo)
-            
+
             let pipes = System.pipeOutput(&processTwo)
 
             pipes.stdOut.fileHandleForReading.readabilityHandler = { fileHandle in
@@ -604,16 +604,17 @@ public final class System: Systeming {
     public func which(_ name: String) throws -> String {
         try capture("/usr/bin/env", "which", name).spm_chomp()
     }
-    
+
     // MARK: Helpers
-    
+
     /// Converts an array of arguments into a `Foundation.Process`
     /// - Parameters:
     ///   - arguments: Arguments for the process, first item being the executable URL.
     ///   - environment: Environment
     /// - Returns: A `Foundation.Process`
     static func process(_ arguments: [String],
-                        environment: [String: String]) -> Foundation.Process {
+                        environment: [String: String]) -> Foundation.Process
+    {
         let executablePath = arguments.first!
         let process = Foundation.Process()
         process.executableURL = URL(fileURLWithPath: executablePath)
@@ -621,7 +622,7 @@ public final class System: Systeming {
         process.environment = environment
         return process
     }
-    
+
     /// Pipe the output of one Process to another
     /// - Parameters:
     ///   - processOne: First Process
@@ -629,25 +630,26 @@ public final class System: Systeming {
     /// - Returns: The pipe
     @discardableResult
     static func pipe(_ processOne: inout Foundation.Process,
-                     _ processTwo: inout Foundation.Process) -> Pipe {
+                     _ processTwo: inout Foundation.Process) -> Pipe
+    {
         let processPipe = Pipe()
-        
+
         processOne.standardOutput = processPipe
         processTwo.standardInput = processPipe
         return processPipe
     }
-    
+
     /// PIpe the output of a process into separate output and error pipes
     /// - Parameter process: The process to pipe
     /// - Returns: Tuple that contains the output and error Pipe.
     static func pipeOutput(_ process: inout Foundation.Process) -> (stdOut: Pipe, stdErr: Pipe) {
         let stdOut: Pipe = Pipe()
         let stdErr: Pipe = Pipe()
-        
+
         // Redirect output of Process Two
         process.standardOutput = stdOut
         process.standardError = stdErr
-        
+
         return (stdOut, stdErr)
     }
 }

--- a/Tests/TuistCoreTests/DependencyLoaders/FrameworkDependencyLoaderTests.swift
+++ b/Tests/TuistCoreTests/DependencyLoaders/FrameworkDependencyLoaderTests.swift
@@ -1,0 +1,101 @@
+import TSCBasic
+import TuistGraph
+import TuistSupport
+import XCTest
+@testable import TuistCore
+@testable import TuistCoreTesting
+@testable import TuistSupportTesting
+
+final class FrameworkDependencyLoaderErrorTests: TuistUnitTestCase {
+    func test_type_when_frameworkNotFound() {
+        // Given
+        let path = AbsolutePath("/frameworks/tuist.framework")
+        let subject = FrameworkDependencyLoaderError.frameworkNotFound(path)
+
+        // When
+        let got = subject.type
+
+        // Then
+        XCTAssertEqual(got, .abort)
+    }
+
+    func test_description_when_frameworkNotFound() {
+        // Given
+        let path = AbsolutePath("/frameworks/tuist.framework")
+        let subject = FrameworkDependencyLoaderError.frameworkNotFound(path)
+
+        // When
+        let got = subject.description
+
+        // Then
+        XCTAssertEqual(got, "Couldn't find framework at \(path.pathString).")
+    }
+}
+
+final class FrameworkDependencyLoaderTests: TuistUnitTestCase {
+    var frameworkMetadataProvider: MockFrameworkMetadataProvider!
+    var subject: FrameworkDependencyLoader!
+
+    override func setUp() {
+        frameworkMetadataProvider = MockFrameworkMetadataProvider()
+        subject = FrameworkDependencyLoader(frameworkMetadataProvider: frameworkMetadataProvider)
+        super.setUp()
+    }
+
+    override func tearDown() {
+        frameworkMetadataProvider = nil
+        subject = nil
+        super.tearDown()
+    }
+
+    func test_load_when_the_framework_doesnt_exist() throws {
+        // Given
+        let path = try temporaryPath()
+        let frameworkPath = path.appending(component: "tuist.framework")
+
+        // Then
+        XCTAssertThrowsSpecific(try subject.load(path: frameworkPath), FrameworkDependencyLoaderError.frameworkNotFound(frameworkPath))
+    }
+
+    func test_oad_when_the_framework_exists() throws {
+        // Given
+        let path = try temporaryPath()
+        let frameworkPath = path.appending(component: "tuist.framework")
+        let dsymPath = path.appending(component: "tuist.dSYM")
+        let bcsymbolmapPaths = [path.appending(component: "tuist.bcsymbolmap")]
+        let architectures = [BinaryArchitecture.armv7s]
+        let linking = BinaryLinking.dynamic
+        let binaryPath = frameworkPath.appending(component: "tuist")
+
+        try FileHandler.shared.touch(frameworkPath)
+
+        frameworkMetadataProvider.dsymPathStub = { path in
+            XCTAssertEqual(path, frameworkPath)
+            return dsymPath
+        }
+        frameworkMetadataProvider.bcsymbolmapPathsStub = { path in
+            XCTAssertEqual(path, frameworkPath)
+            return bcsymbolmapPaths
+        }
+        frameworkMetadataProvider.linkingStub = { path in
+            XCTAssertEqual(path, binaryPath)
+            return linking
+        }
+        frameworkMetadataProvider.architecturesStub = { path in
+            XCTAssertEqual(path, binaryPath)
+            return architectures
+        }
+
+        // When
+        let got = try subject.load(path: frameworkPath)
+
+        // Then
+        XCTAssertEqual(got, .framework(path: frameworkPath,
+                                       binaryPath: frameworkPath.appending(component: "tuist"),
+                                       dsymPath: dsymPath,
+                                       bcsymbolmapPaths: bcsymbolmapPaths,
+                                       linking: linking,
+                                       architectures: architectures,
+                                       isCarthage: false))
+    }
+}

--- a/Tests/TuistCoreTests/DependencyLoaders/LibraryDependencyLoaderTests.swift
+++ b/Tests/TuistCoreTests/DependencyLoaders/LibraryDependencyLoaderTests.swift
@@ -1,0 +1,176 @@
+import TSCBasic
+import TuistGraph
+import TuistSupport
+import XCTest
+@testable import TuistCore
+@testable import TuistCoreTesting
+@testable import TuistSupportTesting
+
+final class LibraryDependencyLoaderErrorTests: TuistUnitTestCase {
+    func test_type_when_libraryNotFound() {
+        // Given
+        let path = AbsolutePath("/libraries/libTuist.a")
+        let subject = LibraryDependencyLoaderError.libraryNotFound(path)
+
+        // When
+        let got = subject.type
+
+        // Then
+        XCTAssertEqual(got, .abort)
+    }
+
+    func test_description_when_libraryNotFound() {
+        // Given
+        let path = AbsolutePath("/libraries/libTuist.a")
+        let subject = LibraryDependencyLoaderError.libraryNotFound(path)
+
+        // When
+        let got = subject.description
+
+        // Then
+        XCTAssertEqual(got, "The library \(path.pathString) does not exist.")
+    }
+
+    func test_type_when_publicHeadersNotFound() {
+        // Given
+        let path = AbsolutePath("/libraries/libTuist.a")
+        let subject = LibraryDependencyLoaderError.publicHeadersNotFound(path)
+
+        // When
+        let got = subject.type
+
+        // Then
+        XCTAssertEqual(got, .abort)
+    }
+
+    func test_description_when_publicHeadersNotFound() {
+        // Given
+        let path = AbsolutePath("/libraries/libTuist.a")
+        let subject = LibraryDependencyLoaderError.publicHeadersNotFound(path)
+
+        // When
+        let got = subject.description
+
+        // Then
+        XCTAssertEqual(got, "The public headers directory \(path.pathString) does not exist.")
+    }
+
+    func test_type_when_swiftModuleMapNotFound() {
+        // Given
+        let path = AbsolutePath("/libraries/libTuist.a")
+        let subject = LibraryDependencyLoaderError.swiftModuleMapNotFound(path)
+
+        // When
+        let got = subject.type
+
+        // Then
+        XCTAssertEqual(got, .abort)
+    }
+
+    func test_description_when_swiftModuleMapNotFound() {
+        // Given
+        let path = AbsolutePath("/libraries/libTuist.a")
+        let subject = LibraryDependencyLoaderError.swiftModuleMapNotFound(path)
+
+        // When
+        let got = subject.description
+
+        // Then
+        XCTAssertEqual(got, "The Swift modulemap file \(path.pathString) does not exist.")
+    }
+}
+
+final class LibraryDependencyLoaderTests: TuistUnitTestCase {
+    var libraryMetadataProvider: MockLibraryMetadataProvider!
+    var subject: LibraryDependencyLoader!
+
+    override func setUp() {
+        libraryMetadataProvider = MockLibraryMetadataProvider()
+        subject = LibraryDependencyLoader(libraryMetadataProvider: libraryMetadataProvider)
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        libraryMetadataProvider = nil
+        subject = nil
+    }
+
+    func test_load_when_the_path_doesnt_exist() throws {
+        // Given
+        let path = try temporaryPath()
+        let libraryPath = path.appending(component: "libTuist.a")
+        let publicHeadersPath = path.appending(component: "headers")
+
+        try FileHandler.shared.createFolder(publicHeadersPath)
+
+        // Then
+        XCTAssertThrowsSpecific(try subject.load(path: libraryPath,
+                                                 publicHeaders: publicHeadersPath,
+                                                 swiftModuleMap: nil), LibraryDependencyLoaderError.libraryNotFound(libraryPath))
+    }
+
+    func test_load_when_the_public_headers_directory_doesnt_exist() throws {
+        // Given
+        let path = try temporaryPath()
+        let libraryPath = path.appending(component: "libTuist.a")
+        let publicHeadersPath = path.appending(component: "headers")
+
+        try FileHandler.shared.touch(libraryPath)
+
+        // Then
+        XCTAssertThrowsSpecific(try subject.load(path: libraryPath,
+                                                 publicHeaders: publicHeadersPath,
+                                                 swiftModuleMap: nil), LibraryDependencyLoaderError.publicHeadersNotFound(publicHeadersPath))
+    }
+
+    func test_load_when_the_swift_modulemap_doesnt_exist() throws {
+        // Given
+        let path = try temporaryPath()
+        let libraryPath = path.appending(component: "libTuist.a")
+        let publicHeadersPath = path.appending(component: "headers")
+        let swiftModulemapPath = path.appending(component: "tuist.modulemap")
+        try FileHandler.shared.createFolder(publicHeadersPath)
+        try FileHandler.shared.touch(libraryPath)
+
+        // Then
+        XCTAssertThrowsSpecific(try subject.load(path: libraryPath,
+                                                 publicHeaders: publicHeadersPath,
+                                                 swiftModuleMap: swiftModulemapPath), LibraryDependencyLoaderError.swiftModuleMapNotFound(swiftModulemapPath))
+    }
+
+    func test_load_when_all_files_exist() throws {
+        // Given
+        let path = try temporaryPath()
+        let libraryPath = path.appending(component: "libTuist.a")
+        let publicHeadersPath = path.appending(component: "headers")
+        let swiftModulemapPath = path.appending(component: "tuist.modulemap")
+        let architectures: [BinaryArchitecture] = [.armv7, .armv7s]
+        let linking: BinaryLinking = .dynamic
+
+        try FileHandler.shared.createFolder(publicHeadersPath)
+        try FileHandler.shared.touch(libraryPath)
+        try FileHandler.shared.touch(swiftModulemapPath)
+
+        libraryMetadataProvider.architecturesStub = { path in
+            XCTAssertEqual(path, libraryPath)
+            return architectures
+        }
+        libraryMetadataProvider.linkingStub = { path in
+            XCTAssertEqual(path, libraryPath)
+            return linking
+        }
+
+        // When
+        let got = try subject.load(path: libraryPath,
+                                   publicHeaders: publicHeadersPath,
+                                   swiftModuleMap: swiftModulemapPath)
+
+        // Then
+        XCTAssertEqual(got, .library(path: libraryPath,
+                                     publicHeaders: publicHeadersPath,
+                                     linking: linking,
+                                     architectures: architectures,
+                                     swiftModuleMap: swiftModulemapPath))
+    }
+}

--- a/Tests/TuistCoreTests/DependencyLoaders/XCFrameworkDependencyLoaderTests.swift
+++ b/Tests/TuistCoreTests/DependencyLoaders/XCFrameworkDependencyLoaderTests.swift
@@ -1,0 +1,86 @@
+import TSCBasic
+import TuistGraph
+import TuistSupport
+import XCTest
+
+@testable import TuistCore
+@testable import TuistCoreTesting
+@testable import TuistSupportTesting
+
+final class XCFrameworkDependencyLoaderErrorTests: TuistUnitTestCase {
+    func test_type_when_xcframeworkNotFound() {
+        // Given
+        let subject = XCFrameworkDependencyLoaderError.xcframeworkNotFound("/frameworks/tuist.xcframework")
+
+        // Then
+        XCTAssertEqual(subject.type, .abort)
+    }
+
+    func test_description_when_xcframeworkNotFound() {
+        // Given
+        let subject = XCFrameworkDependencyLoaderError.xcframeworkNotFound("/frameworks/tuist.xcframework")
+
+        // Then
+        XCTAssertEqual(subject.description, "Couldn't find xcframework at /frameworks/tuist.xcframework")
+    }
+}
+
+final class XCFrameworkDependencyLoaderTests: TuistUnitTestCase {
+    var xcframeworkMetadataProvider: MockXCFrameworkMetadataProvider!
+    var subject: XCFrameworkDependencyLoader!
+
+    override func setUp() {
+        xcframeworkMetadataProvider = MockXCFrameworkMetadataProvider()
+        subject = XCFrameworkDependencyLoader(xcframeworkMetadataProvider: xcframeworkMetadataProvider)
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        xcframeworkMetadataProvider = nil
+        subject = nil
+    }
+
+    func test_load_throws_when_the_xcframework_doesnt_exist() throws {
+        // Given
+        let path = try temporaryPath()
+        let xcframeworkPath = path.appending(component: "tuist.xcframework")
+
+        // Then
+        XCTAssertThrowsSpecific(try subject.load(path: xcframeworkPath), XCFrameworkDependencyLoaderError.xcframeworkNotFound(xcframeworkPath))
+    }
+
+    func test_load_when_the_xcframework_exists() throws {
+        // Given
+        let path = try temporaryPath()
+        let xcframeworkPath = path.appending(component: "tuist.xcframework")
+        let binaryPath = path.appending(RelativePath("tuist.xcframework/whatever/tuist"))
+        let linking: BinaryLinking = .dynamic
+
+        let infoPlist = XCFrameworkInfoPlist.test()
+        try FileHandler.shared.touch(xcframeworkPath)
+
+        xcframeworkMetadataProvider.infoPlistStub = { path in
+            XCTAssertEqual(xcframeworkPath, path)
+            return infoPlist
+        }
+        xcframeworkMetadataProvider.binaryPathStub = { path, libraries in
+            XCTAssertEqual(xcframeworkPath, path)
+            XCTAssertEqual(libraries, infoPlist.libraries)
+            return binaryPath
+        }
+        xcframeworkMetadataProvider.linkingStub = { path in
+            XCTAssertEqual(binaryPath, path)
+            return linking
+        }
+
+        // When
+        let got = try subject.load(path: xcframeworkPath)
+
+        // Then
+        XCTAssertEqual(got, .xcframework(path: xcframeworkPath,
+                                         infoPlist: infoPlist,
+                                         primaryBinaryPath: binaryPath,
+                                         linking: linking))
+    }
+}


### PR DESCRIPTION
### Short description 📝

The utilities that we have in the codebase for reading a pre-compiled artifact (i.e. framework, library, and xcframework) return an instance of `xxxNode`, which is deprecated in favor of the value type `ValueGraphDependency`. This PR replicates those utilities but returning a value graph dependency instead of a node. I plan to use these utilities in the cache mapper, which needs to load the dependency by reading it from the cache.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] A developer other than the author has verified that the changes work as expected.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
