### PR TITLE
Edit only in current directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
+- `--only-current-directory` flag for `tuist edit` [#3097](https://github.com/tuist/tuist/pull/3097) by [@fortmarek](https://github.com/fortmarek)
 - Fixed `tuist bundle` when path has spaces [#3084](https://github.com/tuist/tuist/pull/3084) by [@fortmarek](https://github.com/fortmarek)
 - Fix manifest loading when using Swift 5.5 [#3062](https://github.com/tuist/tuist/pull/3062) by [@kwridan](https://github.com/kwridan)
 - Fix generation of project groups and build phases for localized Interface Builder files (`.xib` and `.storyboard`) [#3075](https://github.com/tuist/tuist/pull/3075) by [@svenmuennich](https://github.com/svenmuennich/)

--- a/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
@@ -37,6 +37,7 @@ protocol ProjectEditing: AnyObject {
     func edit(
         at editingPath: AbsolutePath,
         in destinationDirectory: AbsolutePath,
+        onlyCurrentDirectory: Bool,
         plugins: Plugins
     ) throws -> AbsolutePath
 }
@@ -94,10 +95,11 @@ final class ProjectEditor: ProjectEditing {
     func edit(
         at editingPath: AbsolutePath,
         in destinationDirectory: AbsolutePath,
+        onlyCurrentDirectory: Bool,
         plugins: Plugins
     ) throws -> AbsolutePath {
         let projectDescriptionPath = try resourceLocator.projectDescription()
-        let projectManifests = manifestFilesLocator.locateProjectManifests(at: editingPath)
+        let projectManifests = manifestFilesLocator.locateProjectManifests(at: editingPath, onlyCurrentDirectory: onlyCurrentDirectory)
         let configPath = manifestFilesLocator.locateConfig(at: editingPath)
         let cacheDirectory = try cacheDirectoryProviderFactory.cacheDirectories(config: nil)
         let projectDescriptionHelpersBuilder = projectDescriptionHelpersBuilderFactory.projectDescriptionHelpersBuilder(
@@ -115,7 +117,11 @@ final class ProjectEditor: ProjectEditing {
 
         let tasks = try tasksLocator.locateTasks(at: editingPath)
 
-        let editablePluginManifests = locateEditablePluginManifests(at: editingPath, plugins: plugins)
+        let editablePluginManifests = locateEditablePluginManifests(
+            at: editingPath,
+            plugins: plugins,
+            onlyCurrentDirectory: onlyCurrentDirectory
+        )
         let builtPluginHelperModules = try buildRemotePluginModules(
             in: editingPath,
             projectDescriptionPath: projectDescriptionPath,
@@ -140,7 +146,7 @@ final class ProjectEditor: ProjectEditing {
             setupPath: setupPath,
             configPath: configPath,
             dependenciesPath: dependenciesPath,
-            projectManifests: projectManifests.map(\.1),
+            projectManifests: projectManifests.map(\.path),
             editablePluginManifests: editablePluginManifests,
             pluginProjectDescriptionHelpersModule: builtPluginHelperModules,
             helpers: helpers,
@@ -157,13 +163,16 @@ final class ProjectEditor: ProjectEditing {
     }
 
     /// - Returns: A list of plugin manifests which should be loaded as part of the project.
-    private func locateEditablePluginManifests(at path: AbsolutePath, plugins: Plugins) -> [EditablePluginManifest] {
+    private func locateEditablePluginManifests(at path: AbsolutePath, plugins: Plugins, onlyCurrentDirectory: Bool) -> [EditablePluginManifest] {
         let loadedEditablePluginManifests = plugins.projectDescriptionHelpers
             .filter { $0.location == .local }
             .map { EditablePluginManifest(name: $0.name, path: $0.path.parentDirectory) }
 
-        let localEditablePluginManifests = manifestFilesLocator.locatePluginManifests(at: path)
-            .map { EditablePluginManifest(name: $0.parentDirectory.basename, path: $0.parentDirectory) }
+        let localEditablePluginManifests = manifestFilesLocator.locatePluginManifests(
+            at: path,
+            onlyCurrentDirectory: onlyCurrentDirectory
+        )
+        .map { EditablePluginManifest(name: $0.parentDirectory.basename, path: $0.parentDirectory) }
 
         return Array(Set(loadedEditablePluginManifests + localEditablePluginManifests))
     }

--- a/Sources/TuistKit/Services/EditService.swift
+++ b/Sources/TuistKit/Services/EditService.swift
@@ -45,10 +45,11 @@ final class EditService {
         self.pluginService = pluginService
     }
 
-    func run(path: String?,
-             permanent: Bool,
-             onlyCurrentDirectory _: Bool) throws
-    {
+    func run(
+        path: String?,
+        permanent: Bool,
+        onlyCurrentDirectory: Bool
+    ) throws {
         let path = self.path(path)
 
         if !permanent {
@@ -66,13 +67,23 @@ final class EditService {
                 }
 
                 let plugins = loadPlugins(at: path)
-                let workspacePath = try projectEditor.edit(at: path, in: generationDirectory, plugins: plugins)
+                let workspacePath = try projectEditor.edit(
+                    at: path,
+                    in: generationDirectory,
+                    onlyCurrentDirectory: onlyCurrentDirectory,
+                    plugins: plugins
+                )
                 logger.pretty("Opening Xcode to edit the project. Press \(.keystroke("CTRL + C")) once you are done editing")
                 try opener.open(path: workspacePath, application: selectedXcode.path, wait: true)
             }
         } else {
             let plugins = loadPlugins(at: path)
-            let workspacePath = try projectEditor.edit(at: path, in: path, plugins: plugins)
+            let workspacePath = try projectEditor.edit(
+                at: path,
+                in: path,
+                onlyCurrentDirectory: onlyCurrentDirectory,
+                plugins: plugins
+            )
             logger.notice("Xcode project generated at \(workspacePath.pathString)", metadata: .success)
         }
     }

--- a/Sources/TuistLoaderTesting/Utils/Mocks/MockManifestFilesLocator.swift
+++ b/Sources/TuistLoaderTesting/Utils/Mocks/MockManifestFilesLocator.swift
@@ -5,8 +5,7 @@ import TSCBasic
 public final class MockManifestFilesLocator: ManifestFilesLocating {
     public var locateManifestsArgs: [AbsolutePath] = []
     public var locateManifestsStub: [(Manifest, AbsolutePath)]?
-    public var locateProjectManifestsStub: [(Manifest, AbsolutePath)]?
-    public var locateProjectManifestsArgs: [AbsolutePath] = []
+    public var locateProjectManifestsStub: ((AbsolutePath, Bool) -> [ManifestFilesLocator.ProjectManifest])?
     public var locatePluginManifestsStub: [AbsolutePath]?
     public var locatePluginManifestsArgs: [AbsolutePath] = []
     public var locateConfigStub: AbsolutePath?
@@ -23,14 +22,21 @@ public final class MockManifestFilesLocator: ManifestFilesLocating {
         return locateManifestsStub ?? [(.project, at.appending(component: "Project.swift"))]
     }
 
-    public func locatePluginManifests(at: AbsolutePath) -> [AbsolutePath] {
+    public func locatePluginManifests(at: AbsolutePath, onlyCurrentDirectory _: Bool) -> [AbsolutePath] {
         locatePluginManifestsArgs.append(at)
         return locatePluginManifestsStub ?? [at.appending(component: "Plugin.swift")]
     }
 
-    public func locateProjectManifests(at: AbsolutePath) -> [(Manifest, AbsolutePath)] {
-        locateProjectManifestsArgs.append(at)
-        return locateProjectManifestsStub ?? [(.project, at.appending(component: "Project.swift"))]
+    public func locateProjectManifests(
+        at locatingPath: AbsolutePath,
+        onlyCurrentDirectory: Bool
+    ) -> [ManifestFilesLocator.ProjectManifest] {
+        return locateProjectManifestsStub?(locatingPath, onlyCurrentDirectory) ?? [
+            ManifestFilesLocator.ProjectManifest(
+                manifest: .project,
+                path: locatingPath.appending(component: "Project.swift")
+            ),
+        ]
     }
 
     public func locateConfig(at: AbsolutePath) -> AbsolutePath? {

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
@@ -89,7 +89,12 @@ final class ProjectEditorTests: TuistUnitTestCase {
         try FileHandler.shared.createFolder(helpersDirectory)
         let helpers = ["A.swift", "B.swift"].map { helpersDirectory.appending(component: $0) }
         try helpers.forEach { try FileHandler.shared.touch($0) }
-        let manifests: [(Manifest, AbsolutePath)] = [(.project, directory.appending(component: "Project.swift"))]
+        let manifests = [
+            ManifestFilesLocator.ProjectManifest(
+                manifest: .project,
+                path: directory.appending(component: "Project.swift")
+            ),
+        ]
         let tuistPath = AbsolutePath(ProcessInfo.processInfo.arguments.first!)
         let setupPath = directory.appending(components: "Setup.swift")
         let configPath = directory.appending(components: "Tuist", "Config.swift")
@@ -101,7 +106,9 @@ final class ProjectEditorTests: TuistUnitTestCase {
 
         resourceLocator.projectDescriptionStub = { projectDescriptionPath }
         resourceLocator.projectAutomationStub = { projectAutomationPath }
-        manifestFilesLocator.locateProjectManifestsStub = manifests
+        manifestFilesLocator.locateProjectManifestsStub = { _, _ in
+            manifests
+        }
         manifestFilesLocator.locateConfigStub = configPath
         manifestFilesLocator.locateDependenciesStub = dependenciesPath
         manifestFilesLocator.locateSetupStub = setupPath
@@ -115,7 +122,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         }
 
         // When
-        try _ = subject.edit(at: directory, in: directory, plugins: .test())
+        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test())
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -140,7 +147,9 @@ final class ProjectEditorTests: TuistUnitTestCase {
         try FileHandler.shared.createFolder(helpersDirectory)
 
         resourceLocator.projectDescriptionStub = { projectDescriptionPath }
-        manifestFilesLocator.locateProjectManifestsStub = []
+        manifestFilesLocator.locateProjectManifestsStub = { _, _ in
+            []
+        }
         manifestFilesLocator.locatePluginManifestsStub = []
         helpersDirectoryLocator.locateStub = helpersDirectory
         projectEditorMapper.mapStub = graph
@@ -151,7 +160,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         // Then
         XCTAssertThrowsSpecific(
             // When
-            try subject.edit(at: directory, in: directory, plugins: .test()), ProjectEditorError.noEditableFiles(directory)
+            try subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test()), ProjectEditorError.noEditableFiles(directory)
         )
     }
 
@@ -173,7 +182,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         }
 
         // When
-        try _ = subject.edit(at: directory, in: directory, plugins: .test())
+        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test())
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -208,7 +217,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         }
 
         // When
-        try _ = subject.edit(at: directory, in: directory, plugins: .test())
+        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test())
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -227,7 +236,12 @@ final class ProjectEditorTests: TuistUnitTestCase {
         let graph = Graph.test(name: "Edit")
 
         // Project
-        let manifests: [(Manifest, AbsolutePath)] = [(.project, directory.appending(component: "Project.swift"))]
+        let manifests = [
+            ManifestFilesLocator.ProjectManifest(
+                manifest: .project,
+                path: directory.appending(component: "Project.swift")
+            ),
+        ]
 
         // Local plugin
         let pluginDirectory = directory.appending(component: "Plugin")
@@ -240,7 +254,9 @@ final class ProjectEditorTests: TuistUnitTestCase {
         let tuistPath = AbsolutePath(ProcessInfo.processInfo.arguments.first!)
 
         resourceLocator.projectDescriptionStub = { projectDescriptionPath }
-        manifestFilesLocator.locateProjectManifestsStub = manifests
+        manifestFilesLocator.locateProjectManifestsStub = { _, _ in
+            manifests
+        }
         manifestFilesLocator.locatePluginManifestsStub = [pluginManifestPath]
         projectEditorMapper.mapStub = graph
         generator.generateWorkspaceStub = { _ in
@@ -251,7 +267,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         let plugins = Plugins.test(projectDescriptionHelpers: [
             .init(name: "LocalPlugin", path: pluginManifestPath, location: .local),
         ])
-        try _ = subject.edit(at: directory, in: directory, plugins: plugins)
+        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: plugins)
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -272,7 +288,12 @@ final class ProjectEditorTests: TuistUnitTestCase {
         let graph = Graph.test(name: "Edit")
 
         // Project
-        let manifests: [(Manifest, AbsolutePath)] = [(.project, editingPath.appending(component: "Project.swift"))]
+        let manifests = [
+            ManifestFilesLocator.ProjectManifest(
+                manifest: .project,
+                path: editingPath.appending(component: "Project.swift")
+            ),
+        ]
 
         // Local plugin
         let pluginManifestPath = rootPath.appending(component: "Plugin.swift")
@@ -280,7 +301,9 @@ final class ProjectEditorTests: TuistUnitTestCase {
         let tuistPath = AbsolutePath(ProcessInfo.processInfo.arguments.first!)
 
         resourceLocator.projectDescriptionStub = { projectDescriptionPath }
-        manifestFilesLocator.locateProjectManifestsStub = manifests
+        manifestFilesLocator.locateProjectManifestsStub = { _, _ in
+            manifests
+        }
         manifestFilesLocator.locatePluginManifestsStub = [pluginManifestPath]
         projectEditorMapper.mapStub = graph
         generator.generateWorkspaceStub = { _ in
@@ -292,7 +315,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
             .init(name: "LocalPlugin", path: pluginManifestPath, location: .local),
         ])
 
-        try _ = subject.edit(at: editingPath, in: editingPath, plugins: plugins)
+        try _ = subject.edit(at: editingPath, in: editingPath, onlyCurrentDirectory: false, plugins: plugins)
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -312,11 +335,18 @@ final class ProjectEditorTests: TuistUnitTestCase {
         let graph = Graph.test(name: "Edit")
 
         // Project
-        let manifests: [(Manifest, AbsolutePath)] = [(.project, directory.appending(component: "Project.swift"))]
+        let manifests = [
+            ManifestFilesLocator.ProjectManifest(
+                manifest: .project,
+                path: directory.appending(component: "Project.swift")
+            ),
+        ]
         let tuistPath = AbsolutePath(ProcessInfo.processInfo.arguments.first!)
 
         resourceLocator.projectDescriptionStub = { projectDescriptionPath }
-        manifestFilesLocator.locateProjectManifestsStub = manifests
+        manifestFilesLocator.locateProjectManifestsStub = { _, _ in
+            manifests
+        }
         manifestFilesLocator.locatePluginManifestsStub = []
         projectEditorMapper.mapStub = graph
         generator.generateWorkspaceStub = { _ in
@@ -331,7 +361,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         let plugins = Plugins.test(projectDescriptionHelpers: [
             .init(name: "RemotePlugin", path: AbsolutePath("/Some/Path/To/Plugin"), location: .remote),
         ])
-        try _ = subject.edit(at: directory, in: directory, plugins: plugins)
+        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: plugins)
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)


### PR DESCRIPTION
### Short description 📝

`tuist edit` has an option`--only-current-directory` - but this option was not used for anything. When trying to use tuist with tuist, I have come across the issues laid out [here](https://github.com/tuist/tuist/discussions/2775).

As a temporary solution, we can use `-o` to only load the manifest in the current directory.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
