### PR TITLE
Add dedicated ConfigLoader component

### DIFF
--- a/Sources/TuistCore/Graph/GraphLoader.swift
+++ b/Sources/TuistCore/Graph/GraphLoader.swift
@@ -11,13 +11,6 @@ public protocol GraphLoading: AnyObject {
     /// Loads the graph for the workspace in the given directory.
     /// - Parameter path: Path to the directory that contains the workspace.
     func loadWorkspace(path: AbsolutePath) throws -> Graph
-
-    /// Loads the configuration.
-    ///
-    /// - Parameter path: Directory from which look up and load the Config.
-    /// - Returns: Loaded Config object.
-    /// - Throws: An error if the Config.swift can't be parsed.
-    func loadConfig(path: AbsolutePath) throws -> Config
 }
 
 public class GraphLoader: GraphLoading {
@@ -115,18 +108,6 @@ public class GraphLoader: GraphLoading {
             workspace: workspace
         )
         return graph
-    }
-
-    public func loadConfig(path: AbsolutePath) throws -> Config {
-        let cache = GraphLoaderCache()
-
-        if let config = cache.config(path) {
-            return config
-        } else {
-            let config = try modelLoader.loadConfig(at: path)
-            cache.add(config: config, path: path)
-            return config
-        }
     }
 
     // MARK: - Fileprivate

--- a/Sources/TuistCore/Protocols/GeneratorModelLoading.swift
+++ b/Sources/TuistCore/Protocols/GeneratorModelLoading.swift
@@ -25,11 +25,4 @@ public protocol GeneratorModelLoading {
     /// - Returns: The workspace loaded from the specified path
     /// - Throws: Error encountered during the loading process (e.g. Missing workspace)
     func loadWorkspace(at path: AbsolutePath) throws -> Workspace
-
-    /// Load a Config model at the specified path
-    ///
-    /// - Parameter path: The absolute path for the Config model to load
-    /// - Returns: The config loaded from the specified path
-    /// - Throws: Error encountered during the loading process (e.g. Missing Config file)
-    func loadConfig(at path: AbsolutePath) throws -> Config
 }

--- a/Sources/TuistCoreTesting/Graph/MockGraphLoader.swift
+++ b/Sources/TuistCoreTesting/Graph/MockGraphLoader.swift
@@ -16,9 +16,4 @@ public final class MockGraphLoader: GraphLoading {
     public func loadWorkspace(path: AbsolutePath) throws -> (Graph) {
         return try loadWorkspaceStub?(path) ?? Graph.test()
     }
-
-    public var loadConfigStub: ((AbsolutePath) throws -> (Config))?
-    public func loadConfig(path: AbsolutePath) throws -> Config {
-        try loadConfigStub?(path) ?? Config.test()
-    }
 }

