### PR TITLE
Add utility to read the https://github.com credentials from the system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 - Native support for ARM architecture [#3010](https://github.com/tuist/tuist/pull/3010) by [@fortmarek](https://github.com/fortmarek) & [@pepibumur](https://github.com/pepibumur).
+- Utility for obtaining the system's Git credentials for authenticating with https://github.com [#3110](https://github.com/tuist/tuist/pull/3110) by [@pepibumur](https://github.com/pepibumur)
 
 ## 1.45.1
 

--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -65,6 +65,7 @@ public enum Constants {
         public static let labToken = "TUIST_LAB_TOKEN"
         public static let cacheManifests = "TUIST_CACHE_MANIFESTS"
         public static let statsOptOut = "TUIST_STATS_OPT_OUT"
+        public static let githubAPIToken = "TUIST_GITHUB_API_TOKEN"
     }
 
     public enum GoogleCloud {

--- a/Sources/TuistSupport/Extensions/AnyPublisher+Extras.swift
+++ b/Sources/TuistSupport/Extensions/AnyPublisher+Extras.swift
@@ -1,0 +1,19 @@
+import Combine
+import CombineExt
+
+public extension AnyPublisher {
+    init(value: Output) {
+        self = AnyPublisher.create { subscriber in
+            subscriber.send(value)
+            subscriber.send(completion: .finished)
+            return AnyCancellable {}
+        }
+    }
+
+    init(error: Failure) {
+        self = AnyPublisher.create { subscriber in
+            subscriber.send(completion: .failure(error))
+            return AnyCancellable {}
+        }
+    }
+}

--- a/Sources/TuistSupport/System/System.swift
+++ b/Sources/TuistSupport/System/System.swift
@@ -684,6 +684,24 @@ public final class System: Systeming {
 }
 
 extension Systeming {
+    public func publisher(_ arguments: [String], pipedToArguments: [String]) -> AnyPublisher<SystemEvent<Data>, Error> {
+        AnyPublisher.create { (subscriber) -> Cancellable in
+            let disposable = self.observable(arguments, pipedToArguments: pipedToArguments).subscribe { event in
+                switch event {
+                case .completed:
+                    subscriber.send(completion: .finished)
+                case let .error(error):
+                    subscriber.send(completion: .failure(error))
+                case let .next(event):
+                    subscriber.send(event)
+                }
+            }
+            return AnyCancellable {
+                disposable.dispose()
+            }
+        }
+    }
+
     public func publisher(_ arguments: [String]) -> AnyPublisher<SystemEvent<Data>, Error> {
         AnyPublisher.create { (subscriber) -> Cancellable in
             let disposable = self.observable(arguments).subscribe { event in

--- a/Sources/TuistSupport/Utils/GitEnvironment.swift
+++ b/Sources/TuistSupport/Utils/GitEnvironment.swift
@@ -10,16 +10,16 @@ public protocol GitEnvironmenting {
     func githubCredentials() -> Deferred<Future<(username: String, password: String)?, Error>>
 }
 
-enum GitEnvironmentError: FatalError {
+public enum GitEnvironmentError: FatalError {
     case githubCredentialsFillError(String)
 
-    var type: ErrorType {
+    public var type: ErrorType {
         switch self {
         case .githubCredentialsFillError: return .bug
         }
     }
 
-    var description: String {
+    public var description: String {
         switch self {
         case let .githubCredentialsFillError(message):
             return "Trying to get your environment's credentials for https://github.com failed with the following error: \(message)"

--- a/Sources/TuistSupport/Utils/GitEnvironment.swift
+++ b/Sources/TuistSupport/Utils/GitEnvironment.swift
@@ -1,0 +1,67 @@
+import Combine
+import CombineExt
+import Foundation
+import TSCUtility
+
+public protocol GitEnvironmenting {
+    /// It treturns the environment's Git credentials for GitHub.
+    /// This is useful for operations such pulling newer Tuist versions from GitHub
+    /// without hitting API limits.
+    func githubCredentials() -> Deferred<Future<(username: String, password: String)?, Error>>
+}
+
+enum GitEnvironmentError: FatalError {
+    case githubCredentialsFillError(String)
+
+    var type: ErrorType {
+        switch self {
+        case .githubCredentialsFillError: return .bug
+        }
+    }
+
+    var description: String {
+        switch self {
+        case let .githubCredentialsFillError(message):
+            return "Trying to get your environment's credentials for https://github.com failed with the following error: \(message)"
+        }
+    }
+}
+
+public class GitEnvironment: GitEnvironmenting {
+    // https://github.com/Carthage/Carthage/blob/19a7f97112052394f3ecc33dac3c67e5384b7514/Source/CarthageKit/GitHub.swift#L85
+    public func githubCredentials() -> Deferred<Future<(username: String, password: String)?, Error>> {
+        Deferred {
+            Future<(username: String, password: String)?, Error> { promise in
+                _ = System.shared.publisher(["echo", "url=https://github.com"], pipedToArguments: ["git", "credentials", "fill"])
+                    .mapToString()
+                    .flatMap { (event: SystemEvent<String>) -> AnyPublisher<(username: String, password: String)?, Error> in
+                        switch event {
+                        case let .standardError(errorString):
+                            return AnyPublisher(error: GitEnvironmentError.githubCredentialsFillError(errorString))
+                        case let .standardOutput(outputString):
+//                            protocol=https
+//                            host=github.com
+//                            username=pepibumur
+//                            password=foo
+                            let lines = outputString.split(separator: "\n")
+                            let values = lines.reduce(into: [String: String]()) { result, next in
+                                let components = next.split(separator: "=")
+                                guard components.count == 2 else { return }
+                                result[String(components.first!).spm_chomp()] = String(components.last!).spm_chomp()
+                            }
+                            guard let username = values["username"], let password = values["password"] else { return AnyPublisher(value: nil) }
+                            return AnyPublisher(value: (username: username, password: password))
+                        }
+                    }
+                    .sink { completion in
+                        switch completion {
+                        case let .failure(error): promise(.failure(error))
+                        default: break
+                        }
+                    } receiveValue: { value in
+                        promise(.success(value))
+                    }
+            }
+        }
+    }
+}

--- a/Tests/TuistSupportTests/Utils/GitEnvironmentTests.swift
+++ b/Tests/TuistSupportTests/Utils/GitEnvironmentTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import XCTest
+
+@testable import TuistSupport
+@testable import TuistSupportTesting
+
+final class GitEnvironmentErrorTests: TuistUnitTestCase {
+    func test_type_when_githubCredentialsFillError() {
+        XCTAssertEqual(GitEnvironmentError.githubCredentialsFillError("test").type, .bug)
+    }
+
+    func test_description_when_githubCredentialsFillError() {
+        XCTAssertEqual(GitEnvironmentError.githubCredentialsFillError("test").description, "Trying to get your environment's credentials for https://github.com failed with the following error: test")
+    }
+}
+
+final class GitEnvironmentTests: TuistUnitTestCase {
+    var subject: GitEnvironment!
+
+    override func setUp() {
+        subject = GitEnvironment()
+        super.setUp()
+    }
+
+    override func tearDown() {
+        subject = nil
+        super.tearDown()
+    }
+
+    func test_githubCredentials_when_the_command_fails() throws {
+        // Given
+        system.errorCommand(["echo", "url=https://github.com"])
+        system.errorCommand(["git", "credentials", "fill"])
+        let expectation = XCTestExpectation(description: "Git credentials fill command")
+
+        // When
+        _ = subject.githubCredentials()
+            .sink { completion in
+                switch completion {
+                case .failure:
+                    expectation.fulfill()
+                case .finished:
+                    XCTFail("Expected to receive an error but it did not.")
+                    expectation.fulfill()
+                }
+            } receiveValue: { _ in }
+        wait(for: [expectation], timeout: 10.0)
+    }
+
+    func test_githubCredentials_when_the_command_returns_the_expected_output() throws {
+        // Given
+        let output = """
+        username=tuist
+        password=rocks
+        """
+        system.succeedCommand(["echo", "url=https://github.com"], output: output)
+        system.succeedCommand(["git", "credentials", "fill"], output: output)
+        let expectation = XCTestExpectation(description: "Git credentials fill command")
+
+        // When
+        _ = subject.githubCredentials()
+            .sink { completion in
+                switch completion {
+                case .failure:
+                    XCTFail("Expected to succeed but it failed")
+                    expectation.fulfill()
+                case .finished:
+                    expectation.fulfill()
+                }
+            } receiveValue: { value in
+                XCTAssertEqual(value?.username, "tuist")
+                XCTAssertEqual(value?.password, "rocks")
+            }
+        wait(for: [expectation], timeout: 10.0)
+    }
+
+    func test_githubCredentials_when_the_commands_output_lacks_username_or_password() throws {
+        // Given
+        let output = """
+        password=rocks
+        """
+        system.succeedCommand(["echo", "url=https://github.com"], output: output)
+        system.succeedCommand(["git", "credentials", "fill"], output: output)
+        let expectation = XCTestExpectation(description: "Git credentials fill command")
+
+        // When
+        _ = subject.githubCredentials()
+            .sink { completion in
+                switch completion {
+                case .failure:
+                    XCTFail("Expected to succeed but it failed")
+                    expectation.fulfill()
+                case .finished:
+                    expectation.fulfill()
+                }
+            } receiveValue: { value in
+                XCTAssertNil(value)
+            }
+        wait(for: [expectation], timeout: 10.0)
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY
Request for comments document (if applies):

### Short description 📝
The cost of Google Cloud Storage for storing the release artefacts is increasing significantly. To eliminate the cost, I'll change the approach and store the artefacts on GitHub releases. This comes with a caveat, we might hit GitHub API limits. To prevent that, I'm following Carthage's approach to authenticate using any existing environment credentials. Locally, we can use the credentials that are stored in the system. Git provides a utility to obtain those. On CI we can allow providing a `TUIST_GITHUB_TOKEN` environment variable.

This PR adds a utility for obtaining the system credentials.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
