### PR TITLE
Ensure that the revisions in lockfiles are consistent

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,6 +8,8 @@ on:
       - main
   pull_request:
     paths:
+      - .package.resolved
+      - Package.resolved
       - Sources/**
       - Tests/**
       - projects/fixturegen/**

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,3 +73,30 @@ jobs:
         run: bundle install
       - name: Run
         run: ./fourier lint all
+  lint_lockfiles:
+    name: Lint lockfiles
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        xcode: ['12.4']
+    steps:
+      - uses: actions/checkout@v1
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Install Bundler dependencies
+        run: bundle install
+      - name: Run
+        run: ./fourier lint lockfiles

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,6 +14,7 @@ on:
       - Tests/**
       - projects/fixturegen/**
       - projects/tuistbench/**
+      - projects/fourier/**
 
 concurrency:
   group: checks-${{ github.head_ref }}

--- a/.github/workflows/meta-tuist.yml
+++ b/.github/workflows/meta-tuist.yml
@@ -6,9 +6,10 @@ on:
       - main
   pull_request:
     paths:
+      - .package.resolved
+      - Package.resolved
       - Gemfile*
       - Package.swift
-      - Package.resolved
       - Sources/**
       - Tests/**
       - projects/tuist/features/**

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -6,9 +6,10 @@ on:
       - main
   pull_request:
     paths:
+      - .package.resolved
+      - Package.resolved
       - Gemfile*
       - Package.swift
-      - Package.resolved
       - Sources/**
       - Project.swift
       - projects/fourier/**

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -6,9 +6,10 @@ on:
       - main
   pull_request:
     paths:
+      - .package.resolved
+      - Package.resolved
       - Gemfile*
       - Package.swift
-      - Package.resolved
       - Sources/**
       - Tests/**
       - projects/tuist/features/**

--- a/.package.resolved
+++ b/.package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
         "state": {
           "branch": null,
-          "revision": "c37e5ae8012fb654af776cc556ff8ae64398c841",
-          "version": "0.5.0"
+          "revision": "f1250faa1c1436ca83950ce676a4fe97a309a457",
+          "version": "0.4.1"
         }
       },
       {
@@ -186,8 +186,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-          "version": "1.4.2"
+          "revision": "12d3a8651d32295794a850307f77407f95b8c881",
+          "version": "1.4.1"
         }
       },
       {
@@ -195,8 +195,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "3b6b97d612b56e25d80d0807f5bc38ea08b7bdf3",
-          "version": "0.2.3"
+          "revision": "ab6339b6a33b69886b3cf2254d3326eddfe58eb0",
+          "version": "0.2.2"
         }
       },
       {
@@ -231,8 +231,8 @@
         "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
         "state": {
           "branch": null,
-          "revision": "152390e9e78ebbf0d767ee52971d41e7f44f39bc",
-          "version": "0.1.1"
+          "revision": "603974e3909ad4b48ba04aad7e0ceee4f077a518",
+          "version": "0.1.0"
         }
       },
       {

--- a/.package.resolved
+++ b/.package.resolved
@@ -186,8 +186,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "12d3a8651d32295794a850307f77407f95b8c881",
-          "version": "1.4.1"
+          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
+          "version": "1.4.2"
         }
       },
       {

--- a/.package.resolved
+++ b/.package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
         "state": {
           "branch": null,
-          "revision": "f1250faa1c1436ca83950ce676a4fe97a309a457",
-          "version": "0.4.1"
+          "revision": "c37e5ae8012fb654af776cc556ff8ae64398c841",
+          "version": "0.5.0"
         }
       },
       {
@@ -186,8 +186,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "12d3a8651d32295794a850307f77407f95b8c881",
-          "version": "1.4.1"
+          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
+          "version": "1.4.2"
         }
       },
       {
@@ -195,8 +195,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "ab6339b6a33b69886b3cf2254d3326eddfe58eb0",
-          "version": "0.2.2"
+          "revision": "3b6b97d612b56e25d80d0807f5bc38ea08b7bdf3",
+          "version": "0.2.3"
         }
       },
       {
@@ -231,8 +231,8 @@
         "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
         "state": {
           "branch": null,
-          "revision": "603974e3909ad4b48ba04aad7e0ceee4f077a518",
-          "version": "0.1.0"
+          "revision": "152390e9e78ebbf0d767ee52971d41e7f44f39bc",
+          "version": "0.1.1"
         }
       },
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Meta tuist support [#3103](https://github.com/tuist/tuist/pull/3103) by [@fortmarek](https://github.com/fortmarek)
 - Add `--result-bundle-path` parameter to test command [#3177](https://github.com/tuist/tuist/pull/3177) by [@olejnjak](https://github.com/olejnjak)
 - The `tuist dependencies` command prints dependency managers' output to console. [#3185](https://github.com/tuist/tuist/pull/3185) by [@laxmorek](https://github.com/laxmorek)
+- CI check to ensure lockfiles are consistent [#3208](https://github.com/tuist/tuist/pull/3208) by by [@pepibumur](https://github.com/pepibumur).
 
 ### Removed
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
         "state": {
           "branch": null,
-          "revision": "c37e5ae8012fb654af776cc556ff8ae64398c841",
-          "version": "0.5.0"
+          "revision": "f1250faa1c1436ca83950ce676a4fe97a309a457",
+          "version": "0.4.1"
         }
       },
       {
@@ -146,6 +146,15 @@
         }
       },
       {
+        "package": "ShellOut",
+        "repositoryURL": "https://github.com/JohnSundell/ShellOut.git",
+        "state": {
+          "branch": null,
+          "revision": "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
+          "version": "2.3.0"
+        }
+      },
+      {
         "package": "Spectre",
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
@@ -173,6 +182,15 @@
         }
       },
       {
+        "package": "StencilSwiftKit",
+        "repositoryURL": "https://github.com/SwiftGen/StencilSwiftKit.git",
+        "state": {
+          "branch": null,
+          "revision": "54cbedcdbb4334e03930adcff7343ffaf317bf0f",
+          "version": "2.8.0"
+        }
+      },
+      {
         "package": "swift-argument-parser",
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
@@ -186,7 +204,7 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
+          "revision": "12d3a8651d32295794a850307f77407f95b8c881",
           "version": "1.4.2"
         }
       },
@@ -195,8 +213,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "3b6b97d612b56e25d80d0807f5bc38ea08b7bdf3",
-          "version": "0.2.3"
+          "revision": "ab6339b6a33b69886b3cf2254d3326eddfe58eb0",
+          "version": "0.2.2"
         }
       },
       {
@@ -231,8 +249,8 @@
         "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
         "state": {
           "branch": null,
-          "revision": "152390e9e78ebbf0d767ee52971d41e7f44f39bc",
-          "version": "0.1.1"
+          "revision": "603974e3909ad4b48ba04aad7e0ceee4f077a518",
+          "version": "0.1.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -146,15 +146,6 @@
         }
       },
       {
-        "package": "ShellOut",
-        "repositoryURL": "https://github.com/JohnSundell/ShellOut.git",
-        "state": {
-          "branch": null,
-          "revision": "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
-          "version": "2.3.0"
-        }
-      },
-      {
         "package": "Spectre",
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
@@ -182,15 +173,6 @@
         }
       },
       {
-        "package": "StencilSwiftKit",
-        "repositoryURL": "https://github.com/SwiftGen/StencilSwiftKit.git",
-        "state": {
-          "branch": null,
-          "revision": "54cbedcdbb4334e03930adcff7343ffaf317bf0f",
-          "version": "2.8.0"
-        }
-      },
-      {
         "package": "swift-argument-parser",
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
@@ -204,7 +186,7 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "12d3a8651d32295794a850307f77407f95b8c881",
+          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
           "version": "1.4.2"
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
         "state": {
           "branch": null,
-          "revision": "f1250faa1c1436ca83950ce676a4fe97a309a457",
-          "version": "0.4.1"
+          "revision": "c37e5ae8012fb654af776cc556ff8ae64398c841",
+          "version": "0.5.0"
         }
       },
       {
@@ -195,8 +195,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "ab6339b6a33b69886b3cf2254d3326eddfe58eb0",
-          "version": "0.2.2"
+          "revision": "3b6b97d612b56e25d80d0807f5bc38ea08b7bdf3",
+          "version": "0.2.3"
         }
       },
       {
@@ -231,8 +231,8 @@
         "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
         "state": {
           "branch": null,
-          "revision": "603974e3909ad4b48ba04aad7e0ceee4f077a518",
-          "version": "0.1.0"
+          "revision": "152390e9e78ebbf0d767ee52971d41e7f44f39bc",
+          "version": "0.1.1"
         }
       },
       {

--- a/fourier
+++ b/fourier
@@ -15,4 +15,9 @@ $LOAD_PATH.unshift(fourier_directory) unless $LOAD_PATH.include?(fourier_directo
 # Load Fourier
 require "fourier"
 
-Fourier::CLI.start(ARGV)
+begin
+  Fourier::CLI.start(ARGV)
+rescue Fourier::Utilities::Errors::Error => error
+  Fourier::Utilities::Output.error(error.message)
+  Kernel.exit(1)
+end

--- a/projects/fourier/lib/fourier/commands/lint.rb
+++ b/projects/fourier/lib/fourier/commands/lint.rb
@@ -20,6 +20,11 @@ module Fourier
         Services::Lint::Swift.call(fix: options[:fix])
         Services::Lint::Ruby.call(fix: options[:fix])
       end
+
+      desc "lockfiles", "Ensures SPM and Tuist's generated lockfiles are consistent"
+      def lockfiles
+        Services::Lint::Lockfiles.call
+      end
     end
   end
 end

--- a/projects/fourier/lib/fourier/services/lint/lockfiles.rb
+++ b/projects/fourier/lib/fourier/services/lint/lockfiles.rb
@@ -5,6 +5,12 @@ module Fourier
   module Services
     module Lint
       class Lockfiles < Base
+        attr_reader :root_directory
+
+        def initialize(root_directory: Constants::ROOT_DIRECTORY)
+          @root_directory = root_directory
+        end
+
         def call
           spm_lockfile = self.spm_lockfile
           tuist_lockfile = self.tuist_lockfile
@@ -31,12 +37,12 @@ module Fourier
           end
 
           def spm_lockfile
-            path = File.expand_path("Package.resolved", Constants::ROOT_DIRECTORY)
+            path = File.expand_path("Package.resolved", root_directory)
             load_lockfile(path)
           end
 
           def tuist_lockfile
-            path = File.expand_path(".package.resolved", Constants::ROOT_DIRECTORY)
+            path = File.expand_path(".package.resolved", root_directory)
             load_lockfile(path)
           end
 

--- a/projects/fourier/lib/fourier/services/lint/lockfiles.rb
+++ b/projects/fourier/lib/fourier/services/lint/lockfiles.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require "json"
+
+module Fourier
+  module Services
+    module Lint
+      class Lockfiles < Base
+        def call
+          spm_lockfile = self.spm_lockfile
+          tuist_lockfile = self.tuist_lockfile
+          assert_same_versions(spm_lockfile: spm_lockfile, tuist_lockfile: tuist_lockfile)
+        end
+
+        private
+          def assert_same_versions(spm_lockfile:, tuist_lockfile:)
+            mismatched_packages = []
+            common_packages = spm_lockfile.keys & tuist_lockfile.keys
+
+            common_packages.each do |package_name|
+              tuist_revision = tuist_lockfile[package_name]["state"]["revision"]
+              spm_revision = spm_lockfile[package_name]["state"]["revision"]
+              mismatched_packages << package_name if tuist_revision != spm_revision
+            end
+
+            if mismatched_packages.count != 0
+              message = "There's a mismatch between the revision of the following pakages in"\
+              " in the Package.resolved and .package.resolved files:"\
+              " #{mismatched_packages.join(", ")}"
+              raise Utilities::Errors::AbortError, message
+            end
+          end
+
+          def spm_lockfile
+            path = File.expand_path("Package.resolved", Constants::ROOT_DIRECTORY)
+            load_lockfile(path)
+          end
+
+          def tuist_lockfile
+            path = File.expand_path(".package.resolved", Constants::ROOT_DIRECTORY)
+            load_lockfile(path)
+          end
+
+          def load_lockfile(path)
+            content = JSON.parse(File.read(path))["object"]["pins"]
+            content.inject({}) do |acc, package|
+              acc[package["package"]] = package
+              acc
+            end
+          end
+      end
+    end
+  end
+end

--- a/projects/fourier/lib/fourier/services/lint/lockfiles.rb
+++ b/projects/fourier/lib/fourier/services/lint/lockfiles.rb
@@ -14,10 +14,20 @@ module Fourier
         def call
           spm_lockfile = self.spm_lockfile
           tuist_lockfile = self.tuist_lockfile
-          assert_same_versions(spm_lockfile: spm_lockfile, tuist_lockfile: tuist_lockfile)
+          same_versions = assert_same_versions(spm_lockfile: spm_lockfile, tuist_lockfile: tuist_lockfile)
+          same_count = assert_same_packages_count(spm_lockfile: spm_lockfile, tuist_lockfile: tuist_lockfile)
+          valid = same_versions && same_count
+          raise Utilities::Errors::AbortSilentError unless valid
         end
 
         private
+          def assert_same_packages_count(spm_lockfile:, tuist_lockfile:)
+            return true if spm_lockfile.count == tuist_lockfile.count
+            message = "The number of packages in the Package.resolved and .package.resolved don't match."
+            Utilities::Output.error(message)
+            false
+          end
+
           def assert_same_versions(spm_lockfile:, tuist_lockfile:)
             mismatched_packages = []
             common_packages = spm_lockfile.keys & tuist_lockfile.keys
@@ -32,8 +42,10 @@ module Fourier
               message = "There's a mismatch between the revision of the following pakages in"\
               " in the Package.resolved and .package.resolved files:"\
               " #{mismatched_packages.join(", ")}"
-              raise Utilities::Errors::AbortError, message
+              Utilities::Output.error(message)
+              return false
             end
+            true
           end
 
           def spm_lockfile

--- a/projects/fourier/lib/fourier/utilities/errors.rb
+++ b/projects/fourier/lib/fourier/utilities/errors.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module Fourier
+  module Utilities
+    class Errors
+      Error = Class.new(StandardError)
+      AbortError = Class.new(Error)
+      AbortSilentError = Class.new(Error)
+      BugError = Class.new(Error)
+      BugSilentError = Class.new(Error)
+    end
+  end
+end

--- a/projects/fourier/test/fourier/services/lint/lockfiles_test.rb
+++ b/projects/fourier/test/fourier/services/lint/lockfiles_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require "test_helper"
+require "json"
+
+module Fourier
+  module Services
+    module Lint
+      class LockfilesTest < TestCase
+        include TestHelpers::TemporaryDirectory
+
+        def test_raises_when_versions_mismatch
+          # Given
+          tuist_lockfile = { "object": { "pins": [{
+            "package": "Test",
+            "state": { "revision": "8623e73b193386909566a9ca20203e33a09af142" },
+          }] } }
+          spm_lockfile = { "object": { "pins": [{
+            "package": "Test",
+            "state": { "revision": "bb23e73b193386909566a9ca20203e33a09af1cc" },
+          }] } }
+          File.write(File.join(@tmp_dir, ".package.resolved"), tuist_lockfile.to_json)
+          File.write(File.join(@tmp_dir, "Package.resolved"), spm_lockfile.to_json)
+
+          # When/then
+          error = assert_raises(Utilities::Errors::AbortError) do
+            Services::Lint::Lockfiles.call(root_directory: @tmp_dir)
+          end
+          expected_message = "There's a mismatch between the revision of the following pakages in"\
+              " in the Package.resolved and .package.resolved files: Test"
+          assert_equal(expected_message, error.message)
+        end
+
+        def test_doesnt_raise_when_versions_match
+          # Given
+          tuist_lockfile = { "object": { "pins": [{
+            "package": "Test",
+            "state": { "revision": "8623e73b193386909566a9ca20203e33a09af142" },
+          }] } }
+          spm_lockfile = { "object": { "pins": [{
+            "package": "Test",
+            "state": { "revision": "8623e73b193386909566a9ca20203e33a09af142" },
+          }] } }
+          File.write(File.join(@tmp_dir, ".package.resolved"), tuist_lockfile.to_json)
+          File.write(File.join(@tmp_dir, "Package.resolved"), spm_lockfile.to_json)
+
+          # When/then
+          Services::Lint::Lockfiles.call(root_directory: @tmp_dir)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Short description 📝
I noticed that the dependency revisions in the lockfiles (SPM and Tuist's) are not consistent. This might lead to compilation issues in the future and unexpected results. To prevent that from happening, I'm adding a new fourier command, `fourier lint lockfiles`, that ensures that versions are consistent across the two project managers. The command is run on CI as part of the checks workflow.