### PR TITLE
Fix broken links in `docs/manifests/project.md`

### DIFF
--- a/projects/docs/docs/manifests/project.md
+++ b/projects/docs/docs/manifests/project.md
@@ -148,7 +148,7 @@ For local:
 .package(path: "MyLibrary")
 ```
 
-Targets can then depend on products from these Swift Packages. See [Dependencies](/docs/features/dependencies/)
+Targets can then depend on products from these Swift Packages. See [Dependencies](/features/dependencies)
 
 :::note Package.resolved
 Tuist creates a `.package.resolved` file, so your team can share the same versions of dependencies without committing your workspace.
@@ -1518,7 +1518,7 @@ description: 'Sets `"ENABLE_BITCODE"` to `"YES"` or `"NO"`',
 
 Notice that you don't depend exclusively on Tuist's built-in functions.
 You can create your own `SettingsDictionary` extension methods and add them to your
-`Project description helpers` this way:
+`Project description helpers` this way:s
 
 ```swift
 public extension SettingsDictionary {

--- a/projects/docs/docs/manifests/project.md
+++ b/projects/docs/docs/manifests/project.md
@@ -1518,7 +1518,7 @@ description: 'Sets `"ENABLE_BITCODE"` to `"YES"` or `"NO"`',
 
 Notice that you don't depend exclusively on Tuist's built-in functions.
 You can create your own `SettingsDictionary` extension methods and add them to your
-`Project description helpers` this way:s
+`Project description helpers` this way:
 
 ```swift
 public extension SettingsDictionary {

--- a/projects/docs/docs/manifests/project.md
+++ b/projects/docs/docs/manifests/project.md
@@ -1518,7 +1518,7 @@ description: 'Sets `"ENABLE_BITCODE"` to `"YES"` or `"NO"`',
 
 Notice that you don't depend exclusively on Tuist's built-in functions.
 You can create your own `SettingsDictionary` extension methods and add them to your
-[Project description helpers](/docs/manifests/project/) this way:
+`Project description helpers` this way:
 
 ```swift
 public extension SettingsDictionary {

--- a/projects/docs/docs/manifests/project.md
+++ b/projects/docs/docs/manifests/project.md
@@ -148,7 +148,7 @@ For local:
 .package(path: "MyLibrary")
 ```
 
-Targets can then depend on products from these Swift Packages. See [Dependencies](/docs/dependencies/local/)
+Targets can then depend on products from these Swift Packages. See [Dependencies](/docs/features/dependencies/)
 
 :::note Package.resolved
 Tuist creates a `.package.resolved` file, so your team can share the same versions of dependencies without committing your workspace.
@@ -1518,7 +1518,7 @@ description: 'Sets `"ENABLE_BITCODE"` to `"YES"` or `"NO"`',
 
 Notice that you don't depend exclusively on Tuist's built-in functions.
 You can create your own `SettingsDictionary` extension methods and add them to your
-[Project description helpers](/docs/usage/helpers/) this way:
+[Project description helpers](/docs/manifests/project/) this way:
 
 ```swift
 public extension SettingsDictionary {


### PR DESCRIPTION
This PR fixes broken links I detected after I had merged `main` into  #2394. 

<img width="1242" alt="114212091-b7d50300-9961-11eb-87f0-cf45986d00c2" src="https://user-images.githubusercontent.com/4774319/114264223-f8785f00-99e9-11eb-8c21-68488788e8ce.png">
