### PR TITLE
[Stats] Set superCommandName in all sub-commands

### DIFF
--- a/Sources/TuistKit/Commands/Cache/CachePrintHashesCommand.swift
+++ b/Sources/TuistKit/Commands/Cache/CachePrintHashesCommand.swift
@@ -6,6 +6,7 @@ import TuistSupport
 struct CachePrintHashesCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(commandName: "print-hashes",
+                             _superCommandName: "cache",
                              abstract: "Print the hashes of the cacheable frameworks in the given project.")
     }
 

--- a/Sources/TuistKit/Commands/Cache/CacheWarmCommand.swift
+++ b/Sources/TuistKit/Commands/Cache/CacheWarmCommand.swift
@@ -7,6 +7,7 @@ import TuistSupport
 struct CacheWarmCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(commandName: "warm",
+                             _superCommandName: "cache",
                              abstract: "Warms the local and remote cache.")
     }
 

--- a/Sources/TuistKit/Commands/Dependencies/DependenciesFetchCommand.swift
+++ b/Sources/TuistKit/Commands/Dependencies/DependenciesFetchCommand.swift
@@ -6,6 +6,7 @@ import TSCBasic
 struct DependenciesFetchCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(commandName: "fetch",
+                             _superCommandName: "dependencies",
                              abstract: "Fetches the project's dependencies defined in `Dependencies.swift`.")
     }
 

--- a/Sources/TuistKit/Commands/Dependencies/DependenciesUpdateCommand.swift
+++ b/Sources/TuistKit/Commands/Dependencies/DependenciesUpdateCommand.swift
@@ -6,6 +6,7 @@ import TSCBasic
 struct DependenciesUpdateCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(commandName: "update",
+                             _superCommandName: "dependencies",
                              abstract: "Updates the project's dependencies defined in `Dependencies.swift`.")
     }
 

--- a/Sources/TuistKit/Commands/Lint/LintCodeCommand.swift
+++ b/Sources/TuistKit/Commands/Lint/LintCodeCommand.swift
@@ -6,6 +6,7 @@ import TSCBasic
 struct LintCodeCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(commandName: "code",
+                             _superCommandName: "lint",
                              abstract: "Lints the code of your projects using Swiftlint.")
     }
 

--- a/Sources/TuistKit/Commands/Lint/LintProjectCommand.swift
+++ b/Sources/TuistKit/Commands/Lint/LintProjectCommand.swift
@@ -6,6 +6,7 @@ import TSCBasic
 struct LintProjectCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(commandName: "project",
+                             _superCommandName: "lint",
                              abstract: "Lints a workspace or a project that check whether they are well configured")
     }
 

--- a/Sources/TuistKit/Commands/ListCommand.swift
+++ b/Sources/TuistKit/Commands/ListCommand.swift
@@ -4,6 +4,7 @@ import Foundation
 struct ListCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(commandName: "list",
+                             _superCommandName: "scaffold",
                              abstract: "Lists available scaffold templates",
                              subcommands: [])
     }

--- a/Sources/TuistKit/Commands/Migration/MigrationCheckEmptyBuildSettingsCommand.swift
+++ b/Sources/TuistKit/Commands/Migration/MigrationCheckEmptyBuildSettingsCommand.swift
@@ -6,6 +6,7 @@ import TuistSupport
 struct MigrationCheckEmptyBuildSettingsCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(commandName: "check-empty-settings",
+                             _superCommandName: "migration",
                              abstract: "It checks if the build settings of a project or target are empty. Otherwise it exits unsuccessfully.")
     }
 

--- a/Sources/TuistKit/Commands/Migration/MigrationSettingsToXCConfigCommand.swift
+++ b/Sources/TuistKit/Commands/Migration/MigrationSettingsToXCConfigCommand.swift
@@ -6,6 +6,7 @@ import TuistSupport
 struct MigrationSettingsToXCConfigCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(commandName: "settings-to-xcconfig",
+                             _superCommandName: "migration",
                              abstract: "It extracts the build settings from a project or a target into an xcconfig file.")
     }
 

--- a/Sources/TuistKit/Commands/Migration/MigrationTargetsByDependenciesCommand.swift
+++ b/Sources/TuistKit/Commands/Migration/MigrationTargetsByDependenciesCommand.swift
@@ -6,6 +6,7 @@ import TuistSupport
 struct MigrationTargetsByDependenciesCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(commandName: "list-targets",
+                             _superCommandName: "migration",
                              abstract: "It lists the targets of a project sorted by number of dependencies.")
     }
 

--- a/Sources/TuistKit/Commands/Scale/CloudAuthCommand.swift
+++ b/Sources/TuistKit/Commands/Scale/CloudAuthCommand.swift
@@ -5,6 +5,7 @@ import TSCBasic
 struct CloudAuthCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(commandName: "auth",
+                             _superCommandName: "cloud",
                              abstract: "Authenticates the user on the server with the URL defined in the Config.swift file")
     }
 

--- a/Sources/TuistKit/Commands/Scale/CloudLogoutCommand.swift
+++ b/Sources/TuistKit/Commands/Scale/CloudLogoutCommand.swift
@@ -5,6 +5,7 @@ import TSCBasic
 struct CloudLogoutCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(commandName: "logout",
+                             _superCommandName: "cloud",
                              abstract: "Removes any existing session to authenticate on the server with the URL defined in the Config.swift file")
     }
 

--- a/Sources/TuistKit/Commands/Scale/CloudSessionCommand.swift
+++ b/Sources/TuistKit/Commands/Scale/CloudSessionCommand.swift
@@ -5,6 +5,7 @@ import TSCBasic
 struct CloudSessionCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(commandName: "session",
+                             _superCommandName: "cloud",
                              abstract: "Prints any existing session to authenticate on the server with the URL defined in the Config.swift file")
     }
 

--- a/Sources/TuistKit/Commands/Signing/DecryptCommand.swift
+++ b/Sources/TuistKit/Commands/Signing/DecryptCommand.swift
@@ -8,6 +8,7 @@ import TuistSupport
 struct DecryptCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(commandName: "decrypt",
+                             _superCommandName: "signing",
                              abstract: "Decrypts all files in Tuist/Signing directory")
     }
 

--- a/Sources/TuistKit/Commands/Signing/EncryptCommand.swift
+++ b/Sources/TuistKit/Commands/Signing/EncryptCommand.swift
@@ -5,6 +5,7 @@ import TSCBasic
 struct EncryptCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(commandName: "encrypt",
+                             _superCommandName: "signing",
                              abstract: "Encrypts all files in Tuist/Signing directory")
     }
 


### PR DESCRIPTION
### Short description 📝

To better report sub-commands, we need to set their `superCommandName`.
For example, `tuist cache warm` is now reported as `warm` 