### PR TITLE
Fix autocompletion not appearing on website.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
+- Fix missing autocompletion link on website [#2396](https://github.com/tuist/tuist/pull/2396) by [@fortmarek](https://github.com/fortmarek).
 - Fix memory leak related to xcbeautify [#2380](https://github.com/tuist/tuist/pull/2380) by [@adellibovi](https://github.com/adellibovi).
 
 ### Changed

--- a/website/markdown/docs/links.mdx
+++ b/website/markdown/docs/links.mdx
@@ -54,6 +54,7 @@ import {
 - [Generate documentation](/docs/commands/doc/)
 - [Generate secrets](/docs/commands/secret/)
 - [Clean the local environment](/docs/commands/clean/)
+- [Autocompletion](/docs/commands/autocompletion/)
 
 #### Contributors
 


### PR DESCRIPTION
### Short description 📝

Autocompletion documentation did not appear on the website because I forgot to add it to the sidebar 😐 

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] A developer other than the author has verified that the changes work as expected.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
