### PR TITLE
[SC] - Add workaround to cache frameworks with resources

### DIFF
--- a/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
@@ -94,6 +94,13 @@ public final class GraphContentHasher: GraphContentHashing {
             visited[target] = false
             return false
         }
+
+        // Ignore bundles becase they can not be cached
+        if target.target.product == .bundle {
+            visited[target] = true
+            return true
+        }
+
         if let visitedValue = visited[target] { return visitedValue }
         let allTargetDependenciesAreHashable = target.targetDependencies
             .allSatisfy {

--- a/Sources/TuistCache/GraphMappers/CacheGraphMutator.swift
+++ b/Sources/TuistCache/GraphMappers/CacheGraphMutator.swift
@@ -156,7 +156,14 @@ class CacheGraphMutator: CacheGraphMutating {
 
             // We load the .framework (or fallback on .xcframework)
             let precompiledFramework: PrecompiledNode = try loadPrecompiledFramework(path: precompiledFrameworkPath, loadedPrecompiledFrameworks: &loadedPrecompiledFrameworks)
-
+            
+            // Remove bundle dependencies for precompiled nodes since they get added
+            // directly into runnable targets that need them
+            targetDependency.dependencies = targetDependency.dependencies.filter { dep in
+                guard let dep = dep as? TargetNode else { return true }
+                return dep.target.product != .bundle
+            }
+            
             try mapDependencies(targetDependency,
                                 precompiledFrameworks: precompiledFrameworks,
                                 sources: sources,

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -183,11 +183,7 @@ public class Graph: Encodable, Equatable {
         guard let targetNode = findTargetNode(path: path, name: name) else {
             return []
         }
-
-        guard targetNode.target.supportsResources else {
-            return []
-        }
-
+        
         let canHostResources: (TargetNode) -> Bool = {
             $0.target.supportsResources
         }

--- a/Sources/TuistCore/Graph/Graph.swift
+++ b/Sources/TuistCore/Graph/Graph.swift
@@ -174,13 +174,18 @@ public class Graph: Encodable, Equatable {
             .filter(isStaticLibrary)
             .map(productDependencyReference)
     }
-
+    
     /// Returns the transitive resource bundle dependencies for the given target.
     /// - Parameters:
     ///   - path: Path to the directory where the project that defines the target is located.
     ///   - name: Name of the target.
-    public func resourceBundleDependencies(path: AbsolutePath, name: String) -> [TargetNode] {
+    ///   - allowNonSupportingTargets: Allow to search non-supporting targets.
+    public func resourceBundleDependencies(path: AbsolutePath, name: String, allowNonSupportingTargets: Bool = false) -> [TargetNode] {
         guard let targetNode = findTargetNode(path: path, name: name) else {
+            return []
+        }
+        
+        guard targetNode.target.supportsResources || allowNonSupportingTargets else {
             return []
         }
         

--- a/Sources/TuistKit/Cache/CacheController.swift
+++ b/Sources/TuistKit/Cache/CacheController.swift
@@ -121,8 +121,11 @@ final class CacheController: CacheControlling {
             filteredTargets = Array(hashesByCacheableTarget.keys.filter { targetsToFilter.contains($0.name) })
         }
 
+        logger.notice("Removing Bundle targets")
+        let filteredTargetsWithoutBundles = filteredTargets.filter { $0.target.product != .bundle }
+
         logger.notice("Building cacheable targets")
-        let sortedCacheableTargets = try topologicalSort(filteredTargets, successors: \.targetDependencies)
+        let sortedCacheableTargets = try topologicalSort(filteredTargetsWithoutBundles, successors: \.targetDependencies)
 
         for (index, target) in sortedCacheableTargets.reversed().enumerated() {
             logger.notice("Building cacheable targets: \(target.name), \(index + 1) out of \(sortedCacheableTargets.count)")

--- a/Tests/TuistCacheTests/Cache/CacheGraphMutatorTests.swift
+++ b/Tests/TuistCacheTests/Cache/CacheGraphMutatorTests.swift
@@ -626,6 +626,7 @@ final class CacheGraphMapperTests: TuistUnitTestCase {
         let app = try XCTUnwrap(got.entryNodes.first as? TargetNode)
         _ = try XCTUnwrap(app.dependencies.compactMap { $0 as? TargetNode }.first(where: { $0 == bFrameworkNode }))
         XCTAssertTrue(app.dependencies.contains(where: { $0 == cBundle }))
+        XCTAssertEqual(1, bFrameworkNode.dependencies.count)
     }
     
     // 11th scenario
@@ -677,6 +678,7 @@ final class CacheGraphMapperTests: TuistUnitTestCase {
         let app = try XCTUnwrap(got.entryNodes.first as? TargetNode)
         _ = try XCTUnwrap(app.dependencies.compactMap { $0 as? FrameworkNode }.first(where: { $0 == bCachedFramework }))
         XCTAssertTrue(app.dependencies.contains(where: { $0 == cBundle }))
+        XCTAssertEqual(0, bFrameworkNode.dependencies.count)
     }
 
     fileprivate func graphProjects(_ targets: [TargetNode]) -> [Project] {


### PR DESCRIPTION
Partly resolves https://github.com/tuist/tuist/issues/1975 (caching of transitive bundles)

### Short description 📝

This is an update of the work started by @remover on [this PR](https://github.com/tuist/tuist/pull/2105) 

The problem is that bundle targets cannot be cached. As a result anything that depends on the bundle cannot be cached either.

### Solution 📦

We agreed on a workaround as a first step

- Ignore bundle targets in the process of caching / swapping out cached targets
- Add any bundles, that are dependencies of static targets, to `runnable` targets that need them, e.g. app targets.

### Implementation 👩‍💻👨‍💻

> Detail in a checklist the steps that you took to implement the PR.

- [x] `isCacheable` == `true` for bundle types in `GraphContentHasher.swift`
- [x] Add resource targets, that are dependencies of static targets, to runnable targets that depend on these static targets.
- [x] Remove bundle dependencies of any nodes that are swapped out for their cached versions
