### PR TITLE
Make documentation of `tuist bundle` better. 

### DIFF
--- a/projects/docs/docs/features/version-management.md
+++ b/projects/docs/docs/features/version-management.md
@@ -53,7 +53,7 @@ Bundling the version 0.4.0 in the directory /Tuist/.tuist-bin
 ✅ Success: tuist bundled successfully at /Tuist/.tuist-bin
 ```
 
-It creates a `.tuist-bin` directory in the current directory that contains the `tuist` binary and its artifacts. When you run `tuist [COMMADN]` the version manager determines bundled version should be executed. Read more [here](#running-tuist).
+It creates a `.tuist-bin` directory in the current directory that contains the `tuist` binary and its artifacts. When you run `tuist [COMMAND]` the version manager uses the bundled version automatically.
 
 #### Install
 

--- a/projects/docs/docs/features/version-management.md
+++ b/projects/docs/docs/features/version-management.md
@@ -53,7 +53,7 @@ Bundling the version 0.4.0 in the directory /Tuist/.tuist-bin
 ✅ Success: tuist bundled successfully at /Tuist/.tuist-bin
 ```
 
-It creates a `.tuist-bin` directory in the current directory that contains the `tuist` binary and its artifacts. You can use bundled version of `tuist` by running `.tuist-bin/tuist generate`.
+It creates a `.tuist-bin` directory in the current directory that contains the `tuist` binary and its artifacts. When you run `tuist [COMMADN]` the version manager determines bundled version should be executed. Read more [here](#running-tuist).
 
 #### Install
 


### PR DESCRIPTION
### Short description 📝

Documentation may suggest users to use bundled `tuist` directly. I changed it to highlight how `tuist`'s  version management works. 