### PR TITLE
[Caching] Hash dependencies by file and not by path

### DIFF
--- a/Sources/TuistCache/ContentHashing/DependencyContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/DependencyContentHasher.swift
@@ -31,19 +31,28 @@ public final class DependenciesContentHasher: DependenciesContentHashing {
         case let .target(name):
             return try contentHasher.hash("target-\(name)")
         case let .project(target, path):
-            return try contentHasher.hash(["project-", target, path.pathString])
+            let projectHash = try contentHasher.hash(path: path)
+            return try contentHasher.hash("project-\(projectHash)-\(target)")
         case let .framework(path):
-            return try contentHasher.hash("framework-\(path.pathString)")
+            return try contentHasher.hash(path: path)
         case let .xcFramework(path):
-            return try contentHasher.hash("xcframework-\(path.pathString)")
+            return try contentHasher.hash(path: path)
         case let .library(path, publicHeaders, swiftModuleMap):
-            return try contentHasher.hash(["library", path.pathString, publicHeaders.pathString, swiftModuleMap?.pathString].compactMap { $0 })
+            let libraryHash = try contentHasher.hash(path: path)
+            let publicHeadersHash = try contentHasher.hash(path: publicHeaders)
+            if let swiftModuleMap = swiftModuleMap {
+                let swiftModuleHash = try contentHasher.hash(path: swiftModuleMap)
+                return try contentHasher.hash("library-\(libraryHash)-\(publicHeadersHash)-\(swiftModuleHash)")
+            } else {
+                return try contentHasher.hash("library-\(libraryHash)-\(publicHeadersHash)")
+            }
         case let .package(product):
             return try contentHasher.hash("package-\(product)")
         case let .sdk(name, status):
             return try contentHasher.hash("sdk-\(name)-\(status)")
         case let .cocoapods(path):
-            return try contentHasher.hash(["cocoapods", path.pathString])
+            let podsHash = try contentHasher.hash(path: path)
+            return try contentHasher.hash("cocoapods-\(podsHash)")
         case .xctest:
             return try contentHasher.hash("xctest")
         }

--- a/Tests/TuistCacheTests/ContentHashing/DependenciesContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/DependenciesContentHasherTests.swift
@@ -43,37 +43,41 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
     func test_hash_whenDependencyIsProject_callsContentHasherAsExpected() throws {
         // Given
         let dependency = Dependency.project(target: "foo", path: filePath1)
+        mockContentHasher.stubHashForPath[filePath1] = "file-hashed"
 
         // When
         let hash = try subject.hash(dependencies: [dependency])
 
         // Then
-        XCTAssertEqual(hash, "project-;foo;/file1")
-        XCTAssertEqual(mockContentHasher.hashStringsCallCount, 1)
+        XCTAssertEqual(hash, "project-file-hashed-foo-hash")
+        XCTAssertEqual(mockContentHasher.hashStringCallCount, 1)
+        XCTAssertEqual(mockContentHasher.hashPathCallCount, 1)
     }
 
     func test_hash_whenDependencyIsFramework_callsContentHasherAsExpected() throws {
         // Given
         let dependency = Dependency.framework(path: filePath1)
+        mockContentHasher.stubHashForPath[filePath1] = "file-hashed"
 
         // When
         let hash = try subject.hash(dependencies: [dependency])
 
         // Then
-        XCTAssertEqual(hash, "framework-/file1-hash")
-        XCTAssertEqual(mockContentHasher.hashStringCallCount, 1)
+        XCTAssertEqual(hash, "file-hashed")
+        XCTAssertEqual(mockContentHasher.hashPathCallCount, 1)
     }
 
     func test_hash_whenDependencyIsXCFramework_callsContentHasherAsExpected() throws {
         // Given
         let dependency = Dependency.xcFramework(path: filePath1)
+        mockContentHasher.stubHashForPath[filePath1] = "file-hashed"
 
         // When
         let hash = try subject.hash(dependencies: [dependency])
 
         // Then
-        XCTAssertEqual(hash, "xcframework-/file1-hash")
-        XCTAssertEqual(mockContentHasher.hashStringCallCount, 1)
+        XCTAssertEqual(hash, "file-hashed")
+        XCTAssertEqual(mockContentHasher.hashPathCallCount, 1)
     }
 
     func test_hash_whenDependencyIsLibrary_callsContentHasherAsExpected() throws {
@@ -81,13 +85,34 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         let dependency = Dependency.library(path: filePath1,
                                             publicHeaders: filePath2,
                                             swiftModuleMap: filePath3)
+        mockContentHasher.stubHashForPath[filePath1] = "file1-hashed"
+        mockContentHasher.stubHashForPath[filePath2] = "file2-hashed"
+        mockContentHasher.stubHashForPath[filePath3] = "file3-hashed"
 
         // When
         let hash = try subject.hash(dependencies: [dependency])
 
         // Then
-        XCTAssertEqual(hash, "library;/file1;/file2;/file3")
-        XCTAssertEqual(mockContentHasher.hashStringsCallCount, 1)
+        XCTAssertEqual(hash, "library-file1-hashed-file2-hashed-file3-hashed-hash")
+        XCTAssertEqual(mockContentHasher.hashPathCallCount, 3)
+        XCTAssertEqual(mockContentHasher.hashStringCallCount, 1)
+    }
+
+    func test_hash_whenDependencyIsLibrary_swiftModuleMapIsNil_callsContentHasherAsExpected() throws {
+        // Given
+        let dependency = Dependency.library(path: filePath1,
+                                            publicHeaders: filePath2,
+                                            swiftModuleMap: nil)
+        mockContentHasher.stubHashForPath[filePath1] = "file1-hashed"
+        mockContentHasher.stubHashForPath[filePath2] = "file2-hashed"
+
+        // When
+        let hash = try subject.hash(dependencies: [dependency])
+
+        // Then
+        XCTAssertEqual(hash, "library-file1-hashed-file2-hashed-hash")
+        XCTAssertEqual(mockContentHasher.hashPathCallCount, 2)
+        XCTAssertEqual(mockContentHasher.hashStringCallCount, 1)
     }
 
     func test_hash_whenDependencyIsPackage_callsContentHasherAsExpected() throws {
@@ -129,13 +154,14 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
     func test_hash_whenDependencyIsCocoapods_callsContentHasherAsExpected() throws {
         // Given
         let dependency = Dependency.cocoapods(path: filePath1)
+        mockContentHasher.stubHashForPath[filePath1] = "file1-hashed"
 
         // When
         let hash = try subject.hash(dependencies: [dependency])
 
         // Then
-        XCTAssertEqual(hash, "cocoapods;/file1")
-        XCTAssertEqual(mockContentHasher.hashStringsCallCount, 1)
+        XCTAssertEqual(hash, "cocoapods-file1-hashed-hash")
+        XCTAssertEqual(mockContentHasher.hashPathCallCount, 1)
     }
 
     func test_hash_whenDependencyIsXCTest_callsContentHasherAsExpected() throws {


### PR DESCRIPTION
### Short description 📝

@natanrolnik brought up a [bug](https://github.com/tuist/tuist/pull/2389) happening on hashing when paths were different on different machines.
@pepibumur pointed out that a better fix would be hashing the files instead of the paths.
This PR is intended for this change.
After the PR gets merged, I suggest @natanrolnik to drop that fix from [his pr](https://github.com/tuist/tuist/pull/2389) and merge the other fix (DS_STORE)