### PR TITLE
Renaming `TuistGraph.Dependency` -> `TuistGraph.TargetDependency`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Remove build action for project generated in `tuist test` [#2592]()https://github.com/tuist/tuist/pull/2592 [@fortmarek](https://github.com/fortmarek)
 - Change the graph tree-shaker mapper to work with the value graph too [#2545](https://github.com/tuist/tuist/pull/2545) by [@pepibumur](https://github.com/pepibumur).
 - Migrate `GraphViz` to `ValueGraph` [#2542](https://github.com/tuist/tuist/pull/2542) by [@fortmarek](https://github.com/fortmarek)
+- Rename `TuistGraph.Dependency` to `TuistGraph.TargetDepedency`. [#2614](https://github.com/tuist/tuist/pull/2614) by [@laxmorek](https://github.com/laxmorek)
 
 ### Fixed
 

--- a/Sources/TuistCache/ContentHashing/DependencyContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/DependencyContentHasher.swift
@@ -3,7 +3,7 @@ import TuistCore
 import TuistGraph
 
 public protocol DependenciesContentHashing {
-    func hash(dependencies: [Dependency]) throws -> String
+    func hash(dependencies: [TargetDependency]) throws -> String
 }
 
 /// `DependencyContentHasher`
@@ -19,14 +19,14 @@ public final class DependenciesContentHasher: DependenciesContentHashing {
 
     // MARK: - DependenciesContentHashing
 
-    public func hash(dependencies: [Dependency]) throws -> String {
+    public func hash(dependencies: [TargetDependency]) throws -> String {
         let hashes = dependencies.map { try? hash(dependency: $0) }
         return hashes.compactMap { $0 }.joined()
     }
 
     // MARK: - Private
 
-    private func hash(dependency: Dependency) throws -> String {
+    private func hash(dependency: TargetDependency) throws -> String {
         switch dependency {
         case let .target(name):
             return try contentHasher.hash("target-\(name)")

--- a/Sources/TuistCore/Graph/GraphLoader.swift
+++ b/Sources/TuistCore/Graph/GraphLoader.swift
@@ -193,7 +193,7 @@ public class GraphLoader: GraphLoading {
     ///   - platform: Platform of the target whose dependency is being loaded.
     ///   - graphLoaderCache: Graph loader cache.
     ///   - graphCircularDetector: Graph circular dependency detector.
-    fileprivate func loadDependency(for dependency: Dependency,
+    fileprivate func loadDependency(for dependency: TargetDependency,
                                     path: AbsolutePath,
                                     name: String,
                                     platform: Platform,

--- a/Sources/TuistCore/ValueGraph/ValueGraphLoader.swift
+++ b/Sources/TuistCore/ValueGraph/ValueGraphLoader.swift
@@ -155,7 +155,7 @@ public final class ValueGraphLoader: ValueGraphLoading {
         path: AbsolutePath,
         fromTarget: String,
         fromPlatform: Platform,
-        dependency: Dependency,
+        dependency: TargetDependency,
         cache: Cache,
         cycleDetector: GraphCircularDetector
     ) throws -> ValueGraphDependency {

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -218,7 +218,7 @@ class TargetLinter: TargetLinting {
 
     private func lintDuplicateDependency(target: Target) -> [LintingIssue] {
         typealias Occurence = Int
-        var seen: [Dependency: Occurence] = [:]
+        var seen: [TargetDependency: Occurence] = [:]
         target.dependencies.forEach { seen[$0, default: 0] += 1 }
         let duplicates = seen.enumerated().filter { $0.element.value > 1 }
         return duplicates.map {
@@ -227,7 +227,7 @@ class TargetLinter: TargetLinting {
     }
 }
 
-private extension Dependency {
+private extension TargetDependency {
     var typeName: String {
         switch self {
         case .target:

--- a/Sources/TuistGraph/Models/Target.swift
+++ b/Sources/TuistGraph/Models/Target.swift
@@ -21,7 +21,7 @@ public struct Target: Equatable, Hashable, Comparable {
     public var infoPlist: InfoPlist?
     public var entitlements: AbsolutePath?
     public var settings: Settings?
-    public var dependencies: [Dependency]
+    public var dependencies: [TargetDependency]
     public var sources: [SourceFile]
     public var resources: [ResourceFileElement]
     public var copyFiles: [CopyFilesAction]
@@ -55,7 +55,7 @@ public struct Target: Equatable, Hashable, Comparable {
                 environment: [String: String] = [:],
                 launchArguments: [LaunchArgument] = [],
                 filesGroup: ProjectGroup,
-                dependencies: [Dependency] = [],
+                dependencies: [TargetDependency] = [],
                 scripts: [TargetScript] = [],
                 playgrounds: [AbsolutePath] = [],
                 prune: Bool = false)

--- a/Sources/TuistGraph/Models/TargetDependency.swift
+++ b/Sources/TuistGraph/Models/TargetDependency.swift
@@ -6,7 +6,7 @@ public enum SDKStatus {
     case optional
 }
 
-public enum Dependency: Equatable, Hashable {
+public enum TargetDependency: Equatable, Hashable {
     case target(name: String)
     case project(target: String, path: AbsolutePath)
     case framework(path: AbsolutePath)

--- a/Sources/TuistGraphTesting/Models/Target+TestData.swift
+++ b/Sources/TuistGraphTesting/Models/Target+TestData.swift
@@ -22,7 +22,7 @@ public extension Target {
                      actions: [TargetAction] = [],
                      environment: [String: String] = [:],
                      filesGroup: ProjectGroup = .group(name: "Project"),
-                     dependencies: [Dependency] = [],
+                     dependencies: [TargetDependency] = [],
                      scripts: [TargetScript] = [],
                      launchArguments: [LaunchArgument] = [],
                      playgrounds: [AbsolutePath] = [],
@@ -72,7 +72,7 @@ public extension Target {
                       actions: [TargetAction] = [],
                       environment: [String: String] = [:],
                       filesGroup: ProjectGroup = .group(name: "Project"),
-                      dependencies: [Dependency] = [],
+                      dependencies: [TargetDependency] = [],
                       scripts: [TargetScript] = []) -> Target
     {
         Target(

--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -180,7 +180,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
         }()
 
         let manifestsTargets = namedManifests(projectManifests).map { name, projectManifestSourcePath -> Target in
-            let helperDependencies = helpersTarget.map { [Dependency.target(name: $0.name)] } ?? []
+            let helperDependencies = helpersTarget.map { [TargetDependency.target(name: $0.name)] } ?? []
             return editorHelperTarget(
                 name: name,
                 filesGroup: manifestsFilesGroup,
@@ -366,7 +366,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
         filesGroup: ProjectGroup,
         targetSettings: Settings,
         sourcePaths: [AbsolutePath],
-        dependencies: [Dependency] = []
+        dependencies: [TargetDependency] = []
     ) -> Target {
         Target(
             name: name,

--- a/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
@@ -33,7 +33,7 @@ extension TuistGraph.Target {
         let productName = manifest.productName
         let deploymentTarget = manifest.deploymentTarget.map { TuistGraph.DeploymentTarget.from(manifest: $0) }
 
-        let dependencies = try manifest.dependencies.map { try TuistGraph.Dependency.from(manifest: $0, generatorPaths: generatorPaths) }
+        let dependencies = try manifest.dependencies.map { try TuistGraph.TargetDependency.from(manifest: $0, generatorPaths: generatorPaths) }
 
         let infoPlist = try TuistGraph.InfoPlist.from(manifest: manifest.infoPlist, generatorPaths: generatorPaths)
         let entitlements = try manifest.entitlements.map { try generatorPaths.resolve(path: $0) }

--- a/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
@@ -4,12 +4,12 @@ import TSCBasic
 import TuistCore
 import TuistGraph
 
-extension TuistGraph.Dependency {
-    /// Maps a ProjectDescription.TargetDependency instance into a TuistCore.Dependency instance.
+extension TuistGraph.TargetDependency {
+    /// Maps a ProjectDescription.TargetDependency instance into a TuistGraph.TargetDependency instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of the target dependency model.
     ///   - generatorPaths: Generator paths.
-    static func from(manifest: ProjectDescription.TargetDependency, generatorPaths: GeneratorPaths) throws -> TuistGraph.Dependency {
+    static func from(manifest: ProjectDescription.TargetDependency, generatorPaths: GeneratorPaths) throws -> TuistGraph.TargetDependency {
         switch manifest {
         case let .target(name):
             return .target(name: name)

--- a/Tests/TuistCacheTests/ContentHashing/DependenciesContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/DependenciesContentHasherTests.swift
@@ -30,7 +30,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
     func test_hash_whenDependencyIsTarget_callsContentHasherAsExpected() throws {
         // Given
-        let dependency = Dependency.target(name: "foo")
+        let dependency = TargetDependency.target(name: "foo")
 
         // When
         let hash = try subject.hash(dependencies: [dependency])
@@ -42,7 +42,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
     func test_hash_whenDependencyIsProject_callsContentHasherAsExpected() throws {
         // Given
-        let dependency = Dependency.project(target: "foo", path: filePath1)
+        let dependency = TargetDependency.project(target: "foo", path: filePath1)
         mockContentHasher.stubHashForPath[filePath1] = "file-hashed"
 
         // When
@@ -56,7 +56,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
     func test_hash_whenDependencyIsFramework_callsContentHasherAsExpected() throws {
         // Given
-        let dependency = Dependency.framework(path: filePath1)
+        let dependency = TargetDependency.framework(path: filePath1)
         mockContentHasher.stubHashForPath[filePath1] = "file-hashed"
 
         // When
@@ -69,7 +69,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
     func test_hash_whenDependencyIsXCFramework_callsContentHasherAsExpected() throws {
         // Given
-        let dependency = Dependency.xcFramework(path: filePath1)
+        let dependency = TargetDependency.xcFramework(path: filePath1)
         mockContentHasher.stubHashForPath[filePath1] = "file-hashed"
 
         // When
@@ -82,7 +82,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
     func test_hash_whenDependencyIsLibrary_callsContentHasherAsExpected() throws {
         // Given
-        let dependency = Dependency.library(
+        let dependency = TargetDependency.library(
             path: filePath1,
             publicHeaders: filePath2,
             swiftModuleMap: filePath3
@@ -102,7 +102,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
     func test_hash_whenDependencyIsLibrary_swiftModuleMapIsNil_callsContentHasherAsExpected() throws {
         // Given
-        let dependency = Dependency.library(
+        let dependency = TargetDependency.library(
             path: filePath1,
             publicHeaders: filePath2,
             swiftModuleMap: nil
@@ -121,7 +121,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
     func test_hash_whenDependencyIsPackage_callsContentHasherAsExpected() throws {
         // Given
-        let dependency = Dependency.package(product: "foo")
+        let dependency = TargetDependency.package(product: "foo")
 
         // When
         let hash = try subject.hash(dependencies: [dependency])
@@ -133,7 +133,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
     func test_hash_whenDependencyIsOptionalSDK_callsContentHasherAsExpected() throws {
         // Given
-        let dependency = Dependency.sdk(name: "foo", status: .optional)
+        let dependency = TargetDependency.sdk(name: "foo", status: .optional)
 
         // When
         let hash = try subject.hash(dependencies: [dependency])
@@ -145,7 +145,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
     func test_hash_whenDependencyIsRequiredSDK_callsContentHasherAsExpected() throws {
         // Given
-        let dependency = Dependency.sdk(name: "foo", status: .required)
+        let dependency = TargetDependency.sdk(name: "foo", status: .required)
 
         // When
         let hash = try subject.hash(dependencies: [dependency])
@@ -157,7 +157,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
     func test_hash_whenDependencyIsCocoapods_callsContentHasherAsExpected() throws {
         // Given
-        let dependency = Dependency.cocoapods(path: filePath1)
+        let dependency = TargetDependency.cocoapods(path: filePath1)
         mockContentHasher.stubHashForPath[filePath1] = "file1-hashed"
 
         // When
@@ -170,7 +170,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
     func test_hash_whenDependencyIsXCTest_callsContentHasherAsExpected() throws {
         // Given
-        let dependency = Dependency.xctest
+        let dependency = TargetDependency.xctest
 
         // When
         let hash = try subject.hash(dependencies: [dependency])

--- a/Tests/TuistGeneratorIntegrationTests/Generator/SwiftPackageManagerInteractorTests.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Generator/SwiftPackageManagerInteractorTests.swift
@@ -130,7 +130,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
 
     // MARK: - Helpers
 
-    func anyTarget(dependencies: [Dependency] = []) -> Target {
+    func anyTarget(dependencies: [TargetDependency] = []) -> Target {
         Target.test(
             infoPlist: nil,
             entitlements: nil,

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceDescriptorGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceDescriptorGeneratorTests.swift
@@ -116,7 +116,7 @@ final class WorkspaceDescriptorGeneratorTests: TuistUnitTestCase {
 
     // MARK: - Helpers
 
-    func anyTarget(dependencies: [Dependency] = []) -> Target {
+    func anyTarget(dependencies: [TargetDependency] = []) -> Target {
         Target.test(
             infoPlist: nil,
             entitlements: nil,

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -235,7 +235,7 @@ final class TargetLinterTests: TuistUnitTestCase {
     }
 
     func test_lint_when_target_has_duplicate_dependencies_specified() {
-        let testDependency: Dependency = .sdk(name: "libc++.tbd", status: .optional)
+        let testDependency: TargetDependency = .sdk(name: "libc++.tbd", status: .optional)
 
         // Given
         let target = Target.test(dependencies: .init(repeating: testDependency, count: 2))

--- a/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -58,7 +58,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(gotTarget.sources.count, 1)
         XCTAssertEqual(gotTarget.sources.first?.path, expectedPath)
         XCTAssertEqual(gotTarget.dependencies.count, 1)
-        XCTAssertEqual(gotTarget.dependencies.first, Dependency.target(name: "\(target.name)Resources"))
+        XCTAssertEqual(gotTarget.dependencies.first, TargetDependency.target(name: "\(target.name)Resources"))
 
         let resourcesTarget = try XCTUnwrap(gotProject.targets.last)
         XCTAssertEqual(resourcesTarget.name, "\(target.name)Resources")
@@ -104,7 +104,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(gotTarget.sources.count, 1)
         XCTAssertEqual(gotTarget.sources.first?.path, expectedPath)
         XCTAssertEqual(gotTarget.dependencies.count, 1)
-        XCTAssertEqual(gotTarget.dependencies.first, Dependency.target(name: "\(target.name)Resources"))
+        XCTAssertEqual(gotTarget.dependencies.first, TargetDependency.target(name: "\(target.name)Resources"))
 
         let resourcesTarget = try XCTUnwrap(gotProject.targets.last)
         XCTAssertEqual(resourcesTarget.name, "\(target.name)Resources")

--- a/Tests/TuistIntegrationTests/Generator/TestModelGenerator.swift
+++ b/Tests/TuistIntegrationTests/Generator/TestModelGenerator.swift
@@ -138,7 +138,7 @@ final class TestModelGenerator {
             resources: createResources(path: path),
             headers: createHeaders(path: path),
             filesGroup: .group(name: "ProjectGroup"),
-            dependencies: dependencies.map { Dependency.target(name: $0) }
+            dependencies: dependencies.map { TargetDependency.target(name: $0) }
         )
     }
 
@@ -206,7 +206,7 @@ final class TestModelGenerator {
     }
 
     private func createFrameworkTarget(name: String,
-                                       depenendencies: [Dependency] = []) throws -> Target
+                                       depenendencies: [TargetDependency] = []) throws -> Target
     {
         Target(
             name: name,
@@ -221,18 +221,18 @@ final class TestModelGenerator {
         )
     }
 
-    private func createDependencies(relativeTo path: AbsolutePath) throws -> [Dependency] {
+    private func createDependencies(relativeTo path: AbsolutePath) throws -> [TargetDependency] {
         let frameworks = (0 ..< 10)
             .map { "Frameworks/Framework\($0).framework" }
-            .map { Dependency.framework(path: path.appending(RelativePath($0))) }
+            .map { TargetDependency.framework(path: path.appending(RelativePath($0))) }
 
         let libraries = try createLibraries(relativeTo: path)
 
         return (frameworks + libraries).shuffled()
     }
 
-    private func createLibraries(relativeTo path: AbsolutePath) throws -> [Dependency] {
-        var libraries = [Dependency]()
+    private func createLibraries(relativeTo path: AbsolutePath) throws -> [TargetDependency] {
+        var libraries = [TargetDependency]()
 
         for i in 0 ..< 10 {
             let libraryName = "Library\(i)"

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/TargetDependency+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/TargetDependency+ManifestMapperTests.swift
@@ -12,11 +12,11 @@ import XCTest
 final class DependencyManifestMapperTests: TuistUnitTestCase {
     func test_from_when_cocoapods() throws {
         // Given
-        let dependency = TargetDependency.cocoapods(path: "./path/to/project")
+        let dependency = ProjectDescription.TargetDependency.cocoapods(path: "./path/to/project")
         let generatorPaths = GeneratorPaths(manifestDirectory: AbsolutePath("/"))
 
         // When
-        let got = try TuistGraph.Dependency.from(manifest: dependency, generatorPaths: generatorPaths)
+        let got = try TuistGraph.TargetDependency.from(manifest: dependency, generatorPaths: generatorPaths)
 
         // Then
         guard case let .cocoapods(path) = got else {
@@ -28,11 +28,11 @@ final class DependencyManifestMapperTests: TuistUnitTestCase {
 
     func test_from_when_localPackage() throws {
         // Given
-        let dependency = TargetDependency.package(product: "library")
+        let dependency = ProjectDescription.TargetDependency.package(product: "library")
         let generatorPaths = GeneratorPaths(manifestDirectory: AbsolutePath("/"))
 
         // When
-        let got = try TuistGraph.Dependency.from(manifest: dependency, generatorPaths: generatorPaths)
+        let got = try TuistGraph.TargetDependency.from(manifest: dependency, generatorPaths: generatorPaths)
 
         // Then
         guard


### PR DESCRIPTION
### Short description 📝

This PR renames `TuistGraph.Dependency` to `TuistGraph.TargetDependency`.

The motivations behind this change are:
- keeping the same naming of corresponding models in `ProjectDescription` and `TuistGraph`
- distinguish differences between target’s dependencies and dependencies that will be provided by `Depedencies.swift`

Main place of PR: [here](https://github.com/tuist/tuist/pull/2614/files#diff-1779b94775d634799634b9533a39bb42222c4da26a2e6ab8c85147f6d3672be8).

### Other solution ❓

On the other hand we could just rename `ProjectDescription.TargetDepedency` to `ProjectDescription.Depedency` but it may create naming conflicts with models related to `Depedencies.swift` feature that may be introduces in the future. 

`Target*` prefix clear describes propose of model. 
