### PR TITLE
Fix incorrect detection of current Core Data model version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Added
 
+
 - Add option for enabling XCFrameworks production for Carthage in `Setup.swift`. [#2565](https://github.com/tuist/tuist/pull/2565) by [@laxmorek](https://github.com/laxmorek)
 
 ### Changed
@@ -18,6 +19,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
+- Fix incorrect detection of current Core Data model version. [#2612](https://github.com/tuist/tuist/pull/2612) by [@freak4pc](https://github.com/freak4pc)
 - Ignore `.DS_Store` files when hashing directory contents [#2591](https://github.com/tuist/tuist/pull/2591) by [@natanrolnik](https://github.com/natanrolnik).
 
 ## 1.36.0 - Digital Love

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Added
 
-
 - Add option for enabling XCFrameworks production for Carthage in `Setup.swift`. [#2565](https://github.com/tuist/tuist/pull/2565) by [@laxmorek](https://github.com/laxmorek)
 
 ### Changed

--- a/Sources/TuistSupport/CoreDataVersionExtractor.swift
+++ b/Sources/TuistSupport/CoreDataVersionExtractor.swift
@@ -14,11 +14,11 @@ public final class CoreDataVersionExtractor {
             let dict = try decoder.decode([String: String].self, from: data)
             guard
                 let currentVersionName = dict["_XCCurrentVersionName"],
-                let versionNumberString = currentVersionName.split(separator: ".").first
+                currentVersionName.hasSuffix(".xcdatamodel")
             else {
                 throw CoreDataVersionExtractorError.couldNotExtractVersionFrom(filePath)
             }
-            return String(versionNumberString)
+            return currentVersionName.dropSuffix(".xcdatamodel")
         } catch {
             throw CoreDataVersionExtractorError.couldNotReadCurrentVersion(filePath)
         }

--- a/Sources/TuistSupport/Extensions/String+Extras.swift
+++ b/Sources/TuistSupport/Extensions/String+Extras.swift
@@ -13,6 +13,14 @@ extension String {
         ).replacingOccurrences(of: "\0", with: "␀")
     }
 
+    public func dropSuffix(_ suffix: String) -> String {
+        hasSuffix(suffix) ? String(dropLast(suffix.count)) : self
+    }
+
+    public func dropPrefix(_ prefix: String) -> String {
+        hasPrefix(prefix) ? String(dropFirst(prefix.count)) : self
+    }
+
     public func chomp(separator: String? = nil) -> String {
         func scrub(_ separator: String) -> String {
             var e = endIndex

--- a/features/generate-6.feature
+++ b/features/generate-6.feature
@@ -16,6 +16,7 @@ Scenario: The project is an iOS application with core data models (ios_app_with_
     Then tuist generates the project
     Then I should be able to build for iOS the scheme App
     Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'Users.momd'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'UsersAutoDetect.momd'
     Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource '1_2.cdm'
 
 Scenario: The project is an iOS application with appclip (ios_app_with_appclip)

--- a/fixtures/ios_app_with_coredata/CoreData/UsersAutoDetect.xcdatamodeld/.xccurrentversion
+++ b/fixtures/ios_app_with_coredata/CoreData/UsersAutoDetect.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_XCCurrentVersionName</key>
+	<string>2.5.xcdatamodel</string>
+</dict>
+</plist>

--- a/fixtures/ios_app_with_coredata/CoreData/UsersAutoDetect.xcdatamodeld/1.xcdatamodel/contents
+++ b/fixtures/ios_app_with_coredata/CoreData/UsersAutoDetect.xcdatamodeld/1.xcdatamodel/contents
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19E287" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="DetectedUser" representedClassName="DetectedUser" syncable="YES" codeGenerationType="class">
+        <attribute name="identifier" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+    </entity>
+    <elements>
+        <element name="DetectedUser" positionX="-63" positionY="-18" width="128" height="73"/>
+    </elements>
+</model>

--- a/fixtures/ios_app_with_coredata/CoreData/UsersAutoDetect.xcdatamodeld/2.5.xcdatamodel/contents
+++ b/fixtures/ios_app_with_coredata/CoreData/UsersAutoDetect.xcdatamodeld/2.5.xcdatamodel/contents
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="15508" systemVersion="18G87" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="DetectedUser" representedClassName="DetectedUser" syncable="YES" codeGenerationType="class">
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+    </entity>
+    <elements>
+        <element name="DetectedUser" positionX="-63" positionY="-18" width="128" height="73"/>
+    </elements>
+</model>

--- a/fixtures/ios_app_with_coredata/CoreData/UsersAutoDetect.xcdatamodeld/2.xcdatamodel/contents
+++ b/fixtures/ios_app_with_coredata/CoreData/UsersAutoDetect.xcdatamodeld/2.xcdatamodel/contents
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="15508" systemVersion="18G87" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="DetectedUser" representedClassName="DetectedUser" syncable="YES" codeGenerationType="class">
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+    </entity>
+    <elements>
+        <element name="DetectedUser" positionX="-63" positionY="-18" width="128" height="73"/>
+    </elements>
+</model>

--- a/fixtures/ios_app_with_coredata/Project.swift
+++ b/fixtures/ios_app_with_coredata/Project.swift
@@ -8,5 +8,8 @@ let project = Project(name: "App",
                                bundleId: "io.tuist.app",
                                infoPlist: "Info.plist",
                                sources: ["Sources/**"],
-                               coreDataModels: [CoreDataModel("CoreData/Users.xcdatamodeld", currentVersion: "1")])
+                               coreDataModels: [
+                                 CoreDataModel("CoreData/Users.xcdatamodeld", currentVersion: "1"),
+                                 CoreDataModel("CoreData/UsersAutoDetect.xcdatamodeld")
+                               ])
                       ])


### PR DESCRIPTION
### Short description 📝

The core data version extractor assumes the first dot-separated portion of the filename is the version name, but this doesn't accommodate for dotted versions:

<img width="212" alt="image" src="https://user-images.githubusercontent.com/605076/110238246-44e30180-7f49-11eb-8e4c-8a0632512aca.png">

Doesn't seem there are any tests for the extraction at all, so let me know if I should add them.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
