### PR TITLE
settings-to-xcconfig migration command no longer produces the array e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+- settings-to-xcconfig migration command produces correct string format. [#3260](https://github.com/tuist/tuist/3260) by [@saim80](https://github.com/saim80)
+
 ### Added
 
 - Add support for localized intent definition files using `.strings`. [#3236](https://github.com/tuist/tuist/pull/3236) by [@dbarden](https://github.com/dbarden)

--- a/Sources/TuistMigration/Utilities/SettingsToXCConfigExtractor.swift
+++ b/Sources/TuistMigration/Utilities/SettingsToXCConfigExtractor.swift
@@ -111,8 +111,7 @@ public class SettingsToXCConfigExtractor: SettingsToXCConfigExtracting {
         // We need to flatten the array into string to avoid expressions of `SETTING_KEY=["VALUE1", "VALUE2", ...]`
         // Xcode rather understands only expressions, such as `SETTING_KEY=VALUE1 VALUE2 ...`
         if let arrayValue = value as? [Any] {
-            // We cannot assume the given value is [String]. Use reduce(...) instead of joined(separator:)
-            flattened = arrayValue.reduce("", { $0.isEmpty ? "\($1)" : "\($0) \($1)" })
+            flattened = arrayValue.map { "\($0)" }.joined(separator: " ")
         } else {
             flattened = "\(value)"
         }

--- a/Sources/TuistMigration/Utilities/SettingsToXCConfigExtractor.swift
+++ b/Sources/TuistMigration/Utilities/SettingsToXCConfigExtractor.swift
@@ -71,14 +71,15 @@ public class SettingsToXCConfigExtractor: SettingsToXCConfigExtracting {
 
         // Common build settings
         commonBuildSettings.forEach { setting in
-            commonBuildSettingsLines.append("\(setting)=\(buildConfigurations.first!.buildSettings[setting]!)")
+            let value = buildConfigurations.first!.buildSettings[setting]!
+            commonBuildSettingsLines.append("\(setting)=\(flattenedValue(from: value))")
         }
 
         // Per-configuration build settings
         buildConfigurations.forEach { configuration in
             configuration.buildSettings.forEach { key, value in
                 if commonBuildSettings.contains(key) { return }
-                buildSettingsLines.append("\(key)[config=\(configuration.name)]=\(value)")
+                buildSettingsLines.append("\(key)[config=\(configuration.name)]=\(flattenedValue(from: value))")
             }
         }
 
@@ -103,5 +104,19 @@ public class SettingsToXCConfigExtractor: SettingsToXCConfigExtracting {
             }
             return project.buildConfigurationList.buildConfigurations
         }
+    }
+
+    private func flattenedValue(from value: Any) -> String {
+        var flattened: String
+        // We need to flatten the array into string to avoid expressions of `SETTING_KEY=["VALUE1", "VALUE2", ...]`
+        // Xcode rather understands only expressions, such as `SETTING_KEY=VALUE1 VALUE2 ...`
+        if let arrayValue = value as? [Any] {
+            // We cannot assume the given value is [String]. Use reduce(...) instead of joined(separator:)
+            flattened = arrayValue.reduce("", { $0.isEmpty ? "\($1)" : "\($0) \($1)" })
+        } else {
+            flattened = "\(value)"
+        }
+
+        return flattened
     }
 }

--- a/Tests/TuistMigrationIntegrationTests/Utilities/SettingsToXCConfigExtractorIntegrationTests.swift
+++ b/Tests/TuistMigrationIntegrationTests/Utilities/SettingsToXCConfigExtractorIntegrationTests.swift
@@ -121,7 +121,7 @@ final class SettingsToXCConfigExtractorIntegrationTests: TuistTestCase {
         ENABLE_TESTABILITY[config=Debug]=YES
         GCC_DYNAMIC_NO_PIC[config=Debug]=NO
         GCC_OPTIMIZATION_LEVEL[config=Debug]=0
-        GCC_PREPROCESSOR_DEFINITIONS[config=Debug]=["DEBUG=1", "$(inherited)"]
+        GCC_PREPROCESSOR_DEFINITIONS[config=Debug]=DEBUG=1 $(inherited)
         MTL_ENABLE_DEBUG_INFO[config=Debug]=INCLUDE_SOURCE
         MTL_ENABLE_DEBUG_INFO[config=Release]=NO
         ONLY_ACTIVE_ARCH[config=Debug]=YES


### PR DESCRIPTION
…xpression from Swift style string interpolation.

Request for comments document (if applies):

### Short description 📝

settings-to-xcconfig migration comment produces the value expression like

["VALUE1", "VALUE2", ...]

This is just because of how Swift string interpolation produces the string value from Array data structure. And, Xcode
simply ignores such expression when applied to Xcode build settings. It understands:

VALUE1, VALUE2, ...

### Checklist ✅

- [X] The code architecture and patterns are consistent with the rest of the codebase.
- [X] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [X] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [X] In case the PR introduces changes that affect users, the documentation has been updated.
