### PR TITLE
[fix-tuistloader-docs] fix - `ManifestMappers`'s documentation

### DIFF
--- a/Sources/TuistLoader/Models+ManifestMappers/ArchiveAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/ArchiveAction+ManifestMapper.swift
@@ -5,7 +5,7 @@ import TuistCore
 import TuistGraph
 
 extension TuistGraph.ArchiveAction {
-    /// Maps a ProjectDescription.ArchiveAction instance into a TuistCore.ArchiveAction instance.
+    /// Maps a ProjectDescription.ArchiveAction instance into a TuistGraph.ArchiveAction instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of archive action model.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/Arguments+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Arguments+ManifestMapper.swift
@@ -4,7 +4,7 @@ import TuistCore
 import TuistGraph
 
 extension TuistGraph.Arguments {
-    /// Maps a ProjectDescription.Arguments instance into a TuistCore.Arguments instance.
+    /// Maps a ProjectDescription.Arguments instance into a TuistGraph.Arguments instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of arguments model.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/BuildAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/BuildAction+ManifestMapper.swift
@@ -5,7 +5,7 @@ import TuistCore
 import TuistGraph
 
 extension TuistGraph.BuildAction {
-    /// Maps a ProjectDescription.BuildAction instance into a TuistCore.BuildAction instance.
+    /// Maps a ProjectDescription.BuildAction instance into a TuistGraph.BuildAction instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of build action model.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/BuildConfiguration+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/BuildConfiguration+ManifestMapper.swift
@@ -4,7 +4,7 @@ import TuistCore
 import TuistGraph
 
 extension TuistGraph.BuildConfiguration {
-    /// Maps a ProjectDescription.BuildConfiguration instance into a TuistCore.BuildConfiguration instance.
+    /// Maps a ProjectDescription.BuildConfiguration instance into a TuistGraph.BuildConfiguration instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of build configuration model.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/CompatibleXcodeVersions+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/CompatibleXcodeVersions+ManifestMapper.swift
@@ -6,7 +6,7 @@ import TuistGraph
 import TuistSupport
 
 extension TuistGraph.CompatibleXcodeVersions {
-    /// Maps a ProjectDescription.CompatibleXcodeVersions instance into a TuistCore.CompatibleXcodeVersions model.
+    /// Maps a ProjectDescription.CompatibleXcodeVersions instance into a TuistGraph.CompatibleXcodeVersions model.
     /// - Parameters:
     ///   - manifest: Manifest representation of compatible Xcode versions.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/Config+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Config+ManifestMapper.swift
@@ -6,7 +6,7 @@ import TuistGraph
 import TuistSupport
 
 extension TuistGraph.Config {
-    /// Maps a ProjectDescription.Config instance into a TuistCore.Config model.
+    /// Maps a ProjectDescription.Config instance into a TuistGraph.Config model.
     /// - Parameters:
     ///   - manifest: Manifest representation of Tuist config.
     ///   - path: The path of the config file.
@@ -38,7 +38,7 @@ extension TuistGraph.Config {
 }
 
 extension TuistGraph.Config.GenerationOption {
-    /// Maps a ProjectDescription.Config.GenerationOptions instance into a TuistCore.Config.GenerationOptions model.
+    /// Maps a ProjectDescription.Config.GenerationOptions instance into a TuistGraph.Config.GenerationOptions model.
     /// - Parameters:
     ///   - manifest: Manifest representation of Tuist config generation options
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/Configuration+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Configuration+ManifestMapper.swift
@@ -6,7 +6,7 @@ import TuistGraph
 import TuistSupport
 
 extension TuistGraph.Configuration {
-    /// Maps a ProjectDescription.Configuration instance into a TuistCore.Configuration instance.
+    /// Maps a ProjectDescription.Configuration instance into a TuistGraph.Configuration instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of configuration.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/CopyFilesAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/CopyFilesAction+ManifestMapper.swift
@@ -19,7 +19,7 @@ public enum CopyFilesManifestMapperError: FatalError {
 }
 
 extension TuistGraph.CopyFilesAction {
-    /// Maps a ProjectDescription.CopyFilesAction instance into a TuistCore.CopyFilesAction instance.
+    /// Maps a ProjectDescription.CopyFilesAction instance into a TuistGraph.CopyFilesAction instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of platform model.
     ///   - generatorPaths: Generator paths.
@@ -53,7 +53,7 @@ extension TuistGraph.CopyFilesAction {
 }
 
 extension TuistGraph.CopyFilesAction.Destination {
-    /// Maps a ProjectDescription.TargetAction.Destination instance into a TuistCore.TargetAction.Destination model.
+    /// Maps a ProjectDescription.TargetAction.Destination instance into a TuistGraph.TargetAction.Destination model.
     /// - Parameters:
     ///   - manifest: Manifest representation of target action destination.
     static func from(manifest: ProjectDescription.CopyFilesAction.Destination) -> TuistGraph.CopyFilesAction.Destination {

--- a/Sources/TuistLoader/Models+ManifestMappers/CoreDataModel+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/CoreDataModel+ManifestMapper.swift
@@ -6,7 +6,7 @@ import TuistGraph
 import TuistSupport
 
 extension TuistGraph.CoreDataModel {
-    /// Maps a ProjectDescription.CoreDataModel instance into a TuistCore.CoreDataModel instance.
+    /// Maps a ProjectDescription.CoreDataModel instance into a TuistGraph.CoreDataModel instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of Core Data model.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/DefaultSettings+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/DefaultSettings+ManifestMapper.swift
@@ -6,7 +6,7 @@ import TuistGraph
 import TuistSupport
 
 extension TuistGraph.DefaultSettings {
-    /// Maps a ProjectDescription.DefaultSettings instance into a TuistCore.DefaultSettings model.
+    /// Maps a ProjectDescription.DefaultSettings instance into a TuistGraph.DefaultSettings model.
     /// - Parameters:
     ///   - manifest: Manifest representation of default settings.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/DeploymentTarget+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/DeploymentTarget+ManifestMapper.swift
@@ -4,7 +4,7 @@ import TuistCore
 import TuistGraph
 
 extension TuistGraph.DeploymentTarget {
-    /// Maps a ProjectDescription.DeploymentTarget instance into a TuistCore.DeploymentTarget instance.
+    /// Maps a ProjectDescription.DeploymentTarget instance into a TuistGraph.DeploymentTarget instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of deployment target model.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/ExecutionAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/ExecutionAction+ManifestMapper.swift
@@ -4,7 +4,7 @@ import TSCBasic
 import TuistGraph
 
 extension TuistGraph.ExecutionAction {
-    /// Maps a ProjectDescription.ExecutionAction instance into a TuistCore.ExecutionAction instance.
+    /// Maps a ProjectDescription.ExecutionAction instance into a TuistGraph.ExecutionAction instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of execution action model.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/FileElement+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/FileElement+ManifestMapper.swift
@@ -6,7 +6,7 @@ import TuistGraph
 import TuistSupport
 
 extension TuistGraph.FileElement {
-    /// Maps a ProjectDescription.FileElement instance into a [TuistCore.FileElement] instance.
+    /// Maps a ProjectDescription.FileElement instance into a [TuistGraph.FileElement] instance.
     /// Glob patterns in file elements are unfolded as part of the mapping.
     /// - Parameters:
     ///   - manifest: Manifest representation of  the file element.

--- a/Sources/TuistLoader/Models+ManifestMappers/Headers+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Headers+ManifestMapper.swift
@@ -6,7 +6,7 @@ import TuistGraph
 import TuistSupport
 
 extension TuistGraph.Headers {
-    /// Maps a ProjectDescription.Headers instance into a TuistCore.Headers model.
+    /// Maps a ProjectDescription.Headers instance into a TuistGraph.Headers model.
     /// Glob patterns are resolved as part of the mapping process.
     /// - Parameters:
     ///   - manifest: Manifest representation of Headers.

--- a/Sources/TuistLoader/Models+ManifestMappers/InfoPlist+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/InfoPlist+ManifestMapper.swift
@@ -5,7 +5,7 @@ import TuistCore
 import TuistGraph
 
 extension TuistGraph.InfoPlist {
-    /// Maps a ProjectDescription.InfoPlist instance into a TuistCore.InfoPlist instance.
+    /// Maps a ProjectDescription.InfoPlist instance into a TuistGraph.InfoPlist instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of the Info plist model.
     ///   - generatorPaths: Generator paths.
@@ -25,7 +25,7 @@ extension TuistGraph.InfoPlist {
 }
 
 extension TuistGraph.InfoPlist.Value {
-    /// Maps a ProjectDescription.InfoPlist.Value instance into a TuistCore.InfoPlist.Value instance.
+    /// Maps a ProjectDescription.InfoPlist.Value instance into a TuistGraph.InfoPlist.Value instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of the Info plist value model.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/LaunchArgument+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/LaunchArgument+ManifestMapper.swift
@@ -4,7 +4,7 @@ import TuistCore
 import TuistGraph
 
 extension TuistGraph.LaunchArgument {
-    /// Maps a ProjectDescription.LaunchArgument instance into a TuistCore.LaunchArgument instance.
+    /// Maps a ProjectDescription.LaunchArgument instance into a TuistGraph.LaunchArgument instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of launch argument model.
     static func from(manifest: ProjectDescription.LaunchArgument) -> TuistGraph.LaunchArgument {

--- a/Sources/TuistLoader/Models+ManifestMappers/Package+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Package+ManifestMapper.swift
@@ -6,7 +6,7 @@ import TuistGraph
 import TuistSupport
 
 extension TuistGraph.Package {
-    /// Maps a ProjectDescription.Package instance into a TuistCore.Package model.
+    /// Maps a ProjectDescription.Package instance into a TuistGraph.Package model.
     /// - Parameters:
     ///   - manifest: Manifest representation of Package.
     ///   - generatorPaths: Generator paths.
@@ -21,7 +21,7 @@ extension TuistGraph.Package {
 }
 
 extension TuistGraph.Requirement {
-    /// Maps a ProjectDescription.Package.Requirement instance into a TuistCore.Package.Requirement model.
+    /// Maps a ProjectDescription.Package.Requirement instance into a TuistGraph.Package.Requirement model.
     /// - Parameters:
     ///   - manifest: Manifest representation of Package.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/Platform+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Platform+ManifestMapper.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 import TuistGraph
 
 extension TuistGraph.Platform {
-    /// Maps a ProjectDescription.Platform instance into a TuistCore.Platform instance.
+    /// Maps a ProjectDescription.Platform instance into a TuistGraph.Platform instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of platform model.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/PluginLocation+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/PluginLocation+ManifestMapper.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 import TuistGraph
 
 extension TuistGraph.PluginLocation {
-    /// Convert from `ProjectDescription.PluginLocation` to `TuistCore.PluginLocation`
+    /// Convert from `ProjectDescription.PluginLocation` to `TuistGraph.PluginLocation`
     static func from(
         manifest: ProjectDescription.PluginLocation,
         generatorPaths: GeneratorPaths

--- a/Sources/TuistLoader/Models+ManifestMappers/Product+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Product+ManifestMapper.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 import TuistGraph
 
 extension TuistGraph.Product {
-    /// Maps a ProjectDescription.Product instance into a TuistCore.Product instance.
+    /// Maps a ProjectDescription.Product instance into a TuistGraph.Product instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of product model.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Project+ManifestMapper.swift
@@ -4,7 +4,7 @@ import TSCBasic
 import TuistGraph
 
 extension TuistGraph.Project {
-    /// Maps a ProjectDescription.FileElement instance into a [TuistCore.FileElement] instance.
+    /// Maps a ProjectDescription.FileElement instance into a [TuistGraph.FileElement] instance.
     /// Glob patterns in file elements are unfolded as part of the mapping.
     /// - Parameters:
     ///   - manifest: Manifest representation of  the file element.

--- a/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
@@ -6,7 +6,7 @@ import TuistGraph
 import TuistSupport
 
 extension TuistGraph.ResourceFileElement {
-    /// Maps a ProjectDescription.ResourceFileElement instance into a [TuistCore.ResourceFileElement] instance.
+    /// Maps a ProjectDescription.ResourceFileElement instance into a [TuistGraph.ResourceFileElement] instance.
     /// Glob patterns in file elements are unfolded as part of the mapping.
     /// - Parameters:
     ///   - manifest: Manifest representation of  the file element.

--- a/Sources/TuistLoader/Models+ManifestMappers/RunAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/RunAction+ManifestMapper.swift
@@ -5,7 +5,7 @@ import TuistCore
 import TuistGraph
 
 extension TuistGraph.RunAction {
-    /// Maps a ProjectDescription.RunAction instance into a TuistCore.RunAction instance.
+    /// Maps a ProjectDescription.RunAction instance into a TuistGraph.RunAction instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of  the settings.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/SDKStatus+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/SDKStatus+ManifestMapper.swift
@@ -4,7 +4,7 @@ import TuistCore
 import TuistGraph
 
 extension TuistGraph.SDKStatus {
-    /// Maps a ProjectDescription.SDKStatus instance into a TuistCore.SDKStatus instance.
+    /// Maps a ProjectDescription.SDKStatus instance into a TuistGraph.SDKStatus instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of SDK status model.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/Scheme+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Scheme+ManifestMapper.swift
@@ -5,7 +5,7 @@ import TuistCore
 import TuistGraph
 
 extension TuistGraph.Scheme {
-    /// Maps a ProjectDescription.Scheme instance into a TuistCore.Scheme instance.
+    /// Maps a ProjectDescription.Scheme instance into a TuistGraph.Scheme instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of build action model.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/SettingValue+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/SettingValue+ManifestMapper.swift
@@ -6,7 +6,7 @@ import TuistGraph
 import TuistSupport
 
 extension TuistGraph.SettingValue {
-    /// Maps a ProjectDescription.SettingValue instance into a TuistCore.SettingValue model.
+    /// Maps a ProjectDescription.SettingValue instance into a TuistGraph.SettingValue model.
     /// - Parameters:
     ///   - manifest: Manifest representation of setting value.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/Settings+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Settings+ManifestMapper.swift
@@ -7,7 +7,7 @@ import TuistGraph
 extension TuistGraph.Settings {
     typealias BuildConfigurationTuple = (TuistGraph.BuildConfiguration, TuistGraph.Configuration?)
 
-    /// Maps a ProjectDescription.Settings instance into a TuistCore.Settings instance.
+    /// Maps a ProjectDescription.Settings instance into a TuistGraph.Settings instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of  the settings.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
@@ -20,7 +20,7 @@ public enum TargetManifestMapperError: FatalError {
 
 // swiftlint:disable function_body_length
 extension TuistGraph.Target {
-    /// Maps a ProjectDescription.Target instance into a TuistCore.Target instance.
+    /// Maps a ProjectDescription.Target instance into a TuistGraph.Target instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of  the target.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
@@ -6,7 +6,7 @@ import TuistGraph
 import TuistSupport
 
 extension TuistGraph.TargetAction {
-    /// Maps a ProjectDescription.TargetAction instance into a TuistCore.TargetAction model.
+    /// Maps a ProjectDescription.TargetAction instance into a TuistGraph.TargetAction model.
     /// - Parameters:
     ///   - manifest: Manifest representation of target action.
     ///   - generatorPaths: Generator paths.
@@ -46,7 +46,7 @@ extension TuistGraph.TargetAction {
 }
 
 extension TuistGraph.TargetAction.Order {
-    /// Maps a ProjectDescription.TargetAction.Order instance into a TuistCore.TargetAction.Order model.
+    /// Maps a ProjectDescription.TargetAction.Order instance into a TuistGraph.TargetAction.Order model.
     /// - Parameters:
     ///   - manifest: Manifest representation of target action order.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
@@ -5,7 +5,7 @@ import TuistCore
 import TuistGraph
 
 extension TuistGraph.TestAction {
-    /// Maps a ProjectDescription.TestAction instance into a TuistCore.TestAction instance.
+    /// Maps a ProjectDescription.TestAction instance into a TuistGraph.TestAction instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of test action model.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/TestableTarget+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TestableTarget+ManifestMapper.swift
@@ -5,7 +5,7 @@ import TuistCore
 import TuistGraph
 
 extension TuistGraph.TestableTarget {
-    /// Maps a ProjectDescription.TestableTarget instance into a TuistCore.TestableTarget instance.
+    /// Maps a ProjectDescription.TestableTarget instance into a TuistGraph.TestableTarget instance.
     /// - Parameters:
     ///   - manifest: Manifest representation of testable target model.
     ///   - generatorPaths: Generator paths.

--- a/Sources/TuistLoader/Models+ManifestMappers/Workspace+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Workspace+ManifestMapper.swift
@@ -6,7 +6,7 @@ import TuistGraph
 import TuistSupport
 
 extension TuistGraph.Workspace {
-    /// Maps a ProjectDescription.Workspace instance into a TuistCore.Workspace model.
+    /// Maps a ProjectDescription.Workspace instance into a TuistGraph.Workspace model.
     /// - Parameters:
     ///   - manifest: Manifest representation of  workspace.
     ///   - generatorPaths: Generator paths.


### PR DESCRIPTION
### Short description 📝

In this [PR](https://github.com/tuist/tuist/pull/2324) graph models were moved from `TuistCore` to `TuistGraph`. Because of that documentation of `ManifestMappers` from `TuistLoader` has been outdated.  

`TuistCore.*` prefix may confuse contributors whose doesn't know the project's history. In this PR I updated mappers documentation to meet todays state. 

### Question ❓ 

- Should I mention this change in the `Changelog`? 