### PR TITLE
Remove sudo requirement from install & uninstall scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - **Breaking** Remove `tuist create-issue` command [#3194](https://github.com/tuist/tuist/pull/3194) by [@pepibumur](https://github.com/pepibumur).
 - **Breaking** Remove `tuist secret` command [#3194](https://github.com/tuist/tuist/pull/3194) by [@pepibumur](https://github.com/pepibumur).
 
+### Changed
+
+- Remove the `sudo` requirement for the install and uninstall scripts. [#3056](https://github.com/tuist/tuist/pull/3056) by [@luispadron](https://github.com/luispadron).
+
 ## 1.46.1
 
 ### Fixed

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
         "state": {
           "branch": null,
-          "revision": "c37e5ae8012fb654af776cc556ff8ae64398c841",
-          "version": "0.5.0"
+          "revision": "ae2f434e81017bb7de02c168fb0bde83cd8370c1",
+          "version": "0.3.1"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
         "state": {
           "branch": null,
-          "revision": "8d4f6384e0a8cc41f2005247241dd553963a492a",
-          "version": "1.4.1"
+          "revision": "5669f222e46c8134fb1f399c745fa6882b43532e",
+          "version": "1.3.8"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/tid-kijyun/Kanna.git",
         "state": {
           "branch": null,
-          "revision": "126bdc9600e30b4a8aeb8d14088953c16aebf495",
-          "version": "5.2.6"
+          "revision": "c657fb9f5827ef138068215c76ad0bb62bbc92da",
+          "version": "5.2.4"
         }
       },
       {
@@ -89,24 +89,6 @@
           "branch": null,
           "revision": "84e546727d66f1adc5439debad16270d0fdd04e7",
           "version": "4.2.2"
-        }
-      },
-      {
-        "package": "Komondor",
-        "repositoryURL": "https://github.com/shibapm/Komondor.git",
-        "state": {
-          "branch": null,
-          "revision": "855c74f395a4dc9e02828f58d931be6920bcbf6f",
-          "version": "1.0.6"
-        }
-      },
-      {
-        "package": "PackageConfig",
-        "repositoryURL": "https://github.com/shibapm/PackageConfig.git",
-        "state": {
-          "branch": null,
-          "revision": "bf90dc69fa0792894b08a0b74cf34029694ae486",
-          "version": "0.13.0"
         }
       },
       {
@@ -132,17 +114,8 @@
         "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
         "state": {
           "branch": null,
-          "revision": "254617dd7fae0c45319ba5fbea435bf4d0e15b5d",
-          "version": "5.1.2"
-        }
-      },
-      {
-        "package": "ShellOut",
-        "repositoryURL": "https://github.com/JohnSundell/ShellOut.git",
-        "state": {
-          "branch": null,
-          "revision": "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
-          "version": "2.3.0"
+          "revision": "002d325b0bdee94e7882e1114af5ff4fe1e96afa",
+          "version": "5.1.1"
         }
       },
       {
@@ -159,17 +132,8 @@
         "repositoryURL": "https://github.com/stencilproject/Stencil.git",
         "state": {
           "branch": null,
-          "revision": "973e190edf5d09274e4a6bc2e636c86899ed84c3",
-          "version": "0.14.1"
-        }
-      },
-      {
-        "package": "StencilSwiftKit",
-        "repositoryURL": "https://github.com/SwiftGen/StencilSwiftKit.git",
-        "state": {
-          "branch": null,
-          "revision": "54cbedcdbb4334e03930adcff7343ffaf317bf0f",
-          "version": "2.8.0"
+          "revision": "94197b3adbbf926348ad8765476a158aa4e54f8a",
+          "version": "0.14.0"
         }
       },
       {
@@ -195,25 +159,16 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "3b6b97d612b56e25d80d0807f5bc38ea08b7bdf3",
-          "version": "0.2.3"
-        }
-      },
-      {
-        "package": "Swifter",
-        "repositoryURL": "https://github.com/fortmarek/swifter.git",
-        "state": {
-          "branch": "stable",
-          "revision": "38349dbb02a2658acce50e53476c7284761e063f",
-          "version": null
+          "revision": "2954e55faee5bfee928e844bb09e97fcfa8d24af",
+          "version": "0.2.0"
         }
       },
       {
         "package": "SwiftGen",
         "repositoryURL": "https://github.com/fortmarek/SwiftGen",
         "state": {
-          "branch": "stable",
-          "revision": "5514d331d8ff1273b5c88747d646edcb63e13d69",
+          "branch": null,
+          "revision": "ef8d6b186a03622cec8d228b18f0e2b3bb20b81c",
           "version": null
         }
       },
@@ -222,17 +177,8 @@
         "repositoryURL": "https://github.com/tuist/XcodeProj.git",
         "state": {
           "branch": null,
-          "revision": "0b18c3e7a10c241323397a80cb445051f4494971",
-          "version": "8.0.0"
-        }
-      },
-      {
-        "package": "xctest-dynamic-overlay",
-        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
-        "state": {
-          "branch": null,
-          "revision": "152390e9e78ebbf0d767ee52971d41e7f44f39bc",
-          "version": "0.1.1"
+          "revision": "94e55232d227f9d78b811c98cb2e5d0cbd08987b",
+          "version": "7.22.0"
         }
       },
       {
@@ -240,8 +186,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-          "version": "4.0.6"
+          "revision": "9003d51672e516cc59297b7e96bff1dfdedcb4ea",
+          "version": "4.0.4"
         }
       },
       {

--- a/script/install
+++ b/script/install
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 shell_join() {
   local arg
   printf "%s" "$1"
@@ -10,59 +12,12 @@ shell_join() {
   done
 }
 
-execute() {
-  if ! "$@"; then
-    abort "$(printf "Failed during: %s" "$(shell_join "$@")")"
-  fi
-}
-
-have_sudo_access() {
-  local -a args
-  if [[ -n "${SUDO_ASKPASS-}" ]]; then
-    args=("-A")
-  elif [[ -n "${NONINTERACTIVE-}" ]]; then
-    args=("-n")
-  fi
-
-  if [[ -z "${HAVE_SUDO_ACCESS-}" ]]; then
-    if [[ -n "${args[*]-}" ]]; then
-      SUDO="/usr/bin/sudo ${args[*]}"
-    else
-      SUDO="/usr/bin/sudo"
-    fi
-    if [[ -n "${NONINTERACTIVE-}" ]]; then
-      ${SUDO} -l mkdir &>/dev/null
-    else
-      ${SUDO} -v && ${SUDO} -l mkdir &>/dev/null
-    fi
-    HAVE_SUDO_ACCESS="$?"
-  fi
-
-  if [[ -z "${HOMEBREW_ON_LINUX-}" ]] && [[ "$HAVE_SUDO_ACCESS" -ne 0 ]]; then
-    abort "Need sudo access on macOS (e.g. the user $USER to be an Administrator)!"
-  fi
-
-  return "$HAVE_SUDO_ACCESS"
-}
-
 ohai() {
   printf "${tty_blue}==>${tty_bold} %s${tty_reset}\n" "$(shell_join "$@")"
 }
 
 warn() {
   printf "${tty_red}Warning${tty_reset}: %s\n" "$(chomp "$1")"
-}
-
-execute_sudo() {
-  local -a args=("$@")
-  if have_sudo_access; then
-    if [[ -n "${SUDO_ASKPASS-}" ]]; then
-      args=("-A" "${args[@]}")
-    fi
-    execute "/usr/bin/sudo" "${args[@]}"
-  else
-    execute "${args[@]}"
-  fi
 }
 
 ohai "Downloading tuistenv..."
@@ -72,12 +27,15 @@ unzip -o /tmp/tuistenv.zip -d /tmp/tuistenv > /dev/null
 ohai "Installing tuistenv..."
 
 if [[ ! -d "/usr/local/bin" ]]; then
-  execute_sudo mkdir /usr/local/bin/
+  mkdir -p /usr/local/bin/
 fi
-execute_sudo mkdir -p /usr/local/bin
-execute_sudo rm -rf /usr/local/bin/tuist
-execute_sudo mv /tmp/tuistenv/tuistenv /usr/local/bin/tuist
-execute_sudo chmod +x /usr/local/bin/tuist
+
+if [[ -f "/usr/local/bin/tuist" ]]; then
+  rm /usr/local/bin/tuist
+fi
+
+mv /tmp/tuistenv/tuistenv /usr/local/bin/tuist
+chmod +x /usr/local/bin/tuist
 
 rm -rf /tmp/tuistenv
 rm /tmp/tuistenv.zip

--- a/script/uninstall
+++ b/script/uninstall
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 shell_join() {
   local arg
   printf "%s" "$1"
@@ -10,41 +12,6 @@ shell_join() {
   done
 }
 
-execute() {
-  if ! "$@"; then
-    abort "$(printf "Failed during: %s" "$(shell_join "$@")")"
-  fi
-}
-
-have_sudo_access() {
-  local -a args
-  if [[ -n "${SUDO_ASKPASS-}" ]]; then
-    args=("-A")
-  elif [[ -n "${NONINTERACTIVE-}" ]]; then
-    args=("-n")
-  fi
-
-  if [[ -z "${HAVE_SUDO_ACCESS-}" ]]; then
-    if [[ -n "${args[*]-}" ]]; then
-      SUDO="/usr/bin/sudo ${args[*]}"
-    else
-      SUDO="/usr/bin/sudo"
-    fi
-    if [[ -n "${NONINTERACTIVE-}" ]]; then
-      ${SUDO} -l mkdir &>/dev/null
-    else
-      ${SUDO} -v && ${SUDO} -l mkdir &>/dev/null
-    fi
-    HAVE_SUDO_ACCESS="$?"
-  fi
-
-  if [[ -z "${HOMEBREW_ON_LINUX-}" ]] && [[ "$HAVE_SUDO_ACCESS" -ne 0 ]]; then
-    abort "Need sudo access on macOS (e.g. the user $USER to be an Administrator)!"
-  fi
-
-  return "$HAVE_SUDO_ACCESS"
-}
-
 ohai() {
   printf "${tty_blue}==>${tty_bold} %s${tty_reset}\n" "$(shell_join "$@")"
 }
@@ -53,19 +20,7 @@ warn() {
   printf "${tty_red}Warning${tty_reset}: %s\n" "$(chomp "$1")"
 }
 
-execute_sudo() {
-  local -a args=("$@")
-  if have_sudo_access; then
-    if [[ -n "${SUDO_ASKPASS-}" ]]; then
-      args=("-A" "${args[@]}")
-    fi
-    execute "/usr/bin/sudo" "${args[@]}"
-  else
-    execute "${args[@]}"
-  fi
-}
-
-execute_sudo rm -rf /usr/local/bin/tuist
-execute_sudo rm -rf ~/.tuist
+rm -rf /usr/local/bin/tuist
+rm -rf ~/.tuist
 
 ohai "Tuist uninstalled"


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/2806
Request for comments document (if applies):

### Short description 📝

This PR removes the need to require sudo access. This is problematic in contexts where TTY is not available to enter password (such as in CI/CD). This also makes it more clear that the install script isn't doing anything crazy on someones machine that would require sudo.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
