### PR TITLE
feat: add mapping of SPM languages versions

### DIFF
--- a/Sources/TuistDependencies/DependenciesController.swift
+++ b/Sources/TuistDependencies/DependenciesController.swift
@@ -1,5 +1,6 @@
 import ProjectDescription
 import TSCBasic
+import TSCUtility
 import TuistCore
 import TuistGraph
 import TuistSupport
@@ -60,7 +61,7 @@ public protocol DependenciesControlling {
     func fetch(
         at path: AbsolutePath,
         dependencies: TuistGraph.Dependencies,
-        swiftVersion: String?
+        swiftVersion: TSCUtility.Version?
     ) throws -> TuistCore.DependenciesGraph
 
     /// Updates dependencies.
@@ -71,7 +72,7 @@ public protocol DependenciesControlling {
     func update(
         at path: AbsolutePath,
         dependencies: TuistGraph.Dependencies,
-        swiftVersion: String?
+        swiftVersion: TSCUtility.Version?
     ) throws -> TuistCore.DependenciesGraph
 
     /// Save dependencies graph.
@@ -107,7 +108,7 @@ public final class DependenciesController: DependenciesControlling {
     public func fetch(
         at path: AbsolutePath,
         dependencies: TuistGraph.Dependencies,
-        swiftVersion: String?
+        swiftVersion: TSCUtility.Version?
     ) throws -> TuistCore.DependenciesGraph {
         return try install(
             at: path,
@@ -120,7 +121,7 @@ public final class DependenciesController: DependenciesControlling {
     public func update(
         at path: AbsolutePath,
         dependencies: TuistGraph.Dependencies,
-        swiftVersion: String?
+        swiftVersion: TSCUtility.Version?
     ) throws -> TuistCore.DependenciesGraph {
         return try install(
             at: path,
@@ -147,7 +148,7 @@ public final class DependenciesController: DependenciesControlling {
         at path: AbsolutePath,
         dependencies: TuistGraph.Dependencies,
         shouldUpdate: Bool,
-        swiftVersion: String?
+        swiftVersion: TSCUtility.Version?
     ) throws -> TuistCore.DependenciesGraph {
         logger.warning(
             """

--- a/Sources/TuistDependencies/SwiftPackageManager/Models/PackageInfo.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Models/PackageInfo.swift
@@ -278,12 +278,12 @@ extension PackageInfo: Decodable {
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
-        self.products = try values.decode([Product].self, forKey: .products)
-        self.targets = try values.decode([Target].self, forKey: .targets)
-        self.platforms = try values.decode([Platform].self, forKey: .platforms)
-        self.cLanguageStandard = try values.decodeIfPresent(String.self, forKey: .cLanguageStandard)
-        self.cxxLanguageStandard = try values.decodeIfPresent(String.self, forKey: .cxxLanguageStandard)
-        self.swiftLanguageVersions = try values
+        products = try values.decode([Product].self, forKey: .products)
+        targets = try values.decode([Target].self, forKey: .targets)
+        platforms = try values.decode([Platform].self, forKey: .platforms)
+        cLanguageStandard = try values.decodeIfPresent(String.self, forKey: .cLanguageStandard)
+        cxxLanguageStandard = try values.decodeIfPresent(String.self, forKey: .cxxLanguageStandard)
+        swiftLanguageVersions = try values
             .decodeIfPresent([String].self, forKey: .swiftLanguageVersions)?
             .compactMap { TSCUtility.Version(unformattedString: $0) }
     }

--- a/Sources/TuistDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
@@ -1,5 +1,6 @@
 import ProjectDescription
 import TSCBasic
+import TSCUtility
 import TuistCore
 import TuistGraph
 import TuistSupport
@@ -47,7 +48,7 @@ public protocol SwiftPackageManagerInteracting {
         dependencies: TuistGraph.SwiftPackageManagerDependencies,
         platforms: Set<TuistGraph.Platform>,
         shouldUpdate: Bool,
-        swiftToolsVersion: String?
+        swiftToolsVersion: TSCUtility.Version?
     ) throws -> TuistCore.DependenciesGraph
 
     /// Removes all cached `Swift Package Manager` dependencies.
@@ -79,7 +80,7 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
         dependencies: TuistGraph.SwiftPackageManagerDependencies,
         platforms: Set<TuistGraph.Platform>,
         shouldUpdate: Bool,
-        swiftToolsVersion: String?
+        swiftToolsVersion: TSCUtility.Version?
     ) throws -> TuistCore.DependenciesGraph {
         logger.info("Installing Swift Package Manager dependencies.", metadata: .subsection)
 
@@ -111,7 +112,8 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
                 at: pathsProvider.destinationBuildDirectory,
                 productTypes: dependencies.productTypes,
                 platforms: platforms,
-                deploymentTargets: dependencies.deploymentTargets
+                deploymentTargets: dependencies.deploymentTargets,
+                swiftToolsVersion: swiftToolsVersion
             )
         }
 
@@ -137,7 +139,7 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
     private func loadDependencies(
         pathsProvider: SwiftPackageManagerPathsProvider,
         dependencies: TuistGraph.SwiftPackageManagerDependencies,
-        swiftToolsVersion: String?
+        swiftToolsVersion: TSCUtility.Version?
     ) throws {
         // copy `.build` directory from previous run if exist
         if fileHandler.exists(pathsProvider.destinationBuildDirectory) {
@@ -160,7 +162,7 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
         try fileHandler.write(dependencies.manifestValue(), path: packageManifestPath, atomically: true)
 
         // set `swift-tools-version` in `Package.swift`
-        try swiftPackageManagerController.setToolsVersion(at: pathsProvider.temporaryDirectoryPath, to: swiftToolsVersion)
+        try swiftPackageManagerController.setToolsVersion(at: pathsProvider.temporaryDirectoryPath, to: swiftToolsVersion?.description)
 
         // log
         let generatedManifestContent = try fileHandler.readTextFile(packageManifestPath)

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerGraphGenerator.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerGraphGenerator.swift
@@ -42,11 +42,13 @@ public protocol SwiftPackageManagerGraphGenerating {
     /// - Parameter productTypes: The custom `Product` types to be used for SPM targets.
     /// - Parameter platforms: The supported platforms.
     /// - Parameter deploymentTargets: The configured deployment targets.
+    /// - Parameter swiftToolsVersion: The version of Swift tools that will be used to generate dependencies.
     func generate(
         at path: AbsolutePath,
         productTypes: [String: TuistGraph.Product],
         platforms: Set<TuistGraph.Platform>,
-        deploymentTargets: Set<TuistGraph.DeploymentTarget>
+        deploymentTargets: Set<TuistGraph.DeploymentTarget>,
+        swiftToolsVersion: TSCUtility.Version?
     ) throws -> TuistCore.DependenciesGraph
 }
 
@@ -67,7 +69,8 @@ public final class SwiftPackageManagerGraphGenerator: SwiftPackageManagerGraphGe
         at path: AbsolutePath,
         productTypes: [String: TuistGraph.Product],
         platforms: Set<TuistGraph.Platform>,
-        deploymentTargets: Set<TuistGraph.DeploymentTarget>
+        deploymentTargets: Set<TuistGraph.DeploymentTarget>,
+        swiftToolsVersion: TSCUtility.Version?
     ) throws -> TuistCore.DependenciesGraph {
         let artifactsFolder = path.appending(component: "artifacts")
         let checkoutsFolder = path.appending(component: "checkouts")
@@ -135,7 +138,7 @@ public final class SwiftPackageManagerGraphGenerator: SwiftPackageManagerGraphGe
                 targetToProducts: targetToProducts,
                 targetToResolvedDependencies: targetToResolvedDependencies,
                 packageToProject: packageToProject,
-                productToPackage: productToPackage
+                swiftToolsVersion: swiftToolsVersion
             )
             result[Path(packageInfo.folder.pathString)] = manifest
         }

--- a/Sources/TuistDependenciesTesting/DependenciesGraph/DependenciesGraph+TestData.swift
+++ b/Sources/TuistDependenciesTesting/DependenciesGraph/DependenciesGraph+TestData.swift
@@ -50,6 +50,9 @@ public extension TuistCore.DependenciesGraph {
             externalProjects: [
                 packageFolder: .init(
                     name: "test",
+                    settings: .init(base: [
+                        "GCC_C_LANGUAGE_STANDARD": "c99",
+                    ]),
                     targets: [
                         .init(
                             name: "Tuist",
@@ -73,14 +76,12 @@ public extension TuistCore.DependenciesGraph {
                                 .project(target: "ALibraryUtils", path: Self.packageFolder(spmFolder: spmFolder, packageName: "ADependency")),
                             ],
                             settings: Self.spmSettings(with: [
-                                "HEADER_SEARCH_PATHS": .array(
-                                    ["$(SRCROOT)/customPath/cSearchPath", "$(SRCROOT)/customPath/cxxSearchPath"]
-                                ),
-                                "OTHER_CFLAGS": .array(["CUSTOM_C_FLAG"]),
-                                "OTHER_CPLUSPLUSFLAGS": .array(["CUSTOM_CXX_FLAG"]),
-                                "OTHER_SWIFT_FLAGS": .array(["CUSTOM_SWIFT_FLAG1", "CUSTOM_SWIFT_FLAG2"]),
-                                "GCC_PREPROCESSOR_DEFINITIONS": .array(["CXX_DEFINE=CXX_VALUE", "C_DEFINE=C_VALUE"]),
-                                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": .array(["SWIFT_DEFINE"]),
+                                "HEADER_SEARCH_PATHS": ["$(SRCROOT)/customPath/cSearchPath", "$(SRCROOT)/customPath/cxxSearchPath"],
+                                "OTHER_CFLAGS": ["CUSTOM_C_FLAG"],
+                                "OTHER_CPLUSPLUSFLAGS": ["CUSTOM_CXX_FLAG"],
+                                "OTHER_SWIFT_FLAGS": ["CUSTOM_SWIFT_FLAG1", "CUSTOM_SWIFT_FLAG2"],
+                                "GCC_PREPROCESSOR_DEFINITIONS": ["CXX_DEFINE=CXX_VALUE", "C_DEFINE=C_VALUE"],
+                                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": ["SWIFT_DEFINE"],
                             ])
                         ),
                         .init(
@@ -194,6 +195,7 @@ public extension TuistCore.DependenciesGraph {
             externalProjects: [
                 packageFolder: .init(
                     name: "Alamofire",
+                    settings: .init(base: ["SWIFT_VERSION": "5.0.0"]),
                     targets: [
                         .init(
                             name: "Alamofire",
@@ -234,6 +236,10 @@ public extension TuistCore.DependenciesGraph {
             externalProjects: [
                 packageFolder: .init(
                     name: "GoogleAppMeasurement",
+                    settings: .init(base: [
+                        "GCC_C_LANGUAGE_STANDARD": "c99",
+                        "CLANG_CXX_LANGUAGE_STANDARD": "gnu++14",
+                    ]),
                     targets: [
                         .init(
                             name: "GoogleAppMeasurementTarget",

--- a/Sources/TuistDependenciesTesting/MockDependenciesController.swift
+++ b/Sources/TuistDependenciesTesting/MockDependenciesController.swift
@@ -1,5 +1,6 @@
 import ProjectDescription
 import TSCBasic
+import TSCUtility
 import TuistCore
 import TuistGraph
 
@@ -9,24 +10,24 @@ public final class MockDependenciesController: DependenciesControlling {
     public init() {}
 
     var invokedFetch = false
-    var fetchStub: ((AbsolutePath, TuistGraph.Dependencies, String?) throws -> TuistCore.DependenciesGraph)?
+    var fetchStub: ((AbsolutePath, TuistGraph.Dependencies, TSCUtility.Version?) throws -> TuistCore.DependenciesGraph)?
 
     public func fetch(
         at path: AbsolutePath,
         dependencies: TuistGraph.Dependencies,
-        swiftVersion: String?
+        swiftVersion: TSCUtility.Version?
     ) throws -> TuistCore.DependenciesGraph {
         invokedFetch = true
         return try fetchStub?(path, dependencies, swiftVersion) ?? .none
     }
 
     var invokedUpdate = false
-    var updateStub: ((AbsolutePath, TuistGraph.Dependencies, String?) throws -> TuistCore.DependenciesGraph)?
+    var updateStub: ((AbsolutePath, TuistGraph.Dependencies, TSCUtility.Version?) throws -> TuistCore.DependenciesGraph)?
 
     public func update(
         at path: AbsolutePath,
         dependencies: TuistGraph.Dependencies,
-        swiftVersion: String?
+        swiftVersion: TSCUtility.Version?
     ) throws -> TuistCore.DependenciesGraph {
         invokedUpdate = true
         return try updateStub?(path, dependencies, swiftVersion) ?? .none

--- a/Sources/TuistDependenciesTesting/SwiftPackageManager/MockSwiftPackageManagerInteractor.swift
+++ b/Sources/TuistDependenciesTesting/SwiftPackageManager/MockSwiftPackageManagerInteractor.swift
@@ -1,5 +1,6 @@
 import ProjectDescription
 import TSCBasic
+import TSCUtility
 import TuistCore
 import TuistGraph
 
@@ -15,7 +16,7 @@ public final class MockSwiftPackageManagerInteractor: SwiftPackageManagerInterac
             TuistGraph.SwiftPackageManagerDependencies,
             Set<TuistGraph.Platform>,
             Bool,
-            String?
+            TSCUtility.Version?
         ) throws -> TuistCore.DependenciesGraph
     )?
 
@@ -24,7 +25,7 @@ public final class MockSwiftPackageManagerInteractor: SwiftPackageManagerInterac
         dependencies: TuistGraph.SwiftPackageManagerDependencies,
         platforms: Set<TuistGraph.Platform>,
         shouldUpdate: Bool,
-        swiftToolsVersion: String?
+        swiftToolsVersion: TSCUtility.Version?
     ) throws -> TuistCore.DependenciesGraph {
         invokedInstall = true
         return try installStub?(dependenciesDirectory, dependencies, platforms, shouldUpdate, swiftToolsVersion) ?? .none

--- a/Sources/TuistDependenciesTesting/SwiftPackageManager/Models/PackageInfo+TestData.swift
+++ b/Sources/TuistDependenciesTesting/SwiftPackageManager/Models/PackageInfo+TestData.swift
@@ -8,7 +8,7 @@ extension PackageInfo {
     static var testJSON: String {
         """
         {
-          "cLanguageStandard" : "something",
+          "cLanguageStandard" : "c99",
           "cxxLanguageStandard" : null,
           "dependencies" : [
             {
@@ -360,7 +360,10 @@ extension PackageInfo {
                 .init(platformName: "ios", version: "13.0", options: []),
                 .init(platformName: "macos", version: "10.15", options: []),
                 .init(platformName: "watchos", version: "6.0", options: []),
-            ]
+            ],
+            cLanguageStandard: "c99",
+            cxxLanguageStandard: nil,
+            swiftLanguageVersions: nil
         )
     }
 
@@ -399,7 +402,10 @@ extension PackageInfo {
                     checksum: nil
                 ),
             ],
-            platforms: []
+            platforms: [],
+            cLanguageStandard: nil,
+            cxxLanguageStandard: nil,
+            swiftLanguageVersions: nil
         )
     }
 
@@ -427,7 +433,10 @@ extension PackageInfo {
                 .init(platformName: "ios", version: "13.0", options: []),
                 .init(platformName: "macos", version: "10.15", options: []),
                 .init(platformName: "watchos", version: "6.0", options: []),
-            ]
+            ],
+            cLanguageStandard: nil,
+            cxxLanguageStandard: nil,
+            swiftLanguageVersions: nil
         )
     }
 }
@@ -606,7 +615,10 @@ extension PackageInfo {
                 .init(platformName: "ios", version: "10.0", options: []),
                 .init(platformName: "tvos", version: "10.0", options: []),
                 .init(platformName: "watchos", version: "3.0", options: []),
-            ]
+            ],
+            cLanguageStandard: nil,
+            cxxLanguageStandard: nil,
+            swiftLanguageVersions: ["5.0.0"]
         )
     }
 }
