### PR TITLE
Fix messagesExtension default settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Improve performance of `tuist generate` by optimizing up md5 hash generation. [#2815](https://github.com/tuist/tuist/pull/2815) by [@adellibovi](https://github.com/adellibovi)
 - Speed up frameworks metadata reading using Mach-o parsing instead of `file`, `lipo` and `dwarfdump` external processes. [#2814](https://github.com/tuist/tuist/pull/2814) by [@adellibovi](https://github.com/adellibovi)
 
+### Fixed
+
+- Fix `.messagesExtension` default settings to include the appropriate `LD_RUNPATH_SEARCH_PATHS` [#2824](https://github.com/tuist/tuist/pull/2824) by [@kwridan](https://github.com/kwridan)
+
 ## 1.40.0
 
 ### Added

--- a/Sources/TuistGenerator/Utils/SettingsHelper.swift
+++ b/Sources/TuistGenerator/Utils/SettingsHelper.swift
@@ -39,7 +39,7 @@ final class SettingsHelper {
             return .staticLibrary
         case .framework, .staticFramework:
             return .framework
-        case .appExtension:
+        case .appExtension, .messagesExtension:
             return .appExtension
         case .watch2Extension:
             return .watchExtension

--- a/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
@@ -181,6 +181,8 @@ final class SettingsHelpersTests: XCTestCase {
         XCTAssertEqual(subject.settingsProviderProduct(.test(product: .unitTests)), .unitTests)
         XCTAssertEqual(subject.settingsProviderProduct(.test(product: .uiTests)), .uiTests)
         XCTAssertEqual(subject.settingsProviderProduct(.test(product: .appClip)), .application)
+        XCTAssertEqual(subject.settingsProviderProduct(.test(product: .appExtension)), .appExtension)
+        XCTAssertEqual(subject.settingsProviderProduct(.test(product: .messagesExtension)), .appExtension)
         XCTAssertNil(subject.settingsProviderProduct(.test(product: .bundle)))
     }
 


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/2818

### Short description 📝

- The `.messagesExtension` product type was missing the default `LD_RUNPATH_SEARCH_PATHS` resuling in a failure to locate dynamic frameworks at runtime
- Xcode by default assigns `@executable_path/../../Frameworks` as the search parth for message extension products
- To resolve this for the purposes of default settings `.messagesExtension` can be assigned the default build settings for `.appExtensions`

### Test Plan 🛠

- Run `swift run tuist generate --path projects/tuist/fixtures/ios_app_with_extensions`
- Inspect the generated workspace
- Verify the `LD_RUNPATH_SEARCH_PATHS` has the appropriate search paths set

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- ~In case the PR introduces changes that affect users, the documentation has been updated.~
