### PR TITLE
Ignore .DS_Store files when hashing directory contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
-- Ignore .DS_Store files when hashing directory contents [#2591](https://github.com/tuist/tuist/pull/2591) by [@natanrolnik](https://github.com/natanrolnik).
+- Ignore `.DS_Store` files when hashing directory contents [#2591](https://github.com/tuist/tuist/pull/2591) by [@natanrolnik](https://github.com/natanrolnik).
 
 ## 1.36.0 - Digital Love
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,14 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Add option for enabling XCFrameworks production for Carthage in `Setup.swift`. [#2565](https://github.com/tuist/tuist/pull/2565) by [@laxmorek](https://github.com/laxmorek)
 
 ### Changed
+
 - Change the graph tree-shaker mapper to work with the value graph too [#2545](https://github.com/tuist/tuist/pull/2545) by [@pepibumur](https://github.com/pepibumur).
 - Migrate `GraphViz` to `ValueGraph` [#2542](https://github.com/tuist/tuist/pull/2542) by [@fortmarek](https://github.com/fortmarek)
+
+
+### Fixed
+
+- Ignore .DS_Store files when hashing directory contents [#2591](https://github.com/tuist/tuist/pull/2591) by [@natanrolnik](https://github.com/natanrolnik).
 
 ## 1.36.0 - Digital Love
 

--- a/Sources/TuistCore/ContentHashing/ContentHasher.swift
+++ b/Sources/TuistCore/ContentHashing/ContentHasher.swift
@@ -9,7 +9,7 @@ import TuistSupport
 /// Consider using CacheContentHasher to avoid computing the same hash twice
 public final class ContentHasher: ContentHashing {
     private let fileHandler: FileHandling
-    private let filterFiles = FilterHashingFiles()
+    private let filesFilter = HashingFilesFilter()
 
     public init(fileHandler: FileHandling = FileHandler.shared) {
         self.fileHandler = fileHandler
@@ -52,7 +52,7 @@ public final class ContentHasher: ContentHashing {
     public func hash(path filePath: AbsolutePath) throws -> String {
         if fileHandler.isFolder(filePath) {
             return try fileHandler.contentsOfDirectory(filePath)
-                .filter { filterFiles($0) }
+                .filter { filesFilter($0) }
                 .sorted(by: { $0 < $1 })
                 .map { try hash(path: $0) }
                 .joined(separator: "-")

--- a/Sources/TuistCore/ContentHashing/FilterHashingFiles.swift
+++ b/Sources/TuistCore/ContentHashing/FilterHashingFiles.swift
@@ -1,0 +1,17 @@
+import Foundation
+import TSCBasic
+
+internal class FilterHashingFiles {
+    /// an array of filters, which should return if a path should be included in hashing calculations or not.
+    private let filters: [((AbsolutePath) -> Bool)]
+
+    internal init() {
+        filters = [
+            { $0.basename.uppercased() != ".DS_STORE" },
+        ]
+    }
+
+    func callAsFunction(_ path: AbsolutePath) -> Bool {
+        !filters.contains(where: { $0(path) == false })
+    }
+}

--- a/Sources/TuistCore/ContentHashing/HashingFilesFilter.swift
+++ b/Sources/TuistCore/ContentHashing/HashingFilesFilter.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-internal class FilterHashingFiles {
+internal class HashingFilesFilter {
     /// an array of filters, which should return if a path should be included in hashing calculations or not.
     private let filters: [((AbsolutePath) -> Bool)]
 

--- a/Sources/TuistCore/ContentHashing/HashingFilesFilter.swift
+++ b/Sources/TuistCore/ContentHashing/HashingFilesFilter.swift
@@ -3,7 +3,7 @@ import TSCBasic
 
 internal class HashingFilesFilter {
     /// an array of filters, which should return if a path should be included in hashing calculations or not.
-    private let filters: [((AbsolutePath) -> Bool)]
+    private let filters: [(AbsolutePath) -> Bool]
 
     internal init() {
         filters = [
@@ -11,7 +11,7 @@ internal class HashingFilesFilter {
         ]
     }
 
-    func callAsFunction(_ path: AbsolutePath) -> Bool {
+    internal func callAsFunction(_ path: AbsolutePath) -> Bool {
         !filters.contains(where: { $0(path) == false })
     }
 }

--- a/Sources/TuistCore/ContentHashing/HashingFilesFilter.swift
+++ b/Sources/TuistCore/ContentHashing/HashingFilesFilter.swift
@@ -1,17 +1,17 @@
 import Foundation
 import TSCBasic
 
-internal class HashingFilesFilter {
+class HashingFilesFilter {
     /// an array of filters, which should return if a path should be included in hashing calculations or not.
     private let filters: [(AbsolutePath) -> Bool]
 
-    internal init() {
+    init() {
         filters = [
             { $0.basename.uppercased() != ".DS_STORE" },
         ]
     }
 
-    internal func callAsFunction(_ path: AbsolutePath) -> Bool {
+    func callAsFunction(_ path: AbsolutePath) -> Bool {
         !filters.contains(where: { $0(path) == false })
     }
 }

--- a/Tests/TuistCoreTests/ContentHashing/ContentHasherTests.swift
+++ b/Tests/TuistCoreTests/ContentHashing/ContentHasherTests.swift
@@ -87,7 +87,7 @@ final class ContentHasherTests: TuistUnitTestCase {
     }
 
     func test_hash_sortedContentsOfADirectorySkippingDSStore() throws {
-        //given
+        // given
         let folderPath = try temporaryPath().appending(component: "assets.xcassets")
         try mockFileHandler.createFolder(folderPath)
 


### PR DESCRIPTION
Resolves one of the issues mentioned in #2389 (the other one was already dealt by @andreacipriani in #2499): 

`ResourcesContentHasher` relies on `ContentHasher` which could incorrectly take into account `.DS_STORE` files, for example inside `.xcassets` folders.

So as recommended in by @pepibumur I've extracted the filters into a separate class, which allows adding different filters via composition. Now `ContentHasher` filters the files based on this new class, `HashingFilesFilter`.

In `HashingFilesFilter`, I decided to use `callAsFunction(_)` to make it simpler, as the **sole purpose** of that class is to… filter! Otherwise, the caller site would look like this: `.filter(filesFilter.filter)`.

Instead, it allows us calling it as: `.filter { filesFilter($0) }`

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
