### PR TITLE
Use Tuist to define TuistSupport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ mkmf.log
 .rubocop-http---shopify-github-io-ruby-style-guide-rubocop-yml
 generated_fixtures
 .fixtures.generated.json
+Tuist.xcworkspace

--- a/.package.resolved
+++ b/.package.resolved
@@ -1,0 +1,124 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "AEXML",
+        "repositoryURL": "https://github.com/tadija/AEXML",
+        "state": {
+          "branch": null,
+          "revision": "8623e73b193386909566a9ca20203e33a09af142",
+          "version": "4.5.0"
+        }
+      },
+      {
+        "package": "Signals",
+        "repositoryURL": "https://github.com/tuist/BlueSignals.git",
+        "state": {
+          "branch": null,
+          "revision": "1f6c49e186c8a4eeef87ba14f2f97b8646559d13",
+          "version": "1.0.200"
+        }
+      },
+      {
+        "package": "Checksum",
+        "repositoryURL": "https://github.com/rnine/Checksum.git",
+        "state": {
+          "branch": null,
+          "revision": "cd1ae53384dd578a84a0afef492a4f5d6202b068",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "package": "CombineExt",
+        "repositoryURL": "https://github.com/CombineCommunity/CombineExt.git",
+        "state": {
+          "branch": null,
+          "revision": "6664678135c6aec049c887a51c9da2545f184882",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "package": "KeychainAccess",
+        "repositoryURL": "https://github.com/kishikawakatsumi/KeychainAccess.git",
+        "state": {
+          "branch": null,
+          "revision": "84e546727d66f1adc5439debad16270d0fdd04e7",
+          "version": "4.2.2"
+        }
+      },
+      {
+        "package": "PathKit",
+        "repositoryURL": "https://github.com/kylef/PathKit",
+        "state": {
+          "branch": null,
+          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "RxSwift",
+        "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "254617dd7fae0c45319ba5fbea435bf4d0e15b5d",
+          "version": "5.1.2"
+        }
+      },
+      {
+        "package": "Spectre",
+        "repositoryURL": "https://github.com/kylef/Spectre.git",
+        "state": {
+          "branch": null,
+          "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
+          "version": "0.9.2"
+        }
+      },
+      {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "state": {
+          "branch": null,
+          "revision": "12d3a8651d32295794a850307f77407f95b8c881",
+          "version": "1.4.1"
+        }
+      },
+      {
+        "package": "swift-tools-support-core",
+        "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
+        "state": {
+          "branch": null,
+          "revision": "243beea77d20db46647a3de4765c96e2c801c7c7",
+          "version": "0.1.12"
+        }
+      },
+      {
+        "package": "Swifter",
+        "repositoryURL": "https://github.com/httpswift/swifter.git",
+        "state": {
+          "branch": null,
+          "revision": "9483a5d459b45c3ffd059f7b55f9638e268632fd",
+          "version": "1.5.0"
+        }
+      },
+      {
+        "package": "XcodeProj",
+        "repositoryURL": "https://github.com/tuist/XcodeProj.git",
+        "state": {
+          "branch": null,
+          "revision": "c8afc799be95bbc6c329ba12d15342ffa7c4577d",
+          "version": "7.19.0"
+        }
+      },
+      {
+        "package": "Zip",
+        "repositoryURL": "https://github.com/marmelroy/Zip.git",
+        "state": {
+          "branch": null,
+          "revision": "bd19d974e8a38cc8d3a88c90c8a107386c3b8ccf",
+          "version": "2.1.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Project.swift
+++ b/Project.swift
@@ -1,0 +1,56 @@
+import ProjectDescription
+
+let deploymentTarget: DeploymentTarget = .macOS(targetVersion: "10.15")
+
+let project = Project(name: "Tuist",
+                      packages: [
+                        .package(url: "https://github.com/tuist/XcodeProj.git", .upToNextMajor(from: "7.17.0")),
+                        .package(url: "https://github.com/CombineCommunity/CombineExt.git", .upToNextMajor(from: "1.2.0")),
+                        .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.1.12")),
+                        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.1.1")),
+                        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.0")),
+                        .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", .upToNextMajor(from: "4.1.0")),
+                        .package(url: "https://github.com/httpswift/swifter.git", .upToNextMajor(from: "1.5.0")),
+                        .package(url: "https://github.com/tuist/BlueSignals.git", .upToNextMajor(from: "1.0.21")),
+                        .package(url: "https://github.com/marmelroy/Zip.git", .upToNextMinor(from: "2.1.1")),
+                        .package(url: "https://github.com/rnine/Checksum.git", .upToNextMajor(from: "1.0.2")),
+                      ],
+                      settings: Settings.init(configurations: [
+                        .release(name: "Debug", settings: [:], xcconfig: nil),
+                        .release(name: "Release", settings: [:], xcconfig: nil)
+                      ]),
+                      targets: [
+                        Target(name: "TuistSupport",
+                               platform: .macOS,
+                               product: .staticLibrary,
+                               bundleId: "io.tuist.TuistSupport",
+                               deploymentTarget: deploymentTarget,
+                               infoPlist: .default,
+                               sources: ["Sources/TuistSupport/**/*.swift"],
+                               resources: [],
+                               copyFiles: [],
+                               headers: nil,
+                               entitlements: nil,
+                               actions: [],
+                               dependencies: [
+                                    .package(product: "CombineExt"),
+                                    .package(product: "SwiftToolsSupport-auto"),
+                                    .package(product: "RxSwift"),
+                                    .package(product: "RxDelay"),
+                                    .package(product: "Logging"),
+                                    .package(product: "KeychainAccess"),
+                                    .package(product: "Swifter"),
+                                    .package(product: "Signals"),
+                                    .package(product: "Zip"),
+                                    .package(product: "Checksum")
+                               ],
+                               settings: Settings.init(configurations: [
+                                .release(name: "Debug", settings: [:], xcconfig: nil),
+                                .release(name: "Release", settings: [:], xcconfig: nil)
+                              ]),
+                               coreDataModels: [],
+                               environment: [:],
+                               launchArguments: [])
+                      ],
+                      schemes: [],
+                      additionalFiles: [])

--- a/Project.swift
+++ b/Project.swift
@@ -1,6 +1,7 @@
 import ProjectDescription
 
 let deploymentTarget: DeploymentTarget = .macOS(targetVersion: "10.15")
+let baseSettings: SettingsDictionary = ["EXCLUDED_ARCHS": "arm64"]
 
 let project = Project(name: "Tuist",
                       packages: [
@@ -16,8 +17,8 @@ let project = Project(name: "Tuist",
                         .package(url: "https://github.com/rnine/Checksum.git", .upToNextMajor(from: "1.0.2")),
                       ],
                       settings: Settings.init(configurations: [
-                        .release(name: "Debug", settings: [:], xcconfig: nil),
-                        .release(name: "Release", settings: [:], xcconfig: nil)
+                        .release(name: "Debug", settings: baseSettings, xcconfig: nil),
+                        .release(name: "Release", settings: baseSettings, xcconfig: nil)
                       ]),
                       targets: [
                         Target(name: "TuistSupport",


### PR DESCRIPTION
### Short description 📝
I'm starting to take steps to use Tuist with Tuist. In this first PR I'm adding a `Project.swift` file at the root to describe the `TuistSupport` target. I'll gradually migrate all the targets of the project and once all of them have been migrated and we've updated all our tasks in `Rakefile` to use `tuist`, we'll be in the position of switching over to Tuist.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
