### PR TITLE
Add GitHubClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 - Native support for ARM architecture [#3010](https://github.com/tuist/tuist/pull/3010) by [@fortmarek](https://github.com/fortmarek) & [@pepibumur](https://github.com/pepibumur).
-- Utility for obtaining the system's Git credentials for authenticating with https://github.com [#3110](https://github.com/tuist/tuist/pull/3110) by [@pepibumur](https://github.com/pepibumur)
+- Utility for obtaining the system's Git credentials for authenticating with [#3110](https://github.com/tuist/tuist/pull/3110) by [@pepibumur](https://github.com/pepibumur).
+- `GitHubClient` to interact with GitHub's API [#3144](https://github.com/tuist/tuist/pull/3144) by [@pepibumur](https://github.com/pepibumur).
 
 ## 1.45.1
 

--- a/Sources/TuistSupport/Utils/GitHubClient.swift
+++ b/Sources/TuistSupport/Utils/GitHubClient.swift
@@ -1,0 +1,70 @@
+import Combine
+import CombineExt
+import Foundation
+
+public protocol GitHubClienting {
+    func deferred<T, E: Error>(resource: HTTPResource<T, E>) -> Deferred<Future<(object: T, response: HTTPURLResponse), Error>>
+}
+
+public final class GitHubClient: GitHubClienting {
+    let requestDispatcher: HTTPRequestDispatching
+    let gitEnvironment: GitEnvironmenting
+
+    init(requestDispatcher: HTTPRequestDispatching = HTTPRequestDispatcher(),
+         gitEnvironment: GitEnvironmenting = GitEnvironment())
+    {
+        self.requestDispatcher = requestDispatcher
+        self.gitEnvironment = gitEnvironment
+    }
+
+    public func deferred<T, E: Error>(resource: HTTPResource<T, E>) -> Deferred<Future<(object: T, response: HTTPURLResponse), Error>> {
+        return Deferred {
+            Future<(object: T, response: HTTPURLResponse), Error> { promise in
+                _ = self.gitEnvironment.githubAuthentication().sink { completion in
+                    if case let .failure(error) = completion {
+                        promise(.failure(error))
+                    }
+                } receiveValue: { authentication in
+                    var mappedResource: HTTPResource<T, E> = resource
+                    do {
+                        mappedResource = try self.authenticatedResource(resource: resource, authentication: authentication)
+                    } catch {
+                        promise(.failure(error))
+                        return
+                    }
+                    _ = self.requestDispatcher.deferred(resource: mappedResource)
+                        .sink { completion in
+                            if case let .failure(error) = completion {
+                                promise(.failure(error))
+                            }
+                        } receiveValue: { response in
+                            promise(.success(response))
+                        }
+                }
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func authenticatedResource<T, E: Error>(resource: HTTPResource<T, E>, authentication: GitHubAuthentication?) throws -> HTTPResource<T, E> {
+        return try resource.mappingRequest { (request: URLRequest) -> URLRequest in
+            var request = request
+            var headers: [String: String]! = request.allHTTPHeaderFields
+            if headers == nil { headers = [:] }
+            if let authentication = authentication {
+                switch authentication {
+                case let .credentials(credentials):
+                    let data = "\(credentials.username):\(credentials.password)".data(using: String.Encoding.utf8)!
+                    let encodedString = data.base64EncodedString()
+                    headers["Authorization"] = "Basic \(encodedString)"
+                case let .token(token):
+                    headers["Authorization"] = "token \(token)"
+                }
+            }
+            headers["Accept"] = "application/vnd.github.v3+json"
+            request.allHTTPHeaderFields = headers
+            return request
+        }
+    }
+}

--- a/Sources/TuistSupportTesting/HTTP/HTTPResource+TestData.swift
+++ b/Sources/TuistSupportTesting/HTTP/HTTPResource+TestData.swift
@@ -1,0 +1,14 @@
+import Foundation
+import TuistSupport
+
+public extension HTTPResource {
+    static func noop() -> HTTPResource<Void, Error> {
+        return HTTPResource<Void, Error> {
+            return URLRequest(url: URL(string: "https://test.tuist.io")!)
+        } parse: { _, _ in
+            ()
+        } parseError: { _, _ in
+            TestError("noop HTTPResource")
+        }
+    }
+}

--- a/Sources/TuistSupportTesting/HTTP/MockHTTPRequestDispatcher.swift
+++ b/Sources/TuistSupportTesting/HTTP/MockHTTPRequestDispatcher.swift
@@ -1,0 +1,35 @@
+import Combine
+import Foundation
+import RxSwift
+import TuistSupport
+
+public class MockHTTPRequestDispatcher: HTTPRequestDispatching {
+    public var requests: [URLRequest] = []
+
+    public func dispatch<T, E>(resource: HTTPResource<T, E>) -> Single<(object: T, response: HTTPURLResponse)> where E: Error {
+        return Single.create { observer in
+            if T.self != Void.self {
+                fatalError("MockHTTPRequestDispatcher only supports resources with Void as its generic value. Use HTTPResource.noop from TuistSupportTesting.")
+            }
+            self.requests.append(resource.request())
+            let response = HTTPURLResponse()
+            // swiftlint:disable:next force_cast
+            observer(.success((object: () as! T, response: response)))
+            return Disposables.create()
+        }
+    }
+
+    public func deferred<T, E>(resource: HTTPResource<T, E>) -> Deferred<Future<(object: T, response: HTTPURLResponse), Error>> where E: Error {
+        return Deferred {
+            Future<(object: T, response: HTTPURLResponse), Error> { promise in
+                if T.self != Void.self {
+                    fatalError("MockHTTPRequestDispatcher only supports resources with Void as its generic value. Use HTTPResource.noop from TuistSupportTesting.")
+                }
+                self.requests.append(resource.request())
+                let response = HTTPURLResponse()
+                // swiftlint:disable:next force_cast
+                promise(.success((object: () as! T, response: response)))
+            }
+        }
+    }
+}

--- a/Sources/TuistSupportTesting/Utils/MockGitEnvironment.swift
+++ b/Sources/TuistSupportTesting/Utils/MockGitEnvironment.swift
@@ -1,0 +1,33 @@
+import Combine
+import Foundation
+import TuistSupport
+
+public final class MockGitEnvironment: GitEnvironmenting {
+    public var invokedGithubAuthentication = false
+    public var invokedGithubAuthenticationCount = 0
+    public var stubbedGithubAuthenticationResult: Result<GitHubAuthentication?, Error>!
+
+    public func githubAuthentication() -> Deferred<Future<GitHubAuthentication?, Error>> {
+        invokedGithubAuthentication = true
+        invokedGithubAuthenticationCount += 1
+        return Deferred {
+            Future { promise in
+                promise(self.stubbedGithubAuthenticationResult)
+            }
+        }
+    }
+
+    public var invokedGithubCredentials = false
+    public var invokedGithubCredentialsCount = 0
+    public var stubbedGithubCredentialsResult: Result<GithubCredentials?, Error>!
+
+    public func githubCredentials() -> Deferred<Future<GithubCredentials?, Error>> {
+        invokedGithubCredentials = true
+        invokedGithubCredentialsCount += 1
+        return Deferred {
+            Future { promise in
+                promise(self.stubbedGithubCredentialsResult)
+            }
+        }
+    }
+}

--- a/Tests/TuistSupportTests/Utils/GitEnvironmentTests.swift
+++ b/Tests/TuistSupportTests/Utils/GitEnvironmentTests.swift
@@ -16,7 +16,7 @@ final class GitEnvironmentErrorTests: TuistUnitTestCase {
 
 final class GitEnvironmentTests: TuistUnitTestCase {
     var subject: GitEnvironment!
-    var envVariables: [String: String] = [:]
+    var envVariables: [String: String]! = [:]
 
     override func setUp() {
         super.setUp()
@@ -25,6 +25,7 @@ final class GitEnvironmentTests: TuistUnitTestCase {
 
     override func tearDown() {
         subject = nil
+        envVariables = nil
         super.tearDown()
     }
 

--- a/Tests/TuistSupportTests/Utils/GitHubClientTests.swift
+++ b/Tests/TuistSupportTests/Utils/GitHubClientTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import XCTest
+
+@testable import TuistSupport
+@testable import TuistSupportTesting
+
+final class GitHubClientTests: TuistUnitTestCase {
+    var subject: GitHubClient!
+    var requestDisptacher: MockHTTPRequestDispatcher!
+    var gitEnvironment: MockGitEnvironment!
+
+    override func setUp() {
+        super.setUp()
+        requestDisptacher = MockHTTPRequestDispatcher()
+        gitEnvironment = MockGitEnvironment()
+        subject = GitHubClient(
+            requestDispatcher: requestDisptacher,
+            gitEnvironment: gitEnvironment
+        )
+    }
+
+    override func tearDown() {
+        requestDisptacher = nil
+        gitEnvironment = nil
+        subject = nil
+        super.tearDown()
+    }
+
+    func test_deferred_includes_the_token_in_the_request() throws {
+        // Given
+        gitEnvironment.stubbedGithubAuthenticationResult = .success(.token("TOKEN"))
+
+        // When
+        let expectation = XCTestExpectation(description: "GitHubClient deferred when token")
+        _ = subject.deferred(resource: HTTPResource<Void, Never>.noop())
+            .sink(
+                receiveCompletion: { _ in expectation.fulfill() },
+                receiveValue: { _ in }
+            )
+        wait(for: [expectation], timeout: 10.0)
+
+        // Then
+        let request = try XCTUnwrap(requestDisptacher.requests.first)
+        let headers = try XCTUnwrap(request.allHTTPHeaderFields)
+        XCTAssertEqual(headers["Authorization"], "token TOKEN")
+        XCTAssertEqual(headers["Accept"], "application/vnd.github.v3+json")
+    }
+
+    func test_deferred_includes_the_username_and_password_in_the_request() throws {
+        // Given
+        gitEnvironment.stubbedGithubAuthenticationResult = .success(
+            .credentials(.init(username: "username", password: "password"))
+        )
+
+        // When
+        let expectation = XCTestExpectation(description: "GitHubClient deferred when token")
+        _ = subject.deferred(resource: HTTPResource<Void, Never>.noop())
+            .sink(
+                receiveCompletion: { _ in expectation.fulfill() },
+                receiveValue: { _ in }
+            )
+        wait(for: [expectation], timeout: 10.0)
+
+        // Then
+        let request = try XCTUnwrap(requestDisptacher.requests.first)
+        let headers = try XCTUnwrap(request.allHTTPHeaderFields)
+        let data = "username:password".data(using: String.Encoding.utf8)!
+        let encodedString = data.base64EncodedString()
+        XCTAssertEqual(headers["Authorization"], "Basic \(encodedString)")
+        XCTAssertEqual(headers["Accept"], "application/vnd.github.v3+json")
+    }
+
+    func test_deferred_when_no_authentication_is_available() throws {
+        // Given
+        gitEnvironment.stubbedGithubAuthenticationResult = .success(nil)
+
+        // When
+        let expectation = XCTestExpectation(description: "GitHubClient deferred when token")
+        _ = subject.deferred(resource: HTTPResource<Void, Never>.noop())
+            .sink(
+                receiveCompletion: { _ in expectation.fulfill() },
+                receiveValue: { _ in }
+            )
+        wait(for: [expectation], timeout: 10.0)
+
+        // Then
+        let request = try XCTUnwrap(requestDisptacher.requests.first)
+        let headers = try XCTUnwrap(request.allHTTPHeaderFields)
+        XCTAssertNil(headers["Authorization"])
+        XCTAssertEqual(headers["Accept"], "application/vnd.github.v3+json")
+    }
+}


### PR DESCRIPTION
### Short description 📝
This PR is follow-up work of https://github.com/tuist/tuist/pull/3110. I'm adding a new utility, `GitHubClient`, that we can use to send requests to GitHub's API. When Git credentials are available in the environment, the client includes them automatically using the HTTP header `Authorization`.

In the next PR I'll add an HTTP resource for fetching the releases and their artifacts. The plan is to use it in the installer logic to pull Tuist from the GitHub's release instead of Google Cloud Storage (Google Cloud Storage).

### Checklist ✅

- x ] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
