### PR TITLE
feat: add Firebase to SPM fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- Fix mapping of SPM linker flags [#3276](https://github.com/tuist/tuist/pull/3276) by [@danyf90](https://github.com/danyf90)
+
 ## 1.48.0 - Packer
 
 ### Added

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -497,6 +497,7 @@ extension ProjectDescription.Settings {
         var cFlags: [String] = []
         var cxxFlags: [String] = []
         var swiftFlags: [String] = []
+        var linkerFlags: [String] = []
 
         if moduleMap.type != .none {
             headerSearchPaths.append("$(SRCROOT)/\(target.relativePath.appending(target.relativePublicHeadersPath))")
@@ -539,6 +540,8 @@ extension ProjectDescription.Settings {
                 swiftDefines.append(setting.value[0])
             case (.swift, .unsafeFlags):
                 swiftFlags.append(contentsOf: setting.value)
+            case (.linker, .unsafeFlags):
+                linkerFlags.append(contentsOf: setting.value)
 
             case (.linker, .linkedFramework), (.linker, .linkedLibrary):
                 // Handled as dependency
@@ -546,7 +549,7 @@ extension ProjectDescription.Settings {
 
             case (.c, .linkedFramework), (.c, .linkedLibrary), (.cxx, .linkedFramework), (.cxx, .linkedLibrary),
                  (.swift, .headerSearchPath), (.swift, .linkedFramework), (.swift, .linkedLibrary),
-                 (.linker, .headerSearchPath), (.linker, .define), (.linker, .unsafeFlags):
+                 (.linker, .headerSearchPath), (.linker, .define):
                 throw PackageInfoMapperError.unsupportedSetting(setting.tool, setting.name)
             }
         }
@@ -592,6 +595,10 @@ extension ProjectDescription.Settings {
 
         if !swiftFlags.isEmpty {
             settingsDictionary["OTHER_SWIFT_FLAGS"] = .array(["$(inherited)"] + swiftFlags)
+        }
+
+        if !linkerFlags.isEmpty {
+            settingsDictionary["OTHER_LDFLAGS"] = .array(["$(inherited)"] + linkerFlags)
         }
 
         return .init(base: settingsDictionary)

--- a/Sources/TuistDependenciesTesting/DependenciesGraph/DependenciesGraph+TestData.swift
+++ b/Sources/TuistDependenciesTesting/DependenciesGraph/DependenciesGraph+TestData.swift
@@ -459,6 +459,10 @@ extension DependenciesGraph {
             settingsDictionary["OTHER_SWIFT_FLAGS"] = .array(["$(inherited)"] + swiftFlags)
         }
 
+        if case let .array(linkerFlags) = settingsDictionary["OTHER_LDFLAGS"] {
+            settingsDictionary["OTHER_LDFLAGS"] = .array(["$(inherited)"] + linkerFlags)
+        }
+
         return Settings(base: settingsDictionary)
     }
 }

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -1020,6 +1020,41 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         )
     }
 
