### PR TITLE
Support resolving SPM dependencies using system SCM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Added
 
+- Allow using system SCM (for example: Git) when resolving SPM dependencies, instead of Xcode's accounts. [#2638](https://github.com/tuist/tuist/pull/2638) by [@freak4pc](https://github.com/freak4pc)
 - Add support for simulated location in a run action's options. [#2616](https://github.com/tuist/tuist/pull/2616) by [@freak4pc](https://github.com/freak4pc)
 - Add option for enabling XCFrameworks production for Carthage in `Setup.swift`. [#2565](https://github.com/tuist/tuist/pull/2565) by [@laxmorek](https://github.com/laxmorek)
 - Add support for custom file header templates that are used for built-in Xcode file templates [#2568](https://github.com/tuist/tuist/pull/2568) by [@olejnjak](https://github.com/olejnjak)

--- a/Sources/TuistGraph/Models/Config.swift
+++ b/Sources/TuistGraph/Models/Config.swift
@@ -15,6 +15,7 @@ public struct Config: Equatable, Hashable {
         case disableShowEnvironmentVarsInScriptPhases
         case enableCodeCoverage
         case templateMacros(IDETemplateMacros)
+        case resolveDependenciesWithSystemScm
     }
 
     /// List of `Plugin`s used to extend Tuist.

--- a/Sources/TuistKit/Generator/Generator.swift
+++ b/Sources/TuistKit/Generator/Generator.swift
@@ -218,8 +218,10 @@ class Generator: Generating {
     }
 
     private func postGenerationActions(graphTraverser: GraphTraversing, workspaceName: String) throws {
+        let config = try configLoader.loadConfig(path: graphTraverser.path)
+
         try signingInteractor.install(graphTraverser: graphTraverser)
-        try swiftPackageManagerInteractor.install(graphTraverser: graphTraverser, workspaceName: workspaceName)
+        try swiftPackageManagerInteractor.install(graphTraverser: graphTraverser, workspaceName: workspaceName, config: config)
         try cocoapodsInteractor.install(graphTraverser: graphTraverser)
     }
 

--- a/website/markdown/docs/usage/config.mdx
+++ b/website/markdown/docs/usage/config.mdx
@@ -130,6 +130,16 @@ Generation options allow customizing the generation of Xcode projects.
       description:
         'Enable code coverage for auto generated schemes.',
     },
+    {
+      case: '.templateMacros(IDETemplateMacros)',
+      description:
+        'Apply IDE Template macros to your project.',
+    },
+    {
+      case: '.resolveDependenciesWithSystemScm',
+      description:
+        'Resolve SPM dependencies using your system\'s SCM credentials, instead of Xcode\s accounts.',
+    },
   ]}
 />
 


### PR DESCRIPTION
### Short description 📝

This adds the ability to pass `-scmProvider system` to `xcodebuild -resolveDependencies` so it uses the system's credentials for Git, for example, instead of forcing users to add their Git account to Xcode's Accounts tab.

I contemplated with either doing `resolveDependenciesWithSystemScm` or something like:

```swift
dependencyResolutionScm(SCMProvider)

enum SCMProvider: String, Codable { 
    case xcode
    case system
}
```

The default is Xcode so I thought allowing to specify it wouldn't be too valuable, but I'm happy to change if you prefer that option. 

Let me know what you think :) 

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
