### PR TITLE
Improve `tuist generate` speed by caching Swift version fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Make sure security and codesign can access certificates in signing.keychain [#2528]((https://github.com/tuist/tuist/pull/2528) by [@rist](https://github.com/rist).
 - Expose `ResourceFileElements` initializer [#2541](https://github.com/tuist/tuist/pull/2541) by [@kwridan](https://github.com/kwridan).
     - Note: This fixes an issue where `ResourceFileElements` could not be created using variables within helpers
-    
+
+### Changed
+
+- Improve `tuist generate` speed by caching Swift version fetching [#2546](https://github.com/tuist/tuist/pull/2546) by [@adellibovi](https://github.com/adellibovi/)
+
 ## 1.35.0 - Miracle
 
 - Fix missing linkable products for static frameworks with transitive precompiled dependencies [#2500](https://github.com/tuist/tuist/pull/2500) by [@kwridan](https://github.com/kwridan).

--- a/Sources/TuistSupport/System/System.swift
+++ b/Sources/TuistSupport/System/System.swift
@@ -585,17 +585,24 @@ public final class System: Systeming {
         try process.launch()
     }
 
+    @Atomic
+    var cachedSwiftVersion: String?
+
     /// Returns the Swift version.
     ///
     /// - Returns: Swift version.
     /// - Throws: An error if Swift is not installed or it exists unsuccessfully.
     public func swiftVersion() throws -> String {
+        if let cachedSwiftVersion = cachedSwiftVersion {
+            return cachedSwiftVersion
+        }
         let output = try capture("/usr/bin/xcrun", "swift", "--version")
         let range = NSRange(location: 0, length: output.count)
         guard let match = System.swiftVersionRegex.firstMatch(in: output, options: [], range: range) else {
             throw SystemError.parseSwiftVersion(output)
         }
-        return NSString(string: output).substring(with: match.range(at: 1)).spm_chomp()
+        cachedSwiftVersion = NSString(string: output).substring(with: match.range(at: 1)).spm_chomp()
+        return cachedSwiftVersion!
     }
 
     /// Runs /usr/bin/which passing the given tool.


### PR DESCRIPTION
### Short description 📝

Hello,
Currently every time a Target is generated we try to fetch what Swift version we have on the system.
This is an expensive operation since we need to execute an external shell command.
The impact can be easily seen when having a good number of targets.
In my tests, I've got `tuist generate` (release mode) to run **from 20s to 13s, a nice 40% of improvement**!

Update: got similar (or even better) results using `tuistbenchmark` for an existing fixture:

    Fixture       : ios_app_with_tests
    Runs          : 4
    Result
        - cold : 0.76s  vs  1.14s (⬇︎ -0.39s -33.81%)
        - warm : 0.23s  vs  0.66s (⬇︎ -0.43s -64.98%)

and for a generated fixture: (`fixturegen --projects 2 --targets 50 --sources 50`):

    Fixture       : generated
    Runs          : 4
    Result
        - cold : 2.19s  vs  5.11s (⬇︎ -2.93s -57.21%)
        - warm : 1.16s  vs  3.75s (⬇︎ -2.59s -69.01%)

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
