### PR TITLE
Fix generated variant groups for localized Interface Builder files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Fix manifest loading when using Swift 5.5 [#3062](https://github.com/tuist/tuist/pull/3062) by [@kwridan](https://github.com/kwridan)
+- Fix generation of project groups and build phases for localized Interface Builder files (`.xib` and `.storyboard`) [#3075](https://github.com/tuist/tuist/pull/3075) by [@svenmuennich](https://github.com/svenmuennich/)
 
 ## 1.44.0 - DubDub
 

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -375,9 +375,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
             var element: (element: PBXFileElement, path: AbsolutePath)?
 
             if isLocalized {
-                let name = buildFilePath.basename
-                let path = buildFilePath.parentDirectory.parentDirectory.appending(component: name)
-                guard let group = fileElements.group(path: path) else {
+                guard let (group, path) = fileElements.variantGroup(containing: buildFilePath) else {
                     throw BuildPhaseGenerationError.missingFileReference(buildFilePath)
                 }
                 element = (group, path)

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -245,8 +245,10 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         let temporaryPath = try self.temporaryPath()
         let resources = try createFiles([
             "resources/en.lproj/App.strings",
+            "resources/en.lproj/App.stringsdict",
             "resources/en.lproj/Extension.strings",
             "resources/fr.lproj/App.strings",
+            "resources/fr.lproj/App.stringsdict",
             "resources/fr.lproj/Extension.strings",
         ])
 
@@ -273,13 +275,63 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         XCTAssertEqual(projectGroup?.flattenedChildren, [
             "resources/App.strings/en",
             "resources/App.strings/fr",
+            "resources/App.stringsdict/en",
+            "resources/App.stringsdict/fr",
             "resources/Extension.strings/en",
             "resources/Extension.strings/fr",
         ])
 
         XCTAssertEqual(projectGroup?.debugVariantGroupPaths, [
             "resources/App.strings",
+            "resources/App.stringsdict",
             "resources/Extension.strings",
+        ])
+    }
+
+    func test_addElement_lproj_xib_variant_groups() throws {
+        // Given
+        let temporaryPath = try self.temporaryPath()
+        let resources = try createFiles([
+            "resources/fr.lproj/Controller.strings",
+            "resources/Base.lproj/Controller.xib",
+            "resources/Base.lproj/Storyboard.storyboard",
+            "resources/en.lproj/Controller.xib",
+            "resources/en.lproj/Storyboard.strings",
+            "resources/fr.lproj/Storyboard.strings",
+        ])
+
+        let elements = resources.map {
+            GroupFileElement(
+                path: $0,
+                group: .group(name: "Project"),
+                isReference: true
+            )
+        }
+
+        // When
+        try elements.forEach {
+            try subject.generate(
+                fileElement: $0,
+                groups: groups,
+                pbxproj: pbxproj,
+                sourceRootPath: temporaryPath
+            )
+        }
+
+        // Then
+        let projectGroup = groups.sortedMain.group(named: "Project")
+        XCTAssertEqual(projectGroup?.flattenedChildren, [
+            "resources/Controller.xib/Base",
+            "resources/Controller.xib/en",
+            "resources/Controller.xib/fr",
+            "resources/Storyboard.storyboard/Base",
+            "resources/Storyboard.storyboard/en",
+            "resources/Storyboard.storyboard/fr",
+        ])
+
+        XCTAssertEqual(projectGroup?.debugVariantGroupPaths, [
+            "resources/Controller.xib",
+            "resources/Storyboard.storyboard",
         ])
     }
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1607
Request for comments document (if applies): n/a

### Short description 📝

When localizing Interface Builder files (i.e. `.xib` and `.storyboard`) using Xcode, any localization files (`.strings`) or language specific versions of the IB file are nested into a _variant group_ , which also contains the main IB file itself. As a result only the IB file is included in the _copy resources_ build phase.

Prior to this PR, Tuist just grouped any localized files based on their file name (including extension) and the custom behavior for localized IB files was not applied.

Now _variant groups_ are formed based on the path and file name, without considering the extension. This allows IB files to share a group with respective `.strings` files. Furthermore such `.strings` files are no longer added to the _copy resources_ build phase. 

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
