### PR TITLE
Expose `ResourceFileElements` initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Fix adding framework targets to AppClip  [#2530](https://github.com/tuist/tuist/pull/2530) by [@sampettersson](https://github.com/sampettersson)
+- Expose `ResourceFileElements` initializer [#2541](https://github.com/tuist/tuist/pull/2500) by [@kwridan](https://github.com/kwridan).
+    - Note: This fixes an issue where `ResourceFileElements` could not be created using variables within helpers
 
 ## 1.35.0 - Miracle
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Fix adding framework targets to AppClip  [#2530](https://github.com/tuist/tuist/pull/2530) by [@sampettersson](https://github.com/sampettersson)
-- Expose `ResourceFileElements` initializer [#2541](https://github.com/tuist/tuist/pull/2500) by [@kwridan](https://github.com/kwridan).
+- Expose `ResourceFileElements` initializer [#2541](https://github.com/tuist/tuist/pull/2541) by [@kwridan](https://github.com/kwridan).
     - Note: This fixes an issue where `ResourceFileElements` could not be created using variables within helpers
 
 ## 1.35.0 - Miracle

--- a/Sources/ProjectDescription/ResourceFileElements.swift
+++ b/Sources/ProjectDescription/ResourceFileElements.swift
@@ -7,6 +7,10 @@ import Foundation
 public struct ResourceFileElements: Codable, Equatable {
     /// List of resource file elements
     public let resources: [ResourceFileElement]
+
+    public init(resources: [ResourceFileElement]) {
+        self.resources = resources
+    }
 }
 
 extension ResourceFileElements: ExpressibleByStringInterpolation {

--- a/fixtures/ios_app_with_framework_and_resources/Framework1/Project.swift
+++ b/fixtures/ios_app_with_framework_and_resources/Framework1/Project.swift
@@ -1,13 +1,24 @@
 import ProjectDescription
 
+// Example of resources specified via variables instead of direct literals.
+// Often sources and resources are declared in helpers where their values
+// are computed, as such we need to support non-literal declarations.
+let resourcesDirectory = "Resources"
+let resources: [ResourceFileElement] = [
+    "\(resourcesDirectory)/framework_resource.txt"
+]
+
 let project = Project(
     name: "Framework1",
     targets: [
-        Target(name: "Framework1",
-               platform: .iOS,
-               product: .framework,
-               bundleId: "io.tuist.Framework1",
-               infoPlist: "Config/Framework1-Info.plist",
-               sources: "Sources/**"),
+        Target(
+            name: "Framework1",
+            platform: .iOS,
+            product: .framework,
+            bundleId: "io.tuist.Framework1",
+            infoPlist: "Config/Framework1-Info.plist",
+            sources: "Sources/**",
+            resources: ResourceFileElements(resources: resources)
+        ),
     ]
 )

--- a/fixtures/ios_app_with_framework_and_resources/Framework1/Resources/framework_resource.txt
+++ b/fixtures/ios_app_with_framework_and_resources/Framework1/Resources/framework_resource.txt
@@ -1,0 +1,2 @@
+
+framework_resource


### PR DESCRIPTION
### Short description 📝

- To support cases where resources are defined in helpers, we need to support both literal as well as non literal declarations for resource file elements
- Updating fixture to help capture the scenario where non literal declarations are used

### Test Plan 🛠

- Run `swift build & swift run tuist generate --path fixtures/ios_app_with_framework_and_resources`
- Verify generation succeeds

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- ~In case the PR introduces changes that affect users, the documentation has been updated.~
