### PR TITLE
Fix invalid ProjectDescription and ProjectAutomation frameworks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - projects/tuistbench/**
 
-concurrency: 
+concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: true
 
@@ -22,7 +22,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        xcode: ['12', '12.4']
+        xcode: ['12.2', '12.4']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ on:
       - projects/fixturegen/**
       - projects/tuistbench/**
 
-concurrency: 
+concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: true
 
@@ -26,7 +26,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        xcode: ['12', '12.4']
+        xcode: ['12.2', '12.4']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode ${{ matrix.xcode }}
@@ -51,7 +51,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        xcode: ['12', '12.4']
+        xcode: ['12.2', '12.4']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/fixture-generator.yml
+++ b/.github/workflows/fixture-generator.yml
@@ -11,7 +11,7 @@ on:
       - Package.resolved
       - Sources/**
 
-concurrency: 
+concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: true
 
@@ -24,7 +24,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        xcode: ['12', '12.4']
+        xcode: ['12.2', '12.4']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/meta-tuist.yml
+++ b/.github/workflows/meta-tuist.yml
@@ -14,7 +14,7 @@ on:
       - projects/tuist/features/**
       - Project.swift
 
-concurrency: 
+concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: true
 
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        xcode: ['12', '12.4']
+        xcode: ['12.2', '12.4']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
@@ -57,7 +57,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        xcode: ['12', '12.4']
+        xcode: ['12.2', '12.4']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        xcode: ['12']
+        xcode: ['12.2']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,0 +1,46 @@
+name: Release dry-run
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - Gemfile*
+      - Package.swift
+      - Package.resolved
+      - Sources/**
+      - Project.swift
+      - projects/fourier/**
+
+env:
+  RUBY_VERSION: '3.0.1'
+  TUIST_STATS_OPT_OUT: true
+
+jobs:
+  bundle-all:
+    name: Bundle tuist and tuistenv with Xcode ${{ matrix.xcode }}
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        xcode: ['12']
+    steps:
+      - uses: actions/checkout@v1
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Build
+        run: |
+          ./fourier bundle all

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -14,7 +14,7 @@ on:
       - projects/tuist/features/**
       - projects/tuist/fixtures/**
 
-concurrency: 
+concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: true
 
@@ -109,7 +109,7 @@ jobs:
             'test',
             'up',
             'graph',
-            'tasks'
+            'tasks',
           ]
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        xcode: ['12', '12.4']
+        xcode: ['12.2', '12.4']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
@@ -61,7 +61,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        xcode: ['12', '12.4']
+        xcode: ['12.2', '12.4']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
     google-cloud-env (1.5.0)
       faraday (>= 0.17.3, < 2.0)
     google-cloud-errors (1.1.0)
-    google-cloud-storage (1.34.0)
+    google-cloud-storage (1.34.1)
       addressable (~> 2.5)
       digest-crc (~> 0.4)
       google-apis-iamcredentials_v1 (~> 0.1)
@@ -189,6 +189,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0704)
     mini_mime (1.1.0)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
     minitest-reporters (1.4.3)
       ansi
@@ -204,14 +205,15 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
-    nokogiri (1.11.7-x86_64-darwin)
+    nokogiri (1.11.7)
+      mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     octokit (4.21.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     os (1.1.1)
     parallel (1.20.1)
-    parser (3.0.1.1)
+    parser (3.0.2.0)
       ast (~> 2.4.1)
     protobuf-cucumber (3.10.8)
       activesupport (>= 3.2)
@@ -235,7 +237,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
-    rake (13.0.5)
+    rake (13.0.6)
     regexp_parser (2.1.1)
     representable (3.1.1)
       declarative (< 0.1.0)
@@ -314,7 +316,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
-  x86_64-darwin-20
+  ruby
 
 DEPENDENCIES
   byebug (~> 11.1)
@@ -350,4 +352,4 @@ RUBY VERSION
    ruby 3.0.1p64
 
 BUNDLED WITH
-   2.2.19
+   2.2.21

--- a/projects/fourier/lib/fourier/services/bundle/tuist.rb
+++ b/projects/fourier/lib/fourier/services/bundle/tuist.rb
@@ -43,12 +43,10 @@ module Fourier
                   "zip", "-q", "-r", "--symlinks",
                   output_zip_path,
                   "tuist",
-                  "ProjectDescription.swiftmodule/",
-                  "libProjectDescription.dylib",
-                  "ProjectDescription.swiftinterface/",
-                  "ProjectAutomation.swiftmodule/",
-                  "libProjectAutomation.dylib",
-                  "ProjectAutomation.swiftinterface/",
+                  "ProjectDescription.framework",
+                  "ProjectDescription.framework.dSYM",
+                  "ProjectAutomation.framework",
+                  "ProjectAutomation.framework.dSYM",
                   "Templates",
                   "vendor"
                 )
@@ -70,17 +68,9 @@ module Fourier
 
           def build_project_library(name:, output_directory:, swift_build_directory:)
             Utilities::Output.section("Building #{name}...")
-            Utilities::System.system(
-              "swift", "build",
-              "--product", name,
-              "--configuration", "release",
-              "--build-path", swift_build_directory,
-              "--package-path", Constants::ROOT_DIRECTORY
-            )
             Utilities::SwiftPackageManager.build_fat_release_library(
               path: Constants::ROOT_DIRECTORY,
               product: name,
-              binary_name: "lib#{name}.dylib",
               output_directory: output_directory,
               swift_build_directory: swift_build_directory
             )


### PR DESCRIPTION
### Short description 📝
After updating the release logic to build all the binaries as fat binaries that include the `arm64` architecture *(M1)*, Tuist fails to run with Xcode versions other than the one used for releasing Tuist. The issue seems to come from an invalid `.swiftinterface`.
