### PR TITLE
📦 [Dependencies.swift] Generate modulemap files if needed

### DIFF
--- a/Sources/TuistGenerator/Mappers/GenerateInfoPlistProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/GenerateInfoPlistProjectMapper.swift
@@ -33,8 +33,7 @@ public final class GenerateInfoPlistProjectMapper: ProjectMapping {
     // MARK: - ProjectMapping
 
     public func map(project: Project) throws -> (Project, [SideEffectDescriptor]) {
-        var results = (targets: [Target](), sideEffects: [SideEffectDescriptor]())
-        results = try project.targets.reduce(into: results) { results, target in
+        let results = try project.targets.reduce(into: (targets: [Target](), sideEffects: [SideEffectDescriptor]())) { results, target in
             let (updatedTarget, sideEffects) = try map(target: target, project: project)
             results.targets.append(updatedTarget)
             results.sideEffects.append(contentsOf: sideEffects)

--- a/Sources/TuistGenerator/Mappers/GenerateModuleMapProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/GenerateModuleMapProjectMapper.swift
@@ -23,8 +23,7 @@ public final class GenerateModuleMapProjectMapper: ProjectMapping {
     // MARK: - ProjectMapping
 
     public func map(project: Project) throws -> (Project, [SideEffectDescriptor]) {
-        var results = (targets: [Target](), sideEffects: [SideEffectDescriptor]())
-        results = try project.targets.reduce(into: results) { results, target in
+        let results = try project.targets.reduce(into: (targets: [Target](), sideEffects: [SideEffectDescriptor]())) { results, target in
             let (updatedTarget, sideEffects) = try map(target: target, project: project)
             results.targets.append(updatedTarget)
             results.sideEffects.append(contentsOf: sideEffects)
@@ -43,7 +42,8 @@ public final class GenerateModuleMapProjectMapper: ProjectMapping {
             return (target, [])
         }
 
-        guard (target.headers?.public.count ?? 0) == 1 else {
+        let publicHeadersCount = target.headers?.public.count ?? 0
+        guard publicHeadersCount == 1 else {
             // No header or multiple headers, nothing to do
             return (target, [])
         }
@@ -62,7 +62,7 @@ public final class GenerateModuleMapProjectMapper: ProjectMapping {
             export *
             module * { export * }
         }
-        """.data(using: .utf8)!
+        """.data(using: .utf8)
 
         let moduleMapPath = project.path
             .appending(component: derivedDirectoryName)

--- a/Sources/TuistGenerator/Mappers/GenerateModuleMapProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/GenerateModuleMapProjectMapper.swift
@@ -68,9 +68,10 @@ public final class GenerateModuleMapProjectMapper: ProjectMapping {
             .appending(component: derivedDirectoryName)
             .appending(component: moduleMapsDirectoryName)
             .appending(component: "\(target.name).modulemap")
+
         let sideEffect = SideEffectDescriptor.file(FileDescriptor(path: moduleMapPath, contents: data))
 
-        let newTarget = target.with(additionalSettings: [moduleMapSetting: .string(moduleMapPath.pathString)])
+        let newTarget = target.with(additionalSettings: [moduleMapSetting: .string(moduleMapPath.relative(to: project.path).pathString)])
 
         return (newTarget, [sideEffect])
     }

--- a/Sources/TuistGenerator/Mappers/GenerateModuleMapProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/GenerateModuleMapProjectMapper.swift
@@ -1,0 +1,77 @@
+import Foundation
+import TSCBasic
+import TuistCore
+import TuistGraph
+import TuistSupport
+import XcodeProj
+
+/// A project mapper that generates derived modulemap for targets which:
+/// - don't define a modulemap
+/// - contain a single header with a name different from the target name.
+public final class GenerateModuleMapProjectMapper: ProjectMapping {
+    private let derivedDirectoryName: String
+    private let moduleMapsDirectoryName: String
+
+    public init(
+        derivedDirectoryName: String = Constants.DerivedDirectory.name,
+        moduleMapsDirectoryName: String = Constants.DerivedDirectory.moduleMaps
+    ) {
+        self.derivedDirectoryName = derivedDirectoryName
+        self.moduleMapsDirectoryName = moduleMapsDirectoryName
+    }
+
+    // MARK: - ProjectMapping
+
+    public func map(project: Project) throws -> (Project, [SideEffectDescriptor]) {
+        var results = (targets: [Target](), sideEffects: [SideEffectDescriptor]())
+        results = try project.targets.reduce(into: results) { results, target in
+            let (updatedTarget, sideEffects) = try map(target: target, project: project)
+            results.targets.append(updatedTarget)
+            results.sideEffects.append(contentsOf: sideEffects)
+        }
+
+        return (project.with(targets: results.targets), results.sideEffects)
+    }
+
+    // MARK: - Private
+
+    private func map(target: Target, project: Project) throws -> (Target, [SideEffectDescriptor]) {
+        let moduleMapSetting = "MODULEMAP_FILE"
+
+        guard target.settings?.base[moduleMapSetting] == nil else {
+            // Module map manually defined, nothing to do
+            return (target, [])
+        }
+
+        guard (target.headers?.public.count ?? 0) == 1 else {
+            // No header or multiple headers, nothing to do
+            return (target, [])
+        }
+
+        guard
+            let header = target.headers?.public.first,
+            header.basenameWithoutExt != target.name
+        else {
+            // Header with same name of target, nothing to do
+            return (target, [])
+        }
+
+        let data = """
+        framework module \(target.name) {
+            umbrella header "\(header.basename)"
+            export *
+            module * { export * }
+        }
+        """.data(using: .utf8)!
+
+        let moduleMapPath = project.path
+            .appending(component: derivedDirectoryName)
+            .appending(component: moduleMapsDirectoryName)
+            .appending(component: "\(target.name).modulemap")
+        let sideEffect = SideEffectDescriptor.file(FileDescriptor(path: moduleMapPath, contents: data))
+
+        let newTarget = target.with(additionalSettings: [moduleMapSetting: .string(moduleMapPath.pathString)])
+
+        return (newTarget, [sideEffect])
+    }
+}

--- a/Sources/TuistGraph/Models/Target.swift
+++ b/Sources/TuistGraph/Models/Target.swift
@@ -202,6 +202,25 @@ public struct Target: Equatable, Hashable, Comparable, Codable {
         return copy
     }
 
+    /// Returns a new copy of the target with the given additional settings
+    /// - Parameter settingsDictionary: settings to be added.
+    public func with(additionalSettings: SettingsDictionary) -> Target {
+        var copy = self
+        if let oldSettings = copy.settings {
+            copy.settings = Settings(
+                base: oldSettings.base.merging(additionalSettings, uniquingKeysWith: { $1 }),
+                configurations: oldSettings.configurations,
+                defaultSettings: oldSettings.defaultSettings
+            )
+        } else {
+            copy.settings = Settings(
+                base: additionalSettings,
+                configurations: [:]
+            )
+        }
+        return copy
+    }
+
     // MARK: - Comparable
 
     public static func < (lhs: Target, rhs: Target) -> Bool {

--- a/Sources/TuistKit/GraphMappers/ProjectMapperProvider.swift
+++ b/Sources/TuistKit/GraphMappers/ProjectMapperProvider.swift
@@ -58,6 +58,9 @@ final class ProjectMapperProvider: ProjectMapperProviding {
         // Info Plist
         mappers.append(GenerateInfoPlistProjectMapper())
 
+        // Module Map
+        mappers.append(GenerateModuleMapProjectMapper())
+
         // Project name and organization
         mappers.append(ProjectNameAndOrganizationMapper(config: config))
 

--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -43,6 +43,7 @@ public enum Constants {
     public enum DerivedDirectory {
         public static let name = "Derived"
         public static let infoPlists = "InfoPlists"
+        public static let moduleMaps = "ModuleMaps"
         public static let sources = "Sources"
         public static let signingKeychain = "signing.keychain"
     }

--- a/Tests/TuistDependenciesTests/DependenciesGraph/DependenciesGraphControllerTests.swift
+++ b/Tests/TuistDependenciesTests/DependenciesGraph/DependenciesGraphControllerTests.swift
@@ -14,14 +14,12 @@ public final class DependenciesGraphControllerTests: TuistUnitTestCase {
 
     override public func setUp() {
         super.setUp()
-
         subject = DependenciesGraphController()
     }
 
     override public func tearDown() {
-        super.tearDown()
-
         subject = nil
+        super.tearDown()
     }
 
     func test_save() throws {

--- a/Tests/TuistGeneratorTests/ProjectMappers/DeleteDerivedDirectoryProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/DeleteDerivedDirectoryProjectMapperTests.swift
@@ -18,8 +18,8 @@ public final class DeleteDerivedDirectoryProjectMapperTests: TuistUnitTestCase {
     }
 
     override public func tearDown() {
-        super.tearDown()
         subject = nil
+        super.tearDown()
     }
 
     func test_map_returns_sideEffectsToDeleteDerivedDirectories() throws {

--- a/Tests/TuistGeneratorTests/ProjectMappers/GenerateInfoPlistProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/GenerateInfoPlistProjectMapperTests.swift
@@ -24,9 +24,9 @@ public final class GenerateInfoPlistProjectMapperTests: TuistUnitTestCase {
     }
 
     override public func tearDown() {
-        super.tearDown()
         infoPlistContentProvider = nil
         subject = nil
+        super.tearDown()
     }
 
     func test_map() throws {

--- a/Tests/TuistGeneratorTests/ProjectMappers/GenerateModuleMapProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/GenerateModuleMapProjectMapperTests.swift
@@ -21,8 +21,8 @@ public final class GenerateModuleMapProjectMapperTests: TuistUnitTestCase {
     }
 
     override public func tearDown() {
-        super.tearDown()
         subject = nil
+        super.tearDown()
     }
 
     func test_map() throws {

--- a/Tests/TuistGeneratorTests/ProjectMappers/GenerateModuleMapProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/GenerateModuleMapProjectMapperTests.swift
@@ -35,10 +35,8 @@ public final class GenerateModuleMapProjectMapperTests: TuistUnitTestCase {
         let (mappedProject, sideEffects) = try subject.map(project: project)
 
         // Then
-        let expectedPath = project.path
-            .appending(component: Constants.DerivedDirectory.name)
-            .appending(component: Constants.DerivedDirectory.moduleMaps)
-            .appending(component: "A.modulemap")
+        let expectedPath = RelativePath("Derived/ModuleMaps/A.modulemap")
+
         XCTAssertEqual(
             mappedProject,
             Project.test(
@@ -56,7 +54,7 @@ public final class GenerateModuleMapProjectMapperTests: TuistUnitTestCase {
             sideEffects,
             [
                 .file(FileDescriptor(
-                    path: AbsolutePath("/"),
+                    path: AbsolutePath("/Project/Derived/ModuleMaps/A.modulemap"),
                     contents: """
                     framework module A {
                         umbrella header "header.h"

--- a/Tests/TuistGeneratorTests/ProjectMappers/GenerateModuleMapProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/GenerateModuleMapProjectMapperTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import TSCBasic
+import TuistCore
+import TuistGraph
+import TuistGraphTesting
+import TuistSupport
+import XCTest
+@testable import TuistCoreTesting
+@testable import TuistGenerator
+@testable import TuistSupportTesting
+
+public final class GenerateModuleMapProjectMapperTests: TuistUnitTestCase {
+    var subject: GenerateModuleMapProjectMapper!
+
+    override public func setUp() {
+        super.setUp()
+        subject = GenerateModuleMapProjectMapper(
+            derivedDirectoryName: Constants.DerivedDirectory.name,
+            moduleMapsDirectoryName: Constants.DerivedDirectory.moduleMaps
+        )
+    }
+
+    override public func tearDown() {
+        super.tearDown()
+        subject = nil
+    }
+
+    func test_map() throws {
+        // Given
+        let targetA = Target.test(name: "A", headers: .init(public: ["/a/public/header.h"], private: [], project: []))
+        let targetB = Target.test(name: "B")
+        let project = Project.test(targets: [targetA, targetB])
+
+        // When
+        let (mappedProject, sideEffects) = try subject.map(project: project)
+
+        // Then
+        let expectedPath = project.path
+            .appending(component: Constants.DerivedDirectory.name)
+            .appending(component: Constants.DerivedDirectory.moduleMaps)
+            .appending(component: "A.modulemap")
+        XCTAssertEqual(
+            mappedProject,
+            Project.test(
+                targets: [
+                    Target.test(
+                        name: "A",
+                        settings: Settings(base: ["MODULEMAP_FILE": .string(expectedPath.pathString)], configurations: [:]),
+                        headers: .init(public: ["/a/public/header.h"], private: [], project: [])
+                    ),
+                    Target.test(name: "B"),
+                ]
+            )
+        )
+        XCTAssertEqual(
+            sideEffects,
+            [
+                .file(FileDescriptor(
+                        path: AbsolutePath("/"),
+                        contents: """
+                        framework module A {
+                            umbrella header "header.h"
+                            export *
+                            module * { export * }
+                        }
+                        """.data(using: .utf8)
+                ))
+            ]
+        )
+    }
+
+    func test_map_when_modulemap_already_defined_does_nothing() throws {
+        // Given
+        let targetA = Target.test(
+            name: "A",
+            settings: Settings(base: ["MODULEMAP_FILE": "/path.modulemap"], configurations: [:]),
+            headers: .init(public: ["/a/public/header.h"], private: [], project: [])
+        )
+        let targetB = Target.test(name: "B")
+        let project = Project.test(targets: [targetA, targetB])
+
+        // When
+        let (mappedProject, sideEffects) = try subject.map(project: project)
+
+        // Then
+        XCTAssertEqual(mappedProject, project)
+        XCTAssertEqual(sideEffects, [])
+    }
+
+    func test_map_when_no_public_headers_does_nothing() throws {
+        // Given
+        let targetA = Target.test(name: "A")
+        let targetB = Target.test(name: "B")
+        let project = Project.test(targets: [targetA, targetB])
+
+        // When
+        let (mappedProject, sideEffects) = try subject.map(project: project)
+
+        // Then
+        XCTAssertEqual(mappedProject, project)
+        XCTAssertEqual(sideEffects, [])
+    }
+
+    func test_map_when_multiple_public_headers_does_nothing() throws {
+        // Given
+        let targetA = Target.test(
+            name: "A",
+            headers: .init(public: ["/a/public/header.h", "/another/public/header.h"], private: [], project: [])
+        )
+        let targetB = Target.test(name: "B")
+        let project = Project.test(targets: [targetA, targetB])
+
+        // When
+        let (mappedProject, sideEffects) = try subject.map(project: project)
+
+        // Then
+        XCTAssertEqual(mappedProject, project)
+        XCTAssertEqual(sideEffects, [])
+    }
+
+    func test_map_when_public_header_matches_target_does_nothing() throws {
+        // Given
+        let targetA = Target.test(
+            name: "A",
+            headers: .init(public: ["/a/public/A.h"], private: [], project: [])
+        )
+        let targetB = Target.test(name: "B")
+        let project = Project.test(targets: [targetA, targetB])
+
+        // When
+        let (mappedProject, sideEffects) = try subject.map(project: project)
+
+        // Then
+        XCTAssertEqual(mappedProject, project)
+        XCTAssertEqual(sideEffects, [])
+    }
+}

--- a/Tests/TuistGeneratorTests/ProjectMappers/GenerateModuleMapProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/GenerateModuleMapProjectMapperTests.swift
@@ -56,15 +56,15 @@ public final class GenerateModuleMapProjectMapperTests: TuistUnitTestCase {
             sideEffects,
             [
                 .file(FileDescriptor(
-                        path: AbsolutePath("/"),
-                        contents: """
-                        framework module A {
-                            umbrella header "header.h"
-                            export *
-                            module * { export * }
-                        }
-                        """.data(using: .utf8)
-                ))
+                    path: AbsolutePath("/"),
+                    contents: """
+                    framework module A {
+                        umbrella header "header.h"
+                        export *
+                        module * { export * }
+                    }
+                    """.data(using: .utf8)
+                )),
             ]
         )
     }


### PR DESCRIPTION
Creates a modulemap file for a target if:
- the target doesn't define a modulemap
- the target contains a single header file with a name different from the target name.

It is required to properly build some SPM packages like https://github.com/mattgallagher/CwlCatchException

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