+    func testMap_whenSettingsContainsLinkerUnsafeFlags_mapsToOtherLdFlags() throws {
+        let project = try subject.map(
+            package: "Package",
+            packageInfos: [
+                "Package": .init(
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(
+                            name: "Target1",
+                            settings: [
+                                .init(tool: .linker, name: .unsafeFlags, condition: nil, value: ["key1"]),
+                                .init(tool: .linker, name: .unsafeFlags, condition: nil, value: ["key2", "key3"]),
+                            ]
+                        ),
+                    ],
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+        XCTAssertEqual(
+            project,
+            .test(
+                name: "Package",
+                targets: [
+                    .test("Target1", customSettings: ["OTHER_LDFLAGS": ["key1", "key2", "key3"]]),
+                ]
+            )
+        )
+    }
+
     func testMap_whenConditionalSetting_ignoresByPlatform() throws {
         let project = try subject.map(
             package: "Package",

--- a/projects/tuist/fixtures/app_with_spm_dependencies/App/AppDelegate.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/App/AppDelegate.swift
@@ -18,6 +18,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.rootViewController = viewController
         window?.makeKeyAndVisible()
 
+        // Use Adjust to make sure it links fine
+        Adjust.adid()
+
         // Use Alamofire to make sure it links fine
         _ = AF.download("http://www.tuist.io")
 

--- a/projects/tuist/fixtures/app_with_spm_dependencies/App/AppDelegate.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/App/AppDelegate.swift
@@ -1,7 +1,10 @@
 import Adjust
 import Alamofire
 import ComposableArchitecture
-import FacebookCore
+import FBSDKCoreKit
+import FirebaseAnalytics
+import FirebaseCore
+import FirebaseDatabase
 import UIKit
 
 @UIApplicationMain
@@ -14,6 +17,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         viewController.view.backgroundColor = .white
         window?.rootViewController = viewController
         window?.makeKeyAndVisible()
+
+        // Use Alamofire to make sure it links fine
+        _ = AF.download("http://www.tuist.io")
+
+        // Use FirebaseAnalytics to make sure it links fine
+        Analytics.logEvent("Event", parameters: [:])
+
+        // Use FirebaseDatabase to make sure it links fine
+        Database.database(app: FirebaseApp.app()!).reference().setValue("value")
+
+        // Use Facebook to make sure it links fine
+        Settings.setAdvertiserTrackingEnabled(true)
+
         return true
     }
     

--- a/projects/tuist/fixtures/app_with_spm_dependencies/AppTests/AppTests.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/AppTests/AppTests.swift
@@ -5,6 +5,7 @@ import XCTest
 
 @testable import App
 
+// Use Quick&Nimble to make sure they link fine
 class CrashTests: QuickSpec {
   override func spec() {
       context("when importing Nimble through SPM") {

--- a/projects/tuist/fixtures/app_with_spm_dependencies/Project.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/Project.swift
@@ -20,7 +20,7 @@ let project = Project(
                 .external(name: "FirebaseDatabase"),
             ],
             settings: .init(base: [
-                "OTHER_LDFLAGS": "-ObjC",
+                "OTHER_LDFLAGS": "-framework \"FirebaseAnalytics\"",
             ])
         ),
         Target(

--- a/projects/tuist/fixtures/app_with_spm_dependencies/Project.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/Project.swift
@@ -11,10 +11,13 @@ let project = Project(
             infoPlist: .default,
             sources: "App/**",
             dependencies: [
+                .sdk(name: "libc++.tbd", status: .required),
                 .external(name: "Adjust"),
                 .external(name: "Alamofire"),
                 .external(name: "ComposableArchitecture"),
                 .external(name: "FacebookCore"),
+                .external(name: "FirebaseAnalytics"),
+                .external(name: "FirebaseDatabase"),
             ]
         ),
         Target(

--- a/projects/tuist/fixtures/app_with_spm_dependencies/Project.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/Project.swift
@@ -18,7 +18,10 @@ let project = Project(
                 .external(name: "FacebookCore"),
                 .external(name: "FirebaseAnalytics"),
                 .external(name: "FirebaseDatabase"),
-            ]
+            ],
+            settings: .init(base: [
+                "OTHER_LDFLAGS": "-ObjC",
+            ])
         ),
         Target(
             name: "AppTests",

--- a/projects/tuist/fixtures/app_with_spm_dependencies/Tuist/Dependencies.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/Tuist/Dependencies.swift
@@ -5,6 +5,7 @@ let dependencies = Dependencies(
         [
             .package(url: "https://github.com/adjust/ios_sdk/", .upToNextMajor(from: "4.0.0")),
             .package(url: "https://github.com/facebook/facebook-ios-sdk", .upToNextMajor(from: "11.0.0")),
+            .package(url: "https://github.com/firebase/firebase-ios-sdk", .upToNextMajor(from: "8.0.0")),
             .package(url: "https://github.com/Alamofire/Alamofire", .upToNextMajor(from: "5.0.0")),
             .package(url: "https://github.com/pointfreeco/swift-composable-architecture", .upToNextMinor(from: "0.22.0")),
             .package(url: "https://github.com/Quick/Quick", .upToNextMajor(from: "4.0.0")),


### PR DESCRIPTION
Add Firebase to SPM dependencies and actually use dependencies to make sure they link correctly

- In the resulting project the `App` target depends on `FirebaseAnalyticsTarget` target which is a static framework generated from the SPM package
- The `FirebaseAnalyticsTarget` then depends on the `FirebaseAnalytics` binary target

To fix the problem we either have to add the `--framework FirebaseAnalytics`  as `OTHER_LDFLAGS` or manually add the `FirebaseAnalytics` directly as link dependency of `App`.


### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
