### PR TITLE
Fix typo Recommented to Recommended

### DIFF
--- a/website/markdown/docs/usage/project-description.mdx
+++ b/website/markdown/docs/usage/project-description.mdx
@@ -1592,7 +1592,7 @@ A `DefaultSettings` can be one of the following options:
     {
       case: '.recommended(excluding: Set<String>)',
       description:
-        "Recommented settings including warning flags to help you catch some of the bugs at the early stage of development. If you need to override certain settings in a `CustomConfiguration` it's possible to add those keys to `excluding`.",
+        "Recommended settings including warning flags to help you catch some of the bugs at the early stage of development. If you need to override certain settings in a `CustomConfiguration` it's possible to add those keys to `excluding`.",
     },
     {
       case: '.essential(excluding: Set<String>)',


### PR DESCRIPTION
### Short description 📝

While looking at a docmentation, I came across a typo from [project-description](https://tuist.io/docs/usage/project-description/#configuration) and fixed it.
* `Recommented` -> `Recommended`
