### PR TITLE
Migrate TestsCacheGraphMapper to ValueGraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Changed
+
+- Migrate TestsCacheGraphMapper to ValueGraph [#2674](https://github.com/tuist/tuist/pull/2674) by [@fortmarek](https://github.com/fortmarek)
+
 ## 1.38.0 - Cold Waves
 
 ### Added

--- a/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
@@ -7,6 +7,8 @@ import TuistSupport
 public protocol TargetContentHashing {
     func contentHash(for target: TargetNode) throws -> String
     func contentHash(for target: TargetNode, additionalStrings: [String]) throws -> String
+    func contentHash(for target: ValueGraphTarget) throws -> String
+    func contentHash(for target: ValueGraphTarget, additionalStrings: [String]) throws -> String
 }
 
 /// `TargetContentHasher`
@@ -75,7 +77,18 @@ public final class TargetContentHasher: TargetContentHashing {
     }
 
     public func contentHash(for target: TargetNode, additionalStrings: [String]) throws -> String {
-        let target = target.target
+        try contentHash(for: target.target, additionalStrings: additionalStrings)
+    }
+
+    public func contentHash(for target: ValueGraphTarget) throws -> String {
+        try contentHash(for: target, additionalStrings: [])
+    }
+
+    public func contentHash(for target: ValueGraphTarget, additionalStrings: [String]) throws -> String {
+        try contentHash(for: target.target, additionalStrings: additionalStrings)
+    }
+
+    private func contentHash(for target: Target, additionalStrings: [String]) throws -> String {
         let sourcesHash = try sourceFilesContentHasher.hash(sources: target.sources)
         let resourcesHash = try resourcesContentHasher.hash(resources: target.resources)
         let copyFilesHash = try copyFilesContentHasher.hash(copyFiles: target.copyFiles)

--- a/Sources/TuistCache/GraphMappers/TestsCacheGraphMapper.swift
+++ b/Sources/TuistCache/GraphMappers/TestsCacheGraphMapper.swift
@@ -31,6 +31,7 @@ public final class TestsCacheGraphMapper: GraphMapping {
         self.graphContentHasher = graphContentHasher
     }
 
+    @available(*, deprecated, message: "This method will be deleted soon. If you need to change code here, add it to map with ValueGraph, too")
     public func map(graph: Graph) throws -> (Graph, [SideEffectDescriptor]) {
         let hashableTargets = self.hashableTargets(graph: graph)
         let hashes = try graphContentHasher.contentHashes(for: graph, filter: hashableTargets.contains)
@@ -66,7 +67,167 @@ public final class TestsCacheGraphMapper: GraphMapping {
         )
     }
 
+    public func map(graph: ValueGraph) throws -> (ValueGraph, [SideEffectDescriptor]) {
+        let graphTraverser = ValueGraphTraverser(graph: graph)
+        let hashableTargets = self.hashableTargets(graphTraverser: graphTraverser)
+        let hashes = try graphContentHasher.contentHashes(for: graph, filter: hashableTargets.contains)
+
+        var visitedNodes: [ValueGraphTarget: Bool] = [:]
+        var workspace = graph.workspace
+        let mappedSchemes = try workspace.schemes
+            .map { scheme -> (Scheme, [ValueGraphTarget]) in
+                try map(
+                    scheme: scheme,
+                    graphTraverser: graphTraverser,
+                    hashes: hashes,
+                    visited: &visitedNodes
+                )
+            }
+        let schemes = mappedSchemes.map(\.0)
+        let cachedTestableTargets = mappedSchemes.flatMap(\.1)
+        Set(cachedTestableTargets).forEach {
+            logger.notice("\($0.target.name) has not changed from last successful run, skipping...")
+        }
+        workspace.schemes = schemes
+        var graph = graph
+        graph.workspace = workspace
+        return (
+            graph,
+            hashes.values.map {
+                .file(
+                    FileDescriptor(
+                        path: testsCacheDirectory.appending(component: $0)
+                    )
+                )
+            }
+        )
+    }
+
     // MARK: - Helpers
+
+    private func hashableTargets(graphTraverser: GraphTraversing) -> Set<ValueGraphTarget> {
+        var visitedTargets: [ValueGraphTarget: Bool] = [:]
+        return Set(
+            graphTraverser.allTargets()
+                // UI tests depend on the device they are run on
+                // This can be done in the future if we hash the ID of the device
+                // But currently, we consider for hashing only unit tests and its dependencies
+                .filter { $0.target.product == .unitTests }
+                .flatMap { target -> [ValueGraphTarget] in
+                    targetDependencies(
+                        target,
+                        graphTraverser: graphTraverser,
+                        visited: &visitedTargets
+                    )
+                }
+        )
+    }
+
+    private func targetDependencies(
+        _ target: ValueGraphTarget,
+        graphTraverser: GraphTraversing,
+        visited: inout [ValueGraphTarget: Bool]
+    ) -> [ValueGraphTarget] {
+        if visited[target] == true { return [] }
+        let targetDependencies = graphTraverser.directTargetDependencies(
+            path: target.path,
+            name: target.target.name
+        )
+        .flatMap {
+            self.targetDependencies(
+                $0,
+                graphTraverser: graphTraverser,
+                visited: &visited
+            )
+        }
+        visited[target] = true
+        return targetDependencies + [target]
+    }
+
+    private func testableTargets(scheme: Scheme, graphTraverser: GraphTraversing) -> [ValueGraphTarget] {
+        scheme.testAction
+            .map(\.targets)
+            .map { testTargets in
+                testTargets.compactMap { testTarget in
+                    guard
+                        let target = graphTraverser.targets[testTarget.target.projectPath]?[testTarget.target.name],
+                        let project = graphTraverser.projects[testTarget.target.projectPath]
+                    else { return nil }
+                    return ValueGraphTarget(
+                        path: testTarget.target.projectPath,
+                        target: target,
+                        project: project
+                    )
+                }
+            } ?? []
+    }
+
+    /// - Returns: Mapped scheme and cached testable targets
+    private func map(
+        scheme: Scheme,
+        graphTraverser: GraphTraversing,
+        hashes: [ValueGraphTarget: String],
+        visited: inout [ValueGraphTarget: Bool]
+    ) throws -> (Scheme, [ValueGraphTarget]) {
+        var scheme = scheme
+        guard let testAction = scheme.testAction else { return (scheme, []) }
+        let cachedTestableTargets = testableTargets(
+            scheme: scheme,
+            graphTraverser: graphTraverser
+        )
+        .filter { testableTarget in
+            isCached(
+                testableTarget,
+                graphTraverser: graphTraverser,
+                hashes: hashes,
+                visited: &visited
+            )
+        }
+
+        scheme.testAction?.targets = testAction.targets.filter { testTarget in
+            !cachedTestableTargets.contains(where: { $0.target.name == testTarget.target.name })
+        }
+
+        if let buildAction = scheme.buildAction {
+            scheme.buildAction?.targets = buildAction.targets.filter { buildTarget in
+                !cachedTestableTargets.contains(where: { $0.target.name == buildTarget.name })
+            }
+        }
+
+        return (scheme, cachedTestableTargets)
+    }
+
+    private func isCached(
+        _ target: ValueGraphTarget,
+        graphTraverser: GraphTraversing,
+        hashes: [ValueGraphTarget: String],
+        visited: inout [ValueGraphTarget: Bool]
+    ) -> Bool {
+        if let visitedValue = visited[target] { return visitedValue }
+        let allTargetDependenciesAreHashed = graphTraverser.directTargetDependencies(
+            path: target.path,
+            name: target.target.name
+        )
+        .allSatisfy {
+            self.isCached(
+                $0,
+                graphTraverser: graphTraverser,
+                hashes: hashes,
+                visited: &visited
+            )
+        }
+        guard let hash = hashes[target] else {
+            visited[target] = false
+            return false
+        }
+        /// Target is considered as cached if all its dependencies are cached and its hash is present in `testsCacheDirectory`
+        /// Hash of the target is saved to that directory only after a successful test run
+        let isCached = FileHandler.shared.exists(
+            Environment.shared.testsCacheDirectory.appending(component: hash)
+        ) && allTargetDependenciesAreHashed
+        visited[target] = isCached
+        return isCached
+    }
 
     private func hashableTargets(graph: Graph) -> Set<TargetNode> {
         var visitedTargets: [TargetNode: Bool] = [:]

--- a/Sources/TuistCacheTesting/ContentHashing/Mocks/MockGraphContentHasher.swift
+++ b/Sources/TuistCacheTesting/ContentHashing/Mocks/MockGraphContentHasher.swift
@@ -6,12 +6,21 @@ import TuistGraph
 public final class MockGraphContentHasher: GraphContentHashing {
     public init() {}
 
-    public var contentHashesStub: ((TuistCore.Graph, (TargetNode) -> Bool, [String]) throws -> [TargetNode: String])?
+    public var graphContentHashesStub: ((TuistCore.Graph, (TargetNode) -> Bool, [String]) throws -> [TargetNode: String])?
     public func contentHashes(
         for graph: TuistCore.Graph,
         filter: (TargetNode) -> Bool,
         additionalStrings: [String]
     ) throws -> [TargetNode: String] {
+        try graphContentHashesStub?(graph, filter, additionalStrings) ?? [:]
+    }
+
+    public var contentHashesStub: ((ValueGraph, (ValueGraphTarget) -> Bool, [String]) throws -> [ValueGraphTarget: String])?
+    public func contentHashes(
+        for graph: ValueGraph,
+        filter: (ValueGraphTarget) -> Bool,
+        additionalStrings: [String]
+    ) throws -> [ValueGraphTarget: String] {
         try contentHashesStub?(graph, filter, additionalStrings) ?? [:]
     }
 }

--- a/Sources/TuistKit/GraphMappers/UpdateWorkspaceProjectsGraphMapper.swift
+++ b/Sources/TuistKit/GraphMappers/UpdateWorkspaceProjectsGraphMapper.swift
@@ -1,5 +1,6 @@
 import Foundation
 import TuistCore
+import TuistGraph
 
 /// A mapper that ensures that the list of projects of the workspace is in sync
 /// with the projects available in the graph.
@@ -10,5 +11,15 @@ final class UpdateWorkspaceProjectsGraphMapper: GraphMapping {
         var workspace = graph.workspace
         workspace.projects = Array(workspaceProjects.union(graphProjects))
         return (graph.with(workspace: workspace), [])
+    }
+
+    func map(graph: ValueGraph) throws -> (ValueGraph, [SideEffectDescriptor]) {
+        var graph = graph
+        let graphProjects = Set(graph.projects.map(\.key))
+        let workspaceProjects = Set(graph.workspace.projects).intersection(graphProjects)
+        var workspace = graph.workspace
+        workspace.projects = Array(workspaceProjects.union(graphProjects))
+        graph.workspace = workspace
+        return (graph, [])
     }
 }

--- a/Tests/TuistCacheTests/GraphMappers/TestsCacheGraphMapperTests.swift
+++ b/Tests/TuistCacheTests/GraphMappers/TestsCacheGraphMapperTests.swift
@@ -36,32 +36,29 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
     // SchemeB: UnitTestsA -> FrameworkA, UnitTestsB (UnitTestsB cached)
     func test_map_all_cached() throws {
         let project = Project.test()
-        let frameworkA = TargetNode.test(
-            project: project,
+        let frameworkA = ValueGraphTarget.test(
+            path: project.path,
             target: Target.test(
                 name: "FrameworkA"
-            )
+            ),
+            project: project
         )
-        let unitTestsA = TargetNode.test(
-            project: project,
+        let unitTestsA = ValueGraphTarget.test(
+            path: project.path,
             target: Target.test(
                 name: "UnitTestsA",
                 dependencies: [
                     .target(name: "FrameworkA"),
                 ]
             ),
-            dependencies: [
-                frameworkA,
-            ]
+            project: project
         )
-        let unitTestsB = TargetNode.test(
-            project: project,
+        let unitTestsB = ValueGraphTarget.test(
+            path: project.path,
             target: Target.test(
                 name: "UnitTestsB"
             ),
-            dependencies: [
-                frameworkA,
-            ]
+            project: project
         )
 
         let workspace = Workspace.test(
@@ -72,7 +69,7 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
                         targets: [
                             TargetReference(
                                 projectPath: project.path,
-                                name: unitTestsA.name
+                                name: unitTestsA.target.name
                             ),
                         ]
                     ),
@@ -81,7 +78,7 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
                             TestableTarget(
                                 target: TargetReference(
                                     projectPath: project.path,
-                                    name: unitTestsA.name
+                                    name: unitTestsA.target.name
                                 )
                             ),
                         ]
@@ -93,11 +90,11 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
                         targets: [
                             TargetReference(
                                 projectPath: project.path,
-                                name: unitTestsA.name
+                                name: unitTestsA.target.name
                             ),
                             TargetReference(
                                 projectPath: project.path,
-                                name: unitTestsB.name
+                                name: unitTestsB.target.name
                             ),
                         ]
                     ),
@@ -106,13 +103,13 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
                             TestableTarget(
                                 target: TargetReference(
                                     projectPath: project.path,
-                                    name: unitTestsA.name
+                                    name: unitTestsA.target.name
                                 )
                             ),
                             TestableTarget(
                                 target: TargetReference(
                                     projectPath: project.path,
-                                    name: unitTestsB.name
+                                    name: unitTestsB.target.name
                                 )
                             ),
                         ]
@@ -121,20 +118,28 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
             ]
         )
 
