### PR TITLE
🚧 [Experimental] Add signposts to measure various components within tuist

### DIFF
--- a/Sources/TuistGenerator/Generator/TargetGenerator.swift
+++ b/Sources/TuistGenerator/Generator/TargetGenerator.swift
@@ -54,6 +54,12 @@ final class TargetGenerator: TargetGenerating {
                         path: AbsolutePath,
                         graphTraverser: GraphTraversing) throws -> PBXNativeTarget
     {
+        let signPost = Signpost(category: "TargetGenerator", identifier: "generate", label: target.name)
+        signPost.begin()
+        defer {
+            signPost.end()
+        }
+
         /// Products reference.
         let productFileReference = fileElements.products[target.name]!
 

--- a/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -101,6 +101,12 @@ public class CachedManifestLoader: ManifestLoading {
     // MARK: - Private
 
     private func load<T: Codable>(manifest: Manifest, at path: AbsolutePath, loader: () throws -> T) throws -> T {
+        let signPost = Signpost(category: "CachedManifestLoader", identifier: "load", label: "[\(manifest)] \(path.basename)")
+        signPost.begin()
+        defer {
+            signPost.end()
+        }
+
         guard let manifestPath = findManifestPath(for: manifest, at: path) else {
             throw ManifestLoaderError.manifestNotFound(manifest, path)
         }

--- a/Sources/TuistLoader/Loaders/ConfigLoader.swift
+++ b/Sources/TuistLoader/Loaders/ConfigLoader.swift
@@ -31,8 +31,18 @@ public final class ConfigLoader: ConfigLoading {
     }
 
     public func loadConfig(path: AbsolutePath) throws -> TuistGraph.Config {
+        let signPost = Signpost(category: "ConfigLoader", identifier: "loadConfig", label: path.basename)
+        signPost.begin()
+
         if let cached = cachedConfigs[path] {
+            defer {
+                signPost.end(label: "[Cached] \(path.basename)")
+            }
             return cached
+        }
+
+        defer {
+            signPost.end()
         }
 
         // If the Config.swift file exists in the root Tuist/ directory, we load it from there

--- a/Sources/TuistLoader/Loaders/GeneratorModelLoader.swift
+++ b/Sources/TuistLoader/Loaders/GeneratorModelLoader.swift
@@ -58,11 +58,21 @@ extension GeneratorModelLoader: GeneratorModelLoading {
 
 extension GeneratorModelLoader: ManifestModelConverting {
     public func convert(manifest: ProjectDescription.Project, path: AbsolutePath) throws -> TuistGraph.Project {
+        let signPost = Signpost(category: "GeneratorModelLoader", identifier: "convertProject", label: path.basename)
+        signPost.begin()
+        defer {
+            signPost.end()
+        }
         let generatorPaths = GeneratorPaths(manifestDirectory: path)
         return try TuistGraph.Project.from(manifest: manifest, generatorPaths: generatorPaths)
     }
 
     public func convert(manifest: ProjectDescription.Workspace, path: AbsolutePath) throws -> TuistGraph.Workspace {
+        let signPost = Signpost(category: "GeneratorModelLoader", identifier: "convertWorkspace", label: path.basename)
+        signPost.begin()
+        defer {
+            signPost.end()
+        }
         let generatorPaths = GeneratorPaths(manifestDirectory: path)
         let workspace = try TuistGraph.Workspace.from(
             manifest: manifest,

--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -207,6 +207,12 @@ public class ManifestLoader: ManifestLoading {
         _ manifest: Manifest,
         at path: AbsolutePath
     ) throws -> T {
+        let signPost = Signpost(category: "ManifestLoader", identifier: "loadManifest", label: "[\(manifest)] \(path.basename)")
+        signPost.begin()
+        defer {
+            signPost.end()
+        }
+
         var fileNames = [manifest.fileName(path)]
         if let deprecatedFileName = manifest.deprecatedFileName {
             fileNames.insert(deprecatedFileName, at: 0)

--- a/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
+++ b/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
@@ -69,6 +69,12 @@ public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBu
         projectDescriptionSearchPaths: ProjectDescriptionSearchPaths,
         projectDescriptionHelperPlugins: [ProjectDescriptionHelpersPlugin]
     ) throws -> [ProjectDescriptionHelpersModule] {
+        let signpost = Signpost(category: "ProjectDescriptionHelpersBuilder", identifier: "build", label: path.basename)
+        signpost.begin()
+        defer {
+            signpost.end()
+        }
+
         let pluginHelpers = try buildPlugins(
             at: path,
             projectDescriptionSearchPaths: projectDescriptionSearchPaths,
@@ -87,10 +93,16 @@ public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBu
     }
 
     public func buildPlugins(
-        at _: AbsolutePath,
+        at path: AbsolutePath,
         projectDescriptionSearchPaths: ProjectDescriptionSearchPaths,
         projectDescriptionHelperPlugins: [ProjectDescriptionHelpersPlugin]
     ) throws -> [ProjectDescriptionHelpersModule] {
+        let signpost = Signpost(category: "ProjectDescriptionHelpersBuilder", identifier: "buildPlugins", label: path.basename)
+        signpost.begin()
+        defer {
+            signpost.end()
+        }
+
         let pluginHelpers = try projectDescriptionHelperPlugins.map {
             try buildHelpers(name: $0.name, in: $0.path, projectDescriptionSearchPaths: projectDescriptionSearchPaths)
         }
@@ -103,6 +115,11 @@ public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBu
         projectDescriptionSearchPaths: ProjectDescriptionSearchPaths,
         customProjectDescriptionHelperModules: [ProjectDescriptionHelpersModule]
     ) throws -> ProjectDescriptionHelpersModule? {
+        let signpost = Signpost(category: "ProjectDescriptionHelpersBuilder", identifier: "buildDefaultHelpers", label: path.basename)
+        signpost.begin()
+        defer {
+            signpost.end()
+        }
         guard let tuistHelpersDirectory = helpersDirectoryLocator.locate(at: path) else { return nil }
         return try buildHelpers(
             name: Self.defaultHelpersName,

--- a/Sources/TuistPlugin/PluginService.swift
+++ b/Sources/TuistPlugin/PluginService.swift
@@ -40,6 +40,12 @@ public final class PluginService: PluginServicing {
     }
 
     public func loadPlugins(using config: Config) throws -> Plugins {
+        let signPost = Signpost(category: "PluginsService", identifier: "loadPlugins")
+        signPost.begin()
+        defer {
+            signPost.end()
+        }
+
         guard !config.plugins.isEmpty else { return .none }
 
         let localPluginPaths: [AbsolutePath] = config.plugins

--- a/Sources/TuistSupport/Utils/SignPosts.swift
+++ b/Sources/TuistSupport/Utils/SignPosts.swift
@@ -1,0 +1,69 @@
+import Foundation
+import os.log
+
+public class Signpost {
+    private let identifier: StaticString
+    private let label: String?
+    private let log: OSLog
+    private let signpostID: OSSignpostID
+
+    public init(category: StaticString, identifier: StaticString, label: String? = nil) {
+        self.identifier = identifier
+        self.label = label
+        log = OSLog(subsystem: "io.tuist", category: "\(category)")
+        signpostID = OSSignpostID(log: log)
+    }
+
+    public func begin() {
+        Signpost.createSignPost(.begin, log: log, name: identifier, signpostID: signpostID, label: label)
+    }
+
+    public func end(label: String? = nil) {
+        Signpost.createSignPost(.end, log: log, name: identifier, signpostID: signpostID, label: label ?? self.label)
+    }
+
+    public static func measure<T>(
+        category: StaticString,
+        identifier: StaticString,
+        label: String? = nil,
+        _ code: () throws -> T
+    ) rethrows -> T {
+        let log = OSLog(subsystem: "io.tuist", category: "\(category)")
+        let signpostID = OSSignpostID(log: log)
+
+        createSignPost(.begin, log: log, name: identifier, signpostID: signpostID, label: label)
+        defer {
+            createSignPost(.end, log: log, name: identifier, signpostID: signpostID, label: label)
+        }
+        return try code()
+    }
+
+    public static func measure(
+        category: StaticString,
+        identifier: StaticString,
+        label: String? = nil,
+        _ code: () throws -> Void
+    ) rethrows {
+        let log = OSLog(subsystem: "io.tuist", category: "\(category)")
+        let signpostID = OSSignpostID(log: log)
+
+        createSignPost(.begin, log: log, name: identifier, signpostID: signpostID, label: label)
+        defer {
+            createSignPost(.end, log: log, name: identifier, signpostID: signpostID, label: label)
+        }
+        return try code()
+    }
+
+    private static func createSignPost(_ event: OSSignpostType,
+                                       log: OSLog,
+                                       name: StaticString,
+                                       signpostID: OSSignpostID,
+                                       label: String? = nil)
+    {
+        if let label = label {
+            os_signpost(event, log: log, name: name, signpostID: signpostID, "%{public}s", label)
+        } else {
+            os_signpost(event, log: log, name: name, signpostID: signpostID)
+        }
+    }
+}


### PR DESCRIPTION
### Short description 📝

To help reason about Tuist's performance, sign posts can be added in various locations throughout the code base. This can then be visualised within Xcode instruments while Tuist is running.

Feel free to try this on your projects and report back any insights you gain to help make improvements 🙂

### Note 📝

- I don't think we can merge this - at least not in it's current form as it's quite intrusive to the various components. I'd be open to ideas or suggestions on alternatives on how something like this can be integrated.

- I've only added signposts to the generate command, but the same technique can be applied to other commands and components if needed

- Tuist relies heavily on caching, as such it's worth repeating the measurement a few times as you may find "cold" and "warm" measurements differ drastically. If you'd like to repeat a "cold" measurement you can remove all the cached data in `~/.tuist/Cache`

### How to profile your project

- Checkout this branch locally
- Compile the release version of Tuist

```sh
swift build -c release --product ProjectDescription
swift build -c release --product tuist
```

- Open Xcode Instruments (Xcode > Developer Tools > Instruments)
- Select the "Logging" template
![template](https://user-images.githubusercontent.com/11914919/112675296-e54c8780-8e5e-11eb-91e2-7e35a390c187.png)


- Select "Choose Target"

![target](https://user-images.githubusercontent.com/11914919/112675699-6441c000-8e5f-11eb-867c-d0da5a5ca882.png)

- Toggle "Show Hidden Files"
- Locate the `tuist` release binary

```sh
open $(swift build -c release --show-bin-path)
```

_(You can drag the `tuist` binary to the open window)_

- Add `generate` as the argument and your project / workspace absolute path as the working directory

![arguments](https://user-images.githubusercontent.com/11914919/112677392-93593100-8e61-11eb-9273-a93c9a0eac60.png)

- Optionally, you can also ensure the console output is piped to instruments to help troubleshoot any failures 

![console](https://user-images.githubusercontent.com/11914919/113569297-29334f80-960a-11eb-9c92-0bb5656864a7.png)


You're now set to start profiling! One addition to make the profiling non obtrusive (or as much as possible) to the final measurements is to change to recording mode to "Deferred", this means the results will be collected and displayed at the very end rather than attempt to stream it live.

- Option click the record button & select the "Deferred" recording mode in global options

![defered](https://user-images.githubusercontent.com/11914919/112677414-9ce29900-8e61-11eb-8c93-860a5bbe8378.png)

- **🔴 Record**

If all went well, after some time you should be able to see some results

![results](https://user-images.githubusercontent.com/11914919/112677598-dddaad80-8e61-11eb-80fe-5024c3931b51.png)

You can expand the `io.tuist` section to see the various components and processes that have had sign posts added to them.

Where possible, the signposts have the project and target names to help provide some context around the operations.
