### PR TITLE
Support SourceFileLists in TargetActions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Changed
 
 - Add missing disabling of swiftformat and swift-format [#2795](https://github.com/tuist/tuist/pull/2795) by [@fortmarek](https://github.com/fortmarek)
+- Add support for globbing in build phase input file and file lists as well as output and output file lists. [#2686](https://github.com/tuist/tuist/pull/2686) by [@FranzBusch](https://github.com/FranzBusch)
 
 ### Fixed
 

--- a/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
+++ b/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
@@ -93,12 +93,20 @@ extension TargetAction {
     public static func test(name: String = "Action",
                             tool: String = "",
                             order: Order = .pre,
-                            arguments: [String] = []) -> TargetAction
+                            arguments: [String] = [],
+                            inputPaths: [Path] = [],
+                            inputFileListPaths: [Path] = [],
+                            outputPaths: [Path] = [],
+                            outputFileListPaths: [Path] = []) -> TargetAction
     {
         TargetAction(
             name: name,
             script: .tool(tool, arguments),
-            order: order
+            order: order,
+            inputPaths: inputPaths,
+            inputFileListPaths: inputFileListPaths,
+            outputPaths: outputPaths,
+            outputFileListPaths: outputFileListPaths
         )
     }
 }

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/TargetAction+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/TargetAction+ManifestMapperTests.swift
@@ -28,4 +28,31 @@ final class TargetActionManifestMapperTests: TuistUnitTestCase {
         XCTAssertEqual(model.script, .tool("my_tool", ["arg1", "arg2"]))
         XCTAssertEqual(model.order, .pre)
     }
+
+    func test_doesntGlob_whenVariable() throws {
+        // Given
+        let temporaryPath = try self.temporaryPath()
+        let generatorPaths = GeneratorPaths(manifestDirectory: temporaryPath)
+        let manifest = ProjectDescription.TargetAction.test(
+            name: "MyScript",
+            tool: "my_tool",
+            order: .pre,
+            arguments: ["arg1", "arg2"],
+            inputPaths: ["$(SRCROOT)/foo/bar/**/*.swift"],
+            inputFileListPaths: ["$(SRCROOT)/foo/bar/**/*.swift"],
+            outputPaths: ["$(SRCROOT)/foo/bar/**/*.swift"],
+            outputFileListPaths: ["$(SRCROOT)/foo/bar/**/*.swift"]
+        )
+        // When
+        let model = try TuistGraph.TargetAction.from(manifest: manifest, generatorPaths: generatorPaths)
+
+        // Then
+        XCTAssertEqual(model.name, "MyScript")
+        XCTAssertEqual(model.script, .tool("my_tool", ["arg1", "arg2"]))
+        XCTAssertEqual(model.order, .pre)
+        XCTAssertEqual(model.inputPaths, [temporaryPath.appending(RelativePath("$(SRCROOT)/foo/bar/**/*.swift"))])
+        XCTAssertEqual(model.inputFileListPaths, [temporaryPath.appending(RelativePath("$(SRCROOT)/foo/bar/**/*.swift"))])
+        XCTAssertEqual(model.outputPaths, [temporaryPath.appending(RelativePath("$(SRCROOT)/foo/bar/**/*.swift"))])
+        XCTAssertEqual(model.outputFileListPaths, [temporaryPath.appending(RelativePath("$(SRCROOT)/foo/bar/**/*.swift"))])
+    }
 }

--- a/projects/tuist/fixtures/ios_app_with_actions/App/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_actions/App/Project.swift
@@ -9,7 +9,7 @@ let project = Project(name: "App",
                                infoPlist: "Info.plist",
                                sources: ["Sources/**"],
                                actions: [
-                                .pre(tool: "/bin/echo", arguments: ["\"tuist\""], name: "Tuist"),
+                                .pre(tool: "/bin/echo", arguments: ["\"tuist\""], name: "Tuist", inputPaths: ["Sources/**/*.swift"]),
                                 .post(tool: "/bin/echo", arguments: ["rocks"], name: "Rocks"),
                                 .pre(path: "script.sh", name: "Run script"),
                                 .pre(script: "echo 'Hello World'", name: "Embedded script"),


### PR DESCRIPTION
### Short description 📝

Build phases in Xcode need proper input and output files or file lists. Normally we have to manually add each individual file there. However since Tuist supports `SourceFileLists` which support globs it is way easier to properly define your build phases.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
