### PR TITLE
Fix calculating dependencies hash on different machines or project clones

### DIFF
--- a/Sources/TuistCache/ContentHashing/DependencyContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/DependencyContentHasher.swift
@@ -1,9 +1,10 @@
 import Foundation
 import TuistCore
 import TuistGraph
+import TSCBasic
 
 public protocol DependenciesContentHashing {
-    func hash(dependencies: [Dependency]) throws -> String
+    func hash(dependencies: [Dependency], sourceRootPath: AbsolutePath) throws -> String
 }
 
 /// `DependencyContentHasher`
@@ -19,31 +20,35 @@ public final class DependenciesContentHasher: DependenciesContentHashing {
 
     // MARK: - DependenciesContentHashing
 
-    public func hash(dependencies: [Dependency]) throws -> String {
-        let hashes = dependencies.map { try? hash(dependency: $0) }
+    public func hash(dependencies: [Dependency], sourceRootPath: AbsolutePath) throws -> String {
+        let hashes = dependencies.map { try? hash(dependency: $0, sourceRootPath: sourceRootPath) }
         return hashes.compactMap { $0 }.joined()
     }
 
     // MARK: - Private
 
-    private func hash(dependency: Dependency) throws -> String {
+    private func hash(dependency: Dependency, sourceRootPath rootPath: AbsolutePath) throws -> String {
+        func relativeToRoot(_ path: AbsolutePath) -> String {
+            path.relative(to: rootPath).pathString
+        }
+
         switch dependency {
         case let .target(name):
             return try contentHasher.hash("target-\(name)")
         case let .project(target, path):
-            return try contentHasher.hash(["project-", target, path.pathString])
+            return try contentHasher.hash(["project-", target, relativeToRoot(path)])
         case let .framework(path):
-            return try contentHasher.hash("framework-\(path.pathString)")
+            return try contentHasher.hash("framework-\(relativeToRoot(path))")
         case let .xcFramework(path):
-            return try contentHasher.hash("xcframework-\(path.pathString)")
+            return try contentHasher.hash("xcframework-\(relativeToRoot(path))")
         case let .library(path, publicHeaders, swiftModuleMap):
-            return try contentHasher.hash(["library", path.pathString, publicHeaders.pathString, swiftModuleMap?.pathString].compactMap { $0 })
+            return try contentHasher.hash(["library", relativeToRoot(path), relativeToRoot(publicHeaders), swiftModuleMap.map(relativeToRoot)].compactMap { $0 })
         case let .package(product):
             return try contentHasher.hash("package-\(product)")
         case let .sdk(name, status):
             return try contentHasher.hash("sdk-\(name)-\(status)")
         case let .cocoapods(path):
-            return try contentHasher.hash(["cocoapods", path.pathString])
+            return try contentHasher.hash(["cocoapods", relativeToRoot(path)])
         case .xctest:
             return try contentHasher.hash("xctest")
         }

--- a/Sources/TuistCache/ContentHashing/DependencyContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/DependencyContentHasher.swift
@@ -27,9 +27,9 @@ public final class DependenciesContentHasher: DependenciesContentHashing {
 
     // MARK: - Private
 
-    private func hash(dependency: Dependency, sourceRootPath rootPath: AbsolutePath) throws -> String {
+    private func hash(dependency: Dependency, sourceRootPath: AbsolutePath) throws -> String {
         func relativeToRoot(_ path: AbsolutePath) -> String {
-            path.relative(to: rootPath).pathString
+            path.relative(to: sourceRootPath).pathString
         }
 
         switch dependency {

--- a/Sources/TuistCache/ContentHashing/ResourcesContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/ResourcesContentHasher.swift
@@ -1,9 +1,10 @@
 import Foundation
 import TuistCore
 import TuistGraph
+import TSCBasic
 
 public protocol ResourcesContentHashing {
-    func hash(resources: [FileElement]) throws -> String
+    func hash(resources: [FileElement], sourceRootPath: AbsolutePath) throws -> String
 }
 
 /// `ResourcesContentHasher`
@@ -19,10 +20,14 @@ public final class ResourcesContentHasher: ResourcesContentHashing {
 
     // MARK: - ResourcesContentHashing
 
-    public func hash(resources: [FileElement]) throws -> String {
+    public func hash(resources: [FileElement], sourceRootPath: AbsolutePath) throws -> String {
         let hashes = try resources
-            .sorted(by: { $0.path < $1.path })
-            .map { try contentHasher.hash(path: $0.path) }
+            .sorted { $0.path.pathString < $1.path.pathString }
+            .map {
+                try contentHasher.hash($0.path.relative(to: sourceRootPath).pathString)
+                    + ":"
+                    + contentHasher.hash(path: $0.path)
+            }
 
         return try contentHasher.hash(hashes)
     }

--- a/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
@@ -70,12 +70,14 @@ public final class TargetContentHasher: TargetContentHashing {
 
     public func contentHash(for targetNode: TargetNode, cacheOutputType: CacheOutputType) throws -> String {
         let target = targetNode.target
+        let sourceRootPath = targetNode.project.sourceRootPath
+
         let sourcesHash = try sourceFilesContentHasher.hash(sources: target.sources)
-        let resourcesHash = try resourcesContentHasher.hash(resources: target.resources)
+        let resourcesHash = try resourcesContentHasher.hash(resources: target.resources, sourceRootPath: sourceRootPath)
         let copyFilesHash = try copyFilesContentHasher.hash(copyFiles: target.copyFiles)
         let coreDataModelHash = try coreDataModelsContentHasher.hash(coreDataModels: target.coreDataModels)
         let targetActionsHash = try targetActionsContentHasher.hash(targetActions: target.actions)
-        let dependenciesHash = try dependenciesContentHasher.hash(dependencies: target.dependencies, sourceRootPath: targetNode.project.sourceRootPath)
+        let dependenciesHash = try dependenciesContentHasher.hash(dependencies: target.dependencies, sourceRootPath: sourceRootPath)
         let environmentHash = try contentHasher.hash(target.environment)
         var stringsToHash = [target.name,
                              target.platform.rawValue,
@@ -111,6 +113,7 @@ public final class TargetContentHasher: TargetContentHashing {
         }
 
         stringsToHash.append(cacheOutputType.description)
+
         return try contentHasher.hash(stringsToHash)
     }
 }

--- a/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
@@ -75,7 +75,7 @@ public final class TargetContentHasher: TargetContentHashing {
         let copyFilesHash = try copyFilesContentHasher.hash(copyFiles: target.copyFiles)
         let coreDataModelHash = try coreDataModelsContentHasher.hash(coreDataModels: target.coreDataModels)
         let targetActionsHash = try targetActionsContentHasher.hash(targetActions: target.actions)
-        let dependenciesHash = try dependenciesContentHasher.hash(dependencies: target.dependencies)
+        let dependenciesHash = try dependenciesContentHasher.hash(dependencies: target.dependencies, sourceRootPath: targetNode.project.sourceRootPath)
         let environmentHash = try contentHasher.hash(target.environment)
         var stringsToHash = [target.name,
                              target.platform.rawValue,

--- a/Tests/TuistCacheTests/ContentHashing/DependenciesContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/DependenciesContentHasherTests.swift
@@ -12,9 +12,11 @@ import XCTest
 final class DependenciesContentHasherTests: TuistUnitTestCase {
     private var subject: DependenciesContentHasher!
     private var mockContentHasher: MockContentHasher!
-    private let filePath1 = AbsolutePath("/file1")
-    private let filePath2 = AbsolutePath("/file2")
-    private let filePath3 = AbsolutePath("/file3")
+    private let filePath1 = AbsolutePath("/Briochify/file1")
+    private let filePath2 = AbsolutePath("/Briochify/file2")
+    private let filePath3 = AbsolutePath("/Briochify/file3")
+
+    private let sourceRootPath = AbsolutePath("/Briochify")
 
     override func setUp() {
         super.setUp()
@@ -33,7 +35,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         let dependency = Dependency.target(name: "foo")
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let hash = try subject.hash(dependencies: [dependency], sourceRootPath: sourceRootPath)
 
         // Then
         XCTAssertEqual(hash, "target-foo-hash")
@@ -45,10 +47,10 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         let dependency = Dependency.project(target: "foo", path: filePath1)
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let hash = try subject.hash(dependencies: [dependency], sourceRootPath: sourceRootPath)
 
         // Then
-        XCTAssertEqual(hash, "project-;foo;/file1")
+        XCTAssertEqual(hash, "project-;foo;file1")
         XCTAssertEqual(mockContentHasher.hashStringsCallCount, 1)
     }
 
@@ -57,10 +59,10 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         let dependency = Dependency.framework(path: filePath1)
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let hash = try subject.hash(dependencies: [dependency], sourceRootPath: sourceRootPath)
 
         // Then
-        XCTAssertEqual(hash, "framework-/file1-hash")
+        XCTAssertEqual(hash, "framework-file1-hash")
         XCTAssertEqual(mockContentHasher.hashStringCallCount, 1)
     }
 
@@ -69,10 +71,10 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         let dependency = Dependency.xcFramework(path: filePath1)
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let hash = try subject.hash(dependencies: [dependency], sourceRootPath: sourceRootPath)
 
         // Then
-        XCTAssertEqual(hash, "xcframework-/file1-hash")
+        XCTAssertEqual(hash, "xcframework-file1-hash")
         XCTAssertEqual(mockContentHasher.hashStringCallCount, 1)
     }
 
@@ -83,10 +85,10 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
                                             swiftModuleMap: filePath3)
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let hash = try subject.hash(dependencies: [dependency], sourceRootPath: sourceRootPath)
 
         // Then
-        XCTAssertEqual(hash, "library;/file1;/file2;/file3")
+        XCTAssertEqual(hash, "library;file1;file2;file3")
         XCTAssertEqual(mockContentHasher.hashStringsCallCount, 1)
     }
 
@@ -95,7 +97,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         let dependency = Dependency.package(product: "foo")
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let hash = try subject.hash(dependencies: [dependency], sourceRootPath: sourceRootPath)
 
         // Then
         XCTAssertEqual(hash, "package-foo-hash")
@@ -107,7 +109,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         let dependency = Dependency.sdk(name: "foo", status: .optional)
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let hash = try subject.hash(dependencies: [dependency], sourceRootPath: sourceRootPath)
 
         // Then
         XCTAssertEqual(hash, "sdk-foo-optional-hash")
@@ -119,7 +121,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         let dependency = Dependency.sdk(name: "foo", status: .required)
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let hash = try subject.hash(dependencies: [dependency], sourceRootPath: sourceRootPath)
 
         // Then
         XCTAssertEqual(hash, "sdk-foo-required-hash")
@@ -131,10 +133,10 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         let dependency = Dependency.cocoapods(path: filePath1)
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let hash = try subject.hash(dependencies: [dependency], sourceRootPath: sourceRootPath)
 
         // Then
-        XCTAssertEqual(hash, "cocoapods;/file1")
+        XCTAssertEqual(hash, "cocoapods;file1")
         XCTAssertEqual(mockContentHasher.hashStringsCallCount, 1)
     }
 
@@ -143,7 +145,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         let dependency = Dependency.xctest
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let hash = try subject.hash(dependencies: [dependency], sourceRootPath: sourceRootPath)
 
         // Then
         XCTAssertEqual(hash, "xctest-hash")

--- a/Tests/TuistCacheTests/ContentHashing/ResourcesContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/ResourcesContentHasherTests.swift
@@ -12,8 +12,9 @@ import XCTest
 final class ResourcesContentHasherTests: TuistUnitTestCase {
     private var subject: ResourcesContentHasher!
     private var mockContentHasher: MockContentHasher!
-    private let filePath1 = AbsolutePath("/file1")
-    private let filePath2 = AbsolutePath("/file2")
+    private let filePath1 = AbsolutePath("/Briochify/file1")
+    private let filePath2 = AbsolutePath("/Briochify/file2")
+    private let sourceRootPath = AbsolutePath("/Briochify")
 
     override func setUp() {
         super.setUp()
@@ -37,7 +38,7 @@ final class ResourcesContentHasherTests: TuistUnitTestCase {
         mockContentHasher.stubHashForPath[filePath2] = "2"
 
         // When
-        let hash = try subject.hash(resources: [file1, file2])
+        let hash = try subject.hash(resources: [file1, file2], sourceRootPath: sourceRootPath)
 
         // Then
         XCTAssertEqual(mockContentHasher.hashPathCallCount, 2)
@@ -52,7 +53,7 @@ final class ResourcesContentHasherTests: TuistUnitTestCase {
         mockContentHasher.stubHashForPath[filePath2] = "2"
 
         // When
-        let hash = try subject.hash(resources: [file1, file2])
+        let hash = try subject.hash(resources: [file1, file2], sourceRootPath: sourceRootPath)
 
         // Then
         XCTAssertEqual(mockContentHasher.hashPathCallCount, 2)
@@ -67,6 +68,6 @@ final class ResourcesContentHasherTests: TuistUnitTestCase {
         mockContentHasher.stubHashForPath[filePath2] = "2"
 
         // When/Then
-        XCTAssertEqual(try subject.hash(resources: [file1, file2]), try subject.hash(resources: [file2, file1]))
+        XCTAssertEqual(try subject.hash(resources: [file1, file2], sourceRootPath: sourceRootPath), try subject.hash(resources: [file2, file1], sourceRootPath: sourceRootPath))
     }
 }

--- a/Tests/TuistCacheTests/ContentHashing/ResourcesContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/ResourcesContentHasherTests.swift
@@ -14,6 +14,8 @@ final class ResourcesContentHasherTests: TuistUnitTestCase {
     private var mockContentHasher: MockContentHasher!
     private let filePath1 = AbsolutePath("/Briochify/file1")
     private let filePath2 = AbsolutePath("/Briochify/file2")
+    private let filePath3 = AbsolutePath("/Briochify/more-resources/file3")
+    private let filePath4 = AbsolutePath("/file4")
     private let sourceRootPath = AbsolutePath("/Briochify")
 
     override func setUp() {
@@ -42,7 +44,7 @@ final class ResourcesContentHasherTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(mockContentHasher.hashPathCallCount, 2)
-        XCTAssertEqual(hash, "1;2")
+        XCTAssertEqual(hash, "file1-hash:1;file2-hash:2")
     }
 
     func test_hash_includesFolderReference() throws {
@@ -57,7 +59,7 @@ final class ResourcesContentHasherTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(mockContentHasher.hashPathCallCount, 2)
-        XCTAssertEqual(hash, "1;2")
+        XCTAssertEqual(hash, "file1-hash:1;file2-hash:2")
     }
 
     func test_hash_sortsTheResourcesBeforeCalculatingTheHash() throws {
@@ -69,5 +71,35 @@ final class ResourcesContentHasherTests: TuistUnitTestCase {
 
         // When/Then
         XCTAssertEqual(try subject.hash(resources: [file1, file2], sourceRootPath: sourceRootPath), try subject.hash(resources: [file2, file1], sourceRootPath: sourceRootPath))
+    }
+
+    func test_hash_nameAlsoCalculatedNotOnlyContent() throws {
+        // Given
+        let file1 = FileElement.file(path: filePath1)
+        mockContentHasher.stubHashForPath[filePath1] = "1"
+
+        // When
+        let hash = try subject.hash(resources: [file1], sourceRootPath: sourceRootPath)
+
+        // Then
+        XCTAssertEqual(mockContentHasher.hashPathCallCount, 1)
+        XCTAssertEqual(hash, "file1-hash:1")
+    }
+
+    func test_hash_relativePathUsedNotAbsolute() throws {
+        // Given
+        let file1 = FileElement.file(path: filePath1)
+        let file3 = FileElement.file(path: filePath3)
+        let file4 = FileElement.file(path: filePath4)
+        mockContentHasher.stubHashForPath[filePath1] = "1"
+        mockContentHasher.stubHashForPath[filePath3] = "3"
+        mockContentHasher.stubHashForPath[filePath4] = "4"
+
+        // When
+        let hash = try subject.hash(resources: [file1, file3, file4], sourceRootPath: sourceRootPath)
+
+        // Then
+        XCTAssertEqual(mockContentHasher.hashPathCallCount, 3)
+        XCTAssertEqual(hash, "file1-hash:1;more-resources/file3-hash:3;../file4-hash:4")
     }
 }


### PR DESCRIPTION
I noticed that `tuist cache print-hashes` was returning different values for the same branch and commit, in two different machines. I cloned the same repo in my own computer, and noticed that the hash was different - debugging took me to:

* `DependencyContentHasher` (which used the absolute path, instead of the relative one) 
 * `ResourcesContentHasher` (again 😄), which in turn was relying on `ContentHasher` which could incorrectly take into account `.DS_STORE` files, for example inside `.xcassets` folders.

Tests were updated accordingly.

This should fix a lot of stuff for remote caching: many developers will calculate the hashes in their own computers and they should match to the hashes in their colleagues' machines 😃 