### PR TITLE
Use double quoted ruby imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Changed
 
+- Double-quoted strings in ruby files [#2634](https://github.com/tuist/tuist/pull/2634) by [@fortmarek](https://github.com/fortmarek)
 - Improve `tuist generate` performance for projects with large amount of files [#2598](https://github.com/tuist/tuist/pull/2598) by [@adellibovi](https://github.com/adellibovi/)
 - Added wrap arguments swiftformat option [#2606](https://github.com/tuist/tuist/pull/2606) by [@fortmarek](https://github.com/fortmarek)
 - Remove build action for project generated in `tuist test` [#2592]()https://github.com/tuist/tuist/pull/2592 [@fortmarek](https://github.com/fortmarek)

--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,8 @@ gem "thor", "~> 1.1"
 
 group :test do
   gem "mocha", "~> 1.12"
-  gem 'minitest'
-  gem 'minitest-reporters'
+  gem "minitest"
+  gem "minitest-reporters"
 end
 
 group :development do

--- a/Rakefile
+++ b/Rakefile
@@ -4,27 +4,27 @@ SWIFTDOC_VERSION = "1.0.0-beta.5"
 SWIFTLINT_VERSION = "0.40.2"
 XCBEAUTIFY_VERSION = "0.8.1"
 
-require 'rake/testtask'
-require 'rubygems'
-require 'cucumber'
-require 'cucumber/rake/task'
-require 'mkmf'
-require 'fileutils'
+require "rake/testtask"
+require "rubygems"
+require "cucumber"
+require "cucumber/rake/task"
+require "mkmf"
+require "fileutils"
 require "google/cloud/storage"
 require "encrypted/environment"
-require 'colorize'
-require 'highline'
-require 'tmpdir'
-require 'json'
-require 'zip'
-require 'macho'
+require "colorize"
+require "highline"
+require "tmpdir"
+require "json"
+require "zip"
+require "macho"
 
 desc("Runs the Fourier tests")
 Rake::TestTask.new do |t|
   t.name = "test_fourier"
-  t.libs += [File.expand_path('./tools/fourier/test', __dir__)]
-  test_root = File.expand_path('./tools/fourier/test', __dir__)
-  t.test_files = FileList[File.join(test_root, '**', '*_test.rb')]
+  t.libs += [File.expand_path("./tools/fourier/test", __dir__)]
+  test_root = File.expand_path("./tools/fourier/test", __dir__)
+  t.test_files = FileList[File.join(test_root, "**", "*_test.rb")]
   t.verbose = false
   t.warning = false
 end

--- a/bin/fourier
+++ b/bin/fourier
@@ -13,6 +13,6 @@ fourier_directory = File.expand_path("../tools/fourier/lib", __dir__)
 $LOAD_PATH.unshift(fourier_directory) unless $LOAD_PATH.include?(fourier_directory)
 
 # Load Fourier
-require 'fourier'
+require "fourier"
 
 Fourier::CLI.start(ARGV)

--- a/features/step_definitions/cache.rb
+++ b/features/step_definitions/cache.rb
@@ -1,4 +1,4 @@
-require 'xcodeproj'
+require "xcodeproj"
 
 Then(/^tuist warms the cache$/) do
   system("swift", "run", "tuist", "cache", "warm", "--path", @dir)

--- a/features/step_definitions/shared/fixtures.rb
+++ b/features/step_definitions/shared/fixtures.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'fileutils'
+require "fileutils"
 
 Then(/I copy the fixture (.+) into the working directory/) do |fixture|
   fixtures_path = File.expand_path("../../../fixtures", __dir__)

--- a/features/step_definitions/shared/tuist.rb
+++ b/features/step_definitions/shared/tuist.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'open3'
+require "open3"
 
 Given(/tuist is available/) do
   system("swift", "build", "--package-path", File.expand_path("../../..", __dir__))

--- a/features/step_definitions/shared/workspace.rb
+++ b/features/step_definitions/shared/workspace.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'tmpdir'
-require 'fileutils'
+require "tmpdir"
+require "fileutils"
 
 And(/I have a working directory/) do
   @dir = Dir.mktmpdir

--- a/features/step_definitions/shared/xcode.rb
+++ b/features/step_definitions/shared/xcode.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'simctl'
-require 'xcodeproj'
+require "simctl"
+require "xcodeproj"
 
 Then(/I should be able to (.+) for (iOS|macOS|tvOS|watchOS) the scheme (.+)/) do |action, platform, scheme|
   @derived_data_path = File.join(@dir, "DerivedData")

--- a/features/step_definitions/test.rb
+++ b/features/step_definitions/test.rb
@@ -1,4 +1,4 @@
-require 'xcodeproj'
+require "xcodeproj"
 
 Then(/^tuist tests the scheme ([a-zA-Z\-]+) from the project$/) do |scheme|
   system("swift", "run", "tuist", "test", scheme, "--path", @dir)

--- a/features/support/assertions.rb
+++ b/features/support/assertions.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'minitest/spec'
-require 'minitest/assertions'
+require "minitest/spec"
+require "minitest/assertions"
 
 class MinitestWorld
   include Minitest::Assertions

--- a/features/support/xcode.rb
+++ b/features/support/xcode.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-require 'minitest/assertions'
-require 'xcodeproj'
-require 'simctl'
+require "minitest/assertions"
+require "xcodeproj"
+require "simctl"
 
 module Xcode
   include Minitest::Assertions

--- a/tools/fourier/lib/fourier.rb
+++ b/tools/fourier/lib/fourier.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'cli/ui'
+require "cli/ui"
 
 module Fourier
   autoload :CLI,        "fourier/cli"

--- a/tools/fourier/lib/fourier/services/test/tuist/acceptance.rb
+++ b/tools/fourier/lib/fourier/services/test/tuist/acceptance.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'cucumber/cli/main'
+require "cucumber/cli/main"
 
 module Fourier
   module Services
@@ -24,7 +24,7 @@ module Fourier
             end
 
             failure = Cucumber::Cli::Main.execute(args)
-            raise Error, 'Cucumber failed' if failure
+            raise Error, "Cucumber failed" if failure
           end
         end
       end

--- a/tools/fourier/lib/fourier/utilities/github_client.rb
+++ b/tools/fourier/lib/fourier/utilities/github_client.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'octokit'
+require "octokit"
 
 module Fourier
   module Utilities

--- a/tools/fourier/test/fourier/services/test/tuist/acceptance_test.rb
+++ b/tools/fourier/test/fourier/services/test/tuist/acceptance_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require "test_helper"
-require 'cucumber/cli/main'
+require "cucumber/cli/main"
 
 module Fourier
   module Services

--- a/tools/fourier/test/fourier/services/test/tuist/acceptance_test.rb
+++ b/tools/fourier/test/fourier/services/test/tuist/acceptance_test.rb
@@ -42,7 +42,7 @@ module Fourier
             end
 
             # Then
-            assert_equal('Cucumber failed', error.message)
+            assert_equal("Cucumber failed", error.message)
           end
         end
       end

--- a/tools/fourier/test/fourier/utilities/github_client_test.rb
+++ b/tools/fourier/test/fourier/utilities/github_client_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require "test_helper"
-require 'octokit'
+require "octokit"
 
 module Fourier
   module Utilities

--- a/tools/fourier/test/test_helper.rb
+++ b/tools/fourier/test/test_helper.rb
@@ -4,23 +4,23 @@ addpath = lambda do |p|
 end
 addpath.call(File.expand_path("../lib", __dir__))
 
-require 'cli/ui'
-require 'fileutils'
-require 'tmpdir'
-require 'tempfile'
-require 'byebug'
+require "cli/ui"
+require "fileutils"
+require "tmpdir"
+require "tempfile"
+require "byebug"
 
 CLI::UI::StdoutRouter.enable
 
-require 'minitest/autorun'
+require "minitest/autorun"
 require "minitest/unit"
-require 'minitest/reporters'
+require "minitest/reporters"
 
 reporter_options = { color: true }
 Minitest::Reporters.use!([Minitest::Reporters::DefaultReporter.new(reporter_options)])
 
-require 'mocha/minitest'
-require 'fourier'
+require "mocha/minitest"
+require "fourier"
 
 class TestCase < MiniTest::Test
   def root_directory


### PR DESCRIPTION
### Short description 📝

It seems like main is failing because rubocop is warning about single-quoted strings for eg. `require` instead of double-quoted: https://github.com/tuist/tuist/runs/2063816194

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
