### PR TITLE
📦 [Dependencies.swift] Use `WorkspaceState.subpath` field to determine path of remote SPM dependencies

### DIFF
--- a/Sources/TuistDependencies/SwiftPackageManager/Models/WorkspaceState.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Models/WorkspaceState.swift
@@ -7,17 +7,24 @@ struct SwiftPackageManagerWorkspaceState: Decodable, Equatable {
     let object: Object
 
     struct Object: Decodable, Equatable {
+        /// The list of SPM dependencies
         let dependencies: [Dependency]
     }
 
     struct Dependency: Decodable, Equatable {
+        /// The package reference of the dependency
         let packageRef: PackageRef
+
+        /// The path of the remote dependency, relative to the checkouts folder
         let subpath: String
     }
 
     struct PackageRef: Decodable, Equatable {
+        /// The name of the dependency
         let name: String
+        /// The king of the dependency (either local or remote)
         let kind: String
+        /// The path of the local dependency
         let path: String
     }
 }

--- a/Sources/TuistDependencies/SwiftPackageManager/Models/WorkspaceState.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Models/WorkspaceState.swift
@@ -12,6 +12,7 @@ struct SwiftPackageManagerWorkspaceState: Decodable, Equatable {
 
     struct Dependency: Decodable, Equatable {
         let packageRef: PackageRef
+        let subpath: String
     }
 
     struct PackageRef: Decodable, Equatable {

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerGraphGenerator.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerGraphGenerator.swift
@@ -125,6 +125,8 @@ public final class SwiftPackageManagerGraphGenerator: SwiftPackageManagerGraphGe
                 result[product.name] = product.targets.map { .project(target: $0, path: Path(packageInfo.folder.pathString)) }
             }
         }
+
+        let packageToProject = Dictionary(uniqueKeysWithValues: packageInfos.map { ($0.name, Path($0.folder.pathString)) })
         let packageInfoDictionary = Dictionary(uniqueKeysWithValues: packageInfos.map { ($0.name, $0.info) })
         let externalProjects: [Path: ProjectDescription.Project] = try packageInfos.reduce(into: [:]) { result, packageInfo in
             let artifactsFolder = artifactsFolder.appending(component: packageInfo.name)
@@ -142,6 +144,7 @@ public final class SwiftPackageManagerGraphGenerator: SwiftPackageManagerGraphGe
                 productTypes: productTypes,
                 platforms: platforms,
                 deploymentTargets: deploymentTargets,
+                packageToProject: packageToProject,
                 productToPackage: productToPackage,
                 targetDependencyToFramework: targetDependencyToFramework
             )