@@ -1035,7 +1047,10 @@ extension PackageInfo {
             ],
             platforms: [
                 .init(platformName: "ios", version: "10.0", options: []),
-            ]
+            ],
+            cLanguageStandard: "c99",
+            cxxLanguageStandard: "gnu++14",
+            swiftLanguageVersions: nil
         )
     }
 
@@ -1103,7 +1118,10 @@ extension PackageInfo {
             ],
             platforms: [
                 .init(platformName: "ios", version: "10.0", options: []),
-            ]
+            ],
+            cLanguageStandard: nil,
+            cxxLanguageStandard: nil,
+            swiftLanguageVersions: nil
         )
     }
 
@@ -1129,7 +1147,10 @@ extension PackageInfo {
             ],
             platforms: [
                 .init(platformName: "ios", version: "10.0", options: []),
-            ]
+            ],
+            cLanguageStandard: nil,
+            cxxLanguageStandard: nil,
+            swiftLanguageVersions: nil
         )
     }
 }

--- a/Sources/TuistDependenciesTesting/SwiftPackageManager/Utils/MockSwiftPackageManagerController.swift
+++ b/Sources/TuistDependenciesTesting/SwiftPackageManager/Utils/MockSwiftPackageManagerController.swift
@@ -35,6 +35,7 @@ public final class MockSwiftPackageManagerController: SwiftPackageManagerControl
 
     public func loadPackageInfo(at path: AbsolutePath) throws -> PackageInfo {
         invokedLoadPackageInfo = true
-        return try loadPackageInfoStub?(path) ?? .init(products: [], targets: [], platforms: [])
+        return try loadPackageInfoStub?(path)
+            ?? .init(products: [], targets: [], platforms: [], cLanguageStandard: nil, cxxLanguageStandard: nil, swiftLanguageVersions: nil)
     }
 }

