### PR TITLE
Fix missing vendor directory in built from source versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Fix cache's hash calculation of resources [#2325](https://github.com/tuist/tuist/pull/2325) by [@natanrolnik](https://github.com/natanrolnik).
 - Fixed known issue that causes the `xcodebuild` process hang when running `tuist test` and `tuist build`. [#2297](https://github.com/tuist/tuist/pull/2297) by [@Jake-Prickett](https://github.com/Jake-Prickett).
+- Fix missing vendor directory in built from source versions [#2388](https://github.com/tuist/tuist/pull/2388) by [@natanrolnik](https://github.com/natanrolnik).
 
 ## 1.31.0 - Arctic
 

--- a/Sources/TuistEnvKit/Installer/Installer.swift
+++ b/Sources/TuistEnvKit/Installer/Installer.swift
@@ -191,6 +191,12 @@ final class Installer: Installing {
                                             to: buildDirectory.appending(component: Constants.templatesDirectoryName))
             }
 
+            let vendorDirectory = temporaryDirectory.appending(component: Constants.vendorDirectoryName)
+            if FileHandler.shared.exists(vendorDirectory) {
+                try FileHandler.shared.copy(from: vendorDirectory,
+                                            to: buildDirectory.appending(component: Constants.vendorDirectoryName))
+            }
+
             try buildCopier.copy(from: buildDirectory,
                                  to: installationDirectory)
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/2387

When building from source, now the vendor directory is copied to the build directory, in the same way that the templates already were copied.