--- a/Sources/TuistKit/Services/Cache/CachePrintHashesService.swift
+++ b/Sources/TuistKit/Services/Cache/CachePrintHashesService.swift
@@ -12,14 +12,14 @@ final class CachePrintHashesService {
 
     let cacheGraphContentHasher: CacheGraphContentHashing
     private let clock: Clock
-    private let generatorModelLoader: GeneratorModelLoading
+    private let configLoader: ConfigLoading
 
     convenience init(contentHasher: ContentHashing = CacheContentHasher()) {
         self.init(
             generator: Generator(contentHasher: contentHasher),
             cacheGraphContentHasher: CacheGraphContentHasher(contentHasher: contentHasher),
             clock: WallClock(),
-            generatorModelLoader: GeneratorModelLoader()
+            configLoader: ConfigLoader(manifestLoader: ManifestLoader())
         )
     }
 
@@ -27,19 +27,19 @@ final class CachePrintHashesService {
         generator: Generating,
         cacheGraphContentHasher: CacheGraphContentHashing,
         clock: Clock,
-        generatorModelLoader: GeneratorModelLoading
+        configLoader: ConfigLoading
     ) {
         self.generator = generator
         self.cacheGraphContentHasher = cacheGraphContentHasher
         self.clock = clock
-        self.generatorModelLoader = generatorModelLoader
+        self.configLoader = configLoader
     }
 
     func run(path: AbsolutePath, xcframeworks: Bool, profile: String?) throws {
         let timer = clock.startTimer()
 
         let graph = try generator.load(path: path)
-        let config = try generatorModelLoader.loadConfig(at: path)
+        let config = try configLoader.loadConfig(path: path)
         let cacheOutputType: CacheOutputType = xcframeworks ? .xcframework : .framework
         let cacheProfile = try CacheProfileResolver().resolveCacheProfile(named: profile, from: config)
         let hashes = try cacheGraphContentHasher.contentHashes(

--- a/Sources/TuistKit/Services/Cache/CacheWarmService.swift
+++ b/Sources/TuistKit/Services/Cache/CacheWarmService.swift
@@ -7,19 +7,15 @@ import TuistLoader
 import TuistSupport
 
 final class CacheWarmService {
-    /// Generator Model Loader, used for getting the user config
-    private let generatorModelLoader: GeneratorModelLoader
+    private let configLoader: ConfigLoading
 
-    init(manifestLoader: ManifestLoader = ManifestLoader(),
-         manifestLinter: ManifestLinter = ManifestLinter())
-    {
-        generatorModelLoader = GeneratorModelLoader(manifestLoader: manifestLoader,
-                                                    manifestLinter: manifestLinter)
+    init() {
+        configLoader = ConfigLoader(manifestLoader: ManifestLoader())
     }
 
     func run(path: String?, profile: String?, xcframeworks: Bool, targets: [String]) throws {
         let path = self.path(path)
-        let config = try generatorModelLoader.loadConfig(at: path)
+        let config = try configLoader.loadConfig(path: path)
         let cache = Cache(storageProvider: CacheStorageProvider(config: config))
         let cacheControllerFactory = CacheControllerFactory(cache: cache)
         let contentHasher = CacheContentHasher()

--- a/Sources/TuistKit/Services/Cloud/CloudAuthService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudAuthService.swift
@@ -34,33 +34,32 @@ enum CloudAuthServiceError: FatalError, Equatable {
 final class CloudAuthService: CloudAuthServicing {
     /// Cloud session controller.
     let cloudSessionController: CloudSessionControlling
-
-    /// Generator model loader.
-    let generatorModelLoader: GeneratorModelLoading
+    let configLoader: ConfigLoading
 
     // MARK: - Init
 
     convenience init() {
-        let manifetLoader = ManifestLoader()
-        let manifestLinter = ManifestLinter()
-        let generatorModelLoader = GeneratorModelLoader(manifestLoader: manifetLoader,
-                                                        manifestLinter: manifestLinter)
-        self.init(cloudSessionController: CloudSessionController(),
-                  generatorModelLoader: generatorModelLoader)
+        let manifestLoader = ManifestLoader()
+        let configLoader = ConfigLoader(manifestLoader: manifestLoader)
+        self.init(
+            cloudSessionController: CloudSessionController(),
+            configLoader: configLoader
+        )
     }
 
-    init(cloudSessionController: CloudSessionControlling,
-         generatorModelLoader: GeneratorModelLoading)
-    {
+    init(
+        cloudSessionController: CloudSessionControlling,
+        configLoader: ConfigLoading
+    ) {
         self.cloudSessionController = cloudSessionController
-        self.generatorModelLoader = generatorModelLoader
+        self.configLoader = configLoader
     }
 
     // MARK: - CloudAuthServicing
 
     func authenticate() throws {
         let path = FileHandler.shared.currentPath
-        let config = try generatorModelLoader.loadConfig(at: path)
+        let config = try configLoader.loadConfig(path: path)
         guard let cloudURL = config.cloud?.url else {
             throw CloudAuthServiceError.missingCloudURL
         }

--- a/Sources/TuistKit/Services/Cloud/CloudLogoutService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudLogoutService.swift
@@ -35,32 +35,32 @@ final class CloudLogoutService: CloudLogoutServicing {
     /// Cloud session controller.
     let cloudSessionController: CloudSessionControlling
 
-    /// Generator model loader.
-    let generatorModelLoader: GeneratorModelLoading
+    let configLoader: ConfigLoading
 
     // MARK: - Init
 
     convenience init() {
-        let manifetLoader = ManifestLoader()
-        let manifestLinter = ManifestLinter()
-        let generatorModelLoader = GeneratorModelLoader(manifestLoader: manifetLoader,
-                                                        manifestLinter: manifestLinter)
-        self.init(cloudSessionController: CloudSessionController(),
-                  generatorModelLoader: generatorModelLoader)
+        let manifestLoader = ManifestLoader()
+        let configLoader = ConfigLoader(manifestLoader: manifestLoader)
+        self.init(
+            cloudSessionController: CloudSessionController(),
+            configLoader: configLoader
+        )
     }
 
-    init(cloudSessionController: CloudSessionControlling,
-         generatorModelLoader: GeneratorModelLoading)
-    {
+    init(
+        cloudSessionController: CloudSessionControlling,
+        configLoader: ConfigLoading
+    ) {
         self.cloudSessionController = cloudSessionController
-        self.generatorModelLoader = generatorModelLoader
+        self.configLoader = configLoader
     }
 
     // MARK: - CloudAuthServicing
 
     func logout() throws {
         let path = FileHandler.shared.currentPath
-        let config = try generatorModelLoader.loadConfig(at: path)
+        let config = try configLoader.loadConfig(path: path)
         guard let cloudURL = config.cloud?.url else {
             throw CloudLogoutServiceError.missingCloudURL
         }

--- a/Sources/TuistKit/Services/Cloud/CloudSessionService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudSessionService.swift
@@ -35,32 +35,32 @@ final class CloudSessionService: CloudSessionServicing {
     /// Cloud session controller.
     let cloudSessionController: CloudSessionControlling
 
-    /// Generator model loader.
-    let generatorModelLoader: GeneratorModelLoading
+    let configLoader: ConfigLoading
 
     // MARK: - Init
 
     convenience init() {
-        let manifetLoader = ManifestLoader()
-        let manifestLinter = ManifestLinter()
-        let generatorModelLoader = GeneratorModelLoader(manifestLoader: manifetLoader,
-                                                        manifestLinter: manifestLinter)
-        self.init(cloudSessionController: CloudSessionController(),
-                  generatorModelLoader: generatorModelLoader)
+        let manifestLoader = ManifestLoader()
+        let configLoader = ConfigLoader(manifestLoader: manifestLoader)
+        self.init(
+            cloudSessionController: CloudSessionController(),
+            configLoader: configLoader
+        )
     }
 
-    init(cloudSessionController: CloudSessionControlling,
-         generatorModelLoader: GeneratorModelLoading)
-    {
+    init(
+        cloudSessionController: CloudSessionControlling,
+        configLoader: ConfigLoading
+    ) {
         self.cloudSessionController = cloudSessionController
-        self.generatorModelLoader = generatorModelLoader
+        self.configLoader = configLoader
     }
 
     // MARK: - CloudAuthServicing
 
     func printSession() throws {
         let path = FileHandler.shared.currentPath
-        let config = try generatorModelLoader.loadConfig(at: path)
+        let config = try configLoader.loadConfig(path: path)
         guard let cloudURL = config.cloud?.url else {
             throw CloudSessionServiceError.missingCloudURL
         }

--- a/Sources/TuistKit/Services/FocusService.swift
+++ b/Sources/TuistKit/Services/FocusService.swift
@@ -34,20 +34,21 @@ final class FocusServiceProjectGeneratorFactory: FocusServiceProjectGeneratorFac
 final class FocusService {
     private let opener: Opening
     private let projectGeneratorFactory: FocusServiceProjectGeneratorFactorying
-    private let generatorModelLoader: GeneratorModelLoading
+    private let configLoader: ConfigLoading
 
-    init(generatorModelLoader: GeneratorModelLoading = GeneratorModelLoader(),
-         opener: Opening = Opener(),
-         projectGeneratorFactory: FocusServiceProjectGeneratorFactorying = FocusServiceProjectGeneratorFactory())
-    {
-        self.generatorModelLoader = generatorModelLoader
+    init(
+        configLoader: ConfigLoading = ConfigLoader(manifestLoader: ManifestLoader()),
+        opener: Opening = Opener(),
+        projectGeneratorFactory: FocusServiceProjectGeneratorFactorying = FocusServiceProjectGeneratorFactory()
+    ) {
+        self.configLoader = configLoader
         self.opener = opener
         self.projectGeneratorFactory = projectGeneratorFactory
     }
 
     func run(path: String?, sources: Set<String>, noOpen: Bool, xcframeworks: Bool, profile: String?, ignoreCache: Bool) throws {
         let path = self.path(path)
-        let config = try generatorModelLoader.loadConfig(at: path)
+        let config = try configLoader.loadConfig(path: path)
 
         let cacheProfile = ignoreCache
             ? CacheProfileResolver.defaultCacheProfileFromTuist

--- a/Sources/TuistKit/Services/Lint/LintProjectService.swift
+++ b/Sources/TuistKit/Services/Lint/LintProjectService.swift
@@ -33,17 +33,39 @@ final class LintProjectService {
     private let environmentLinter: EnvironmentLinting
     private let manifestLoading: ManifestLoading
     private let graphLoader: GraphLoading
+    private let configLoader: ConfigLoading
 
-    init(graphLinter: GraphLinting = GraphLinter(),
-         environmentLinter: EnvironmentLinting = EnvironmentLinter(),
-         manifestLoading: ManifestLoading = ManifestLoader(),
-         graphLoader: GraphLoading = GraphLoader(modelLoader: GeneratorModelLoader(manifestLoader: ManifestLoader(),
-                                                                                   manifestLinter: AnyManifestLinter())))
-    {
+    convenience init() {
+        let manifestLoader = ManifestLoader()
+        let modelLoader = GeneratorModelLoader(
+            manifestLoader: manifestLoader,
+            manifestLinter: AnyManifestLinter()
+        )
+        let graphLoader = GraphLoader(modelLoader: modelLoader)
+        let configLoader = ConfigLoader(manifestLoader: manifestLoader)
+        let graphLinter = GraphLinter()
+        let environmentLinter = EnvironmentLinter()
+        self.init(
+            graphLinter: graphLinter,
+            environmentLinter: environmentLinter,
+            manifestLoading: manifestLoader,
+            graphLoader: graphLoader,
+            configLoader: configLoader
+        )
+    }
+
+    init(
+        graphLinter: GraphLinting,
+        environmentLinter: EnvironmentLinting,
+        manifestLoading: ManifestLoading,
+        graphLoader: GraphLoading,
+        configLoader: ConfigLoading
+    ) {
         self.graphLinter = graphLinter
         self.environmentLinter = environmentLinter
         self.manifestLoading = manifestLoading
         self.graphLoader = graphLoader
+        self.configLoader = configLoader
     }
 
     func run(path: String?) throws {
@@ -67,7 +89,7 @@ final class LintProjectService {
         let graphTraverser = ValueGraphTraverser(graph: valueGraph)
 
         logger.notice("Running linters")
-        let config = try graphLoader.loadConfig(path: path)
+        let config = try configLoader.loadConfig(path: path)
 
         var issues: [LintingIssue] = []
         logger.notice("Linting the environment")

--- a/Sources/TuistLoader/Loaders/ConfigLoader.swift
+++ b/Sources/TuistLoader/Loaders/ConfigLoader.swift
@@ -1,0 +1,69 @@
+import Foundation
+import struct ProjectDescription.Config
+import TSCBasic
+import TuistCore
+import TuistGraph
+import TuistSupport
+
+public protocol ConfigLoading {
+    /// Loads the Tuist configuration by traversing the file system till the Config manifest is found,
+    /// otherwise returns the default configuration.
+    ///
+    /// - Parameter path: Directory from which look up and load the Config.
+    /// - Returns: Loaded Config object.
+    /// - Throws: An error if the Config.swift can't be parsed.
+    func loadConfig(path: AbsolutePath) throws -> TuistGraph.Config
+}
+
+public final class ConfigLoader: ConfigLoading {
+    private let manifestLoader: ManifestLoading
+    private let rootDirectoryLocator: RootDirectoryLocating
+    private let fileHandler: FileHandling
+    private var cachedConfigs: [AbsolutePath: TuistGraph.Config] = [:]
+    public init(
+        manifestLoader: ManifestLoading,
+        rootDirectoryLocator: RootDirectoryLocating = RootDirectoryLocator(),
+        fileHandler: FileHandling = FileHandler.shared
+    ) {
+        self.manifestLoader = manifestLoader
+        self.rootDirectoryLocator = rootDirectoryLocator
+        self.fileHandler = fileHandler
+    }
+
+    public func loadConfig(path: AbsolutePath) throws -> TuistGraph.Config {
+        if let cached = cachedConfigs[path] {
+            return cached
+        }
+
+        // If the Config.swift file exists in the root Tuist/ directory, we load it from there
+        if let rootDirectoryPath = rootDirectoryLocator.locate(from: path) {
+            let configPath = rootDirectoryPath.appending(RelativePath("\(Constants.tuistDirectoryName)/\(Manifest.config.fileName(path))"))
+
+            if fileHandler.exists(configPath) {
+                let manifest = try manifestLoader.loadConfig(at: configPath.parentDirectory)
+                let config = try TuistGraph.Config.from(manifest: manifest, at: configPath)
+                cachedConfigs[path] = config
+                return config
+            }
+        }
+
+        // We first try to load the deprecated file. If it doesn't exist, we load the new file name.
+        let fileNames = [Manifest.config]
+            .flatMap { [$0.deprecatedFileName, $0.fileName(path)] }
+            .compactMap { $0 }
+
+        for fileName in fileNames {
+            guard let configPath = fileHandler.locateDirectoryTraversingParents(from: path, path: fileName) else {
+                continue
+            }
+            let manifest = try manifestLoader.loadConfig(at: configPath.parentDirectory)
+            let config = try TuistGraph.Config.from(manifest: manifest, at: configPath)
+            cachedConfigs[path] = config
+            return config
+        }
+
+        let config = TuistGraph.Config.default
+        cachedConfigs[path] = config
+        return config
+    }
+}

--- a/Sources/TuistLoader/Loaders/GeneratorModelLoader.swift
+++ b/Sources/TuistLoader/Loaders/GeneratorModelLoader.swift
@@ -50,33 +50,6 @@ extension GeneratorModelLoader: GeneratorModelLoading {
         let manifest = try manifestLoader.loadWorkspace(at: path)
         return try convert(manifest: manifest, path: path)
     }
-
-    public func loadConfig(at path: AbsolutePath) throws -> TuistGraph.Config {
-        // If the Config.swift file exists in the root Tuist/ directory, we load it from there
-        if let rootDirectoryPath = rootDirectoryLocator.locate(from: path) {
-            let configPath = rootDirectoryPath.appending(RelativePath("\(Constants.tuistDirectoryName)/\(Manifest.config.fileName(path))"))
-
-            if FileHandler.shared.exists(configPath) {
-                let manifest = try manifestLoader.loadConfig(at: configPath.parentDirectory)
-                return try TuistGraph.Config.from(manifest: manifest, at: configPath)
-            }
-        }
-
-        // We first try to load the deprecated file. If it doesn't exist, we load the new file name.
-        let fileNames = [Manifest.config]
-            .flatMap { [$0.deprecatedFileName, $0.fileName(path)] }
-            .compactMap { $0 }
-
-        for fileName in fileNames {
-            guard let configPath = FileHandler.shared.locateDirectoryTraversingParents(from: path, path: fileName) else {
-                continue
-            }
-            let manifest = try manifestLoader.loadConfig(at: configPath.parentDirectory)
-            return try TuistGraph.Config.from(manifest: manifest, at: configPath)
-        }
-
-        return TuistGraph.Config.default
-    }
 }
 
 extension GeneratorModelLoader: ManifestModelConverting {

--- a/Sources/TuistLoaderTesting/Loaders/Mocks/MockConfigLoader.swift
+++ b/Sources/TuistLoaderTesting/Loaders/Mocks/MockConfigLoader.swift
@@ -1,0 +1,13 @@
+import Foundation
+import TSCBasic
+import TuistGraph
+import TuistLoader
+
+public final class MockConfigLoader: ConfigLoading {
+    public init() {}
+
+    public var loadConfigStub: ((AbsolutePath) throws -> Config)?
+    public func loadConfig(path: AbsolutePath) throws -> Config {
+        try loadConfigStub?(path) ?? .default
+    }
+}

--- a/Sources/TuistLoaderTesting/Loaders/Mocks/MockGeneratorModelLoader.swift
+++ b/Sources/TuistLoaderTesting/Loaders/Mocks/MockGeneratorModelLoader.swift
@@ -6,7 +6,6 @@ import TuistSupport
 public class MockGeneratorModelLoader: GeneratorModelLoading {
     private var projects = [String: (AbsolutePath) throws -> Project]()
     private var workspaces = [String: (AbsolutePath) throws -> Workspace]()
-    private var configs = [String: (AbsolutePath) throws -> Config]()
 
     private let basePath: AbsolutePath
 
@@ -24,10 +23,6 @@ public class MockGeneratorModelLoader: GeneratorModelLoading {
         try workspaces[path.pathString]!(path)
     }
 
-    public func loadConfig(at path: AbsolutePath) throws -> Config {
-        try configs[path.pathString]!(path)
-    }
-
     // MARK: - Mock
 
     public func mockProject(_ path: String, loadClosure: @escaping (AbsolutePath) throws -> Project) {
@@ -36,9 +31,5 @@ public class MockGeneratorModelLoader: GeneratorModelLoading {
 
     public func mockWorkspace(_ path: String = "", loadClosure: @escaping (AbsolutePath) throws -> Workspace) {
         workspaces[basePath.appending(component: path).pathString] = loadClosure
-    }
-
-    public func mockConfig(_ path: String = "", loadClosure: @escaping (AbsolutePath) throws -> Config) {
-        configs[basePath.appending(component: path).pathString] = loadClosure
     }
 }

--- a/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -328,11 +328,9 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         let appTarget = try createAppTarget(settings: targetSettings)
         let project = createProject(path: try pathTo("App"), settings: projectSettings, targets: [appTarget], schemes: [])
         let workspace = try createWorkspace(path: temporaryPath, projects: ["App"])
-        let config = createConfig()
 
         modelLoader.mockProject("App") { _ in project }
         modelLoader.mockWorkspace { _ in workspace }
-        modelLoader.mockConfig { _ in config }
 
         return modelLoader
     }

--- a/Tests/TuistKitTests/Services/Cache/CachePrintHashesServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cache/CachePrintHashesServiceTests.swift
@@ -16,7 +16,7 @@ final class CachePrintHashesServiceTests: TuistUnitTestCase {
     var cacheGraphContentHasher: MockCacheGraphContentHasher!
     var clock: Clock!
     var path: AbsolutePath!
-    var generatorModelLoader: MockGeneratorModelLoader!
+    var configLoader: MockConfigLoader!
 
     override func setUp() {
         super.setUp()
@@ -26,15 +26,17 @@ final class CachePrintHashesServiceTests: TuistUnitTestCase {
         cacheGraphContentHasher = MockCacheGraphContentHasher()
         clock = StubClock()
 
-        generatorModelLoader = MockGeneratorModelLoader(basePath: path)
-        generatorModelLoader.mockConfig("") { (_) -> Config in
+        configLoader = MockConfigLoader()
+        configLoader.loadConfigStub = { _ in
             Config.test()
         }
 
-        subject = CachePrintHashesService(generator: generator,
-                                          cacheGraphContentHasher: cacheGraphContentHasher,
-                                          clock: clock,
-                                          generatorModelLoader: generatorModelLoader)
+        subject = CachePrintHashesService(
+            generator: generator,
+            cacheGraphContentHasher: cacheGraphContentHasher,
+            clock: clock,
+            configLoader: configLoader
+        )
     }
 
     override func tearDown() {
@@ -50,7 +52,7 @@ final class CachePrintHashesServiceTests: TuistUnitTestCase {
         subject = CachePrintHashesService(generator: generator,
                                           cacheGraphContentHasher: cacheGraphContentHasher,
                                           clock: clock,
-                                          generatorModelLoader: generatorModelLoader)
+                                          configLoader: configLoader)
 
         // When
         _ = try subject.run(path: path, xcframeworks: false, profile: nil)
@@ -64,7 +66,7 @@ final class CachePrintHashesServiceTests: TuistUnitTestCase {
         subject = CachePrintHashesService(generator: generator,
                                           cacheGraphContentHasher: cacheGraphContentHasher,
                                           clock: clock,
-                                          generatorModelLoader: generatorModelLoader)
+                                          configLoader: configLoader)
         let graph = Graph.test()
         generator.loadStub = { _ in graph }
 
@@ -92,7 +94,7 @@ final class CachePrintHashesServiceTests: TuistUnitTestCase {
         subject = CachePrintHashesService(generator: generator,
                                           cacheGraphContentHasher: cacheGraphContentHasher,
                                           clock: clock,
-                                          generatorModelLoader: generatorModelLoader)
+                                          configLoader: configLoader)
 
         // When
         _ = try subject.run(path: path, xcframeworks: false, profile: nil)
@@ -133,7 +135,7 @@ final class CachePrintHashesServiceTests: TuistUnitTestCase {
     func test_run_gives_correct_cache_profile_type_to_hasher() throws {
         // Given
         let profile: Cache.Profile = .test(name: "Simulator", configuration: "Debug")
-        generatorModelLoader.mockConfig("") { (_) -> Config in
+        configLoader.loadConfigStub = { _ in
             Config.test(cache: .test(profiles: [profile]))
         }
 

--- a/Tests/TuistKitTests/Services/GraphServiceTests.swift
+++ b/Tests/TuistKitTests/Services/GraphServiceTests.swift
@@ -16,13 +16,13 @@ final class GraphServiceTests: TuistUnitTestCase {
     var subject: GraphService!
     var graphVizGenerator: MockGraphVizGenerator!
     var manifestLoader: MockManifestLoader!
-    var graphLoader: MockGraphLoader!
+    var configLoader: MockConfigLoader!
 
     override func setUp() {
         super.setUp()
         graphVizGenerator = MockGraphVizGenerator()
         manifestLoader = MockManifestLoader()
-        graphLoader = MockGraphLoader()
+        configLoader = MockConfigLoader()
 
         subject = GraphService(
             graphVizGenerator: graphVizGenerator,
@@ -32,7 +32,7 @@ final class GraphServiceTests: TuistUnitTestCase {
                 fileHandler: fileHandler,
                 gitHandler: MockGitHandler()
             ),
-            graphLoader: graphLoader
+            configLoader: configLoader
         )
     }
 

--- a/Tests/TuistKitTests/Services/Lint/LintProjectServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Lint/LintProjectServiceTests.swift
@@ -14,6 +14,7 @@ final class LintProjectServiceTests: TuistUnitTestCase {
     var environmentLinter: MockEnvironmentLinter!
     var manifestLoader: MockManifestLoader!
     var graphLoader: MockGraphLoader!
+    var configLoader: MockConfigLoader!
     var subject: LintProjectService!
 
     override func setUp() {
@@ -21,10 +22,14 @@ final class LintProjectServiceTests: TuistUnitTestCase {
         environmentLinter = MockEnvironmentLinter()
         manifestLoader = MockManifestLoader()
         graphLoader = MockGraphLoader()
-        subject = LintProjectService(graphLinter: graphLinter,
-                                     environmentLinter: environmentLinter,
-                                     manifestLoading: manifestLoader,
-                                     graphLoader: graphLoader)
+        configLoader = MockConfigLoader()
+        subject = LintProjectService(
+            graphLinter: graphLinter,
+            environmentLinter: environmentLinter,
+            manifestLoading: manifestLoader,
+            graphLoader: graphLoader,
+            configLoader: configLoader
+        )
         super.setUp()
     }
 

--- a/Tests/TuistKitTests/Services/Scale/CloudAuthServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Scale/CloudAuthServiceTests.swift
@@ -39,27 +39,29 @@ final class CloudAuthServiceErrorTests: TuistUnitTestCase {
 
 final class CloudAuthServiceTests: TuistUnitTestCase {
     var cloudSessionController: MockCloudSessionController!
-    var generatorModelLoader: MockGeneratorModelLoader!
+    var configLoader: MockConfigLoader!
     var subject: CloudAuthService!
 
     override func setUp() {
         super.setUp()
         cloudSessionController = MockCloudSessionController()
-        generatorModelLoader = MockGeneratorModelLoader(basePath: FileHandler.shared.currentPath)
-        subject = CloudAuthService(cloudSessionController: cloudSessionController,
-                                   generatorModelLoader: generatorModelLoader)
+        configLoader = MockConfigLoader()
+        subject = CloudAuthService(
+            cloudSessionController: cloudSessionController,
+            configLoader: configLoader
+        )
     }
 
     override func tearDown() {
         super.tearDown()
         cloudSessionController = nil
-        generatorModelLoader = nil
+        configLoader = nil
         subject = nil
     }
 
     func test_authenticate_when_cloudURL_is_missing() {
         // Given
-        generatorModelLoader.mockConfig("") { (_) -> Config in
+        configLoader.loadConfigStub = { _ in
             Config.test(cloud: nil)
         }
 
@@ -70,7 +72,7 @@ final class CloudAuthServiceTests: TuistUnitTestCase {
     func test_authenticate() throws {
         // Given
         let cloudURL = URL.test()
-        generatorModelLoader.mockConfig("") { (_) -> Config in
+        configLoader.loadConfigStub = { _ in
             Config.test(cloud: Cloud(url: cloudURL, projectId: "123", options: []))
         }
 

--- a/Tests/TuistKitTests/Services/Scale/CloudLogoutServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Scale/CloudLogoutServiceTests.swift
@@ -39,27 +39,29 @@ final class CloudLogoutServiceErrorTests: TuistUnitTestCase {
 
 final class CloudLogoutServiceTests: TuistUnitTestCase {
     var cloudSessionController: MockCloudSessionController!
-    var generatorModelLoader: MockGeneratorModelLoader!
+    var configLoader: MockConfigLoader!
     var subject: CloudLogoutService!
 
     override func setUp() {
         super.setUp()
         cloudSessionController = MockCloudSessionController()
-        generatorModelLoader = MockGeneratorModelLoader(basePath: FileHandler.shared.currentPath)
-        subject = CloudLogoutService(cloudSessionController: cloudSessionController,
-                                     generatorModelLoader: generatorModelLoader)
+        configLoader = MockConfigLoader()
+        subject = CloudLogoutService(
+            cloudSessionController: cloudSessionController,
+            configLoader: configLoader
+        )
     }
 
     override func tearDown() {
         super.tearDown()
         cloudSessionController = nil
-        generatorModelLoader = nil
+        configLoader = nil
         subject = nil
     }
 
     func test_printSession_when_cloudURL_is_missing() {
         // Given
-        generatorModelLoader.mockConfig("") { (_) -> Config in
+        configLoader.loadConfigStub = { _ in
             Config.test(cloud: nil)
         }
 
@@ -70,7 +72,7 @@ final class CloudLogoutServiceTests: TuistUnitTestCase {
     func test_printSession() throws {
         // Given
         let cloudURL = URL.test()
-        generatorModelLoader.mockConfig("") { (_) -> Config in
+        configLoader.loadConfigStub = { _ in
             Config.test(cloud: Cloud(url: cloudURL, projectId: "123", options: []))
         }
 

--- a/Tests/TuistKitTests/Services/Scale/CloudSessionServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Scale/CloudSessionServiceTests.swift
@@ -39,27 +39,29 @@ final class CloudSessionServiceErrorTests: TuistUnitTestCase {
 
 final class CloudSessionServiceTests: TuistUnitTestCase {
     var cloudSessionController: MockCloudSessionController!
-    var generatorModelLoader: MockGeneratorModelLoader!
+    var configLoader: MockConfigLoader!
     var subject: CloudSessionService!
 
     override func setUp() {
         super.setUp()
         cloudSessionController = MockCloudSessionController()
-        generatorModelLoader = MockGeneratorModelLoader(basePath: FileHandler.shared.currentPath)
-        subject = CloudSessionService(cloudSessionController: cloudSessionController,
-                                      generatorModelLoader: generatorModelLoader)
+        configLoader = MockConfigLoader()
+        subject = CloudSessionService(
+            cloudSessionController: cloudSessionController,
+            configLoader: configLoader
+        )
     }
 
     override func tearDown() {
         super.tearDown()
         cloudSessionController = nil
-        generatorModelLoader = nil
+        configLoader = nil
         subject = nil
     }
 
     func test_printSession_when_cloudURL_is_missing() {
         // Given
-        generatorModelLoader.mockConfig("") { (_) -> Config in
+        configLoader.loadConfigStub = { _ in
             Config.test(cloud: nil)
         }
 
@@ -70,7 +72,7 @@ final class CloudSessionServiceTests: TuistUnitTestCase {
     func test_printSession() throws {
         // Given
         let cloudURL = URL.test()
-        generatorModelLoader.mockConfig("") { (_) -> Config in
+        configLoader.loadConfigStub = { _ in
             Config.test(cloud: Cloud(url: cloudURL, projectId: "123", options: []))
         }
 

--- a/Tests/TuistLoaderTests/Loaders/ConfigLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/ConfigLoaderTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import ProjectDescription
+import TSCBasic
+import TuistGraph
+import TuistSupport
+import XCTest
+@testable import TuistCoreTesting
+@testable import TuistLoader
+@testable import TuistLoaderTesting
+@testable import TuistSupportTesting
+
+final class ConfigLoaderTests: TuistUnitTestCase {
+    private var rootDirectoryLocator = MockRootDirectoryLocator()
+    private var manifestLoader = MockManifestLoader()
+    private var subject: ConfigLoader!
+    private var registeredPaths: [AbsolutePath: Bool] = [:]
+    private var registeredConfigs: [AbsolutePath: Result<ProjectDescription.Config, Error>] = [:]
+
+    override func setUp() {
+        super.setUp()
+        subject = ConfigLoader(
+            manifestLoader: manifestLoader,
+            rootDirectoryLocator: rootDirectoryLocator,
+            fileHandler: fileHandler
+        )
+        fileHandler.stubExists = { [weak self] path in
+            self?.registeredPaths[path] == true
+        }
+        manifestLoader.loadConfigStub = { [weak self] path in
+            guard let self = self,
+                let config = self.registeredConfigs[path]
+            else {
+                throw ManifestLoaderError.manifestNotFound(.config, path)
+            }
+            return try config.get()
+        }
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        subject = nil
+        manifestLoader.loadConfigStub = nil
+        fileHandler.stubExists = nil
+    }
+
+    // MARK: - Tests
+
+    func test_loadConfig_defaultReturnedWhenPathDoesNotExist() throws {
+        // Given
+        let path: AbsolutePath = "/some/random/path"
+        stub(path: path, exists: false)
+
+        // When
+        let result = try subject.loadConfig(path: path)
+
+        // Then
+        XCTAssertEqual(result, .default)
+    }
+
+    func test_loadConfig_loadTuistConfig() throws {
+        // Given
+        let path: AbsolutePath = "/project/Tuist/Config.swift"
+        stub(path: path, exists: true)
+        stub(
+            config: .test(
+                generationOptions: [.developmentRegion("fr")]
+            ),
+            at: path.parentDirectory
+        )
+
+        // When
+        let result = try subject.loadConfig(path: path)
+
+        // Then
+        XCTAssertEqual(result, TuistGraph.Config(
+            compatibleXcodeVersions: .all,
+            cloud: nil,
+            cache: nil,
+            plugins: [],
+            generationOptions: [.developmentRegion("fr")],
+            path: path
+        ))
+    }
+
+    func test_loadConfig_loadTuistConfigError() throws {
+        // Given
+        let path: AbsolutePath = "/project/Tuist/Config.swift"
+        stub(path: path, exists: true)
+        stub(configError: TestError.testError, at: "/project/Tuist")
+
+        // When / Then
+        XCTAssertThrowsSpecific(try subject.loadConfig(path: path), TestError.testError)
+    }
+
+    func test_loadConfig_loadTuistConfigInRootDirectory() throws {
+        // Given
+        stub(rootDirectory: "/project")
+        let paths: [AbsolutePath] = [
+            "/project/Tuist/Config.swift",
+            "/project/Module/",
+            "/project/Module/A/",
+        ]
+        paths.forEach {
+            stub(path: $0, exists: true)
+        }
+        stub(
+            config: .test(
+                generationOptions: [.developmentRegion("fr")]
+            ),
+            at: "/project/Tuist"
+        )
+
+        // When
+        let result = try subject.loadConfig(path: "/project/Module/A/")
+
+        // Then
+        XCTAssertEqual(result, TuistGraph.Config(
+            compatibleXcodeVersions: .all,
+            cloud: nil,
+            cache: nil,
+            plugins: [],
+            generationOptions: [.developmentRegion("fr")],
+            path: "/project/Tuist/Config.swift"
+        ))
+    }
+
+    // MARK: - Helpers
+
+    private func stub(path: AbsolutePath, exists: Bool) {
+        registeredPaths[path] = exists
+    }
+
+    private func stub(configError: Error, at path: AbsolutePath) {
+        registeredConfigs[path] = .failure(configError)
+    }
+
+    private func stub(config: ProjectDescription.Config, at path: AbsolutePath) {
+        registeredConfigs[path] = .success(config)
+    }
+
+    private func stub(rootDirectory: AbsolutePath) {
+        rootDirectoryLocator.locateStub = rootDirectory
+    }
+
+    private enum TestError: Error, Equatable {
+        case testError
+    }
+}


### PR DESCRIPTION
### Short description 📝

- To aid the migration from `Graph` to `ValueGraph`, a new `ConfigLoader` component is being added
- This will allow decoupling config loading from graph loading (configs are not tied to graph, they are standalone manifests/models)
- Replaced all usages where config loading was required to leverage the dedicated component instead of the graph loader or the model loader

### Test Plan 🛠

- Verify all unit tests pass
- Smoke test running the generation process on a few fixtures where configs are defined

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- ~In case the PR introduces changes that affect users, the documentation has been updated.~
