### PR TITLE
Add platformFilter

### DIFF
--- a/Sources/TuistCore/Graph/GraphDependencyReference.swift
+++ b/Sources/TuistCore/Graph/GraphDependencyReference.swift
@@ -25,7 +25,7 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
         architectures: [BinaryArchitecture],
         product: Product
     )
-    case product(target: String, productName: String)
+    case product(target: String, productName: String, platformFilter: String? = nil)
     case sdk(path: AbsolutePath, status: SDKStatus, source: SDKSource)
 
     init(_ dependency: GraphDependency) {
@@ -68,9 +68,10 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
             hasher.combine(path)
         case let .xcframework(path, _, _, _):
             hasher.combine(path)
-        case let .product(target, productName):
+        case let .product(target, productName, platformFilter):
             hasher.combine(target)
             hasher.combine(productName)
+            hasher.combine(platformFilter)
         case let .sdk(path, status, source):
             hasher.combine(path)
             hasher.combine(status)
@@ -101,7 +102,7 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
             return lhsPath < rhsPath
         case let (.library(lhsPath, _, _, _), .library(rhsPath, _, _, _)):
             return lhsPath < rhsPath
-        case let (.product(lhsTarget, lhsProductName), .product(rhsTarget, rhsProductName)):
+        case let (.product(lhsTarget, lhsProductName, _), .product(rhsTarget, rhsProductName, _)):
             if lhsTarget == rhsTarget {
                 return lhsProductName < rhsProductName
             }

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -203,7 +203,7 @@ public class GraphTraverser: GraphTraversing {
             }
             .compactMap { graph.targets[$0.path]?[$0.name] }
             .filter { $0.product.isStatic }
-            .map { .product(target: $0.name, productName: $0.productNameWithExtension) } ?? [])
+            .map { .product(target: $0.name, productName: $0.productNameWithExtension, platformFilter: $0.deploymentTarget?.platformFilter) } ?? [])
     }
 
     public func embeddableFrameworks(path: AbsolutePath, name: String) -> Set<GraphDependencyReference> {
@@ -531,7 +531,7 @@ public class GraphTraverser: GraphTraversing {
     }
 
     func targetProductReference(target: GraphTarget) -> GraphDependencyReference {
-        .product(target: target.target.name, productName: target.target.productNameWithExtension)
+        .product(target: target.target.name, productName: target.target.productNameWithExtension, platformFilter: target.target.deploymentTarget?.platformFilter)
     }
 
     func isDependencyPrecompiledLibrary(dependency: GraphDependency) -> Bool {
@@ -661,7 +661,7 @@ public class GraphTraverser: GraphTraversing {
             )
         case let .target(name, path):
             guard let target = self.target(path: path, name: name) else { return nil }
-            return .product(target: target.target.name, productName: target.target.productNameWithExtension)
+            return .product(target: target.target.name, productName: target.target.productNameWithExtension, platformFilter: target.target.deploymentTarget?.platformFilter)
         case let .xcframework(path, infoPlist, primaryBinaryPath, _):
             return .xcframework(
                 path: path,

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -531,7 +531,11 @@ public class GraphTraverser: GraphTraversing {
     }
 
     func targetProductReference(target: GraphTarget) -> GraphDependencyReference {
-        .product(target: target.target.name, productName: target.target.productNameWithExtension, platformFilter: target.target.deploymentTarget?.platformFilter)
+        .product(
+            target: target.target.name,
+            productName: target.target.productNameWithExtension,
+            platformFilter: target.target.deploymentTarget?.platformFilter
+        )
     }
 
     func isDependencyPrecompiledLibrary(dependency: GraphDependency) -> Bool {
@@ -661,7 +665,11 @@ public class GraphTraverser: GraphTraversing {
             )
         case let .target(name, path):
             guard let target = self.target(path: path, name: name) else { return nil }
-            return .product(target: target.target.name, productName: target.target.productNameWithExtension, platformFilter: target.target.deploymentTarget?.platformFilter)
+            return .product(
+                target: target.target.name,
+                productName: target.target.productNameWithExtension,
+                platformFilter: target.target.deploymentTarget?.platformFilter
+            )
         case let .xcframework(path, infoPlist, primaryBinaryPath, _):
             return .xcframework(
                 path: path,

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -234,7 +234,7 @@ final class LinkGenerator: LinkGenerating {
             case .sdk:
                 // Do nothing
                 break
-            case let .product(target, _):
+            case let .product(target, _, platformFilter):
                 guard let fileRef = fileElements.product(target: target) else {
                     throw LinkGeneratorError.missingProduct(name: target)
                 }
@@ -242,6 +242,7 @@ final class LinkGenerator: LinkGenerating {
                     file: fileRef,
                     settings: ["ATTRIBUTES": ["CodeSignOnCopy", "RemoveHeadersOnCopy"]]
                 )
+                buildFile.platformFilter = platformFilter
                 pbxproj.add(object: buildFile)
                 embedPhase.files?.append(buildFile)
             }
@@ -382,11 +383,12 @@ final class LinkGenerator: LinkGenerating {
                     try addBuildFile(path)
                 case let .xcframework(path, _, _, _):
                     try addBuildFile(path)
-                case let .product(target, _):
+                case let .product(target, _, platformFilter):
                     guard let fileRef = fileElements.product(target: target) else {
                         throw LinkGeneratorError.missingProduct(name: target)
                     }
                     let buildFile = PBXBuildFile(file: fileRef)
+                    buildFile.platformFilter = platformFilter
                     pbxproj.add(object: buildFile)
                     buildPhase.files?.append(buildFile)
                 case let .sdk(sdkPath, sdkStatus, _):
@@ -441,12 +443,13 @@ final class LinkGenerator: LinkGenerating {
     {
         var files: [PBXBuildFile] = []
 
-        for case let .product(target, _) in dependencies.sorted() {
+        for case let .product(target, _, platformFilter) in dependencies.sorted() {
             guard let fileRef = fileElements.product(target: target) else {
                 throw LinkGeneratorError.missingProduct(name: target)
             }
 
             let buildFile = PBXBuildFile(file: fileRef)
+            buildFile.platformFilter = platformFilter
             pbxproj.add(object: buildFile)
             files.append(buildFile)
         }

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -226,7 +226,7 @@ class ProjectFileElements {
                     toGroup: groups.frameworks,
                     pbxproj: pbxproj
                 )
-            case let .product(target: target, productName: productName):
+            case let .product(target: target, productName: productName, _):
                 generateProduct(
                     targetName: target,
                     productName: productName,

--- a/Sources/TuistGraph/Models/DeploymentTarget.swift
+++ b/Sources/TuistGraph/Models/DeploymentTarget.swift
@@ -16,6 +16,23 @@ public enum DeploymentTarget: Equatable, Codable {
         case .tvOS: return "tvOS"
         }
     }
+    
+    public var platformFilter: String? {
+        switch self {
+        case let .iOS(_, devices):
+            if devices == .mac {
+                return "maccatalyst"
+            }
+            
+            if !devices.contains(.mac) {
+                return "ios"
+            }
+            
+            return nil
+        default:
+            return nil
+        }
+    }
 
     public var version: String {
         switch self {


### PR DESCRIPTION
### Short description 📝

> This makes sure that `PBXBuildFile.platformFilter` is set with the correct value `ios` or `maccatalyst` when creating references to other targets in the workspace. This not being set (which fallbacks to `All Platforms`) caused an issue where we ended up getting `framework not found` for a framework that was iOS only and thus shouldn't be included in the resulting Catalyst app.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
