### PR TITLE
XCFrameworks cache support for external dependencies

### DIFF
--- a/Sources/TuistCache/Utilities/CacheXCFrameworkBuilder.swift
+++ b/Sources/TuistCache/Utilities/CacheXCFrameworkBuilder.swift
@@ -119,7 +119,6 @@ public final class CacheXCFrameworkBuilder: CacheArtifactBuilding {
                                  configuration: String,
                                  archivePath: AbsolutePath) throws
     {
-        // Without the BUILD_LIBRARY_FOR_DISTRIBUTION argument xcodebuild doesn't generate the .swiftinterface file
         _ = try xcodeBuildController.archive(
             projectTarget,
             scheme: scheme,
@@ -127,8 +126,6 @@ public final class CacheXCFrameworkBuilder: CacheArtifactBuilding {
             archivePath: archivePath,
             arguments: [
                 .sdk(target.platform.xcodeDeviceSDK),
-                .xcarg("SKIP_INSTALL", "NO"),
-                .xcarg("BUILD_LIBRARY_FOR_DISTRIBUTION", "YES"),
                 .configuration(configuration),
             ]
         )
@@ -147,7 +144,6 @@ public final class CacheXCFrameworkBuilder: CacheArtifactBuilding {
                                     configuration: String,
                                     archivePath: AbsolutePath) throws
     {
-        // Without the BUILD_LIBRARY_FOR_DISTRIBUTION argument xcodebuild doesn't generate the .swiftinterface file
         _ = try xcodeBuildController.archive(
             projectTarget,
             scheme: scheme,
@@ -156,7 +152,6 @@ public final class CacheXCFrameworkBuilder: CacheArtifactBuilding {
             arguments: [
                 .sdk(target.platform.xcodeSimulatorSDK!),
                 .xcarg("SKIP_INSTALL", "NO"),
-                .xcarg("BUILD_LIBRARY_FOR_DISTRIBUTION", "YES"),
                 .configuration(configuration),
             ]
         )

--- a/Sources/TuistKit/Cache/CacheController.swift
+++ b/Sources/TuistKit/Cache/CacheController.swift
@@ -22,7 +22,23 @@ class CacheControllerProjectMapperProvider: ProjectMapperProviding {
     func mapper(config: Config) -> ProjectMapping {
         let defaultProjectMapperProvider = ProjectMapperProvider(contentHasher: contentHasher)
         let defaultMapper = defaultProjectMapperProvider.mapper(config: config)
-        return SequentialProjectMapper(mappers: [defaultMapper])
+        return SequentialProjectMapper(
+            mappers: [
+                defaultMapper,
+                XCFrameworkProjectMapper(),
+            ]
+        )
+    }
+}
+
+final class XCFrameworkProjectMapper: ProjectMapping {
+    func map(project: Project) throws -> (Project, [SideEffectDescriptor]) {
+        var project = project
+        var base = project.settings.base
+        base["BUILD_LIBRARY_FOR_DISTRIBUTION"] = "YES"
+        base["SKIP_INSTALL"] = "NO"
+        project.settings = project.settings.with(base: base)
+        return (project, [])
     }
 }
 

--- a/fixtures/ios_workspace_with_microfeature_architecture/.package.resolved
+++ b/fixtures/ios_workspace_with_microfeature_architecture/.package.resolved
@@ -1,0 +1,79 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "grpc-swift",
+        "repositoryURL": "https://github.com/grpc/grpc-swift.git",
+        "state": {
+          "branch": null,
+          "revision": "9e464a75079928366aa7041769a271fac89271bf",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "state": {
+          "branch": null,
+          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
+          "version": "1.4.2"
+        }
+      },
+      {
+        "package": "swift-nio",
+        "repositoryURL": "https://github.com/apple/swift-nio.git",
+        "state": {
+          "branch": null,
+          "revision": "6d3ca7e54e06a69d0f2612c2ce8bb8b7319085a4",
+          "version": "2.26.0"
+        }
+      },
+      {
+        "package": "swift-nio-extras",
+        "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
+        "state": {
+          "branch": null,
+          "revision": "de1c80ad1fdff1ba772bcef6b392c3ef735f39a6",
+          "version": "1.8.0"
+        }
+      },
+      {
+        "package": "swift-nio-http2",
+        "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
+        "state": {
+          "branch": null,
+          "revision": "f4736a3b78a2bbe3feb7fc0f33f6683a8c27974c",
+          "version": "1.16.3"
+        }
+      },
+      {
+        "package": "swift-nio-ssl",
+        "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
+        "state": {
+          "branch": null,
+          "revision": "bbb38fbcbbe9dc4665b2c638dfa5681b01079bfb",
+          "version": "2.10.4"
+        }
+      },
+      {
+        "package": "swift-nio-transport-services",
+        "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
+        "state": {
+          "branch": null,
+          "revision": "1d28d48e071727f4558a8a4bb1894472abc47a58",
+          "version": "1.9.2"
+        }
+      },
+      {
+        "package": "SwiftProtobuf",
+        "repositoryURL": "https://github.com/apple/swift-protobuf.git",
+        "state": {
+          "branch": null,
+          "revision": "e1904bf5a5f79cb7e0ff68a427a53a93b652fcd1",
+          "version": "1.15.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/CoreFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/CoreFramework/Project.swift
@@ -1,25 +1,37 @@
 import ProjectDescription
 import BundlePlugin
 
-let project = Project(name: "Core",
-                      targets: [
-                        Target(name: "Core",
-                               platform: .iOS,
-                               product: .framework,
-                               bundleId: .bundleId(for: "Core"),
-                               infoPlist: "Info.plist",
-                               sources: ["Sources/**"],
-                               resources: [
-                                       /* Path to resources can be defined here */
-                                       // "Resources/**"
-                               ]),
-                        Target(name: "CoreTests",
-                               platform: .iOS,
-                               product: .unitTests,
-                               bundleId: .bundleId(for: "CoreTests"),
-                               infoPlist: "Tests.plist",
-                               sources: "Tests/**",
-                               dependencies: [
-                                    .target(name: "Core")
-                               ])
-                      ])
+let project = Project(
+    name: "Core",
+    packages: [
+        .package(url: "https://github.com/grpc/grpc-swift.git", .upToNextMajor(from: "1.0.0")),
+    ],
+    targets: [
+        Target(
+            name: "Core",
+            platform: .iOS,
+            product: .framework,
+            bundleId: .bundleId(for: "Core"),
+            infoPlist: "Info.plist",
+            sources: ["Sources/**"],
+            resources: [
+                /* Path to resources can be defined here */
+                // "Resources/**"
+            ],
+            dependencies: [
+                .package(product: "GRPC"),
+            ]
+        ),
+        Target(
+            name: "CoreTests",
+            platform: .iOS,
+            product: .unitTests,
+            bundleId: .bundleId(for: "CoreTests"),
+            infoPlist: "Tests.plist",
+            sources: "Tests/**",
+            dependencies: [
+                .target(name: "Core")
+            ]
+        )
+    ]
+)

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/CoreFramework/Sources/CoreClass.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/CoreFramework/Sources/CoreClass.swift
@@ -1,5 +1,9 @@
 import Foundation
+@_implementationOnly import GRPC
 
 public class CoreClass {
-    public init() {}
+    public init() {
+        let statusCode = GRPCStatus.Code.alreadyExists
+        print(statusCode)
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/2635

### Short description 📝

This is a WIP approach for [this](https://github.com/tuist/tuist/issues/2635) issue. It currently changes `BUILD_LIBRARY_FOR_DISTRIBUTION` to true for project settings + plus does not add this flag to `xcodebuild`.

Fixture `ios_app_with_microfeature_architecture` with tuist version from this PR is cacheable with `--xcframeworks` flag whereas the latest tuist version `1.36.0` does not.

Now, we need to decide whether to create a new project in a temp dir as we do for `tuist test` or we are fine with modifying the `.xcodeproj` in the current dir (not ideal, though).

If we want to use a temp dir, we probably should resolve [pods](https://github.com/tuist/tuist/issues/2453) issue

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
