### PR TITLE
Conform ProjectDescription objects to ExpressibleByStringInterpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Added
+
+- Add ODR support [#2490](https://github.com/tuist/tuist/pull/2490) by [@DimaMishchenko](https://github.com/DimaMishchenko)
+
+### Changed
+
+- Replace `ExpressibleByStringLiteral` with `ExpressibleByStringInterpolation` for `ProjectDescription` objects by [@DimaMishchenko](https://github.com/DimaMishchenko)
+
 ## 1.34.0 - Shipit
 
 ### Added
@@ -11,7 +19,6 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Add support for `tuist cache warm` to cache a subset of targets via `tuist cache warm FrameworkA FrameworkB` [#2393]((https://github.com/tuist/tuist/pull/2393) by [@adellibovi](https://github.com/adellibovi).
 - Add documentation on how to use & create plugins by [@luispadron](https://github.com/luispadron)
 - Warn when targets with duplicate bundle identifiers exist per platform [#2444](https://github.com/tuist/tuist/pull/2444) by [@natanrolnik](https://github.com/natanrolnik).
-- Add ODR support by [@DimaMishchenko](https://github.com/DimaMishchenko)
 
 ### Fixed
 

--- a/Sources/ProjectDescription/CompatibleXcodeVersions.swift
+++ b/Sources/ProjectDescription/CompatibleXcodeVersions.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Enum that represents all the Xcode versions that a project or set of projects is compatible with.
-public enum CompatibleXcodeVersions: ExpressibleByArrayLiteral, ExpressibleByStringLiteral, Codable, Equatable {
+public enum CompatibleXcodeVersions: ExpressibleByArrayLiteral, ExpressibleByStringInterpolation, Codable, Equatable {
     /// The project supports all Xcode versions.
     case all
 
@@ -23,7 +23,7 @@ public enum CompatibleXcodeVersions: ExpressibleByArrayLiteral, ExpressibleByStr
         case value
     }
 
-    // MARK: - ExpressibleByStringLiteral
+    // MARK: - ExpressibleByStringInterpolation
 
     public init(stringLiteral value: String) {
         self = .list([value])

--- a/Sources/ProjectDescription/FileElement.swift
+++ b/Sources/ProjectDescription/FileElement.swift
@@ -60,13 +60,11 @@ public enum FileElement: Codable, Equatable {
     }
 }
 
-extension FileElement: ExpressibleByStringLiteral {
+extension FileElement: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
         self = .glob(pattern: Path(value))
     }
 }
-
-extension FileElement: ExpressibleByStringInterpolation {}
 
 extension Array: ExpressibleByUnicodeScalarLiteral where Element == FileElement {
     public typealias UnicodeScalarLiteralType = String

--- a/Sources/ProjectDescription/FileList.swift
+++ b/Sources/ProjectDescription/FileList.swift
@@ -16,7 +16,7 @@ public struct FileList: Codable, Equatable {
     }
 }
 
-extension FileList: ExpressibleByStringLiteral {
+extension FileList: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
         self.init(globs: [Path(value)])
     }

--- a/Sources/ProjectDescription/InfoPlist.swift
+++ b/Sources/ProjectDescription/InfoPlist.swift
@@ -156,21 +156,17 @@ public enum InfoPlist: Codable, Equatable {
     }
 }
 
-// MARK: - InfoPlist - ExpressibleByStringLiteral
+// MARK: - InfoPlist - ExpressibleByStringInterpolation
 
-extension InfoPlist: ExpressibleByStringLiteral, ExpressibleByUnicodeScalarLiteral, ExpressibleByExtendedGraphemeClusterLiteral {
-    public typealias UnicodeScalarLiteralType = String
-    public typealias ExtendedGraphemeClusterLiteralType = String
-    public typealias StringLiteralType = String
-
+extension InfoPlist: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
         self = .file(path: Path(value))
     }
 }
 
-// MARK: - InfoPlist.Value - ExpressibleByStringLiteral
+// MARK: - InfoPlist.Value - ExpressibleByStringInterpolation
 
-extension InfoPlist.Value: ExpressibleByStringLiteral {
+extension InfoPlist.Value: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
         self = .string(value)
     }

--- a/Sources/ProjectDescription/Path.swift
+++ b/Sources/ProjectDescription/Path.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Path: Codable, ExpressibleByStringLiteral, ExpressibleByStringInterpolation, Equatable {
+public struct Path: ExpressibleByStringInterpolation, Codable, Equatable {
     public enum PathType: String, Codable {
         case relativeToCurrentFile
         case relativeToManifest
@@ -36,7 +36,7 @@ public struct Path: Codable, ExpressibleByStringLiteral, ExpressibleByStringInte
         Path(pathString, type: .relativeToRoot)
     }
 
-    // MARK: - ExpressibleByStringLiteral
+    // MARK: - ExpressibleByStringInterpolation
 
     public init(stringLiteral: String) {
         if stringLiteral.starts(with: "//") {

--- a/Sources/ProjectDescription/ResourceFileElement.swift
+++ b/Sources/ProjectDescription/ResourceFileElement.swift
@@ -66,10 +66,8 @@ public enum ResourceFileElement: Codable, Equatable {
     }
 }
 
-extension ResourceFileElement: ExpressibleByStringLiteral {
+extension ResourceFileElement: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
         self = .glob(pattern: Path(value))
     }
 }
-
-extension ResourceFileElement: ExpressibleByStringInterpolation {}

--- a/Sources/ProjectDescription/ResourceFileElements.swift
+++ b/Sources/ProjectDescription/ResourceFileElements.swift
@@ -9,13 +9,11 @@ public struct ResourceFileElements: Codable, Equatable {
     public let resources: [ResourceFileElement]
 }
 
-extension ResourceFileElements: ExpressibleByStringLiteral {
+extension ResourceFileElements: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
         self.init(resources: [.glob(pattern: Path(value))])
     }
 }
-
-extension ResourceFileElements: ExpressibleByStringInterpolation {}
 
 extension ResourceFileElements: ExpressibleByArrayLiteral {
     public init(arrayLiteral elements: ResourceFileElement...) {

--- a/Sources/ProjectDescription/Settings.swift
+++ b/Sources/ProjectDescription/Settings.swift
@@ -4,7 +4,7 @@ public typealias SettingsDictionary = [String: SettingValue]
 
 // MARK: - SettingValue
 
-public enum SettingValue: ExpressibleByStringLiteral, ExpressibleByArrayLiteral, ExpressibleByBooleanLiteral, Equatable, Codable {
+public enum SettingValue: ExpressibleByStringInterpolation, ExpressibleByArrayLiteral, ExpressibleByBooleanLiteral, Equatable, Codable {
     case string(String)
     case array([String])
 

--- a/Sources/ProjectDescription/SourceFilesList.swift
+++ b/Sources/ProjectDescription/SourceFilesList.swift
@@ -1,7 +1,7 @@
 // MARK: - FileList
 
 /// A model to refer to source files that supports passing compiler flags.
-public struct SourceFileGlob: ExpressibleByStringLiteral, ExpressibleByStringInterpolation, Codable, Equatable {
+public struct SourceFileGlob: ExpressibleByStringInterpolation, Codable, Equatable {
     /// Relative glob pattern.
     public let glob: Path
 
@@ -73,7 +73,7 @@ public struct SourceFilesList: Codable, Equatable {
 }
 
 /// Support file as single string
-extension SourceFilesList: ExpressibleByStringLiteral {
+extension SourceFilesList: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
         self.init(globs: [value])
     }

--- a/Sources/ProjectDescription/TargetReference.swift
+++ b/Sources/ProjectDescription/TargetReference.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct TargetReference: Equatable, Codable, ExpressibleByStringLiteral {
+public struct TargetReference: Equatable, Codable, ExpressibleByStringInterpolation {
     public var projectPath: Path?
     public var targetName: String
 

--- a/Sources/ProjectDescription/TestableTarget.swift
+++ b/Sources/ProjectDescription/TestableTarget.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct TestableTarget: Equatable, Codable, ExpressibleByStringLiteral {
+public struct TestableTarget: Equatable, Codable, ExpressibleByStringInterpolation {
     public let target: TargetReference
     public let isSkipped: Bool
     public let isParallelizable: Bool

--- a/Sources/ProjectDescription/Version.swift
+++ b/Sources/ProjectDescription/Version.swift
@@ -128,20 +128,12 @@ public extension Version {
     }
 }
 
-extension Version: ExpressibleByStringLiteral {
+extension Version: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
         guard let version = Version(string: value) else {
             fatalError("\(value) is not a valid version")
         }
         self = version
-    }
-
-    public init(extendedGraphemeClusterLiteral value: String) {
-        self.init(stringLiteral: value)
-    }
-
-    public init(unicodeScalarLiteral value: String) {
-        self.init(stringLiteral: value)
     }
 }
 

--- a/website/markdown/docs/usage/project-description.mdx
+++ b/website/markdown/docs/usage/project-description.mdx
@@ -208,8 +208,8 @@ Each target in the list of project targets can be initialized with the following
     {
       name: 'Info plist',
       description: 'Relative path to the Info.plist',
-      type: 'Path',
-      typeLink: '#path',
+      type: 'InfoPlist',
+      typeLink: '#infoplist',
       optional: false,
       default: '',
     },


### PR DESCRIPTION
### Short description 📝

> Replaced `ExpressibleByStringLiteral` with `ExpressibleByStringInterpolation` for `ProjectDescription` objects.
> Wanted to add `ExpressibleByStringInterpolation` support only to `InfoPlist`, to make `Project` configuration more flexible. But I think it makes sense to have this in other types as well.
> Updated `Target` docs (fixed `InfoPlist` type).

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
