### PR TITLE
Fix manifest loading when using Swift 5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Added
+
 - Add `tvTopShelfExtension` and `tvIntentsExtension` target product. [#2793](https://github.com/tuist/tuist/pull/2793) by [@rmnblm](https://github.com/rmnblm)
+
+### Fixed
+
+- Fix manifest loading when using Swift 5.5 [#3062](https://github.com/tuist/tuist/pull/3062) by [@kwridan](https://github.com/kwridan)
 
 ## 1.44.0 - DubDub
 

--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -310,8 +310,7 @@ public class ManifestLoader: ManifestLoading {
         }
         var arguments = [
             "/usr/bin/xcrun",
-            "swiftc",
-            "--driver-mode=swift",
+            "swift",
             "-suppress-warnings",
             "-I", searchPaths.includeSearchPath.pathString,
             "-L", searchPaths.librarySearchPath.pathString,


### PR DESCRIPTION
### Short description 📝

 Projects fail to generate when building and running Tuist with Swift 5.5

- The issue occurs due a failure to load the manifests (i.e. extracting the resulting JSON description from running the manifest's swift code)
- Swift 5.5 has had some changes related to the introduction of a new Swift driver
   - This changed the [environment and arguments](https://github.com/apple/swift/blob/b3518aa2d9b88da0abe9582663f0bb3bfb05d988/tools/driver/driver.cpp#L220) needed when running `swiftc`
- For running stand alone Swift files like the manifests using the `swift` command directly instead of `swiftc` should suffice and work for both Swift 5.5 and prior versions

### Test Plan 🛠:

- With both Swift 5.5 and prior versions
- Run `swift build`
- Generate a project with manifest caching disabled and verify it works via:

```
TUIST_CACHE_MANIFESTS=NO swift run tuist generate --path projects/tuist/fixtures/ios_app_with_tests/
```

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- ~In case the PR introduces changes that affect users, the documentation has been updated.~
