### PR TITLE
Fix tuist edit when path has spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
+- Fixed `tuist bundle` when path has spaces [#3084](https://github.com/tuist/tuist/pull/3084) by [@fortmarek](https://github.com/fortmarek)
 - Fix manifest loading when using Swift 5.5 [#3062](https://github.com/tuist/tuist/pull/3062) by [@kwridan](https://github.com/kwridan)
 - Fix generation of project groups and build phases for localized Interface Builder files (`.xib` and `.storyboard`) [#3075](https://github.com/tuist/tuist/pull/3075) by [@svenmuennich](https://github.com/svenmuennich/)
 

--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -423,7 +423,9 @@ final class ProjectEditorMapper: ProjectEditorMapping {
     }
 
     private func targetBaseSettings(for includes: [AbsolutePath], swiftVersion: String) -> SettingsDictionary {
-        let includePaths = includes.map(\.parentDirectory.pathString)
+        let includePaths = includes
+            .map(\.parentDirectory.pathString)
+            .map { "\"\($0)\"" }
         return [
             "FRAMEWORK_SEARCH_PATHS": .array(includePaths),
             "LIBRARY_SEARCH_PATHS": .array(includePaths),

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
@@ -688,7 +688,9 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
     }
 
     fileprivate func expectedSettings(includePaths: [AbsolutePath]) -> Settings {
-        let paths = includePaths.map(\.pathString)
+        let paths = includePaths
+            .map(\.pathString)
+            .map { "\"\($0)\"" }
         return Settings(
             base: [
                 "FRAMEWORK_SEARCH_PATHS": .array(paths),


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3081

### Short description 📝

Fixes issue linked above. Fix is easy - wrap paths into quotation marks.

cc @mgray88

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
