### PR TITLE
Add SRCROOT for Info.plist only when necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Changed
 
+- Add SRCROOT for Info.plist only when necessary [#2706](https://github.com/tuist/tuist/pull/2706) by [@fortmarek](https://github.com/fortmarek)
 - Support expand variables configuration in test scheme Environment Variables [#2697] by [@davebcn87](https://github.com/davebcn87)
 - Support unversioned core data models [#2694](https://github.com/tuist/tuist/pull/2694) by [@freak4pc](https://github.com/freak4pc)
 - Remove reference type Graph [#2689](https://github.com/tuist/tuist/pull/2689) by [@fortmarek](https://github.com/fortmarek)

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -168,7 +168,7 @@ final class ConfigGenerator: ConfigGenerating {
             target: target,
             graphTraverser: graphTraverser,
             swiftVersion: swiftVersion,
-            projectPath: project.path,
+            project: project,
             sourceRootPath: sourceRootPath
         )
 
@@ -194,26 +194,39 @@ final class ConfigGenerator: ConfigGenerating {
                                      target: Target,
                                      graphTraverser: GraphTraversing,
                                      swiftVersion: String,
-                                     projectPath: AbsolutePath,
+                                     project: Project,
                                      sourceRootPath: AbsolutePath)
     {
-        settings.merge(generalTargetDerivedSettings(target: target, swiftVersion: swiftVersion, sourceRootPath: sourceRootPath)) { $1 }
-        settings.merge(testBundleTargetDerivedSettings(target: target, graphTraverser: graphTraverser, projectPath: projectPath)) { $1 }
+        settings.merge(
+            generalTargetDerivedSettings(
+                target: target,
+                swiftVersion: swiftVersion,
+                sourceRootPath: sourceRootPath,
+                project: project
+            )
+        ) { $1 }
+        settings.merge(testBundleTargetDerivedSettings(target: target, graphTraverser: graphTraverser, projectPath: project.path)) { $1 }
         settings.merge(deploymentTargetDerivedSettings(target: target)) { $1 }
-        settings.merge(watchTargetDerivedSettings(target: target, graphTraverser: graphTraverser, projectPath: projectPath)) { $1 }
+        settings.merge(watchTargetDerivedSettings(target: target, graphTraverser: graphTraverser, projectPath: project.path)) { $1 }
     }
 
-    private func generalTargetDerivedSettings(target: Target,
-                                              swiftVersion: String,
-                                              sourceRootPath: AbsolutePath) -> SettingsDictionary
-    {
+    private func generalTargetDerivedSettings(
+        target: Target,
+        swiftVersion: String,
+        sourceRootPath: AbsolutePath,
+        project: Project
+    ) -> SettingsDictionary {
         var settings: SettingsDictionary = [:]
         settings["PRODUCT_BUNDLE_IDENTIFIER"] = .string(target.bundleId)
 
         // Info.plist
         if let infoPlist = target.infoPlist, let path = infoPlist.path {
             let relativePath = path.relative(to: sourceRootPath).pathString
-            settings["INFOPLIST_FILE"] = .string("$(SRCROOT)/\(relativePath)")
+            if project.xcodeProjPath.parentDirectory == sourceRootPath {
+                settings["INFOPLIST_FILE"] = .string(relativePath)
+            } else {
+                settings["INFOPLIST_FILE"] = .string("$(SRCROOT)/\(relativePath)")
+            }
         }
 
         if let entitlements = target.entitlements {

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -103,6 +103,44 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         assert(config: customReleaseConfig, contains: releaseSettings)
     }
 
+    func test_generateTargetConfig_whenSourceRootIsEqualToXcodeprojPath() throws {
+        // Given
+        let sourceRootPath = try temporaryPath()
+        let project = Project.test(
+            sourceRootPath: sourceRootPath,
+            xcodeProjPath: sourceRootPath.appending(component: "Project.xcodeproj")
+        )
+        let target = Target.test(
+            infoPlist: .file(path: sourceRootPath.appending(component: "Info.plist"))
+        )
+        let graph = ValueGraph.test(path: project.path)
+        let graphTraverser = ValueGraphTraverser(graph: graph)
+
+        // When
+        try subject.generateTargetConfig(
+            target,
+            project: project,
+            pbxTarget: pbxTarget,
+            pbxproj: pbxproj,
+            projectSettings: .default,
+            fileElements: ProjectFileElements(),
+            graphTraverser: graphTraverser,
+            sourceRootPath: sourceRootPath
+        )
+
+        // Then
+        let configurationList = pbxTarget.buildConfigurationList
+        let debugConfig = configurationList?.configuration(name: "Debug")
+        let releaseConfig = configurationList?.configuration(name: "Release")
+
+        let expectedSettings = [
+            "INFOPLIST_FILE": "Info.plist",
+        ]
+
+        assert(config: debugConfig, contains: expectedSettings)
+        assert(config: releaseConfig, contains: expectedSettings)
+    }
+
     func test_generateTestTargetConfiguration_iOS() throws {
         // Given / When
         try generateTestTargetConfig(appName: "App")


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/2645

### Short description 📝

Unfortunately, `agvtool`, on which many teams depend on directly or indirectly (eg via `fastlane`), does not expand variables present in `INFOPLIST_FILE` when bumping the bundle version. That means it's not able to find `$(SRCROOT)/Info.plist` - since it reads it literally. 

The fix is to omit `$(SRCROOT)` path prefix for `Info.plist` when source root path is equal to the path of Xcode project.

I don't really like the fix as it deviates from the standard we have set where we try to prepend the paths with `$(SRCROOT)` but there is not really other way around it (I know of)

cc @SergeyKovalenko

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
