### PR TITLE
Fix CoreData project attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Fix reading configuration from project if `Target.settings` is nil [#2399](https://github.com/tuist/tuist/pull/2399) by [@danyf90](https://github.com/danyf90).
+- Fix CoreData project attributes [#2397](https://github.com/tuist/tuist/pull/2397) by [@kwridan](https://github.com/kwridan).
 
 ## 1.32.0 - Neubau
 

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -392,12 +392,13 @@ class ProjectFileElements {
                                 toGroup: PBXGroup,
                                 pbxproj: PBXProj) -> (element: PBXFileElement, path: AbsolutePath)
     {
-        let versionGroupType = Xcode.filetype(extension: folderRelativePath.extension!)
-        let group = XCVersionGroup(currentVersion: nil,
-                                   path: folderRelativePath.pathString,
-                                   name: name,
-                                   sourceTree: .group,
-                                   versionGroupType: versionGroupType)
+        let group = XCVersionGroup(
+            currentVersion: nil,
+            path: folderRelativePath.pathString,
+            name: name,
+            sourceTree: .group,
+            versionGroupType: versionGroupType(for: folderRelativePath)
+        )
         pbxproj.add(object: group)
         toGroup.children.append(group)
         elements[folderAbsolutePath] = group
@@ -547,6 +548,17 @@ class ProjectFileElements {
             return RelativePath(relativePathComponents.first!)
         } else {
             return RelativePath(firstElementComponents.joined(separator: "/"))
+        }
+    }
+
+    private func versionGroupType(for filePath: RelativePath) -> String? {
+        switch filePath.extension {
+        case "xcdatamodeld":
+            return "wrapper.xcdatamodel"
+        case let fileExtension?:
+            return Xcode.filetype(extension: fileExtension)
+        default:
+            return nil
         }
     }
 }

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -538,23 +538,30 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
     }
 
     func test_addVersionGroupElement() throws {
+        // Given
         let from = AbsolutePath("/project/")
-        let folderAbsolutePath = AbsolutePath("/project/model.xcdatamodel")
-        let folderRelativePath = RelativePath("./model.xcdatamodel")
+        let folderAbsolutePath = AbsolutePath("/project/model.xcdatamodeld")
+        let folderRelativePath = RelativePath("./model.xcdatamodeld")
         let group = PBXGroup()
         let pbxproj = PBXProj()
         pbxproj.add(object: group)
-        _ = subject.addVersionGroupElement(from: from,
-                                           folderAbsolutePath: folderAbsolutePath,
-                                           folderRelativePath: folderRelativePath,
-                                           name: nil,
-                                           toGroup: group,
-                                           pbxproj: pbxproj)
-        let versionGroup: XCVersionGroup? = group.children.first as? XCVersionGroup
-        XCTAssertEqual(versionGroup?.path, "model.xcdatamodel")
-        XCTAssertEqual(versionGroup?.sourceTree, .group)
-        XCTAssertNil(versionGroup?.name)
-        XCTAssertEqual(versionGroup?.versionGroupType, Xcode.filetype(extension: "xcdatamodel"))
+
+        // When
+        _ = subject.addVersionGroupElement(
+            from: from,
+            folderAbsolutePath: folderAbsolutePath,
+            folderRelativePath: folderRelativePath,
+            name: nil,
+            toGroup: group,
+            pbxproj: pbxproj
+        )
+
+        // Then
+        let versionGroup = try XCTUnwrap(group.children.first as? XCVersionGroup)
+        XCTAssertEqual(versionGroup.path, "model.xcdatamodeld")
+        XCTAssertEqual(versionGroup.sourceTree, .group)
+        XCTAssertNil(versionGroup.name)
+        XCTAssertEqual(versionGroup.versionGroupType, "wrapper.xcdatamodel")
     }
 
     func test_addFileElement() throws {


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/998

### Short description 📝

- The CoreData models group in Xcode was incorrectly being set to `wrapper.xcdatamodeld` (with a `d` at the end)
- Even though the extension of the container path on disk does end with a `d`, in Xcode the `versionGroupType` should be set to `wrapper.xcdatamodel`
- This small discrepancy causes `xcodebuild -showBuildSettings` to crash

### Test Plan 🛠

- Run `swift build && swift run tuist generate --path fixtures/ios_app_with_coredata`
- Verify generation continues to work
- Veirfy the application builds and runs without issues
- Run `xcodebuild -showBuildSettings -scheme App -project App.xcodeproj` and verify it does not crash

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] A developer other than the author has verified that the changes work as expected.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- ~[ ] In case the PR introduces changes that affect users, the documentation has been updated.~