--- a/Sources/TuistDependenciesTesting/SwiftPackageManager/Utils/MockSwiftPackageManagerGraphGenerator.swift
+++ b/Sources/TuistDependenciesTesting/SwiftPackageManager/Utils/MockSwiftPackageManagerGraphGenerator.swift
@@ -1,3 +1,4 @@
+import ProjectDescription
 import TSCBasic
 import TSCUtility
 import TuistCore
@@ -10,16 +11,23 @@ public final class MockSwiftPackageManagerGraphGenerator: SwiftPackageManagerGra
 
     var invokedGenerate = false
     var generateStub: (
-        (AbsolutePath, [String: TuistGraph.Product], Set<TuistGraph.Platform>, Set<TuistGraph.DeploymentTarget>) throws -> TuistCore.DependenciesGraph
+        (
+            AbsolutePath,
+            [String: TuistGraph.Product],
+            Set<TuistGraph.Platform>,
+            Set<TuistGraph.DeploymentTarget>,
+            TSCUtility.Version?
+        ) throws -> TuistCore.DependenciesGraph
     )?
 
     public func generate(
         at path: AbsolutePath,
         productTypes: [String: TuistGraph.Product],
         platforms: Set<TuistGraph.Platform>,
-        deploymentTargets: Set<TuistGraph.DeploymentTarget>
+        deploymentTargets: Set<TuistGraph.DeploymentTarget>,
+        swiftToolsVersion: TSCUtility.Version?
     ) throws -> TuistCore.DependenciesGraph {
         invokedGenerate = true
-        return try generateStub?(path, productTypes, platforms, deploymentTargets) ?? .test()
+        return try generateStub?(path, productTypes, platforms, deploymentTargets, swiftToolsVersion) ?? .test()
     }
 }

