### PR TITLE
Update post-generation interactors to use the graph traverser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Changed
+
+- Update post-generation interactors to use the graph traverser [#2451](https://github.com/tuist/tuist/pull/2451) by [@pepibumur](https://github.com/pepibumur).
+
 ## 1.33.0 - Plugin
 
 ### Added

--- a/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
+++ b/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
@@ -9,6 +9,9 @@ public protocol GraphTraversing {
     /// Returns true if the project has package dependencies.
     var hasPackages: Bool { get }
 
+    /// Returns true if the graph has remote packages.
+    var hasRemotePackages: Bool { get }
+
     /// The path to the directory from where the graph has been loaded.
     var path: AbsolutePath { get }
 
@@ -29,6 +32,12 @@ public protocol GraphTraversing {
 
     /// Returns the targets from the project that lives in the directory from which the graph has been loaded.
     func rootTargets() -> Set<ValueGraphTarget>
+
+    /// Returns all the targets of the project.
+    func allTargets() -> Set<ValueGraphTarget>
+
+    /// Returns the paths to directories containing a Podfile
+    func cocoapodsPaths() -> Set<AbsolutePath>
 
     /// Returns the project from which the graph has been loaded.
     func rootProjects() -> Set<Project>

--- a/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
+++ b/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
@@ -19,9 +19,27 @@ public class ValueGraphTraverser: GraphTraversing {
         self.graph = graph
     }
 
+    public var hasRemotePackages: Bool {
+        graph.packages.values.flatMap(\.values).first(where: {
+            switch $0 {
+            case .remote: return true
+            case .local: return false
+            }
+        }) != nil
+    }
+
     public func rootTargets() -> Set<ValueGraphTarget> {
         Set(graph.workspace.projects.reduce(into: Set()) { result, path in
             result.formUnion(targets(at: path))
+        })
+    }
+
+    public func allTargets() -> Set<ValueGraphTarget> {
+        Set(projects.flatMap { (projectPath, project) -> [ValueGraphTarget] in
+            let targets = graph.targets[projectPath, default: [:]]
+            return targets.values.map { target in
+                ValueGraphTarget(path: projectPath, target: target, project: project)
+            }
         })
     }
 
@@ -29,6 +47,21 @@ public class ValueGraphTraverser: GraphTraversing {
         Set(graph.workspace.projects.compactMap {
             projects[$0]
         })
+    }
+
+    public func cocoapodsPaths() -> Set<AbsolutePath> {
+        dependencies.reduce(into: Set<AbsolutePath>()) { acc, next in
+            let fromDependency = next.key
+            let toDependencies = next.value
+            if case let ValueGraphDependency.cocoapods(path) = fromDependency {
+                acc.insert(path)
+            }
+            toDependencies.forEach { toDependency in
+                if case let ValueGraphDependency.cocoapods(path) = toDependency {
+                    acc.insert(path)
+                }
+            }
+        }
     }
 
     public func precompiledFrameworksPaths() -> Set<AbsolutePath> {

--- a/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
+++ b/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
@@ -24,6 +24,16 @@ final class MockGraphTraverser: GraphTraversing {
         return stubbedHasPackages
     }
 
+    var invokedHasRemotePackagesGetter = false
+    var invokedHasRemotePackagesGetterCount = 0
+    var stubbedHasRemotePackages: Bool! = false
+
+    var hasRemotePackages: Bool {
+        invokedHasRemotePackagesGetter = true
+        invokedHasRemotePackagesGetterCount += 1
+        return stubbedHasRemotePackages
+    }
+
     var invokedPathGetter = false
     var invokedPathGetterCount = 0
     var stubbedPath: AbsolutePath!
@@ -92,6 +102,26 @@ final class MockGraphTraverser: GraphTraversing {
         invokedRootTargets = true
         invokedRootTargetsCount += 1
         return stubbedRootTargetsResult
+    }
+
+    var invokedAllTargets = false
+    var invokedAllTargetsCount = 0
+    var stubbedAllTargetsResult: Set<ValueGraphTarget>! = []
+
+    func allTargets() -> Set<ValueGraphTarget> {
+        invokedAllTargets = true
+        invokedAllTargetsCount += 1
+        return stubbedAllTargetsResult
+    }
+
+    var invokedCocoapodsPaths = false
+    var invokedCocoapodsPathsCount = 0
+    var stubbedCocoapodsPathsResult: Set<AbsolutePath>! = []
+
+    func cocoapodsPaths() -> Set<AbsolutePath> {
+        invokedCocoapodsPaths = true
+        invokedCocoapodsPathsCount += 1
+        return stubbedCocoapodsPathsResult
     }
 
     var invokedRootProjects = false

--- a/Sources/TuistGenerator/Utils/CocoaPodsInteractor.swift
+++ b/Sources/TuistGenerator/Utils/CocoaPodsInteractor.swift
@@ -64,7 +64,7 @@ public final class CocoaPodsInteractor: CocoaPodsInteracting {
         let canUseBundler = canUseCocoaPodsThroughBundler()
         let canUseSystem = canUseSystemPod()
 
-        try graphTraverser.cocoapodsPaths().forEach { path in
+        try graphTraverser.cocoapodsPaths().sorted().forEach { path in
             var command: [String]
 
             if canUseBundler {

--- a/Sources/TuistGenerator/Utils/CocoaPodsInteractor.swift
+++ b/Sources/TuistGenerator/Utils/CocoaPodsInteractor.swift
@@ -33,7 +33,7 @@ public protocol CocoaPodsInteracting {
     ///
     /// - Parameter graph: Project graph.
     /// - Throws: An error if the installation of the pods fails.
-    func install(graph: Graph) throws
+    func install(graphTraverser: GraphTraversing) throws
 }
 
 public final class CocoaPodsInteractor: CocoaPodsInteracting {
@@ -43,28 +43,28 @@ public final class CocoaPodsInteractor: CocoaPodsInteracting {
     ///
     /// - Parameter graph: Project graph.
     /// - Throws: An error if the installation of the pods fails.
-    public func install(graph: Graph) throws {
+    public func install(graphTraverser: GraphTraversing) throws {
         do {
-            try install(graph: graph, updatingRepo: false)
+            try install(graphTraverser: graphTraverser, updatingRepo: false)
         } catch let error as CocoaPodsInteractorError {
             if case CocoaPodsInteractorError.outdatedRepository = error {
                 logger.warning("The local CocoaPods specs repository is outdated. Re-running 'pod install' updating the repository.")
-                try self.install(graph: graph, updatingRepo: true)
+                try self.install(graphTraverser: graphTraverser, updatingRepo: true)
             } else {
                 throw error
             }
         }
     }
 
-    fileprivate func install(graph: Graph, updatingRepo: Bool) throws {
-        guard !graph.cocoapods.isEmpty else {
+    fileprivate func install(graphTraverser: GraphTraversing, updatingRepo: Bool) throws {
+        guard !graphTraverser.cocoapodsPaths().isEmpty else {
             return
         }
 
         let canUseBundler = canUseCocoaPodsThroughBundler()
         let canUseSystem = canUseSystemPod()
 
-        try graph.cocoapods.forEach { node in
+        try graphTraverser.cocoapodsPaths().forEach { path in
             var command: [String]
 
             if canUseBundler {
@@ -75,7 +75,7 @@ public final class CocoaPodsInteractor: CocoaPodsInteracting {
                 throw CocoaPodsInteractorError.cocoapodsNotFound
             }
 
-            command.append(contentsOf: ["install", "--project-directory=\(node.path.pathString)"])
+            command.append(contentsOf: ["install", "--project-directory=\(path.pathString)"])
 
             if updatingRepo {
                 command.append("--repo-update")
@@ -83,7 +83,7 @@ public final class CocoaPodsInteractor: CocoaPodsInteracting {
 
             // The installation of Pods might fail if the local repository that contains the specs
             // is outdated.
-            logger.notice("Installing CocoaPods dependencies defined in \(node.podfilePath)", metadata: .section)
+            logger.notice("Installing CocoaPods dependencies defined in \(path.pathString)", metadata: .section)
 
             var mightNeedRepoUpdate: Bool = false
             let outputClosure: ([UInt8]) -> Void = { bytes in

--- a/Sources/TuistKit/Generator/Generator.swift
+++ b/Sources/TuistKit/Generator/Generator.swift
@@ -152,7 +152,7 @@ class Generator: Generating {
         try sideEffectDescriptorExecutor.execute(sideEffects: sideEffects)
 
         // Post Generate Actions
-        try postGenerationActions(for: graph, workspaceName: projectDescriptor.xcodeprojPath.basename)
+        try postGenerationActions(graphTraverser: graphTraverser, workspaceName: projectDescriptor.xcodeprojPath.basename)
 
         return (projectDescriptor.xcodeprojPath, graph)
     }
@@ -176,7 +176,7 @@ class Generator: Generating {
         try sideEffectDescriptorExecutor.execute(sideEffects: sideEffects)
 
         // Post Generate Actions
-        try postGenerationActions(for: graph, workspaceName: workspaceDescriptor.xcworkspacePath.basename)
+        try postGenerationActions(graphTraverser: graphTraverser, workspaceName: workspaceDescriptor.xcworkspacePath.basename)
 
         return (workspaceDescriptor.xcworkspacePath, graph)
     }
@@ -200,7 +200,7 @@ class Generator: Generating {
         try sideEffectDescriptorExecutor.execute(sideEffects: sideEffects)
 
         // Post Generate Actions
-        try postGenerationActions(for: graph, workspaceName: workspaceDescriptor.xcworkspacePath.basename)
+        try postGenerationActions(graphTraverser: graphTraverser, workspaceName: workspaceDescriptor.xcworkspacePath.basename)
 
         return (workspaceDescriptor.xcworkspacePath, graph)
     }
@@ -212,10 +212,10 @@ class Generator: Generating {
         try graphLinter.lint(graphTraverser: graphTraverser).printAndThrowIfNeeded()
     }
 
-    private func postGenerationActions(for graph: Graph, workspaceName: String) throws {
-        try signingInteractor.install(graph: graph)
-        try swiftPackageManagerInteractor.install(graph: graph, workspaceName: workspaceName)
-        try cocoapodsInteractor.install(graph: graph)
+    private func postGenerationActions(graphTraverser: GraphTraversing, workspaceName: String) throws {
+        try signingInteractor.install(graphTraverser: graphTraverser)
+        try swiftPackageManagerInteractor.install(graphTraverser: graphTraverser, workspaceName: workspaceName)
+        try cocoapodsInteractor.install(graphTraverser: graphTraverser)
     }
 
     // swiftlint:disable:next large_tuple

--- a/Sources/TuistSigning/SigningInteractor.swift
+++ b/Sources/TuistSigning/SigningInteractor.swift
@@ -7,7 +7,7 @@ import TuistSupport
 /// Interacts with signing
 public protocol SigningInteracting {
     /// Install signing for a given graph
-    func install(graph: Graph) throws
+    func install(graphTraverser: GraphTraversing) throws
 }
 
 public final class SigningInteractor: SigningInteracting {
@@ -46,8 +46,8 @@ public final class SigningInteractor: SigningInteracting {
         self.signingCipher = signingCipher
     }
 
-    public func install(graph: Graph) throws {
-        let entryPath = graph.entryPath
+    public func install(graphTraverser: GraphTraversing) throws {
+        let entryPath = graphTraverser.path
         guard
             let signingDirectory = try signingFilesLocator.locateSigningDirectory(from: entryPath),
             let derivedDirectory = rootDirectoryLocator.locate(from: entryPath)?.appending(component: Constants.DerivedDirectory.name)
@@ -66,38 +66,34 @@ public final class SigningInteractor: SigningInteracting {
         try signingCipher.decryptSigning(at: entryPath, keepFiles: true)
         defer { try? signingCipher.encryptSigning(at: entryPath, keepFiles: false) }
 
-        let (certificates, provisioningProfiles) = try signingMatcher.match(from: graph.entryPath)
+        let (certificates, provisioningProfiles) = try signingMatcher.match(from: graphTraverser.path)
 
-        try graph.projects.forEach { project in
-            try project.targets.forEach {
-                try install(target: $0,
-                            project: project,
-                            keychainPath: keychainPath,
-                            certificates: certificates,
-                            provisioningProfiles: provisioningProfiles)
-            }
+        try graphTraverser.allTargets().forEach { target in
+            try install(target: target,
+                        keychainPath: keychainPath,
+                        certificates: certificates,
+                        provisioningProfiles: provisioningProfiles)
         }
     }
 
     // MARK: - Helpers
 
-    private func install(target: Target,
-                         project: Project,
+    private func install(target: ValueGraphTarget,
                          keychainPath: AbsolutePath,
                          certificates: [Fingerprint: Certificate],
                          provisioningProfiles: [TargetName: [ConfigurationName: ProvisioningProfile]]) throws
     {
-        let targetConfigurations = target.settings?.configurations ?? [:]
+        let targetConfigurations = target.target.settings?.configurations ?? [:]
         /// Filtering certificate-provisioning profile pairs, so they are installed only when necessary (they correspond to some configuration and target in the project)
         let signingPairs = Set(
             targetConfigurations
-                .merging(project.settings.configurations,
+                .merging(target.project.settings.configurations,
                          uniquingKeysWith: { config, _ in config })
                 .keys
         )
         .compactMap { configuration -> (certificate: Certificate, provisioningProfile: ProvisioningProfile)? in
             guard
-                let provisioningProfile = provisioningProfiles[target.name]?[configuration.name],
+                let provisioningProfile = provisioningProfiles[target.target.name]?[configuration.name],
                 let certificate = certificates.first(for: provisioningProfile)
             else {
                 return nil
@@ -110,7 +106,7 @@ public final class SigningInteractor: SigningInteracting {
         }
         try signingPairs.map(\.provisioningProfile).forEach(signingInstaller.installProvisioningProfile)
         try signingPairs.map(\.provisioningProfile).flatMap {
-            signingLinter.lint(provisioningProfile: $0, target: target)
+            signingLinter.lint(provisioningProfile: $0, target: target.target)
         }.printAndThrowIfNeeded()
 
         try signingPairs.flatMap(signingLinter.lint).printAndThrowIfNeeded()

--- a/Sources/TuistSigning/SigningInteractor.swift
+++ b/Sources/TuistSigning/SigningInteractor.swift
@@ -68,7 +68,7 @@ public final class SigningInteractor: SigningInteracting {
 
         let (certificates, provisioningProfiles) = try signingMatcher.match(from: graphTraverser.path)
 
-        try graphTraverser.allTargets().forEach { target in
+        try graphTraverser.allTargets().sorted().forEach { target in
             try install(target: target,
                         keychainPath: keychainPath,
                         certificates: certificates,

--- a/Tests/TuistCoreTests/ValueGraph/ValueGraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/ValueGraph/ValueGraphTraverserTests.swift
@@ -2032,6 +2032,52 @@ final class ValueGraphTraverserTests: TuistUnitTestCase {
         XCTAssertTrue(got.contains(ValueGraphTarget(path: project.path, target: tvosApp, project: project)))
     }
 
+    func test_allTargets_returns_all_the_targets() {
+        // Given
+        let firstPath = AbsolutePath("/first")
+        let firstProject = Project.test(path: firstPath)
+        let secondPath = AbsolutePath("/second")
+        let secondProject = Project.test(path: secondPath)
+        let firstTarget = Target.test(name: "first")
+        let secondTarget = Target.test(name: "second")
+        let graph = ValueGraph.test(projects: [firstPath: firstProject,
+                                               secondPath: secondProject],
+                                    targets: [firstPath: [firstTarget.name: firstTarget],
+                                              secondPath: [secondTarget.name: secondTarget]])
+        let graphTraverser = ValueGraphTraverser(graph: graph)
+
+        // When
+        let got = graphTraverser.allTargets().sorted()
+
+        // Then
+        XCTAssertEqual(got.count, 2)
+        XCTAssertEqual(got.first?.project, firstProject)
+        XCTAssertEqual(got.first?.target, firstTarget)
+        XCTAssertEqual(got.last?.project, secondProject)
+        XCTAssertEqual(got.last?.target, secondTarget)
+    }
+
+    func test_hasRemotePackages_when_has_remotePackages() {
+        // Given
+        let path = AbsolutePath("/project")
+        let package = Package.remote(url: "https://git.tuist.io", requirement: .branch("main"))
+        let graph = ValueGraph.test(packages: [path: ["Test": package]],
+                                    dependencies: [.packageProduct(path: path, product: "Test"): Set()])
+        let graphTraverser = ValueGraphTraverser(graph: graph)
+
+        // Then
+        XCTAssertTrue(graphTraverser.hasRemotePackages)
+    }
+
+    func test_hasRemotePackages_when_doesnt_have_remove_packages() {
+        // Given
+        let graph = ValueGraph.test()
+        let graphTraverser = ValueGraphTraverser(graph: graph)
+
+        // Then
+        XCTAssertFalse(graphTraverser.hasRemotePackages)
+    }
+
     // MARK: - Helpers
 
     private func sdkDependency(from dependency: GraphDependencyReference) -> SDKPathAndStatus? {

--- a/Tests/TuistGeneratorIntegrationTests/Utils/Mocks/MockCocoaPodsInteractor.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Utils/Mocks/MockCocoaPodsInteractor.swift
@@ -1,13 +1,22 @@
 import Foundation
+import TSCBasic
 import TuistCore
 @testable import TuistGenerator
 
 final class MockCocoaPodsInteractor: CocoaPodsInteracting {
-    var installArgs: [Graph] = []
-    var installStub: Error?
+    var invokedInstall = false
+    var invokedInstallCount = 0
+    var invokedInstallParameters: GraphTraversing?
+    var invokedInstallParametersList = [GraphTraversing]()
+    var stubbedInstallError: Error?
 
-    func install(graph: Graph) throws {
-        installArgs.append(graph)
-        if let error = installStub { throw error }
+    func install(graphTraverser: GraphTraversing) throws {
+        invokedInstall = true
+        invokedInstallCount += 1
+        invokedInstallParameters = graphTraverser
+        invokedInstallParametersList.append(graphTraverser)
+        if let error = stubbedInstallError {
+            throw error
+        }
     }
 }

--- a/Tests/TuistGeneratorTests/Utils/CocoaPodsInteractorTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/CocoaPodsInteractorTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import TuistCore
 import TuistCoreTesting
+import TuistGraph
 import TuistSupport
 import XCTest
 @testable import TuistGenerator
@@ -37,62 +38,62 @@ final class CocoaPodsInteractorTests: TuistUnitTestCase {
         system.whichStub = { _ in
             throw NSError.test()
         }
-        let cocoapods = CocoaPodsNode.test()
-        let graph = Graph.test(cocoapods: [cocoapods])
+        let graph = ValueGraph.test(dependencies: [ValueGraphDependency.cocoapods(path: "/"): Set()])
+        let graphTraverser = ValueGraphTraverser(graph: graph)
 
         // Then
-        XCTAssertThrowsSpecific(try subject.install(graph: graph),
+        XCTAssertThrowsSpecific(try subject.install(graphTraverser: graphTraverser),
                                 CocoaPodsInteractorError.cocoapodsNotFound)
     }
 
     func test_install_when_theCocoaPodsFromBundlerCanBeUsed() throws {
         // Given
-        let cocoapods = CocoaPodsNode.test()
-        let graph = Graph.test(cocoapods: [cocoapods])
+        let graph = ValueGraph.test(dependencies: [ValueGraphDependency.cocoapods(path: "/"): Set()])
+        let graphTraverser = ValueGraphTraverser(graph: graph)
 
         system.succeedCommand(["bundle", "show", "cocoapods"])
-        system.succeedCommand(["bundle", "exec", "pod", "install", "--project-directory=\(cocoapods.path.pathString)"])
+        system.succeedCommand(["bundle", "exec", "pod", "install", "--project-directory=/"])
 
         // When
-        try subject.install(graph: graph)
+        try subject.install(graphTraverser: graphTraverser)
 
         // Then
-        XCTAssertPrinterOutputContains("Installing CocoaPods dependencies defined in \(cocoapods.podfilePath)")
+        XCTAssertPrinterOutputContains("Installing CocoaPods dependencies defined in /")
     }
 
     func test_install_when_theCocoaPodsFromTheSystemCanBeUsed() throws {
         // Given
-        let cocoapods = CocoaPodsNode.test()
-        let graph = Graph.test(cocoapods: [cocoapods])
+        let graph = ValueGraph.test(dependencies: [ValueGraphDependency.cocoapods(path: "/"): Set()])
+        let graphTraverser = ValueGraphTraverser(graph: graph)
 
         system.errorCommand(["bundle", "show", "cocoapods"])
         system.whichStub = {
             if $0 == "pod" { return "/path/to/pod" }
             else { throw NSError.test() }
         }
-        system.succeedCommand(["pod", "install", "--project-directory=\(cocoapods.path.pathString)"])
+        system.succeedCommand(["pod", "install", "--project-directory=/"])
 
         // When
-        try subject.install(graph: graph)
+        try subject.install(graphTraverser: graphTraverser)
 
         // Then
-        XCTAssertPrinterOutputContains("Installing CocoaPods dependencies defined in \(cocoapods.podfilePath)")
+        XCTAssertPrinterOutputContains("Installing CocoaPods dependencies defined in /")
     }
 
     func test_install_when_theCocoaPodsSpecsRepoIsOutdated() throws {
         // Given
-        let cocoapods = CocoaPodsNode.test()
-        let graph = Graph.test(cocoapods: [cocoapods])
+        let graph = ValueGraph.test(dependencies: [ValueGraphDependency.cocoapods(path: "/"): Set()])
+        let graphTraverser = ValueGraphTraverser(graph: graph)
 
         system.succeedCommand(["bundle", "show", "cocoapods"])
-        system.errorCommand(["bundle", "exec", "pod", "install", "--project-directory=\(cocoapods.path.pathString)"], error: "[!] CocoaPods could not find compatible versions for pod")
-        system.succeedCommand(["bundle", "exec", "pod", "install", "--project-directory=\(cocoapods.path.pathString)", "--repo-update"])
+        system.errorCommand(["bundle", "exec", "pod", "install", "--project-directory=/"], error: "[!] CocoaPods could not find compatible versions for pod")
+        system.succeedCommand(["bundle", "exec", "pod", "install", "--project-directory=/", "--repo-update"])
 
         // When
-        try subject.install(graph: graph)
+        try subject.install(graphTraverser: graphTraverser)
 
         // Then
         XCTAssertPrinterOutputContains("The local CocoaPods specs repository is outdated. Re-running 'pod install' updating the repository.")
-        XCTAssertPrinterOutputContains("Installing CocoaPods dependencies defined in \(cocoapods.podfilePath)")
+        XCTAssertPrinterOutputContains("Installing CocoaPods dependencies defined in /")
     }
 }

--- a/Tests/TuistSigningTests/SigningInteractorTests.swift
+++ b/Tests/TuistSigningTests/SigningInteractorTests.swift
@@ -53,7 +53,8 @@ final class SigningInteractorTests: TuistUnitTestCase {
 
     func test_install_creates_keychain() throws {
         // Given
-        let graph = Graph.test()
+        let graph = ValueGraph.test()
+        let graphTraverser = ValueGraphTraverser(graph: graph)
         let signingDirectory = try temporaryPath()
         signingFilesLocator.locateSigningDirectoryStub = { _ in
             signingDirectory
@@ -76,7 +77,7 @@ final class SigningInteractorTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.install(graph: graph)
+        try subject.install(graphTraverser: graphTraverser)
 
         // Then
         XCTAssertEqual(masterKey, receivedMasterKey)
@@ -85,7 +86,8 @@ final class SigningInteractorTests: TuistUnitTestCase {
 
     func test_install_unlocks_keychain() throws {
         // Given
-        let graph = Graph.test()
+        let graph = ValueGraph.test()
+        let graphTraverser = ValueGraphTraverser(graph: graph)
         let signingDirectory = try temporaryPath()
         signingFilesLocator.locateSigningDirectoryStub = { _ in
             signingDirectory
@@ -108,7 +110,7 @@ final class SigningInteractorTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.install(graph: graph)
+        try subject.install(graphTraverser: graphTraverser)
 
         // Then
         XCTAssertEqual(masterKey, receivedMasterKey)
@@ -117,7 +119,8 @@ final class SigningInteractorTests: TuistUnitTestCase {
 
     func test_install_locks_keychain() throws {
         // Given
-        let graph = Graph.test()
+        let graph = ValueGraph.test()
+        let graphTraverser = ValueGraphTraverser(graph: graph)
         signingFilesLocator.locateSigningDirectoryStub = { _ in
             try self.temporaryPath()
         }
@@ -139,7 +142,7 @@ final class SigningInteractorTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.install(graph: graph)
+        try subject.install(graphTraverser: graphTraverser)
 
         // Then
         XCTAssertEqual(masterKey, receivedMasterKey)
@@ -149,7 +152,8 @@ final class SigningInteractorTests: TuistUnitTestCase {
     func test_install_decrypts_signing() throws {
         // Given
         let entryPath = try temporaryPath()
-        let graph = Graph.test(entryPath: entryPath)
+        let graph = ValueGraph.test(path: entryPath)
+        let graphTraverser = ValueGraphTraverser(graph: graph)
         signingFilesLocator.locateSigningDirectoryStub = { _ in
             try self.temporaryPath()
         }
@@ -167,7 +171,7 @@ final class SigningInteractorTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.install(graph: graph)
+        try subject.install(graphTraverser: graphTraverser)
 
         // Then
         XCTAssertEqual(signingPath, entryPath)
@@ -177,7 +181,8 @@ final class SigningInteractorTests: TuistUnitTestCase {
     func test_install_encrypts_signing() throws {
         // Given
         let entryPath = try temporaryPath()
-        let graph = Graph.test(entryPath: entryPath)
+        let graph = ValueGraph.test(path: entryPath)
+        let graphTraverser = ValueGraphTraverser(graph: graph)
         signingFilesLocator.locateSigningDirectoryStub = { _ in
             try self.temporaryPath()
         }
@@ -195,7 +200,7 @@ final class SigningInteractorTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.install(graph: graph)
+        try subject.install(graphTraverser: graphTraverser)
 
         // Then
         XCTAssertEqual(signingPath, entryPath)
@@ -234,7 +239,8 @@ final class SigningInteractorTests: TuistUnitTestCase {
             )
         )
         let project = Project.test(targets: [target])
-        let graph = Graph.test(projects: [project])
+        let graph = ValueGraph.test(projects: [project.path: project], targets: [project.path: [target.name: target]])
+        let graphTraverser = ValueGraphTraverser(graph: graph)
 
         var installedCertificates: [Certificate] = []
         signingInstaller.installCertificateStub = { certificate, _ in
@@ -246,7 +252,7 @@ final class SigningInteractorTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.install(graph: graph)
+        try subject.install(graphTraverser: graphTraverser)
 
         // Then
         XCTAssertEqual([expectedCertificate], installedCertificates)


### PR DESCRIPTION
### Short description 📝
In the effort of removing the old Graph. I'm continuing to update components that are still using the old graph format. In particular, in this PR I'm updating the `CocoaPodsInteractor`, `SigningManager`, and the `SwiftPackageManagerInteractor`.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
