### PR TITLE
Fix the installation of Tuist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Fix false positive duplicate bundle id lint warning [#2707](https://github.com/tuist/tuist/pull/2707) by [@kwridan](https://github.com/kwridan)
+- Installation of Tuist when `/usr/local/bin` doesn't exist [#2710](https://github.com/tuist/tuist/pull/2710) by [@pepibumur](https://github.com/pepibumur)
 
 ## 1.38.0 - Cold Waves
 

--- a/script/install
+++ b/script/install
@@ -74,8 +74,9 @@ ohai "Installing tuistenv..."
 if [[ ! -d "/usr/local/bin" ]]; then
   execute_sudo mkdir /usr/local/bin/
 fi
+execute_sudo mkdir -p /usr/local/bin
+execute_sudo rm -rf /usr/local/bin/tuist
 execute_sudo mv /tmp/tuistenv/tuistenv /usr/local/bin/tuist
-execute_sudo ln -sf /usr/local/bin/tuist /usr/local/bin/swift-project
 execute_sudo chmod +x /usr/local/bin/tuist
 
 rm -rf /tmp/tuistenv


### PR DESCRIPTION
### Short description 📝

As mentioned [here](https://github.com/tuist/tuist/issues/2082), the installation script fails if the `/usr/local/bin` directory doesn't exist in the system. This PR fixes it.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
