### PR TITLE
Fix false positive duplicate bundle id lint warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Updated Queuer to 2.1.1 [#2679](https://github.com/tuist/tuist/pull/2679) by [@pepibumur](https://github.com/pepibumur)
 - Updated CombineExt to 1.3.0 [#2679](https://github.com/tuist/tuist/pull/2679) by [@pepibumur](https://github.com/pepibumur)
 
+### Fixed
+
+- Fix false positive duplicate bundle id lint warning [#2707](https://github.com/tuist/tuist/pull/2707) by [@kwridan](https://github.com/kwridan)
+
 ## 1.38.0 - Cold Waves
 
 ### Added

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -251,12 +251,15 @@ public class GraphLinter: GraphLinting {
 
     private func lintBundleIdentifiers(graphTraverser: GraphTraversing) -> [LintingIssue] {
         var bundleIds = [BundleIdKey: [String]]()
-        let buildSettingRegex = "\\$[\\({](.*)[\\)}]"
-
         graphTraverser.targets
             .flatMap { $0.value.map(\.value) }
             .forEach { target in
-                if target.bundleId.matches(pattern: buildSettingRegex) {
+                // skip duplicate check for bundle Ids that contain variables
+                // e.g.
+                // - `${MY_BUNDLE_ID}`
+                // - `prefix.${PRODUCT_NAME:rfc1034identifier}`
+                // - `${PRODUCT_NAME:rfc1034identifier}.suffix`
+                if target.bundleId.contains("$") {
                     return
                 }
 

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -1171,28 +1171,35 @@ final class GraphLinterTests: TuistUnitTestCase {
         let appTarget = Target.test(name: "AppTarget", product: .app)
         let frameworkA = Target.test(name: "frameworkA", product: .framework, bundleId: "${ANY_VARIABLE}")
         let frameworkB = Target.test(name: "frameworkB", product: .framework, bundleId: "${ANY_VARIABLE}")
+        let frameworkC = Target.test(name: "frameworkC", product: .framework, bundleId: "prefix.${ANY_VARIABLE}")
+        let frameworkD = Target.test(name: "frameworkD", product: .framework, bundleId: "prefix.${ANY_VARIABLE}")
+        let frameworkE = Target.test(name: "frameworkE", product: .framework, bundleId: "${ANY_VARIABLE}.suffix")
+        let frameworkF = Target.test(name: "frameworkF", product: .framework, bundleId: "${ANY_VARIABLE}.suffix")
 
-        let app = Project.test(path: path, name: "App", targets: [appTarget])
-        let frameworks1 = Project.test(
-            path: "/tmp/frameworks1",
-            name: "Frameworks1",
-            targets: [frameworkA, frameworkB]
+        let project = Project.test(
+            path: path,
+            name: "App",
+            targets: [appTarget, frameworkA, frameworkB, frameworkC, frameworkD, frameworkE, frameworkF]
         )
-
-        let dependencies: [ValueGraphDependency: Set<ValueGraphDependency>] = [
-            .target(name: app.name, path: path): Set([.target(name: frameworkA.name, path: frameworks1.path),
-                                                      .target(name: frameworkB.name, path: frameworks1.path)]),
-        ]
-
-        let project = Project.test(path: path, targets: [appTarget, frameworkA, frameworkB])
 
         let graph = ValueGraph.test(
             path: path,
-            workspace: Workspace.test(projects: [path]),
-            projects: [path: project],
-            targets: [path: [appTarget.name: appTarget],
-                      frameworks1.path: [frameworkA.name: frameworkA, frameworkB.name: frameworkB]],
-            dependencies: dependencies
+            workspace: Workspace.test(projects: [project.path]),
+            projects: [
+                project.path: project,
+            ],
+            targets: [
+                project.path: [
+                    appTarget.name: appTarget,
+                    frameworkA.name: frameworkA,
+                    frameworkB.name: frameworkB,
+                    frameworkC.name: frameworkC,
+                    frameworkD.name: frameworkD,
+                    frameworkE.name: frameworkE,
+                    frameworkF.name: frameworkF,
+                ],
+            ],
+            dependencies: [:]
         )
         let graphTraverser = ValueGraphTraverser(graph: graph)
 


### PR DESCRIPTION
### Short description 📝

- In the event a bundle ID is in the form of `prefix.${VARIABLE}` (e.g. `com.mydomain.${PRODUCT_NAME:rfc1034identifier}`) which can safely be shared between multiple target a lint warning is produced indicating there are duplicate bundle ids
- There was an existing check to exclude checking variables, however it only worked if the entire bundle ID was a variable (e.g. `${variable}`) and didn't take into account prefixes / suffixes
- To address this the variable check is being simplified to check for the existence of a `$` rather than use a regex

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- ~In case the PR introduces changes that affect users, the documentation has been updated.~
