### PR TITLE
Tuist test derived data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Changed
 
+- Ensure reusing derived data for `tuist test` [#2563](https://github.com/tuist/tuist/pull/2563) by [@fortmarek](https://github.com/fortmarek)
 - **Breaking** Redesign `ProjectDescription.CarthageDependencies` manifest model. [#2608](https://github.com/tuist/tuist/pull/2608) by [@laxmorek](https://github.com/laxmorek)
 - Changed the auto generated scheme heuristic to pick test bundles that have a matching name prefixed with either `Tests`, `IntegrationTests` or `UITests`. [#2641](https://github.com/tuist/tuist/pull/2641) by [@FranzBusch](https://github.com/FranzBusch) 
 - Remove building of ProjectDescriptionHelpers for `Plugin.swift` and `Config.swift` manifests (not supported for these manifests). [#2642](https://github.com/tuist/tuist/pull/2642) by [@luispadron](https://github.com/luispadron)

--- a/Sources/TuistCache/Utilities/CacheFrameworkBuilder.swift
+++ b/Sources/TuistCache/Utilities/CacheFrameworkBuilder.swift
@@ -42,7 +42,7 @@ public final class CacheFrameworkBuilder: CacheArtifactBuilding {
 
     /// Developer's environment.
     private let developerEnvironment: DeveloperEnvironmenting
-    
+
     private let derivedDataLocator: DerivedDataLocating
 
     // MARK: - Init

--- a/Sources/TuistCache/Utilities/CacheFrameworkBuilder.swift
+++ b/Sources/TuistCache/Utilities/CacheFrameworkBuilder.swift
@@ -42,6 +42,8 @@ public final class CacheFrameworkBuilder: CacheArtifactBuilding {
 
     /// Developer's environment.
     private let developerEnvironment: DeveloperEnvironmenting
+    
+    private let derivedDataLocator: DerivedDataLocating
 
     // MARK: - Init
 
@@ -50,13 +52,16 @@ public final class CacheFrameworkBuilder: CacheArtifactBuilding {
     ///   - xcodeBuildController: Xcode build controller.
     ///   - simulatorController: Simulator controller.
     ///   - developerEnvironment: Developer environment.
-    public init(xcodeBuildController: XcodeBuildControlling,
-                simulatorController: SimulatorControlling = SimulatorController(),
-                developerEnvironment: DeveloperEnvironmenting = DeveloperEnvironment.shared)
-    {
+    public init(
+        xcodeBuildController: XcodeBuildControlling,
+        simulatorController: SimulatorControlling = SimulatorController(),
+        developerEnvironment: DeveloperEnvironmenting = DeveloperEnvironment.shared,
+        derivedDataLocator: DerivedDataLocating = DerivedDataLocator()
+    ) {
         self.xcodeBuildController = xcodeBuildController
         self.simulatorController = simulatorController
         self.developerEnvironment = developerEnvironment
+        self.derivedDataLocator = derivedDataLocator
     }
 
     // MARK: - ArtifactBuilding
@@ -141,10 +146,8 @@ public final class CacheFrameworkBuilder: CacheArtifactBuilding {
         let projectPath = projectTarget.path
         let pathString = projectPath.pathString
 
-        let derivedDataPath = developerEnvironment.derivedDataDirectory
-        let hash = try XcodeProjectPathHasher.hashString(for: pathString)
+        let derivedDataPath = try derivedDataLocator.locate(for: projectPath)
         var buildDirectory = derivedDataPath
-            .appending(component: "\(projectTarget.path.basenameWithoutExt)-\(hash)")
             .appending(component: "Build")
             .appending(component: "Products")
         if target.platform == .macOS {

--- a/Sources/TuistSupport/Utils/DerivedDataLocator.swift
+++ b/Sources/TuistSupport/Utils/DerivedDataLocator.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CryptoKit
+import Foundation
 import TSCBasic
 
 public protocol DerivedDataLocating {
@@ -8,7 +8,7 @@ public protocol DerivedDataLocating {
 
 public final class DerivedDataLocator: DerivedDataLocating {
     public init() {}
-    
+
     public func locate(for projectPath: AbsolutePath) throws -> AbsolutePath {
         let hash = try XcodeProjectPathHasher.hashString(for: projectPath.pathString)
         return DeveloperEnvironment.shared.derivedDataDirectory
@@ -68,4 +68,3 @@ internal class XcodeProjectPathHasher {
         return result.joined()
     }
 }
-

--- a/Sources/TuistSupport/Utils/DerivedDataLocator.swift
+++ b/Sources/TuistSupport/Utils/DerivedDataLocator.swift
@@ -1,5 +1,20 @@
-import CryptoKit
 import Foundation
+import CryptoKit
+import TSCBasic
+
+public protocol DerivedDataLocating {
+    func locate(for projectPath: AbsolutePath) throws -> AbsolutePath
+}
+
+public final class DerivedDataLocator: DerivedDataLocating {
+    public init() {}
+    
+    public func locate(for projectPath: AbsolutePath) throws -> AbsolutePath {
+        let hash = try XcodeProjectPathHasher.hashString(for: projectPath.pathString)
+        return DeveloperEnvironment.shared.derivedDataDirectory
+            .appending(component: "\(projectPath.basenameWithoutExt)-\(hash)")
+    }
+}
 
 // Thanks to https://pewpewthespells.com/blog/xcode_deriveddata_hashes.html for
 // the initial Objective-C implementation.
@@ -53,3 +68,4 @@ internal class XcodeProjectPathHasher {
         return result.joined()
     }
 }
+

--- a/Sources/TuistSupport/Utils/Environment.swift
+++ b/Sources/TuistSupport/Utils/Environment.swift
@@ -143,6 +143,7 @@ public class Environment: Environmenting {
         cacheDirectory.appending(component: "ProjectDescriptionHelpers")
     }
 
+    /// Returns the directory where the projects generated for automation tasks are generated to
     public var projectsCacheDirectory: AbsolutePath {
         cacheDirectory.appending(component: "Projects")
     }

--- a/Sources/TuistSupport/Utils/FileHandler.swift
+++ b/Sources/TuistSupport/Utils/FileHandler.swift
@@ -50,6 +50,8 @@ public protocol FileHandling: AnyObject {
     func readFile(_ at: AbsolutePath) throws -> Data
     func readTextFile(_ at: AbsolutePath) throws -> String
     func readPlistFile<T: Decodable>(_ at: AbsolutePath) throws -> T
+    /// Determine temporary directory either default for user or specified by ENV variable
+    func determineTemporaryDirectory() throws -> AbsolutePath
     func temporaryDirectory() throws -> AbsolutePath
     func inTemporaryDirectory(_ closure: (AbsolutePath) throws -> Void) throws
     func inTemporaryDirectory(removeOnCompletion: Bool, _ closure: (AbsolutePath) throws -> Void) throws
@@ -118,6 +120,10 @@ public class FileHandler: FileHandling {
     public func temporaryDirectory() throws -> AbsolutePath {
         let directory = try TemporaryDirectory(removeTreeOnDeinit: false)
         return directory.path
+    }
+
+    public func determineTemporaryDirectory() throws -> AbsolutePath {
+        try determineTempDirectory()
     }
 
     public func inTemporaryDirectory<Result>(_ closure: (AbsolutePath) throws -> Result) throws -> Result {

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
@@ -342,6 +342,10 @@ final class WorkspaceStructureGeneratorTests: XCTestCase {
             try JSONDecoder().decode(T.self, from: Data())
         }
 
+        func determineTemporaryDirectory() throws -> AbsolutePath {
+            currentPath
+        }
+
         func inTemporaryDirectory(_: (AbsolutePath) throws -> Void) throws {}
         func inTemporaryDirectory(removeOnCompletion _: Bool, _: (AbsolutePath) throws -> Void) throws {}
         func inTemporaryDirectory<Result>(_ closure: (AbsolutePath) throws -> Result) throws -> Result {

--- a/Tests/TuistSupportTests/Utils/XcodeProjectPathHasherTests.swift
+++ b/Tests/TuistSupportTests/Utils/XcodeProjectPathHasherTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import TuistCache
+@testable import TuistSupport
 @testable import TuistSupportTesting
 
 final class XcodeProjectPathHasherTests: TuistUnitTestCase {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/2401

### Short description 📝

This is just a draft PR, so we have something concrete to talk about.

To explain the problem:
`tuist test` generates a project to a new temporary directory which has always a different location. This also means that its derived data location is always different => therefore if you run `tuist test` twice in a row, you'll always have to build the project as if it was cleaned before since it can not reuse anything from the last one.

What this PR does:
Directs `xcodebuild` to always point to the same location of derived data which is a result of a hash `path-to-the-project/Name.xcworkspace`. 

Drawback:
- Unfortunately, `xcodebuild` seems to invalidate derived data if `.xcworkspace`/`.xcodeproj` location is changed
- this means that only thing that seems to be reused are third-party dependencies (Swift packages) which don't seem to be invalidated even if `.xcworkspace` path changes
- It also invalidates derived data for the "normal" project that the user uses

Possible different solutions:
- figure out how *not* to invalidate derived data even if `.xcworkspace` is in a different location
- do not change the location of derived data but just copy the derived data of the "normal" project to the automation one -> this way at least eg. SPM packages are reused
- create derived data just for `tuist test` and generate the test project to the same location. This seems to me the best solution so far as it does not mess up the derived data of the "normal" project while making sure that subsequent `tuist test` runs are reused. Unfortunately, this means that if you run `tuist test` for the same project in parallel, it'd fail. We could eg. check if a directory exists and only for this scenario create a new one but it still feels a little fragile.
-  live with the fact that `tuist test` is basically run with cleaned derived data - this might be fine for CI but it makes the value of `tuist test` for normal use quite disadvantageous. 
- something else I did not think of?

I'd appreciate any feedback/ideas as I think this is quite an important problem to solve to make `tuist test` really great.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
