### PR TITLE
Autocancel workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - projects/tuistbench/**
 
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 env:
   TUIST_STATS_OPT_OUT: true
   RUBY_VERSION: '3.0.1'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,6 +13,10 @@ on:
       - projects/fixturegen/**
       - projects/tuistbench/**
 
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 env:
   RUBY_VERSION: '3.0.1'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     paths:
       - projects/docs/**
+
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 env:
   RUBY_VERSION: '3.0.1'
 

--- a/.github/workflows/fixture-generator.yml
+++ b/.github/workflows/fixture-generator.yml
@@ -10,6 +10,11 @@ on:
       - Package.swift
       - Package.resolved
       - Sources/**
+
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 env:
   RUBY_VERSION: '3.0.1'
 

--- a/.github/workflows/fourier.yml
+++ b/.github/workflows/fourier.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - projects/fourier/**
 
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 env:
   RUBY_VERSION: '3.0.1'
 

--- a/.github/workflows/lab-backend..yml
+++ b/.github/workflows/lab-backend..yml
@@ -9,6 +9,10 @@ on:
       - projects/lab-backend-api/**
       - .github/workflows/lab.yml
 
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 env:
   RAILS_ENV: test
   RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}

--- a/.github/workflows/meta-tuist.yml
+++ b/.github/workflows/meta-tuist.yml
@@ -14,6 +14,10 @@ on:
       - projects/tuist/features/**
       - Project.swift
 
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 env:
   RUBY_VERSION: '3.0.1'
   TUIST_STATS_OPT_OUT: true

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - projects/next/**
 
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -12,6 +12,10 @@ on:
       - Sources/**
       - Project.swift
 
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 env:
   RUBY_VERSION: '3.0.1'
   TUIST_STATS_OPT_OUT: true

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -14,6 +14,10 @@ on:
       - projects/tuist/features/**
       - projects/tuist/fixtures/**
 
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 env:
   RUBY_VERSION: '3.0.1'
   TUIST_STATS_OPT_OUT: true

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     paths:
       - projects/website/**
+
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 env:
   RUBY_VERSION: '3.0.1'
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/2773
Request for comments document (if applies):

### Short description 📝

Hello, GitHub Action recently introduced the concurrency for GitHub Action, that would fulfil the problem of the issue #2773 .
It is in beta: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
Yet, I would say we could start using it, I made some quick tests and seems to work nicely.
What do you think?

I am using as a concurrency group the `github.head_ref`, which as per the documentation is: 

> The branch or tag ref that triggered the workflow run. For branches this in the format refs/heads/<branch_name>, and for tags it is refs/tags/<tag_name>.

Therefore the PR, would change the current workflows so that they automatically cancel previous pending or in progress actions for a specific branch or tag PR, speeding up waiting time for CI.
We would, of course, still allow concurrent actions for different branches.
The list of workflows which are updated with the new logic are the one that would affect the main branch, I left untouched `stale` and `release` workflow.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
