### PR TITLE
Speed up frameworks metadata reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Changed
 
 - Improve performance of `tuist generate` by optimizing up md5 hash generation. [#2815](https://github.com/tuist/tuist/pull/2815) by [@adellibovi](https://github.com/adellibovi)
+- Speed up frameworks metadata reading using Mach-o parsing instead of `file`, `lipo` and `dwarfdump` external processes. [#2814](https://github.com/tuist/tuist/pull/2814) by [@adellibovi](https://github.com/adellibovi)
 
 ## 1.40.0
 

--- a/Tests/TuistCoreTests/MetadataProviders/PrecompiledMetadataProviderTests.swift
+++ b/Tests/TuistCoreTests/MetadataProviders/PrecompiledMetadataProviderTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import TSCBasic
+import TuistGraph
 import TuistSupport
 import XCTest
 
@@ -19,25 +20,97 @@ final class PrecompiledMetadataProviderTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_architectures() throws {
+    func test_metadata_static() throws {
         // Given
-        system.succeedCommand("/usr/bin/lipo", "-info", "/test.a", output: "Non-fat file: path is architecture: x86_64")
+        let binaryPath = fixturePath(path: RelativePath("libStaticLibrary.a"))
 
         // When
-        let got = try subject.architectures(binaryPath: AbsolutePath("/test.a"))
+        let architectures = try subject.architectures(binaryPath: binaryPath)
+        let linking = try subject.linking(binaryPath: binaryPath)
+        let uuids = try subject.uuids(binaryPath: binaryPath)
 
         // Then
-        XCTAssertEqual(got.first, .x8664)
+        XCTAssertEqual(architectures, [.x8664])
+        XCTAssertEqual(linking, BinaryLinking.static)
+        XCTAssertEqual(uuids, Set())
     }
 
-    func test_linking() throws {
+    func test_metadata_carthage() throws {
         // Given
-        system.succeedCommand("/usr/bin/file", "/test.a", output: "whatever dynamically linked")
+        let binaryPath = fixturePath(path: RelativePath("Carthage/RxBlocking.framework/RxBlocking"))
 
         // When
-        let got = try subject.linking(binaryPath: AbsolutePath("/test.a"))
+        let architectures = try subject.architectures(binaryPath: binaryPath)
+        let linking = try subject.linking(binaryPath: binaryPath)
+        let uuids = try subject.uuids(binaryPath: binaryPath)
 
         // Then
-        XCTAssertEqual(got, .dynamic)
+        XCTAssertEqual(architectures, [.i386, .x8664, .armv7, .arm64])
+        XCTAssertEqual(linking, BinaryLinking.dynamic)
+        XCTAssertEqual(
+            uuids,
+            Set([
+                UUID(uuidString: "2510FE01-4D40-3956-BB71-857D3B2D9E73"),
+                UUID(uuidString: "1C061BD7-371A-3039-8510-15CDF61531F6"),
+                UUID(uuidString: "1208EC2E-0B7C-3B13-B5E1-6341E6AE6859"),
+                UUID(uuidString: "773847A9-0D05-35AF-9865-94A9A670080B"),
+            ])
+        )
+    }
+
+    func test_metadata_framework() throws {
+        // Given
+        let binaryPath = fixturePath(path: RelativePath("xpm.framework/xpm"))
+
+        // When
+        let architectures = try subject.architectures(binaryPath: binaryPath)
+        let linking = try subject.linking(binaryPath: binaryPath)
+        let uuids = try subject.uuids(binaryPath: binaryPath)
+
+        // Then
+        XCTAssertEqual(architectures, [.x8664, .arm64])
+        XCTAssertEqual(linking, BinaryLinking.dynamic)
+        XCTAssertEqual(
+            uuids,
+            Set([
+                UUID(uuidString: "FB17107A-86FA-3880-92AC-C9AA9E04BA98"),
+                UUID(uuidString: "510FD121-B669-3524-A748-2DDF357A051C"),
+            ])
+        )
+    }
+
+    func test_metadata_xcframework() throws {
+        // Given
+        let binaryPath = fixturePath(path: RelativePath("MyFramework.xcframework/ios-x86_64-simulator/MyFramework.framework/MyFramework"))
+
+        // When
+        let architectures = try subject.architectures(binaryPath: binaryPath)
+        let linking = try subject.linking(binaryPath: binaryPath)
+        let uuids = try subject.uuids(binaryPath: binaryPath)
+
+        // Then
+        XCTAssertEqual(architectures, [.x8664])
+        XCTAssertEqual(linking, BinaryLinking.dynamic)
+        XCTAssertEqual(
+            uuids,
+            Set([
+                UUID(uuidString: "725302D8-8353-312F-8BF4-564B24F7B3E8"),
+            ])
+        )
+    }
+
+    func test_metadata_static_xcframework() throws {
+        // Given
+        let binaryPath = fixturePath(path: RelativePath("MyStaticLibrary.xcframework/ios-arm64/libMyStaticLibrary.a"))
+
+        // When
+        let architectures = try subject.architectures(binaryPath: binaryPath)
+        let linking = try subject.linking(binaryPath: binaryPath)
+        let uuids = try subject.uuids(binaryPath: binaryPath)
+
+        // Then
+        XCTAssertEqual(architectures, [.arm64])
+        XCTAssertEqual(linking, BinaryLinking.static)
+        XCTAssertEqual(uuids, Set())
     }
 }


### PR DESCRIPTION
### Short description 📝

Hi, I noticed we are using `file`, `lipo` and `dwarfdump` for retrieve architecture, linking type and uuids.
Running external processes can be expensive, under my tests having 10 frameworks references increase `tuist generated` of ~1s (10% of my total `tuist generate` time, which in my case was of ~10s).

This PR replace the external commands by fetching the metadata parsing the binaries directly (using Mach-o Format File for Fat and not Fat libraries or Archive Format), this resulted in a ~0.02s computed time instead.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
