### PR TITLE
Improve performance of md5 hash generation by updating to XcodeProj to 7.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Make `ValueGraph` serializable. [#2811](https://github.com/tuist/tuist/pull/2811) by [@laxmorek](https://github.com/laxmorek)
 - Add support for configuration of cache directory [#2566](https://github.com/tuist/tuist/pull/2566) by [@adellibovi](https://github.com/adellibovi).
 
+### Changed
+
+- Improve performance of `tuist generate` by optimizing up md5 hash generation. [#2815](https://github.com/tuist/tuist/pull/2815) by [@adellibovi](https://github.com/adellibovi)
+
 ## 1.40.0
 
 ### Added

--- a/Package.resolved
+++ b/Package.resolved
@@ -195,8 +195,8 @@
         "repositoryURL": "https://github.com/tuist/XcodeProj.git",
         "state": {
           "branch": null,
-          "revision": "6943d5c5f9085d070dbde3c669144e30d41ec635",
-          "version": "7.20.0"
+          "revision": "0c889906136b7cba277b9327e9a8217669bb4eb3",
+          "version": "7.21.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/tuist/XcodeProj.git", .upToNextMajor(from: "7.20.0")),
+        .package(url: "https://github.com/tuist/XcodeProj.git", .upToNextMajor(from: "7.21.0")),
         .package(name: "Signals", url: "https://github.com/tuist/BlueSignals.git", .upToNextMajor(from: "1.0.21")),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.1.1")),
         .package(url: "https://github.com/rnine/Checksum.git", .upToNextMajor(from: "1.0.2")),


### PR DESCRIPTION
### Short description 📝

Improve performance of `tuist generate` by optimizing up md5 hash generation.
The new XcodeProj 7.21.0 includes an optimisation for md5 generation, under my tests the time spent generating MD5 went from ~1.4s to ~0.1s

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
