### PR TITLE
Fix editing the project in development and exclude the unnecessary architectures

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
         "state": {
           "branch": null,
-          "revision": "c37e5ae8012fb654af776cc556ff8ae64398c841",
-          "version": "0.5.0"
+          "revision": "f1250faa1c1436ca83950ce676a4fe97a309a457",
+          "version": "0.4.1"
         }
       },
       {
@@ -186,8 +186,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-          "version": "1.4.2"
+          "revision": "12d3a8651d32295794a850307f77407f95b8c881",
+          "version": "1.4.1"
         }
       },
       {
@@ -195,8 +195,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "3b6b97d612b56e25d80d0807f5bc38ea08b7bdf3",
-          "version": "0.2.3"
+          "revision": "ab6339b6a33b69886b3cf2254d3326eddfe58eb0",
+          "version": "0.2.2"
         }
       },
       {
@@ -231,8 +231,8 @@
         "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
         "state": {
           "branch": null,
-          "revision": "152390e9e78ebbf0d767ee52971d41e7f44f39bc",
-          "version": "0.1.1"
+          "revision": "603974e3909ad4b48ba04aad7e0ceee4f077a518",
+          "version": "0.1.0"
         }
       },
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Remove the `sudo` requirement for the install and uninstall scripts. [#3056](https://github.com/tuist/tuist/pull/3056) by [@luispadron](https://github.com/luispadron).
 
+### Fixed
+
+- Editing projects in development [#3199](https://github.com/tuist/tuist/pull/3199) by [@pepibumur](https://github.com/pepibumur).
+
 ## 1.46.1
 
 ### Fixed

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
         "state": {
           "branch": null,
-          "revision": "c37e5ae8012fb654af776cc556ff8ae64398c841",
-          "version": "0.5.0"
+          "revision": "f1250faa1c1436ca83950ce676a4fe97a309a457",
+          "version": "0.4.1"
         }
       },
       {
@@ -146,6 +146,15 @@
         }
       },
       {
+        "package": "ShellOut",
+        "repositoryURL": "https://github.com/JohnSundell/ShellOut.git",
+        "state": {
+          "branch": null,
+          "revision": "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
+          "version": "2.3.0"
+        }
+      },
+      {
         "package": "Spectre",
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
@@ -173,6 +182,15 @@
         }
       },
       {
+        "package": "StencilSwiftKit",
+        "repositoryURL": "https://github.com/SwiftGen/StencilSwiftKit.git",
+        "state": {
+          "branch": null,
+          "revision": "54cbedcdbb4334e03930adcff7343ffaf317bf0f",
+          "version": "2.8.0"
+        }
+      },
+      {
         "package": "swift-argument-parser",
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
@@ -186,7 +204,7 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
+          "revision": "12d3a8651d32295794a850307f77407f95b8c881",
           "version": "1.4.2"
         }
       },
