### PR TITLE
Suppress "no sources" warning when the target has dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Changed
 
-- Warnings for targets with no source files are now suppressed if the target does contain a dependency. [#2838](https://github.com/tuist/tuist/pull/2838) by [@jsorge](https://github.com/jsorge)
+- Warnings for targets with no source files are now suppressed if the target does contain a dependency or action. [#2838](https://github.com/tuist/tuist/pull/2838) by [@jsorge](https://github.com/jsorge)
 
 ### Fixed
 
@@ -31,7 +31,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Speed up frameworks metadata reading using Mach-o parsing instead of `file`, `lipo` and `dwarfdump` external processes. [#2814](https://github.com/tuist/tuist/pull/2814) by [@adellibovi](https://github.com/adellibovi)
 
 ### Fixed
-- `tuist generate` your projects without having to re-open them! 🧑‍💻 [#2828] by [@ferologics](https://github.com/ferologics) 
+- `tuist generate` your projects without having to re-open them! 🧑‍💻 [#2828] by [@ferologics](https://github.com/ferologics)
 - Fix a bug for which when generating a `Resources` target from a `staticLibrary` or `staticFramework`, the parent's deployment target isn't passed to the new target. [#2830](https://github.com/tuist/tuist/pull/2830) by [@fila95](https://github.com/fila95)
 - Fix `.messagesExtension` default settings to include the appropriate `LD_RUNPATH_SEARCH_PATHS` [#2824](https://github.com/tuist/tuist/pull/2824) by [@kwridan](https://github.com/kwridan)
 - Fix the link to documented guidelines in pull request template [#2833](https://github.com/tuist/tuist/pull/2833) by [@mollyIV](https://github.com/mollyIV).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Add `tuist dependencies update` command. [#2819](https://github.com/tuist/tuist/pull/2819) by [@laxmorek](https://github.com/laxmorek)
 
+### Changed
+
+- Warnings for targets with no source files are now suppressed if the target does contain a dependency. [#2838](https://github.com/tuist/tuist/pull/2838) by [@jsorge](https://github.com/jsorge)
+
 ### Fixed
 
 - Fix `tuist focus` not excluding targets from `codeCoverageTargets` of custom schemes by [@Luis Padron](https://github.com/luispadron).
 
-## 1.41.0 
+## 1.41.0
 
 ### Added
 

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -83,7 +83,11 @@ class TargetLinter: TargetLinting {
         let supportsSources = target.supportsSources
         let sources = target.sources
 
-        if supportsSources, sources.isEmpty, target.dependencies.isEmpty {
+        let hasNoSources = supportsSources && sources.isEmpty
+        let hasNoDependencies = target.dependencies.isEmpty
+        let hasNoActions = target.actions.isEmpty
+
+        if hasNoSources, hasNoDependencies, hasNoActions {
             return [LintingIssue(reason: "The target \(target.name) doesn't contain source files.", severity: .warning)]
         } else if !supportsSources, !sources.isEmpty {
             return [LintingIssue(reason: "Target \(target.name) cannot contain sources. \(target.platform) \(target.product) targets don't support source files", severity: .error)]

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -83,7 +83,7 @@ class TargetLinter: TargetLinting {
         let supportsSources = target.supportsSources
         let sources = target.sources
 
-        if supportsSources, sources.isEmpty {
+        if supportsSources, sources.isEmpty, target.dependencies.isEmpty {
             return [LintingIssue(reason: "The target \(target.name) doesn't contain source files.", severity: .warning)]
         } else if !supportsSources, !sources.isEmpty {
             return [LintingIssue(reason: "Target \(target.name) cannot contain sources. \(target.platform) \(target.product) targets don't support source files", severity: .error)]

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -71,6 +71,15 @@ final class TargetLinterTests: TuistUnitTestCase {
         XCTContainsLintingIssue(got, LintingIssue(reason: "The target \(target.name) doesn't contain source files.", severity: .warning))
     }
 
+    func test_lint_when_target_no_source_files_but_has_dependency() {
+        let target = Target.test(sources: [], dependencies: [
+            TargetDependency.sdk(name: "libc++.tbd", status: .optional)
+        ])
+        let got = subject.lint(target: target)
+
+        XCTAssertEqual(0, got.count)
+    }
+
     func test_lint_when_a_infoplist_file_is_being_copied() {
         let infoPlistPath = AbsolutePath("/Info.plist")
         let googeServiceInfoPlistPath = AbsolutePath("/GoogleService-Info.plist")

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -80,6 +80,15 @@ final class TargetLinterTests: TuistUnitTestCase {
         XCTAssertEqual(0, got.count)
     }
 
+    func test_lint_when_target_no_source_files_but_has_actions() {
+        let target = Target.test(sources: [], actions: [
+            TargetAction(name: "Test script", order: .post, script: .embedded("echo 'This is a test'")),
+        ])
+        let got = subject.lint(target: target)
+
+        XCTAssertEqual(0, got.count)
+    }
+
     func test_lint_when_a_infoplist_file_is_being_copied() {
         let infoPlistPath = AbsolutePath("/Info.plist")
         let googeServiceInfoPlistPath = AbsolutePath("/GoogleService-Info.plist")

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -73,7 +73,7 @@ final class TargetLinterTests: TuistUnitTestCase {
 
     func test_lint_when_target_no_source_files_but_has_dependency() {
         let target = Target.test(sources: [], dependencies: [
-            TargetDependency.sdk(name: "libc++.tbd", status: .optional)
+            TargetDependency.sdk(name: "libc++.tbd", status: .optional),
         ])
         let got = subject.lint(target: target)
 


### PR DESCRIPTION
### Short description 📝

If there is a target which contains no source files, but has dependencies (such as dynamic target wrappers for static products) then Tuist produces a warning saying `The target {TargetName} doesn't contain source files.` However for these wrapper types there shouldn't be any source files.

This change suppresses that message for targets which don't have sources, but do have dependencies.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
