### PR TITLE
Make sure security and codesign can access certificates in signing.keychain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
-- Fix adding framework targets to AppClip  [#2530](https://github.com/tuist/tuist/pull/2530) by [@sampettersson](https://github.com/sampettersson)
+- Fix adding framework targets to AppClip [#2530](https://github.com/tuist/tuist/pull/2530) by [@sampettersson](https://github.com/sampettersson)
+- Make sure security and codesign can access certificates in signing.keychain [#2528]((https://github.com/tuist/tuist/pull/2528) by [@rist](https://github.com/rist).
 
 ## 1.35.0 - Miracle
 
@@ -22,6 +23,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
+- Fix missing linkable products for static frameworks with transitive precompiled dependencies [#2500](https://github.com/tuist/tuist/pull/2500) by [@kwridan](https://github.com/kwridan).
 - Fix crash when using `tuist graph` in a project that leverages plugins [#2507](https://github.com/tuist/tuist/pull/2507) by [@bolismauro](https://github.com/bolismauro).
 
 ### Changed

--- a/Sources/TuistSigning/SecurityController.swift
+++ b/Sources/TuistSigning/SecurityController.swift
@@ -55,6 +55,6 @@ final class SecurityController: SecurityControlling {
     }
 
     private func importToKeychain(at path: AbsolutePath, keychainPath: AbsolutePath) throws {
-        try System.shared.run("/usr/bin/security", "import", path.pathString, "-P", "", "-k", keychainPath.pathString)
+        try System.shared.run("/usr/bin/security", "import", path.pathString, "-P", "", "-T", "/usr/bin/codesign", "-T", "/usr/bin/security", "-k", keychainPath.pathString)
     }
 }

--- a/Sources/TuistSigning/SecurityController.swift
+++ b/Sources/TuistSigning/SecurityController.swift
@@ -55,6 +55,13 @@ final class SecurityController: SecurityControlling {
     }
 
     private func importToKeychain(at path: AbsolutePath, keychainPath: AbsolutePath) throws {
-        try System.shared.run("/usr/bin/security", "import", path.pathString, "-P", "", "-T", "/usr/bin/codesign", "-T", "/usr/bin/security", "-k", keychainPath.pathString)
+        try System.shared.run(
+            "/usr/bin/security",
+            "import", path.pathString,
+            "-P", "",
+            "-T", "/usr/bin/codesign",
+            "-T", "/usr/bin/security",
+            "-k", keychainPath.pathString
+        )
     }
 }

--- a/Tests/TuistSigningTests/SecurityControllerTests.swift
+++ b/Tests/TuistSigningTests/SecurityControllerTests.swift
@@ -43,8 +43,8 @@ final class SecurityControllerTests: TuistUnitTestCase {
 
         system.errorCommand("/usr/bin/security", "find-certificate", certificatePath.pathString, "-P", "", "-k", keychainPath.pathString)
         system.errorCommand("/usr/bin/security", "find-key", privateKeyPath.pathString, "-P", "", "-k", keychainPath.pathString)
-        system.succeedCommand("/usr/bin/security", "import", certificatePath.pathString, "-P", "", "-k", keychainPath.pathString)
-        system.succeedCommand("/usr/bin/security", "import", privateKeyPath.pathString, "-P", "", "-k", keychainPath.pathString)
+        system.succeedCommand("/usr/bin/security", "import", certificatePath.pathString, "-P", "", "-T", "/usr/bin/codesign", "-T", "/usr/bin/security", "-k", keychainPath.pathString)
+        system.succeedCommand("/usr/bin/security", "import", privateKeyPath.pathString, "-P", "", "-T", "/usr/bin/codesign", "-T", "/usr/bin/security", "-k", keychainPath.pathString)
 
         // When
         try subject.importCertificate(certificate, keychainPath: keychainPath)


### PR DESCRIPTION
### Short description 📝

Using the argument `-T` to define a list of applications which should be able to access the imported certificates.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