--- a/Sources/TuistGraph/Models/Config.swift
+++ b/Sources/TuistGraph/Models/Config.swift
@@ -1,5 +1,6 @@
 import Foundation
 import TSCBasic
+import TSCUtility
 
 /// This model allows to configure Tuist.
 public struct Config: Equatable, Hashable {
@@ -39,7 +40,7 @@ public struct Config: Equatable, Hashable {
 
     /// The version of Swift that will be used by Tuist.
     /// If `nil` is passed then Tuist will use the environment’s version.
-    public let swiftVersion: String?
+    public let swiftVersion: Version?
 
     /// The path of the config file.
     public let path: AbsolutePath?
@@ -71,7 +72,7 @@ public struct Config: Equatable, Hashable {
         compatibleXcodeVersions: CompatibleXcodeVersions,
         cloud: Cloud?,
         cache: Cache?,
-        swiftVersion: String?,
+        swiftVersion: Version?,
         plugins: [PluginLocation],
         generationOptions: [GenerationOption],
         path: AbsolutePath?

--- a/Sources/TuistGraphTesting/Models/Config+TestData.swift
+++ b/Sources/TuistGraphTesting/Models/Config+TestData.swift
@@ -1,5 +1,6 @@
 import Foundation
 import TSCBasic
+import TSCUtility
 @testable import TuistGraph
 
 public extension Config {
@@ -7,7 +8,7 @@ public extension Config {
         compatibleXcodeVersions: CompatibleXcodeVersions = .all,
         cloud: Cloud? = Cloud.test(),
         cache: Cache? = Cache.test(),
-        swiftVersion: String? = nil,
+        swiftVersion: Version? = nil,
         plugins: [PluginLocation] = [],
         generationOptions: [GenerationOption] = [],
         path: AbsolutePath? = nil

--- a/Sources/TuistLoader/Models+ManifestMappers/Config+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Config+ManifestMapper.swift
@@ -1,6 +1,7 @@
 import Foundation
 import ProjectDescription
 import TSCBasic
+import TSCUtility
 import TuistCore
 import TuistGraph
 import TuistSupport
@@ -15,7 +16,12 @@ extension TuistGraph.Config {
         let compatibleXcodeVersions = TuistGraph.CompatibleXcodeVersions.from(manifest: manifest.compatibleXcodeVersions)
         let generatorPaths = GeneratorPaths(manifestDirectory: path)
         let plugins = try manifest.plugins.map { try PluginLocation.from(manifest: $0, generatorPaths: generatorPaths) }
-        let swiftVersion = manifest.swiftVersion?.description
+        let swiftVersion: TSCUtility.Version?
+        if let configuredVersion = manifest.swiftVersion {
+            swiftVersion = TSCUtility.Version(configuredVersion.major, configuredVersion.minor, configuredVersion.patch)
+        } else {
+            swiftVersion = nil
+        }
 
         var cloud: TuistGraph.Cloud?
         if let manifestCloud = manifest.cloud {

--- a/Sources/TuistSupport/Extensions/TSCUtility+Extras.swift
+++ b/Sources/TuistSupport/Extensions/TSCUtility+Extras.swift
@@ -5,7 +5,7 @@ extension Version {
     /// It does not have to be formatted to SPM's standards (i.e. minor and patch versions can be omitted if zero)
     /// - Parameters:
     ///   - unformattedString: The string to parse.
-    init?(unformattedString: String) {
+    public init?(unformattedString: String) {
         let versionComponents = unformattedString.split(separator: ".")
 
         guard 1 ... 3 ~= versionComponents.count else { return nil }

--- a/Tests/TuistDependenciesTests/DependenciesControllerTests.swift
+++ b/Tests/TuistDependenciesTests/DependenciesControllerTests.swift
@@ -1,5 +1,6 @@
 import ProjectDescription
 import TSCBasic
+import TSCUtility
 import TuistCore
 import TuistGraph
 import TuistSupport
@@ -113,14 +114,14 @@ final class DependenciesControllerTests: TuistUnitTestCase {
             swiftPackageManager: swiftPackageManagerDependencies,
             platforms: platforms
         )
-        let swiftVersion = "5.4.0"
+        let swiftVersion = TSCUtility.Version(5, 4, 0)
 
         swiftPackageManagerInteractor.installStub = { arg0, arg1, arg2, arg3, arg4 in
             XCTAssertEqual(arg0, dependenciesDirectoryPath)
             XCTAssertEqual(arg1, swiftPackageManagerDependencies)
             XCTAssertEqual(arg2, [.iOS])
             XCTAssertFalse(arg3)
-            XCTAssertEqual(arg4, swiftVersion)
+            XCTAssertEqual(arg4, TSCUtility.Version(5, 4, 0))
             return .test()
         }
 
@@ -167,7 +168,7 @@ final class DependenciesControllerTests: TuistUnitTestCase {
             swiftPackageManager: swiftPackageManagerDependencies,
             platforms: platforms
         )
-        let swiftVersion = "5.4.0"
+        let swiftVersion = TSCUtility.Version(5, 4, 0)
         let carthageGraph = TuistCore.DependenciesGraph.testXCFramework(name: "Carthage")
         let spmGraph = TuistCore.DependenciesGraph.testXCFramework(name: "SPM")
 
@@ -378,7 +379,7 @@ final class DependenciesControllerTests: TuistUnitTestCase {
             swiftPackageManager: swiftPackageManagerDependencies,
             platforms: platforms
         )
-        let swiftVersion = "5.4.0"
+        let swiftVersion = TSCUtility.Version(5, 4, 0)
 
         swiftPackageManagerInteractor.installStub = { arg0, arg1, arg2, arg3, arg4 in
             XCTAssertEqual(arg0, dependenciesDirectoryPath)
@@ -431,7 +432,7 @@ final class DependenciesControllerTests: TuistUnitTestCase {
             swiftPackageManager: swiftPackageManagerDependencies,
             platforms: platforms
         )
-        let swiftVersion = "5.4.0"
+        let swiftVersion = TSCUtility.Version(5, 4, 0)
         let expectedGraph = TuistCore.DependenciesGraph.testXCFramework(name: "Name")
 
         carthageInteractor.installStub = { arg0, arg1, arg2, arg3 in

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
@@ -1,4 +1,6 @@
+import ProjectDescription
 import TSCBasic
+import TSCUtility
 import TuistCore
 import TuistGraph
 import TuistSupport
@@ -59,11 +61,12 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
             XCTAssertNil(version) // swift-tools-version is not specified
         }
 
-        swiftPackageManagerGraphGenerator.generateStub = { path, automaticProductType, platforms, deploymentTargets in
+        swiftPackageManagerGraphGenerator.generateStub = { path, automaticProductType, platforms, deploymentTargets, swiftToolsVersion in
             XCTAssertEqual(path, dependenciesDirectory.appending(component: "SwiftPackageManager"))
             XCTAssertEqual(platforms, [.iOS])
             XCTAssertEqual(deploymentTargets, [.iOS("13.0", [.iphone])])
             XCTAssertEqual(automaticProductType, [:])
+            XCTAssertNil(swiftToolsVersion)
             return .test()
         }
 
@@ -117,7 +120,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         let swiftPackageManagerDirectory = dependenciesDirectory
             .appending(component: Constants.DependenciesDirectory.swiftPackageManagerDirectoryName)
 
-        let swiftToolsVersion = "5.3.0"
+        let swiftToolsVersion = TSCUtility.Version(5, 3, 0)
         let dependencies = SwiftPackageManagerDependencies(
             [
                 .remote(url: "https://github.com/Alamofire/Alamofire.git", requirement: .upToNextMajor("5.2.0")),
@@ -133,14 +136,15 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         }
         swiftPackageManagerController.setToolsVersionStub = { path, version in
             XCTAssertEqual(path, try self.temporaryPath())
-            XCTAssertEqual(version, swiftToolsVersion) // version should be equal to the version that has been specified
+            XCTAssertEqual(version, swiftToolsVersion.description) // version should be equal to the version that has been specified
         }
 
-        swiftPackageManagerGraphGenerator.generateStub = { path, automaticProductType, platforms, deploymentTargets in
+        swiftPackageManagerGraphGenerator.generateStub = { path, automaticProductType, platforms, deploymentTargets, swiftVersion in
             XCTAssertEqual(path, dependenciesDirectory.appending(component: "SwiftPackageManager"))
             XCTAssertEqual(automaticProductType, [:])
             XCTAssertEqual(platforms, [.iOS])
             XCTAssertEqual(deploymentTargets, [.iOS("13.0", [.iphone])])
+            XCTAssertEqual(swiftVersion, swiftToolsVersion)
             return .test()
         }
 
@@ -212,11 +216,12 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
             XCTAssertNil(version) // swift-tools-version is not specified
         }
 
-        swiftPackageManagerGraphGenerator.generateStub = { path, automaticProductType, platforms, deploymentTargets in
+        swiftPackageManagerGraphGenerator.generateStub = { path, automaticProductType, platforms, deploymentTargets, swiftToolsVersion in
             XCTAssertEqual(path, dependenciesDirectory.appending(component: "SwiftPackageManager"))
             XCTAssertEqual(automaticProductType, [:])
             XCTAssertEqual(platforms, [.iOS])
             XCTAssertEqual(deploymentTargets, [.iOS("13.0", [.iphone])])
+            XCTAssertNil(swiftToolsVersion)
             return .test()
         }
 

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -1,5 +1,6 @@
 import ProjectDescription
 import TSCBasic
+import TSCUtility
 import TuistCore
 import TuistGraph
 import TuistSupport
@@ -35,7 +36,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target1"),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -61,7 +65,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target_1"),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -88,7 +95,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         .test(name: "Target1"),
                         .test(name: "Target2"),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -116,7 +126,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         .test(name: "Target2", type: .test),
                         .test(name: "Target3", type: .binary),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -146,7 +159,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         .test(name: "Target2"),
                         .test(name: "Target3"),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -172,7 +188,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target1", sources: ["Subfolder", "Another/Subfolder/file.swift"]),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -210,7 +229,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -255,7 +277,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             name: "Target1"
                         ),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -299,7 +324,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             name: "Target1"
                         ),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -355,7 +383,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         ),
                         .test(name: "Dependency2"),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -431,7 +462,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             dependencies: [.product(name: "Dependency1", package: "Package2", condition: nil)]
                         ),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
                 "Package2": .init(
                     products: [
@@ -443,7 +477,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             dependencies: [.product(name: "Dependency2", package: "Package3", condition: nil)]
                         ),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
                 "Package3": .init(
                     products: [
@@ -454,7 +491,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             name: "Dependency2"
                         ),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -507,7 +547,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             publicHeadersPath: "Headers"
                         ),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -552,7 +595,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         ),
                         .test(name: "Dependency1"),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -593,7 +639,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target1"),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ],
             platforms: [.iOS, .tvOS]
@@ -620,7 +669,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target1"),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ],
             platforms: [.tvOS]
@@ -648,7 +700,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         targets: [
                             .test(name: "Target1"),
                         ],
-                        platforms: [.init(platformName: "tvos", version: "13.0", options: [])]
+                        platforms: [.init(platformName: "tvos", version: "13.0", options: [])],
+                        cLanguageStandard: nil,
+                        cxxLanguageStandard: nil,
+                        swiftLanguageVersions: nil
                     ),
                 ],
                 platforms: [.iOS]
@@ -672,7 +727,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target1"),
                     ],
-                    platforms: [.init(platformName: "ios", version: "13.0", options: [])]
+                    platforms: [.init(platformName: "ios", version: "13.0", options: [])],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ],
             platforms: [.iOS]
@@ -702,7 +760,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             settings: [.init(tool: .c, name: .headerSearchPath, condition: nil, value: ["value"])]
                         ),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -731,7 +792,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             settings: [.init(tool: .cxx, name: .headerSearchPath, condition: nil, value: ["value"])]
                         ),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -764,7 +828,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -796,7 +863,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -827,7 +897,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -859,7 +932,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -891,7 +967,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -923,7 +1002,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -955,7 +1037,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -986,7 +1071,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -1017,7 +1105,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -1047,7 +1138,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         ),
                         .test(name: "Dependency1"),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -1078,7 +1172,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         ),
                         .test(name: "Dependency1", type: .binary),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ],
             targetDependencyToFramework: [
@@ -1111,7 +1208,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         ),
                         .test(name: "Dependency1"),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ]
         )