-        let graph = Graph.test(
+        let graph = ValueGraph.test(
             workspace: workspace,
-            projects: [project],
+            projects: [project.path: project],
             targets: [
                 project.path: [
-                    frameworkA,
-                    unitTestsA,
-                    unitTestsB,
+                    frameworkA.target.name: frameworkA.target,
+                    unitTestsA.target.name: unitTestsA.target,
+                    unitTestsB.target.name: unitTestsB.target,
+                ],
+            ],
+            dependencies: [
+                .target(name: unitTestsA.target.name, path: unitTestsA.path): [
+                    .target(name: frameworkA.target.name, path: frameworkA.path),
+                ],
+                .target(name: unitTestsB.target.name, path: unitTestsB.path): [
+                    .target(name: frameworkA.target.name, path: frameworkA.path),
                 ],
             ]
         )
 
         graphContentHasher.contentHashesStub = { graph, _, _ in
-            graph.targets.flatMap(\.value).reduce(into: [:]) { acc, target in
+            ValueGraphTraverser(graph: graph).allTargets().reduce(into: [:]) { acc, target in
                 acc[target] = target.target.name
             }
         }
@@ -146,7 +151,7 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
             environment.testsCacheDirectory.appending(component: "UnitTestsA")
         )
 
-        let expectedGraph = Graph.test(
+        let expectedGraph = ValueGraph.test(
             workspace: Workspace.test(
                 schemes: [
                     Scheme.test(
@@ -164,7 +169,7 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
                             targets: [
                                 TargetReference(
                                     projectPath: project.path,
-                                    name: unitTestsB.name
+                                    name: unitTestsB.target.name
                                 ),
                             ]
                         ),
@@ -173,7 +178,7 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
                                 TestableTarget(
                                     target: TargetReference(
                                         projectPath: project.path,
-                                        name: unitTestsB.name
+                                        name: unitTestsB.target.name
                                     )
                                 ),
                             ]
@@ -181,12 +186,20 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
                     ),
                 ]
             ),
-            projects: [project],
+            projects: [project.path: project],
             targets: [
                 project.path: [
-                    frameworkA,
-                    unitTestsA,
-                    unitTestsB,
+                    frameworkA.target.name: frameworkA.target,
+                    unitTestsA.target.name: unitTestsA.target,
+                    unitTestsB.target.name: unitTestsB.target,
+                ],
+            ],
+            dependencies: [
+                .target(name: unitTestsA.target.name, path: unitTestsA.path): [
+                    .target(name: frameworkA.target.name, path: frameworkA.path),
+                ],
+                .target(name: unitTestsB.target.name, path: unitTestsB.path): [
+                    .target(name: frameworkA.target.name, path: frameworkA.path),
                 ],
             ]
         )
