### PR TITLE
Fix hashing of target dependencies

### DIFF
--- a/Sources/TuistCache/ContentHashing/DependenciesContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/DependenciesContentHasher.swift
@@ -1,10 +1,10 @@
 import Foundation
+import TSCBasic
 import TuistCore
 import TuistGraph
-import TSCBasic
 
 public protocol DependenciesContentHashing {
-    func hash(graphTarget: GraphTarget) throws -> String
+    func hash(graphTarget: GraphTarget, hashedTargets: inout [GraphTarget: String]) throws -> String
 }
 
 /// `DependencyContentHasher`
@@ -20,14 +20,14 @@ public final class DependenciesContentHasher: DependenciesContentHashing {
 
     // MARK: - DependenciesContentHashing
 
-    public func hash(graphTarget: GraphTarget) throws -> String {
-        let hashes = graphTarget.target.dependencies.map { try? hash(dependency: $0) }
+    public func hash(graphTarget: GraphTarget, hashedTargets: inout [GraphTarget: String]) throws -> String {
+        let hashes = graphTarget.target.dependencies.map { try? hash(dependency: $0, hashedTargets: &hashedTargets) }
         return hashes.compactMap { $0 }.joined()
     }
 
     // MARK: - Private
 
-    private func hash(dependency: TargetDependency) throws -> String {
+    private func hash(dependency: TargetDependency, hashedTargets _: inout [GraphTarget: String]) throws -> String {
         switch dependency {
         case let .target(name):
             return try contentHasher.hash("target-\(name)")

--- a/Sources/TuistCache/ContentHashing/DependenciesContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/DependenciesContentHasher.swift
@@ -1,9 +1,10 @@
 import Foundation
 import TuistCore
 import TuistGraph
+import TSCBasic
 
 public protocol DependenciesContentHashing {
-    func hash(dependencies: [TargetDependency]) throws -> String
+    func hash(graphTarget: GraphTarget) throws -> String
 }
 
 /// `DependencyContentHasher`
@@ -19,8 +20,8 @@ public final class DependenciesContentHasher: DependenciesContentHashing {
 
     // MARK: - DependenciesContentHashing
 
-    public func hash(dependencies: [TargetDependency]) throws -> String {
-        let hashes = dependencies.map { try? hash(dependency: $0) }
+    public func hash(graphTarget: GraphTarget) throws -> String {
+        let hashes = graphTarget.target.dependencies.map { try? hash(dependency: $0) }
         return hashes.compactMap { $0 }.joined()
     }
 

--- a/Sources/TuistCache/ContentHashing/DependenciesContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/DependenciesContentHasher.swift
@@ -10,16 +10,16 @@ public protocol DependenciesContentHashing {
 
 enum DependenciesContentHasherError: FatalError, Equatable {
     case missingTargetHash(
-            sourceTargetName: String,
-            dependencyProjectPath: AbsolutePath,
-            dependencyTargetName: String
-         )
+        sourceTargetName: String,
+        dependencyProjectPath: AbsolutePath,
+        dependencyTargetName: String
+    )
     case missingProjectTargetHash(
-            sourceProjectPath: AbsolutePath,
-            sourceTargetName: String,
-            dependencyProjectPath: AbsolutePath,
-            dependencyTargetName: String
-        )
+        sourceProjectPath: AbsolutePath,
+        sourceTargetName: String,
+        dependencyProjectPath: AbsolutePath,
+        dependencyTargetName: String
+    )
 
     var description: String {
         switch self {
@@ -29,7 +29,7 @@ enum DependenciesContentHasherError: FatalError, Equatable {
             return "The target '\(sourceTargetName)' from project at path \(sourceProjectPath.pathString) depends on the target '\(dependencyTargetName)' from the project at path \(dependencyProjectPath.pathString) whose hash hasn't been previously calculated."
         }
     }
-    
+
     var type: ErrorType {
         switch self {
         case .missingTargetHash: return .bug
@@ -62,17 +62,21 @@ public final class DependenciesContentHasher: DependenciesContentHashing {
         switch dependency {
         case let .target(targetName):
             guard let dependencyHash = hashedTargets[GraphHashedTarget(projectPath: graphTarget.path, targetName: targetName)] else {
-                throw DependenciesContentHasherError.missingTargetHash(sourceTargetName: graphTarget.target.name,
-                                                                       dependencyProjectPath: graphTarget.path,
-                                                                       dependencyTargetName: targetName)
+                throw DependenciesContentHasherError.missingTargetHash(
+                    sourceTargetName: graphTarget.target.name,
+                    dependencyProjectPath: graphTarget.path,
+                    dependencyTargetName: targetName
+                )
             }
             return dependencyHash
         case let .project(targetName, projectPath):
             guard let dependencyHash = hashedTargets[GraphHashedTarget(projectPath: projectPath, targetName: targetName)] else {
-                throw DependenciesContentHasherError.missingProjectTargetHash(sourceProjectPath: graphTarget.path,
-                                                                              sourceTargetName: graphTarget.target.name,
-                                                                              dependencyProjectPath: projectPath,
-                                                                              dependencyTargetName: targetName)
+                throw DependenciesContentHasherError.missingProjectTargetHash(
+                    sourceProjectPath: graphTarget.path,
+                    sourceTargetName: graphTarget.target.name,
+                    dependencyProjectPath: projectPath,
+                    dependencyTargetName: targetName
+                )
             }
             return dependencyHash
         case let .framework(path):

--- a/Sources/TuistCache/ContentHashing/DependenciesContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/DependenciesContentHasher.swift
@@ -2,9 +2,40 @@ import Foundation
 import TSCBasic
 import TuistCore
 import TuistGraph
+import TuistSupport
 
 public protocol DependenciesContentHashing {
-    func hash(graphTarget: GraphTarget, hashedTargets: inout [GraphTarget: String]) throws -> String
+    func hash(graphTarget: GraphTarget, hashedTargets: inout [GraphHashedTarget: String]) throws -> String
+}
+
+enum DependenciesContentHasherError: FatalError, Equatable {
+    case missingTargetHash(
+            sourceTargetName: String,
+            dependencyProjectPath: AbsolutePath,
+            dependencyTargetName: String
+         )
+    case missingProjectTargetHash(
+            sourceProjectPath: AbsolutePath,
+            sourceTargetName: String,
+            dependencyProjectPath: AbsolutePath,
+            dependencyTargetName: String
+        )
+
+    var description: String {
+        switch self {
+        case let .missingTargetHash(sourceTargetName, dependencyProjectPath, dependencyTargetName):
+            return "The target '\(sourceTargetName)' depends on the target '\(dependencyTargetName)' from the same project at path \(dependencyProjectPath.pathString) whose hash hasn't been previously calculated."
+        case let .missingProjectTargetHash(sourceProjectPath, sourceTargetName, dependencyProjectPath, dependencyTargetName):
+            return "The target '\(sourceTargetName)' from project at path \(sourceProjectPath.pathString) depends on the target '\(dependencyTargetName)' from the project at path \(dependencyProjectPath.pathString) whose hash hasn't been previously calculated."
+        }
+    }
+    
+    var type: ErrorType {
+        switch self {
+        case .missingTargetHash: return .bug
+        case .missingProjectTargetHash: return .bug
+        }
+    }
 }
 
 /// `DependencyContentHasher`
@@ -20,20 +51,30 @@ public final class DependenciesContentHasher: DependenciesContentHashing {
 
     // MARK: - DependenciesContentHashing
 
-    public func hash(graphTarget: GraphTarget, hashedTargets: inout [GraphTarget: String]) throws -> String {
-        let hashes = graphTarget.target.dependencies.map { try? hash(dependency: $0, hashedTargets: &hashedTargets) }
+    public func hash(graphTarget: GraphTarget, hashedTargets: inout [GraphHashedTarget: String]) throws -> String {
+        let hashes = try graphTarget.target.dependencies.map { try hash(graphTarget: graphTarget, dependency: $0, hashedTargets: &hashedTargets) }
         return hashes.compactMap { $0 }.joined()
     }
 
     // MARK: - Private
 
-    private func hash(dependency: TargetDependency, hashedTargets _: inout [GraphTarget: String]) throws -> String {
+    private func hash(graphTarget: GraphTarget, dependency: TargetDependency, hashedTargets: inout [GraphHashedTarget: String]) throws -> String {
         switch dependency {
-        case let .target(name):
-            return try contentHasher.hash("target-\(name)")
-        case let .project(target, path):
-            let projectHash = try contentHasher.hash(path: path)
-            return try contentHasher.hash("project-\(projectHash)-\(target)")
+        case let .target(targetName):
+            guard let dependencyHash = hashedTargets[GraphHashedTarget(projectPath: graphTarget.path, targetName: targetName)] else {
+                throw DependenciesContentHasherError.missingTargetHash(sourceTargetName: graphTarget.target.name,
+                                                                       dependencyProjectPath: graphTarget.path,
+                                                                       dependencyTargetName: targetName)
+            }
+            return dependencyHash
+        case let .project(targetName, projectPath):
+            guard let dependencyHash = hashedTargets[GraphHashedTarget(projectPath: projectPath, targetName: targetName)] else {
+                throw DependenciesContentHasherError.missingProjectTargetHash(sourceProjectPath: graphTarget.path,
+                                                                              sourceTargetName: graphTarget.target.name,
+                                                                              dependencyProjectPath: projectPath,
+                                                                              dependencyTargetName: targetName)
+            }
+            return dependencyHash
         case let .framework(path):
             return try contentHasher.hash(path: path)
         case let .xcFramework(path):

--- a/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
@@ -69,7 +69,8 @@ public final class GraphContentHasher: GraphContentHashing {
             successors: {
                 Array(graphTraverser.directTargetDependencies(path: $0.path, name: $0.target.name))
             }
-        )
+        ).reversed()
+
         let hashableTargets = sortedCacheableTargets.compactMap { target -> GraphTarget? in
             if isHashable(
                 target,

--- a/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
@@ -62,7 +62,7 @@ public final class GraphContentHasher: GraphContentHashing {
     ) throws -> [GraphTarget: String] {
         let graphTraverser = GraphTraverser(graph: graph)
         var visitedIsHasheableNodes: [GraphTarget: Bool] = [:]
-        var hashedTargets: [GraphTarget: String] = [:]
+        var hashedTargets: [GraphHashedTarget: String] = [:]
 
         let sortedCacheableTargets = try topologicalSort(
             Array(graphTraverser.allTargets()),
@@ -88,7 +88,7 @@ public final class GraphContentHasher: GraphContentHashing {
                 hashedTargets: &hashedTargets,
                 additionalStrings: additionalStrings
             )
-            hashedTargets[target] = hash
+            hashedTargets[GraphHashedTarget(projectPath: target.path, targetName: target.target.name)] = hash
             return hash
         }
         return Dictionary(uniqueKeysWithValues: zip(hashableTargets, hashes))

--- a/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
@@ -61,7 +61,8 @@ public final class GraphContentHasher: GraphContentHashing {
         additionalStrings: [String]
     ) throws -> [GraphTarget: String] {
         let graphTraverser = GraphTraverser(graph: graph)
-        var visitedNodes: [GraphTarget: Bool] = [:]
+        var visitedIsHasheableNodes: [GraphTarget: Bool] = [:]
+        var hashedTargets: [GraphTarget: String] = [:]
 
         let sortedCacheableTargets = try topologicalSort(
             Array(graphTraverser.allTargets()),
@@ -73,7 +74,7 @@ public final class GraphContentHasher: GraphContentHashing {
             if isHashable(
                 target,
                 graphTraverser: graphTraverser,
-                visited: &visitedNodes,
+                visited: &visitedIsHasheableNodes,
                 filter: filter
             ) {
                 return target
@@ -81,11 +82,14 @@ public final class GraphContentHasher: GraphContentHashing {
                 return nil
             }
         }
-        let hashes = try hashableTargets.map {
-            try targetContentHasher.contentHash(
-                for: $0,
+        let hashes = try hashableTargets.map { (target: GraphTarget) -> String in
+            let hash = try targetContentHasher.contentHash(
+                for: target,
+                hashedTargets: &hashedTargets,
                 additionalStrings: additionalStrings
             )
+            hashedTargets[target] = hash
+            return hash
         }
         return Dictionary(uniqueKeysWithValues: zip(hashableTargets, hashes))
     }

--- a/Sources/TuistCache/ContentHashing/GraphHashedTarget.swift
+++ b/Sources/TuistCache/ContentHashing/GraphHashedTarget.swift
@@ -1,0 +1,12 @@
+import Foundation
+import TSCBasic
+
+/// It represents a target that has been hashed.
+public struct GraphHashedTarget: Equatable, Hashable {
+    
+    /// Path to the directory containing the project.
+    let projectPath: AbsolutePath
+    
+    /// Name of the hashed target.
+    let targetName: String
+}

--- a/Sources/TuistCache/ContentHashing/GraphHashedTarget.swift
+++ b/Sources/TuistCache/ContentHashing/GraphHashedTarget.swift
@@ -3,10 +3,9 @@ import TSCBasic
 
 /// It represents a target that has been hashed.
 public struct GraphHashedTarget: Equatable, Hashable {
-    
     /// Path to the directory containing the project.
     let projectPath: AbsolutePath
-    
+
     /// Name of the hashed target.
     let targetName: String
 }

--- a/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
@@ -74,24 +74,20 @@ public final class TargetContentHasher: TargetContentHashing {
         try contentHash(for: target, additionalStrings: [])
     }
 
-    public func contentHash(for target: GraphTarget, additionalStrings: [String]) throws -> String {
-        try contentHash(for: target.target, additionalStrings: additionalStrings)
-    }
-
-    private func contentHash(for target: Target, additionalStrings: [String]) throws -> String {
-        let sourcesHash = try sourceFilesContentHasher.hash(sources: target.sources)
-        let resourcesHash = try resourcesContentHasher.hash(resources: target.resources)
-        let copyFilesHash = try copyFilesContentHasher.hash(copyFiles: target.copyFiles)
-        let coreDataModelHash = try coreDataModelsContentHasher.hash(coreDataModels: target.coreDataModels)
-        let targetActionsHash = try targetActionsContentHasher.hash(targetActions: target.actions)
-        let dependenciesHash = try dependenciesContentHasher.hash(dependencies: target.dependencies)
-        let environmentHash = try contentHasher.hash(target.environment)
+    public func contentHash(for graphTarget: GraphTarget, additionalStrings: [String]) throws -> String {
+        let sourcesHash = try sourceFilesContentHasher.hash(sources: graphTarget.target.sources)
+        let resourcesHash = try resourcesContentHasher.hash(resources: graphTarget.target.resources)
+        let copyFilesHash = try copyFilesContentHasher.hash(copyFiles: graphTarget.target.copyFiles)
+        let coreDataModelHash = try coreDataModelsContentHasher.hash(coreDataModels: graphTarget.target.coreDataModels)
+        let targetActionsHash = try targetActionsContentHasher.hash(targetActions: graphTarget.target.actions)
+        let dependenciesHash = try dependenciesContentHasher.hash(graphTarget: graphTarget)
+        let environmentHash = try contentHasher.hash(graphTarget.target.environment)
         var stringsToHash = [
-            target.name,
-            target.platform.rawValue,
-            target.product.rawValue,
-            target.bundleId,
-            target.productName,
+            graphTarget.target.name,
+            graphTarget.target.platform.rawValue,
+            graphTarget.target.product.rawValue,
+            graphTarget.target.bundleId,
+            graphTarget.target.productName,
             dependenciesHash,
             sourcesHash,
             resourcesHash,
@@ -100,23 +96,23 @@ public final class TargetContentHasher: TargetContentHashing {
             targetActionsHash,
             environmentHash,
         ]
-        if let headers = target.headers {
+        if let headers = graphTarget.target.headers {
             let headersHash = try headersContentHasher.hash(headers: headers)
             stringsToHash.append(headersHash)
         }
-        if let deploymentTarget = target.deploymentTarget {
+        if let deploymentTarget = graphTarget.target.deploymentTarget {
             let deploymentTargetHash = try deploymentTargetContentHasher.hash(deploymentTarget: deploymentTarget)
             stringsToHash.append(deploymentTargetHash)
         }
-        if let infoPlist = target.infoPlist {
+        if let infoPlist = graphTarget.target.infoPlist {
             let infoPlistHash = try infoPlistContentHasher.hash(plist: infoPlist)
             stringsToHash.append(infoPlistHash)
         }
-        if let entitlements = target.entitlements {
+        if let entitlements = graphTarget.target.entitlements {
             let entitlementsHash = try contentHasher.hash(path: entitlements)
             stringsToHash.append(entitlementsHash)
         }
-        if let settings = target.settings {
+        if let settings = graphTarget.target.settings {
             let settingsHash = try settingsContentHasher.hash(settings: settings)
             stringsToHash.append(settingsHash)
         }

--- a/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
@@ -5,8 +5,8 @@ import TuistGraph
 import TuistSupport
 
 public protocol TargetContentHashing {
-    func contentHash(for target: GraphTarget, hashedTargets: inout [GraphTarget: String]) throws -> String
-    func contentHash(for target: GraphTarget, hashedTargets: inout [GraphTarget: String], additionalStrings: [String]) throws -> String
+    func contentHash(for target: GraphTarget, hashedTargets: inout [GraphHashedTarget: String]) throws -> String
+    func contentHash(for target: GraphTarget, hashedTargets: inout [GraphHashedTarget: String], additionalStrings: [String]) throws -> String
 }
 
 /// `TargetContentHasher`
@@ -70,11 +70,11 @@ public final class TargetContentHasher: TargetContentHashing {
 
     // MARK: - TargetContentHashing
 
-    public func contentHash(for target: GraphTarget, hashedTargets: inout [GraphTarget: String]) throws -> String {
+    public func contentHash(for target: GraphTarget, hashedTargets: inout [GraphHashedTarget: String]) throws -> String {
         try contentHash(for: target, hashedTargets: &hashedTargets, additionalStrings: [])
     }
 
-    public func contentHash(for graphTarget: GraphTarget, hashedTargets: inout [GraphTarget: String], additionalStrings: [String]) throws -> String {
+    public func contentHash(for graphTarget: GraphTarget, hashedTargets: inout [GraphHashedTarget: String], additionalStrings: [String]) throws -> String {
         let sourcesHash = try sourceFilesContentHasher.hash(sources: graphTarget.target.sources)
         let resourcesHash = try resourcesContentHasher.hash(resources: graphTarget.target.resources)
         let copyFilesHash = try copyFilesContentHasher.hash(copyFiles: graphTarget.target.copyFiles)

--- a/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
@@ -5,8 +5,8 @@ import TuistGraph
 import TuistSupport
 
 public protocol TargetContentHashing {
-    func contentHash(for target: GraphTarget) throws -> String
-    func contentHash(for target: GraphTarget, additionalStrings: [String]) throws -> String
+    func contentHash(for target: GraphTarget, hashedTargets: inout [GraphTarget: String]) throws -> String
+    func contentHash(for target: GraphTarget, hashedTargets: inout [GraphTarget: String], additionalStrings: [String]) throws -> String
 }
 
 /// `TargetContentHasher`
@@ -70,17 +70,17 @@ public final class TargetContentHasher: TargetContentHashing {
 
     // MARK: - TargetContentHashing
 
-    public func contentHash(for target: GraphTarget) throws -> String {
-        try contentHash(for: target, additionalStrings: [])
+    public func contentHash(for target: GraphTarget, hashedTargets: inout [GraphTarget: String]) throws -> String {
+        try contentHash(for: target, hashedTargets: &hashedTargets, additionalStrings: [])
     }
 
-    public func contentHash(for graphTarget: GraphTarget, additionalStrings: [String]) throws -> String {
+    public func contentHash(for graphTarget: GraphTarget, hashedTargets: inout [GraphTarget: String], additionalStrings: [String]) throws -> String {
         let sourcesHash = try sourceFilesContentHasher.hash(sources: graphTarget.target.sources)
         let resourcesHash = try resourcesContentHasher.hash(resources: graphTarget.target.resources)
         let copyFilesHash = try copyFilesContentHasher.hash(copyFiles: graphTarget.target.copyFiles)
         let coreDataModelHash = try coreDataModelsContentHasher.hash(coreDataModels: graphTarget.target.coreDataModels)
         let targetActionsHash = try targetActionsContentHasher.hash(targetActions: graphTarget.target.actions)
-        let dependenciesHash = try dependenciesContentHasher.hash(graphTarget: graphTarget)
+        let dependenciesHash = try dependenciesContentHasher.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
         let environmentHash = try contentHasher.hash(graphTarget.target.environment)
         var stringsToHash = [
             graphTarget.target.name,

--- a/Sources/TuistKit/Cache/CacheController.swift
+++ b/Sources/TuistKit/Cache/CacheController.swift
@@ -135,7 +135,7 @@ final class CacheController: CacheControlling {
             successors: {
                 Array(graphTraveser.directTargetDependencies(path: $0.path, name: $0.target.name))
             }
-        )
+        ).reversed()
 
         for (index, target) in sortedCacheableTargets.reversed().enumerated() {
             logger.notice("Building cacheable targets: \(target.target.name), \(index + 1) out of \(sortedCacheableTargets.count)")

--- a/Sources/TuistKit/Cache/CacheController.swift
+++ b/Sources/TuistKit/Cache/CacheController.swift
@@ -135,7 +135,7 @@ final class CacheController: CacheControlling {
             successors: {
                 Array(graphTraveser.directTargetDependencies(path: $0.path, name: $0.target.name))
             }
-        ).reversed()
+        )
 
         for (index, target) in sortedCacheableTargets.reversed().enumerated() {
             logger.notice("Building cacheable targets: \(target.target.name), \(index + 1) out of \(sortedCacheableTargets.count)")

--- a/Tests/TuistCacheTests/ContentHashing/DependenciesContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/DependenciesContentHasherTests.swift
@@ -48,16 +48,18 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         // Then
         XCTAssertEqual(hash, "target-foo-hash")
     }
-    
+
     func test_hash_whenDependencyIsTarget_throwsWhenTheDependencyHasntBeenHashed() throws {
         // Given
         let dependency = TargetDependency.target(name: "foo")
 
         // When/Then
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let expectedError = DependenciesContentHasherError.missingTargetHash(sourceTargetName: graphTarget.target.name,
-                                                                             dependencyProjectPath: graphTarget.path,
-                                                                             dependencyTargetName: "foo")
+        let expectedError = DependenciesContentHasherError.missingTargetHash(
+            sourceTargetName: graphTarget.target.name,
+            dependencyProjectPath: graphTarget.path,
+            dependencyTargetName: "foo"
+        )
         XCTAssertThrowsSpecific(try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets), expectedError)
     }
 
@@ -73,17 +75,19 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         // Then
         XCTAssertEqual(hash, "project-file-hashed-foo-hash")
     }
-    
+
     func test_hash_whenDependencyIsProject_throwsAnErrorIfTheDependencyHashDoesntExist() throws {
         // Given
         let dependency = TargetDependency.project(target: "foo", path: filePath1)
 
         // When/Then
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let expectedError = DependenciesContentHasherError.missingProjectTargetHash(sourceProjectPath: graphTarget.path,
-                                                                                    sourceTargetName: graphTarget.target.name,
-                                                                                    dependencyProjectPath: filePath1,
-                                                                                    dependencyTargetName: "foo")
+        let expectedError = DependenciesContentHasherError.missingProjectTargetHash(
+            sourceProjectPath: graphTarget.path,
+            sourceTargetName: graphTarget.target.name,
+            dependencyProjectPath: filePath1,
+            dependencyTargetName: "foo"
+        )
         XCTAssertThrowsSpecific(try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets), expectedError)
     }
 

--- a/Tests/TuistCacheTests/ContentHashing/DependenciesContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/DependenciesContentHasherTests.swift
@@ -16,16 +16,19 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
     private var filePath2: AbsolutePath! = AbsolutePath("/file2")
     private var filePath3: AbsolutePath! = AbsolutePath("/file3")
     private var graphTarget: GraphTarget!
-    
+    private var hashedTargets: [GraphTarget: String]!
+
     override func setUp() {
         super.setUp()
         mockContentHasher = MockContentHasher()
+        hashedTargets = [:]
         subject = DependenciesContentHasher(contentHasher: mockContentHasher)
     }
 
     override func tearDown() {
         subject = nil
         mockContentHasher = nil
+        hashedTargets = nil
         graphTarget = nil
         filePath1 = nil
         filePath2 = nil
@@ -39,7 +42,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
 
         // Then
         XCTAssertEqual(hash, "target-foo-hash")
@@ -53,7 +56,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
 
         // Then
         XCTAssertEqual(hash, "project-file-hashed-foo-hash")
@@ -68,7 +71,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
 
         // Then
         XCTAssertEqual(hash, "file-hashed")
@@ -82,7 +85,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
 
         // Then
         XCTAssertEqual(hash, "file-hashed")
@@ -102,7 +105,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
 
         // Then
         XCTAssertEqual(hash, "library-file1-hashed-file2-hashed-file3-hashed-hash")
@@ -122,8 +125,8 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget)
-        
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
+
         // Then
         XCTAssertEqual(hash, "library-file1-hashed-file2-hashed-hash")
         XCTAssertEqual(mockContentHasher.hashPathCallCount, 2)
@@ -136,7 +139,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
 
         // Then
         XCTAssertEqual(hash, "package-foo-hash")
@@ -149,7 +152,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
 
         // Then
         XCTAssertEqual(hash, "sdk-foo-optional-hash")
@@ -162,7 +165,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
 
         // Then
         XCTAssertEqual(hash, "sdk-foo-required-hash")
@@ -176,7 +179,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
 
         // Then
         XCTAssertEqual(hash, "cocoapods-file1-hashed-hash")
@@ -189,7 +192,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
 
         // Then
         XCTAssertEqual(hash, "xctest-hash")

--- a/Tests/TuistCacheTests/ContentHashing/DependenciesContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/DependenciesContentHasherTests.swift
@@ -12,10 +12,11 @@ import XCTest
 final class DependenciesContentHasherTests: TuistUnitTestCase {
     private var subject: DependenciesContentHasher!
     private var mockContentHasher: MockContentHasher!
-    private let filePath1 = AbsolutePath("/file1")
-    private let filePath2 = AbsolutePath("/file2")
-    private let filePath3 = AbsolutePath("/file3")
-
+    private var filePath1: AbsolutePath! = AbsolutePath("/file1")
+    private var filePath2: AbsolutePath! = AbsolutePath("/file2")
+    private var filePath3: AbsolutePath! = AbsolutePath("/file3")
+    private var graphTarget: GraphTarget!
+    
     override func setUp() {
         super.setUp()
         mockContentHasher = MockContentHasher()
@@ -25,6 +26,10 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
     override func tearDown() {
         subject = nil
         mockContentHasher = nil
+        graphTarget = nil
+        filePath1 = nil
+        filePath2 = nil
+        filePath3 = nil
         super.tearDown()
     }
 
@@ -33,7 +38,8 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         let dependency = TargetDependency.target(name: "foo")
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
+        let hash = try subject.hash(graphTarget: graphTarget)
 
         // Then
         XCTAssertEqual(hash, "target-foo-hash")
@@ -46,7 +52,8 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         mockContentHasher.stubHashForPath[filePath1] = "file-hashed"
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
+        let hash = try subject.hash(graphTarget: graphTarget)
 
         // Then
         XCTAssertEqual(hash, "project-file-hashed-foo-hash")
@@ -60,7 +67,8 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         mockContentHasher.stubHashForPath[filePath1] = "file-hashed"
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
+        let hash = try subject.hash(graphTarget: graphTarget)
 
         // Then
         XCTAssertEqual(hash, "file-hashed")
@@ -73,7 +81,8 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         mockContentHasher.stubHashForPath[filePath1] = "file-hashed"
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
+        let hash = try subject.hash(graphTarget: graphTarget)
 
         // Then
         XCTAssertEqual(hash, "file-hashed")
@@ -92,7 +101,8 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         mockContentHasher.stubHashForPath[filePath3] = "file3-hashed"
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
+        let hash = try subject.hash(graphTarget: graphTarget)
 
         // Then
         XCTAssertEqual(hash, "library-file1-hashed-file2-hashed-file3-hashed-hash")
@@ -111,8 +121,9 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         mockContentHasher.stubHashForPath[filePath2] = "file2-hashed"
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
-
+        let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
+        let hash = try subject.hash(graphTarget: graphTarget)
+        
         // Then
         XCTAssertEqual(hash, "library-file1-hashed-file2-hashed-hash")
         XCTAssertEqual(mockContentHasher.hashPathCallCount, 2)
@@ -124,7 +135,8 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         let dependency = TargetDependency.package(product: "foo")
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
+        let hash = try subject.hash(graphTarget: graphTarget)
 
         // Then
         XCTAssertEqual(hash, "package-foo-hash")
@@ -136,7 +148,8 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         let dependency = TargetDependency.sdk(name: "foo", status: .optional)
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
+        let hash = try subject.hash(graphTarget: graphTarget)
 
         // Then
         XCTAssertEqual(hash, "sdk-foo-optional-hash")
@@ -148,7 +161,8 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         let dependency = TargetDependency.sdk(name: "foo", status: .required)
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
+        let hash = try subject.hash(graphTarget: graphTarget)
 
         // Then
         XCTAssertEqual(hash, "sdk-foo-required-hash")
@@ -161,7 +175,8 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         mockContentHasher.stubHashForPath[filePath1] = "file1-hashed"
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
+        let hash = try subject.hash(graphTarget: graphTarget)
 
         // Then
         XCTAssertEqual(hash, "cocoapods-file1-hashed-hash")
@@ -173,7 +188,8 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         let dependency = TargetDependency.xctest
 
         // When
-        let hash = try subject.hash(dependencies: [dependency])
+        let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
+        let hash = try subject.hash(graphTarget: graphTarget)
 
         // Then
         XCTAssertEqual(hash, "xctest-hash")


### PR DESCRIPTION
### Short description 📝
The current logic for hashing target dependencies uses the name of the dependency target. Because of that, if we have a target `A` that depends on a target `B`, if `B` changes, the changes are not reflected in the hash of A, and therefore we might end up with an invalid binary for `A`.

This PR aims to fix that. Before hashing, we sort the targets topologically, and keep track of the already-generated hashes in a dictionary. I pass it down to the `DependenciesContentHasher` so that the actual hash of the dependency target is used instead.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
