### PR TITLE
Remove pruned targets from codeCoverageTargets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- Fix `tuist focus` not excluding targets from `codeCoverageTargets` of custom schemes by [@Luis Padron](https://github.com/luispadron).
+
 ## 1.41.0 
 
 ### Added


### PR DESCRIPTION
### Short description 📝

This PR fixes a bug with `tuist focus` where we are not removing pruned targets from `codeCoverageTargets` of custom `Scheme`s.

This leads to issues where the project fails to generate as the focused project does not include all targets:

Before this change:
```sh
tuist focus --path projects/tuist/fixtures/app_with_coverage_scheme Framework1
Resolved cache profile 'Development' from Tuist's defaults
The target 'AppTests' specified in App-Coverage code coverage targets list isn't defined in the project.
The target 'Framework1Tests' specified in App-Coverage code coverage targets list isn't defined in the project.
The target 'Framework2Tests' specified in App-Coverage code coverage targets list isn't defined in the project.
Fatal linting issues found
```

After this change:
```sh
tuist focus --path projects/tuist/fixtures/app_with_coverage_scheme Framework1
Resolved cache profile 'Development' from Tuist's defaults
Generating workspace Workspace.xcworkspace
Generating project Framework1
Generating project Framework2
```

The fix is simple, we need to remove any targets that are not part of the focused project from `codeCoverageTargets` of any custom scheme. This allows us to keep the scheme but we can filter out targets that aren't part of the focused project.

### Checklist ✅

- [X] The code architecture and patterns are consistent with the rest of the codebase.
- [X] The changes have been tested following the [documented guidelines](https://tuist.io/docs/contribution/testing-strategy/).
- [X] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [X] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] Remove fixture when done reviewing
