### PR TITLE
Install script bug fix: Adding bin folder to usr/local/ when it is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Fixed running `tuist test` with `--clean` flag [#2649](https://github.com/tuist/tuist/pull/2649) by [@fortmarek](https://github.com/fortmarek)
+- Install script bug fix: Adding bin folder to usr/local/bin when it is missing [#2655](https://github.com/tuist/tuist/pull/2655) by [@tiarnann](https://github.com/tiarnann)
 
 ## 1.37.0 - Twister
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Fixed running `tuist test` with `--clean` flag [#2649](https://github.com/tuist/tuist/pull/2649) by [@fortmarek](https://github.com/fortmarek)
-- Install script bug fix: Adding bin folder to usr/local/bin when it is missing [#2655](https://github.com/tuist/tuist/pull/2655) by [@tiarnann](https://github.com/tiarnann)
+- Install script bug fix: Adding bin folder to usr/local/ when it is missing [#2655](https://github.com/tuist/tuist/pull/2655) by [@tiarnann](https://github.com/tiarnann)
 
 ## 1.37.0 - Twister
 

--- a/script/install
+++ b/script/install
@@ -80,6 +80,7 @@ curl -LSs --output /tmp/tuistenv.zip https://storage.googleapis.com/tuist-releas
 ohai "Unzipping tuistenv..."
 unzip -o /tmp/tuistenv.zip -d /tmp/tuistenv > /dev/null
 ohai "Installing tuistenv..."
+[ ! -d "/usr/local/bin" ] && execute_sudo mkdir /usr/local/bin/
 execute_sudo mv /tmp/tuistenv/tuistenv /usr/local/bin/tuist
 execute_sudo ln -sf /usr/local/bin/tuist /usr/local/bin/swift-project
 execute_sudo chmod +x /usr/local/bin/tuist

--- a/script/install
+++ b/script/install
@@ -80,7 +80,10 @@ curl -LSs --output /tmp/tuistenv.zip https://storage.googleapis.com/tuist-releas
 ohai "Unzipping tuistenv..."
 unzip -o /tmp/tuistenv.zip -d /tmp/tuistenv > /dev/null
 ohai "Installing tuistenv..."
-[ ! -d "/usr/local/bin" ] && execute_sudo mkdir /usr/local/bin/
+
+if [[ ! -d "/usr/local/bin" ]]; then
+  execute_sudo mkdir /usr/local/bin/
+fi
 execute_sudo mv /tmp/tuistenv/tuistenv /usr/local/bin/tuist
 execute_sudo ln -sf /usr/local/bin/tuist /usr/local/bin/swift-project
 execute_sudo chmod +x /usr/local/bin/tuist


### PR DESCRIPTION
### Short description 📝

The install script can fail to add the `tuist` executable when the `bin` folder does not exist inside `/usr/local/`. I added a command to check if it does not exist and create it.

### Checklist ✅

- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
