### PR TITLE
Remove tests build action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Changed
 
+- Remove build action for project generated in `tuist test` [#2592]()https://github.com/tuist/tuist/pull/2592 [@fortmarek](https://github.com/fortmarek)
 - Change the graph tree-shaker mapper to work with the value graph too [#2545](https://github.com/tuist/tuist/pull/2545) by [@pepibumur](https://github.com/pepibumur).
 - Migrate `GraphViz` to `ValueGraph` [#2542](https://github.com/tuist/tuist/pull/2542) by [@fortmarek](https://github.com/fortmarek)
 

--- a/Sources/TuistCache/GraphMappers/TestsCacheGraphMapper.swift
+++ b/Sources/TuistCache/GraphMappers/TestsCacheGraphMapper.swift
@@ -140,6 +140,9 @@ public final class TestsCacheGraphMapper: GraphMapping {
             !cachedTestableTargets.contains(where: { $0.target.name == testTarget.target.name })
         }
 
+        // Only `testAction` is necessary
+        scheme.buildAction = nil
+
         return (scheme, cachedTestableTargets)
     }
 

--- a/Tests/TuistCacheTests/GraphMappers/TestsCacheGraphMapperTests.swift
+++ b/Tests/TuistCacheTests/GraphMappers/TestsCacheGraphMapperTests.swift
@@ -131,12 +131,14 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
                 schemes: [
                     Scheme.test(
                         name: "SchemeA",
+                        buildAction: nil,
                         testAction: TestAction.test(
                             targets: []
                         )
                     ),
                     Scheme.test(
                         name: "SchemeB",
+                        buildAction: nil,
                         testAction: TestAction.test(
                             targets: [
                                 TestableTarget(
@@ -165,8 +167,12 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(
-            gotGraph,
-            expectedGraph
+            gotGraph.workspace,
+            expectedGraph.workspace
+        )
+        XCTAssertEqual(
+            gotGraph.targets,
+            expectedGraph.targets
         )
         XCTAssertEqual(
             gotSideEffects.sorted(by: {
@@ -263,7 +269,20 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
         let expectedGraph = Graph.test(
             workspace: Workspace.test(
                 schemes: [
-                    schemeA,
+                    Scheme.test(
+                        name: "SchemeA",
+                        buildAction: nil,
+                        testAction: TestAction.test(
+                            targets: [
+                                TestableTarget(
+                                    target: TargetReference(
+                                        projectPath: project.path,
+                                        name: unitTestsA.name
+                                    )
+                                ),
+                            ]
+                        )
+                    ),
                 ]
             ),
             projects: [project],
@@ -280,8 +299,12 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(
-            gotGraph,
-            expectedGraph
+            gotGraph.workspace,
+            expectedGraph.workspace
+        )
+        XCTAssertEqual(
+            gotGraph.targets,
+            expectedGraph.targets
         )
         XCTAssertEqual(
             gotSideEffects.sorted(by: {


### PR DESCRIPTION
### Short description 📝

The build action of the generated project for `tuist test` was not only unnecessary - it meant that even targets that did not have to be built for the tests to succeed, would be built. Solution is straightforward - delete `buildAction` altogether as it's not used for `tuist test` in any way.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
