### PR TITLE
📦 [Dependencies.swift] Map SPM custom build settings to ThirdPartyDependency 

### DIFF
--- a/Sources/TuistDependencies/SwiftPackageManager/Models/PackageInfo.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Models/PackageInfo.swift
@@ -160,19 +160,14 @@ extension PackageInfo {
 extension PackageInfo.Target {
     /// A dependency of the target.
     public enum Dependency: Equatable {
-        public struct PackageConditionDescription: Decodable, Equatable {
-            public let platformNames: [String]
-            public let config: String?
-        }
-
         /// A dependency internal to the same package.
-        case target(name: String, condition: PackageConditionDescription?)
+        case target(name: String, condition: PackageInfo.PackageConditionDescription?)
 
         /// A product from a third party package.
-        case product(name: String, package: String, condition: PackageConditionDescription?)
+        case product(name: String, package: String, condition: PackageInfo.PackageConditionDescription?)
 
         /// A dependency to be resolved by name.
-        case byName(name: String, condition: PackageConditionDescription?)
+        case byName(name: String, condition: PackageInfo.PackageConditionDescription?)
     }
 }
 
@@ -280,18 +275,18 @@ extension PackageInfo.Target.Dependency: Decodable {
         case .target:
             self = .target(
                 name: try unkeyedValues.decode(String.self),
-                condition: try unkeyedValues.decodeIfPresent(PackageConditionDescription.self)
+                condition: try unkeyedValues.decodeIfPresent(PackageInfo.PackageConditionDescription.self)
             )
         case .product:
             self = .product(
                 name: try unkeyedValues.decode(String.self),
                 package: try unkeyedValues.decode(String.self),
-                condition: try unkeyedValues.decodeIfPresent(PackageConditionDescription.self)
+                condition: try unkeyedValues.decodeIfPresent(PackageInfo.PackageConditionDescription.self)
             )
         case .byName:
             self = .byName(
                 name: try unkeyedValues.decode(String.self),
-                condition: try unkeyedValues.decodeIfPresent(PackageConditionDescription.self)
+                condition: try unkeyedValues.decodeIfPresent(PackageInfo.PackageConditionDescription.self)
             )
         }
     }

--- a/Sources/TuistDependenciesTesting/SwiftPackageManager/Models/PackageInfo+TestData.swift
+++ b/Sources/TuistDependenciesTesting/SwiftPackageManager/Models/PackageInfo+TestData.swift
@@ -98,13 +98,14 @@ extension PackageInfo {
                       ]
                     }
                   ]
-                },
+                }
               ],
               "exclude" : [
 
               ],
               "name" : "Tuist",
-              "path": "customPath",
+              "path" : "customPath",
+              "publicHeadersPath" : "customPublicHeadersPath",
               "sources": [
                 "customSources"
               ],
@@ -116,13 +117,62 @@ extension PackageInfo {
               ],
               "settings" : [
                 {
-                  "tool": "swift",
-                  "name": "linkedLibrary",
+                  "tool": "c",
+                  "name": "headerSearchPath",
                   "value": [
-                    "settingValue"
+                    "cSearchPath"
+                  ]
+                },
+                {
+                  "tool": "cxx",
+                  "name": "headerSearchPath",
+                  "value": [
+                    "cxxSearchPath"
+                  ]
+                },
+                {
+                  "tool": "c",
+                  "name": "unsafeFlags",
+                  "value": [
+                    "CUSTOM_C_FLAG"
+                  ]
+                },
+                {
+                  "tool": "cxx",
+                  "name": "unsafeFlags",
+                  "value": [
+                    "CUSTOM_CXX_FLAG"
+                  ]
+                },
+                {
+                  "tool": "swift",
+                  "name": "unsafeFlags",
+                  "value": [
+                    "CUSTOM_SWIFT_FLAG1",
+                    "CUSTOM_SWIFT_FLAG2"
+                  ]
+                },
+                {
+                  "tool": "c",
+                  "name": "define",
+                  "value": [
+                    "C_DEFINE=C_VALUE"
+                  ]
+                },
+                {
+                  "tool": "cxx",
+                  "name": "define",
+                  "value": [
+                    "CXX_DEFINE=CXX_VALUE"
+                  ]
+                },
+                {
+                  "tool": "swift",
+                  "name": "define",
+                  "value": [
+                    "SWIFT_DEFINE"
                   ]
                 }
-
               ],
               "type" : "regular"
             },
