### PR TITLE
Fix Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
-inherit_from:
-  - http://shopify.github.io/ruby-style-guide/rubocop.yml
+inherit_gem:
+  rubocop-shopify: rubocop.yml
 require:
   - rubocop-rake
   - rubocop-minitest

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group :test do
 end
 
 group :development do
-  gem "rubocop", "~> 1.11.0"
+  gem 'rubocop-shopify'
   gem "rubocop-minitest", "~> 0.10.3"
   gem "rubocop-rake", "~> 0.5.1"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,8 @@ GEM
       rubocop (>= 0.87, < 2.0)
     rubocop-rake (0.5.1)
       rubocop
+    rubocop-shopify (1.0.7)
+      rubocop (~> 1.4)
     ruby-macho (1.4.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.4)
@@ -261,9 +263,9 @@ DEPENDENCIES
   mocha (~> 1.12)
   octokit (~> 4.20)
   rake (~> 13.0)
-  rubocop (~> 1.11.0)
   rubocop-minitest (~> 0.10.3)
   rubocop-rake (~> 0.5.1)
+  rubocop-shopify
   ruby-macho (~> 1.4)
   rubyzip (~> 2.3.0)
   semantic (~> 1.6)


### PR DESCRIPTION
### Short description 📝
Rubocop is failing with the following error:
```
404 "Not Found" while downloading remote config file http://shopify.github.io/ruby-style-guide/rubocop.yml
```

This PR fixes it.