### PR TITLE
📦 [Dependencies.swift] Ignore package internal targets during project generation

### DIFF
--- a/Sources/TuistDependenciesTesting/SwiftPackageManager/Models/PackageInfo+TestData.swift
+++ b/Sources/TuistDependenciesTesting/SwiftPackageManager/Models/PackageInfo+TestData.swift
@@ -198,10 +198,30 @@ extension PackageInfo {
               "type" : "regular"
             },
             {
+              "dependencies" : [],
+              "exclude" : [
+
+              ],
+              "name" : "TestUtilities",
+              "resources" : [
+
+              ],
+              "settings" : [
+
+              ],
+              "type" : "regular"
+            },
+            {
               "dependencies" : [
                 {
                   "byName" : [
                     "TuistKit",
+                    null
+                  ]
+                },
+                {
+                  "byName" : [
+                    "TestUtilities",
                     null
                   ]
                 }
@@ -278,6 +298,19 @@ extension PackageInfo {
                     checksum: nil
                 ),
                 .init(
+                    name: "TestUtilities",
+                    path: nil,
+                    url: nil,
+                    sources: nil,
+                    resources: [],
+                    exclude: [],
+                    dependencies: [],
+                    publicHeadersPath: nil,
+                    type: .regular,
+                    settings: [],
+                    checksum: nil
+                ),
+                .init(
                     name: "TuistKitTests",
                     path: nil,
                     url: nil,
@@ -286,6 +319,7 @@ extension PackageInfo {
                     exclude: [],
                     dependencies: [
                         .byName(name: "TuistKit", condition: nil),
+                        .byName(name: "TestUtilities", condition: nil),
                     ],
                     publicHeadersPath: nil,
                     type: .test,


### PR DESCRIPTION
### Short description 📝

Avoid creating Tuist targets for packages which are not part of a product (either directly or indirectly as a dependency)

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
