### PR TITLE
Fix link to `Docs` on https://tuist.io/ 

### DIFF
--- a/projects/website/markdown/docs/usage/get-started.mdx
+++ b/projects/website/markdown/docs/usage/get-started.mdx
@@ -1,7 +1,7 @@
 ---
 name: Get started
 excerpt: ''
-migrated_path: '/tutorials/get-started'
+migrated_path: '/tutorial/get-started'
 redirect_from:
   - /docs/
 ---


### PR DESCRIPTION
This PR fixes issues that has been reported on Slack: 

<img width="1006" alt="Zrzut ekranu 2021-04-10 o 11 12 41" src="https://user-images.githubusercontent.com/4774319/114264856-ac2f1e00-99ed-11eb-912d-147e612dcae0.png">

