### PR TITLE
Scheme location simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Added
 
+- Add support for simulated location in a run action's options. [#2616](https://github.com/tuist/tuist/pull/2616) by [@freak4pc](https://github.com/freak4pc)
 - Add option for enabling XCFrameworks production for Carthage in `Setup.swift`. [#2565](https://github.com/tuist/tuist/pull/2565) by [@laxmorek](https://github.com/laxmorek)
 
 ### Changed

--- a/Sources/ProjectDescription/RunActionOptions.swift
+++ b/Sources/ProjectDescription/RunActionOptions.swift
@@ -34,6 +34,9 @@ public struct RunActionOptions: Equatable, Codable {
     ///     [StoreKit configuration file](https://developer.apple.com/documentation/xcode/setting_up_storekit_testing_in_xcode#3625700).
     ///     Please note that this file is automatically added to the Project/Workpace. You should not add it manually.
     ///     The default value is `nil`, which results in no configuration defined for the scheme
+    ///
+    ///     - simulatedLocation: The simulated GPS location to use when running the app.
+    ///     Please note that the `.custom(gpxPath:)` case must refer to a valid GPX file in your project's resources.
     public static func options(
         storeKitConfigurationPath: Path? = nil,
         simulatedLocation: SimulatedLocation? = nil
@@ -46,102 +49,64 @@ public struct RunActionOptions: Equatable, Codable {
 }
 
 extension RunActionOptions {
-    /// Represents a simulated location used when running the provided run action
-    public enum SimulatedLocation {
-        case london
-        case johannesburg
-        case moscow
-        case mumbai
-        case tokyo
-        case sydney
-        case hongKong
-        case honolulu
-        case sanFrancisco
-        case mexicoCity
-        case newYork
-        case rioDeJaneiro
-        case custom(gpxFile: Path)
+    /// Represents a simulated location used when running the provided run action.
+    public struct SimulatedLocation: Codable, Equatable {
+        public let identifier: String
 
-        /// A unique identifier string for the selected simulated location.
-        ///
-        /// In case of Xcode's simulated locations, this is a string representing the location.
-        /// In case of a custom GPX file, this is a path to that file.
-        public var identifier: String {
-            switch self {
-            case .london:
-                return "London, England"
-            case .johannesburg:
-                return "Johannesburg, South Africa"
-            case .moscow:
-                return "Moscow, Russia"
-            case .mumbai:
-                return "Mumbai, India"
-            case .tokyo:
-                return "Tokyo, Japan"
-            case .sydney:
-                return "Sydney, Australia"
-            case .hongKong:
-                return "Hong Kong, China"
-            case .honolulu:
-                return "Honolulu, HI, USA"
-            case .sanFrancisco:
-                return "San Francisco, CA, USA"
-            case .mexicoCity:
-                return "Mexico City, Mexico"
-            case .newYork:
-                return "New York, NY, USA"
-            case .rioDeJaneiro:
-                return "Rio De Janeiro, Brazil"
-            case let .custom(path):
-                return path.pathString
-            }
+        private init(identifier: String) {
+            self.identifier = identifier
         }
-    }
-}
 
-extension RunActionOptions.SimulatedLocation: Equatable, Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        let value = try container.decode(String.self)
-
-        switch value {
-        case "London, England":
-            self = .london
-        case "Johannesburg, South Africa":
-            self = .johannesburg
-        case "Moscow, Russia":
-            self = .moscow
-        case "Mumbai, India":
-            self = .mumbai
-        case "Tokyo, Japan":
-            self = .tokyo
-        case "Sydney, Australia":
-            self = .sydney
-        case "Hong Kong, China":
-            self = .hongKong
-        case "Honolulu, HI, USA":
-            self = .honolulu
-        case "San Francisco, CA, USA":
-            self = .sanFrancisco
-        case "Mexico City, Mexico":
-            self = .mexicoCity
-        case "New York, NY, USA":
-            self = .newYork
-        case "Rio De Janeiro, Brazil":
-            self = .rioDeJaneiro
-        case _ where value.contains("/"):
-            self = .custom(gpxFile: Path(value))
-        default:
-            throw CodingError.unknownLocation
+        public static func custom(gpxFile: Path) -> SimulatedLocation {
+            .init(identifier: gpxFile.pathString)
         }
-    }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(identifier)
-    }
+        public static var london: SimulatedLocation {
+            .init(identifier: "London, England")
+        }
 
-    enum CodingError: Error {
-        case unknownLocation
+        public static var johannesburg: SimulatedLocation {
+            .init(identifier: "Johannesburg, South Africa")
+        }
+
+        public static var moscow: SimulatedLocation {
+            .init(identifier: "Moscow, Russia")
+        }
+
+        public static var mumbai: SimulatedLocation {
+            .init(identifier: "Mumbai, India")
+        }
+
+        public static var tokyo: SimulatedLocation {
+            .init(identifier: "Tokyo, Japan")
+        }
+
+        public static var sydney: SimulatedLocation {
+            .init(identifier: "Sydney, Australia")
+        }
+
+        public static var hongKong: SimulatedLocation {
+            .init(identifier: "Hong Kong, China")
+        }
+
+        public static var honolulu: SimulatedLocation {
+            .init(identifier: "Honolulu, HI, USA")
+        }
+
+        public static var sanFrancisco: SimulatedLocation {
+            .init(identifier: "San Francisco, CA, USA")
+        }
+
+        public static var mexicoCity: SimulatedLocation {
+            .init(identifier: "Mexico City, Mexico")
+        }
+
+        public static var newYork: SimulatedLocation {
+            .init(identifier: "New York, NY, USA")
+        }
+
+        public static var rioDeJaneiro: SimulatedLocation {
+            .init(identifier: "Rio De Janeiro, Brazil")
+        }
     }
 }

--- a/Sources/ProjectDescription/RunActionOptions.swift
+++ b/Sources/ProjectDescription/RunActionOptions.swift
@@ -6,6 +6,9 @@ public struct RunActionOptions: Equatable, Codable {
     /// [StoreKit configuration file](https://developer.apple.com/documentation/xcode/setting_up_storekit_testing_in_xcode#3625700).
     public let storeKitConfigurationPath: Path?
 
+    /// A simulated location used when running the provided run action.
+    public let simulatedLocation: SimulatedLocation?
+
     /// Creates an `RunActionOptions` instance
     ///
     /// - Parameters:
@@ -13,10 +16,15 @@ public struct RunActionOptions: Equatable, Codable {
     ///     [StoreKit configuration file](https://developer.apple.com/documentation/xcode/setting_up_storekit_testing_in_xcode#3625700).
     ///     Please note that this file is automatically added to the Project/Workpace. You should not add it manually.
     ///     The default value is `nil`, which results in no configuration defined for the scheme
+    ///
+    ///     - simulatedLocation: The simulated GPS location to use when running the app.
+    ///     Please note that the `.custom(gpxPath:)` case must refer to a valid GPX file in your project's resources.
     init(
-        storeKitConfigurationPath: Path? = nil
+        storeKitConfigurationPath: Path? = nil,
+        simulatedLocation: SimulatedLocation? = nil
     ) {
         self.storeKitConfigurationPath = storeKitConfigurationPath
+        self.simulatedLocation = simulatedLocation
     }
 
     /// Creates an `RunActionOptions` instance
@@ -27,8 +35,113 @@ public struct RunActionOptions: Equatable, Codable {
     ///     Please note that this file is automatically added to the Project/Workpace. You should not add it manually.
     ///     The default value is `nil`, which results in no configuration defined for the scheme
     public static func options(
-        storeKitConfigurationPath: Path? = nil
+        storeKitConfigurationPath: Path? = nil,
+        simulatedLocation: SimulatedLocation? = nil
     ) -> Self {
-        self.init(storeKitConfigurationPath: storeKitConfigurationPath)
+        self.init(
+            storeKitConfigurationPath: storeKitConfigurationPath,
+            simulatedLocation: simulatedLocation
+        )
+    }
+}
+
+extension RunActionOptions {
+    /// Represents a simulated location used when running the provided run action
+    public enum SimulatedLocation {
+        case london
+        case johannesburg
+        case moscow
+        case mumbai
+        case tokyo
+        case sydney
+        case hongKong
+        case honolulu
+        case sanFrancisco
+        case mexicoCity
+        case newYork
+        case rioDeJaneiro
+        case custom(gpxFile: Path)
+
+        /// A unique identifier string for the selected simulated location.
+        ///
+        /// In case of Xcode's simulated locations, this is a string representing the location.
+        /// In case of a custom GPX file, this is a path to that file.
+        public var identifier: String {
+            switch self {
+            case .london:
+                return "London, England"
+            case .johannesburg:
+                return "Johannesburg, South Africa"
+            case .moscow:
+                return "Moscow, Russia"
+            case .mumbai:
+                return "Mumbai, India"
+            case .tokyo:
+                return "Tokyo, Japan"
+            case .sydney:
+                return "Sydney, Australia"
+            case .hongKong:
+                return "Hong Kong, China"
+            case .honolulu:
+                return "Honolulu, HI, USA"
+            case .sanFrancisco:
+                return "San Francisco, CA, USA"
+            case .mexicoCity:
+                return "Mexico City, Mexico"
+            case .newYork:
+                return "New York, NY, USA"
+            case .rioDeJaneiro:
+                return "Rio De Janeiro, Brazil"
+            case let .custom(path):
+                return path.pathString
+            }
+        }
+    }
+}
+
+extension RunActionOptions.SimulatedLocation: Equatable, Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+
+        switch value {
+        case "London, England":
+            self = .london
+        case "Johannesburg, South Africa":
+            self = .johannesburg
+        case "Moscow, Russia":
+            self = .moscow
+        case "Mumbai, India":
+            self = .mumbai
+        case "Tokyo, Japan":
+            self = .tokyo
+        case "Sydney, Australia":
+            self = .sydney
+        case "Hong Kong, China":
+            self = .hongKong
+        case "Honolulu, HI, USA":
+            self = .honolulu
+        case "San Francisco, CA, USA":
+            self = .sanFrancisco
+        case "Mexico City, Mexico":
+            self = .mexicoCity
+        case "New York, NY, USA":
+            self = .newYork
+        case "Rio De Janeiro, Brazil":
+            self = .rioDeJaneiro
+        case _ where value.contains("/"):
+            self = .custom(gpxFile: Path(value))
+        default:
+            throw CodingError.unknownLocation
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(identifier)
+    }
+
+    enum CodingError: Error {
+        case unknownLocation
     }
 }

--- a/Sources/ProjectDescription/RunActionOptions.swift
+++ b/Sources/ProjectDescription/RunActionOptions.swift
@@ -51,14 +51,18 @@ public struct RunActionOptions: Equatable, Codable {
 extension RunActionOptions {
     /// Represents a simulated location used when running the provided run action.
     public struct SimulatedLocation: Codable, Equatable {
-        public let identifier: String
+        public let identifier: String?
+        public let gpxFile: Path?
 
-        private init(identifier: String) {
+        private init(identifier: String? = nil,
+                     gpxFile: Path? = nil)
+        {
             self.identifier = identifier
+            self.gpxFile = gpxFile
         }
 
         public static func custom(gpxFile: Path) -> SimulatedLocation {
-            .init(identifier: gpxFile.pathString)
+            .init(gpxFile: gpxFile)
         }
 
         public static var london: SimulatedLocation {

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -111,6 +111,19 @@ class ProjectFileElements {
 
         fileElements.formUnion(storekitFiles)
 
+        // Add the .gpx files if needed. GPS Exchange files must be added to the
+        // project/workspace so that the scheme can correctly reference them.
+        // In case the configuration already contains such file, we should avoid adding it twice
+        let gpxFiles = project.schemes.compactMap { scheme -> GroupFileElement? in
+            guard case let .gpxFile(path) = scheme.runAction?.options.simulatedLocation else {
+                return nil
+            }
+
+            return GroupFileElement(path: path, group: project.filesGroup)
+        }
+
+        fileElements.formUnion(gpxFiles)
+
         return fileElements
     }
 

--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -404,7 +404,6 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
         {
             var identifier = locationScenario.identifier
 
-            /// GPX file path is the relative path between the storekit file, and the xcode project
             if case let .gpxFile(gpxPath) = locationScenario {
                 let fileRelativePath = gpxPath.relative(to: graphTarget.project.xcodeProjPath)
                 identifier = fileRelativePath.pathString

--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -398,14 +398,11 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
             storeKitConfigurationFileReference = .init(identifier: fileRelativePath.pathString)
         }
 
-        if
-            let locationScenario = scheme.runAction?.options.simulatedLocation,
-            let graphTarget = graphTarget
-        {
+        if let locationScenario = scheme.runAction?.options.simulatedLocation {
             var identifier = locationScenario.identifier
 
             if case let .gpxFile(gpxPath) = locationScenario {
-                let fileRelativePath = gpxPath.relative(to: graphTarget.project.xcodeProjPath)
+                let fileRelativePath = gpxPath.relative(to: graphTraverser.workspace.xcWorkspacePath)
                 identifier = fileRelativePath.pathString
             }
 

--- a/Sources/TuistGraph/Models/RunActionOptions.swift
+++ b/Sources/TuistGraph/Models/RunActionOptions.swift
@@ -60,7 +60,7 @@ extension RunActionOptions.SimulatedLocation: Equatable, Codable {
         let container = try decoder.singleValueContainer()
         let value = try container.decode(String.self)
 
-        guard value.contains("/") else {
+        guard value.hasSuffix(".gpx") else {
             self = .reference(value)
             return
         }

--- a/Sources/TuistGraph/Models/RunActionOptions.swift
+++ b/Sources/TuistGraph/Models/RunActionOptions.swift
@@ -7,6 +7,9 @@ public struct RunActionOptions: Equatable, Codable {
     /// [StoreKit configuration file](https://developer.apple.com/documentation/xcode/setting_up_storekit_testing_in_xcode#3625700)
     public let storeKitConfigurationPath: AbsolutePath?
 
+    /// A simulated location used when running the provided run action.
+    public let simulatedLocation: SimulatedLocation?
+
     /// Creates an `RunActionOptions` instance
     ///
     /// - Parameters:
@@ -14,9 +17,59 @@ public struct RunActionOptions: Equatable, Codable {
     ///     [StoreKit configuration file](https://developer.apple.com/documentation/xcode/setting_up_storekit_testing_in_xcode#3625700).
     ///     The default value is `nil`, which results in no
     ///     configuration defined for the scheme
+    ///
+    ///     - simulatedLocation: The simulated GPS location to use when running the app.
     public init(
-        storeKitConfigurationPath: AbsolutePath? = nil
+        storeKitConfigurationPath: AbsolutePath? = nil,
+        simulatedLocation: SimulatedLocation? = nil
     ) {
         self.storeKitConfigurationPath = storeKitConfigurationPath
+        self.simulatedLocation = simulatedLocation
+    }
+}
+
+extension RunActionOptions {
+    public enum SimulatedLocation {
+        case gpxFile(AbsolutePath)
+        case reference(String)
+
+        /// A unique identifier string for the selected simulated location.
+        ///
+        /// In case of Xcode's simulated locations, this is a string representing the location.
+        /// In case of a custom GPX file, this is a path to that file.
+        public var identifier: String {
+            switch self {
+            case let .gpxFile(path):
+                return path.pathString
+            case let .reference(identifier):
+                return identifier
+            }
+        }
+
+        /// A reference type is 1 if using Xcode's built-in simulated locations.
+        /// Otherwise, it is 0.
+        public var referenceType: String {
+            if case .gpxFile = self { return "0" }
+            return "1"
+        }
+    }
+}
+
+extension RunActionOptions.SimulatedLocation: Equatable, Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+
+        guard value.contains("/") else {
+            self = .reference(value)
+            return
+        }
+
+        self = .gpxFile(try AbsolutePath(validating: value))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(identifier)
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/RunActionOptions+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/RunActionOptions+ManifestMapper.swift
@@ -19,11 +19,14 @@ extension TuistGraph.RunActionOptions {
             storeKitConfigurationPath = try generatorPaths.resolveSchemeActionProjectPath(path)
         }
 
-        if let simulatedLocationIdentifier = manifest.simulatedLocation?.identifier {
-            if simulatedLocationIdentifier.hasSuffix(".gpx") {
-                simulatedLocation = .gpxFile(try generatorPaths.resolveSchemeActionProjectPath(Path(simulatedLocationIdentifier)))
-            } else {
-                simulatedLocation = .reference(simulatedLocationIdentifier)
+        if let manifestLocation = manifest.simulatedLocation {
+            switch (manifestLocation.identifier, manifestLocation.gpxFile) {
+            case let (identifier?, .none):
+                simulatedLocation = .reference(identifier)
+            case let (.none, gpxFile?):
+                simulatedLocation = .gpxFile(try generatorPaths.resolveSchemeActionProjectPath(gpxFile))
+            default:
+                break
             }
         }
 

--- a/Sources/TuistLoader/Models+ManifestMappers/RunActionOptions+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/RunActionOptions+ManifestMapper.swift
@@ -13,13 +13,24 @@ extension TuistGraph.RunActionOptions {
                      generatorPaths: GeneratorPaths) throws -> TuistGraph.RunActionOptions
     {
         var storeKitConfigurationPath: AbsolutePath?
+        var simulatedLocation: SimulatedLocation?
 
         if let path = manifest.storeKitConfigurationPath {
             storeKitConfigurationPath = try generatorPaths.resolveSchemeActionProjectPath(path)
         }
 
+        if let simulatedLocationManifest = manifest.simulatedLocation {
+            switch simulatedLocationManifest {
+            case let .custom(gpxFile):
+                simulatedLocation = .gpxFile(try generatorPaths.resolveSchemeActionProjectPath(gpxFile))
+            default:
+                simulatedLocation = .reference(simulatedLocationManifest.identifier)
+            }
+        }
+
         return TuistGraph.RunActionOptions(
-            storeKitConfigurationPath: storeKitConfigurationPath
+            storeKitConfigurationPath: storeKitConfigurationPath,
+            simulatedLocation: simulatedLocation
         )
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/RunActionOptions+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/RunActionOptions+ManifestMapper.swift
@@ -19,12 +19,11 @@ extension TuistGraph.RunActionOptions {
             storeKitConfigurationPath = try generatorPaths.resolveSchemeActionProjectPath(path)
         }
 
-        if let simulatedLocationManifest = manifest.simulatedLocation {
-            switch simulatedLocationManifest {
-            case let .custom(gpxFile):
-                simulatedLocation = .gpxFile(try generatorPaths.resolveSchemeActionProjectPath(gpxFile))
-            default:
-                simulatedLocation = .reference(simulatedLocationManifest.identifier)
+        if let simulatedLocationIdentifier = manifest.simulatedLocation?.identifier {
+            if simulatedLocationIdentifier.hasSuffix(".gpx") {
+                simulatedLocation = .gpxFile(try generatorPaths.resolveSchemeActionProjectPath(Path(simulatedLocationIdentifier)))
+            } else {
+                simulatedLocation = .reference(simulatedLocationIdentifier)
             }
         }
 

--- a/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -523,7 +523,10 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
             configurationName: "Release",
             executable: TargetReference(projectPath: projectPath, name: "App"),
             arguments: Arguments(environment: environment, launchArguments: launchArguments),
-            options: .init(storeKitConfigurationPath: "/somepath/Workspace/Projects/Project/nested/configuration/configuration.storekit")
+            options: .init(
+                storeKitConfigurationPath: "/somepath/Workspace/Projects/Project/nested/configuration/configuration.storekit",
+                simulatedLocation: .reference("New York, NY, USA")
+            )
         )
 
         let scheme = Scheme.test(buildAction: buildAction, runAction: runAction)
@@ -576,6 +579,8 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         XCTAssertEqual(buildableReference.blueprintName, "App")
         XCTAssertEqual(buildableReference.buildableIdentifier, "primary")
         XCTAssertEqual(result.storeKitConfigurationFileReference, .init(identifier: "../nested/configuration/configuration.storekit"))
+        XCTAssertEqual(result.locationScenarioReference?.referenceType, "1")
+        XCTAssertEqual(result.locationScenarioReference?.identifier, "New York, NY, USA")
     }
 
     func test_schemeLaunchAction_argumentsOrder() throws {

--- a/fixtures/ios_app_with_custom_scheme/App/Project.swift
+++ b/fixtures/ios_app_with_custom_scheme/App/Project.swift
@@ -28,7 +28,6 @@ let project = Project(name: "MainApp",
                                  bundleId: "io.tuist.App",
                                  infoPlist: "Config/App-Info.plist",
                                  sources: "Sources/**",
-                                 resources: ["Resources/**"],
                                  dependencies: [
                                      .project(target: "Framework1", path: "../Frameworks/Framework1"),
                                      .project(target: "Framework2", path: "../Frameworks/Framework2"),

--- a/fixtures/ios_app_with_custom_scheme/App/Project.swift
+++ b/fixtures/ios_app_with_custom_scheme/App/Project.swift
@@ -5,14 +5,14 @@ let debugScheme = Scheme(name: "App-Debug",
                          shared: true,
                          buildAction: BuildAction(targets: ["App"], preActions: [debugAction]),
                          testAction: TestAction(targets: ["AppTests"]),
-                         runAction: RunAction(executable: "App"))
+                         runAction: RunAction(executable: "App", options: .options(simulatedLocation: .johannesburg)))
 
 let releaseAction = ExecutionAction(scriptText: "echo Release", target: "App")
 let releaseScheme = Scheme(name: "App-Release",
                            shared: true,
                            buildAction: BuildAction(targets: ["App"], preActions: [releaseAction]),
                            testAction: TestAction(targets: ["AppTests"]),
-                           runAction: RunAction(executable: "App"))
+                           runAction: RunAction(executable: "App", options: .options(simulatedLocation: .custom(gpxFile: "Resources/Grand Canyon.gpx"))))
 
 let userScheme = Scheme(name: "App-Local",
                         shared: false,
@@ -28,6 +28,7 @@ let project = Project(name: "MainApp",
                                  bundleId: "io.tuist.App",
                                  infoPlist: "Config/App-Info.plist",
                                  sources: "Sources/**",
+                                 resources: ["Resources/**"],
                                  dependencies: [
                                      .project(target: "Framework1", path: "../Frameworks/Framework1"),
                                      .project(target: "Framework2", path: "../Frameworks/Framework2"),

--- a/fixtures/ios_app_with_custom_scheme/App/Resources/Grand Canyon.gpx
+++ b/fixtures/ios_app_with_custom_scheme/App/Resources/Grand Canyon.gpx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<gpx
+xmlns="http://www.topografix.com/GPX/1/1"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd"
+version="1.1" 
+creator="gpx-poi.com">
+
+    <wpt lat="36.148789668355285" lon="-112.11270968753877">
+      <name>Grand Canyon</name>
+   </wpt>
+</gpx>

--- a/website/markdown/docs/usage/project-description.mdx
+++ b/website/markdown/docs/usage/project-description.mdx
@@ -1185,7 +1185,15 @@ Run action options represent the configuration of a run action.
       type: 'Path',
       optional: true,
       default: 'nil',
-    }
+    },
+    {
+      name: 'SimulatedLocation',
+      description:
+        'A simulated GPS location to use when running the app.',
+      type: 'SimulatedLocation',
+      optional: true,
+      default: 'nil',
+    },
   ]}
 />
 


### PR DESCRIPTION
### Short description 📝

This PR adds a new `simulatedLocation` property on RunAction's options. 

This allows setting either one of Xcode's built-in simulated locations for a scheme, or provide your own GPX file (as long as it's in the project's resources).

For example, this is done using

```swift
runAction: RunAction(config: .debug,
                     executable: "QA",
                     arguments: Arguments(
                       environment: [:],
                       launchArguments: []
                     ),
                     options: .options(
                       storeKitConfigurationPath: nil,
                       simulatedLocation: .custom(gpxFile: "Gett/Resources/Habarzel 21.gpx")
                     )
)
```

<img width="940" alt="image" src="https://user-images.githubusercontent.com/605076/110255194-20177a00-7f9b-11eb-90c9-02d2dd39a9bb.png">


I've tested this locally and added a quick unit test for the "inner" part, but not entirely sure how to test it from the outer interface (ProjectDescription side) - would love some guidance on that.

I'd also appreciate some guidance on where should I update the documentation - is it just the MDX file or anything beyond that? 

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
