### PR TITLE
Add missing disabling of swiftformat and swift-format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Changed
+
+- Add missing disabling of swiftformat and swift-format [#2795](https://github.com/tuist/tuist/pull/2795) by [@fortmarek](https://github.com/fortmarek)
+
 ### Fixed
 
 - Fixed missing `.resolveDependenciesWithSystemScm` config option in the `PackageDescription` portion of tuist [#2769](https://github.com/tuist/tuist/pull/2769) by [@freak4pc](https://github.com/freak4pc)

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -76,6 +76,7 @@ public class ResourcesProjectMapper: ProjectMapping {
         if !target.supportsResources {
             return """
             // swiftlint:disable all
+            // swift-format-ignore-file
             // swiftformat:disable all
             import Foundation
 
@@ -118,6 +119,7 @@ public class ResourcesProjectMapper: ProjectMapping {
         } else {
             return """
             // swiftlint:disable all
+            // swift-format-ignore-file
             // swiftformat:disable all
             import Foundation
 

--- a/Sources/TuistGenerator/Templates/AssetsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/AssetsTemplate.swift
@@ -2,6 +2,8 @@
 extension SynthesizedResourceInterfaceTemplates {
     static let assetsTemplate = """
     // swiftlint:disable all
+    // swift-format-ignore-file
+    // swiftformat:disable all
     // Generated using tuist — https://github.com/tuist/tuist
 
     {% if catalogs %}
@@ -252,6 +254,8 @@ extension SynthesizedResourceInterfaceTemplates {
     {% else %}
     // No assets found
     {% endif %}
+    // swiftlint:enable all
+    // swiftformat:enable all
 
     """
 }

--- a/Sources/TuistGenerator/Templates/FontsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/FontsTemplate.swift
@@ -2,6 +2,8 @@
 extension SynthesizedResourceInterfaceTemplates {
     static let fontsTemplate = """
     // swiftlint:disable all
+    // swift-format-ignore-file
+    // swiftformat:disable all
     // Generated using tuist — https://github.com/tuist/tuist
 
     {% if families %}
@@ -106,6 +108,8 @@ extension SynthesizedResourceInterfaceTemplates {
     {% else %}
     // No fonts found
     {% endif %}
+    // swiftlint:enable all
+    // swiftformat:enable all
 
     """
 }

--- a/Sources/TuistGenerator/Templates/PlistsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/PlistsTemplate.swift
@@ -1,6 +1,8 @@
 extension SynthesizedResourceInterfaceTemplates {
     static let plistsTemplate = """
     // swiftlint:disable all
+    // swift-format-ignore-file
+    // swiftformat:disable all
     // Generated using tuist — https://github.com/tuist/tuist
 
     {% if files %}
@@ -80,6 +82,8 @@ extension SynthesizedResourceInterfaceTemplates {
     {% else %}
     // No files found
     {% endif %}
+    // swiftlint:enable all
+    // swiftformat:enable all
 
     """
 }

--- a/Sources/TuistGenerator/Templates/StringsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/StringsTemplate.swift
@@ -2,6 +2,8 @@
 extension SynthesizedResourceInterfaceTemplates {
     static let stringsTemplate = """
     // swiftlint:disable all
+    // swift-format-ignore-file
+    // swiftformat:disable all
     // Generated using tuist — https://github.com/tuist/tuist
 
     {% if tables.count > 0 %}
@@ -94,6 +96,8 @@ extension SynthesizedResourceInterfaceTemplates {
     {% else %}
     // No string found
     {% endif %}
+    // swiftlint:enable all
+    // swiftformat:enable all
 
     """
 }


### PR DESCRIPTION
### Short description 📝

We are integrating `swift-format` into one of our projects and I have noticed it was being run on our `Derived` folder since we don't disable it. `swiftformat` was missing in a bunch of places as well

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