@@ -198,10 +248,17 @@ extension PackageInfo {
                         .target(name: "TuistKit", condition: nil),
                         .product(name: "ALibrary", package: "a-dependency", condition: .init(platformNames: ["ios"], config: nil)),
                     ],
-                    publicHeadersPath: nil,
+                    publicHeadersPath: "customPublicHeadersPath",
                     type: .regular,
                     settings: [
-                        .init(tool: .swift, name: .linkedLibrary, condition: nil, value: ["settingValue"]),
+                        .init(tool: .c, name: .headerSearchPath, condition: nil, value: ["cSearchPath"]),
+                        .init(tool: .cxx, name: .headerSearchPath, condition: nil, value: ["cxxSearchPath"]),
+                        .init(tool: .c, name: .unsafeFlags, condition: nil, value: ["CUSTOM_C_FLAG"]),
+                        .init(tool: .cxx, name: .unsafeFlags, condition: nil, value: ["CUSTOM_CXX_FLAG"]),
+                        .init(tool: .swift, name: .unsafeFlags, condition: nil, value: ["CUSTOM_SWIFT_FLAG1", "CUSTOM_SWIFT_FLAG2"]),
+                        .init(tool: .c, name: .define, condition: nil, value: ["C_DEFINE=C_VALUE"]),
+                        .init(tool: .cxx, name: .define, condition: nil, value: ["CXX_DEFINE=CXX_VALUE"]),
+                        .init(tool: .swift, name: .define, condition: nil, value: ["SWIFT_DEFINE"]),
                     ],
                     checksum: nil
                 ),

--- a/Sources/TuistGraph/DependenciesGraph/ThirdPartyDependency.swift
+++ b/Sources/TuistGraph/DependenciesGraph/ThirdPartyDependency.swift
@@ -63,16 +63,64 @@ extension ThirdPartyDependency {
         /// The paths containing the target resources.
         public let resources: [AbsolutePath]
 
-        /// The target dependencies
+        /// The target dependencies.
         public let dependencies: [Dependency]
 
-        // TODO: check and add any other information needed to compile the sources (e.g. build flags)
+        /// The custom public headers path.
+        public let publicHeadersPath: String?
 
-        public init(name: String, sources: [AbsolutePath], resources: [AbsolutePath], dependencies: [Dependency]) {
+        /// The header search paths for C code.
+        public let cHeaderSearchPaths: [String]
+
+        /// The header search paths for CXX code.
+        public let cxxHeaderSearchPaths: [String]
+
+        /// The compilation conditions to be defined for C code.
+        public let cDefines: [String: String]
+
+        /// The compilation conditions to be defined for CXX code.
+        public let cxxDefines: [String: String]
+
+        /// The compilation conditions to be definedfor Swift code.
+        public let swiftDefines: [String: String]
+
+        /// The additional build flags for C code.
+        public let cFlags: [String]
+
+        /// The additional build flags for CXX code.
+        public let cxxFlags: [String]
+
+        /// The additional build flags for Swift code.
+        public let swiftFlags: [String]
+
+        public init(
+            name: String,
+            sources: [AbsolutePath],
+            resources: [AbsolutePath],
+            dependencies: [Dependency],
+            publicHeadersPath: String?,
+            cHeaderSearchPaths: [String],
+            cxxHeaderSearchPaths: [String],
+            cDefines: [String: String],
+            cxxDefines: [String: String],
+            swiftDefines: [String: String],
+            cFlags: [String],
+            cxxFlags: [String],
+            swiftFlags: [String]
+        ) {
             self.name = name
             self.sources = sources
             self.resources = resources
             self.dependencies = dependencies
+            self.publicHeadersPath = publicHeadersPath
+            self.cHeaderSearchPaths = cHeaderSearchPaths
+            self.cxxHeaderSearchPaths = cxxHeaderSearchPaths
+            self.cDefines = cDefines
+            self.cxxDefines = cxxDefines
+            self.swiftDefines = swiftDefines
+            self.cFlags = cFlags
+            self.cxxFlags = cxxFlags
+            self.swiftFlags = swiftFlags
         }
     }
 }

