### PR TITLE
Throw error when cache source not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
-## 1.45.0
+### Fixed
 
-## 1.45.0
+- Throw error when target given in `tuist focus` is not found. [#3104](https://github.com/tuist/tuist/pull/3104) by [@fortmarek](https://github.com/fortmarek)
 
 ## 1.45.0 - Jungle
 

--- a/Sources/TuistCache/GraphMappers/CacheMapper.swift
+++ b/Sources/TuistCache/GraphMappers/CacheMapper.swift
@@ -6,7 +6,25 @@ import TuistCore
 import TuistGraph
 import TuistSupport
 
-public class CacheMapper: GraphMapping {
+enum CacheMapperError: FatalError, Equatable {
+    case missingTargets(missingTargets: [String], availableTargets: [String])
+
+    var description: String {
+        switch self {
+        case let .missingTargets(missingTargets: missingTargets, availableTargets: availableTargets):
+            return "Targets \(missingTargets.joined(separator: ", ")) cannot be found. Available targets are \(availableTargets.joined(separator: ", "))"
+        }
+    }
+
+    var type: ErrorType {
+        switch self {
+        case .missingTargets:
+            return .abort
+        }
+    }
+}
+
+public final class CacheMapper: GraphMapping {
     // MARK: - Attributes
 
     /// Cache.
@@ -73,6 +91,14 @@ public class CacheMapper: GraphMapping {
     // MARK: - GraphMapping
 
     public func map(graph: Graph) throws -> (Graph, [SideEffectDescriptor]) {
+        let graphTraverser = GraphTraverser(graph: graph)
+        let availableTargets = graphTraverser.allTargets().map(\.target.name)
+        let missingTargets = sources.filter { !availableTargets.contains($0) }
+        guard
+            missingTargets.isEmpty
+        else {
+            throw CacheMapperError.missingTargets(missingTargets: Array(missingTargets), availableTargets: availableTargets)
+        }
         let single = hashes(graph: graph).flatMap { self.map(graph: graph, hashes: $0, sources: self.sources) }
         return try (single.toBlocking().single(), [])
     }

--- a/Tests/TuistCacheTests/GraphMappers/CacheMapperTests.swift
+++ b/Tests/TuistCacheTests/GraphMappers/CacheMapperTests.swift
@@ -19,6 +19,7 @@ final class CacheMapperTests: TuistUnitTestCase {
     var config: Config!
 
     override func setUp() {
+        super.setUp()
         cache = MockCacheStorage()
         cacheGraphContentHasher = MockCacheGraphContentHasher()
         cacheGraphMutator = MockCacheGraphMutator()
@@ -33,7 +34,6 @@ final class CacheMapperTests: TuistUnitTestCase {
             cacheGraphMutator: cacheGraphMutator,
             queue: DispatchQueue.main
         )
-        super.setUp()
     }
 
     override func tearDown() {
@@ -43,6 +43,38 @@ final class CacheMapperTests: TuistUnitTestCase {
         cacheGraphMutator = nil
         subject = nil
         super.tearDown()
+    }
+
+    func test_map_when_a_source_is_not_available() throws {
+        // Given
+        subject = CacheMapper(
+            config: config,
+            cache: cache,
+            cacheGraphContentHasher: cacheGraphContentHasher,
+            sources: ["B", "C", "D"],
+            cacheProfile: .test(),
+            cacheOutputType: .framework,
+            cacheGraphMutator: cacheGraphMutator,
+            queue: DispatchQueue.main
+        )
+        let projectPath = try temporaryPath()
+        let graph = Graph.test(
+            projects: [
+                projectPath: .test(),
+            ],
+            targets: [
+                projectPath: [
+                    "A": .test(name: "A"),
+                    "B": .test(name: "B"),
+                ],
+            ]
+        )
+
+        // When / Then
+        XCTAssertThrowsSpecific(
+            try subject.map(graph: graph),
+            CacheMapperError.missingTargets(missingTargets: ["C", "D"], availableTargets: ["A", "B"])
+        )
     }
 
     func test_map_when_all_binaries_are_fetched_successfully() throws {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3102

### Short description 📝

If you ran `tuist focus A B C`, we did not actually check if those targets exist.
In this PR I have changed the logic, so an error is thrown when a target is not found.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
