### PR TITLE
Update acceptance tests docs.

### DIFF
--- a/website/markdown/docs/contribution/testing-strategy.mdx
+++ b/website/markdown/docs/contribution/testing-strategy.mdx
@@ -14,8 +14,8 @@ Acceptance tests run the built `tuist` command line against a wide range of [fix
 Those are written in [Cucumber](https://cucumber.io/docs) and Ruby and can be found in [features](https://github.com/tuist/tuist/tree/main/features). Those are run when calling `./bin/fourier test tuist acceptance`:
 
 ```bash
-# 32 is the line where the definition of the test starts
-./bin fourier test tuist acceptance features/generate.feature:32
+# 3 is the line where the definition of the test starts
+./bin/fourier test tuist acceptance features/generate-1.feature:3
 ```
 
 <Message


### PR DESCRIPTION
### Short description 📝

The acceptance tests documentation had a mistake since it told the users to run `./bin fourier` instead of `./bin/fourier`.
I also point to an existing acceptance tests, so the users can just copy the command and see the tests run.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
