### PR TITLE
Make `ValueGraph` serializable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Added
 - Add support for `runPostActionsOnFailure` for post build actions. [#2752](https://github.com/tuist/tuist/pull/2752) by [@FranzBusch](https://github.com/FranzBusch)
+- Make `ValueGraph` serializable. [#2811](https://github.com/tuist/tuist/pull/2811) by [@laxmorek](https://github.com/laxmorek)
 
 ## 1.40.0
 

--- a/Sources/TuistGraph/Models/AnalyzeAction.swift
+++ b/Sources/TuistGraph/Models/AnalyzeAction.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct AnalyzeAction: Equatable {
+public struct AnalyzeAction: Equatable, Codable {
     // MARK: - Attributes
 
     public let configurationName: String

--- a/Sources/TuistGraph/Models/ArchiveAction.swift
+++ b/Sources/TuistGraph/Models/ArchiveAction.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public struct ArchiveAction: Equatable {
+public struct ArchiveAction: Equatable, Codable {
     // MARK: - Attributes
 
     public let configurationName: String

--- a/Sources/TuistGraph/Models/Arguments.swift
+++ b/Sources/TuistGraph/Models/Arguments.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Arguments: Equatable {
+public struct Arguments: Equatable, Codable {
     // MARK: - Attributes
 
     public let environment: [String: String]

--- a/Sources/TuistGraph/Models/BuildAction.swift
+++ b/Sources/TuistGraph/Models/BuildAction.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public struct BuildAction: Equatable {
+public struct BuildAction: Equatable, Codable {
     // MARK: - Attributes
 
     public var targets: [TargetReference]

--- a/Sources/TuistGraph/Models/BuildConfiguration.swift
+++ b/Sources/TuistGraph/Models/BuildConfiguration.swift
@@ -7,8 +7,8 @@ import Foundation
 /// It hosts the name as well as the variant of
 /// a configuration to help infer the appropriate
 /// default settings.
-public struct BuildConfiguration {
-    public enum Variant: String {
+public struct BuildConfiguration: Codable {
+    public enum Variant: String, Codable {
         case debug, release
     }
 

--- a/Sources/TuistGraph/Models/CopyFilesAction.swift
+++ b/Sources/TuistGraph/Models/CopyFilesAction.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public struct CopyFilesAction: Equatable {
+public struct CopyFilesAction: Equatable, Codable {
     /// Name of the build phase when the project gets generated.
     public var name: String
 
@@ -15,7 +15,7 @@ public struct CopyFilesAction: Equatable {
     public var files: [FileElement]
 
     /// Destination path.
-    public enum Destination: String, Equatable {
+    public enum Destination: String, Equatable, Codable {
         case absolutePath
         case productsDirectory
         case wrapper

--- a/Sources/TuistGraph/Models/CoreDataModel.swift
+++ b/Sources/TuistGraph/Models/CoreDataModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public struct CoreDataModel: Equatable {
+public struct CoreDataModel: Equatable, Codable {
     // MARK: - Attributes
 
     public let path: AbsolutePath

--- a/Sources/TuistGraph/Models/DeploymentDevice.swift
+++ b/Sources/TuistGraph/Models/DeploymentDevice.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - DeploymentDevice
 
-public struct DeploymentDevice: OptionSet {
+public struct DeploymentDevice: OptionSet, Codable {
     public static let iphone = DeploymentDevice(rawValue: 1 << 0)
     public static let ipad = DeploymentDevice(rawValue: 1 << 1)
     public static let mac = DeploymentDevice(rawValue: 1 << 2)

--- a/Sources/TuistGraph/Models/DeploymentTarget.swift
+++ b/Sources/TuistGraph/Models/DeploymentTarget.swift
@@ -37,7 +37,7 @@ extension DeploymentTarget {
         case tvOS
     }
 
-    enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case kind
         case version
         case deploymentDevices

--- a/Sources/TuistGraph/Models/DeploymentTarget.swift
+++ b/Sources/TuistGraph/Models/DeploymentTarget.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - DeploymentTarget
 
-public enum DeploymentTarget: Codable {
+public enum DeploymentTarget: Equatable, Codable {
     case iOS(String, DeploymentDevice)
     case macOS(String)
     case watchOS(String)

--- a/Sources/TuistGraph/Models/DeploymentTarget.swift
+++ b/Sources/TuistGraph/Models/DeploymentTarget.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - DeploymentTarget
 
-public enum DeploymentTarget {
+public enum DeploymentTarget: Codable {
     case iOS(String, DeploymentDevice)
     case macOS(String)
     case watchOS(String)
@@ -23,6 +23,62 @@ public enum DeploymentTarget {
         case let .macOS(version): return version
         case let .watchOS(version): return version
         case let .tvOS(version): return version
+        }
+    }
+}
+
+// MARK: - Codable
+
+extension DeploymentTarget {
+    private enum Kind: String, Codable {
+        case iOS
+        case macOS
+        case watchOS
+        case tvOS
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case version
+        case deploymentDevices
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .iOS:
+            let version = try container.decode(String.self, forKey: .version)
+            let deploymentDevices = try container.decode(DeploymentDevice.self, forKey: .deploymentDevices)
+            self = .iOS(version, deploymentDevices)
+        case .macOS:
+            let version = try container.decode(String.self, forKey: .version)
+            self = .macOS(version)
+        case .watchOS:
+            let version = try container.decode(String.self, forKey: .version)
+            self = .watchOS(version)
+        case .tvOS:
+            let version = try container.decode(String.self, forKey: .version)
+            self = .tvOS(version)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .iOS(version, deploymentDevices):
+            try container.encode(Kind.iOS.self, forKey: .kind)
+            try container.encode(version, forKey: .version)
+            try container.encode(deploymentDevices, forKey: .deploymentDevices)
+        case let .macOS(version):
+            try container.encode(Kind.macOS.self, forKey: .kind)
+            try container.encode(version, forKey: .version)
+        case let .watchOS(version):
+            try container.encode(Kind.watchOS.self, forKey: .kind)
+            try container.encode(version, forKey: .version)
+        case let .tvOS(version):
+            try container.encode(Kind.tvOS.self, forKey: .kind)
+            try container.encode(version, forKey: .version)
         }
     }
 }

--- a/Sources/TuistGraph/Models/DeploymentTarget.swift
+++ b/Sources/TuistGraph/Models/DeploymentTarget.swift
@@ -42,7 +42,7 @@ extension DeploymentTarget {
         case version
         case deploymentDevices
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(Kind.self, forKey: .kind)

--- a/Sources/TuistGraph/Models/ExecutionAction.swift
+++ b/Sources/TuistGraph/Models/ExecutionAction.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public struct ExecutionAction: Equatable {
+public struct ExecutionAction: Equatable, Codable {
     // MARK: - Attributes
 
     public let title: String

--- a/Sources/TuistGraph/Models/FileElement.swift
+++ b/Sources/TuistGraph/Models/FileElement.swift
@@ -31,12 +31,12 @@ extension FileElement {
         case file
         case folderReference
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case kind
         case path
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(Kind.self, forKey: .kind)
@@ -49,7 +49,7 @@ extension FileElement {
             self = .folderReference(path: path)
         }
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
@@ -62,4 +62,3 @@ extension FileElement {
         }
     }
 }
-

--- a/Sources/TuistGraph/Models/FileElement.swift
+++ b/Sources/TuistGraph/Models/FileElement.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public enum FileElement: Equatable, Hashable {
+public enum FileElement: Equatable, Hashable, Codable {
     case file(path: AbsolutePath)
     case folderReference(path: AbsolutePath)
 
@@ -23,3 +23,43 @@ public enum FileElement: Equatable, Hashable {
         }
     }
 }
+
+// MARK: - Codable
+
+extension FileElement {
+    private enum Kind: String, Codable {
+        case file
+        case folderReference
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case path
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .file:
+            let path = try container.decode(AbsolutePath.self, forKey: .path)
+            self = .file(path: path)
+        case .folderReference:
+            let path = try container.decode(AbsolutePath.self, forKey: .path)
+            self = .folderReference(path: path)
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .file(path):
+            try container.encode(Kind.file, forKey: .kind)
+            try container.encode(path, forKey: .path)
+        case let .folderReference(path):
+            try container.encode(Kind.file, forKey: .kind)
+            try container.encode(path, forKey: .path)
+        }
+    }
+}
+

--- a/Sources/TuistGraph/Models/FileElement.swift
+++ b/Sources/TuistGraph/Models/FileElement.swift
@@ -32,7 +32,7 @@ extension FileElement {
         case folderReference
     }
 
-    enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case kind
         case path
     }

--- a/Sources/TuistGraph/Models/FileElement.swift
+++ b/Sources/TuistGraph/Models/FileElement.swift
@@ -57,7 +57,7 @@ extension FileElement {
             try container.encode(Kind.file, forKey: .kind)
             try container.encode(path, forKey: .path)
         case let .folderReference(path):
-            try container.encode(Kind.file, forKey: .kind)
+            try container.encode(Kind.folderReference, forKey: .kind)
             try container.encode(path, forKey: .path)
         }
     }

--- a/Sources/TuistGraph/Models/Headers.swift
+++ b/Sources/TuistGraph/Models/Headers.swift
@@ -2,7 +2,7 @@ import Foundation
 import TSCBasic
 
 /// Headers
-public struct Headers: Equatable {
+public struct Headers: Equatable, Codable {
     // MARK: - Attributes
 
     public let `public`: [AbsolutePath]

--- a/Sources/TuistGraph/Models/IDETemplateMacros.swift
+++ b/Sources/TuistGraph/Models/IDETemplateMacros.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public struct IDETemplateMacros: Codable, Hashable {
-    enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case fileHeader = "FILEHEADER"
     }
 

--- a/Sources/TuistGraph/Models/InfoPlist.swift
+++ b/Sources/TuistGraph/Models/InfoPlist.swift
@@ -86,7 +86,7 @@ extension InfoPlist {
         case extendingDefault
     }
 
-    enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case kind
         case path
         case data
@@ -184,7 +184,7 @@ extension InfoPlist.Value {
         case array
     }
 
-    enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case kind
         case string
         case integer

--- a/Sources/TuistGraph/Models/InfoPlist.swift
+++ b/Sources/TuistGraph/Models/InfoPlist.swift
@@ -85,14 +85,14 @@ extension InfoPlist {
         case dictionary
         case extendingDefault
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case kind
         case path
         case data
         case dictionary
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(Kind.self, forKey: .kind)
@@ -112,7 +112,7 @@ extension InfoPlist {
             self = .extendingDefault(with: directory)
         }
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
@@ -183,7 +183,7 @@ extension InfoPlist.Value {
         case dictionary
         case array
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case kind
         case string
@@ -192,7 +192,7 @@ extension InfoPlist.Value {
         case dictionary
         case array
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(Kind.self, forKey: .kind)
@@ -214,7 +214,7 @@ extension InfoPlist.Value {
             self = .dictionary(dictionary)
         }
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {

--- a/Sources/TuistGraph/Models/InfoPlist.swift
+++ b/Sources/TuistGraph/Models/InfoPlist.swift
@@ -1,8 +1,8 @@
 import Foundation
 import TSCBasic
 
-public enum InfoPlist: Equatable {
-    public indirect enum Value: Equatable {
+public enum InfoPlist: Equatable, Codable {
+    public indirect enum Value: Equatable, Codable {
         case string(String)
         case integer(Int)
         case boolean(Bool)
@@ -76,6 +76,63 @@ extension InfoPlist: ExpressibleByStringLiteral {
     }
 }
 
+// MARK: - InfoPlist - Codable
+
+extension InfoPlist {
+    private enum Kind: String, Codable {
+        case file
+        case generatedFile
+        case dictionary
+        case extendingDefault
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case path
+        case data
+        case dictionary
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .file:
+            let path = try container.decode(AbsolutePath.self, forKey: .path)
+            self = .file(path: path)
+        case .generatedFile:
+            let path = try container.decode(AbsolutePath.self, forKey: .path)
+            let data = try container.decode(Data.self, forKey: .data)
+            self = .generatedFile(path: path, data: data)
+        case .dictionary:
+            let directory = try container.decode([String: Value].self, forKey: .dictionary)
+            self = .dictionary(directory)
+        case .extendingDefault:
+            let directory = try container.decode([String: Value].self, forKey: .dictionary)
+            self = .extendingDefault(with: directory)
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .file(path):
+            try container.encode(Kind.file, forKey: .kind)
+            try container.encode(path, forKey: .path)
+        case let .generatedFile(path, data):
+            try container.encode(Kind.generatedFile, forKey: .kind)
+            try container.encode(data, forKey: .data)
+            try container.encode(path, forKey: .path)
+        case let .dictionary(dictionary):
+            try container.encode(Kind.dictionary, forKey: .kind)
+            try container.encode(dictionary, forKey: .dictionary)
+        case let .extendingDefault(dictionary):
+            try container.encode(Kind.extendingDefault, forKey: .kind)
+            try container.encode(dictionary, forKey: .dictionary)
+        }
+    }
+}
+
 // MARK: - InfoPlist.Value - ExpressibleByStringLiteral
 
 extension InfoPlist.Value: ExpressibleByStringLiteral {
@@ -113,6 +170,70 @@ extension InfoPlist.Value: ExpressibleByDictionaryLiteral {
 extension InfoPlist.Value: ExpressibleByArrayLiteral {
     public init(arrayLiteral elements: InfoPlist.Value...) {
         self = .array(elements)
+    }
+}
+
+// MARK: - InfoPlist.Value - Codable
+
+extension InfoPlist.Value {
+    private enum Kind: String, Codable {
+        case string
+        case integer
+        case boolean
+        case dictionary
+        case array
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case string
+        case integer
+        case boolean
+        case dictionary
+        case array
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .string:
+            let string = try container.decode(String.self, forKey: .string)
+            self = .string(string)
+        case .integer:
+            let integer = try container.decode(Int.self, forKey: .integer)
+            self = .integer(integer)
+        case .boolean:
+            let boolean = try container.decode(Bool.self, forKey: .boolean)
+            self = .boolean(boolean)
+        case .array:
+            let array = try container.decode([Value].self, forKey: .array)
+            self = .array(array)
+        case .dictionary:
+            let dictionary = try container.decode([String: Value].self, forKey: .dictionary)
+            self = .dictionary(dictionary)
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .string(string):
+            try container.encode(Kind.string, forKey: .kind)
+            try container.encode(string, forKey: .string)
+        case let .integer(integer):
+            try container.encode(Kind.integer, forKey: .kind)
+            try container.encode(integer, forKey: .integer)
+        case let .boolean(boolean):
+            try container.encode(Kind.boolean, forKey: .kind)
+            try container.encode(boolean, forKey: .boolean)
+        case let .array(array):
+            try container.encode(Kind.array, forKey: .kind)
+            try container.encode(array, forKey: .array)
+        case let .dictionary(dictionary):
+            try container.encode(Kind.dictionary, forKey: .kind)
+            try container.encode(dictionary, forKey: .dictionary)
+        }
     }
 }
 

--- a/Sources/TuistGraph/Models/Package.swift
+++ b/Sources/TuistGraph/Models/Package.swift
@@ -14,7 +14,7 @@ extension Package {
         case local
     }
 
-    enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case kind
         case url
         case requirement

--- a/Sources/TuistGraph/Models/Package.swift
+++ b/Sources/TuistGraph/Models/Package.swift
@@ -1,7 +1,51 @@
 import Foundation
 import TSCBasic
 
-public enum Package: Equatable {
+public enum Package: Equatable, Codable {
     case remote(url: String, requirement: Requirement)
     case local(path: AbsolutePath)
+}
+
+
+// MARK: - Codable
+
+extension Package {
+    private enum Kind: String, Codable {
+        case remote
+        case local
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case url
+        case requirement
+        case path
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .remote:
+            let url = try container.decode(String.self, forKey: .url)
+            let requirement = try container.decode(Requirement.self, forKey: .requirement)
+            self = .remote(url: url, requirement: requirement)
+        case .local:
+            let path = try container.decode(AbsolutePath.self, forKey: .path)
+            self = .local(path: path)
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .remote(url, requirement):
+            try container.encode(Kind.remote, forKey: .kind)
+            try container.encode(url, forKey: .url)
+            try container.encode(requirement, forKey: .requirement)
+        case let .local(path):
+            try container.encode(Kind.local, forKey: .kind)
+            try container.encode(path, forKey: .path)
+        }
+    }
 }

--- a/Sources/TuistGraph/Models/Package.swift
+++ b/Sources/TuistGraph/Models/Package.swift
@@ -6,7 +6,6 @@ public enum Package: Equatable, Codable {
     case local(path: AbsolutePath)
 }
 
-
 // MARK: - Codable
 
 extension Package {
@@ -21,7 +20,7 @@ extension Package {
         case requirement
         case path
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(Kind.self, forKey: .kind)
@@ -35,7 +34,7 @@ extension Package {
             self = .local(path: path)
         }
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {

--- a/Sources/TuistGraph/Models/Platform.swift
+++ b/Sources/TuistGraph/Models/Platform.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum Platform: String, CaseIterable {
+public enum Platform: String, CaseIterable, Codable {
     case iOS = "ios"
     case macOS = "macos"
     case tvOS = "tvos"

--- a/Sources/TuistGraph/Models/Product.swift
+++ b/Sources/TuistGraph/Models/Product.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum Product: String, CustomStringConvertible, CaseIterable, Encodable {
+public enum Product: String, CustomStringConvertible, CaseIterable, Codable {
     case app
     case staticLibrary = "static_library"
     case dynamicLibrary = "dynamic_library"

--- a/Sources/TuistGraph/Models/ProfileAction.swift
+++ b/Sources/TuistGraph/Models/ProfileAction.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct ProfileAction: Equatable {
+public struct ProfileAction: Equatable, Codable {
     // MARK: - Attributes
 
     public let configurationName: String

--- a/Sources/TuistGraph/Models/Project.swift
+++ b/Sources/TuistGraph/Models/Project.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebugStringConvertible {
+public struct Project: Hashable, Equatable, CustomStringConvertible, CustomDebugStringConvertible, Codable {
     // MARK: - Attributes
 
     /// Path to the folder that contains the project manifest.

--- a/Sources/TuistGraph/Models/ProjectGroup.swift
+++ b/Sources/TuistGraph/Models/ProjectGroup.swift
@@ -15,7 +15,7 @@ extension ProjectGroup {
         case kind
         case name
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(Kind.self, forKey: .kind)
@@ -25,7 +25,7 @@ extension ProjectGroup {
             self = .group(name: name)
         }
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {

--- a/Sources/TuistGraph/Models/ProjectGroup.swift
+++ b/Sources/TuistGraph/Models/ProjectGroup.swift
@@ -11,7 +11,7 @@ extension ProjectGroup {
         case group
     }
 
-    enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case kind
         case name
     }

--- a/Sources/TuistGraph/Models/ProjectGroup.swift
+++ b/Sources/TuistGraph/Models/ProjectGroup.swift
@@ -1,5 +1,37 @@
 import Foundation
 
-public enum ProjectGroup: Hashable {
+public enum ProjectGroup: Hashable, Codable {
     case group(name: String)
+}
+
+// MARK: - Codable
+
+extension ProjectGroup {
+    private enum Kind: String, Codable {
+        case group
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case name
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .group:
+            let name = try container.decode(String.self, forKey: .name)
+            self = .group(name: name)
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .group(name):
+            try container.encode(Kind.group, forKey: .kind)
+            try container.encode(name, forKey: .name)
+        }
+    }
 }

--- a/Sources/TuistGraph/Models/Requirement.swift
+++ b/Sources/TuistGraph/Models/Requirement.swift
@@ -21,7 +21,7 @@ extension Requirement {
         case revision
     }
 
-    enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case kind
         case version
         case from

--- a/Sources/TuistGraph/Models/Requirement.swift
+++ b/Sources/TuistGraph/Models/Requirement.swift
@@ -29,7 +29,7 @@ extension Requirement {
         case branch
         case revision
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(Kind.self, forKey: .kind)
@@ -55,7 +55,7 @@ extension Requirement {
             self = .revision(revision)
         }
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {

--- a/Sources/TuistGraph/Models/Requirement.swift
+++ b/Sources/TuistGraph/Models/Requirement.swift
@@ -1,10 +1,83 @@
 import Foundation
 
-public enum Requirement: Equatable {
+public enum Requirement: Equatable, Codable {
     case upToNextMajor(String)
     case upToNextMinor(String)
     case range(from: String, to: String)
     case exact(String)
     case branch(String)
     case revision(String)
+}
+
+// MARK: - Codable
+
+extension Requirement {
+    private enum Kind: String, Codable {
+        case upToNextMajor
+        case upToNextMinor
+        case range
+        case exact
+        case branch
+        case revision
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case version
+        case from
+        case to
+        case branch
+        case revision
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .upToNextMajor:
+            let version = try container.decode(String.self, forKey: .version)
+            self = .upToNextMajor(version)
+        case .upToNextMinor:
+            let version = try container.decode(String.self, forKey: .version)
+            self = .upToNextMinor(version)
+        case .range:
+            let from = try container.decode(String.self, forKey: .from)
+            let to = try container.decode(String.self, forKey: .to)
+            self = .range(from: from, to: to)
+        case .exact:
+            let version = try container.decode(String.self, forKey: .version)
+            self = .exact(version)
+        case .branch:
+            let branch = try container.decode(String.self, forKey: .branch)
+            self = .branch(branch)
+        case .revision:
+            let revision = try container.decode(String.self, forKey: .revision)
+            self = .revision(revision)
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .upToNextMajor(version):
+            try container.encode(Kind.upToNextMajor, forKey: .kind)
+            try container.encode(version, forKey: .version)
+        case let .upToNextMinor(version):
+            try container.encode(Kind.upToNextMinor, forKey: .kind)
+            try container.encode(version, forKey: .version)
+        case let .range(from, to):
+            try container.encode(Kind.range, forKey: .kind)
+            try container.encode(from, forKey: .from)
+            try container.encode(to, forKey: .to)
+        case let .exact(version):
+            try container.encode(Kind.exact, forKey: .kind)
+            try container.encode(version, forKey: .version)
+        case let .branch(branch):
+            try container.encode(Kind.branch, forKey: .kind)
+            try container.encode(branch, forKey: .branch)
+        case let .revision(revision):
+            try container.encode(Kind.revision, forKey: .kind)
+            try container.encode(revision, forKey: .revision)
+        }
+    }
 }

--- a/Sources/TuistGraph/Models/ResourceFileElement.swift
+++ b/Sources/TuistGraph/Models/ResourceFileElement.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public enum ResourceFileElement: Equatable, Hashable {
+public enum ResourceFileElement: Equatable, Hashable, Codable {
     case file(path: AbsolutePath, tags: [String] = [])
     case folderReference(path: AbsolutePath, tags: [String] = [])
 
@@ -29,6 +29,50 @@ public enum ResourceFileElement: Equatable, Hashable {
             return tags
         case let .folderReference(_, tags):
             return tags
+        }
+    }
+}
+
+// MARK: - Codable
+
+extension ResourceFileElement {
+    private enum Kind: String, Codable {
+        case file
+        case folderReference
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case path
+        case tags
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .file:
+            let path = try container.decode(AbsolutePath.self, forKey: .path)
+            let tags = try container.decode([String].self, forKey: .tags)
+            self = .file(path: path, tags: tags)
+        case .folderReference:
+            let path = try container.decode(AbsolutePath.self, forKey: .path)
+            let tags = try container.decode([String].self, forKey: .tags)
+            self = .folderReference(path: path, tags: tags)
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .file(path, tags):
+            try container.encode(Kind.file, forKey: .kind)
+            try container.encode(path, forKey: .path)
+            try container.encode(tags, forKey: .tags)
+        case let .folderReference(path, tags):
+            try container.encode(Kind.folderReference, forKey: .kind)
+            try container.encode(path, forKey: .path)
+            try container.encode(tags, forKey: .tags)
         }
     }
 }

--- a/Sources/TuistGraph/Models/ResourceFileElement.swift
+++ b/Sources/TuistGraph/Models/ResourceFileElement.swift
@@ -41,7 +41,7 @@ extension ResourceFileElement {
         case folderReference
     }
 
-    enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case kind
         case path
         case tags

--- a/Sources/TuistGraph/Models/ResourceFileElement.swift
+++ b/Sources/TuistGraph/Models/ResourceFileElement.swift
@@ -46,7 +46,7 @@ extension ResourceFileElement {
         case path
         case tags
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(Kind.self, forKey: .kind)
@@ -61,7 +61,7 @@ extension ResourceFileElement {
             self = .folderReference(path: path, tags: tags)
         }
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {

--- a/Sources/TuistGraph/Models/ResourceSynthesizer.swift
+++ b/Sources/TuistGraph/Models/ResourceSynthesizer.swift
@@ -1,17 +1,17 @@
 import Foundation
 import TSCBasic
 
-public struct ResourceSynthesizer: Equatable, Hashable {
+public struct ResourceSynthesizer: Equatable, Hashable, Codable {
     public let parser: Parser
     public let extensions: Set<String>
     public let template: Template
 
-    public enum Template: Equatable, Hashable {
+    public enum Template: Equatable, Hashable, Codable {
         case file(AbsolutePath)
         case defaultTemplate(String)
     }
 
-    public enum Parser: Equatable, Hashable {
+    public enum Parser: String, Equatable, Hashable, Codable {
         case strings
         case assets
         case plists
@@ -30,5 +30,45 @@ public struct ResourceSynthesizer: Equatable, Hashable {
         self.parser = parser
         self.extensions = extensions
         self.template = template
+    }
+}
+
+// MARK: - ResourceSynthesizer.Template - Codable
+
+extension ResourceSynthesizer.Template {
+    private enum Kind: String, Codable {
+        case file
+        case defaultTemplate
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case file
+        case template
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .file:
+            let file = try container.decode(AbsolutePath.self, forKey: .file)
+            self = .file(file)
+        case .defaultTemplate:
+            let template = try container.decode(String.self, forKey: .template)
+            self = .defaultTemplate(template)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .file(file):
+            try container.encode(Kind.file, forKey: .kind)
+            try container.encode(file, forKey: .file)
+        case let .defaultTemplate(template):
+            try container.encode(Kind.defaultTemplate, forKey: .kind)
+            try container.encode(template, forKey: .template)
+        }
     }
 }

--- a/Sources/TuistGraph/Models/ResourceSynthesizer.swift
+++ b/Sources/TuistGraph/Models/ResourceSynthesizer.swift
@@ -46,7 +46,7 @@ extension ResourceSynthesizer.Template {
         case file
         case template
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(Kind.self, forKey: .kind)

--- a/Sources/TuistGraph/Models/ResourceSynthesizer.swift
+++ b/Sources/TuistGraph/Models/ResourceSynthesizer.swift
@@ -41,7 +41,7 @@ extension ResourceSynthesizer.Template {
         case defaultTemplate
     }
 
-    enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case kind
         case file
         case template

--- a/Sources/TuistGraph/Models/RunAction.swift
+++ b/Sources/TuistGraph/Models/RunAction.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public struct RunAction: Equatable {
+public struct RunAction: Equatable, Codable {
     // MARK: - Attributes
 
     public let configurationName: String

--- a/Sources/TuistGraph/Models/SDKSource.swift
+++ b/Sources/TuistGraph/Models/SDKSource.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum SDKSource: Equatable {
+public enum SDKSource: String, Equatable, Codable {
     case developer // Platforms/iPhoneOS.platform/Developer/Library
     case system // Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library
 

--- a/Sources/TuistGraph/Models/Scheme.swift
+++ b/Sources/TuistGraph/Models/Scheme.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public struct Scheme: Equatable {
+public struct Scheme: Equatable, Codable {
     // MARK: - Attributes
 
     public var name: String

--- a/Sources/TuistGraph/Models/SchemeDiagnosticsOption.swift
+++ b/Sources/TuistGraph/Models/SchemeDiagnosticsOption.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-public enum SchemeDiagnosticsOption: Equatable {
+public enum SchemeDiagnosticsOption: String, Equatable, Codable {
     case mainThreadChecker
 }

--- a/Sources/TuistGraph/Models/Settings.swift
+++ b/Sources/TuistGraph/Models/Settings.swift
@@ -164,7 +164,7 @@ extension SettingValue {
         case array
     }
 
-    enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case kind
         case string
         case array
@@ -205,7 +205,7 @@ extension DefaultSettings {
         case none
     }
 
-    enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case kind
         case excluding
     }

--- a/Sources/TuistGraph/Models/Settings.swift
+++ b/Sources/TuistGraph/Models/Settings.swift
@@ -169,7 +169,7 @@ extension SettingValue {
         case string
         case array
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(Kind.self, forKey: .kind)
@@ -182,7 +182,7 @@ extension SettingValue {
             self = .array(array)
         }
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
@@ -209,7 +209,7 @@ extension DefaultSettings {
         case kind
         case excluding
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(Kind.self, forKey: .kind)
@@ -224,7 +224,7 @@ extension DefaultSettings {
             self = .none
         }
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {

--- a/Sources/TuistGraph/Models/SourceFile.swift
+++ b/Sources/TuistGraph/Models/SourceFile.swift
@@ -2,7 +2,7 @@ import Foundation
 import TSCBasic
 
 /// A type that represents a source file.
-public struct SourceFile: ExpressibleByStringLiteral, Equatable {
+public struct SourceFile: ExpressibleByStringLiteral, Equatable, Codable {
     /// Source file path.
     public var path: AbsolutePath
 

--- a/Sources/TuistGraph/Models/Target.swift
+++ b/Sources/TuistGraph/Models/Target.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public struct Target: Equatable, Hashable, Comparable {
+public struct Target: Equatable, Hashable, Comparable, Codable {
     // MARK: - Static
 
     public static let validSourceExtensions: [String] = [

--- a/Sources/TuistGraph/Models/TargetAction.swift
+++ b/Sources/TuistGraph/Models/TargetAction.swift
@@ -142,7 +142,7 @@ extension TargetAction.Script {
         case embedded
     }
 
-    enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case kind
         case path
         case absolutePath

--- a/Sources/TuistGraph/Models/TargetAction.swift
+++ b/Sources/TuistGraph/Models/TargetAction.swift
@@ -135,9 +135,9 @@ extension Array where Element == TargetAction {
 
 // MARK: - TargetAction.Script - Codable
 
-//case tool(_ path: String, _ args: [String] = [])
-//case scriptPath(_ path: AbsolutePath, args: [String] = [])
-//case embedded(String)
+// case tool(_ path: String, _ args: [String] = [])
+// case scriptPath(_ path: AbsolutePath, args: [String] = [])
+// case embedded(String)
 
 extension TargetAction.Script {
     private enum Kind: String, Codable {
@@ -152,7 +152,7 @@ extension TargetAction.Script {
         case absolutePath
         case args
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(Kind.self, forKey: .kind)
@@ -170,7 +170,7 @@ extension TargetAction.Script {
             self = .embedded(path)
         }
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {

--- a/Sources/TuistGraph/Models/TargetAction.swift
+++ b/Sources/TuistGraph/Models/TargetAction.swift
@@ -2,12 +2,12 @@ import Foundation
 import TSCBasic
 
 /// It represents a target script build phase
-public struct TargetAction: Equatable {
+public struct TargetAction: Equatable, Codable {
     /// Order when the action gets executed.
     ///
     /// - pre: Before the sources and resources build phase.
     /// - post: After the sources and resources build phase.
-    public enum Order: String, Equatable {
+    public enum Order: String, Equatable, Codable {
         case pre
         case post
     }
@@ -16,8 +16,8 @@ public struct TargetAction: Equatable {
     ///
     /// - tool: Executes the tool with the given arguments. Tuist will look up the tool on the environment's PATH.
     /// - scriptPath: Executes the file at the path with the given arguments.
-    /// - text: Executes the embedded script. This should be a short command.
-    public enum Script: Equatable {
+    /// - embedded: Executes the embedded script. This should be a short command.
+    public enum Script: Equatable, Codable {
         case tool(_ path: String, _ args: [String] = [])
         case scriptPath(_ path: AbsolutePath, args: [String] = [])
         case embedded(String)
@@ -130,5 +130,61 @@ extension Array where Element == TargetAction {
 
     public var postActions: [TargetAction] {
         filter { $0.order == .post }
+    }
+}
+
+// MARK: - TargetAction.Script - Codable
+
+//case tool(_ path: String, _ args: [String] = [])
+//case scriptPath(_ path: AbsolutePath, args: [String] = [])
+//case embedded(String)
+
+extension TargetAction.Script {
+    private enum Kind: String, Codable {
+        case tool
+        case scriptPath
+        case embedded
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case path
+        case absolutePath
+        case args
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .tool:
+            let path = try container.decode(String.self, forKey: .path)
+            let args = try container.decode([String].self, forKey: .args)
+            self = .tool(path, args)
+        case .scriptPath:
+            let absolutePath = try container.decode(AbsolutePath.self, forKey: .absolutePath)
+            let args = try container.decode([String].self, forKey: .args)
+            self = .scriptPath(absolutePath, args: args)
+        case .embedded:
+            let path = try container.decode(String.self, forKey: .path)
+            self = .embedded(path)
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .tool(path, args):
+            try container.encode(Kind.tool, forKey: .kind)
+            try container.encode(path, forKey: .path)
+            try container.encode(args, forKey: .args)
+        case let .scriptPath(absolutePath, args):
+            try container.encode(Kind.scriptPath, forKey: .kind)
+            try container.encode(absolutePath, forKey: .absolutePath)
+            try container.encode(args, forKey: .args)
+        case let .embedded(path):
+            try container.encode(Kind.embedded, forKey: .kind)
+            try container.encode(path, forKey: .path)
+        }
     }
 }

--- a/Sources/TuistGraph/Models/TargetAction.swift
+++ b/Sources/TuistGraph/Models/TargetAction.swift
@@ -135,10 +135,6 @@ extension Array where Element == TargetAction {
 
 // MARK: - TargetAction.Script - Codable
 
-// case tool(_ path: String, _ args: [String] = [])
-// case scriptPath(_ path: AbsolutePath, args: [String] = [])
-// case embedded(String)
-
 extension TargetAction.Script {
     private enum Kind: String, Codable {
         case tool

--- a/Sources/TuistGraph/Models/TargetDependency.swift
+++ b/Sources/TuistGraph/Models/TargetDependency.swift
@@ -64,7 +64,7 @@ extension TargetDependency {
         case .library:
             let path = try container.decode(AbsolutePath.self, forKey: .path)
             let publicHeaders = try container.decode(AbsolutePath.self, forKey: .publicHeaders)
-            let swiftModuleMap = try container.decode(AbsolutePath?.self, forKey: .swiftModuleMap)
+            let swiftModuleMap = try container.decodeIfPresent(AbsolutePath.self, forKey: .swiftModuleMap)
             self = .library(path: path, publicHeaders: publicHeaders, swiftModuleMap: swiftModuleMap)
         case .package:
             let product = try container.decode(String.self, forKey: .product)

--- a/Sources/TuistGraph/Models/TargetDependency.swift
+++ b/Sources/TuistGraph/Models/TargetDependency.swift
@@ -43,7 +43,7 @@ extension TargetDependency {
         case product
         case status
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(Kind.self, forKey: .kind)
@@ -80,7 +80,7 @@ extension TargetDependency {
             self = .xctest
         }
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {

--- a/Sources/TuistGraph/Models/TargetDependency.swift
+++ b/Sources/TuistGraph/Models/TargetDependency.swift
@@ -33,7 +33,7 @@ extension TargetDependency {
         case xctest
     }
 
-    enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case kind
         case name
         case target

--- a/Sources/TuistGraph/Models/TargetDependency.swift
+++ b/Sources/TuistGraph/Models/TargetDependency.swift
@@ -1,12 +1,12 @@
 import Foundation
 import TSCBasic
 
-public enum SDKStatus {
+public enum SDKStatus: String, Codable {
     case required
     case optional
 }
 
-public enum TargetDependency: Equatable, Hashable {
+public enum TargetDependency: Equatable, Hashable, Codable {
     case target(name: String)
     case project(target: String, path: AbsolutePath)
     case framework(path: AbsolutePath)
@@ -16,4 +16,104 @@ public enum TargetDependency: Equatable, Hashable {
     case sdk(name: String, status: SDKStatus)
     case cocoapods(path: AbsolutePath)
     case xctest
+}
+
+// MARK: - Codable
+
+extension TargetDependency {
+    private enum Kind: String, Codable {
+        case target
+        case project
+        case framework
+        case xcFramework
+        case library
+        case package
+        case sdk
+        case cocoapods
+        case xctest
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case name
+        case target
+        case path
+        case publicHeaders
+        case swiftModuleMap
+        case product
+        case status
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .target:
+            let name = try container.decode(String.self, forKey: .name)
+            self = .target(name: name)
+        case .project:
+            let target = try container.decode(String.self, forKey: .target)
+            let path = try container.decode(AbsolutePath.self, forKey: .path)
+            self = .project(target: target, path: path)
+        case .framework:
+            let path = try container.decode(AbsolutePath.self, forKey: .path)
+            self = .framework(path: path)
+        case .xcFramework:
+            let path = try container.decode(AbsolutePath.self, forKey: .path)
+            self = .xcFramework(path: path)
+        case .library:
+            let path = try container.decode(AbsolutePath.self, forKey: .path)
+            let publicHeaders = try container.decode(AbsolutePath.self, forKey: .publicHeaders)
+            let swiftModuleMap = try container.decode(AbsolutePath?.self, forKey: .swiftModuleMap)
+            self = .library(path: path, publicHeaders: publicHeaders, swiftModuleMap: swiftModuleMap)
+        case .package:
+            let product = try container.decode(String.self, forKey: .product)
+            self = .package(product: product)
+        case .sdk:
+            let name = try container.decode(String.self, forKey: .name)
+            let status = try container.decode(SDKStatus.self, forKey: .status)
+            self = .sdk(name: name, status: status)
+        case .cocoapods:
+            let path = try container.decode(AbsolutePath.self, forKey: .path)
+            self = .cocoapods(path: path)
+        case .xctest:
+            self = .xctest
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .target(name):
+            try container.encode(Kind.target, forKey: .kind)
+            try container.encode(name, forKey: .name)
+        case let .project(target, path):
+            try container.encode(Kind.project, forKey: .kind)
+            try container.encode(target, forKey: .target)
+            try container.encode(path, forKey: .path)
+        case let .framework(path):
+            try container.encode(Kind.framework, forKey: .kind)
+            try container.encode(path, forKey: .path)
+        case let .xcFramework(path):
+            try container.encode(Kind.xcFramework, forKey: .kind)
+            try container.encode(path, forKey: .path)
+        case let .library(path, publicHeaders, swiftModuleMap):
+            try container.encode(Kind.library, forKey: .kind)
+            try container.encode(path, forKey: .path)
+            try container.encode(publicHeaders, forKey: .publicHeaders)
+            try container.encode(swiftModuleMap, forKey: .swiftModuleMap)
+        case let .package(product):
+            try container.encode(Kind.package, forKey: .kind)
+            try container.encode(product, forKey: .product)
+        case let .sdk(name, status):
+            try container.encode(Kind.sdk, forKey: .kind)
+            try container.encode(name, forKey: .name)
+            try container.encode(status, forKey: .status)
+        case let .cocoapods(path):
+            try container.encode(Kind.cocoapods, forKey: .kind)
+            try container.encode(path, forKey: .path)
+        case .xctest:
+            try container.encode(Kind.xctest, forKey: .kind)
+        }
+    }
 }

--- a/Sources/TuistGraph/Models/TargetDependency.swift
+++ b/Sources/TuistGraph/Models/TargetDependency.swift
@@ -101,7 +101,7 @@ extension TargetDependency {
             try container.encode(Kind.library, forKey: .kind)
             try container.encode(path, forKey: .path)
             try container.encode(publicHeaders, forKey: .publicHeaders)
-            try container.encode(swiftModuleMap, forKey: .swiftModuleMap)
+            try container.encodeIfPresent(swiftModuleMap, forKey: .swiftModuleMap)
         case let .package(product):
             try container.encode(Kind.package, forKey: .kind)
             try container.encode(product, forKey: .product)

--- a/Sources/TuistGraph/Models/TargetReference.swift
+++ b/Sources/TuistGraph/Models/TargetReference.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public struct TargetReference: Hashable {
+public struct TargetReference: Hashable, Codable {
     public var projectPath: AbsolutePath
     public var name: String
 

--- a/Sources/TuistGraph/Models/TargetScript.swift
+++ b/Sources/TuistGraph/Models/TargetScript.swift
@@ -2,7 +2,7 @@ import Foundation
 import TSCBasic
 
 /// It represents a target build phase.
-public struct TargetScript: Equatable {
+public struct TargetScript: Equatable, Codable {
     /// The  name of the build phase.
     public let name: String
 

--- a/Sources/TuistGraph/Models/TestAction.swift
+++ b/Sources/TuistGraph/Models/TestAction.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public struct TestAction: Equatable {
+public struct TestAction: Equatable, Codable {
     // MARK: - Attributes
 
     public var testPlans: [TestPlan]?

--- a/Sources/TuistGraph/Models/TestPlan.swift
+++ b/Sources/TuistGraph/Models/TestPlan.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public struct TestPlan: Equatable {
+public struct TestPlan: Equatable, Codable {
     public let path: AbsolutePath
     public let isDefault: Bool
 

--- a/Sources/TuistGraph/Models/TestableTarget.swift
+++ b/Sources/TuistGraph/Models/TestableTarget.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public struct TestableTarget: Equatable, Hashable {
+public struct TestableTarget: Equatable, Hashable, Codable {
     public let target: TargetReference
     public let isSkipped: Bool
     public let isParallelizable: Bool

--- a/Sources/TuistGraph/Models/Workspace.swift
+++ b/Sources/TuistGraph/Models/Workspace.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public struct Workspace: Equatable {
+public struct Workspace: Equatable, Codable {
     // MARK: - Attributes
 
     /// Path to where the manifest / root directory of this workspace is located

--- a/Sources/TuistGraph/Models/XCFrameworkInfoPlist.swift
+++ b/Sources/TuistGraph/Models/XCFrameworkInfoPlist.swift
@@ -3,13 +3,13 @@ import TSCBasic
 
 /// It represents th Info.plist contained in an .xcframework bundle.
 public struct XCFrameworkInfoPlist: Codable, Equatable {
-    enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case libraries = "AvailableLibraries"
     }
 
     /// It represents a library inside an .xcframework
     public struct Library: Codable, Equatable {
-        enum CodingKeys: String, CodingKey {
+        private enum CodingKeys: String, CodingKey {
             case identifier = "LibraryIdentifier"
             case path = "LibraryPath"
             case architectures = "SupportedArchitectures"

--- a/Sources/TuistGraph/ValueGraph/ValueGraph.swift
+++ b/Sources/TuistGraph/ValueGraph/ValueGraph.swift
@@ -2,7 +2,7 @@ import Foundation
 import TSCBasic
 
 /// An directed acyclic graph (DAG) that Tuist uses to represent the dependency tree.
-public struct ValueGraph: Equatable {
+public struct ValueGraph: Equatable, Codable {
     /// The name of the graph
     public var name: String
 

--- a/Sources/TuistGraph/ValueGraph/ValueGraphDependency.swift
+++ b/Sources/TuistGraph/ValueGraph/ValueGraphDependency.swift
@@ -147,7 +147,7 @@ public enum ValueGraphDependency: Hashable, CustomStringConvertible, Comparable,
         case cocoapods
     }
 
-    enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case kind
         case path
         case infoPlist

--- a/Sources/TuistGraph/ValueGraph/ValueGraphDependency.swift
+++ b/Sources/TuistGraph/ValueGraph/ValueGraphDependency.swift
@@ -249,7 +249,7 @@ public enum ValueGraphDependency: Hashable, CustomStringConvertible, Comparable,
             try container.encode(Kind.framework, forKey: .kind)
             try container.encode(path, forKey: .path)
             try container.encode(binaryPath, forKey: .binaryPath)
-            try container.encode(dsymPath, forKey: .dsymPath)
+            try container.encodeIfPresent(dsymPath, forKey: .dsymPath)
             try container.encode(bcsymbolmapPaths, forKey: .bcsymbolmapPaths)
             try container.encode(linking, forKey: .linking)
             try container.encode(architectures, forKey: .architectures)
@@ -260,7 +260,7 @@ public enum ValueGraphDependency: Hashable, CustomStringConvertible, Comparable,
             try container.encode(publicHeaders, forKey: .publicHeaders)
             try container.encode(linking, forKey: .linking)
             try container.encode(architectures, forKey: .architectures)
-            try container.encode(swiftModuleMap, forKey: .swiftModuleMap)
+            try container.encodeIfPresent(swiftModuleMap, forKey: .swiftModuleMap)
         case let .packageProduct(path, product):
             try container.encode(Kind.packageProduct, forKey: .kind)
             try container.encode(path, forKey: .path)

--- a/Sources/TuistGraph/ValueGraph/ValueGraphDependency.swift
+++ b/Sources/TuistGraph/ValueGraph/ValueGraphDependency.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public enum ValueGraphDependency: Hashable, CustomStringConvertible, Comparable {
+public enum ValueGraphDependency: Hashable, CustomStringConvertible, Comparable, Codable {
     /// A dependency that represents a pre-compiled .xcframework.
     case xcframework(
         path: AbsolutePath,
@@ -133,5 +133,151 @@ public enum ValueGraphDependency: Hashable, CustomStringConvertible, Comparable 
 
     public static func < (lhs: ValueGraphDependency, rhs: ValueGraphDependency) -> Bool {
         lhs.description < rhs.description
+    }
+    
+    // MARK: - Codable
+    
+    private enum Kind: String, Codable {
+        case xcframework
+        case framework
+        case library
+        case packageProduct
+        case target
+        case sdk
+        case cocoapods
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case path
+        case infoPlist
+        case primaryBinaryPath
+        case linking
+        case binaryPath
+        case dsymPath
+        case bcsymbolmapPaths
+        case architectures
+        case isCarthage
+        case publicHeaders
+        case swiftModuleMap
+        case product
+        case name
+        case status
+        case source
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .xcframework:
+            let path = try container.decode(AbsolutePath.self, forKey: .path)
+            let infoPlist = try container.decode(XCFrameworkInfoPlist.self, forKey: .infoPlist)
+            let primaryBinaryPath = try container.decode(AbsolutePath.self, forKey: .primaryBinaryPath)
+            let linking = try container.decode(BinaryLinking.self, forKey: .linking)
+            self = .xcframework(
+                path: path,
+                infoPlist: infoPlist,
+                primaryBinaryPath: primaryBinaryPath,
+                linking: linking
+            )
+        case .framework:
+            let path = try container.decode(AbsolutePath.self, forKey: .path)
+            let binaryPath = try container.decode(AbsolutePath.self, forKey: .binaryPath)
+            let dsymPath = try container.decode(AbsolutePath?.self, forKey: .dsymPath)
+            let bcsymbolmapPaths = try container.decode([AbsolutePath].self, forKey: .bcsymbolmapPaths)
+            let linking = try container.decode(BinaryLinking.self, forKey: .linking)
+            let architectures = try container.decode([BinaryArchitecture].self, forKey: .architectures)
+            let isCarthage = try container.decode(Bool.self, forKey: .isCarthage)
+            self = .framework(
+                path: path,
+                binaryPath: binaryPath,
+                dsymPath: dsymPath,
+                bcsymbolmapPaths: bcsymbolmapPaths,
+                linking: linking,
+                architectures: architectures,
+                isCarthage: isCarthage
+            )
+        case .library:
+            let path = try container.decode(AbsolutePath.self, forKey: .path)
+            let publicHeaders = try container.decode(AbsolutePath.self, forKey: .publicHeaders)
+            let linking = try container.decode(BinaryLinking.self, forKey: .linking)
+            let architectures = try container.decode([BinaryArchitecture].self, forKey: .architectures)
+            let swiftModuleMap = try container.decode(AbsolutePath?.self, forKey: .swiftModuleMap)
+            self = .library(
+                path: path,
+                publicHeaders: publicHeaders,
+                linking: linking,
+                architectures: architectures,
+                swiftModuleMap: swiftModuleMap
+            )
+        case .packageProduct:
+            let path = try container.decode(AbsolutePath.self, forKey: .path)
+            let product = try container.decode(String.self, forKey: .product)
+            self = .packageProduct(path: path, product: product)
+        case .target:
+            let name = try container.decode(String.self, forKey: .path)
+            let path = try container.decode(AbsolutePath.self, forKey: .path)
+            self = .target(name: name, path: path)
+        case .sdk:
+            let name = try container.decode(String.self, forKey: .path)
+            let path = try container.decode(AbsolutePath.self, forKey: .path)
+            let status = try container.decode(SDKStatus.self, forKey: .status)
+            let source = try container.decode(SDKSource.self, forKey: .source)
+            self = .sdk(
+                name: name,
+                path: path,
+                status: status,
+                source: source
+            )
+        case .cocoapods:
+            let path = try container.decode(AbsolutePath.self, forKey: .path)
+            self = .cocoapods(path: path)
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .xcframework(path, infoPlist, primaryBinaryPath, linking):
+            try container.encode(Kind.xcframework, forKey: .kind)
+            try container.encode(path, forKey: .path)
+            try container.encode(infoPlist, forKey: .infoPlist)
+            try container.encode(primaryBinaryPath, forKey: .primaryBinaryPath)
+            try container.encode(linking, forKey: .linking)
+        case let .framework(path, binaryPath, dsymPath, bcsymbolmapPaths, linking, architectures, isCarthage):
+            try container.encode(Kind.framework, forKey: .kind)
+            try container.encode(path, forKey: .path)
+            try container.encode(binaryPath, forKey: .binaryPath)
+            try container.encode(dsymPath, forKey: .dsymPath)
+            try container.encode(bcsymbolmapPaths, forKey: .bcsymbolmapPaths)
+            try container.encode(linking, forKey: .linking)
+            try container.encode(architectures, forKey: .architectures)
+            try container.encode(isCarthage, forKey: .isCarthage)
+        case let .library(path, publicHeaders, linking, architectures, swiftModuleMap):
+            try container.encode(Kind.library, forKey: .kind)
+            try container.encode(path, forKey: .path)
+            try container.encode(publicHeaders, forKey: .publicHeaders)
+            try container.encode(linking, forKey: .linking)
+            try container.encode(architectures, forKey: .architectures)
+            try container.encode(swiftModuleMap, forKey: .swiftModuleMap)
+        case let .packageProduct(path, product):
+            try container.encode(Kind.packageProduct, forKey: .kind)
+            try container.encode(path, forKey: .path)
+            try container.encode(product, forKey: .product)
+        case let .target(name, path):
+            try container.encode(Kind.target, forKey: .kind)
+            try container.encode(name, forKey: .name)
+            try container.encode(path, forKey: .path)
+        case let .sdk(name, path, status, source):
+            try container.encode(Kind.sdk, forKey: .kind)
+            try container.encode(name, forKey: .name)
+            try container.encode(path, forKey: .path)
+            try container.encode(status, forKey: .status)
+            try container.encode(source, forKey: .source)
+        case let .cocoapods(path):
+            try container.encode(Kind.cocoapods, forKey: .kind)
+            try container.encode(path, forKey: .path)
+        }
     }
 }

--- a/Sources/TuistGraph/ValueGraph/ValueGraphDependency.swift
+++ b/Sources/TuistGraph/ValueGraph/ValueGraphDependency.swift
@@ -184,7 +184,7 @@ public enum ValueGraphDependency: Hashable, CustomStringConvertible, Comparable,
         case .framework:
             let path = try container.decode(AbsolutePath.self, forKey: .path)
             let binaryPath = try container.decode(AbsolutePath.self, forKey: .binaryPath)
-            let dsymPath = try container.decode(AbsolutePath?.self, forKey: .dsymPath)
+            let dsymPath = try container.decodeIfPresent(AbsolutePath.self, forKey: .dsymPath)
             let bcsymbolmapPaths = try container.decode([AbsolutePath].self, forKey: .bcsymbolmapPaths)
             let linking = try container.decode(BinaryLinking.self, forKey: .linking)
             let architectures = try container.decode([BinaryArchitecture].self, forKey: .architectures)
@@ -203,7 +203,7 @@ public enum ValueGraphDependency: Hashable, CustomStringConvertible, Comparable,
             let publicHeaders = try container.decode(AbsolutePath.self, forKey: .publicHeaders)
             let linking = try container.decode(BinaryLinking.self, forKey: .linking)
             let architectures = try container.decode([BinaryArchitecture].self, forKey: .architectures)
-            let swiftModuleMap = try container.decode(AbsolutePath?.self, forKey: .swiftModuleMap)
+            let swiftModuleMap = try container.decodeIfPresent(AbsolutePath.self, forKey: .swiftModuleMap)
             self = .library(
                 path: path,
                 publicHeaders: publicHeaders,

--- a/Sources/TuistGraph/ValueGraph/ValueGraphDependency.swift
+++ b/Sources/TuistGraph/ValueGraph/ValueGraphDependency.swift
@@ -216,11 +216,11 @@ public enum ValueGraphDependency: Hashable, CustomStringConvertible, Comparable,
             let product = try container.decode(String.self, forKey: .product)
             self = .packageProduct(path: path, product: product)
         case .target:
-            let name = try container.decode(String.self, forKey: .path)
+            let name = try container.decode(String.self, forKey: .name)
             let path = try container.decode(AbsolutePath.self, forKey: .path)
             self = .target(name: name, path: path)
         case .sdk:
-            let name = try container.decode(String.self, forKey: .path)
+            let name = try container.decode(String.self, forKey: .name)
             let path = try container.decode(AbsolutePath.self, forKey: .path)
             let status = try container.decode(SDKStatus.self, forKey: .status)
             let source = try container.decode(SDKSource.self, forKey: .source)

--- a/Sources/TuistGraph/ValueGraph/ValueGraphDependency.swift
+++ b/Sources/TuistGraph/ValueGraph/ValueGraphDependency.swift
@@ -134,9 +134,9 @@ public enum ValueGraphDependency: Hashable, CustomStringConvertible, Comparable,
     public static func < (lhs: ValueGraphDependency, rhs: ValueGraphDependency) -> Bool {
         lhs.description < rhs.description
     }
-    
+
     // MARK: - Codable
-    
+
     private enum Kind: String, Codable {
         case xcframework
         case framework
@@ -146,7 +146,7 @@ public enum ValueGraphDependency: Hashable, CustomStringConvertible, Comparable,
         case sdk
         case cocoapods
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case kind
         case path
@@ -165,7 +165,7 @@ public enum ValueGraphDependency: Hashable, CustomStringConvertible, Comparable,
         case status
         case source
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(Kind.self, forKey: .kind)
@@ -235,7 +235,7 @@ public enum ValueGraphDependency: Hashable, CustomStringConvertible, Comparable,
             self = .cocoapods(path: path)
         }
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {

--- a/Sources/TuistGraph/ValueGraph/ValueGraphTarget.swift
+++ b/Sources/TuistGraph/ValueGraph/ValueGraphTarget.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public struct ValueGraphTarget: Equatable, Hashable, Comparable, CustomDebugStringConvertible, CustomStringConvertible {
+public struct ValueGraphTarget: Equatable, Hashable, Comparable, CustomDebugStringConvertible, CustomStringConvertible, Codable {
     /// Path to the directory that contains the project where the target is defined.
     public let path: AbsolutePath
 

--- a/Tests/TuistGraphTests/Models/AnalyzeActionTests.swift
+++ b/Tests/TuistGraphTests/Models/AnalyzeActionTests.swift
@@ -1,0 +1,15 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class AnalyzeActionTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = AnalyzeAction(configurationName: "name")
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/AnalyzeActionTests.swift
+++ b/Tests/TuistGraphTests/Models/AnalyzeActionTests.swift
@@ -8,7 +8,7 @@ final class AnalyzeActionTests: TuistUnitTestCase {
     func test_codable() {
         // Given
         let subject = AnalyzeAction(configurationName: "name")
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/ArchiveActionTests.swift
+++ b/Tests/TuistGraphTests/Models/ArchiveActionTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class ArchiveActionTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = ArchiveAction(
+            configurationName: "name",
+            revealArchiveInOrganizer: true,
+            customArchiveName: "archiveName",
+            preActions: [
+                .init(
+                    title: "preActionTitle",
+                    scriptText: "text",
+                    target: nil,
+                    showEnvVarsInLog: false
+                )
+            ],
+            postActions: [
+                .init(
+                    title: "postActionTitle",
+                    scriptText: "text",
+                    target: nil,
+                    showEnvVarsInLog: true
+                )
+            ]
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/ArchiveActionTests.swift
+++ b/Tests/TuistGraphTests/Models/ArchiveActionTests.swift
@@ -17,7 +17,7 @@ final class ArchiveActionTests: TuistUnitTestCase {
                     scriptText: "text",
                     target: nil,
                     showEnvVarsInLog: false
-                )
+                ),
             ],
             postActions: [
                 .init(
@@ -25,10 +25,10 @@ final class ArchiveActionTests: TuistUnitTestCase {
                     scriptText: "text",
                     target: nil,
                     showEnvVarsInLog: true
-                )
+                ),
             ]
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/ArgumentsTests.swift
+++ b/Tests/TuistGraphTests/Models/ArgumentsTests.swift
@@ -18,7 +18,7 @@ final class ArgumentsTests: TuistUnitTestCase {
                 ),
             ]
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/ArgumentsTests.swift
+++ b/Tests/TuistGraphTests/Models/ArgumentsTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class ArgumentsTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = Arguments(
+            environment: [
+                "key": "value",
+            ],
+            launchArguments: [
+                .init(
+                    name: "name",
+                    isEnabled: true
+                ),
+            ]
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/BuildActionTests.swift
+++ b/Tests/TuistGraphTests/Models/BuildActionTests.swift
@@ -12,7 +12,7 @@ final class BuildActionTests: TuistUnitTestCase {
                 .init(
                     projectPath: "/path/to/project",
                     name: "name"
-                )
+                ),
             ],
             preActions: [
                 .init(
@@ -20,7 +20,7 @@ final class BuildActionTests: TuistUnitTestCase {
                     scriptText: "text",
                     target: nil,
                     showEnvVarsInLog: true
-                )
+                ),
             ],
             postActions: [
                 .init(
@@ -28,10 +28,10 @@ final class BuildActionTests: TuistUnitTestCase {
                     scriptText: "text",
                     target: nil,
                     showEnvVarsInLog: false
-                )
+                ),
             ]
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/BuildActionTests.swift
+++ b/Tests/TuistGraphTests/Models/BuildActionTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class BuildActionTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = BuildAction(
+            targets: [
+                .init(
+                    projectPath: "/path/to/project",
+                    name: "name"
+                )
+            ],
+            preActions: [
+                .init(
+                    title: "preActionTitle",
+                    scriptText: "text",
+                    target: nil,
+                    showEnvVarsInLog: true
+                )
+            ],
+            postActions: [
+                .init(
+                    title: "postActionTitle",
+                    scriptText: "text",
+                    target: nil,
+                    showEnvVarsInLog: false
+                )
+            ]
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/BuildConfigurationTests.swift
+++ b/Tests/TuistGraphTests/Models/BuildConfigurationTests.swift
@@ -11,11 +11,11 @@ final class BuildConfigurationTests: TuistUnitTestCase {
             name: "Debug",
             variant: .debug
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_name_returnsTheRightValue_whenDebug() {
         XCTAssertEqual(BuildConfiguration.debug.name, "Debug")
     }

--- a/Tests/TuistGraphTests/Models/BuildConfigurationTests.swift
+++ b/Tests/TuistGraphTests/Models/BuildConfigurationTests.swift
@@ -1,9 +1,21 @@
 import Foundation
-import TuistGraph
 import XCTest
-@testable import TuistCore
 
-final class BuildConfigurationTests: XCTestCase {
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class BuildConfigurationTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = BuildConfiguration(
+            name: "Debug",
+            variant: .debug
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
     func test_name_returnsTheRightValue_whenDebug() {
         XCTAssertEqual(BuildConfiguration.debug.name, "Debug")
     }

--- a/Tests/TuistGraphTests/Models/CopyFilesActionTests.swift
+++ b/Tests/TuistGraphTests/Models/CopyFilesActionTests.swift
@@ -12,10 +12,10 @@ final class CopyFilesActionTests: TuistUnitTestCase {
             destination: .frameworks,
             subpath: "subpath",
             files: [
-                .file(path: "/path/to/file")
+                .file(path: "/path/to/file"),
             ]
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/CopyFilesActionTests.swift
+++ b/Tests/TuistGraphTests/Models/CopyFilesActionTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class CopyFilesActionTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = CopyFilesAction(
+            name: "name",
+            destination: .frameworks,
+            subpath: "subpath",
+            files: [
+                .file(path: "/path/to/file")
+            ]
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/CoreDataModelTests.swift
+++ b/Tests/TuistGraphTests/Models/CoreDataModelTests.swift
@@ -1,0 +1,21 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class CoreDataModelTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = CoreDataModel(
+            path: "/path/to/model",
+            versions: [
+                "/path/to/version",
+            ],
+            currentVersion: "1.1.1"
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/CoreDataModelTests.swift
+++ b/Tests/TuistGraphTests/Models/CoreDataModelTests.swift
@@ -14,7 +14,7 @@ final class CoreDataModelTests: TuistUnitTestCase {
             ],
             currentVersion: "1.1.1"
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/DeploymentDeviceTests.swift
+++ b/Tests/TuistGraphTests/Models/DeploymentDeviceTests.swift
@@ -8,15 +8,15 @@ final class DeploymentDeviceTests: TuistUnitTestCase {
     func test_codable_iphone() {
         // Given
         let subject = DeploymentDevice.iphone
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_codable_mac() {
         // Given
         let subject = DeploymentDevice.mac
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/DeploymentDeviceTests.swift
+++ b/Tests/TuistGraphTests/Models/DeploymentDeviceTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class DeploymentDeviceTests: TuistUnitTestCase {
+    func test_codable_iphone() {
+        // Given
+        let subject = DeploymentDevice.iphone
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
+    func test_codable_mac() {
+        // Given
+        let subject = DeploymentDevice.mac
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/DeploymentTargetTests.swift
+++ b/Tests/TuistGraphTests/Models/DeploymentTargetTests.swift
@@ -8,17 +8,16 @@ final class DeploymentTargetTests: TuistUnitTestCase {
     func test_codable_iOS() {
         // Given
         let subject = DeploymentTarget.iOS("12.1", [.iphone, .mac])
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_codable_tvOS() {
         // Given
         let subject = DeploymentTarget.tvOS("13.2.1")
-        
+
         // Then
         XCTAssertCodable(subject)
     }
 }
-

--- a/Tests/TuistGraphTests/Models/DeploymentTargetTests.swift
+++ b/Tests/TuistGraphTests/Models/DeploymentTargetTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class DeploymentTargetTests: TuistUnitTestCase {
+    func test_codable_iOS() {
+        // Given
+        let subject = DeploymentTarget.iOS("12.1", [.iphone, .mac])
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
+    func test_codable_tvOS() {
+        // Given
+        let subject = DeploymentTarget.tvOS("13.2.1")
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}
+

--- a/Tests/TuistGraphTests/Models/ExecutionActionTests.swift
+++ b/Tests/TuistGraphTests/Models/ExecutionActionTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class ExecutionActionTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = ExecutionAction(
+            title: "title",
+            scriptText: "text",
+            target: .init(
+                projectPath: "/path/to/project",
+                name: "name"
+            ),
+            showEnvVarsInLog: false
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/ExecutionActionTests.swift
+++ b/Tests/TuistGraphTests/Models/ExecutionActionTests.swift
@@ -16,7 +16,7 @@ final class ExecutionActionTests: TuistUnitTestCase {
             ),
             showEnvVarsInLog: false
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/FileElementTests.swift
+++ b/Tests/TuistGraphTests/Models/FileElementTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class FileElementTests: TuistUnitTestCase {
+    func test_codable_file() {
+        // Given
+        let subject = FileElement.file(path: "/path/to/file")
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
+    func test_codable_folderReference() {
+        // Given
+        let subject = FileElement.folderReference(path: "/folder/reference")
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/FileElementTests.swift
+++ b/Tests/TuistGraphTests/Models/FileElementTests.swift
@@ -8,15 +8,15 @@ final class FileElementTests: TuistUnitTestCase {
     func test_codable_file() {
         // Given
         let subject = FileElement.file(path: "/path/to/file")
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_codable_folderReference() {
         // Given
         let subject = FileElement.folderReference(path: "/folder/reference")
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/HeadersTests.swift
+++ b/Tests/TuistGraphTests/Models/HeadersTests.swift
@@ -18,7 +18,7 @@ final class HeadersTests: TuistUnitTestCase {
                 "/path/to/project/header",
             ]
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/HeadersTests.swift
+++ b/Tests/TuistGraphTests/Models/HeadersTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class HeadersTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = Headers(
+            public: [
+                "/path/to/public/header",
+            ],
+            private: [
+                "/path/to/private/header",
+            ],
+            project: [
+                "/path/to/project/header",
+            ]
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/InfoPlistTests.swift
+++ b/Tests/TuistGraphTests/Models/InfoPlistTests.swift
@@ -1,10 +1,31 @@
 import Foundation
 import TSCBasic
 import XCTest
+
 @testable import TuistGraph
 @testable import TuistSupportTesting
 
 final class InfoPlistTests: XCTestCase {
+    func test_codable_file() {
+        // Given
+        let subject = InfoPlist.file(path: "/path/to/file")
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
+    func test_codable_dictionary() {
+        // Given
+        let subject = InfoPlist.dictionary([
+            "key1": "value1",
+            "key2": "value2",
+            "key3": "value3",
+        ])
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
     func test_path_when_file() {
         // Given
         let path = AbsolutePath("/path/Info.list")

--- a/Tests/TuistGraphTests/Models/InfoPlistTests.swift
+++ b/Tests/TuistGraphTests/Models/InfoPlistTests.swift
@@ -9,11 +9,11 @@ final class InfoPlistTests: XCTestCase {
     func test_codable_file() {
         // Given
         let subject = InfoPlist.file(path: "/path/to/file")
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_codable_dictionary() {
         // Given
         let subject = InfoPlist.dictionary([
@@ -21,11 +21,11 @@ final class InfoPlistTests: XCTestCase {
             "key2": "value2",
             "key3": "value3",
         ])
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_path_when_file() {
         // Given
         let path = AbsolutePath("/path/Info.list")

--- a/Tests/TuistGraphTests/Models/PackageTests.swift
+++ b/Tests/TuistGraphTests/Models/PackageTests.swift
@@ -8,18 +8,18 @@ final class PackageTests: TuistUnitTestCase {
     func test_codable_local() {
         // Given
         let subject = Package.local(path: "/path/to/package")
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_codable_remote() {
         // Given
         let subject = Package.remote(
             url: "/url/to/package",
             requirement: .branch("branch")
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/PackageTests.swift
+++ b/Tests/TuistGraphTests/Models/PackageTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class PackageTests: TuistUnitTestCase {
+    func test_codable_local() {
+        // Given
+        let subject = Package.local(path: "/path/to/package")
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
+    func test_codable_remote() {
+        // Given
+        let subject = Package.remote(
+            url: "/url/to/package",
+            requirement: .branch("branch")
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/PlatformTests.swift
+++ b/Tests/TuistGraphTests/Models/PlatformTests.swift
@@ -6,19 +6,19 @@ final class PlatformTests: XCTestCase {
     func test_codable_iOS() {
         // Given
         let subject = Platform.iOS
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_codable_tvOS() {
         // Given
         let subject = Platform.tvOS
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_xcodeSdkRoot_returns_the_right_value() {
         XCTAssertEqual(Platform.macOS.xcodeSdkRoot, "macosx")
         XCTAssertEqual(Platform.iOS.xcodeSdkRoot, "iphoneos")

--- a/Tests/TuistGraphTests/Models/PlatformTests.swift
+++ b/Tests/TuistGraphTests/Models/PlatformTests.swift
@@ -3,6 +3,22 @@ import XCTest
 @testable import TuistGraph
 
 final class PlatformTests: XCTestCase {
+    func test_codable_iOS() {
+        // Given
+        let subject = Platform.iOS
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
+    func test_codable_tvOS() {
+        // Given
+        let subject = Platform.tvOS
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
     func test_xcodeSdkRoot_returns_the_right_value() {
         XCTAssertEqual(Platform.macOS.xcodeSdkRoot, "macosx")
         XCTAssertEqual(Platform.iOS.xcodeSdkRoot, "iphoneos")

--- a/Tests/TuistGraphTests/Models/ProductTests.swift
+++ b/Tests/TuistGraphTests/Models/ProductTests.swift
@@ -7,19 +7,19 @@ final class ProductTests: XCTestCase {
     func test_codable_app() {
         // Given
         let subject = Product.app
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_codable_staticFramework() {
         // Given
         let subject = Product.staticFramework
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_xcodeValue() {
         XCTAssertEqual(Product.app.xcodeValue, PBXProductType.application)
         XCTAssertEqual(Product.staticLibrary.xcodeValue, PBXProductType.staticLibrary)

--- a/Tests/TuistGraphTests/Models/ProductTests.swift
+++ b/Tests/TuistGraphTests/Models/ProductTests.swift
@@ -4,6 +4,22 @@ import XCTest
 @testable import TuistGraph
 
 final class ProductTests: XCTestCase {
+    func test_codable_app() {
+        // Given
+        let subject = Product.app
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
+    func test_codable_staticFramework() {
+        // Given
+        let subject = Product.staticFramework
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
     func test_xcodeValue() {
         XCTAssertEqual(Product.app.xcodeValue, PBXProductType.application)
         XCTAssertEqual(Product.staticLibrary.xcodeValue, PBXProductType.staticLibrary)

--- a/Tests/TuistGraphTests/Models/ProfileActionTests.swift
+++ b/Tests/TuistGraphTests/Models/ProfileActionTests.swift
@@ -21,11 +21,11 @@ final class ProfileActionTests: TuistUnitTestCase {
                     .init(
                         name: "name",
                         isEnabled: false
-                    )
+                    ),
                 ]
             )
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/ProfileActionTests.swift
+++ b/Tests/TuistGraphTests/Models/ProfileActionTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class ProfileActionTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = ProfileAction(
+            configurationName: "name",
+            executable: .init(
+                projectPath: "/path/to/project",
+                name: "name"
+            ),
+            arguments: .init(
+                environment: [
+                    "key": "value",
+                ],
+                launchArguments: [
+                    .init(
+                        name: "name",
+                        isEnabled: false
+                    )
+                ]
+            )
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/ProjectGroupTests.swift
+++ b/Tests/TuistGraphTests/Models/ProjectGroupTests.swift
@@ -8,7 +8,7 @@ final class ProjectGroupTests: TuistUnitTestCase {
     func test_codable() {
         // Given
         let subject = ProjectGroup.group(name: "name")
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/ProjectGroupTests.swift
+++ b/Tests/TuistGraphTests/Models/ProjectGroupTests.swift
@@ -1,0 +1,15 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class ProjectGroupTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = ProjectGroup.group(name: "name")
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/ProjectTests.swift
+++ b/Tests/TuistGraphTests/Models/ProjectTests.swift
@@ -7,6 +7,20 @@ import XCTest
 @testable import TuistGraph
 
 final class ProjectTests: XCTestCase {
+    func test_codable() {
+        // Given
+        let framework = Target.test(name: "Framework", product: .framework)
+        let app = Target.test(name: "App", product: .app)
+        let appTests = Target.test(name: "AppTets", product: .unitTests)
+        let frameworkTests = Target.test(name: "FrameworkTests", product: .unitTests)
+        let subject = Project.test(targets: [
+            framework, app, appTests, frameworkTests,
+        ])
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
     func test_sortedTargetsForProjectScheme() {
         // Given
         let framework = Target.test(name: "Framework", product: .framework)

--- a/Tests/TuistGraphTests/Models/ProjectTests.swift
+++ b/Tests/TuistGraphTests/Models/ProjectTests.swift
@@ -16,11 +16,11 @@ final class ProjectTests: XCTestCase {
         let subject = Project.test(targets: [
             framework, app, appTests, frameworkTests,
         ])
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_sortedTargetsForProjectScheme() {
         // Given
         let framework = Target.test(name: "Framework", product: .framework)

--- a/Tests/TuistGraphTests/Models/RequirementTests.swift
+++ b/Tests/TuistGraphTests/Models/RequirementTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class RequirementTests: TuistUnitTestCase {
+    func test_codable_range() {
+        // Given
+        let subject = Requirement.range(from: "1.0.0", to: "2.0.0")
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
+    func test_codable_upToNextMajor() {
+        // Given
+        let subject = Requirement.upToNextMajor("1.2.3")
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/RequirementTests.swift
+++ b/Tests/TuistGraphTests/Models/RequirementTests.swift
@@ -8,15 +8,15 @@ final class RequirementTests: TuistUnitTestCase {
     func test_codable_range() {
         // Given
         let subject = Requirement.range(from: "1.0.0", to: "2.0.0")
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_codable_upToNextMajor() {
         // Given
         let subject = Requirement.upToNextMajor("1.2.3")
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/ResourceFileElementTests.swift
+++ b/Tests/TuistGraphTests/Models/ResourceFileElementTests.swift
@@ -13,20 +13,20 @@ final class ResourceFileElementTests: TuistUnitTestCase {
                 "tag",
             ]
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_codable_folderReference() {
         // Given
         let subject = ResourceFileElement.folderReference(
             path: "/path/to/folder",
             tags: [
-                "tag"
+                "tag",
             ]
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/ResourceFileElementTests.swift
+++ b/Tests/TuistGraphTests/Models/ResourceFileElementTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class ResourceFileElementTests: TuistUnitTestCase {
+    func test_codable_file() {
+        // Given
+        let subject = ResourceFileElement.file(
+            path: "/path/to/element",
+            tags: [
+                "tag",
+            ]
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
+    func test_codable_folderReference() {
+        // Given
+        let subject = ResourceFileElement.folderReference(
+            path: "/path/to/folder",
+            tags: [
+                "tag"
+            ]
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/ResourceSynthesizerTests.swift
+++ b/Tests/TuistGraphTests/Models/ResourceSynthesizerTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class ResourceSynthesizerTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = ResourceSynthesizer(
+            parser: .coreData,
+            extensions: [
+                "extension1",
+                "extension2",
+            ],
+            template: .defaultTemplate("template")
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/ResourceSynthesizerTests.swift
+++ b/Tests/TuistGraphTests/Models/ResourceSynthesizerTests.swift
@@ -15,7 +15,7 @@ final class ResourceSynthesizerTests: TuistUnitTestCase {
             ],
             template: .defaultTemplate("template")
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/RunActionTests.swift
+++ b/Tests/TuistGraphTests/Models/RunActionTests.swift
@@ -22,15 +22,15 @@ final class RunActionTests: TuistUnitTestCase {
                     .init(
                         name: "name",
                         isEnabled: true
-                    )
+                    ),
                 ]
             ),
             options: .init(),
             diagnosticsOptions: [
-                .mainThreadChecker
+                .mainThreadChecker,
             ]
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/RunActionTests.swift
+++ b/Tests/TuistGraphTests/Models/RunActionTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class RunActionTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = RunAction(
+            configurationName: "name",
+            executable: .init(
+                projectPath: "/path/to/project",
+                name: "name"
+            ),
+            filePath: "/path/to/file",
+            arguments: .init(
+                environment: [
+                    "key": "value",
+                ],
+                launchArguments: [
+                    .init(
+                        name: "name",
+                        isEnabled: true
+                    )
+                ]
+            ),
+            options: .init(),
+            diagnosticsOptions: [
+                .mainThreadChecker
+            ]
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/SDKSourceTests.swift
+++ b/Tests/TuistGraphTests/Models/SDKSourceTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class SDKSourceTests: TuistUnitTestCase {
+    func test_codable_developer() {
+        // Given
+        let subject = SDKSource.developer
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
+    func test_codable_system() {
+        // Given
+        let subject = SDKSource.system
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/SDKSourceTests.swift
+++ b/Tests/TuistGraphTests/Models/SDKSourceTests.swift
@@ -8,15 +8,15 @@ final class SDKSourceTests: TuistUnitTestCase {
     func test_codable_developer() {
         // Given
         let subject = SDKSource.developer
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_codable_system() {
         // Given
         let subject = SDKSource.system
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/SchemeDiagnosticsOptionTests.swift
+++ b/Tests/TuistGraphTests/Models/SchemeDiagnosticsOptionTests.swift
@@ -8,7 +8,7 @@ final class SchemeDiagnosticsOptionTests: TuistUnitTestCase {
     func test_codable() {
         // Given
         let subject = SchemeDiagnosticsOption.mainThreadChecker
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/SchemeDiagnosticsOptionTests.swift
+++ b/Tests/TuistGraphTests/Models/SchemeDiagnosticsOptionTests.swift
@@ -1,0 +1,15 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class SchemeDiagnosticsOptionTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = SchemeDiagnosticsOption.mainThreadChecker
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/SchemeTests.swift
+++ b/Tests/TuistGraphTests/Models/SchemeTests.swift
@@ -1,0 +1,15 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class SchemeTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = Scheme.test(name: "name", shared: true)
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/SchemeTests.swift
+++ b/Tests/TuistGraphTests/Models/SchemeTests.swift
@@ -8,7 +8,7 @@ final class SchemeTests: TuistUnitTestCase {
     func test_codable() {
         // Given
         let subject = Scheme.test(name: "name", shared: true)
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/SettingsTests.swift
+++ b/Tests/TuistGraphTests/Models/SettingsTests.swift
@@ -5,6 +5,14 @@ import XCTest
 @testable import TuistGraph
 
 final class SettingsTests: XCTestCase {
+    func test_codable() {
+        // Given
+        let subject = Settings.default
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
     func testXcconfigs() {
         // Given
         let configurations: [BuildConfiguration: Configuration?] = [

--- a/Tests/TuistGraphTests/Models/SettingsTests.swift
+++ b/Tests/TuistGraphTests/Models/SettingsTests.swift
@@ -8,11 +8,11 @@ final class SettingsTests: XCTestCase {
     func test_codable() {
         // Given
         let subject = Settings.default
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func testXcconfigs() {
         // Given
         let configurations: [BuildConfiguration: Configuration?] = [

--- a/Tests/TuistGraphTests/Models/SourceFileTests.swift
+++ b/Tests/TuistGraphTests/Models/SourceFileTests.swift
@@ -1,0 +1,19 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class SourceFileTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = SourceFile(
+            path: "/path/to/file",
+            compilerFlags: "flag",
+            contentHash: "hash"
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/SourceFileTests.swift
+++ b/Tests/TuistGraphTests/Models/SourceFileTests.swift
@@ -12,7 +12,7 @@ final class SourceFileTests: TuistUnitTestCase {
             compilerFlags: "flag",
             contentHash: "hash"
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/TargetActionTests.swift
+++ b/Tests/TuistGraphTests/Models/TargetActionTests.swift
@@ -10,6 +10,14 @@ echo "$wd"
 """
 
 final class TargetActionTests: XCTestCase {
+    func test_codable() {
+        // Given
+        let subject = TargetAction(name: "name", order: .pre, script: .embedded(script))
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
     func test_embedded_script() throws {
         let subject = TargetAction(name: "name", order: .pre, script: .embedded(script))
 

--- a/Tests/TuistGraphTests/Models/TargetActionTests.swift
+++ b/Tests/TuistGraphTests/Models/TargetActionTests.swift
@@ -13,11 +13,11 @@ final class TargetActionTests: XCTestCase {
     func test_codable() {
         // Given
         let subject = TargetAction(name: "name", order: .pre, script: .embedded(script))
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_embedded_script() throws {
         let subject = TargetAction(name: "name", order: .pre, script: .embedded(script))
 

--- a/Tests/TuistGraphTests/Models/TargetDependencyTests.swift
+++ b/Tests/TuistGraphTests/Models/TargetDependencyTests.swift
@@ -20,4 +20,16 @@ final class TargetDependencyTests: TuistUnitTestCase {
         // Then
         XCTAssertCodable(subject)
     }
+    
+    func test_codable_library() {
+        // Given
+        let subject = TargetDependency.library(
+            path: "/path/to/library",
+            publicHeaders: "/path/to/publicheaders",
+            swiftModuleMap: "/path/to/swiftModuleMap"
+        )
+
+        // Then
+        XCTAssertCodable(subject)
+    }
 }

--- a/Tests/TuistGraphTests/Models/TargetDependencyTests.swift
+++ b/Tests/TuistGraphTests/Models/TargetDependencyTests.swift
@@ -20,7 +20,7 @@ final class TargetDependencyTests: TuistUnitTestCase {
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_codable_library() {
         // Given
         let subject = TargetDependency.library(

--- a/Tests/TuistGraphTests/Models/TargetDependencyTests.swift
+++ b/Tests/TuistGraphTests/Models/TargetDependencyTests.swift
@@ -8,15 +8,15 @@ final class TargetDependencyTests: TuistUnitTestCase {
     func test_codable_framework() {
         // Given
         let subject = TargetDependency.framework(path: "/path/to/framework")
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_codable_project() {
         // Given
         let subject = TargetDependency.project(target: "target", path: "/path/to/target")
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/TargetDependencyTests.swift
+++ b/Tests/TuistGraphTests/Models/TargetDependencyTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class TargetDependencyTests: TuistUnitTestCase {
+    func test_codable_framework() {
+        // Given
+        let subject = TargetDependency.framework(path: "/path/to/framework")
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
+    func test_codable_project() {
+        // Given
+        let subject = TargetDependency.project(target: "target", path: "/path/to/target")
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/TargetReferenceTests.swift
+++ b/Tests/TuistGraphTests/Models/TargetReferenceTests.swift
@@ -1,0 +1,18 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class TargetReferenceTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = TargetReference(
+            projectPath: "/path/to/project",
+            name: "name"
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/TargetReferenceTests.swift
+++ b/Tests/TuistGraphTests/Models/TargetReferenceTests.swift
@@ -11,7 +11,7 @@ final class TargetReferenceTests: TuistUnitTestCase {
             projectPath: "/path/to/project",
             name: "name"
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/TargetScriptTests.swift
+++ b/Tests/TuistGraphTests/Models/TargetScriptTests.swift
@@ -1,0 +1,20 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class TargetScriptTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = TargetScript(
+            name: "name",
+            script: "script",
+            showEnvVarsInLog: true,
+            hashable: true
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/TargetScriptTests.swift
+++ b/Tests/TuistGraphTests/Models/TargetScriptTests.swift
@@ -13,7 +13,7 @@ final class TargetScriptTests: TuistUnitTestCase {
             showEnvVarsInLog: true,
             hashable: true
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/TargetTests.swift
+++ b/Tests/TuistGraphTests/Models/TargetTests.swift
@@ -24,11 +24,11 @@ final class TargetTests: TuistUnitTestCase {
     func test_codable() {
         // Given
         let subject = Target.test(name: "Test", product: .staticLibrary)
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_validSourceExtensions() {
         XCTAssertEqual(Target.validSourceExtensions, ["m", "swift", "mm", "cpp", "c", "d", "s", "intentdefinition", "xcmappingmodel", "metal", "mlmodel"])
     }

--- a/Tests/TuistGraphTests/Models/TargetTests.swift
+++ b/Tests/TuistGraphTests/Models/TargetTests.swift
@@ -21,6 +21,14 @@ final class TargetErrorTests: TuistUnitTestCase {
 }
 
 final class TargetTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = Target.test(name: "Test", product: .staticLibrary)
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
     func test_validSourceExtensions() {
         XCTAssertEqual(Target.validSourceExtensions, ["m", "swift", "mm", "cpp", "c", "d", "s", "intentdefinition", "xcmappingmodel", "metal", "mlmodel"])
     }

--- a/Tests/TuistGraphTests/Models/TestActionTests.swift
+++ b/Tests/TuistGraphTests/Models/TestActionTests.swift
@@ -1,0 +1,15 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class TestActionTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = TestAction.test()
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/TestActionTests.swift
+++ b/Tests/TuistGraphTests/Models/TestActionTests.swift
@@ -8,7 +8,7 @@ final class TestActionTests: TuistUnitTestCase {
     func test_codable() {
         // Given
         let subject = TestAction.test()
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/TestPlanTests.swift
+++ b/Tests/TuistGraphTests/Models/TestPlanTests.swift
@@ -1,0 +1,18 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class TestPlanTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = TestPlan(
+            path: "/path/to",
+            isDefault: true
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/TestPlanTests.swift
+++ b/Tests/TuistGraphTests/Models/TestPlanTests.swift
@@ -11,7 +11,7 @@ final class TestPlanTests: TuistUnitTestCase {
             path: "/path/to",
             isDefault: true
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/TestableTargetTests.swift
+++ b/Tests/TuistGraphTests/Models/TestableTargetTests.swift
@@ -16,7 +16,7 @@ final class TestableTargetTests: TuistUnitTestCase {
             parallelizable: true,
             randomExecutionOrdering: true
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/Models/TestableTargetTests.swift
+++ b/Tests/TuistGraphTests/Models/TestableTargetTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class TestableTargetTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = TestableTarget(
+            target: .init(
+                projectPath: "/path/to/project",
+                name: "name"
+            ),
+            skipped: true,
+            parallelizable: true,
+            randomExecutionOrdering: true
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/WorkspaceTests.swift
+++ b/Tests/TuistGraphTests/Models/WorkspaceTests.swift
@@ -1,0 +1,18 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class WorkspaceTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = Workspace.test(
+            path: "/path/to/workspace",
+            name: "name"
+        )
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/Models/WorkspaceTests.swift
+++ b/Tests/TuistGraphTests/Models/WorkspaceTests.swift
@@ -11,7 +11,7 @@ final class WorkspaceTests: TuistUnitTestCase {
             path: "/path/to/workspace",
             name: "name"
         )
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/ValueGraph/ValueGraphDependencyTests.swift
+++ b/Tests/TuistGraphTests/ValueGraph/ValueGraphDependencyTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class ValueGraphDependencyTests: TuistUnitTestCase {
+    func test_codable_target() {
+        // Given
+        let subject = ValueGraphDependency.testTarget()
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+    
+    func test_codable_framework() {
+        // Given
+        let subject = ValueGraphDependency.testFramework()
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/ValueGraph/ValueGraphDependencyTests.swift
+++ b/Tests/TuistGraphTests/ValueGraph/ValueGraphDependencyTests.swift
@@ -8,15 +8,15 @@ final class ValueGraphDependencyTests: TuistUnitTestCase {
     func test_codable_target() {
         // Given
         let subject = ValueGraphDependency.testTarget()
-        
+
         // Then
         XCTAssertCodable(subject)
     }
-    
+
     func test_codable_framework() {
         // Given
         let subject = ValueGraphDependency.testFramework()
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/ValueGraph/ValueGraphTargetTests.swift
+++ b/Tests/TuistGraphTests/ValueGraph/ValueGraphTargetTests.swift
@@ -8,7 +8,7 @@ final class ValueGraphTargetTests: TuistUnitTestCase {
     func test_codable() {
         // Given
         let subject = ValueGraphTarget.test()
-        
+
         // Then
         XCTAssertCodable(subject)
     }

--- a/Tests/TuistGraphTests/ValueGraph/ValueGraphTargetTests.swift
+++ b/Tests/TuistGraphTests/ValueGraph/ValueGraphTargetTests.swift
@@ -1,0 +1,15 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class ValueGraphTargetTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = ValueGraphTarget.test()
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/ValueGraph/ValueGraphTests.swift
+++ b/Tests/TuistGraphTests/ValueGraph/ValueGraphTests.swift
@@ -1,0 +1,15 @@
+import Foundation
+import XCTest
+
+@testable import TuistGraph
+@testable import TuistSupportTesting
+
+final class ValueGraphTests: TuistUnitTestCase {
+    func test_codable() {
+        // Given
+        let subject = ValueGraph.test(name: "name", path: "/path/to")
+        
+        // Then
+        XCTAssertCodable(subject)
+    }
+}

--- a/Tests/TuistGraphTests/ValueGraph/ValueGraphTests.swift
+++ b/Tests/TuistGraphTests/ValueGraph/ValueGraphTests.swift
@@ -8,7 +8,7 @@ final class ValueGraphTests: TuistUnitTestCase {
     func test_codable() {
         // Given
         let subject = ValueGraph.test(name: "name", path: "/path/to")
-        
+
         // Then
         XCTAssertCodable(subject)
     }


### PR DESCRIPTION
### Short description 📝

This PR makes `ValueGraph` serializable.

### Implementation 👨‍💻

- Implement `Codable` protocol in `ValueGraph`'s models. 
- Add unit tests.
- Convert `class TuistGraph.Settings`  to `struct`.
