### PR TITLE
Fix typo 'SwftPackageManager' > 'SwiftPackageManager'

### DIFF
--- a/website/markdown/docs/dependencies/dependencies.mdx
+++ b/website/markdown/docs/dependencies/dependencies.mdx
@@ -61,7 +61,7 @@ Tuist
                 |- Alamofire.framework
         |- Cocoapods # coming soon
             |- RxSwift
-        |- SwftPackageManager # coming soon
+        |- SwiftPackageManager # coming soon
             |- Moya
 ```
 


### PR DESCRIPTION
### Short description 📝
Fixes a typo in [Dependencies docs page](https://tuist.io/docs/dependencies/dependencies/).
