### PR TITLE
Add support for `runForInstallBuildsOnly` (runOnlyForDeploymentPostprocessing) for build actions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Add support for `runPostActionsOnFailure` for post build actions. [#2752](https://github.com/tuist/tuist/pull/2752) by [@FranzBusch](https://github.com/FranzBusch)
 - Make `ValueGraph` serializable. [#2811](https://github.com/tuist/tuist/pull/2811) by [@laxmorek](https://github.com/laxmorek)
 - Add support for configuration of cache directory [#2566](https://github.com/tuist/tuist/pull/2566) by [@adellibovi](https://github.com/adellibovi).
-- Add support for `runForInstallBuildsOnly` for build actions. by [@StefanFessler](https://github.com/apps4everyone)
+- Add support for `runForInstallBuildsOnly` for build actions by [@StefanFessler](https://github.com/apps4everyone)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Add support for `runPostActionsOnFailure` for post build actions. [#2752](https://github.com/tuist/tuist/pull/2752) by [@FranzBusch](https://github.com/FranzBusch)
 - Make `ValueGraph` serializable. [#2811](https://github.com/tuist/tuist/pull/2811) by [@laxmorek](https://github.com/laxmorek)
 - Add support for configuration of cache directory [#2566](https://github.com/tuist/tuist/pull/2566) by [@adellibovi](https://github.com/adellibovi).
-- Add support for `runOnlyForDeploymentPostprocessing` (install builds) for build actions. by [@StefanFessler](https://github.com/apps4everyone)
+- Add support for `runForInstallBuildsOnly` for build actions. by [@StefanFessler](https://github.com/apps4everyone)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Add support for `runPostActionsOnFailure` for post build actions. [#2752](https://github.com/tuist/tuist/pull/2752) by [@FranzBusch](https://github.com/FranzBusch)
 - Make `ValueGraph` serializable. [#2811](https://github.com/tuist/tuist/pull/2811) by [@laxmorek](https://github.com/laxmorek)
 - Add support for configuration of cache directory [#2566](https://github.com/tuist/tuist/pull/2566) by [@adellibovi](https://github.com/adellibovi).
+- Add support for `runOnlyForDeploymentPostprocessing` (install builds) for build actions. by [@StefanFessler](https://github.com/apps4everyone)
 
 ### Changed
 

--- a/Sources/ProjectDescription/TargetAction.swift
+++ b/Sources/ProjectDescription/TargetAction.swift
@@ -45,7 +45,7 @@ public struct TargetAction: Codable, Equatable {
     /// Whether to skip running this script in incremental builds, if nothing has changed
     public let basedOnDependencyAnalysis: Bool?
 
-    /// Whether running this script only runs on install builds (default is false)
+    /// Whether this script only runs on install builds (default is false)
     public let runOnlyForDeploymentPostprocessing: Bool
     
     public enum CodingKeys: String, CodingKey {
@@ -74,7 +74,7 @@ public struct TargetAction: Codable, Equatable {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
+    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
     init(name: String,
          script: Script = .embedded(""),
          order: Order,
@@ -162,7 +162,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
+    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(tool: String,
                            arguments: String...,
@@ -198,7 +198,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
+    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(tool: String,
                            arguments: [String],
@@ -234,7 +234,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
+    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(tool: String,
                             arguments: String...,
@@ -270,7 +270,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
+    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(tool: String,
                             arguments: [String],
@@ -310,7 +310,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
+    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(path: Path,
                            arguments: String...,
@@ -346,7 +346,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
+    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(path: Path,
                            arguments: [String],
@@ -382,7 +382,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
+    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(path: Path,
                             arguments: String...,
@@ -418,7 +418,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
+    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(path: Path,
                             arguments: [String],
@@ -458,7 +458,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
+    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(script: String,
                            name: String,
@@ -493,7 +493,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
+    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(script: String,
                             name: String,

--- a/Sources/ProjectDescription/TargetAction.swift
+++ b/Sources/ProjectDescription/TargetAction.swift
@@ -45,6 +45,9 @@ public struct TargetAction: Codable, Equatable {
     /// Whether to skip running this script in incremental builds, if nothing has changed
     public let basedOnDependencyAnalysis: Bool?
 
+    /// Whether running this script only runs on install builds (default is false)
+    public let runOnlyForDeploymentPostprocessing: Bool
+    
     public enum CodingKeys: String, CodingKey {
         case name
         case tool
@@ -57,6 +60,7 @@ public struct TargetAction: Codable, Equatable {
         case outputPaths
         case outputFileListPaths
         case basedOnDependencyAnalysis
+        case runOnlyForDeploymentPostprocessing
     }
 
     /// Initializes the target action with its attributes.
@@ -70,6 +74,7 @@ public struct TargetAction: Codable, Equatable {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
     init(name: String,
          script: Script = .embedded(""),
          order: Order,
@@ -77,7 +82,8 @@ public struct TargetAction: Codable, Equatable {
          inputFileListPaths: [Path] = [],
          outputPaths: [Path] = [],
          outputFileListPaths: [Path] = [],
-         basedOnDependencyAnalysis: Bool? = nil)
+         basedOnDependencyAnalysis: Bool? = nil,
+         runOnlyForDeploymentPostprocessing: Bool = false)
     {
         self.name = name
         self.script = script
@@ -87,6 +93,7 @@ public struct TargetAction: Codable, Equatable {
         self.outputPaths = outputPaths
         self.outputFileListPaths = outputFileListPaths
         self.basedOnDependencyAnalysis = basedOnDependencyAnalysis
+        self.runOnlyForDeploymentPostprocessing = runOnlyForDeploymentPostprocessing
     }
 
     // MARK: - Codable
@@ -100,6 +107,7 @@ public struct TargetAction: Codable, Equatable {
         outputPaths = try container.decodeIfPresent([Path].self, forKey: .outputPaths) ?? []
         outputFileListPaths = try container.decodeIfPresent([Path].self, forKey: .outputFileListPaths) ?? []
         basedOnDependencyAnalysis = try container.decodeIfPresent(Bool.self, forKey: .basedOnDependencyAnalysis)
+        runOnlyForDeploymentPostprocessing = try container.decode(Bool.self, forKey: .runOnlyForDeploymentPostprocessing)
 
         let arguments: [String] = try container.decodeIfPresent([String].self, forKey: .arguments) ?? []
         if let script = try container.decodeIfPresent(String.self, forKey: .script) {
@@ -123,6 +131,7 @@ public struct TargetAction: Codable, Equatable {
         try container.encode(outputPaths, forKey: .outputPaths)
         try container.encode(outputFileListPaths, forKey: .outputFileListPaths)
         try container.encode(basedOnDependencyAnalysis, forKey: .basedOnDependencyAnalysis)
+        try container.encode(runOnlyForDeploymentPostprocessing, forKey: .runOnlyForDeploymentPostprocessing)
 
         switch script {
         case let .embedded(script):
@@ -153,6 +162,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(tool: String,
                            arguments: String...,
@@ -161,7 +171,8 @@ extension TargetAction {
                            inputFileListPaths: [Path] = [],
                            outputPaths: [Path] = [],
                            outputFileListPaths: [Path] = [],
-                           basedOnDependencyAnalysis: Bool? = nil) -> TargetAction
+                           basedOnDependencyAnalysis: Bool? = nil,
+                           runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -171,7 +182,8 @@ extension TargetAction {
             inputFileListPaths: inputFileListPaths,
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
-            basedOnDependencyAnalysis: basedOnDependencyAnalysis
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
         )
     }
 
@@ -186,6 +198,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(tool: String,
                            arguments: [String],
@@ -194,7 +207,8 @@ extension TargetAction {
                            inputFileListPaths: [Path] = [],
                            outputPaths: [Path] = [],
                            outputFileListPaths: [Path] = [],
-                           basedOnDependencyAnalysis: Bool? = nil) -> TargetAction
+                           basedOnDependencyAnalysis: Bool? = nil,
+                           runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -204,7 +218,8 @@ extension TargetAction {
             inputFileListPaths: inputFileListPaths,
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
-            basedOnDependencyAnalysis: basedOnDependencyAnalysis
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
         )
     }
 
@@ -219,6 +234,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(tool: String,
                             arguments: String...,
@@ -227,7 +243,8 @@ extension TargetAction {
                             inputFileListPaths: [Path] = [],
                             outputPaths: [Path] = [],
                             outputFileListPaths: [Path] = [],
-                            basedOnDependencyAnalysis: Bool? = nil) -> TargetAction
+                            basedOnDependencyAnalysis: Bool? = nil,
+                            runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -237,7 +254,8 @@ extension TargetAction {
             inputFileListPaths: inputFileListPaths,
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
-            basedOnDependencyAnalysis: basedOnDependencyAnalysis
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
         )
     }
 
@@ -252,6 +270,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(tool: String,
                             arguments: [String],
@@ -260,7 +279,8 @@ extension TargetAction {
                             inputFileListPaths: [Path] = [],
                             outputPaths: [Path] = [],
                             outputFileListPaths: [Path] = [],
-                            basedOnDependencyAnalysis: Bool? = nil) -> TargetAction
+                            basedOnDependencyAnalysis: Bool? = nil,
+                            runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -270,7 +290,8 @@ extension TargetAction {
             inputFileListPaths: inputFileListPaths,
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
-            basedOnDependencyAnalysis: basedOnDependencyAnalysis
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
         )
     }
 }
@@ -289,6 +310,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(path: Path,
                            arguments: String...,
@@ -297,7 +319,8 @@ extension TargetAction {
                            inputFileListPaths: [Path] = [],
                            outputPaths: [Path] = [],
                            outputFileListPaths: [Path] = [],
-                           basedOnDependencyAnalysis: Bool? = nil) -> TargetAction
+                           basedOnDependencyAnalysis: Bool? = nil,
+                           runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -307,7 +330,8 @@ extension TargetAction {
             inputFileListPaths: inputFileListPaths,
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
-            basedOnDependencyAnalysis: basedOnDependencyAnalysis
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
         )
     }
 
@@ -322,6 +346,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(path: Path,
                            arguments: [String],
@@ -330,7 +355,8 @@ extension TargetAction {
                            inputFileListPaths: [Path] = [],
                            outputPaths: [Path] = [],
                            outputFileListPaths: [Path] = [],
-                           basedOnDependencyAnalysis: Bool? = nil) -> TargetAction
+                           basedOnDependencyAnalysis: Bool? = nil,
+                           runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -340,7 +366,8 @@ extension TargetAction {
             inputFileListPaths: inputFileListPaths,
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
-            basedOnDependencyAnalysis: basedOnDependencyAnalysis
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
         )
     }
 
@@ -355,6 +382,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(path: Path,
                             arguments: String...,
@@ -363,7 +391,8 @@ extension TargetAction {
                             inputFileListPaths: [Path] = [],
                             outputPaths: [Path] = [],
                             outputFileListPaths: [Path] = [],
-                            basedOnDependencyAnalysis: Bool? = nil) -> TargetAction
+                            basedOnDependencyAnalysis: Bool? = nil,
+                            runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -373,7 +402,8 @@ extension TargetAction {
             inputFileListPaths: inputFileListPaths,
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
-            basedOnDependencyAnalysis: basedOnDependencyAnalysis
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
         )
     }
 
@@ -388,6 +418,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(path: Path,
                             arguments: [String],
@@ -396,7 +427,8 @@ extension TargetAction {
                             inputFileListPaths: [Path] = [],
                             outputPaths: [Path] = [],
                             outputFileListPaths: [Path] = [],
-                            basedOnDependencyAnalysis: Bool? = nil) -> TargetAction
+                            basedOnDependencyAnalysis: Bool? = nil,
+                            runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -406,7 +438,8 @@ extension TargetAction {
             inputFileListPaths: inputFileListPaths,
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
-            basedOnDependencyAnalysis: basedOnDependencyAnalysis
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
         )
     }
 }
@@ -425,6 +458,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(script: String,
                            name: String,
@@ -432,7 +466,8 @@ extension TargetAction {
                            inputFileListPaths: [Path] = [],
                            outputPaths: [Path] = [],
                            outputFileListPaths: [Path] = [],
-                           basedOnDependencyAnalysis: Bool? = nil) -> TargetAction
+                           basedOnDependencyAnalysis: Bool? = nil,
+                           runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -442,7 +477,8 @@ extension TargetAction {
             inputFileListPaths: inputFileListPaths,
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
-            basedOnDependencyAnalysis: basedOnDependencyAnalysis
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
         )
     }
 
@@ -457,6 +493,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(script: String,
                             name: String,
@@ -464,7 +501,8 @@ extension TargetAction {
                             inputFileListPaths: [Path] = [],
                             outputPaths: [Path] = [],
                             outputFileListPaths: [Path] = [],
-                            basedOnDependencyAnalysis: Bool? = nil) -> TargetAction
+                            basedOnDependencyAnalysis: Bool? = nil,
+                            runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -474,7 +512,8 @@ extension TargetAction {
             inputFileListPaths: inputFileListPaths,
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
-            basedOnDependencyAnalysis: basedOnDependencyAnalysis
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
         )
     }
 }

--- a/Sources/ProjectDescription/TargetAction.swift
+++ b/Sources/ProjectDescription/TargetAction.swift
@@ -45,9 +45,9 @@ public struct TargetAction: Codable, Equatable {
     /// Whether to skip running this script in incremental builds, if nothing has changed
     public let basedOnDependencyAnalysis: Bool?
 
-    /// Whether this script only runs on install builds (default is false)
+    /// Whether this action only runs on install builds (default is false)
     public let runForInstallBuildsOnly: Bool
-    
+
     public enum CodingKeys: String, CodingKey {
         case name
         case tool
@@ -74,7 +74,7 @@ public struct TargetAction: Codable, Equatable {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this action only runs on install builds (default is false)
     init(name: String,
          script: Script = .embedded(""),
          order: Order,
@@ -162,7 +162,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this action only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(tool: String,
                            arguments: String...,
@@ -198,7 +198,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this action only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(tool: String,
                            arguments: [String],
@@ -234,7 +234,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this action only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(tool: String,
                             arguments: String...,
@@ -270,7 +270,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this action only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(tool: String,
                             arguments: [String],
@@ -310,7 +310,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this action only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(path: Path,
                            arguments: String...,
@@ -346,7 +346,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this action only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(path: Path,
                            arguments: [String],
@@ -382,7 +382,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this action only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(path: Path,
                             arguments: String...,
@@ -418,7 +418,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this action only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(path: Path,
                             arguments: [String],
@@ -458,7 +458,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this action only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(script: String,
                            name: String,
@@ -493,7 +493,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this action only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(script: String,
                             name: String,

--- a/Sources/ProjectDescription/TargetAction.swift
+++ b/Sources/ProjectDescription/TargetAction.swift
@@ -46,7 +46,7 @@ public struct TargetAction: Codable, Equatable {
     public let basedOnDependencyAnalysis: Bool?
 
     /// Whether this script only runs on install builds (default is false)
-    public let runOnlyForDeploymentPostprocessing: Bool
+    public let runForInstallBuildsOnly: Bool
     
     public enum CodingKeys: String, CodingKey {
         case name
@@ -60,7 +60,7 @@ public struct TargetAction: Codable, Equatable {
         case outputPaths
         case outputFileListPaths
         case basedOnDependencyAnalysis
-        case runOnlyForDeploymentPostprocessing
+        case runForInstallBuildsOnly = "runOnlyForDeploymentPostprocessing"
     }
 
     /// Initializes the target action with its attributes.
@@ -74,7 +74,7 @@ public struct TargetAction: Codable, Equatable {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
     init(name: String,
          script: Script = .embedded(""),
          order: Order,
@@ -83,7 +83,7 @@ public struct TargetAction: Codable, Equatable {
          outputPaths: [Path] = [],
          outputFileListPaths: [Path] = [],
          basedOnDependencyAnalysis: Bool? = nil,
-         runOnlyForDeploymentPostprocessing: Bool = false)
+         runForInstallBuildsOnly: Bool = false)
     {
         self.name = name
         self.script = script
@@ -93,7 +93,7 @@ public struct TargetAction: Codable, Equatable {
         self.outputPaths = outputPaths
         self.outputFileListPaths = outputFileListPaths
         self.basedOnDependencyAnalysis = basedOnDependencyAnalysis
-        self.runOnlyForDeploymentPostprocessing = runOnlyForDeploymentPostprocessing
+        self.runForInstallBuildsOnly = runForInstallBuildsOnly
     }
 
     // MARK: - Codable
@@ -107,7 +107,7 @@ public struct TargetAction: Codable, Equatable {
         outputPaths = try container.decodeIfPresent([Path].self, forKey: .outputPaths) ?? []
         outputFileListPaths = try container.decodeIfPresent([Path].self, forKey: .outputFileListPaths) ?? []
         basedOnDependencyAnalysis = try container.decodeIfPresent(Bool.self, forKey: .basedOnDependencyAnalysis)
-        runOnlyForDeploymentPostprocessing = try container.decode(Bool.self, forKey: .runOnlyForDeploymentPostprocessing)
+        runForInstallBuildsOnly = try container.decode(Bool.self, forKey: .runForInstallBuildsOnly)
 
         let arguments: [String] = try container.decodeIfPresent([String].self, forKey: .arguments) ?? []
         if let script = try container.decodeIfPresent(String.self, forKey: .script) {
@@ -131,7 +131,7 @@ public struct TargetAction: Codable, Equatable {
         try container.encode(outputPaths, forKey: .outputPaths)
         try container.encode(outputFileListPaths, forKey: .outputFileListPaths)
         try container.encode(basedOnDependencyAnalysis, forKey: .basedOnDependencyAnalysis)
-        try container.encode(runOnlyForDeploymentPostprocessing, forKey: .runOnlyForDeploymentPostprocessing)
+        try container.encode(runForInstallBuildsOnly, forKey: .runForInstallBuildsOnly)
 
         switch script {
         case let .embedded(script):
@@ -162,7 +162,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(tool: String,
                            arguments: String...,
@@ -172,7 +172,7 @@ extension TargetAction {
                            outputPaths: [Path] = [],
                            outputFileListPaths: [Path] = [],
                            basedOnDependencyAnalysis: Bool? = nil,
-                           runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
+                           runForInstallBuildsOnly: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -183,7 +183,7 @@ extension TargetAction {
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
             basedOnDependencyAnalysis: basedOnDependencyAnalysis,
-            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
+            runForInstallBuildsOnly: runForInstallBuildsOnly
         )
     }
 
@@ -198,7 +198,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(tool: String,
                            arguments: [String],
@@ -208,7 +208,7 @@ extension TargetAction {
                            outputPaths: [Path] = [],
                            outputFileListPaths: [Path] = [],
                            basedOnDependencyAnalysis: Bool? = nil,
-                           runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
+                           runForInstallBuildsOnly: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -219,7 +219,7 @@ extension TargetAction {
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
             basedOnDependencyAnalysis: basedOnDependencyAnalysis,
-            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
+            runForInstallBuildsOnly: runForInstallBuildsOnly
         )
     }
 
@@ -234,7 +234,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(tool: String,
                             arguments: String...,
@@ -244,7 +244,7 @@ extension TargetAction {
                             outputPaths: [Path] = [],
                             outputFileListPaths: [Path] = [],
                             basedOnDependencyAnalysis: Bool? = nil,
-                            runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
+                            runForInstallBuildsOnly: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -255,7 +255,7 @@ extension TargetAction {
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
             basedOnDependencyAnalysis: basedOnDependencyAnalysis,
-            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
+            runForInstallBuildsOnly: runForInstallBuildsOnly
         )
     }
 
@@ -270,7 +270,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(tool: String,
                             arguments: [String],
@@ -280,7 +280,7 @@ extension TargetAction {
                             outputPaths: [Path] = [],
                             outputFileListPaths: [Path] = [],
                             basedOnDependencyAnalysis: Bool? = nil,
-                            runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
+                            runForInstallBuildsOnly: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -291,7 +291,7 @@ extension TargetAction {
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
             basedOnDependencyAnalysis: basedOnDependencyAnalysis,
-            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
+            runForInstallBuildsOnly: runForInstallBuildsOnly
         )
     }
 }
@@ -310,7 +310,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(path: Path,
                            arguments: String...,
@@ -320,7 +320,7 @@ extension TargetAction {
                            outputPaths: [Path] = [],
                            outputFileListPaths: [Path] = [],
                            basedOnDependencyAnalysis: Bool? = nil,
-                           runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
+                           runForInstallBuildsOnly: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -331,7 +331,7 @@ extension TargetAction {
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
             basedOnDependencyAnalysis: basedOnDependencyAnalysis,
-            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
+            runForInstallBuildsOnly: runForInstallBuildsOnly
         )
     }
 
@@ -346,7 +346,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(path: Path,
                            arguments: [String],
@@ -356,7 +356,7 @@ extension TargetAction {
                            outputPaths: [Path] = [],
                            outputFileListPaths: [Path] = [],
                            basedOnDependencyAnalysis: Bool? = nil,
-                           runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
+                           runForInstallBuildsOnly: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -367,7 +367,7 @@ extension TargetAction {
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
             basedOnDependencyAnalysis: basedOnDependencyAnalysis,
-            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
+            runForInstallBuildsOnly: runForInstallBuildsOnly
         )
     }
 
@@ -382,7 +382,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(path: Path,
                             arguments: String...,
@@ -392,7 +392,7 @@ extension TargetAction {
                             outputPaths: [Path] = [],
                             outputFileListPaths: [Path] = [],
                             basedOnDependencyAnalysis: Bool? = nil,
-                            runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
+                            runForInstallBuildsOnly: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -403,7 +403,7 @@ extension TargetAction {
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
             basedOnDependencyAnalysis: basedOnDependencyAnalysis,
-            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
+            runForInstallBuildsOnly: runForInstallBuildsOnly
         )
     }
 
@@ -418,7 +418,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(path: Path,
                             arguments: [String],
@@ -428,7 +428,7 @@ extension TargetAction {
                             outputPaths: [Path] = [],
                             outputFileListPaths: [Path] = [],
                             basedOnDependencyAnalysis: Bool? = nil,
-                            runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
+                            runForInstallBuildsOnly: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -439,7 +439,7 @@ extension TargetAction {
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
             basedOnDependencyAnalysis: basedOnDependencyAnalysis,
-            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
+            runForInstallBuildsOnly: runForInstallBuildsOnly
         )
     }
 }
@@ -458,7 +458,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func pre(script: String,
                            name: String,
@@ -467,7 +467,7 @@ extension TargetAction {
                            outputPaths: [Path] = [],
                            outputFileListPaths: [Path] = [],
                            basedOnDependencyAnalysis: Bool? = nil,
-                           runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
+                           runForInstallBuildsOnly: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -478,7 +478,7 @@ extension TargetAction {
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
             basedOnDependencyAnalysis: basedOnDependencyAnalysis,
-            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
+            runForInstallBuildsOnly: runForInstallBuildsOnly
         )
     }
 
@@ -493,7 +493,7 @@ extension TargetAction {
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
     /// - Returns: Target action.
     public static func post(script: String,
                             name: String,
@@ -502,7 +502,7 @@ extension TargetAction {
                             outputPaths: [Path] = [],
                             outputFileListPaths: [Path] = [],
                             basedOnDependencyAnalysis: Bool? = nil,
-                            runOnlyForDeploymentPostprocessing: Bool = false) -> TargetAction
+                            runForInstallBuildsOnly: Bool = false) -> TargetAction
     {
         TargetAction(
             name: name,
@@ -513,7 +513,7 @@ extension TargetAction {
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
             basedOnDependencyAnalysis: basedOnDependencyAnalysis,
-            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
+            runForInstallBuildsOnly: runForInstallBuildsOnly
         )
     }
 }

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -150,6 +150,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
 
                 shellPath: "/bin/sh",
                 shellScript: action.shellScript(sourceRootPath: sourceRootPath),
+                runOnlyForDeploymentPostprocessing: action.runOnlyForDeploymentPostprocessing,
                 showEnvVarsInLog: action.showEnvVarsInLog
             )
             if let basedOnDependencyAnalysis = action.basedOnDependencyAnalysis {

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -150,7 +150,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
 
                 shellPath: "/bin/sh",
                 shellScript: action.shellScript(sourceRootPath: sourceRootPath),
-                runOnlyForDeploymentPostprocessing: action.runOnlyForDeploymentPostprocessing,
+                runOnlyForDeploymentPostprocessing: action.runForInstallBuildsOnly,
                 showEnvVarsInLog: action.showEnvVarsInLog
             )
             if let basedOnDependencyAnalysis = action.basedOnDependencyAnalysis {

--- a/Sources/TuistGraph/Models/TargetAction.swift
+++ b/Sources/TuistGraph/Models/TargetAction.swift
@@ -88,7 +88,7 @@ public struct TargetAction: Equatable, Codable {
     /// Whether to skip running this script in incremental builds, if nothing has changed
     public let basedOnDependencyAnalysis: Bool?
     
-    /// Whether running this script only runs on install builds (default is false)
+    /// Whether this script only runs on install builds (default is false)
     public let runOnlyForDeploymentPostprocessing: Bool
 
     /// Initializes a new target action with its attributes using a script at the given path to be executed.
@@ -104,7 +104,7 @@ public struct TargetAction: Equatable, Codable {
     ///   - outputFileListPaths: List of output filelist paths
     ///   - showEnvVarsInLog: Show environment variables in the logs
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
+    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
     public init(name: String,
                 order: Order,
                 script: Script = .embedded(""),

--- a/Sources/TuistGraph/Models/TargetAction.swift
+++ b/Sources/TuistGraph/Models/TargetAction.swift
@@ -89,7 +89,7 @@ public struct TargetAction: Equatable, Codable {
     public let basedOnDependencyAnalysis: Bool?
     
     /// Whether this script only runs on install builds (default is false)
-    public let runOnlyForDeploymentPostprocessing: Bool
+    public let runForInstallBuildsOnly: Bool
 
     /// Initializes a new target action with its attributes using a script at the given path to be executed.
     ///
@@ -104,7 +104,7 @@ public struct TargetAction: Equatable, Codable {
     ///   - outputFileListPaths: List of output filelist paths
     ///   - showEnvVarsInLog: Show environment variables in the logs
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runOnlyForDeploymentPostprocessing: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
     public init(name: String,
                 order: Order,
                 script: Script = .embedded(""),
@@ -114,7 +114,7 @@ public struct TargetAction: Equatable, Codable {
                 outputFileListPaths: [AbsolutePath] = [],
                 showEnvVarsInLog: Bool = true,
                 basedOnDependencyAnalysis: Bool? = nil,
-                runOnlyForDeploymentPostprocessing: Bool = false)
+                runForInstallBuildsOnly: Bool = false)
     {
         self.name = name
         self.order = order
@@ -125,7 +125,7 @@ public struct TargetAction: Equatable, Codable {
         self.outputFileListPaths = outputFileListPaths
         self.showEnvVarsInLog = showEnvVarsInLog
         self.basedOnDependencyAnalysis = basedOnDependencyAnalysis
-        self.runOnlyForDeploymentPostprocessing = runOnlyForDeploymentPostprocessing
+        self.runForInstallBuildsOnly = runForInstallBuildsOnly
     }
 }
 

--- a/Sources/TuistGraph/Models/TargetAction.swift
+++ b/Sources/TuistGraph/Models/TargetAction.swift
@@ -87,8 +87,8 @@ public struct TargetAction: Equatable, Codable {
 
     /// Whether to skip running this script in incremental builds, if nothing has changed
     public let basedOnDependencyAnalysis: Bool?
-    
-    /// Whether this script only runs on install builds (default is false)
+
+    /// Whether this action only runs on install builds (default is false)
     public let runForInstallBuildsOnly: Bool
 
     /// Initializes a new target action with its attributes using a script at the given path to be executed.
@@ -104,7 +104,7 @@ public struct TargetAction: Equatable, Codable {
     ///   - outputFileListPaths: List of output filelist paths
     ///   - showEnvVarsInLog: Show environment variables in the logs
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
-    ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
+    ///   - runForInstallBuildsOnly: Whether this action only runs on install builds (default is false)
     public init(name: String,
                 order: Order,
                 script: Script = .embedded(""),

--- a/Sources/TuistGraph/Models/TargetAction.swift
+++ b/Sources/TuistGraph/Models/TargetAction.swift
@@ -87,6 +87,9 @@ public struct TargetAction: Equatable, Codable {
 
     /// Whether to skip running this script in incremental builds, if nothing has changed
     public let basedOnDependencyAnalysis: Bool?
+    
+    /// Whether running this script only runs on install builds (default is false)
+    public let runOnlyForDeploymentPostprocessing: Bool
 
     /// Initializes a new target action with its attributes using a script at the given path to be executed.
     ///
@@ -101,6 +104,7 @@ public struct TargetAction: Equatable, Codable {
     ///   - outputFileListPaths: List of output filelist paths
     ///   - showEnvVarsInLog: Show environment variables in the logs
     ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+    ///   - runOnlyForDeploymentPostprocessing: Whether running this script only runs on install builds (default is false)
     public init(name: String,
                 order: Order,
                 script: Script = .embedded(""),
@@ -109,7 +113,8 @@ public struct TargetAction: Equatable, Codable {
                 outputPaths: [AbsolutePath] = [],
                 outputFileListPaths: [AbsolutePath] = [],
                 showEnvVarsInLog: Bool = true,
-                basedOnDependencyAnalysis: Bool? = nil)
+                basedOnDependencyAnalysis: Bool? = nil,
+                runOnlyForDeploymentPostprocessing: Bool = false)
     {
         self.name = name
         self.order = order
@@ -120,6 +125,7 @@ public struct TargetAction: Equatable, Codable {
         self.outputFileListPaths = outputFileListPaths
         self.showEnvVarsInLog = showEnvVarsInLog
         self.basedOnDependencyAnalysis = basedOnDependencyAnalysis
+        self.runOnlyForDeploymentPostprocessing = runOnlyForDeploymentPostprocessing
     }
 }
 

--- a/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
@@ -18,7 +18,7 @@ extension TuistGraph.TargetAction {
         let outputPaths = try absolutePaths(for: manifest.outputPaths, generatorPaths: generatorPaths)
         let outputFileListPaths = try absolutePaths(for: manifest.outputFileListPaths, generatorPaths: generatorPaths)
         let basedOnDependencyAnalysis = manifest.basedOnDependencyAnalysis
-        let runOnlyForDeploymentPostprocessing = manifest.runOnlyForDeploymentPostprocessing
+        let runForInstallBuildsOnly = manifest.runForInstallBuildsOnly
         
         let script: TuistGraph.TargetAction.Script
         switch manifest.script {
@@ -42,7 +42,7 @@ extension TuistGraph.TargetAction {
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
             basedOnDependencyAnalysis: basedOnDependencyAnalysis,
-            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
+            runForInstallBuildsOnly: runForInstallBuildsOnly
         )
     }
 

--- a/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
@@ -19,7 +19,7 @@ extension TuistGraph.TargetAction {
         let outputFileListPaths = try absolutePaths(for: manifest.outputFileListPaths, generatorPaths: generatorPaths)
         let basedOnDependencyAnalysis = manifest.basedOnDependencyAnalysis
         let runForInstallBuildsOnly = manifest.runForInstallBuildsOnly
-        
+
         let script: TuistGraph.TargetAction.Script
         switch manifest.script {
         case let .embedded(text):

--- a/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
@@ -18,7 +18,8 @@ extension TuistGraph.TargetAction {
         let outputPaths = try absolutePaths(for: manifest.outputPaths, generatorPaths: generatorPaths)
         let outputFileListPaths = try absolutePaths(for: manifest.outputFileListPaths, generatorPaths: generatorPaths)
         let basedOnDependencyAnalysis = manifest.basedOnDependencyAnalysis
-
+        let runOnlyForDeploymentPostprocessing = manifest.runOnlyForDeploymentPostprocessing
+        
         let script: TuistGraph.TargetAction.Script
         switch manifest.script {
         case let .embedded(text):
@@ -40,7 +41,8 @@ extension TuistGraph.TargetAction {
             inputFileListPaths: inputFileListPaths,
             outputPaths: outputPaths,
             outputFileListPaths: outputFileListPaths,
-            basedOnDependencyAnalysis: basedOnDependencyAnalysis
+            basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+            runOnlyForDeploymentPostprocessing: runOnlyForDeploymentPostprocessing
         )
     }
 

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -757,7 +757,8 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
                     order: .post,
                     script: .scriptPath(path.appending(component: "script.sh"), args: ["arg"]),
                     showEnvVarsInLog: false,
-                    basedOnDependencyAnalysis: false
+                    basedOnDependencyAnalysis: false,
+                    runOnlyForDeploymentPostprocessing: true
                 ),
                 TargetAction(
                     name: "pre",
@@ -797,6 +798,7 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
         XCTAssertEqual(preBuildPhase.shellScript, "\"$SRCROOT\"/script.sh arg")
         XCTAssertTrue(preBuildPhase.showEnvVarsInLog)
         XCTAssertFalse(preBuildPhase.alwaysOutOfDate)
+        XCTAssertFalse(preBuildPhase.runOnlyForDeploymentPostprocessing)
 
         let postBuildPhase = try XCTUnwrap(pbxTarget.buildPhases.last as? PBXShellScriptBuildPhase)
         XCTAssertEqual(postBuildPhase.name, "post")
@@ -804,6 +806,7 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
         XCTAssertEqual(postBuildPhase.shellScript, "\"$SRCROOT\"/script.sh arg")
         XCTAssertFalse(postBuildPhase.showEnvVarsInLog)
         XCTAssertTrue(postBuildPhase.alwaysOutOfDate)
+        XCTAssertTrue(postBuildPhase.runOnlyForDeploymentPostprocessing)
     }
 
     func test_generateEmbedAppClipsBuildPhase() throws {

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -758,7 +758,7 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
                     script: .scriptPath(path.appending(component: "script.sh"), args: ["arg"]),
                     showEnvVarsInLog: false,
                     basedOnDependencyAnalysis: false,
-                    runOnlyForDeploymentPostprocessing: true
+                    runForInstallBuildsOnly: true
                 ),
                 TargetAction(
                     name: "pre",

--- a/projects/docs/docs/manifests/project.md
+++ b/projects/docs/docs/manifests/project.md
@@ -290,12 +290,12 @@ Target actions, represented as target script build phases, are useful to define 
 
 | Case                                                                                                                                                                                         | Description                                                                                                                                                       |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `.pre(tool: String, arguments: String..., name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool)`  | Action executed before the target-specific build phases where tool is the name of the tool to be executed.                                                        |
-| `.pre(path: Path, arguments: String..., name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool)`    | Action executed before the target-specific build phases where path is the path to the tool to be executed.                                                        |
-| `.pre(script: String, name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool)`                      | Action executed before the target-specific build phases where script is an embedded script to run. It is advised to keep embedded scripts as small as possible.                              |
-| `.post(tool: String, arguments: String..., name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool)` | Action executed after all the target-specific build phases where tool is the name of the tool to be executed.                                                     |
-| `.post(path: Path, arguments: String..., name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool)`   | Action executed after all the target-specific build phases where path is the path to the tool to be executed.                                                     |
-| `.post(script: String, name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool)`                     | Action executed after all the target-specific build phases where script is an embedded script to run. It is advised to keep embedded scripts as small as possible |
+| `.pre(tool: String, arguments: String..., name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool, runForInstallBuildsOnly: Bool)`  | Action executed before the target-specific build phases where tool is the name of the tool to be executed.                                                        |
+| `.pre(path: Path, arguments: String..., name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool, runForInstallBuildsOnly: Bool)`    | Action executed before the target-specific build phases where path is the path to the tool to be executed.                                                        |
+| `.pre(script: String, name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool, runForInstallBuildsOnly: Bool)`                      | Action executed before the target-specific build phases where script is an embedded script to run. It is advised to keep embedded scripts as small as possible.                              |
+| `.post(tool: String, arguments: String..., name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool, runForInstallBuildsOnly: Bool)` | Action executed after all the target-specific build phases where tool is the name of the tool to be executed.                                                     |
+| `.post(path: Path, arguments: String..., name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool, runForInstallBuildsOnly: Bool)`   | Action executed after all the target-specific build phases where path is the path to the tool to be executed.                                                     |
+| `.post(script: String, name: String, inputPaths: [Path], inputFileListPaths: [Path], outputPaths: [Path], outputFileListPaths: [Path], basedOnDependencyAnalysis: Bool, runForInstallBuildsOnly: Bool)`                     | Action executed after all the target-specific build phases where script is an embedded script to run. It is advised to keep embedded scripts as small as possible |
 
 The following example shows the definition of an action that runs the `my_custom_script.sh` passing the argument `"hello"`:
 
@@ -313,6 +313,12 @@ The following example shows the definition of an action that runs the `my_custom
 
 ```swift
 .pre(path: "my_custom_script.sh", name: "My Custom Script Phase", basedOnDependencyAnalysis: false)
+```
+
+The following example shows the definition of an action that runs the `my_custom_script.sh` only for InstallBuilds:
+
+```swift
+.pre(path: "my_custom_script.sh", name: "My Custom Script Phase", runForInstallBuildsOnly: true)
 ```
 
 ### Preset Build Configuration

--- a/projects/docs/docs/manifests/project.md
+++ b/projects/docs/docs/manifests/project.md
@@ -315,7 +315,7 @@ The following example shows the definition of an action that runs the `my_custom
 .pre(path: "my_custom_script.sh", name: "My Custom Script Phase", basedOnDependencyAnalysis: false)
 ```
 
-The following example shows the definition of an action that runs the `my_custom_script.sh` only for InstallBuilds:
+The following example shows the definition of an action that runs the `my_custom_script.sh` only for install builds:
 
 ```swift
 .pre(path: "my_custom_script.sh", name: "My Custom Script Phase", runForInstallBuildsOnly: true)

--- a/projects/tuist/fixtures/ios_app_with_actions/App/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_actions/App/Project.swift
@@ -13,5 +13,6 @@ let project = Project(name: "App",
                                 .post(tool: "/bin/echo", arguments: ["rocks"], name: "Rocks"),
                                 .pre(path: "script.sh", name: "Run script"),
                                 .pre(script: "echo 'Hello World'", name: "Embedded script"),
+                                .post(script: "echo 'Hello World from InstallBuild'", name: "Embedded script install build", runForInstallBuildsOnly: true)
                               ]),
                       ])

--- a/projects/tuist/fixtures/ios_app_with_actions/App/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_actions/App/Project.swift
@@ -12,7 +12,7 @@ let project = Project(name: "App",
                                 .pre(tool: "/bin/echo", arguments: ["\"tuist\""], name: "Tuist", inputPaths: ["Sources/**/*.swift"]),
                                 .post(tool: "/bin/echo", arguments: ["rocks"], name: "Rocks"),
                                 .pre(path: "script.sh", name: "Run script"),
-                                .pre(script: "echo 'Hello World'", name: "Embedded script"),
-                                .post(script: "echo 'Hello World from InstallBuild'", name: "Embedded script install build", runForInstallBuildsOnly: true)
+                                .post(script: "echo 'Hello World from install build'", name: "Embedded script install build", runForInstallBuildsOnly: true),
+                                .pre(script: "echo 'Hello World'", name: "Embedded script")
                               ]),
                       ])

--- a/projects/tuist/fixtures/ios_app_with_actions/App/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_actions/App/Project.swift
@@ -9,10 +9,16 @@ let project = Project(name: "App",
                                infoPlist: "Info.plist",
                                sources: ["Sources/**"],
                                actions: [
-                                .pre(tool: "/bin/echo", arguments: ["\"tuist\""], name: "Tuist", inputPaths: ["Sources/**/*.swift"]),
+                                // Note there are acceptance tests verifying the first `pre` and last `post` action
+                                // additions not part of the acceptance test should be added in-between
+
+                                // first pre-action
+                                .pre(tool: "/bin/echo", arguments: ["\"tuist\""], name: "Tuist", inputPaths: ["Sources/**/*.swift"]), 
+                                .post(script: "echo 'Hello World from install build'", name: "Embedded script install build", runForInstallBuildsOnly: true),
+
+                                // last post-action
                                 .post(tool: "/bin/echo", arguments: ["rocks"], name: "Rocks"),
                                 .pre(path: "script.sh", name: "Run script"),
-                                .post(script: "echo 'Hello World from install build'", name: "Embedded script install build", runForInstallBuildsOnly: true),
-                                .pre(script: "echo 'Hello World'", name: "Embedded script")
-                              ]),
+                                .pre(script: "echo 'Hello World'", name: "Embedded script"),
+                            ]),
                       ])


### PR DESCRIPTION
### Short description 📝

Add support for `runOnlyForDeploymentPostprocessing` (install builds) for build actions.
<img width="1490" alt="runOnlyForDeploymentPostprocessing" src="https://user-images.githubusercontent.com/1915802/115997329-02ea4980-a5e3-11eb-8c6a-44a50bcea00c.png">

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