@@ -161,6 +164,7 @@ extension ProjectDescription.Project {
         productTypes: [String: TuistGraph.Product],
         platforms: Set<TuistGraph.Platform>,
         deploymentTargets: Set<TuistGraph.DeploymentTarget>,
+        packageToProject: [String: Path],
         productToPackage: [String: String],
         targetDependencyToFramework: [String: Path]
     ) throws -> Self {
@@ -171,6 +175,7 @@ extension ProjectDescription.Project {
                 packageInfo: packageInfo,
                 packageInfos: packageInfos,
                 folder: folder,
+                packageToProject: packageToProject,
                 productTypes: productTypes,
                 platforms: platforms,
                 deploymentTargets: deploymentTargets,
@@ -193,6 +198,7 @@ extension ProjectDescription.Target {
         packageInfo: PackageInfo,
         packageInfos: [String: PackageInfo],
         folder: AbsolutePath,
+        packageToProject: [String: Path],
         productTypes: [String: TuistGraph.Product],
         platforms: Set<TuistGraph.Platform>,
         deploymentTargets: Set<TuistGraph.DeploymentTarget>,
@@ -226,6 +232,7 @@ extension ProjectDescription.Target {
             packageInfos: packageInfos,
             dependencies: target.dependencies,
             settings: target.settings,
+            packageToProject: packageToProject,
             productToPackage: productToPackage,
             targetDependencyToFramework: targetDependencyToFramework
         )
@@ -385,6 +392,7 @@ extension ProjectDescription.TargetDependency {
         packageInfos: [String: PackageInfo],
         dependencies: [PackageInfo.Target.Dependency],
         settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting],
+        packageToProject: [String: Path],
         productToPackage: [String: String],
         targetDependencyToFramework: [String: Path]
     ) throws -> [Self] {
@@ -393,10 +401,13 @@ extension ProjectDescription.TargetDependency {
             case let .target(name, _):
                 return [.target(name: name)]
             case let .product(name, package, _):
-                guard let targets = packageInfos[package]?.products.first(where: { $0.name == name })?.targets else {
+                guard
+                    let targets = packageInfos[package]?.products.first(where: { $0.name == name })?.targets,
+                    let projectPath = packageToProject[package]
+                else {
                     throw SwiftPackageManagerGraphGeneratorError.unknownProductDependency(name, package)
                 }
-                return targets.map { .project(target: $0, path: Path(RelativePath("../\(package)").pathString)) }
+                return targets.map { .project(target: $0, path: projectPath) }
             case let .byName(name, _):
                 if packageInfo.targets.contains(where: { $0.name == name }) {
                     if let framework = targetDependencyToFramework[name] {
@@ -405,10 +416,13 @@ extension ProjectDescription.TargetDependency {
                         return [.target(name: name)]
                     }
                 } else if let package = productToPackage[name] {
-                    guard let targets = packageInfos[package]?.products.first(where: { $0.name == name })?.targets else {
+                    guard
+                        let targets = packageInfos[package]?.products.first(where: { $0.name == name })?.targets,
+                        let projectPath = packageToProject[package]
+                    else {
                         throw SwiftPackageManagerGraphGeneratorError.unknownProductDependency(name, package)
                     }
-                    return targets.map { .project(target: $0, path: Path(RelativePath("../\(package)").pathString)) }
+                    return targets.map { .project(target: $0, path: projectPath) }
                 } else {
                     throw SwiftPackageManagerGraphGeneratorError.unknownByNameDependency(name)
                 }

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerGraphGenerator.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerGraphGenerator.swift
@@ -372,7 +372,7 @@ extension ResourceFileElements {
 
 extension ProjectDescription.Headers {
     fileprivate static func from(path: AbsolutePath, publicHeadersPath: String?) -> Self? {
-        let headersPath = publicHeadersPath.map { path.appending(component: $0) } ?? path
+        let headersPath = publicHeadersPath.map { path.appending(RelativePath($0)) } ?? path
         let possibleHeaders = FileHandler.shared.filesAndDirectoriesContained(in: headersPath) ?? []
         let headers = possibleHeaders.filter { $0.extension == "h" }
         return headers.isEmpty ? nil : .init(public: .init(globs: headers.map { Path($0.pathString) }))

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerGraphGenerator.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerGraphGenerator.swift
@@ -100,7 +100,7 @@ public final class SwiftPackageManagerGraphGenerator: SwiftPackageManagerGraphGe
             let packageFolder: AbsolutePath
             switch dependency.packageRef.kind {
             case "remote":
-                packageFolder = checkoutsFolder.appending(component: name)
+                packageFolder = checkoutsFolder.appending(component: dependency.subpath)
             case "local":
                 packageFolder = AbsolutePath(dependency.packageRef.path)
             default:

--- a/Sources/TuistDependenciesTesting/DependenciesGraph/DependenciesGraph+TestData.swift
+++ b/Sources/TuistDependenciesTesting/DependenciesGraph/DependenciesGraph+TestData.swift
@@ -42,7 +42,7 @@ public extension TuistCore.DependenciesGraph {
     }
 
     // swiftlint:disable:next function_body_length
-    static func test(packageFolder: Path) -> Self {
+    static func test(spmFolder: Path, packageFolder: Path) -> Self {
         return .init(
             externalDependencies: [
                 "Tuist": [.project(target: "Tuist", path: packageFolder)],
@@ -67,8 +67,8 @@ public extension TuistCore.DependenciesGraph {
                             headers: .init(public: ["/an/header.h"]),
                             dependencies: [
                                 .target(name: "TuistKit"),
-                                .project(target: "ALibrary", path: "../a-dependency"),
-                                .project(target: "ALibraryUtils", path: "../a-dependency"),
+                                .project(target: "ALibrary", path: Self.packageFolder(spmFolder: spmFolder, packageName: "ADependency")),
+                                .project(target: "ALibraryUtils", path: Self.packageFolder(spmFolder: spmFolder, packageName: "ADependency")),
                             ],
                             settings: Self.spmSettings(with: [
                                 "HEADER_SEARCH_PATHS": .array(["cSearchPath", "cxxSearchPath"]),
@@ -90,7 +90,7 @@ public extension TuistCore.DependenciesGraph {
                                 "\(packageFolder.pathString)/Sources/TuistKit/**",
                             ],
                             dependencies: [
-                                .project(target: "AnotherLibrary", path: "../another-dependency"),
+                                .project(target: "AnotherLibrary", path: Self.packageFolder(spmFolder: spmFolder, packageName: "another-dependency")),
                             ],
                             settings: Self.spmSettings()
                         ),
@@ -243,11 +243,11 @@ public extension TuistCore.DependenciesGraph {
                             ],
                             dependencies: [
                                 .xcframework(path: "\(artifactsFolder.pathString)/GoogleAppMeasurement.xcframework"),
-                                .project(target: "GULAppDelegateSwizzler", path: "../GoogleUtilities"),
-                                .project(target: "GULMethodSwizzler", path: "../GoogleUtilities"),
-                                .project(target: "GULNSData", path: "../GoogleUtilities"),
-                                .project(target: "GULNetwork", path: "../GoogleUtilities"),
-                                .project(target: "nanopb", path: "../nanopb"),
+                                .project(target: "GULAppDelegateSwizzler", path: Self.packageFolder(spmFolder: spmFolder, packageName: "GoogleUtilities")),
+                                .project(target: "GULMethodSwizzler", path: Self.packageFolder(spmFolder: spmFolder, packageName: "GoogleUtilities")),
+                                .project(target: "GULNSData", path: Self.packageFolder(spmFolder: spmFolder, packageName: "GoogleUtilities")),
+                                .project(target: "GULNetwork", path: Self.packageFolder(spmFolder: spmFolder, packageName: "GoogleUtilities")),
+                                .project(target: "nanopb", path: Self.packageFolder(spmFolder: spmFolder, packageName: "nanopb")),
                                 .sdk(name: "sqlite3.tbd", status: .required),
                                 .sdk(name: "c++.tbd", status: .required),
                                 .sdk(name: "z.tbd", status: .required),
@@ -267,11 +267,11 @@ public extension TuistCore.DependenciesGraph {
                             ],
                             dependencies: [
                                 .xcframework(path: "\(artifactsFolder.pathString)/GoogleAppMeasurementWithoutAdIdSupport.xcframework"),
-                                .project(target: "GULAppDelegateSwizzler", path: "../GoogleUtilities"),
-                                .project(target: "GULMethodSwizzler", path: "../GoogleUtilities"),
-                                .project(target: "GULNSData", path: "../GoogleUtilities"),
-                                .project(target: "GULNetwork", path: "../GoogleUtilities"),
-                                .project(target: "nanopb", path: "../nanopb"),
+                                .project(target: "GULAppDelegateSwizzler", path: Self.packageFolder(spmFolder: spmFolder, packageName: "GoogleUtilities")),
+                                .project(target: "GULMethodSwizzler", path: Self.packageFolder(spmFolder: spmFolder, packageName: "GoogleUtilities")),
+                                .project(target: "GULNSData", path: Self.packageFolder(spmFolder: spmFolder, packageName: "GoogleUtilities")),
+                                .project(target: "GULNetwork", path: Self.packageFolder(spmFolder: spmFolder, packageName: "GoogleUtilities")),
+                                .project(target: "nanopb", path: Self.packageFolder(spmFolder: spmFolder, packageName: "nanopb")),
                                 .sdk(name: "sqlite3.tbd", status: .required),
                                 .sdk(name: "c++.tbd", status: .required),
                                 .sdk(name: "z.tbd", status: .required),

--- a/Sources/TuistDependenciesTesting/DependenciesGraph/DependenciesGraph+TestData.swift
+++ b/Sources/TuistDependenciesTesting/DependenciesGraph/DependenciesGraph+TestData.swift
@@ -243,7 +243,10 @@ public extension TuistCore.DependenciesGraph {
                             ],
                             dependencies: [
                                 .xcframework(path: "\(artifactsFolder.pathString)/GoogleAppMeasurement.xcframework"),
-                                .project(target: "GULAppDelegateSwizzler", path: Self.packageFolder(spmFolder: spmFolder, packageName: "GoogleUtilities")),
+                                .project(
+                                    target: "GULAppDelegateSwizzler",
+                                    path: Self.packageFolder(spmFolder: spmFolder, packageName: "GoogleUtilities")
+                                ),
                                 .project(target: "GULMethodSwizzler", path: Self.packageFolder(spmFolder: spmFolder, packageName: "GoogleUtilities")),
                                 .project(target: "GULNSData", path: Self.packageFolder(spmFolder: spmFolder, packageName: "GoogleUtilities")),
                                 .project(target: "GULNetwork", path: Self.packageFolder(spmFolder: spmFolder, packageName: "GoogleUtilities")),
@@ -267,7 +270,10 @@ public extension TuistCore.DependenciesGraph {
                             ],
                             dependencies: [
                                 .xcframework(path: "\(artifactsFolder.pathString)/GoogleAppMeasurementWithoutAdIdSupport.xcframework"),
-                                .project(target: "GULAppDelegateSwizzler", path: Self.packageFolder(spmFolder: spmFolder, packageName: "GoogleUtilities")),
+                                .project(
+                                    target: "GULAppDelegateSwizzler",
+                                    path: Self.packageFolder(spmFolder: spmFolder, packageName: "GoogleUtilities")
+                                ),
                                 .project(target: "GULMethodSwizzler", path: Self.packageFolder(spmFolder: spmFolder, packageName: "GoogleUtilities")),
                                 .project(target: "GULNSData", path: Self.packageFolder(spmFolder: spmFolder, packageName: "GoogleUtilities")),
                                 .project(target: "GULNetwork", path: Self.packageFolder(spmFolder: spmFolder, packageName: "GoogleUtilities")),

--- a/Sources/TuistDependenciesTesting/DependenciesGraph/DependenciesGraph+TestData.swift
+++ b/Sources/TuistDependenciesTesting/DependenciesGraph/DependenciesGraph+TestData.swift
@@ -102,7 +102,7 @@ public extension TuistCore.DependenciesGraph {
     }
 
     static func aDependency(spmFolder: Path) -> Self {
-        let packageFolder = Self.packageFolder(spmFolder: spmFolder, packageName: "a-dependency")
+        let packageFolder = Self.packageFolder(spmFolder: spmFolder, packageName: "ADependency")
         return .init(
             externalDependencies: [
                 "ALibrary": [

--- a/Sources/TuistDependenciesTesting/SwiftPackageManager/Models/PackageInfo+TestData.swift
+++ b/Sources/TuistDependenciesTesting/SwiftPackageManager/Models/PackageInfo+TestData.swift
@@ -105,7 +105,7 @@ extension PackageInfo {
               ],
               "name" : "Tuist",
               "path" : "customPath",
-              "publicHeadersPath" : "customPublicHeadersPath",
+              "publicHeadersPath" : "custom/Public/Headers/Path",
               "sources": [
                 "customSources"
               ],
@@ -248,7 +248,7 @@ extension PackageInfo {
                         .target(name: "TuistKit", condition: nil),
                         .product(name: "ALibrary", package: "a-dependency", condition: .init(platformNames: ["ios"], config: nil)),
                     ],
-                    publicHeadersPath: "customPublicHeadersPath",
+                    publicHeadersPath: "custom/Public/Headers/Path",
                     type: .regular,
                     settings: [
                         .init(tool: .c, name: .headerSearchPath, condition: nil, value: ["cSearchPath"]),

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
@@ -137,7 +137,13 @@ class SwiftPackageManagerGraphGeneratorTests: TuistTestCase {
             ]
             """,
             stubFilesAndDirectoriesContained: { path in
-                guard path == testPath.appending(component: "customPath").appending(component: "customPublicHeadersPath") else {
+                guard path == testPath
+                        .appending(component: "customPath")
+                        .appending(component: "custom")
+                        .appending(component: "Public")
+                        .appending(component: "Headers")
+                        .appending(component: "Path")
+                else {
                     return nil
                 }
 

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
@@ -138,11 +138,11 @@ class SwiftPackageManagerGraphGeneratorTests: TuistTestCase {
             """,
             stubFilesAndDirectoriesContained: { path in
                 guard path == testPath
-                        .appending(component: "customPath")
-                        .appending(component: "custom")
-                        .appending(component: "Public")
-                        .appending(component: "Headers")
-                        .appending(component: "Path")
+                    .appending(component: "customPath")
+                    .appending(component: "custom")
+                    .appending(component: "Public")
+                    .appending(component: "Headers")
+                    .appending(component: "Path")
                 else {
                     return nil
                 }

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
@@ -168,7 +168,7 @@ class SwiftPackageManagerGraphGeneratorTests: TuistTestCase {
             deploymentTargets: [
                 .iOS("13.0", [.iphone, .ipad, .mac]),
             ],
-            dependenciesGraph: .test(packageFolder: Path(testPath.pathString))
+            dependenciesGraph: .test(spmFolder: spmFolder, packageFolder: Path(testPath.pathString))
                 .merging(with: .aDependency(spmFolder: spmFolder))
                 .merging(with: .anotherDependency(spmFolder: spmFolder))
         )

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
@@ -37,7 +37,8 @@ class SwiftPackageManagerGraphGeneratorTests: TuistTestCase {
                   "kind": "remote",
                   "name": "Alamofire",
                   "path": "https://github.com/Alamofire/Alamofire"
-                }
+                },
+                "subpath": "Alamofire"
               }
             ]
             """,
@@ -58,21 +59,24 @@ class SwiftPackageManagerGraphGeneratorTests: TuistTestCase {
                   "kind": "remote",
                   "name": "GoogleAppMeasurement",
                   "path": "https://github.com/google/GoogleAppMeasurement"
-                }
+                },
+                "subpath": "GoogleAppMeasurement"
               },
               {
                 "packageRef": {
                   "kind": "remote",
                   "name": "GoogleUtilities",
                   "path": "https://github.com/google/GoogleUtilities"
-                }
+                },
+                "subpath": "GoogleUtilities"
               },
               {
                 "packageRef": {
                   "kind": "remote",
                   "name": "nanopb",
                   "path": "https://github.com/nanopb/nanopb"
-                }
+                },
+                "subpath": "nanopb"
               }
             ]
             """,
@@ -111,21 +115,24 @@ class SwiftPackageManagerGraphGeneratorTests: TuistTestCase {
                   "kind": "local",
                   "name": "test",
                   "path": "\(testPath.pathString)"
-                }
+                },
+                "subpath": "test"
               },
               {
                 "packageRef": {
                   "kind": "remote",
                   "name": "a-dependency",
                   "path": "https://github.com/dependencies/a-dependency"
-                }
+                },
+                "subpath": "ADependency"
               },
               {
                 "packageRef": {
                   "kind": "remote",
                   "name": "another-dependency",
                   "path": "https://github.com/dependencies/another-dependency"
-                }
+                },
+                "subpath": "another-dependency"
               }
             ]
             """,
@@ -143,7 +150,7 @@ class SwiftPackageManagerGraphGeneratorTests: TuistTestCase {
                 switch packagePath {
                 case testPath:
                     return PackageInfo.test
-                case self.checkoutsPath.appending(component: "a-dependency"):
+                case self.checkoutsPath.appending(component: "ADependency"):
                     return PackageInfo.aDependency
                 case self.checkoutsPath.appending(component: "another-dependency"):
                     return PackageInfo.anotherDependency

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
@@ -46,7 +46,7 @@ class SwiftPackageManagerGraphGeneratorTests: TuistTestCase {
                 XCTAssertEqual(packagePath, self.path.appending(component: "checkouts").appending(component: "Alamofire"))
                 return PackageInfo.alamofire
             },
-            dependenciesGraph: .alamofire(spmFolder: spmFolder)
+            dependenciesGraph: DependenciesGraph.alamofire(spmFolder: spmFolder)
         )
     }
 
@@ -93,15 +93,15 @@ class SwiftPackageManagerGraphGeneratorTests: TuistTestCase {
                     return .test
                 }
             },
-            dependenciesGraph: try .googleAppMeasurement(spmFolder: spmFolder)
-                .merging(with: .googleUtilities(
+            dependenciesGraph: try DependenciesGraph.googleAppMeasurement(spmFolder: spmFolder)
+                .merging(with: DependenciesGraph.googleUtilities(
                     spmFolder: spmFolder,
                     customProductTypes: [
                         "GULMethodSwizzler": .framework,
                         "GULNetwork": .dynamicLibrary,
                     ]
                 ))
-                .merging(with: .nanopb(spmFolder: spmFolder))
+                .merging(with: DependenciesGraph.nanopb(spmFolder: spmFolder))
         )
     }
 
@@ -168,9 +168,9 @@ class SwiftPackageManagerGraphGeneratorTests: TuistTestCase {
             deploymentTargets: [
                 .iOS("13.0", [.iphone, .ipad, .mac]),
             ],
-            dependenciesGraph: .test(spmFolder: spmFolder, packageFolder: Path(testPath.pathString))
-                .merging(with: .aDependency(spmFolder: spmFolder))
-                .merging(with: .anotherDependency(spmFolder: spmFolder))
+            dependenciesGraph: DependenciesGraph.test(spmFolder: spmFolder, packageFolder: Path(testPath.pathString))
+                .merging(with: DependenciesGraph.aDependency(spmFolder: spmFolder))
+                .merging(with: DependenciesGraph.anotherDependency(spmFolder: spmFolder))
         )
     }
 


### PR DESCRIPTION
### Short description 📝

Some SPM packages are downloaded in a directory with a name different from the SPM package `name`

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
