### PR TITLE
Update links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ tuist build # Builds your project
 
 The repository is a monorepo with multiple projects:
 
-- [Swift Package (CLI) 📦](/)
-- [Main Website 🌍](/website)
+- [Swift Package (CLI) 📦](/../..)
+- [Main Website 🌍](projects/website)
 
 ## Documentation 📝
 


### PR DESCRIPTION
### Short description 📝

I noticed the links on the README.md were 404'ing. The website link was failing due to the recent `website` -> `projects/website` change. The **Swift Package (CLI)** link however was linking to `/` which for GitHub resolves to `https://github.com/tuist/tuist/blob/main` which is a 404. I assume we wanted to link to the root of the repo which can be achieved with `/../..` which resolves to `https://github.com/tuist/tuist`. 

#### Discussion

Did we intend to link to the root of the repo for the CLI? Do we still want to have that link or do we want to update that section of the README to match the contents of the `/projects` directory?


### Checklist ✅

- [ ] N/A ~The code architecture and patterns are consistent with the rest of the codebase.~
- [ ] N/A ~The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).~
- [ ] N/A ~The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.~
- [ ] N/A ~In case the PR introduces changes that affect users, the documentation has been updated.~

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/316931/112917971-8719f000-914f-11eb-88d9-3a1c036f2544.png) | ![image](https://user-images.githubusercontent.com/316931/112918060-c3e5e700-914f-11eb-8c0c-6c87ff6f5e80.png) |