--- a/Sources/TuistGraph/DependenciesGraph/ThirdPartyDependency.swift
+++ b/Sources/TuistGraph/DependenciesGraph/ThirdPartyDependency.swift
@@ -72,13 +72,13 @@ extension ThirdPartyDependency {
         /// The header search paths for C code.
         public let cHeaderSearchPaths: [String]
 
-        /// The header search paths for CXX code.
+        /// The header search paths for C++ code.
         public let cxxHeaderSearchPaths: [String]
 
         /// The compilation conditions to be defined for C code.
         public let cDefines: [String: String]
 
-        /// The compilation conditions to be defined for CXX code.
+        /// The compilation conditions to be defined for C++ code.
         public let cxxDefines: [String: String]
 
         /// The compilation conditions to be definedfor Swift code.
@@ -87,7 +87,7 @@ extension ThirdPartyDependency {
         /// The additional build flags for C code.
         public let cFlags: [String]
 
-        /// The additional build flags for CXX code.
+        /// The additional build flags for C++ code.
         public let cxxFlags: [String]
 
         /// The additional build flags for Swift code.

--- a/Sources/TuistGraph/DependenciesGraph/ThirdPartyDependency.swift
+++ b/Sources/TuistGraph/DependenciesGraph/ThirdPartyDependency.swift
@@ -79,6 +79,12 @@ extension ThirdPartyDependency {
 
 extension ThirdPartyDependency.Target {
     public enum Dependency: Codable, Hashable {
+        /// A linked framework dependency.
+        case linkedFramework(name: String, platforms: Set<Platform>?)
+
+        /// A linked library dependency.
+        case linkedLibrary(name: String, platforms: Set<Platform>?)
+
         /// A target belonging to the dependency itself.
         case target(name: String, platforms: Set<Platform>?)
 
@@ -146,6 +152,8 @@ extension ThirdPartyDependency {
 
 extension ThirdPartyDependency.Target.Dependency {
     private enum Kind: String, Codable {
+        case linkedFramework
+        case linkedLibrary
         case target
         case thirdPartyTarget
         case xcframework
@@ -153,10 +161,9 @@ extension ThirdPartyDependency.Target.Dependency {
 
     private enum CodingKeys: String, CodingKey {
         case kind
-        case dependency
-        case target
+        case name
         case platforms
-        case product
+        case dependency
         case path
     }
 
@@ -165,12 +172,18 @@ extension ThirdPartyDependency.Target.Dependency {
         let kind = try container.decode(Kind.self, forKey: .kind)
         let platforms = try container.decode(Set<Platform>.self, forKey: .platforms)
         switch kind {
+        case .linkedFramework:
+            let name = try container.decode(String.self, forKey: .name)
+            self = .linkedFramework(name: name, platforms: platforms)
+        case .linkedLibrary:
+            let name = try container.decode(String.self, forKey: .name)
+            self = .linkedLibrary(name: name, platforms: platforms)
         case .target:
-            let name = try container.decode(String.self, forKey: .target)
+            let name = try container.decode(String.self, forKey: .name)
             self = .target(name: name, platforms: platforms)
         case .thirdPartyTarget:
             let dependency = try container.decode(String.self, forKey: .dependency)
-            let product = try container.decode(String.self, forKey: .product)
+            let product = try container.decode(String.self, forKey: .name)
             self = .thirdPartyTarget(dependency: dependency, product: product, platforms: platforms)
         case .xcframework:
             let path = try container.decode(AbsolutePath.self, forKey: .path)
@@ -181,14 +194,22 @@ extension ThirdPartyDependency.Target.Dependency {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
+        case let .linkedFramework(name, platforms):
+            try container.encode(Kind.linkedFramework, forKey: .kind)
+            try container.encode(name, forKey: .name)
+            try container.encode(platforms, forKey: .platforms)
+        case let .linkedLibrary(name, platforms):
+            try container.encode(Kind.linkedLibrary, forKey: .kind)
+            try container.encode(name, forKey: .name)
+            try container.encode(platforms, forKey: .platforms)
         case let .target(name, platforms):
             try container.encode(Kind.target, forKey: .kind)
-            try container.encode(name, forKey: .target)
+            try container.encode(name, forKey: .name)
             try container.encode(platforms, forKey: .platforms)
-        case let .thirdPartyTarget(product, target, platforms):
+        case let .thirdPartyTarget(dependency, product, platforms):
             try container.encode(Kind.thirdPartyTarget, forKey: .kind)
-            try container.encode(product, forKey: .product)
-            try container.encode(target, forKey: .target)
+            try container.encode(dependency, forKey: .dependency)
+            try container.encode(product, forKey: .name)
             try container.encode(platforms, forKey: .platforms)
         case let .xcframework(path, platforms):
             try container.encode(Kind.xcframework, forKey: .kind)

--- a/Sources/TuistGraphTesting/DependenciesGraph/ThirdPartyDependency+TestData.swift
+++ b/Sources/TuistGraphTesting/DependenciesGraph/ThirdPartyDependency+TestData.swift
@@ -115,7 +115,9 @@ public extension ThirdPartyDependency {
                     name: "Alamofire",
                     sources: [packageFolder.appending(RelativePath("Source"))],
                     resources: [],
-                    dependencies: []
+                    dependencies: [
+                        .linkedFramework(name: "CFNetwork", platforms: [.iOS, .macOS, .tvOS, .watchOS])
+                    ]
                 ),
             ],
             minDeploymentTargets: [
@@ -126,6 +128,7 @@ public extension ThirdPartyDependency {
             ]
         )
     }
+
     static func googleAppMeasurement(artifactsFolder: AbsolutePath, packageFolder: AbsolutePath) -> Self {
         return .sources(
             name: "GoogleAppMeasurement",
@@ -153,6 +156,10 @@ public extension ThirdPartyDependency {
                         .thirdPartyTarget(dependency: "GoogleUtilities", product: "GULNSData", platforms: nil),
                         .thirdPartyTarget(dependency: "GoogleUtilities", product: "GULNetwork", platforms: nil),
                         .thirdPartyTarget(dependency: "nanopb", product: "nanopb", platforms: nil),
+                        .linkedLibrary(name: "sqlite3", platforms: nil),
+                        .linkedLibrary(name: "c++", platforms: nil),
+                        .linkedLibrary(name: "z", platforms: nil),
+                        .linkedFramework(name: "StoreKit", platforms: nil),
                     ]
                 ),
                 .init(
@@ -169,6 +176,10 @@ public extension ThirdPartyDependency {
                         .thirdPartyTarget(dependency: "GoogleUtilities", product: "GULNSData", platforms: nil),
                         .thirdPartyTarget(dependency: "GoogleUtilities", product: "GULNetwork", platforms: nil),
                         .thirdPartyTarget(dependency: "nanopb", product: "nanopb", platforms: nil),
+                        .linkedLibrary(name: "sqlite3", platforms: nil),
+                        .linkedLibrary(name: "c++", platforms: nil),
+                        .linkedLibrary(name: "z", platforms: nil),
+                        .linkedFramework(name: "StoreKit", platforms: nil),
                     ]
                 ),
             ],

--- a/Sources/TuistGraphTesting/DependenciesGraph/ThirdPartyDependency+TestData.swift
+++ b/Sources/TuistGraphTesting/DependenciesGraph/ThirdPartyDependency+TestData.swift
@@ -11,6 +11,7 @@ public extension ThirdPartyDependency {
         return .xcframework(name: name, path: path, architectures: architectures)
     }
 
+    // swiftlint:disable:next function_body_length
     static func test(packageFolder: AbsolutePath) -> Self {
         return .sources(
             name: "test",
@@ -29,6 +30,32 @@ public extension ThirdPartyDependency {
                     dependencies: [
                         .target(name: "TuistKit", platforms: nil),
                         .thirdPartyTarget(dependency: "a-dependency", product: "ALibrary", platforms: [.iOS]),
+                    ],
+                    publicHeadersPath: "customPublicHeadersPath",
+                    cHeaderSearchPaths: [
+                        "cSearchPath",
+                    ],
+                    cxxHeaderSearchPaths: [
+                        "cxxSearchPath",
+                    ],
+                    cDefines: [
+                        "C_DEFINE": "C_VALUE",
+                    ],
+                    cxxDefines: [
+                        "CXX_DEFINE": "CXX_VALUE",
+                    ],
+                    swiftDefines: [
+                        "SWIFT_DEFINE": "1",
+                    ],
+                    cFlags: [
+                        "CUSTOM_C_FLAG",
+                    ],
+                    cxxFlags: [
+                        "CUSTOM_CXX_FLAG",
+                    ],
+                    swiftFlags: [
+                        "CUSTOM_SWIFT_FLAG1",
+                        "CUSTOM_SWIFT_FLAG2",
                     ]
                 ),
                 .init(
@@ -37,7 +64,16 @@ public extension ThirdPartyDependency {
                     resources: [],
                     dependencies: [
                         .thirdPartyTarget(dependency: "another-dependency", product: "AnotherLibrary", platforms: nil),
-                    ]
+                    ],
+                    publicHeadersPath: nil,
+                    cHeaderSearchPaths: [],
+                    cxxHeaderSearchPaths: [],
+                    cDefines: [:],
+                    cxxDefines: [:],
+                    swiftDefines: [:],
+                    cFlags: [],
+                    cxxFlags: [],
+                    swiftFlags: []
                 ),
             ],
             minDeploymentTargets: [
@@ -63,7 +99,16 @@ public extension ThirdPartyDependency {
                     name: "ALibrary",
                     sources: [packageFolder.appending(RelativePath("Sources/ALibrary"))],
                     resources: [],
-                    dependencies: []
+                    dependencies: [],
+                    publicHeadersPath: nil,
+                    cHeaderSearchPaths: [],
+                    cxxHeaderSearchPaths: [],
+                    cDefines: [:],
+                    cxxDefines: [:],
+                    swiftDefines: [:],
+                    cFlags: [],
+                    cxxFlags: [],
+                    swiftFlags: []
                 ),
             ],
             minDeploymentTargets: [
@@ -89,7 +134,16 @@ public extension ThirdPartyDependency {
                     name: "AnotherLibrary",
                     sources: [packageFolder.appending(RelativePath("Sources/AnotherLibrary"))],
                     resources: [],
-                    dependencies: []
+                    dependencies: [],
+                    publicHeadersPath: nil,
+                    cHeaderSearchPaths: [],
+                    cxxHeaderSearchPaths: [],
+                    cDefines: [:],
+                    cxxDefines: [:],
+                    swiftDefines: [:],
+                    cFlags: [],
+                    cxxFlags: [],
+                    swiftFlags: []
                 ),
             ],
             minDeploymentTargets: [
@@ -116,8 +170,17 @@ public extension ThirdPartyDependency {
                     sources: [packageFolder.appending(RelativePath("Source"))],
                     resources: [],
                     dependencies: [
-                        .linkedFramework(name: "CFNetwork", platforms: [.iOS, .macOS, .tvOS, .watchOS])
-                    ]
+                        .linkedFramework(name: "CFNetwork", platforms: [.iOS, .macOS, .tvOS, .watchOS]),
+                    ],
+                    publicHeadersPath: nil,
+                    cHeaderSearchPaths: [],
+                    cxxHeaderSearchPaths: [],
+                    cDefines: [:],
+                    cxxDefines: [:],
+                    swiftDefines: [:],
+                    cFlags: [],
+                    cxxFlags: [],
+                    swiftFlags: []
                 ),
             ],
             minDeploymentTargets: [
@@ -129,6 +192,7 @@ public extension ThirdPartyDependency {
         )
     }
 
+    // swiftlint:disable:next function_body_length
     static func googleAppMeasurement(artifactsFolder: AbsolutePath, packageFolder: AbsolutePath) -> Self {
         return .sources(
             name: "GoogleAppMeasurement",
@@ -160,7 +224,16 @@ public extension ThirdPartyDependency {
                         .linkedLibrary(name: "c++", platforms: nil),
                         .linkedLibrary(name: "z", platforms: nil),
                         .linkedFramework(name: "StoreKit", platforms: nil),
-                    ]
+                    ],
+                    publicHeadersPath: nil,
+                    cHeaderSearchPaths: [],
+                    cxxHeaderSearchPaths: [],
+                    cDefines: [:],
+                    cxxDefines: [:],
+                    swiftDefines: [:],
+                    cFlags: [],
+                    cxxFlags: [],
+                    swiftFlags: []
                 ),
                 .init(
                     name: "GoogleAppMeasurementWithoutAdIdSupportTarget",
@@ -168,8 +241,8 @@ public extension ThirdPartyDependency {
                     resources: [],
                     dependencies: [
                         .xcframework(
-                          path: artifactsFolder.appending(component: "GoogleAppMeasurementWithoutAdIdSupport.xcframework"),
-                          platforms: nil
+                            path: artifactsFolder.appending(component: "GoogleAppMeasurementWithoutAdIdSupport.xcframework"),
+                            platforms: nil
                         ),
                         .thirdPartyTarget(dependency: "GoogleUtilities", product: "GULAppDelegateSwizzler", platforms: nil),
                         .thirdPartyTarget(dependency: "GoogleUtilities", product: "GULMethodSwizzler", platforms: nil),
@@ -180,7 +253,16 @@ public extension ThirdPartyDependency {
                         .linkedLibrary(name: "c++", platforms: nil),
                         .linkedLibrary(name: "z", platforms: nil),
                         .linkedFramework(name: "StoreKit", platforms: nil),
-                    ]
+                    ],
+                    publicHeadersPath: nil,
+                    cHeaderSearchPaths: [],
+                    cxxHeaderSearchPaths: [],
+                    cDefines: [:],
+                    cxxDefines: [:],
+                    swiftDefines: [:],
+                    cFlags: [],
+                    cxxFlags: [],
+                    swiftFlags: []
                 ),
             ],
             minDeploymentTargets: [
@@ -220,25 +302,61 @@ public extension ThirdPartyDependency {
                     name: "GULAppDelegateSwizzler",
                     sources: [packageFolder.appending(RelativePath("Sources/GULAppDelegateSwizzler"))],
                     resources: [],
-                    dependencies: []
+                    dependencies: [],
+                    publicHeadersPath: nil,
+                    cHeaderSearchPaths: [],
+                    cxxHeaderSearchPaths: [],
+                    cDefines: [:],
+                    cxxDefines: [:],
+                    swiftDefines: [:],
+                    cFlags: [],
+                    cxxFlags: [],
+                    swiftFlags: []
                 ),
                 .init(
                     name: "GULMethodSwizzler",
                     sources: [packageFolder.appending(RelativePath("Sources/GULMethodSwizzler"))],
                     resources: [],
-                    dependencies: []
+                    dependencies: [],
+                    publicHeadersPath: nil,
+                    cHeaderSearchPaths: [],
+                    cxxHeaderSearchPaths: [],
+                    cDefines: [:],
+                    cxxDefines: [:],
+                    swiftDefines: [:],
+                    cFlags: [],
+                    cxxFlags: [],
+                    swiftFlags: []
                 ),
                 .init(
                     name: "GULNSData",
                     sources: [packageFolder.appending(RelativePath("Sources/GULNSData"))],
                     resources: [],
-                    dependencies: []
+                    dependencies: [],
+                    publicHeadersPath: nil,
+                    cHeaderSearchPaths: [],
+                    cxxHeaderSearchPaths: [],
+                    cDefines: [:],
+                    cxxDefines: [:],
+                    swiftDefines: [:],
+                    cFlags: [],
+                    cxxFlags: [],
+                    swiftFlags: []
                 ),
                 .init(
                     name: "GULNetwork",
                     sources: [packageFolder.appending(RelativePath("Sources/GULNetwork"))],
                     resources: [],
-                    dependencies: []
+                    dependencies: [],
+                    publicHeadersPath: nil,
+                    cHeaderSearchPaths: [],
+                    cxxHeaderSearchPaths: [],
+                    cDefines: [:],
+                    cxxDefines: [:],
+                    swiftDefines: [:],
+                    cFlags: [],
+                    cxxFlags: [],
+                    swiftFlags: []
                 ),
             ],
             minDeploymentTargets: [
@@ -262,7 +380,16 @@ public extension ThirdPartyDependency {
                     name: "nanopb",
                     sources: [packageFolder.appending(RelativePath("Sources/nanopb"))],
                     resources: [],
-                    dependencies: []
+                    dependencies: [],
+                    publicHeadersPath: nil,
+                    cHeaderSearchPaths: [],
+                    cxxHeaderSearchPaths: [],
+                    cDefines: [:],
+                    cxxDefines: [:],
+                    swiftDefines: [:],
+                    cFlags: [],
+                    cxxFlags: [],
+                    swiftFlags: []
                 ),
             ],
             minDeploymentTargets: [


### PR DESCRIPTION
Part of #3002

### Short description 📝

Extend ThirdPartyDependency to support custom build settings defined with SPM.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
