### PR TITLE
Add Newline to End of Generated Resource Accessor Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Fix `tuist focus` not excluding targets from `codeCoverageTargets` of custom schemes by [@Luis Padron](https://github.com/luispadron).
 - Fix rubocop warnings [#2898](https://github.com/tuist/tuist/pull/2898) by [@fortmarek](https://github.com/fortmarek)
+- Add newline to end of generated resource accessor files. [#2895](https://github.com/tuist/tuist/pull/2895) by [@Jake Prickett](https://github.com/Jake-Prickett)
 
 ## 1.41.0
 

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -116,6 +116,7 @@ public class ResourcesProjectMapper: ProjectMapping {
             }
             // swiftlint:enable all
             // swiftformat:enable all
+            
             """
         } else {
             return """
@@ -145,6 +146,7 @@ public class ResourcesProjectMapper: ProjectMapping {
             }
             // swiftlint:enable all
             // swiftformat:enable all
+            
             """
         }
     }

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -116,7 +116,7 @@ public class ResourcesProjectMapper: ProjectMapping {
             }
             // swiftlint:enable all
             // swiftformat:enable all
-            
+
             """
         } else {
             return """
@@ -146,7 +146,7 @@ public class ResourcesProjectMapper: ProjectMapping {
             }
             // swiftlint:enable all
             // swiftformat:enable all
-            
+
             """
         }
     }


### PR DESCRIPTION
### Short description 📝
When running `tuist generate`, changes consistently appear in the git diff (even after staging and committing) in the Bundle extension generated by tuist not due to the post generated file not having a new line at the end. Even after staging this line, it still continuously appears. We've been puzzled by this one since our complete migration to Tuist! 🎉 

This resolves the issue for us, but if someone else has a different solution for this problem that doesn't require a code change, I can close this PR 😄 

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
