### PR TITLE
Improve `tuist generate` performance for projects with large amount of files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Changed
 
+- Improve `tuist generate` performance for projects with large amount of files [#2598](https://github.com/tuist/tuist/pull/2598) by [@adellibovi](https://github.com/adellibovi/)
 - Added wrap arguments swiftformat option [#2606](https://github.com/tuist/tuist/pull/2606) by [@fortmarek](https://github.com/fortmarek)
 - Remove build action for project generated in `tuist test` [#2592]()https://github.com/tuist/tuist/pull/2592 [@fortmarek](https://github.com/fortmarek)
 - Change the graph tree-shaker mapper to work with the value graph too [#2545](https://github.com/tuist/tuist/pull/2545) by [@pepibumur](https://github.com/pepibumur).

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -245,12 +245,9 @@ class ProjectFileElements {
         // The file already exists
         if elements[fileElement.path] != nil { return }
 
-        let closestRelativeRelativePath = closestRelativeElementPath(
-            path: fileElement.path,
-            sourceRootPath: sourceRootPath
-        )
-        let closestRelativeAbsolutePath = sourceRootPath.appending(closestRelativeRelativePath)
         let fileElementRelativeToSourceRoot = fileElement.path.relative(to: sourceRootPath)
+        let closestRelativeRelativePath = closestRelativeElementPath(pathRelativeToSourceRoot: fileElementRelativeToSourceRoot)
+        let closestRelativeAbsolutePath = sourceRootPath.appending(closestRelativeRelativePath)
         // Add the first relative element.
         let group: PBXGroup
         switch fileElement.group {
@@ -594,8 +591,8 @@ class ProjectFileElements {
     /// Returns the relative path of the closest relative element to the source root path.
     /// If source root path is /a/b/c/project/ and file path is /a/d/myfile.swift
     /// this method will return ../../../d/
-    func closestRelativeElementPath(path: AbsolutePath, sourceRootPath: AbsolutePath) -> RelativePath {
-        let relativePathComponents = path.relative(to: sourceRootPath).components
+    func closestRelativeElementPath(pathRelativeToSourceRoot: RelativePath) -> RelativePath {
+        let relativePathComponents = pathRelativeToSourceRoot.components
         let firstElementComponents = relativePathComponents.reduce(into: [String]()) { components, component in
             let isLastRelative = components.last == ".." || components.last == "."
             if components.last != nil, !isLastRelative { return }

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -706,10 +706,8 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
     }
 
     func test_closestRelativeElementPath() {
-        let got = subject.closestRelativeElementPath(
-            path: AbsolutePath("/a/framework/framework.framework"),
-            sourceRootPath: AbsolutePath("/a/b/c/project")
-        )
+        let pathRelativeToSourceRoot = AbsolutePath("/a/framework/framework.framework").relative(to: AbsolutePath("/a/b/c/project"))
+        let got = subject.closestRelativeElementPath(pathRelativeToSourceRoot: pathRelativeToSourceRoot)
         XCTAssertEqual(got, RelativePath("../../../framework"))
     }
 


### PR DESCRIPTION
As per title, this PR improves the speed of `tuist generate` when having quite a number of files (source files, resources etc..)

### Short description 📝

The PR fixes a performance issue when appending elements on `PBXBuildPhase.files`.
As the current implementation of `PBXBuildPhase.files` is:
```swift
public var files: [PBXBuildFile]? {
    get {
        fileReferences?.objects()
    }
    set {
        newValue?.forEach { $0.buildPhase = self }
        fileReferences = newValue?.references()
    }
 }
```
Every time we append an element to `files`, we trigger both the getter which recreate an array, and the setter which iterate over the array, becoming an O(n*n) operation. I fixed by setting the `files` only once.

Under my tests I saved a couple of seconds, around -20% 😄 

Apart from this PR, I wonder if we should rethink the `PBXBuildFile`'s API of XcodeProj, I will be happy to have a look. @pepibumur what do you think?

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