@@ -195,8 +213,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "3b6b97d612b56e25d80d0807f5bc38ea08b7bdf3",
-          "version": "0.2.3"
+          "revision": "ab6339b6a33b69886b3cf2254d3326eddfe58eb0",
+          "version": "0.2.2"
         }
       },
       {
@@ -231,8 +249,8 @@
         "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
         "state": {
           "branch": null,
-          "revision": "152390e9e78ebbf0d767ee52971d41e7f44f39bc",
-          "version": "0.1.1"
+          "revision": "603974e3909ad4b48ba04aad7e0ceee4f077a518",
+          "version": "0.1.0"
         }
       },
       {

--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -424,15 +424,15 @@ final class ProjectEditorMapper: ProjectEditorMapping {
 
     private func targetBaseSettings(for includes: [AbsolutePath], swiftVersion: String) -> SettingsDictionary {
         let includePaths = includes
-            .flatMap({ path in
+            .flatMap { path in
                 // In development, the .swiftmodule is generated in a directory up from the directory of the framework.
                 // /path/to/derived/tuist-xyz/
                 //    PackageFrameworks/
                 //      ProjectDescription.framework
                 //    ProjectDescription.swiftmodule
                 // Because of that we need to expose the parent directory too in SWIFT_INCLUDE_PATHS
-                return [path.parentDirectory.pathString, path.parentDirectory.parentDirectory.pathString]
-            })
+                [path.parentDirectory.pathString, path.parentDirectory.parentDirectory.pathString]
+            }
             .map { "\"\($0)\"" }
         return [
             "FRAMEWORK_SEARCH_PATHS": .array(includePaths),
@@ -441,7 +441,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
             "SWIFT_VERSION": .string(swiftVersion),
         ]
     }
-    
+
     private func excludedArchs() -> String {
         let architecture = DeveloperEnvironment.shared.architecture
         switch architecture {

--- a/Sources/TuistSigning/SigningCipher.swift
+++ b/Sources/TuistSigning/SigningCipher.swift
@@ -168,7 +168,7 @@ public final class SigningCipher: SigningCiphering {
         let unencryptedData = try FileHandler.shared.readFile(unencryptedFile)
         let encryptedBase64String = try aesCipher.encrypt(unencryptedData.bytes).toBase64()
         guard
-            let data = (iv.base64EncodedString() + "-" + encryptedBase64String).data(using: .utf8)
+            let data = (iv.base64EncodedString() + "-" + encryptedBase64String!).data(using: .utf8)
         else { throw SigningCipherError.failedToEncrypt }
 
         return try FileHandler.shared.readFile(encryptedFile) != data
@@ -184,7 +184,7 @@ public final class SigningCipher: SigningCiphering {
         let aesCipher = try AES(key: masterKey.bytes, blockMode: CTR(iv: iv.bytes), padding: .noPadding)
         let encryptedBase64String = try aesCipher.encrypt(data.bytes).toBase64()
         guard
-            let data = (iv.base64EncodedString() + "-" + encryptedBase64String).data(using: .utf8)
+            let data = (iv.base64EncodedString() + "-" + encryptedBase64String!).data(using: .utf8)
         else { throw SigningCipherError.failedToEncrypt }
         return data
     }

--- a/Sources/TuistSupport/Utils/DeveloperEnvironment.swift
+++ b/Sources/TuistSupport/Utils/DeveloperEnvironment.swift
@@ -4,24 +4,31 @@ import TSCBasic
 public protocol DeveloperEnvironmenting {
     /// Returns the derived data directory selected in the environment.
     var derivedDataDirectory: AbsolutePath { get }
+    
+    /// Returns the system's architecture.
+    var architecture: MacArchitecture { get }
 }
 
 public final class DeveloperEnvironment: DeveloperEnvironmenting {
     /// Shared instance to be used publicly.
     /// Since the environment doesn't change during the execution of Tuist, we can cache
     /// state internally to speed up future access to environment attributes.
-    public static let shared: DeveloperEnvironmenting = DeveloperEnvironment()
+    public static var shared: DeveloperEnvironmenting = DeveloperEnvironment()
 
     /// File handler instance.
     let fileHandler: FileHandling
+    
+    public convenience init() {
+        self.init(fileHandler: FileHandler())
+    }
 
-    private init(fileHandler: FileHandling = FileHandler()) {
+    private init(fileHandler: FileHandling) {
         self.fileHandler = fileHandler
     }
 
     /// https://pewpewthespells.com/blog/xcode_build_locations.html/// https://pewpewthespells.com/blog/xcode_build_locations.html
     // swiftlint:disable identifier_name
-    private var _derivedDataDirectory: AbsolutePath?
+    @Atomic private var _derivedDataDirectory: AbsolutePath?
     public var derivedDataDirectory: AbsolutePath {
         if let _derivedDataDirectory = _derivedDataDirectory {
             return _derivedDataDirectory
@@ -36,6 +43,15 @@ public final class DeveloperEnvironment: DeveloperEnvironmenting {
         _derivedDataDirectory = location
         return location
     }
-
     // swiftlint:enable identifier_name
+    
+    @Atomic private var _architecture: MacArchitecture?
+    public var architecture: MacArchitecture {
+        if let _architecture = _architecture {
+            return _architecture
+        }
+        let output = try! System.shared.capture("/usr/bin/uname", "-m").chomp()
+        _architecture = MacArchitecture(rawValue: output)
+        return _architecture!
+    }
 }

--- a/Sources/TuistSupport/Utils/DeveloperEnvironment.swift
+++ b/Sources/TuistSupport/Utils/DeveloperEnvironment.swift
@@ -13,12 +13,12 @@ public final class DeveloperEnvironment: DeveloperEnvironmenting {
     /// Shared instance to be used publicly.
     /// Since the environment doesn't change during the execution of Tuist, we can cache
     /// state internally to speed up future access to environment attributes.
-    public static var shared: DeveloperEnvironmenting = DeveloperEnvironment()
+    public internal(set) static var shared: DeveloperEnvironmenting = DeveloperEnvironment()
 
     /// File handler instance.
     let fileHandler: FileHandling
     
-    public convenience init() {
+    convenience init() {
         self.init(fileHandler: FileHandler())
     }
 

--- a/Sources/TuistSupport/Utils/DeveloperEnvironment.swift
+++ b/Sources/TuistSupport/Utils/DeveloperEnvironment.swift
@@ -4,7 +4,7 @@ import TSCBasic
 public protocol DeveloperEnvironmenting {
     /// Returns the derived data directory selected in the environment.
     var derivedDataDirectory: AbsolutePath { get }
-    
+
     /// Returns the system's architecture.
     var architecture: MacArchitecture { get }
 }
@@ -17,7 +17,7 @@ public final class DeveloperEnvironment: DeveloperEnvironmenting {
 
     /// File handler instance.
     let fileHandler: FileHandling
-    
+
     convenience init() {
         self.init(fileHandler: FileHandler())
     }
@@ -43,8 +43,9 @@ public final class DeveloperEnvironment: DeveloperEnvironmenting {
         _derivedDataDirectory = location
         return location
     }
+
     // swiftlint:enable identifier_name
-    
+
     @Atomic private var _architecture: MacArchitecture?
     public var architecture: MacArchitecture {
         if let _architecture = _architecture {

--- a/Sources/TuistSupport/Utils/MacArchitecture.swift
+++ b/Sources/TuistSupport/Utils/MacArchitecture.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public enum MacArchitecture: String, Codable {
+    case x8664 = "x86_64"
+    case arm64
+}

--- a/Sources/TuistSupportTesting/TestCase/TuistUnitTestCase.swift
+++ b/Sources/TuistSupportTesting/TestCase/TuistUnitTestCase.swift
@@ -5,6 +5,7 @@ import XCTest
 
 open class TuistUnitTestCase: TuistTestCase {
     public var system: MockSystem!
+    public var developerEnvironment: MockDeveloperEnvironment!
     public var xcodeController: MockXcodeController!
 
     override open func setUp() {
@@ -16,6 +17,10 @@ open class TuistUnitTestCase: TuistTestCase {
         // Xcode controller
         xcodeController = MockXcodeController()
         XcodeController.shared = xcodeController
+        
+        // Developer environment
+        developerEnvironment = MockDeveloperEnvironment()
+        DeveloperEnvironment.shared = developerEnvironment
     }
 
     override open func tearDown() {
@@ -30,6 +35,10 @@ open class TuistUnitTestCase: TuistTestCase {
         // Environment
         environment = nil
         Environment.shared = Environment()
+        
+        // Developer environment
+        developerEnvironment = nil
+        DeveloperEnvironment.shared = DeveloperEnvironment()
 
         super.tearDown()
     }

--- a/Sources/TuistSupportTesting/TestCase/TuistUnitTestCase.swift
+++ b/Sources/TuistSupportTesting/TestCase/TuistUnitTestCase.swift
@@ -17,7 +17,7 @@ open class TuistUnitTestCase: TuistTestCase {
         // Xcode controller
         xcodeController = MockXcodeController()
         XcodeController.shared = xcodeController
-        
+
         // Developer environment
         developerEnvironment = MockDeveloperEnvironment()
         DeveloperEnvironment.shared = developerEnvironment
@@ -35,7 +35,7 @@ open class TuistUnitTestCase: TuistTestCase {
         // Environment
         environment = nil
         Environment.shared = Environment()
-        
+
         // Developer environment
         developerEnvironment = nil
         DeveloperEnvironment.shared = DeveloperEnvironment()

--- a/Sources/TuistSupportTesting/Utils/MockDeveloperEnvironment.swift
+++ b/Sources/TuistSupportTesting/Utils/MockDeveloperEnvironment.swift
@@ -3,7 +3,6 @@ import TSCBasic
 @testable import TuistSupport
 
 public final class MockDeveloperEnvironment: DeveloperEnvironmenting {
-    public init() {}
 
     public var invokedDerivedDataDirectoryGetter = false
     public var invokedDerivedDataDirectoryGetterCount = 0
@@ -13,5 +12,15 @@ public final class MockDeveloperEnvironment: DeveloperEnvironmenting {
         invokedDerivedDataDirectoryGetter = true
         invokedDerivedDataDirectoryGetterCount += 1
         return stubbedDerivedDataDirectory
+    }
+
+    public var invokedArchitectureGetter = false
+    public var invokedArchitectureGetterCount = 0
+    public var stubbedArchitecture: MacArchitecture!
+
+    public var architecture: MacArchitecture {
+        invokedArchitectureGetter = true
+        invokedArchitectureGetterCount += 1
+        return stubbedArchitecture
     }
 }

--- a/Sources/TuistSupportTesting/Utils/MockDeveloperEnvironment.swift
+++ b/Sources/TuistSupportTesting/Utils/MockDeveloperEnvironment.swift
@@ -3,7 +3,6 @@ import TSCBasic
 @testable import TuistSupport
 
 public final class MockDeveloperEnvironment: DeveloperEnvironmenting {
-
     public var invokedDerivedDataDirectoryGetter = false
     public var invokedDerivedDataDirectoryGetterCount = 0
     public var stubbedDerivedDataDirectory: AbsolutePath!

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
@@ -15,6 +15,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
     override func setUp() {
         super.setUp()
         system.swiftVersionStub = { "5.2" }
+        developerEnvironment.stubbedArchitecture = .arm64
         subject = ProjectEditorMapper()
     }
 
@@ -78,7 +79,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
 
         XCTAssertEqual(manifestsTarget.platform, .macOS)
         XCTAssertEqual(manifestsTarget.product, .staticFramework)
-        XCTAssertEqual(manifestsTarget.settings, expectedSettings(includePaths: [sourceRootPath]))
+        XCTAssertEqual(manifestsTarget.settings, expectedSettings(includePaths: [sourceRootPath, sourceRootPath.parentDirectory]))
         XCTAssertEqual(manifestsTarget.sources.map(\.path), projectManifestPaths)
         XCTAssertEqual(manifestsTarget.filesGroup, projectsGroup)
         XCTAssertEqual(manifestsTarget.dependencies, [.target(name: "ProjectDescriptionHelpers")])
@@ -90,7 +91,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(helpersTarget.name, "ProjectDescriptionHelpers")
         XCTAssertEqual(helpersTarget.platform, .macOS)
         XCTAssertEqual(helpersTarget.product, .staticFramework)
-        XCTAssertEqual(helpersTarget.settings, expectedSettings(includePaths: [sourceRootPath]))
+        XCTAssertEqual(helpersTarget.settings, expectedSettings(includePaths: [sourceRootPath, sourceRootPath.parentDirectory]))
         XCTAssertEqual(helpersTarget.sources.map(\.path), helperPaths)
         XCTAssertEqual(helpersTarget.filesGroup, projectsGroup)
         XCTAssertEmpty(helpersTarget.dependencies)
@@ -102,7 +103,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(templatesTarget.name, "Templates")
         XCTAssertEqual(templatesTarget.platform, .macOS)
         XCTAssertEqual(templatesTarget.product, .staticFramework)
-        XCTAssertEqual(templatesTarget.settings, expectedSettings(includePaths: [sourceRootPath]))
+        XCTAssertEqual(templatesTarget.settings, expectedSettings(includePaths: [sourceRootPath, sourceRootPath.parentDirectory]))
         XCTAssertEqual(templatesTarget.sources.map(\.path), templates)
         XCTAssertEqual(templatesTarget.filesGroup, projectsGroup)
         XCTAssertEmpty(templatesTarget.dependencies)
@@ -114,7 +115,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(setupTarget.name, "Setup")
         XCTAssertEqual(setupTarget.platform, .macOS)
         XCTAssertEqual(setupTarget.product, .staticFramework)
-        XCTAssertEqual(setupTarget.settings, expectedSettings(includePaths: [sourceRootPath]))
+        XCTAssertEqual(setupTarget.settings, expectedSettings(includePaths: [sourceRootPath, sourceRootPath.parentDirectory]))
         XCTAssertEqual(setupTarget.sources.map(\.path), [setupPath])
         XCTAssertEqual(setupTarget.filesGroup, projectsGroup)
         XCTAssertEmpty(setupTarget.dependencies)
@@ -126,7 +127,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(configTarget.name, "Config")
         XCTAssertEqual(configTarget.platform, .macOS)
         XCTAssertEqual(configTarget.product, .staticFramework)
-        XCTAssertEqual(configTarget.settings, expectedSettings(includePaths: [sourceRootPath]))
+        XCTAssertEqual(configTarget.settings, expectedSettings(includePaths: [sourceRootPath, sourceRootPath.parentDirectory]))
         XCTAssertEqual(configTarget.sources.map(\.path), [configPath])
         XCTAssertEqual(configTarget.filesGroup, projectsGroup)
         XCTAssertEmpty(configTarget.dependencies)
@@ -138,7 +139,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(dependenciesTarget.name, "Dependencies")
         XCTAssertEqual(dependenciesTarget.platform, .macOS)
         XCTAssertEqual(dependenciesTarget.product, .staticFramework)
-        XCTAssertEqual(dependenciesTarget.settings, expectedSettings(includePaths: [sourceRootPath]))
+        XCTAssertEqual(dependenciesTarget.settings, expectedSettings(includePaths: [sourceRootPath, sourceRootPath.parentDirectory]))
         XCTAssertEqual(dependenciesTarget.sources.map(\.path), [dependenciesPath])
         XCTAssertEqual(dependenciesTarget.filesGroup, projectsGroup)
         XCTAssertEmpty(dependenciesTarget.dependencies)
@@ -150,7 +151,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(taskOneTarget.name, "TaskOne")
         XCTAssertEqual(taskOneTarget.platform, .macOS)
         XCTAssertEqual(taskOneTarget.product, .staticFramework)
-        XCTAssertEqual(taskOneTarget.settings, expectedSettings(includePaths: [sourceRootPath]))
+        XCTAssertEqual(taskOneTarget.settings, expectedSettings(includePaths: [sourceRootPath, sourceRootPath.parentDirectory]))
         XCTAssertEqual(taskOneTarget.sources.map(\.path), [tasksPaths[0]])
         XCTAssertEqual(taskOneTarget.filesGroup, projectsGroup)
         XCTAssertEmpty(taskOneTarget.dependencies)
@@ -162,7 +163,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(taskTwoTarget.name, "TaskTwo")
         XCTAssertEqual(taskTwoTarget.platform, .macOS)
         XCTAssertEqual(taskTwoTarget.product, .staticFramework)
-        XCTAssertEqual(taskTwoTarget.settings, expectedSettings(includePaths: [sourceRootPath]))
+        XCTAssertEqual(taskTwoTarget.settings, expectedSettings(includePaths: [sourceRootPath, sourceRootPath.parentDirectory]))
         XCTAssertEqual(taskTwoTarget.sources.map(\.path), [tasksPaths[1]])
         XCTAssertEqual(taskTwoTarget.filesGroup, projectsGroup)
         XCTAssertEmpty(taskTwoTarget.dependencies)
@@ -172,7 +173,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(project.name, projectName)
         XCTAssertEqual(project.settings, Settings(
             base: ["ONLY_ACTIVE_ARCH": "NO",
-                   "EXCLUDED_ARCHS": "arm64"],
+                   "EXCLUDED_ARCHS": "x86_64"],
             configurations: Settings.default.configurations,
             defaultSettings: .recommended
         ))
@@ -237,7 +238,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
 
         XCTAssertEqual(manifestsTarget.platform, .macOS)
         XCTAssertEqual(manifestsTarget.product, .staticFramework)
-        XCTAssertEqual(manifestsTarget.settings, expectedSettings(includePaths: [sourceRootPath]))
+        XCTAssertEqual(manifestsTarget.settings, expectedSettings(includePaths: [sourceRootPath, sourceRootPath.parentDirectory]))
         XCTAssertEqual(manifestsTarget.sources.map(\.path), projectManifestPaths)
         XCTAssertEqual(manifestsTarget.filesGroup, projectsGroup)
         XCTAssertEmpty(manifestsTarget.dependencies)
@@ -247,7 +248,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(project.name, projectName)
         XCTAssertEqual(project.settings, Settings(
             base: ["ONLY_ACTIVE_ARCH": "NO",
-                   "EXCLUDED_ARCHS": "arm64"],
+                   "EXCLUDED_ARCHS": "x86_64"],
             configurations: Settings.default.configurations,
             defaultSettings: .recommended
         ))
@@ -320,7 +321,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(manifestOneTarget.name, "ModuleManifests")
         XCTAssertEqual(manifestOneTarget.platform, .macOS)
         XCTAssertEqual(manifestOneTarget.product, .staticFramework)
-        XCTAssertEqual(manifestOneTarget.settings, expectedSettings(includePaths: [sourceRootPath]))
+        XCTAssertEqual(manifestOneTarget.settings, expectedSettings(includePaths: [sourceRootPath, sourceRootPath.parentDirectory]))
         XCTAssertEqual(manifestOneTarget.sources.map(\.path), [try XCTUnwrap(projectManifestPaths.last)])
         XCTAssertEqual(manifestOneTarget.filesGroup, .group(name: projectName))
         XCTAssertEmpty(manifestOneTarget.dependencies)
@@ -330,7 +331,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
 
         XCTAssertEqual(manifestTwoTarget.platform, .macOS)
         XCTAssertEqual(manifestTwoTarget.product, .staticFramework)
-        XCTAssertEqual(manifestTwoTarget.settings, expectedSettings(includePaths: [sourceRootPath]))
+        XCTAssertEqual(manifestTwoTarget.settings, expectedSettings(includePaths: [sourceRootPath, sourceRootPath.parentDirectory]))
         XCTAssertEqual(manifestTwoTarget.sources.map(\.path), [try XCTUnwrap(projectManifestPaths.first)])
         XCTAssertEqual(manifestTwoTarget.filesGroup, .group(name: projectName))
         XCTAssertEmpty(manifestTwoTarget.dependencies)
@@ -341,7 +342,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(setupTarget.name, "Setup")
         XCTAssertEqual(setupTarget.platform, .macOS)
         XCTAssertEqual(setupTarget.product, .staticFramework)
-        XCTAssertEqual(setupTarget.settings, expectedSettings(includePaths: [sourceRootPath]))
+        XCTAssertEqual(setupTarget.settings, expectedSettings(includePaths: [sourceRootPath, sourceRootPath.parentDirectory]))
         XCTAssertEqual(setupTarget.sources.map(\.path), [setupPath])
         XCTAssertEqual(setupTarget.filesGroup, .group(name: projectName))
         XCTAssertEmpty(setupTarget.dependencies)
@@ -352,7 +353,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(configTarget.name, "Config")
         XCTAssertEqual(configTarget.platform, .macOS)
         XCTAssertEqual(configTarget.product, .staticFramework)
-        XCTAssertEqual(configTarget.settings, expectedSettings(includePaths: [sourceRootPath]))
+        XCTAssertEqual(configTarget.settings, expectedSettings(includePaths: [sourceRootPath, sourceRootPath.parentDirectory]))
         XCTAssertEqual(configTarget.sources.map(\.path), [configPath])
         XCTAssertEqual(configTarget.filesGroup, .group(name: projectName))
         XCTAssertEmpty(configTarget.dependencies)
@@ -362,7 +363,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(project.name, projectName)
         XCTAssertEqual(project.settings, Settings(
             base: ["ONLY_ACTIVE_ARCH": "NO",
-                   "EXCLUDED_ARCHS": "arm64"],
+                   "EXCLUDED_ARCHS": "x86_64"],
             configurations: Settings.default.configurations,
             defaultSettings: .recommended
         ))
@@ -429,7 +430,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
 
         XCTAssertEqual(pluginTarget.platform, .macOS)
         XCTAssertEqual(pluginTarget.product, .staticFramework)
-        XCTAssertEqual(pluginTarget.settings, expectedSettings(includePaths: [sourceRootPath]))
+        XCTAssertEqual(pluginTarget.settings, expectedSettings(includePaths: [sourceRootPath, sourceRootPath.parentDirectory]))
         XCTAssertEqual(pluginTarget.sources.map(\.path), pluginManifestPaths)
         XCTAssertEqual(pluginTarget.filesGroup, projectsGroup)
         XCTAssertEmpty(pluginTarget.dependencies)
@@ -439,7 +440,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(project.name, projectName)
         XCTAssertEqual(project.settings, Settings(
             base: ["ONLY_ACTIVE_ARCH": "NO",
-                   "EXCLUDED_ARCHS": "arm64"],
+                   "EXCLUDED_ARCHS": "x86_64"],
             configurations: Settings.default.configurations,
             defaultSettings: .recommended
         ))
@@ -507,7 +508,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
 
         XCTAssertEqual(firstPluginTarget.platform, .macOS)
         XCTAssertEqual(firstPluginTarget.product, .staticFramework)
-        XCTAssertEqual(firstPluginTarget.settings, expectedSettings(includePaths: [sourceRootPath]))
+        XCTAssertEqual(firstPluginTarget.settings, expectedSettings(includePaths: [sourceRootPath, sourceRootPath.parentDirectory]))
         XCTAssertEqual(firstPluginTarget.sources.map(\.path), [pluginManifestPaths[0]])
         XCTAssertEqual(firstPluginTarget.filesGroup, projectsGroup)
         XCTAssertEmpty(firstPluginTarget.dependencies)
@@ -517,7 +518,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
 
         XCTAssertEqual(secondPluginTarget.platform, .macOS)
         XCTAssertEqual(secondPluginTarget.product, .staticFramework)
-        XCTAssertEqual(secondPluginTarget.settings, expectedSettings(includePaths: [sourceRootPath]))
+        XCTAssertEqual(secondPluginTarget.settings, expectedSettings(includePaths: [sourceRootPath, sourceRootPath.parentDirectory]))
         XCTAssertEqual(secondPluginTarget.sources.map(\.path), [pluginManifestPaths[1]])
         XCTAssertEqual(secondPluginTarget.filesGroup, projectsGroup)
         XCTAssertEmpty(secondPluginTarget.dependencies)
@@ -527,7 +528,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(project.name, projectName)
         XCTAssertEqual(project.settings, Settings(
             base: ["ONLY_ACTIVE_ARCH": "NO",
-                   "EXCLUDED_ARCHS": "arm64"],
+                   "EXCLUDED_ARCHS": "x86_64"],
             configurations: Settings.default.configurations,
             defaultSettings: .recommended
         ))
@@ -657,7 +658,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
 
         XCTAssertEqual(manifestsTarget.platform, .macOS)
         XCTAssertEqual(manifestsTarget.product, .staticFramework)
-        XCTAssertEqual(manifestsTarget.settings, expectedSettings(includePaths: [sourceRootPath, pluginHelpersPath.parentDirectory]))
+        XCTAssertEqual(manifestsTarget.settings, expectedSettings(includePaths: [sourceRootPath, sourceRootPath.parentDirectory, pluginHelpersPath.parentDirectory, pluginHelpersPath.parentDirectory.parentDirectory]))
         XCTAssertEqual(manifestsTarget.sources.map(\.path), projectManifestPaths)
         XCTAssertEqual(manifestsTarget.filesGroup, projectsGroup)
         XCTAssertEmpty(manifestsTarget.dependencies)
@@ -667,7 +668,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(project.name, projectName)
         XCTAssertEqual(project.settings, Settings(
             base: ["ONLY_ACTIVE_ARCH": "NO",
-                   "EXCLUDED_ARCHS": "arm64"],
+                   "EXCLUDED_ARCHS": "x86_64"],
             configurations: Settings.default.configurations,
             defaultSettings: .recommended
         ))

--- a/projects/tuist/fixtures/ios_app_with_custom_workspace/App/CHANGELOG
+++ b/projects/tuist/fixtures/ios_app_with_custom_workspace/App/CHANGELOG
@@ -1,1 +1,0 @@
-# Changelog


### PR DESCRIPTION
Fixes https://github.com/tuist/tuist/issues/2319#issuecomment-883528971

### Short description 📝
I'm fixing a few things in this PR:
- Editing of projects failing in development mode. The `.swiftmodule` of `ProjectDescription` & `ProjectAutomation` is generated in a different directory that is not exposed through the import paths settings of the generated targets.
- I'm excluding the architectures other than the one in the system where Tuist is running. Although this is not an issue in production, this might cause problems in development if you try to target an architecture other than the one the `ProjectDescription` and `ProjectAutomation` frameworks have been build for.