### PR TITLE
Temporarily disable signing acceptance test

### DIFF
--- a/projects/tuist/features/generate-1.feature
+++ b/projects/tuist/features/generate-1.feature
@@ -48,20 +48,20 @@ Feature: Generate a new project using Tuist (suite 1)
     Then I copy the fixture invalid_workspace_manifest_name into the working directory
     Then tuist generate yields error "Manifest not found at path ${ARG_PATH}"
 
-  Scenario: The project is an iOS application with signing (ios_app_with_signing)
-    Given that tuist is available
-    And I have a working directory
-    Then I copy the fixture ios_app_with_signing into the working directory
-    Then tuist generates the project
-    Then the scheme SignApp has a build setting CODE_SIGN_IDENTITY with value Apple Development: Marek Fort (54GSF6G47V) for the configuration Debug
-    Then the scheme SignApp has a build setting PROVISIONING_PROFILE_SPECIFIER with value d34fb066-f494-4d85-a556-d469c2196f46 for the configuration Debug
-    Then the scheme SignApp has a build setting CODE_SIGN_IDENTITY with value Apple Development: Marek Fort (54GSF6G47V) for the configuration Release
-    Then the scheme SignApp has a build setting PROVISIONING_PROFILE_SPECIFIER with value 76a7d75c-01d4-4c7f-9140-1d829227883a for the configuration Release
-    Then the scheme SignApp has a build setting PRODUCT_BUNDLE_IDENTIFIER with value team.io.tuist.debug for the configuration Debug
-    Then the scheme SignApp has a build setting PRODUCT_BUNDLE_IDENTIFIER with value team.io.tuist.release for the configuration Release
-    Then the scheme AppA has a build setting CODE_SIGN_IDENTITY with value iPhone Developer: Christoph Lederer (F2X7FM3XMV) for the configuration Debug
-    Then the scheme AppA has a build setting PROVISIONING_PROFILE_SPECIFIER with value 7fcc4b2f-adbf-4a86-be34-fc8bc4f1ad7 for the configuration Debug
-    Then the scheme AppA has a build setting PRODUCT_BUNDLE_IDENTIFIER with value io.tuist.test.appA for the configuration Debug
-    Then the scheme AppB has a build setting CODE_SIGN_IDENTITY with value iPhone Developer: Christoph Lederer (F2X7FM3XMV) for the configuration Debug
-    Then the scheme AppB has a build setting PROVISIONING_PROFILE_SPECIFIER with value 59024d29-40ec-4719-8800-7b539ed98051 for the configuration Debug
-    Then the scheme AppB has a build setting PRODUCT_BUNDLE_IDENTIFIER with value io.tuist.test.appB for the configuration Debug
+# Scenario: The project is an iOS application with signing (ios_app_with_signing)
+#   Given that tuist is available
+#   And I have a working directory
+#   Then I copy the fixture ios_app_with_signing into the working directory
+#   Then tuist generates the project
+#   Then the scheme SignApp has a build setting CODE_SIGN_IDENTITY with value Apple Development: Marek Fort (54GSF6G47V) for the configuration Debug
+#   Then the scheme SignApp has a build setting PROVISIONING_PROFILE_SPECIFIER with value d34fb066-f494-4d85-a556-d469c2196f46 for the configuration Debug
+#   Then the scheme SignApp has a build setting CODE_SIGN_IDENTITY with value Apple Development: Marek Fort (54GSF6G47V) for the configuration Release
+#   Then the scheme SignApp has a build setting PROVISIONING_PROFILE_SPECIFIER with value 76a7d75c-01d4-4c7f-9140-1d829227883a for the configuration Release
+#   Then the scheme SignApp has a build setting PRODUCT_BUNDLE_IDENTIFIER with value team.io.tuist.debug for the configuration Debug
+#   Then the scheme SignApp has a build setting PRODUCT_BUNDLE_IDENTIFIER with value team.io.tuist.release for the configuration Release
+#   Then the scheme AppA has a build setting CODE_SIGN_IDENTITY with value iPhone Developer: Christoph Lederer (F2X7FM3XMV) for the configuration Debug
+#   Then the scheme AppA has a build setting PROVISIONING_PROFILE_SPECIFIER with value 7fcc4b2f-adbf-4a86-be34-fc8bc4f1ad7 for the configuration Debug
+#   Then the scheme AppA has a build setting PRODUCT_BUNDLE_IDENTIFIER with value io.tuist.test.appA for the configuration Debug
+#   Then the scheme AppB has a build setting CODE_SIGN_IDENTITY with value iPhone Developer: Christoph Lederer (F2X7FM3XMV) for the configuration Debug
+#   Then the scheme AppB has a build setting PROVISIONING_PROFILE_SPECIFIER with value 59024d29-40ec-4719-8800-7b539ed98051 for the configuration Debug
+#   Then the scheme AppB has a build setting PRODUCT_BUNDLE_IDENTIFIER with value io.tuist.test.appB for the configuration Debug


### PR DESCRIPTION
Relates to #2826 

### Short description 📝

- The signing acceptance test relies on valid provisioning profiles and certificates which expire each year
- One of the profiles has already expired causing the acceptance test to fail
- The test is temporarily being disabled while we figure out a more stable way to host this test

### Test Plan 🛠

- Verify acceptance tests pass

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- ~The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.~
- ~In case the PR introduces changes that affect users, the documentation has been updated.~
