### PR TITLE
Automation graph

### DIFF
--- a/Sources/ProjectAutomation/Target.swift
+++ b/Sources/ProjectAutomation/Target.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public struct Target: Codable {
+    public let name: String
+    public let sources: [String]
+    
+    public init(
+        name: String,
+        sources: [String]
+    ) {
+        self.name = name
+        self.sources = sources
+    }
+}
+
+public struct Graph: Codable {
+    public let targets: [Target]
+    
+    public init(
+        targets: [Target]
+    ) {
+        self.targets = targets
+    }
+}

--- a/Sources/ProjectAutomation/Task.swift
+++ b/Sources/ProjectAutomation/Task.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public struct Task {
     public let options: [Option]
-    public let task: ([String: String]) throws -> Void
+    public let task: ([String: String], Graph) throws -> Void
 
     public enum Option: Equatable {
         case option(String)
@@ -10,7 +10,7 @@ public struct Task {
 
     public init(
         options: [Option] = [],
-        task: @escaping ([String: String]) throws -> Void
+        task: @escaping ([String: String], Graph) throws -> Void
     ) {
         self.options = options
         self.task = task
@@ -24,12 +24,17 @@ public struct Task {
             CommandLine.argc > taskCommandLineIndex
         else { return }
         let attributesString = CommandLine.arguments[taskCommandLineIndex + 1]
+        let decoder = JSONDecoder()
         // swiftlint:disable force_try
-        let attributes: [String: String] = try! JSONDecoder().decode(
+        let attributes = try! decoder.decode(
             [String: String].self,
             from: attributesString.data(using: .utf8)!
         )
-        try! task(attributes)
+        let graph = try! decoder.decode(
+            Graph.self,
+            from: CommandLine.arguments[taskCommandLineIndex + 2].data(using: .utf8)!
+        )
+        try! task(attributes, graph)
         // swiftlint:enable force_try
     }
 }

--- a/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -77,7 +77,7 @@ final class ManifestGraphLoader: ManifestGraphLoading {
     }
 
     // MARK: - Private
-
+    
     private func loadProjectGraph(at path: AbsolutePath) throws -> (Project, ValueGraph) {
         let plugins = try loadPlugins(at: path)
         let manifests = try recursiveManifestLoader.loadProject(at: path)

--- a/projects/tuist/fixtures/app_with_tasks/Tuist/Tasks/CreateFile.swift
+++ b/projects/tuist/fixtures/app_with_tasks/Tuist/Tasks/CreateFile.swift
@@ -5,8 +5,9 @@ let task = Task(
     options: [
         .option("file-name"),
     ]
-) { options in
+) { options, graph in
     let fileName = options["file-name"] ?? "file"
+    print(graph)
     try "File created with a task".write(
         to: URL(fileURLWithPath: "\(fileName).txt"),
         atomically: true,


### PR DESCRIPTION
### Short description 📝

This PR brings the ability to inspect a current project's `Graph`. This might be very useful if you for example want to get all the sources of the project - I have come across this need when trying to extract `tuist lint code` to a task.

At the moment, I have:
- Created a `Graph` struct in `ProjectAutomation`. This represents a simplified representation of the graph. Right now it only has a list of targets where each target has a list of sources. I am open to suggestions for what you'd add to it,
- Loaded graph when running `tuist exec some_task`, converted it to `ProjectAutomation.Graph` and pass that to a task.
- Added a parameter to the task closure that is invoked when the task is run
- Print this graph in `CreateFile.swift` in the `app_with_tasks` fixture

The current setup also means that the graph is loaded _every_ time. That is obviously undesirable. My current idea how to solve that is to add a boolean flag to `Task` and load the graph only if it is set to true.

Alternative solution:
Instead of loading graph in advance, we could load it when necessary. But `ProjectAutomation` should not depend on `TuistKit`. This means we would have to pass that information via CLI by invoking a `tuist` executable. I did not really like this solution, so that's why I went down the path of preloading it.

This is an early draft, so let me know your thoughts, the current solution definitely leaves a lot to be desired

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
