### PR TITLE
Remove duplicate functions from install/uninstall shell scripts

### DIFF
--- a/script/install
+++ b/script/install
@@ -10,16 +10,6 @@ shell_join() {
   done
 }
 
-shell_join() {
-  local arg
-  printf "%s" "$1"
-  shift
-  for arg in "$@"; do
-    printf " "
-    printf "%s" "${arg// /\ }"
-  done
-}
-
 execute() {
   if ! "$@"; then
     abort "$(printf "Failed during: %s" "$(shell_join "$@")")"

--- a/script/uninstall
+++ b/script/uninstall
@@ -10,16 +10,6 @@ shell_join() {
   done
 }
 
-shell_join() {
-  local arg
-  printf "%s" "$1"
-  shift
-  for arg in "$@"; do
-    printf " "
-    printf "%s" "${arg// /\ }"
-  done
-}
-
 execute() {
   if ! "$@"; then
     abort "$(printf "Failed during: %s" "$(shell_join "$@")")"


### PR DESCRIPTION
### Short description 📝

Remove duplicate functions `shell_join()` from install/uninstall shell scripts