@@ -1142,7 +1242,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         ),
                         .test(name: "Dependency1", type: .binary),
                     ],
-                    platforms: []
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
                 ),
             ],
             targetDependencyToFramework: [
@@ -1172,7 +1275,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 ),
                 .test(name: "Dependency1"),
             ],
-            platforms: []
+            platforms: [],
+            cLanguageStandard: nil,
+            cxxLanguageStandard: nil,
+            swiftLanguageVersions: nil
         )
         let package2 = PackageInfo(
             products: [
@@ -1184,7 +1290,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 .test(name: "Target3"),
                 .test(name: "Target4"),
             ],
-            platforms: []
+            platforms: [],
+            cLanguageStandard: nil,
+            cxxLanguageStandard: nil,
+            swiftLanguageVersions: nil
         )
         let project = try subject.map(
             package: "Package",
@@ -1219,7 +1328,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 ),
                 .test(name: "Dependency1"),
             ],
-            platforms: []
+            platforms: [],
+            cLanguageStandard: nil,
+            cxxLanguageStandard: nil,
+            swiftLanguageVersions: nil
         )
         let package2 = PackageInfo(
             products: [
@@ -1231,7 +1343,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 .test(name: "Target3"),
                 .test(name: "Target4"),
             ],
-            platforms: []
+            platforms: [],
+            cLanguageStandard: nil,
+            cxxLanguageStandard: nil,
+            swiftLanguageVersions: nil
         )
         let project = try subject.map(
             package: "Package",
@@ -1253,6 +1368,157 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             )
         )
     }
