### PR TITLE
Allow excluding non-manifest Project.swift files when editing project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Change the graph tree-shaker mapper to work with the value graph too [#2545](https://github.com/tuist/tuist/pull/2545) by [@pepibumur](https://github.com/pepibumur).
 - Migrate `GraphViz` to `ValueGraph` [#2542](https://github.com/tuist/tuist/pull/2542) by [@fortmarek](https://github.com/fortmarek)
-
+- Exclude `Project.swift` files which are **not manifests** with a `// tuist:not-a-manifest` [#2605](https://github.com/tuist/tuist/pull/2605) comment by [@natanrolnik](https://github.com/natanrolnik)
 
 ### Fixed
 
-- Ignore `.DS_Store` files when hashing directory contents [#2591](https://github.com/tuist/tuist/pull/2591) by [@natanrolnik](https://github.com/natanrolnik).
+- Ignore `.DS_Store` files when hashing directory contents [#2591](https://github.com/tuist/tuist/pull/2591) by [@natanrolnik](https://github.com/natanrolnik)
 
 ## 1.36.0 - Digital Love
 

--- a/website/markdown/docs/commands/edit.mdx
+++ b/website/markdown/docs/commands/edit.mdx
@@ -25,3 +25,11 @@ tuist edit --permanent
 ```
 
 That will generate a `Manifest.xcodeproj` project that you can open manually.
+
+### Excluding files which are not manifests
+
+Tuist looks for all `Project.swift` files in your directory when editing your project. As a consequence, it might include files with this name which **might be part of your sources, instead of being a manifest**. If you would like to exclude a `Project.swift` file (which is not a manifest) from the manifests project, you should add the following comment:
+
+```
+// tuist:not-a-manifest
+```


### PR DESCRIPTION
For users that have a `Project.swift` file which is not a manifest, but a source file, `tuist edit` adds them to the project. This PR allows adding the `// tuist:not-a-manifest` comment in a `Project.swift` file which is not a manifest to exclude it from the edit project.

One option to avoid this would be inspecting the `Workspace.swift` file and only adding manifests referenced from the workspace's project. But this has two drawbacks. First, for users who don't use the `Workspace.swift`. Secondly, the project could not have been added to the workspace yet, while the manifest already exists.

Docs updated accordingly.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
