### PR TITLE
Embed dependencies for tests host application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Fixed missing `.resolveDependenciesWithSystemScm` config option in the `PackageDescription` portion of tuist [#2769](https://github.com/tuist/tuist/pull/2769) by [@freak4pc](https://github.com/freak4pc)
 - Fixed running `tuist dump` for projects with plugins [#2700](https://github.com/tuist/tuist/pull/2700) by [@danyf90](https://github.com/danyf90)
+- Fixed generating unit tests target without host application [#2776](https://github.com/tuist/tuist/pull/2776) by [@softmaxsg](https://github.com/softmaxsg)
 
 ## 1.39.1
 

--- a/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
+++ b/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
@@ -235,6 +235,8 @@ public class ValueGraphTraverser: GraphTraversing {
         if target.target.product == .unitTests {
             if let hostApp = hostApplication(path: path, name: name) {
                 references.subtract(embeddableFrameworks(path: hostApp.path, name: hostApp.target.name))
+            } else {
+                references = Set(precompiledFrameworks)
             }
         }
 

--- a/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
+++ b/Sources/TuistCore/ValueGraph/ValueGraphTraverser.swift
@@ -235,8 +235,6 @@ public class ValueGraphTraverser: GraphTraversing {
         if target.target.product == .unitTests {
             if let hostApp = hostApplication(path: path, name: name) {
                 references.subtract(embeddableFrameworks(path: hostApp.path, name: hostApp.target.name))
-            } else {
-                references = Set()
             }
         }
 

--- a/Tests/TuistCoreTests/ValueGraph/ValueGraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/ValueGraph/ValueGraphTraverserTests.swift
@@ -1120,10 +1120,6 @@ final class ValueGraphTraverserTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(got, [
-            .product(
-                target: "LocallyBuiltFramework",
-                productName: "LocallyBuiltFramework.framework"
-            ),
             .framework(
                 path: "/test/test.framework",
                 binaryPath: "/test/test.framework/test",

--- a/Tests/TuistCoreTests/ValueGraph/ValueGraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/ValueGraph/ValueGraphTraverserTests.swift
@@ -1119,7 +1119,22 @@ final class ValueGraphTraverserTests: TuistUnitTestCase {
         let got = subject.embeddableFrameworks(path: project.path, name: unitTests.name).sorted()
 
         // Then
-        XCTAssertTrue(got.isEmpty)
+        XCTAssertEqual(got, [
+            .product(
+                target: "LocallyBuiltFramework",
+                productName: "LocallyBuiltFramework.framework"
+            ),
+            .framework(
+                path: "/test/test.framework",
+                binaryPath: "/test/test.framework/test",
+                isCarthage: false,
+                dsymPath: nil,
+                bcsymbolmapPaths: [],
+                linking: .dynamic,
+                architectures: [.arm64],
+                product: .framework
+            )
+        ])
     }
 
     func test_embeddableDependencies_whenHostedTestTarget_transitiveDepndencies() throws {

--- a/Tests/TuistCoreTests/ValueGraph/ValueGraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/ValueGraph/ValueGraphTraverserTests.swift
@@ -1133,7 +1133,7 @@ final class ValueGraphTraverserTests: TuistUnitTestCase {
                 linking: .dynamic,
                 architectures: [.arm64],
                 product: .framework
-            )
+            ),
         ])
     }
 


### PR DESCRIPTION
### Short description 📝

Currently, Tuist doesn't embed any dependencies for the tests target if the host application is not specified. This results into a run-time error:
```
The bundle “BundleNameTests” couldn’t be loaded because it is damaged or missing necessary resources. Try reinstalling the bundle.
(dlopen_preflight(/some/path/BundleNameTests.xctest/BundleNameTests): Library not loaded: @rpath/Dependency.framework/Dependency
  Referenced from: /some/path/BundleNameTests.xctest/BundleNameTests
  Reason: image not found)
Program ended with exit code: 82
```

This PR is intended to fix the issue and generate the project with all required dependencies embedded into the tests target.

There is a PR (https://github.com/tuist/tuist/pull/664) that addressed an issue with embedding too many dependencies in case the host application is specified. It might be important to check it for reference.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] <del>In case the PR introduces changes that affect users, the documentation has been updated.</del>
