### PR TITLE
Provide CacheStoring the target name along with hash

### DIFF
--- a/Sources/TuistCache/Cache/Cache.swift
+++ b/Sources/TuistCache/Cache/Cache.swift
@@ -19,10 +19,10 @@ public final class Cache: CacheStoring {
 
     // MARK: - CacheStoring
 
-    public func exists(hash: String) -> Single<Bool> {
+    public func exists(hash: String, targetName: String) -> Single<Bool> {
         /// It calls exists sequentially until one of the storages returns true.
         let storages = storageProvider.storages()
-        return storages.map { $0.exists(hash: hash) }.reduce(Single.just(false)) { (result, next) -> Single<Bool> in
+        return storages.map { $0.exists(hash: hash, targetName: targetName) }.reduce(Single.just(false)) { (result, next) -> Single<Bool> in
             result.flatMap { exists in
                 if exists {
                     return Single.just(exists)
@@ -35,10 +35,10 @@ public final class Cache: CacheStoring {
         }
     }
 
-    public func fetch(hash: String) -> Single<AbsolutePath> {
+    public func fetch(hash: String, targetName: String) -> Single<AbsolutePath> {
         let storages = storageProvider.storages()
         return storages
-            .map { $0.fetch(hash: hash) }
+            .map { $0.fetch(hash: hash, targetName: targetName) }
             .reduce(nil) { (result, next) -> Single<AbsolutePath> in
                 if let result = result {
                     return result.catchError { _ in next }
@@ -48,8 +48,8 @@ public final class Cache: CacheStoring {
             }!
     }
 
-    public func store(hash: String, paths: [AbsolutePath]) -> Completable {
+    public func store(hash: String, targetName: String, paths: [AbsolutePath]) -> Completable {
         let storages = storageProvider.storages()
-        return Completable.zip(storages.map { $0.store(hash: hash, paths: paths) })
+        return Completable.zip(storages.map { $0.store(hash: hash, targetName: targetName, paths: paths) })
     }
 }

--- a/Sources/TuistCache/Cache/CacheLocalStorage.swift
+++ b/Sources/TuistCache/Cache/CacheLocalStorage.swift
@@ -38,14 +38,14 @@ public final class CacheLocalStorage: CacheStoring {
 
     // MARK: - CacheStoring
 
-    public func exists(hash: String) -> Single<Bool> {
+    public func exists(hash: String, targetName _: String) -> Single<Bool> {
         Single.create { (completed) -> Disposable in
             completed(.success(self.lookupFramework(directory: self.cacheDirectory.appending(component: hash)) != nil))
             return Disposables.create()
         }
     }
 
-    public func fetch(hash: String) -> Single<AbsolutePath> {
+    public func fetch(hash: String, targetName _: String) -> Single<AbsolutePath> {
         Single.create { (completed) -> Disposable in
             if let path = self.lookupFramework(directory: self.cacheDirectory.appending(component: hash)) {
                 completed(.success(path))
@@ -56,7 +56,7 @@ public final class CacheLocalStorage: CacheStoring {
         }
     }
 
-    public func store(hash: String, paths: [AbsolutePath]) -> Completable {
+    public func store(hash: String, targetName _: String, paths: [AbsolutePath]) -> Completable {
         let copy = Completable.create { (completed) -> Disposable in
             let hashFolder = self.cacheDirectory.appending(component: hash)
 

--- a/Sources/TuistCache/Cache/CacheStoring.swift
+++ b/Sources/TuistCache/Cache/CacheStoring.swift
@@ -8,7 +8,7 @@ public protocol CacheStoring {
     /// - Parameters:
     ///   - hash: Target's hash.
     /// - Returns: An observable that returns a boolean indicating whether the target is cached.
-    func exists(hash: String) -> Single<Bool>
+    func exists(hash: String, targetName: String) -> Single<Bool>
 
     /// For the target with the given hash, it fetches it from the cache and returns a path
     /// pointint to the .xcframework that represents it.
@@ -16,11 +16,11 @@ public protocol CacheStoring {
     /// - Parameters:
     ///   - hash: Target's hash.
     /// - Returns: An observable that returns a boolean indicating whether the target is cached.
-    func fetch(hash: String) -> Single<AbsolutePath>
+    func fetch(hash: String, targetName: String) -> Single<AbsolutePath>
 
     /// It stores the xcframework at the given path in the cache.
     /// - Parameters:
     ///   - hash: Hash of the target the xcframework belongs to.
     ///   - paths: Path to the files that will be stored.
-    func store(hash: String, paths: [AbsolutePath]) -> Completable
+    func store(hash: String, targetName: String, paths: [AbsolutePath]) -> Completable
 }

--- a/Sources/TuistCache/Cache/CloudCacheResponse.swift
+++ b/Sources/TuistCache/Cache/CloudCacheResponse.swift
@@ -8,20 +8,22 @@ struct CloudCacheResponse: Decodable {
 
     let url: URL
     let expiresAt: TimeInterval
+    let additionalHeaders: [String: String]?
 
-    init(url: URL, expiresAt: TimeInterval) {
+    init(url: URL, expiresAt: TimeInterval, additionalHeaders: [String: String]? = nil) {
         self.url = url
         self.expiresAt = expiresAt
+        self.additionalHeaders = additionalHeaders
     }
 
-    public static func fetchResource(hash: String, cloud: Cloud) throws -> CloudCacheResource {
-        var request = URLRequest(url: try URL.apiCacheURL(hash: hash, cacheURL: cloud.url, projectId: cloud.projectId))
+    public static func fetchResource(hash: String, targetName: String, cloud: Cloud) throws -> CloudCacheResource {
+        var request = URLRequest(url: try URL.apiCacheURL(hash: hash, cacheURL: cloud.url, projectId: cloud.projectId, targetName: targetName))
         request.httpMethod = "GET"
         return .jsonResource { request }
     }
 
-    public static func storeResource(hash: String, cloud: Cloud, contentMD5: String) throws -> CloudCacheResource {
-        let url = try URL.apiCacheURL(hash: hash, cacheURL: cloud.url, projectId: cloud.projectId)
+    public static func storeResource(hash: String, targetName: String, cloud: Cloud, contentMD5: String) throws -> CloudCacheResource {
+        let url = try URL.apiCacheURL(hash: hash, cacheURL: cloud.url, projectId: cloud.projectId, targetName: targetName)
         var request = URLRequest(url: url.addingQueryItem(name: "content_md5", value: contentMD5))
         request.httpMethod = "POST"
         return .jsonResource { request }

--- a/Sources/TuistCache/Cache/CloudHEADResponse.swift
+++ b/Sources/TuistCache/Cache/CloudHEADResponse.swift
@@ -6,8 +6,8 @@ import TuistSupport
 struct CloudHEADResponse: Decodable {
     public init() {}
 
-    public static func existsResource(hash: String, cloud: Cloud) throws -> HTTPResource<CloudResponse<CloudHEADResponse>, CloudHEADResponseError> {
-        let url = try URL.apiCacheURL(hash: hash, cacheURL: cloud.url, projectId: cloud.projectId)
+    public static func existsResource(hash: String, targetName: String, cloud: Cloud) throws -> HTTPResource<CloudResponse<CloudHEADResponse>, CloudHEADResponseError> {
+        let url = try URL.apiCacheURL(hash: hash, cacheURL: cloud.url, projectId: cloud.projectId, targetName: targetName)
         var request = URLRequest(url: url)
         request.httpMethod = "HEAD"
         return HTTPResource(request: { request },

--- a/Sources/TuistCache/Cache/URL+Cache.swift
+++ b/Sources/TuistCache/Cache/URL+Cache.swift
@@ -3,7 +3,8 @@ import Foundation
 extension URL {
     static func apiCacheURL(hash: String,
                             cacheURL: URL,
-                            projectId: String) throws -> URL
+                            projectId: String,
+                            targetName: String) throws -> URL
     {
         guard var urlComponents = URLComponents(url: cacheURL, resolvingAgainstBaseURL: false) else {
             throw CacheAPIError.incorrectCloudURL
@@ -13,6 +14,7 @@ extension URL {
         urlComponents.queryItems = [
             URLQueryItem(name: "project_id", value: projectId),
             URLQueryItem(name: "hash", value: hash),
+            URLQueryItem(name: "target_name", value: targetName),
         ]
         return urlComponents.url!
     }

--- a/Sources/TuistCache/GraphMappers/CacheMapper.swift
+++ b/Sources/TuistCache/GraphMappers/CacheMapper.swift
@@ -100,10 +100,10 @@ public class CacheMapper: GraphMapping {
 
     fileprivate func fetch(hashes: [TargetNode: String]) -> Single<[TargetNode: AbsolutePath]> {
         Single.zip(hashes.map { target, hash in
-            self.cache.exists(hash: hash)
+            self.cache.exists(hash: hash, targetName: target.name)
                 .flatMap { (exists) -> Single<(target: TargetNode, path: AbsolutePath?)> in
                     guard exists else { return Single.just((target: target, path: nil)) }
-                    return self.cache.fetch(hash: hash).map { (target: target, path: $0) }
+                    return self.cache.fetch(hash: hash, targetName: target.name).map { (target: target, path: $0) }
                 }
         })
             .map { result in

--- a/Sources/TuistCacheTesting/Cache/Mocks/MockCacheStorage.swift
+++ b/Sources/TuistCacheTesting/Cache/Mocks/MockCacheStorage.swift
@@ -9,7 +9,7 @@ public final class MockCacheStorage: CacheStoring {
 
     public init() {}
 
-    public func exists(hash: String) -> Single<Bool> {
+    public func exists(hash: String, targetName _: String) -> Single<Bool> {
         if let existsStub = existsStub {
             return Single.just(existsStub(hash))
         } else {
@@ -18,7 +18,7 @@ public final class MockCacheStorage: CacheStoring {
     }
 
     var fetchStub: ((String) throws -> AbsolutePath)?
-    public func fetch(hash: String) -> Single<AbsolutePath> {
+    public func fetch(hash: String, targetName _: String) -> Single<AbsolutePath> {
         if let fetchStub = fetchStub {
             do {
                 return Single.just(try fetchStub(hash))
@@ -31,7 +31,7 @@ public final class MockCacheStorage: CacheStoring {
     }
 
     var storeStub: ((_ hash: String, _ paths: [AbsolutePath]) -> Void)?
-    public func store(hash: String, paths: [AbsolutePath]) -> Completable {
+    public func store(hash: String, targetName _: String, paths: [AbsolutePath]) -> Completable {
         if let storeStub = storeStub {
             storeStub(hash, paths)
         }

--- a/Sources/TuistKit/Cache/CacheController.swift
+++ b/Sources/TuistKit/Cache/CacheController.swift
@@ -123,7 +123,7 @@ final class CacheController: CacheControlling {
     fileprivate func cacheableTargets(graph: Graph) throws -> [TargetNode: String] {
         try graphContentHasher.contentHashes(for: graph, cacheOutputType: artifactBuilder.cacheOutputType)
             .filter { target, hash in
-                if let exists = try self.cache.exists(hash: hash).toBlocking().first(), exists {
+                if let exists = try self.cache.exists(hash: hash, targetName: target.name).toBlocking().first(), exists {
                     logger.pretty("The target \(.bold(.raw(target.name))) with hash \(.bold(.raw(hash))) and type \(artifactBuilder.cacheOutputType.description) is already in the cache. Skipping...")
                     return false
                 }
@@ -155,6 +155,6 @@ final class CacheController: CacheControlling {
                                       into: outputDirectory)
         }
 
-        _ = try cache.store(hash: hash, paths: FileHandler.shared.glob(outputDirectory, glob: "*")).toBlocking().last()
+        _ = try cache.store(hash: hash, targetName: target.name, paths: FileHandler.shared.glob(outputDirectory, glob: "*")).toBlocking().last()
     }
 }

--- a/Sources/TuistSupportTesting/HTTP/MockFileClient.swift
+++ b/Sources/TuistSupportTesting/HTTP/MockFileClient.swift
@@ -8,17 +8,18 @@ import TuistSupport
 public final class MockFileClient: FileClienting {
     public init() {}
 
+    public typealias UploadParameters = (file: AbsolutePath, hash: String, url: URL, additionalHeaders: [String: String]?)
     public var invokedUpload = false
     public var invokedUploadCount = 0
-    public var invokedUploadParameters: (file: AbsolutePath, hash: String, url: URL)?
-    public var invokedUploadParametersList = [(file: AbsolutePath, hash: String, url: URL)]()
+    public var invokedUploadParameters: UploadParameters?
+    public var invokedUploadParametersList = [UploadParameters]()
     public var stubbedUploadResult: Single<Bool> = Single.just(true)
 
-    public func upload(file: AbsolutePath, hash: String, to url: URL) -> Single<Bool> {
+    public func upload(file: AbsolutePath, hash: String, to url: URL, additionalHeaders: [String: String]?) -> Single<Bool> {
         invokedUpload = true
         invokedUploadCount += 1
-        invokedUploadParameters = (file, hash, url)
-        invokedUploadParametersList.append((file, hash, url))
+        invokedUploadParameters = (file, hash, url, additionalHeaders)
+        invokedUploadParametersList.append((file, hash, url, additionalHeaders))
         return stubbedUploadResult
     }
 

--- a/Tests/TuistCacheIntegrationTests/Cache/CacheLocalStorageIntegrationTests.swift
+++ b/Tests/TuistCacheIntegrationTests/Cache/CacheLocalStorageIntegrationTests.swift
@@ -32,7 +32,7 @@ final class CacheLocalStorageIntegrationTests: TuistTestCase {
         try FileHandler.shared.createFolder(xcframeworkPath)
 
         // When
-        let got = try subject.exists(hash: hash).toBlocking().first()
+        let got = try subject.exists(hash: hash, targetName: "AnyName").toBlocking().first()
 
         // Then
         XCTAssertTrue(got == true)
@@ -42,7 +42,7 @@ final class CacheLocalStorageIntegrationTests: TuistTestCase {
         // When
         let hash = "abcde"
 
-        let got = try subject.exists(hash: hash).toBlocking().first()
+        let got = try subject.exists(hash: hash, targetName: "AnyName").toBlocking().first()
 
         // Then
         XCTAssertTrue(got == false)
@@ -58,7 +58,7 @@ final class CacheLocalStorageIntegrationTests: TuistTestCase {
         try FileHandler.shared.createFolder(xcframeworkPath)
 
         // When
-        let got = try subject.fetch(hash: hash).toBlocking().first()
+        let got = try subject.fetch(hash: hash, targetName: "AnyName").toBlocking().first()
 
         // Then
         XCTAssertTrue(got == xcframeworkPath)
@@ -67,7 +67,7 @@ final class CacheLocalStorageIntegrationTests: TuistTestCase {
     func test_fetch_when_a_cached_xcframework_does_not_exist() throws {
         let hash = "abcde"
 
-        XCTAssertThrowsSpecific(try subject.fetch(hash: hash).toBlocking().first(),
+        XCTAssertThrowsSpecific(try subject.fetch(hash: hash, targetName: "AnyName").toBlocking().first(),
                                 CacheLocalStorageError.xcframeworkNotFound(hash: hash))
     }
 
@@ -79,7 +79,7 @@ final class CacheLocalStorageIntegrationTests: TuistTestCase {
         try FileHandler.shared.createFolder(xcframeworkPath)
 
         // When
-        _ = try subject.store(hash: hash, paths: [xcframeworkPath]).toBlocking().first()
+        _ = try subject.store(hash: hash, targetName: "AnyName", paths: [xcframeworkPath]).toBlocking().first()
 
         // Then
         XCTAssertTrue(FileHandler.shared.exists(cacheDirectory.appending(RelativePath("\(hash)/framework.xcframework"))))

--- a/Tests/TuistCacheTests/Cache/CacheRemoteStorageTests.swift
+++ b/Tests/TuistCacheTests/Cache/CacheRemoteStorageTests.swift
@@ -63,7 +63,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         subject = CacheRemoteStorage(cloudConfig: config, cloudClient: cloudClient, fileArchiverFactory: fileArchiverFactory, fileClient: fileClient)
 
         // When
-        let result = subject.exists(hash: "acho tio")
+        let result = subject.exists(hash: "acho tio", targetName: "AnyName")
             .toBlocking()
             .materialize()
 
@@ -89,7 +89,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         subject = CacheRemoteStorage(cloudConfig: config, cloudClient: cloudClient, fileArchiverFactory: fileArchiverFactory, fileClient: fileClient)
 
         // When
-        let result = try subject.exists(hash: "acho tio")
+        let result = try subject.exists(hash: "acho tio", targetName: "AnyName")
             .toBlocking()
             .single()
 
@@ -108,7 +108,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         subject = CacheRemoteStorage(cloudConfig: config, cloudClient: cloudClient, fileArchiverFactory: fileArchiverFactory, fileClient: fileClient)
 
         // When
-        let result = try subject.exists(hash: "acho tio")
+        let result = try subject.exists(hash: "acho tio", targetName: "AnyName")
             .toBlocking()
             .single()
 
@@ -128,7 +128,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         subject = CacheRemoteStorage(cloudConfig: config, cloudClient: cloudClient, fileArchiverFactory: fileArchiverFactory, fileClient: fileClient)
 
         // When
-        let result = try subject.exists(hash: "acho tio")
+        let result = try subject.exists(hash: "acho tio", targetName: "AnyName")
             .toBlocking()
             .single()
 
@@ -148,7 +148,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         subject = CacheRemoteStorage(cloudConfig: config, cloudClient: cloudClient, fileArchiverFactory: fileArchiverFactory, fileClient: fileClient)
 
         // When
-        let result = subject.fetch(hash: "acho tio")
+        let result = subject.fetch(hash: "acho tio", targetName: "AnyName")
             .toBlocking()
             .materialize()
 
@@ -179,7 +179,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         fileUnarchiver.stubbedUnzipResult = paths.first
 
         // When
-        let result = subject.fetch(hash: hash)
+        let result = subject.fetch(hash: hash, targetName: "AnyName")
             .toBlocking()
             .materialize()
 
@@ -211,7 +211,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         fileUnarchiver.stubbedUnzipResult = paths.first?.parentDirectory
 
         // When
-        let result = try subject.fetch(hash: hash)
+        let result = try subject.fetch(hash: hash, targetName: "AnyName")
             .toBlocking()
             .single()
 
@@ -238,7 +238,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         fileUnarchiver.stubbedUnzipResult = paths.first!.parentDirectory
 
         // When
-        _ = try subject.fetch(hash: hash)
+        _ = try subject.fetch(hash: hash, targetName: "AnyName")
             .toBlocking()
             .single()
 
@@ -264,7 +264,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         let hash = "foo_bar"
 
         // When
-        _ = try subject.fetch(hash: hash)
+        _ = try subject.fetch(hash: hash, targetName: "AnyName")
             .toBlocking()
             .single()
 
@@ -284,7 +284,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         subject = CacheRemoteStorage(cloudConfig: config, cloudClient: cloudClient, fileArchiverFactory: fileArchiverFactory, fileClient: fileClient)
 
         // When
-        let result = subject.store(hash: "acho tio", paths: [.root])
+        let result = subject.store(hash: "acho tio", targetName: "AnyName", paths: [.root])
             .toBlocking()
             .materialize()
 
@@ -315,7 +315,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         subject = CacheRemoteStorage(cloudConfig: config, cloudClient: cloudClient, fileArchiverFactory: fileArchiverFactory, fileClient: fileClient)
 
         // When
-        _ = subject.store(hash: "foo_bar", paths: [.root])
+        _ = subject.store(hash: "foo_bar", targetName: "AnyName", paths: [.root])
             .toBlocking()
             .materialize()
 
@@ -343,7 +343,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         subject = CacheRemoteStorage(cloudConfig: config, cloudClient: cloudClient, fileArchiverFactory: fileArchiverFactory, fileClient: fileClient)
 
         // When
-        _ = subject.store(hash: hash, paths: [.root])
+        _ = subject.store(hash: hash, targetName: "AnyName", paths: [.root])
             .toBlocking()
             .materialize()
 
@@ -373,7 +373,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         subject = CacheRemoteStorage(cloudConfig: config, cloudClient: cloudClient, fileArchiverFactory: fileArchiverFactory, fileClient: fileClient)
 
         // When
-        _ = subject.store(hash: hash, paths: [.root])
+        _ = subject.store(hash: hash, targetName: "AnyName", paths: [.root])
             .toBlocking()
             .materialize()
 


### PR DESCRIPTION
While thinking about the cloud implementation, I thought that two things could be interesting:

1 - When calling POST on `/api/cache` to get the PUT URL, it would be great to pass to Tuist also optional headers. For example, for the content md5, S3 expects it to be passed as a header. So if the server could tell Tuist: use this URL, along with these headers.
2 - When calling GET or POST (to fetch or store), besides the project id and the hash, the server could receive also the name of the target, to be able to track what changes/is requested more frequently.

This PR implements both.