+
+    func testMap_whenCustomCVersion_mapsToGccCLanguageStandardSetting() throws {
+        let project = try subject.map(
+            package: "Package",
+            packageInfos: [
+                "Package": .init(
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(name: "Target1"),
+                    ],
+                    platforms: [],
+                    cLanguageStandard: "c99",
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+        XCTAssertEqual(
+            project,
+            .test(
+                name: "Package",
+                settings: .init(base: ["GCC_C_LANGUAGE_STANDARD": "c99"]),
+                targets: [
+                    .test("Target1"),
+                ]
+            )
+        )
+    }
+
+    func testMap_whenCustomCXXVersion_mapsToClangCxxLanguageStandardSetting() throws {
+        let project = try subject.map(
+            package: "Package",
+            packageInfos: [
+                "Package": .init(
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(name: "Target1"),
+                    ],
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: "gnu++14",
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+        XCTAssertEqual(
+            project,
+            .test(
+                name: "Package",
+                settings: .init(base: ["CLANG_CXX_LANGUAGE_STANDARD": "gnu++14"]),
+                targets: [
+                    .test("Target1"),
+                ]
+            )
+        )
+    }
+
+    func testMap_whenCustomSwiftVersion_mapsToSwiftVersionSetting() throws {
+        let project = try subject.map(
+            package: "Package",
+            packageInfos: [
+                "Package": .init(
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(name: "Target1"),
+                    ],
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: ["4.0.0"]
+                ),
+            ]
+        )
+        XCTAssertEqual(
+            project,
+            .test(
+                name: "Package",
+                settings: .init(base: ["SWIFT_VERSION": "4.0.0"]),
+                targets: [
+                    .test("Target1"),
+                ]
+            )
+        )
+    }
+
+    func testMap_whenMultipleCustomSwiftVersions_mapsLargestToSwiftVersionSetting() throws {
+        let project = try subject.map(
+            package: "Package",
+            packageInfos: [
+                "Package": .init(
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(name: "Target1"),
+                    ],
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: ["4.0.0", "5.0.0", "4.2.0"]
+                ),
+            ]
+        )
+        XCTAssertEqual(
+            project,
+            .test(
+                name: "Package",
+                settings: .init(base: ["SWIFT_VERSION": "5.0.0"]),
+                targets: [
+                    .test("Target1"),
+                ]
+            )
+        )
+    }
+
+    func testMap_whenMultipleCustomSwiftVersionsAndConfiguredVersion_mapsLargestToSwiftVersionLowerThanConfigured() throws {
+        let project = try subject.map(
+            package: "Package",
+            packageInfos: [
+                "Package": .init(
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(name: "Target1"),
+                    ],
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: ["4.0.0", "5.0.0", "4.2.0"]
+                ),
+            ],
+            swiftToolsVersion: "4.4.0"
+        )
+        XCTAssertEqual(
+            project,
+            .test(
+                name: "Package",
+                settings: .init(base: ["SWIFT_VERSION": "4.2.0"]),
+                targets: [
+                    .test("Target1"),
+                ]
+            )
+        )
+    }
 }
 
 extension PackageInfoMapping {
@@ -1261,7 +1527,8 @@ extension PackageInfoMapping {
         basePath: AbsolutePath = "/",
         packageInfos: [String: PackageInfo] = [:],
         platforms: Set<TuistGraph.Platform> = [.iOS],
-        targetDependencyToFramework: [String: Path] = [:]
+        targetDependencyToFramework: [String: Path] = [:],
+        swiftToolsVersion: TSCUtility.Version? = nil
     ) throws -> ProjectDescription.Project {
         let productToPackage: [String: String] = packageInfos.reduce(into: [:]) { result, packageInfo in
             for product in packageInfo.value.products {
@@ -1285,9 +1552,8 @@ extension PackageInfoMapping {
             targetToResolvedDependencies: targetToResolvedDependencies,
             packageToProject: Dictionary(uniqueKeysWithValues: packageInfos.keys.map {
                 ($0, basePath.appending(component: $0).appending(component: "Path"))
-            }
-            ),
-            productToPackage: productToPackage
+            }),
+            swiftToolsVersion: swiftToolsVersion
         )
     }
 }
