### PR TITLE
Support for localized intents definition files via strings files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Added
+
+- Add support for localized intent definition files using `.strings`. [#3236](https://github.com/tuist/tuist/pull/3236) by [@dbarden](https://github.com/dbarden)
 ## 1.47.0 - Mirror
 
 ### Added

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -356,6 +356,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
     {
         var buildFilesCache = Set<AbsolutePath>()
         var pbxBuildFiles = [PBXBuildFile]()
+        let ignoredVariantGroupExtensions = [".intentdefinition"]
 
         try files.sorted(by: { $0.path < $1.path }).forEach { resource in
             let buildFilePath = resource.path
@@ -378,6 +379,13 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
                 guard let (group, path) = fileElements.variantGroup(containing: buildFilePath) else {
                     throw BuildPhaseGenerationError.missingFileReference(buildFilePath)
                 }
+
+                // Xcode automatically copies the string files for some files (i.e. .intentdefinition files), hence we need
+                // to remove them from the Copy Resources build phase
+                if let suffix = path.suffix, ignoredVariantGroupExtensions.contains(suffix) {
+                    return
+                }
+
                 element = (group, path)
             } else if !isLproj {
                 guard let fileReference = fileElements.file(path: buildFilePath) else {

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -31,7 +31,7 @@ class ProjectFileElements {
         "storyboard",
         "strings",
         "xib",
-        "intentdefinition"
+        "intentdefinition",
     ]
 
     // MARK: - Attributes

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -27,10 +27,11 @@ class ProjectFileElements {
         options: []
     )
 
-    private static let localizedInterfaceBuilderGroupExtensions = [
+    private static let localizedGroupExtensions = [
         "storyboard",
         "strings",
         "xib",
+        "intentdefinition"
     ]
 
     // MARK: - Attributes
@@ -637,16 +638,16 @@ class ProjectFileElements {
     func variantGroup(containing localizedFile: AbsolutePath) -> (group: PBXVariantGroup, path: AbsolutePath)? {
         let variantGroupBasePath = localizedFile.parentDirectory.parentDirectory
 
-        // Variant groups used to localize Interface Builder files (.xib or .storyboard) can contain files of these
-        // types, respectively, and corresponding .strings files. However, the groups' names must always use the
-        // extension of the Interface Builder file, i.e. either .xib or .storyboard. Since the order in which such
+        // Variant groups used to localize Interface Builder or Intent Definition files (.xib, .storyboard or .intentdefition)
+        // can contain files of these, respectively, and corresponding .strings files. However, the groups' names must always
+        // use the extension of the main file, i.e. either .xib or .storyboard. Since the order in which such
         // groups are formed is not deterministic, we must check for existing groups having the same name as the
         // localized file and any of these extensions.
         if
             let fileExtension = localizedFile.extension,
-            Self.localizedInterfaceBuilderGroupExtensions.contains(fileExtension)
+            Self.localizedGroupExtensions.contains(fileExtension)
         {
-            for groupExtension in Self.localizedInterfaceBuilderGroupExtensions {
+            for groupExtension in Self.localizedGroupExtensions {
                 let variantGroupPath = variantGroupBasePath.appending(
                     component: "\(localizedFile.basenameWithoutExt).\(groupExtension)"
                 )

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -288,16 +288,19 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         ])
     }
 
-    func test_addElement_lproj_xib_variant_groups() throws {
+    func test_addElement_lproj_variant_groups() throws {
         // Given
         let temporaryPath = try self.temporaryPath()
         let resources = try createFiles([
-            "resources/fr.lproj/Controller.strings",
             "resources/Base.lproj/Controller.xib",
+            "resources/Base.lproj/Intents.intentdefinition",
             "resources/Base.lproj/Storyboard.storyboard",
             "resources/en.lproj/Controller.xib",
+            "resources/en.lproj/Intents.strings",
             "resources/en.lproj/Storyboard.strings",
-            "resources/fr.lproj/Storyboard.strings",
+            "resources/fr.lproj/Controller.strings",
+            "resources/fr.lproj/Intents.strings",
+            "resources/fr.lproj/Storyboard.strings"
         ])
 
         let elements = resources.map {
@@ -324,6 +327,9 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
             "resources/Controller.xib/Base",
             "resources/Controller.xib/en",
             "resources/Controller.xib/fr",
+            "resources/Intents.intentdefinition/Base",
+            "resources/Intents.intentdefinition/en",
+            "resources/Intents.intentdefinition/fr",
             "resources/Storyboard.storyboard/Base",
             "resources/Storyboard.storyboard/en",
             "resources/Storyboard.storyboard/fr",
@@ -331,6 +337,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
 
         XCTAssertEqual(projectGroup?.debugVariantGroupPaths, [
             "resources/Controller.xib",
+            "resources/Intents.intentdefinition",
             "resources/Storyboard.storyboard",
         ])
     }

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -300,7 +300,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
             "resources/en.lproj/Storyboard.strings",
             "resources/fr.lproj/Controller.strings",
             "resources/fr.lproj/Intents.strings",
-            "resources/fr.lproj/Storyboard.strings"
+            "resources/fr.lproj/Storyboard.strings",
         ])
 
         let elements = resources.map {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3079
Request for comments document (if applies):

### Short description 📝

This patch provides support for localized intent files using `.strings` for translations.

This support brings two modifications:
1. It creates a variant group with the intent file and it's translated `.strings` files
2. It removes the `.strings` files from the resources to be copied at build phase, since it is done automatically by Xcode during the build phase.

### Checklist ✅

- [X] The code architecture and patterns are consistent with the rest of the codebase.
- [X] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
