### PR TITLE
Omit `runPostActionsOnFailure` scheme attribute when not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fixed `tuist bundle` when path has spaces [#3084](https://github.com/tuist/tuist/pull/3084) by [@fortmarek](https://github.com/fortmarek)
 - Fix manifest loading when using Swift 5.5 [#3062](https://github.com/tuist/tuist/pull/3062) by [@kwridan](https://github.com/kwridan)
 - Fix generation of project groups and build phases for localized Interface Builder files (`.xib` and `.storyboard`) [#3075](https://github.com/tuist/tuist/pull/3075) by [@svenmuennich](https://github.com/svenmuennich/)
+- Omit `runPostActionsOnFailure` scheme attribute when not enabled [#3087](https://github.com/tuist/tuist/pull/3087) by [@kwridan](https://github.com/kwridan)
 
 ## 1.44.0 - DubDub
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -195,8 +195,8 @@
         "repositoryURL": "https://github.com/tuist/XcodeProj.git",
         "state": {
           "branch": null,
-          "revision": "94e55232d227f9d78b811c98cb2e5d0cbd08987b",
-          "version": "7.22.0"
+          "revision": "0b18c3e7a10c241323397a80cb445051f4494971",
+          "version": "8.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/tuist/XcodeProj.git", .upToNextMajor(from: "7.22.0")),
+        .package(url: "https://github.com/tuist/XcodeProj.git", .upToNextMajor(from: "8.0.0")),
         .package(name: "Signals", url: "https://github.com/tuist/BlueSignals.git", .upToNextMajor(from: "1.0.21")),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.1.1")),
         .package(url: "https://github.com/rnine/Checksum.git", .upToNextMajor(from: "1.0.2")),

--- a/Project.swift
+++ b/Project.swift
@@ -15,7 +15,7 @@ func releaseSettings() -> SettingsDictionary {
 }
 
 let packages: [Package] = [
-    .package(url: "https://github.com/tuist/XcodeProj.git", .upToNextMajor(from: "7.17.0")),
+    .package(url: "https://github.com/tuist/XcodeProj.git", .upToNextMajor(from: "8.0.0")),
     .package(url: "https://github.com/CombineCommunity/CombineExt.git", .upToNextMajor(from: "1.3.0")),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.2.0")),
     .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.1.1")),

--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -232,7 +232,7 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
             postActions: postActions,
             parallelizeBuild: true,
             buildImplicitDependencies: true,
-            runPostActionsOnFailure: buildAction.runPostActionsOnFailure
+            runPostActionsOnFailure: buildAction.runPostActionsOnFailure ? true : nil
         )
     }
 

--- a/projects/tuist/fixtures/ios_app_with_custom_scheme/App/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_custom_scheme/App/Project.swift
@@ -1,11 +1,20 @@
 import ProjectDescription
 
 let debugAction = ExecutionAction(scriptText: "echo Debug", target: "App")
-let debugScheme = Scheme(name: "App-Debug",
-                         shared: true,
-                         buildAction: BuildAction(targets: ["App"], preActions: [debugAction]),
-                         testAction: TestAction(targets: ["AppTests"]),
-                         runAction: RunAction(executable: "App", options: .options(simulatedLocation: .johannesburg)))
+let debugScheme = Scheme(
+    name: "App-Debug",
+    shared: true,
+    buildAction: BuildAction(
+        targets: ["App"], 
+        preActions: [debugAction], 
+        runPostActionsOnFailure: true
+    ),
+    testAction: TestAction(targets: ["AppTests"]),
+    runAction: RunAction(
+        executable: "App", 
+        options: .options(simulatedLocation: .johannesburg)
+    )
+)
 
 let releaseAction = ExecutionAction(scriptText: "echo Release", target: "App")
 let releaseScheme = Scheme(name: "App-Release",


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/2991

### Short description 📝

- Xcode automatically removes the `runPostActionsOnFailure` when not enabled
- This causes projects to get modified by Xcode after generation even though semantically they are equivalent (causes issues for workflows where generated issues are checked in)
- To mitigate this, the `runPostActionsOnFailure` is omitted incase it's not enabled and only set when enabled

### Test Plan 🛠

- Generate a fixture that does't have the `runPostActionsOnFailure` option enabled

e.g.

```sh
swift build
swift run tuist generate --path projects/tuist/fixtures/ios_app_with_tests
```

- Verify the generated schemes do not contain the `runPostActionsOnFailure` attribute
- Generate a fixture that has the `runPostActionsOnFailure` option enabled

```sh
swift build
swift run tuist generate --path projects/tuist/fixtures/ios_app_with_custom_scheme
```

- Verify the App-debug scheme's build action has the `runPostActionsOnFailure` set

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- ~In case the PR introduces changes that affect users, the documentation has been updated.~