@@ -196,12 +209,8 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(
-            gotGraph.workspace,
-            expectedGraph.workspace
-        )
-        XCTAssertEqual(
-            gotGraph.targets,
-            expectedGraph.targets
+            gotGraph,
+            expectedGraph
         )
         XCTAssertEqual(
             gotSideEffects.sorted(by: {
@@ -235,23 +244,22 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
     // SchemeA: UnitTestsA -> FrameworkA (only UnitTestsA cached)
     func test_map_only_tests_cached() throws {
         let project = Project.test()
-        let frameworkA = TargetNode.test(
-            project: project,
+        let frameworkA = ValueGraphTarget.test(
+            path: project.path,
             target: Target.test(
                 name: "FrameworkA"
-            )
+            ),
+            project: project
         )
-        let unitTestsA = TargetNode.test(
-            project: project,
+        let unitTestsA = ValueGraphTarget.test(
+            path: project.path,
             target: Target.test(
                 name: "UnitTestsA",
                 dependencies: [
                     .target(name: "FrameworkA"),
                 ]
             ),
-            dependencies: [
-                frameworkA,
-            ]
+            project: project
         )
 
         let schemeA = Scheme.test(
@@ -260,7 +268,7 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
                 targets: [
                     TargetReference(
                         projectPath: project.path,
-                        name: unitTestsA.name
+                        name: unitTestsA.target.name
                     ),
                 ]
             ),
@@ -269,7 +277,7 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
                     TestableTarget(
                         target: TargetReference(
                             projectPath: project.path,
-                            name: unitTestsA.name
+                            name: unitTestsA.target.name
                         )
                     ),
                 ]
@@ -282,19 +290,24 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
             ]
         )
 
-        let graph = Graph.test(
+        let graph = ValueGraph.test(
             workspace: workspace,
-            projects: [project],
+            projects: [project.path: project],
             targets: [
                 project.path: [
-                    frameworkA,
-                    unitTestsA,
+                    frameworkA.target.name: frameworkA.target,
+                    unitTestsA.target.name: unitTestsA.target,
+                ],
+            ],
+            dependencies: [
+                .target(name: unitTestsA.target.name, path: unitTestsA.path): [
+                    .target(name: frameworkA.target.name, path: frameworkA.path),
                 ],
             ]
         )
 
         graphContentHasher.contentHashesStub = { graph, _, _ in
-            graph.targets.flatMap(\.value).reduce(into: [:]) { acc, target in
+            ValueGraphTraverser(graph: graph).allTargets().reduce(into: [:]) { acc, target in
                 acc[target] = target.target.name
             }
         }
@@ -303,7 +316,7 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
             environment.testsCacheDirectory.appending(component: "UnitTestsA")
         )
 
-        let expectedGraph = Graph.test(
+        let expectedGraph = ValueGraph.test(
             workspace: Workspace.test(
                 schemes: [
                     Scheme.test(
@@ -312,7 +325,7 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
                             targets: [
                                 TargetReference(
                                     projectPath: project.path,
-                                    name: unitTestsA.name
+                                    name: unitTestsA.target.name
                                 ),
                             ]
                         ),
@@ -321,7 +334,7 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
                                 TestableTarget(
                                     target: TargetReference(
                                         projectPath: project.path,
-                                        name: unitTestsA.name
+                                        name: unitTestsA.target.name
                                     )
                                 ),
                             ]
@@ -329,11 +342,16 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
                     ),
                 ]
             ),
-            projects: [project],
+            projects: [project.path: project],
             targets: [
                 project.path: [
-                    frameworkA,
-                    unitTestsA,
+                    frameworkA.target.name: frameworkA.target,
+                    unitTestsA.target.name: unitTestsA.target,
+                ],
+            ],
+            dependencies: [
+                .target(name: unitTestsA.target.name, path: unitTestsA.path): [
+                    .target(name: frameworkA.target.name, path: frameworkA.path),
                 ],
             ]
         )
@@ -343,12 +361,8 @@ final class TestsCacheMapperTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(
-            gotGraph.workspace,
-            expectedGraph.workspace
-        )
-        XCTAssertEqual(
-            gotGraph.targets,
-            expectedGraph.targets
+            gotGraph,
+            expectedGraph
         )
         XCTAssertEqual(
             gotSideEffects.sorted(by: {

--- a/Tests/TuistKitTests/GraphMappers/UpdateWorkspaceProjectsGraphMapperTests.swift
+++ b/Tests/TuistKitTests/GraphMappers/UpdateWorkspaceProjectsGraphMapperTests.swift
@@ -33,7 +33,12 @@ final class UpdateWorkspaceProjectsGraphMapperTests: TuistUnitTestCase {
         let secondProjectPath: AbsolutePath = "/second-project"
         let secondProject = Project.test(path: secondProjectPath)
         let workspace = Workspace.test(projects: [firstProjectPath, secondProjectPath])
-        let graph = Graph.test(workspace: workspace, projects: [secondProject])
+        let graph = ValueGraph.test(
+            workspace: workspace,
+            projects: [
+                secondProject.path: secondProject,
+            ]
+        )
 
         // When
         let (gotGraph, gotSideEffects) = try subject.map(graph: graph)


### PR DESCRIPTION
### Short description 📝

Migrated `TestsCacheGraphMapper` to `ValueGraph` + `GraphContentHasher`, although, I am keeping the methods with reference `Graph` as it currently still needs to be used (similar to tree shaking mapper)

We can drop it once we convert `CacheMapper` and `UpdateWorkspaceProjectsGraphMapper`.

I'd like to finish that this week as making changes to mappers that have both old and new graph will be now complicated.

Also, @pepibumur, I think it'd make sense to update tests for tree shaking mapper, as you made that migration, could you have a look at that in the foreseeable future?

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
