### PR TITLE
Support hyphens in product names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
-## Next 
+## Next
 
 ### Added
+
 - Add support for `runPostActionsOnFailure` for post build actions. [#2752](https://github.com/tuist/tuist/pull/2752) by [@FranzBusch](https://github.com/FranzBusch)
 - Make `ValueGraph` serializable. [#2811](https://github.com/tuist/tuist/pull/2811) by [@laxmorek](https://github.com/laxmorek)
 - Add support for configuration of cache directory [#2566](https://github.com/tuist/tuist/pull/2566) by [@adellibovi](https://github.com/adellibovi).
@@ -15,10 +16,12 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Speed up frameworks metadata reading using Mach-o parsing instead of `file`, `lipo` and `dwarfdump` external processes. [#2814](https://github.com/tuist/tuist/pull/2814) by [@adellibovi](https://github.com/adellibovi)
 
 ### Fixed
-- `tuist generate` your projects without having to re-open them! 🧑‍💻 [#2828] by [@ferologics](https://github.com/ferologics) 
+
+- `tuist generate` your projects without having to re-open them! 🧑‍💻 [#2828] by [@ferologics](https://github.com/ferologics)
 - Fix a bug for which when generating a `Resources` target from a `staticLibrary` or `staticFramework`, the parent's deployment target isn't passed to the new target. [#2830](https://github.com/tuist/tuist/pull/2830) by [@fila95](https://github.com/fila95)
 - Fix `.messagesExtension` default settings to include the appropriate `LD_RUNPATH_SEARCH_PATHS` [#2824](https://github.com/tuist/tuist/pull/2824) by [@kwridan](https://github.com/kwridan)
 - Fix the link to documented guidelines in pull request template [#2833](https://github.com/tuist/tuist/pull/2833) by [@mollyIV](https://github.com/mollyIV).
+- Support hyphens in product names [#2836](https://github.com/tuist/tuist/pull/2836) by [@pepibumur](https://github.com/pepibumur).
 
 ## 1.40.0
 

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -68,10 +68,10 @@ class TargetLinter: TargetLinting {
     }
 
     private func lintProductName(target: Target) -> [LintingIssue] {
-        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-")
 
         if target.productName.unicodeScalars.allSatisfy(allowed.contains) == false {
-            let reason = "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9) and underscore (_) characters."
+            let reason = "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), hyphen (-), and underscore (_) characters."
 
             return [LintingIssue(reason: reason, severity: .error)]
         }

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -26,7 +26,7 @@ final class TargetLinterTests: TuistUnitTestCase {
         let XCTAssertInvalidProductName: (String) -> Void = { productName in
             let target = Target.test(productName: productName)
             let got = self.subject.lint(target: target)
-            let reason = "Invalid product name '\(productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9) and underscore (_) characters."
+            let reason = "Invalid product name '\(productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), hyphen (-), and underscore (_) characters."
             self.XCTContainsLintingIssue(got, LintingIssue(reason: reason, severity: .error))
         }
 
@@ -40,6 +40,7 @@ final class TargetLinterTests: TuistUnitTestCase {
         XCTAssertInvalidProductName("My.Framework")
         XCTAssertInvalidProductName("ⅫFramework")
         XCTAssertInvalidProductName("ؼFramework")
+        XCTAssertValidProductName("MyFramework-iOS")
         XCTAssertValidProductName("MyFramework_iOS")
         XCTAssertValidProductName("MyFramework")
     }


### PR DESCRIPTION
### Short description 📝
It was reported in Slack that when a product name contains hyphens the generation fails. We have a check that ensures the characters are valid, but the set doesn't include the hyphen. I tried to build a target with a hyphen in the name and it succeeded so I don't see a reason to not support it. If there's, please, let me know.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