@@ -1320,9 +1586,14 @@ extension PackageInfo.Target {
 }
 
 extension ProjectDescription.Project {
-    fileprivate static func test(name: String, targets: [ProjectDescription.Target]) -> Self {
+    fileprivate static func test(
+        name: String,
+        settings: ProjectDescription.Settings? = nil,
+        targets: [ProjectDescription.Target]
+    ) -> Self {
         return .init(
             name: name,
+            settings: settings,
             targets: targets,
             resourceSynthesizers: []
         )

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
@@ -189,7 +189,8 @@ class SwiftPackageManagerGraphGeneratorTests: TuistTestCase {
                 "GULNetwork": .dynamicLibrary,
             ],
             platforms: [.iOS],
-            deploymentTargets: deploymentTargets
+            deploymentTargets: deploymentTargets,
+            swiftToolsVersion: nil
         )
 
         // Then

--- a/Tests/TuistKitTests/Services/Dependencies/DependenciesFetchServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Dependencies/DependenciesFetchServiceTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import TSCBasic
+import TSCUtility
 import TuistCore
 import TuistGraph
 import TuistGraphTesting
@@ -65,7 +66,7 @@ final class DependenciesFetchServiceTests: TuistUnitTestCase {
         )
         dependenciesModelLoader.loadDependenciesStub = { _ in stubbedDependencies }
 
-        let stubbedSwiftVersion = "5.3.0"
+        let stubbedSwiftVersion = TSCUtility.Version(5, 3, 0)
         configLoader.loadConfigStub = { _ in Config.test(swiftVersion: stubbedSwiftVersion) }
 
         dependenciesController.fetchStub = { path, dependencies, swiftVersion in

--- a/Tests/TuistKitTests/Services/Dependencies/DependenciesUpdateServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Dependencies/DependenciesUpdateServiceTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import TSCBasic
+import TSCUtility
 import TuistCore
 import TuistGraph
 import TuistGraphTesting
@@ -65,7 +66,7 @@ final class DependenciesUpdateServiceTests: TuistUnitTestCase {
         )
         dependenciesModelLoader.loadDependenciesStub = { _ in stubbedDependencies }
 
-        let stubbedSwiftVersion = "5.3.0"
+        let stubbedSwiftVersion = TSCUtility.Version(5, 3, 0)
         configLoader.loadConfigStub = { _ in Config.test(swiftVersion: stubbedSwiftVersion) }
 
         dependenciesController.updateStub = { path, dependencies, swiftVersion in

--- a/Tests/TuistSupportTests/Utils/GitHubClientTests.swift
+++ b/Tests/TuistSupportTests/Utils/GitHubClientTests.swift
@@ -92,15 +92,13 @@ final class GitHubClientTests: TuistUnitTestCase {
 
     func test_something() throws {
         let expectation = XCTestExpectation(description: "GitHubClient deferred when token")
-        var release: GitHubRelease?
         let client = GitHubClient()
         _ = client.dispatch(resource: GitHubRelease.latest(repositoryFullName: "tuist/tuist"))
             .sink { error in
                 print(error)
                 expectation.fulfill()
-            } receiveValue: { response in
-                print(response)
-                release = response.object
+            } receiveValue: { _ in
+                XCTFail("GitHubRelease.latest should fail")
             }
         wait(for: [expectation], timeout: 10.0)
     }


### PR DESCRIPTION
Required for SPM packages defining non custom C, C++, or Swift versions, like https://github.com/google/GoogleAppMeasurement/blob/main/Package.swift