### PR TITLE
📦[Dependencies.swift] Print DependencyManagers' output to console. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Added
+
+- The `tuist dependencies` command prints dependency managers' output to console. [#3185](https://github.com/tuist/tuist/pull/3185) by [@laxmorek](https://github.com/laxmorek)
+
 ## 1.46.1
 
 ### Fixed

--- a/Sources/TuistDependencies/Carthage/CarthageInteractor.swift
+++ b/Sources/TuistDependencies/Carthage/CarthageInteractor.swift
@@ -106,12 +106,14 @@ public final class CarthageInteractor: CarthageInteracting {
                 if shouldUpdate {
                     try carthageController.update(
                         at: temporaryDirectoryPath,
-                        platforms: platforms
+                        platforms: platforms,
+                        printOutput: true
                     )
                 } else {
                     try carthageController.bootstrap(
                         at: temporaryDirectoryPath,
-                        platforms: platforms
+                        platforms: platforms,
+                        printOutput: true
                     )
                 }
 

--- a/Sources/TuistDependencies/Carthage/Utils/CarthageController.swift
+++ b/Sources/TuistDependencies/Carthage/Utils/CarthageController.swift
@@ -60,13 +60,15 @@ public protocol CarthageControlling {
     /// - Parameters:
     ///   - path: Directory where project's dependencies will be installed.
     ///   - platforms: The platforms to build for.
-    func bootstrap(at path: AbsolutePath, platforms: Set<TuistGraph.Platform>) throws
+    ///   - printOutput: When true it prints the Carthage's ouput.
+    func bootstrap(at path: AbsolutePath, platforms: Set<TuistGraph.Platform>, printOutput: Bool) throws
 
     /// Updates and rebuilds the project's dependencies
     /// - Parameters:
     ///   - path: Directory where project's dependencies will be installed.
     ///   - platforms: The platforms to build for.
-    func update(at path: AbsolutePath, platforms: Set<TuistGraph.Platform>) throws
+    ///   - printOutput: When true it prints the Carthage's ouput.
+    func update(at path: AbsolutePath, platforms: Set<TuistGraph.Platform>, printOutput: Bool) throws
 }
 
 // MARK: - Carthage Controller
@@ -106,22 +108,28 @@ public final class CarthageController: CarthageControlling {
         return version
     }
 
-    public func bootstrap(at path: AbsolutePath, platforms: Set<TuistGraph.Platform>) throws {
+    public func bootstrap(at path: AbsolutePath, platforms: Set<TuistGraph.Platform>, printOutput: Bool) throws {
         guard try isXCFrameworksProductionSupported() else {
             throw CarthageControllerError.xcFrameworksProductionNotSupported(installedVersion: try carthageVersion())
         }
 
         let command = buildCarthageCommand(path: path, platforms: platforms, subcommand: "bootstrap")
-        try System.shared.run(command)
+        
+        printOutput ?
+            try System.shared.runAndPrint(command) :
+            try System.shared.run(command)
     }
 
-    public func update(at path: AbsolutePath, platforms: Set<TuistGraph.Platform>) throws {
+    public func update(at path: AbsolutePath, platforms: Set<TuistGraph.Platform>, printOutput: Bool) throws {
         guard try isXCFrameworksProductionSupported() else {
             throw CarthageControllerError.xcFrameworksProductionNotSupported(installedVersion: try carthageVersion())
         }
 
         let command = buildCarthageCommand(path: path, platforms: platforms, subcommand: "update")
-        try System.shared.run(command)
+        
+        printOutput ?
+            try System.shared.runAndPrint(command) :
+            try System.shared.run(command)
     }
 
     // MARK: - Helpers

--- a/Sources/TuistDependencies/Carthage/Utils/CarthageController.swift
+++ b/Sources/TuistDependencies/Carthage/Utils/CarthageController.swift
@@ -114,7 +114,7 @@ public final class CarthageController: CarthageControlling {
         }
 
         let command = buildCarthageCommand(path: path, platforms: platforms, subcommand: "bootstrap")
-        
+
         printOutput ?
             try System.shared.runAndPrint(command) :
             try System.shared.run(command)
@@ -126,7 +126,7 @@ public final class CarthageController: CarthageControlling {
         }
 
         let command = buildCarthageCommand(path: path, platforms: platforms, subcommand: "update")
-        
+
         printOutput ?
             try System.shared.runAndPrint(command) :
             try System.shared.run(command)

--- a/Sources/TuistDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
@@ -86,9 +86,9 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
 
             // run `Swift Package Manager`
             if shouldUpdate {
-                try swiftPackageManagerController.update(at: temporaryDirectoryPath)
+                try swiftPackageManagerController.update(at: temporaryDirectoryPath, printOutput: true)
             } else {
-                try swiftPackageManagerController.resolve(at: temporaryDirectoryPath)
+                try swiftPackageManagerController.resolve(at: temporaryDirectoryPath, printOutput: true)
             }
 
             // post installation

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerController.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerController.swift
@@ -6,12 +6,16 @@ import TuistSupport
 /// Protocol that defines an interface to interact with the Swift Package Manager.
 public protocol SwiftPackageManagerControlling {
     /// Resolves package dependencies.
-    /// - Parameter path: Directory where the `Package.swift` is defined.
-    func resolve(at path: AbsolutePath) throws
+    /// - Parameters:
+    ///   - path: Directory where the `Package.swift` is defined.
+    ///   - printOutput: When true it prints the Swift Package Manager's ouput.
+    func resolve(at path: AbsolutePath, printOutput: Bool) throws
 
     /// Updates package dependencies.
-    /// - Parameter path: Directory where the `Package.swift` is defined.
-    func update(at path: AbsolutePath) throws
+    /// - Parameters:
+    ///   - path: Directory where the `Package.swift` is defined.
+    ///   - printOutput: When true it prints the Swift Package Manager's ouput.
+    func update(at path: AbsolutePath, printOutput: Bool) throws
 
     /// Sets tools version of package to the given value.
     /// - Parameter path: Directory where the `Package.swift` is defined.
@@ -22,16 +26,20 @@ public protocol SwiftPackageManagerControlling {
 public final class SwiftPackageManagerController: SwiftPackageManagerControlling {
     public init() {}
 
-    public func resolve(at path: AbsolutePath) throws {
+    public func resolve(at path: AbsolutePath, printOutput: Bool) throws {
         let command = buildSwiftPackageCommand(packagePath: path, extraArguments: ["resolve"])
 
-        try System.shared.run(command)
+        printOutput ?
+            try System.shared.runAndPrint(command) :
+            try System.shared.run(command)
     }
 
-    public func update(at path: AbsolutePath) throws {
+    public func update(at path: AbsolutePath, printOutput: Bool) throws {
         let command = buildSwiftPackageCommand(packagePath: path, extraArguments: ["update"])
 
-        try System.shared.run(command)
+        printOutput ?
+            try System.shared.runAndPrint(command) :
+            try System.shared.run(command)
     }
 
     public func setToolsVersion(at path: AbsolutePath, to version: String?) throws {

--- a/Sources/TuistDependenciesTesting/Carthage/Utils/MockCarthageController.swift
+++ b/Sources/TuistDependenciesTesting/Carthage/Utils/MockCarthageController.swift
@@ -32,24 +32,26 @@ public final class MockCarthageController: CarthageControlling {
     }
 
     var invokedBootstrap = false
-    var bootstrapStub: ((AbsolutePath, Set<TuistGraph.Platform>) throws -> Void)?
+    var bootstrapStub: ((AbsolutePath, Set<TuistGraph.Platform>, Bool) throws -> Void)?
 
     public func bootstrap(
         at path: AbsolutePath,
-        platforms: Set<TuistGraph.Platform>
+        platforms: Set<TuistGraph.Platform>,
+        printOutput: Bool
     ) throws {
         invokedBootstrap = true
-        try bootstrapStub?(path, platforms)
+        try bootstrapStub?(path, platforms, printOutput)
     }
 
     var invokedUpdate = false
-    var updateStub: ((AbsolutePath, Set<TuistGraph.Platform>) throws -> Void)?
+    var updateStub: ((AbsolutePath, Set<TuistGraph.Platform>, Bool) throws -> Void)?
 
     public func update(
         at path: AbsolutePath,
-        platforms: Set<TuistGraph.Platform>
+        platforms: Set<TuistGraph.Platform>,
+        printOutput: Bool
     ) throws {
         invokedUpdate = true
-        try updateStub?(path, platforms)
+        try updateStub?(path, platforms, printOutput)
     }
 }

--- a/Sources/TuistDependenciesTesting/SwiftPackageManager/Utils/MockSwiftPackageManagerController.swift
+++ b/Sources/TuistDependenciesTesting/SwiftPackageManager/Utils/MockSwiftPackageManagerController.swift
@@ -7,19 +7,19 @@ public final class MockSwiftPackageManagerController: SwiftPackageManagerControl
     public init() {}
 
     var invokedResolve = false
-    var resolveStub: ((AbsolutePath) throws -> Void)?
+    var resolveStub: ((AbsolutePath, Bool) throws -> Void)?
 
-    public func resolve(at path: AbsolutePath) throws {
+    public func resolve(at path: AbsolutePath, printOutput: Bool) throws {
         invokedResolve = true
-        try resolveStub?(path)
+        try resolveStub?(path, printOutput)
     }
 
     var invokedUpdate = false
-    var updateStub: ((AbsolutePath) throws -> Void)?
+    var updateStub: ((AbsolutePath, Bool) throws -> Void)?
 
-    public func update(at path: AbsolutePath) throws {
+    public func update(at path: AbsolutePath, printOutput: Bool) throws {
         invokedUpdate = true
-        try updateStub?(path)
+        try updateStub?(path, printOutput)
     }
 
     var invokedSetToolsVersion = false

--- a/Tests/TuistDependenciesTests/Carthage/CarthageInteractorTests.swift
+++ b/Tests/TuistDependenciesTests/Carthage/CarthageInteractorTests.swift
@@ -51,9 +51,10 @@ final class CarthageInteractorTests: TuistUnitTestCase {
             ]
         )
 
-        carthageController.bootstrapStub = { arg0, arg1 in
+        carthageController.bootstrapStub = { arg0, arg1, arg2 in
             XCTAssertEqual(arg0, try self.temporaryPath())
             XCTAssertEqual(arg1, platforms)
+            XCTAssertTrue(arg2)
 
             try self.simulateCarthageOutput(at: arg0)
         }
@@ -149,9 +150,10 @@ final class CarthageInteractorTests: TuistUnitTestCase {
             ]
         )
 
-        carthageController.updateStub = { arg0, arg1 in
+        carthageController.updateStub = { arg0, arg1, arg2 in
             XCTAssertEqual(arg0, try self.temporaryPath())
             XCTAssertEqual(arg1, platforms)
+            XCTAssertTrue(arg2)
 
             try self.simulateCarthageOutput(at: arg0)
         }

--- a/Tests/TuistDependenciesTests/Carthage/Utils/CarthageControllerTests.swift
+++ b/Tests/TuistDependenciesTests/Carthage/Utils/CarthageControllerTests.swift
@@ -73,7 +73,7 @@ final class CarthageControllerTests: TuistUnitTestCase {
         ])
 
         // When / Then
-        XCTAssertNoThrow(try subject.bootstrap(at: path, platforms: []))
+        XCTAssertNoThrow(try subject.bootstrap(at: path, platforms: [], printOutput: false))
     }
 
     func test_bootstrap_with_platforms() throws {
@@ -96,7 +96,7 @@ final class CarthageControllerTests: TuistUnitTestCase {
         ])
 
         // When / Then
-        XCTAssertNoThrow(try subject.bootstrap(at: path, platforms: [.iOS]))
+        XCTAssertNoThrow(try subject.bootstrap(at: path, platforms: [.iOS], printOutput: false))
     }
 
     func test_bootstrap_with_platforms_throws_when_xcFrameworkdProductionUnsupported() throws {
@@ -121,7 +121,7 @@ final class CarthageControllerTests: TuistUnitTestCase {
 
         // When / Then
         XCTAssertThrowsSpecific(
-            try subject.bootstrap(at: path, platforms: [.iOS]),
+            try subject.bootstrap(at: path, platforms: [.iOS], printOutput: false),
             CarthageControllerError.xcFrameworksProductionNotSupported(installedVersion: carthageVersion)
         )
     }
@@ -144,7 +144,7 @@ final class CarthageControllerTests: TuistUnitTestCase {
         ])
 
         // When / Then
-        XCTAssertNoThrow(try subject.update(at: path, platforms: []))
+        XCTAssertNoThrow(try subject.update(at: path, platforms: [], printOutput: false))
     }
 
     func test_update_with_platforms() throws {
@@ -167,7 +167,7 @@ final class CarthageControllerTests: TuistUnitTestCase {
         ])
 
         // When / Then
-        XCTAssertNoThrow(try subject.update(at: path, platforms: [.iOS]))
+        XCTAssertNoThrow(try subject.update(at: path, platforms: [.iOS], printOutput: false))
     }
 
     func test_update_with_platforms_throws_when_xcFrameworkdProductionUnsupported() throws {
@@ -192,7 +192,7 @@ final class CarthageControllerTests: TuistUnitTestCase {
 
         // When / Then
         XCTAssertThrowsSpecific(
-            try subject.bootstrap(at: path, platforms: [.iOS]),
+            try subject.bootstrap(at: path, platforms: [.iOS], printOutput: false),
             CarthageControllerError.xcFrameworksProductionNotSupported(installedVersion: carthageVersion)
         )
     }

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
@@ -44,8 +44,9 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
             ]
         )
 
-        swiftPackageManagerController.resolveStub = { path in
+        swiftPackageManagerController.resolveStub = { path, printOutput in
             XCTAssertEqual(path, try self.temporaryPath())
+            XCTAssertTrue(printOutput)
             try self.simulateSPMOutput(at: path)
         }
         swiftPackageManagerController.setToolsVersionStub = { path, version in
@@ -108,8 +109,9 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
             ]
         )
 
-        swiftPackageManagerController.resolveStub = { path in
+        swiftPackageManagerController.resolveStub = { path, printOutput in
             XCTAssertEqual(path, try self.temporaryPath())
+            XCTAssertTrue(printOutput)
             try self.simulateSPMOutput(at: path)
         }
         swiftPackageManagerController.setToolsVersionStub = { path, version in
@@ -171,8 +173,9 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
             ]
         )
 
-        swiftPackageManagerController.updateStub = { path in
+        swiftPackageManagerController.updateStub = { path, printOutput in
             XCTAssertEqual(path, try self.temporaryPath())
+            XCTAssertTrue(printOutput)
             try self.simulateSPMOutput(at: path)
         }
         swiftPackageManagerController.setToolsVersionStub = { path, version in

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageMangerControllerTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageMangerControllerTests.swift
@@ -34,7 +34,7 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
         ])
 
         // When / Then
-        XCTAssertNoThrow(try subject.resolve(at: path))
+        XCTAssertNoThrow(try subject.resolve(at: path, printOutput: false))
     }
 
     func test_update() throws {
@@ -49,7 +49,7 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
         ])
 
         // When / Then
-        XCTAssertNoThrow(try subject.update(at: path))
+        XCTAssertNoThrow(try subject.update(at: path, printOutput: false))
     }
 
     func test_setToolsVersion_specificVersion() throws {


### PR DESCRIPTION
### Short description 📝

Today an output from the `tuist dependencies [fetch/update]` command looks like:

<img width="678" alt="Zrzut ekranu 2021-07-14 o 21 17 56" src="https://user-images.githubusercontent.com/4774319/125682430-d735535d-edc3-473f-84d7-b7c2b300dee7.png">

I've received a feedback from a few people that the command feels makes a feel that it freezes.

It is because the `Carthage` or the `Swift Package Manager` have to do their work. For example the output waits with message: `Installing Carthage dependencies.` when the Carthage is resolving dependencies. It may take even a few minutes.

As a solution I propose to print  the `Carthage` and/or the `Swift Package Manager`'s output to console. It should clearly present and explain to users what the `tuist dependencies [fetch/update]` does.

The output after my changes looks like: 

<img width="719" alt="Zrzut ekranu 2021-07-14 o 21 49 16" src="https://user-images.githubusercontent.com/4774319/125683878-476e93bb-3bec-4e88-8697-f204939ae245.png">

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
