### PR TITLE
📦 [Dependencies.swift] - #3164 Appendix

### DIFF
--- a/Sources/TuistDependencies/Carthage/Utils/CarthageGraphGenerator.swift
+++ b/Sources/TuistDependencies/Carthage/Utils/CarthageGraphGenerator.swift
@@ -29,21 +29,21 @@ public final class CarthageGraphGenerator: CarthageGraphGenerating {
         let thirdPartyDependencies: [String: ThirdPartyDependency] = Dictionary(grouping: products, by: \.name)
             .compactMapValues { products in
                 guard let product = products.first else { return nil }
-
-                if let xcFrameworkName = product.container {
-                    let path = AbsolutePath("/")
-                        .appending(components: [
-                            Constants.tuistDirectoryName,
-                            Constants.DependenciesDirectory.name,
-                            Constants.DependenciesDirectory.carthageDirectoryName,
-                            xcFrameworkName,
-                        ])
-
-                    return .xcframework(path: path)
+                
+                guard let xcFrameworkName = product.container else {
+                    logger.warning("\(product.name) was not added to the DependenciesGraph.")
+                    return nil
                 }
+                
+                let path = AbsolutePath("/")
+                    .appending(components: [
+                        Constants.tuistDirectoryName,
+                        Constants.DependenciesDirectory.name,
+                        Constants.DependenciesDirectory.carthageDirectoryName,
+                        xcFrameworkName,
+                    ])
 
-                logger.info("\(product.name) was not added to the DependenciesGraph", metadata: .subsection)
-                return nil
+                return .xcframework(path: path)
             }
 
         return DependenciesGraph(thirdPartyDependencies: thirdPartyDependencies)

--- a/Sources/TuistGraph/DependenciesGraph/ThirdPartyDependency.swift
+++ b/Sources/TuistGraph/DependenciesGraph/ThirdPartyDependency.swift
@@ -5,8 +5,6 @@ import TSCBasic
 public enum ThirdPartyDependency: Hashable, Equatable, Codable {
     /// A dependency that represents a pre-compiled .xcframework.
     case xcframework(path: AbsolutePath)
-    /// A dependency that represents a pre-compiled .framework.
-    case framework(path: AbsolutePath)
 }
 
 // MARK: - Codable
@@ -14,7 +12,6 @@ public enum ThirdPartyDependency: Hashable, Equatable, Codable {
 extension ThirdPartyDependency {
     private enum Kind: String, Codable {
         case xcframework
-        case framework
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -29,9 +26,6 @@ extension ThirdPartyDependency {
         case .xcframework:
             let path = try container.decode(AbsolutePath.self, forKey: .path)
             self = .xcframework(path: path)
-        case .framework:
-            let path = try container.decode(AbsolutePath.self, forKey: .path)
-            self = .framework(path: path)
         }
     }
 
@@ -40,9 +34,6 @@ extension ThirdPartyDependency {
         switch self {
         case let .xcframework(path):
             try container.encode(Kind.xcframework, forKey: .kind)
-            try container.encode(path, forKey: .path)
-        case let .framework(path):
-            try container.encode(Kind.framework, forKey: .kind)
             try container.encode(path, forKey: .path)
         }
     }


### PR DESCRIPTION
#3164 Appendix

1. `ThirdPartyDependency.framework` (added in #3164) was removed since we decided to implement it in the separate PR following #3174.
2. Log message in `CarthageGraphGenerator` was moved to warning level. 

<img width="334" alt="Zrzut ekranu 2021-07-12 o 16 27 54" src="https://user-images.githubusercontent.com/4774319/125304753-2002fe80-e32e-11eb-9006-74b0dd3ac99b.png">
