### PR TITLE
Speed up cache warming with topological sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Changed
 
 - Update post-generation interactors to use the graph traverser [#2451](https://github.com/tuist/tuist/pull/2451) by [@pepibumur](https://github.com/pepibumur).
+- Improve the cache warm command significantly by avoiding to recompile already in-cache dependency targets [#2377](https://github.com/tuist/tuist/pull/2377) by [@adellibovi](https://github.com/adellibovi).
 
 ## 1.33.0 - Plugin
 

--- a/Tests/TuistKitTests/Cache/CacheControllerTests.swift
+++ b/Tests/TuistKitTests/Cache/CacheControllerTests.swift
@@ -25,6 +25,7 @@ final class CacheControllerTests: TuistUnitTestCase {
     var projectGeneratorProvider: MockCacheControllerProjectGeneratorProvider!
     var config: Config!
     var cacheGraphLinter: MockCacheGraphLinter!
+    var focusServiceProjectGeneratorFactory: MockFocusServiceProjectGeneratorFactory!
 
     override func setUp() {
         generator = MockGenerator()
@@ -36,12 +37,15 @@ final class CacheControllerTests: TuistUnitTestCase {
         projectGeneratorProvider = MockCacheControllerProjectGeneratorProvider()
         projectGeneratorProvider.stubbedGeneratorResult = generator
         cacheGraphLinter = MockCacheGraphLinter()
+        focusServiceProjectGeneratorFactory = MockFocusServiceProjectGeneratorFactory()
+        focusServiceProjectGeneratorFactory.stubbedGeneratorResult = generator
         subject = CacheController(
             cache: cache,
             artifactBuilder: artifactBuilder,
             projectGeneratorProvider: projectGeneratorProvider,
             cacheGraphContentHasher: cacheGraphContentHasher,
-            cacheGraphLinter: cacheGraphLinter
+            cacheGraphLinter: cacheGraphLinter,
+            focusServiceProjectGeneratorFactory: focusServiceProjectGeneratorFactory
         )
 
         super.setUp()
@@ -56,6 +60,7 @@ final class CacheControllerTests: TuistUnitTestCase {
         cache = nil
         subject = nil
         config = nil
+        focusServiceProjectGeneratorFactory = nil
     }
 
     func test_cache_builds_and_caches_the_frameworks() throws {
@@ -120,8 +125,11 @@ final class CacheControllerTests: TuistUnitTestCase {
         Hashing cacheable targets
         Building cacheable targets
         Building cacheable targets: \(aTarget.name), 1 out of 3
+        Focusing cacheable targets: \(aTarget.name)
         Building cacheable targets: \(bTarget.name), 2 out of 3
+        Focusing cacheable targets: \(bTarget.name)
         Building cacheable targets: \(cTarget.name), 3 out of 3
+        Focusing cacheable targets: \(cTarget.name)
         All cacheable targets have been cached successfully as xcframeworks
         """)
         XCTAssertEqual(cacheGraphLinter.invokedLintCount, 1)
@@ -192,7 +200,9 @@ final class CacheControllerTests: TuistUnitTestCase {
         Hashing cacheable targets
         Building cacheable targets
         Building cacheable targets: \(aTarget.name), 1 out of 2
+        Focusing cacheable targets: \(aTarget.name)
         Building cacheable targets: \(bTarget.name), 2 out of 2
+        Focusing cacheable targets: \(bTarget.name)
         All cacheable targets have been cached successfully as xcframeworks
         """)
         XCTAssertEqual(cacheGraphLinter.invokedLintCount, 1)


### PR DESCRIPTION
On [this PR](https://github.com/tuist/tuist/pull/2377) @adellibovi improved the cache warming time significantly. When we merged the PR, GitHub's CI was not working well, and that caused `main` to become red because the cache acceptance tests were failing. After some debugging, it turns out there's a legit issue in our caching logic that was uncovered after introducing this improvement.

Since `main` is red and it's blocking other PRs from being merged, I reverted the changes there and opened this PR to debug this further.