### PR TITLE
Improve parallelisation on projects manifest loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Changed
 
+- Improved cold start time of `tuist generate` when having multiple projects [#3092](https://github.com/tuist/tuist/pull/3092) by [@adellibovi](https://github.com/adellibovi)
 - Renamed `ValueGraph` to `Graph` [#3083](https://github.com/tuist/tuist/pull/3083) by [@fortmarek](https://github.com/fortmarek)
 - Fixed a typo on the `tuist generate` command documentation for argument --skip-test-targets. [#3069](https://github.com/tuist/tuist/pull/3069) by [@mrcloud](https://github.com/mrcloud)
 - **breaking** The `tuist dependencies` command requires the `Carthage` version to be at least `0.37.0`. [#3043](https://github.com/tuist/tuist/pull/3043) by [@laxmorek](https://github.com/laxmorek)


### PR DESCRIPTION
### Short description 📝

This improve performance for manifest with several projects manifest. Currently each project manifest is compiled one by one, even if `swiftc` could be fast, we still have ~0.5/1s for launching an external process. Under my tests, it went down from 4/5mins to ~60s.

Ideally, I think it would be great if we could compile all the manifest as a single process, (in comparison the same "configuration" using just one project takes ~15/20s) but that would probably require quite a significant change in both the code and Tuist api.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
