### PR TITLE
Fix swiftlint issue

### DIFF
--- a/.github/workflows/fourier.yml
+++ b/.github/workflows/fourier.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     paths:
-      - tools/fourier/**
+      - projects/fourier/**
 
 env:
   RUBY_VERSION: '2.7.2'

--- a/projects/fourier/lib/fourier/services/update/swiftlint.rb
+++ b/projects/fourier/lib/fourier/services/update/swiftlint.rb
@@ -15,6 +15,7 @@ module Fourier
           Dir.mktmpdir do |temporary_dir|
             binary_zip_path = download(temporary_dir: temporary_dir)
             binary_directory_path = extract(binary_zip_path)
+            FileUtils.chmod("u=rwx", File.join(binary_directory_path, "swiftlint"))
             FileUtils.copy_entry(binary_directory_path, OUTPUT_DIRECTORY, false, false, true)
           end
         end

--- a/projects/fourier/test/fourier/services/test/tuist/unit_test.rb
+++ b/projects/fourier/test/fourier/services/test/tuist/unit_test.rb
@@ -13,6 +13,9 @@ module Fourier
             Utilities::System
               .expects(:tuist)
               .with("test")
+            Utilities::System
+              .expects(:system)
+              .with("swift", "test")
 
             # When/Then
             Unit.call

--- a/projects/fourier/test/fourier/services/update/swiftdoc_test.rb
+++ b/projects/fourier/test/fourier/services/update/swiftdoc_test.rb
@@ -8,72 +8,75 @@ module Fourier
     module Update
       class SwiftdocTest < TestCase
         include TestHelpers::TemporaryDirectory
+        include TestHelpers::SupressOutput
 
         def test_call
-          # Given
-          temporary_dir = File.join(@tmp_dir, "temporary_dir")
-          temporary_output_directory = File.join(@tmp_dir, "temporary_output_directory")
-          zip_path = File.join(temporary_dir, "swiftdoc.zip")
-          content_path = File.join(temporary_dir, "content")
-          FileUtils.mkdir_p(content_path)
-          sources_path = File.join(content_path, "swiftdoc/")
-          FileUtils.mkdir_p(sources_path)
-          toolchain_path = File.join(@tmp_dir, "xcode.xctoolchain")
-          swift_syntax_parser_dlyb_path = File.join(toolchain_path, "lib_InternalSwiftSyntaxParser.dylib")
+          supressing_output do
+            # Given
+            temporary_dir = File.join(@tmp_dir, "temporary_dir")
+            temporary_output_directory = File.join(@tmp_dir, "temporary_output_directory")
+            zip_path = File.join(temporary_dir, "swiftdoc.zip")
+            content_path = File.join(temporary_dir, "content")
+            FileUtils.mkdir_p(content_path)
+            sources_path = File.join(content_path, "swiftdoc/")
+            FileUtils.mkdir_p(sources_path)
+            toolchain_path = File.join(@tmp_dir, "xcode.xctoolchain")
+            swift_syntax_parser_dlyb_path = File.join(toolchain_path, "lib_InternalSwiftSyntaxParser.dylib")
 
-          Dir
-            .expects(:mktmpdir)
-            .twice
-            .yields(temporary_dir)
-            .then
-            .yields(temporary_output_directory)
-          Down
-            .expects(:download)
-            .with(Swiftdoc::SOURCE_TAR_URL, destination: zip_path)
-          Utilities::Zip
-            .expects(:extract)
-            .with(zip: zip_path, into: content_path)
-          Utilities::SwiftPackageManager
-            .expects(:build_fat_release_binary)
-            .with(
-              path: sources_path,
-              binary_name: "swift-doc",
-              output_directory: temporary_output_directory
-            )
-          FileUtils
-            .expects(:copy_entry)
-            .with(
-              File.join(sources_path, ".build/arm64-apple-macosx/release/swift-doc_swift-doc.bundle"),
-              File.join(temporary_output_directory, "swift-doc_swift-doc.bundle")
-            )
-          FileUtils
-            .expects(:copy_entry)
-            .with(
-              File.join(sources_path, "LICENSE.md"),
-              File.join(temporary_output_directory, "LICENSE.md")
-            )
-          macho_file = mock("macho_file").responds_like_instance_of(MachO::FatFile)
-          MachO::FatFile
-            .expects(:new)
-            .returns(macho_file)
-          macho_file
-            .expects(:rpaths)
-            .returns([toolchain_path])
-          FileUtils
-            .expects(:copy_entry)
-            .with(
-              swift_syntax_parser_dlyb_path,
-              File.join(temporary_output_directory, File.basename(swift_syntax_parser_dlyb_path))
-            )
-          FileUtils
-            .expects(:copy_entry)
-            .with(
-              temporary_output_directory,
-              Swiftdoc::OUTPUT_DIRECTORY,
-              false, false, true
-            )
-          # When/Then
-          Swiftdoc.call
+            Dir
+              .expects(:mktmpdir)
+              .twice
+              .yields(temporary_dir)
+              .then
+              .yields(temporary_output_directory)
+            Down
+              .expects(:download)
+              .with(Swiftdoc::SOURCE_TAR_URL, destination: zip_path)
+            Utilities::Zip
+              .expects(:extract)
+              .with(zip: zip_path, into: content_path)
+            Utilities::SwiftPackageManager
+              .expects(:build_fat_release_binary)
+              .with(
+                path: sources_path,
+                binary_name: "swift-doc",
+                output_directory: temporary_output_directory
+              )
+            FileUtils
+              .expects(:copy_entry)
+              .with(
+                File.join(sources_path, ".build/arm64-apple-macosx/release/swift-doc_swift-doc.bundle"),
+                File.join(temporary_output_directory, "swift-doc_swift-doc.bundle")
+              )
+            FileUtils
+              .expects(:copy_entry)
+              .with(
+                File.join(sources_path, "LICENSE.md"),
+                File.join(temporary_output_directory, "LICENSE.md")
+              )
+            macho_file = mock("macho_file").responds_like_instance_of(MachO::FatFile)
+            MachO::FatFile
+              .expects(:new)
+              .returns(macho_file)
+            macho_file
+              .expects(:rpaths)
+              .returns([toolchain_path])
+            FileUtils
+              .expects(:copy_entry)
+              .with(
+                swift_syntax_parser_dlyb_path,
+                File.join(temporary_output_directory, File.basename(swift_syntax_parser_dlyb_path))
+              )
+            FileUtils
+              .expects(:copy_entry)
+              .with(
+                temporary_output_directory,
+                Swiftdoc::OUTPUT_DIRECTORY,
+                false, false, true
+              )
+            # When/Then
+            Swiftdoc.call
+          end
         end
       end
     end

--- a/projects/fourier/test/fourier/services/update/swiftlint_test.rb
+++ b/projects/fourier/test/fourier/services/update/swiftlint_test.rb
@@ -7,26 +7,32 @@ module Fourier
     module Update
       class SwiftlintTest < TestCase
         include TestHelpers::TemporaryDirectory
+        include TestHelpers::SupressOutput
 
         def test_call
-          # Given
-          Dir
-            .expects(:mktmpdir)
-            .yields(@tmp_dir)
-          zip_path = File.join(@tmp_dir, "swiftlint.zip")
-          content_path = File.join(@tmp_dir, "bin")
-          Down
-            .expects(:download)
-            .with(Swiftlint::PORTABLE_BINARY_URL, destination: zip_path)
-          Utilities::Zip
-            .expects(:extract)
-            .with(zip: zip_path, into: content_path)
-          FileUtils
-            .expects(:copy_entry)
-            .with(content_path, Swiftlint::OUTPUT_DIRECTORY, false, false, true)
+          supressing_output do
+            # Given
+            Dir
+              .expects(:mktmpdir)
+              .yields(@tmp_dir)
+            zip_path = File.join(@tmp_dir, "swiftlint.zip")
+            content_path = File.join(@tmp_dir, "bin")
+            Down
+              .expects(:download)
+              .with(Swiftlint::PORTABLE_BINARY_URL, destination: zip_path)
+            Utilities::Zip
+              .expects(:extract)
+              .with(zip: zip_path, into: content_path)
+            FileUtils
+              .expects(:chmod)
+              .with("u=rwx", File.join(content_path, "swiftlint"))
+            FileUtils
+              .expects(:copy_entry)
+              .with(content_path, Swiftlint::OUTPUT_DIRECTORY, false, false, true)
 
-          # When
-          Services::Update::Swiftlint.call
+            # When
+            Services::Update::Swiftlint.call
+          end
         end
       end
     end

--- a/projects/fourier/test/fourier/services/update/xcbeautify_test.rb
+++ b/projects/fourier/test/fourier/services/update/xcbeautify_test.rb
@@ -8,45 +8,48 @@ module Fourier
     module Update
       class XcbeautifyTest < TestCase
         include TestHelpers::TemporaryDirectory
+        include TestHelpers::SupressOutput
 
         def test_call
-          # Given
-          temporary_dir = File.join(@tmp_dir, "temporary_dir")
-          temporary_output_directory = File.join(@tmp_dir, "temporary_output_directory")
-          zip_path = File.join(temporary_dir, "xcbeautify.zip")
-          content_path = File.join(temporary_dir, "content")
-          FileUtils.mkdir_p(content_path)
-          sources_path = File.join(content_path, "xcbeautify/")
-          FileUtils.mkdir_p(sources_path)
+          supressing_output do
+            # Given
+            temporary_dir = File.join(@tmp_dir, "temporary_dir")
+            temporary_output_directory = File.join(@tmp_dir, "temporary_output_directory")
+            zip_path = File.join(temporary_dir, "xcbeautify.zip")
+            content_path = File.join(temporary_dir, "content")
+            FileUtils.mkdir_p(content_path)
+            sources_path = File.join(content_path, "xcbeautify/")
+            FileUtils.mkdir_p(sources_path)
 
-          Dir
-            .expects(:mktmpdir)
-            .twice
-            .yields(temporary_dir)
-            .then
-            .yields(temporary_output_directory)
-          Down
-            .expects(:download)
-            .with(Xcbeautify::SOURCE_TAR_URL, destination: zip_path)
-          Utilities::Zip
-            .expects(:extract)
-            .with(zip: zip_path, into: content_path)
-          Utilities::SwiftPackageManager
-            .expects(:build_fat_release_binary)
-            .with(
-              path: sources_path,
-              binary_name: "xcbeautify",
-              output_directory: temporary_output_directory
-            )
-          FileUtils
-            .expects(:copy_entry)
-            .with(File.join(sources_path, "LICENSE"), File.join(temporary_output_directory, "LICENSE"))
-          FileUtils
-            .expects(:copy_entry)
-            .with(temporary_output_directory, Xcbeautify::OUTPUT_DIRECTORY, false, false, true)
+            Dir
+              .expects(:mktmpdir)
+              .twice
+              .yields(temporary_dir)
+              .then
+              .yields(temporary_output_directory)
+            Down
+              .expects(:download)
+              .with(Xcbeautify::SOURCE_TAR_URL, destination: zip_path)
+            Utilities::Zip
+              .expects(:extract)
+              .with(zip: zip_path, into: content_path)
+            Utilities::SwiftPackageManager
+              .expects(:build_fat_release_binary)
+              .with(
+                path: sources_path,
+                binary_name: "xcbeautify",
+                output_directory: temporary_output_directory
+              )
+            FileUtils
+              .expects(:copy_entry)
+              .with(File.join(sources_path, "LICENSE"), File.join(temporary_output_directory, "LICENSE"))
+            FileUtils
+              .expects(:copy_entry)
+              .with(temporary_output_directory, Xcbeautify::OUTPUT_DIRECTORY, false, false, true)
 
-          # When/then
-          Update::Xcbeautify.call
+            # When/then
+            Update::Xcbeautify.call
+          end
         end
       end
     end

--- a/projects/fourier/test/fourier/utilities/swift_package_manager_test.rb
+++ b/projects/fourier/test/fourier/utilities/swift_package_manager_test.rb
@@ -19,8 +19,8 @@ module Fourier
         expected_x86_command = [*expected_command, "--triple", "x86_64-apple-macosx"]
         expected_lipo_command = [
           "lipo", "-create", "-output", File.join(output_directory, binary_name),
-          File.join(path, ".build/arm64-apple-macosx/release/swift-doc"),
-          File.join(path, ".build/x86_64-apple-macosx/release/swift-doc")
+          File.join(path, ".build/arm64-apple-macosx/release/tuist"),
+          File.join(path, ".build/x86_64-apple-macosx/release/tuist")
         ]
         Utilities::System
           .expects(:system)

--- a/projects/fourier/test/test_helpers/supress_output.rb
+++ b/projects/fourier/test/test_helpers/supress_output.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module TestHelpers
+  module SupressOutput
+    def supressing_output
+      original_stderr = $stderr.clone
+      original_stdout = $stdout.clone
+      $stderr.reopen(File.new("/dev/null", "w"))
+      $stdout.reopen(File.new("/dev/null", "w"))
+      yield
+    ensure
+      $stdout.reopen(original_stdout)
+      $stderr.reopen(original_stderr)
+    end
+  end
+end


### PR DESCRIPTION
fixes https://github.com/tuist/tuist/issues/2741

### Short description 📝
`swiftlint` fails to run in the latest Tuist version because the file doesn't have executable permissions. This PR fixes it and vendors a new version of Swiftlint with the executable permissions set.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
