### PR TITLE
Include the URL to create an issue when an unhandled error is presented to the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Add support for localized intent definition files using `.strings`. [#3236](https://github.com/tuist/tuist/pull/3236) by [@dbarden](https://github.com/dbarden)
 - Add `TextSettings` configuration into `Project` [#3253](https://github.com/tuist/tuist/pull/3253) by [@DimaMishchenko](https://github.com/DimaMishchenko)
 - Add `language` option for `RunAction`, add `SchemeLanguage` [#3231](https://github.com/tuist/tuist/pull/3231) by [@zzzkk](https://github.com/zzzkk)
+- Include instructions to create an GitHub issue for unhandled errors [#3278](https://github.com/tuist/tuist/pull/3278) by [@pepibumur](https://github.com/pepibumur).
 
 ### Fixed
 

--- a/Sources/TuistSupport/Errors/FatalError.swift
+++ b/Sources/TuistSupport/Errors/FatalError.swift
@@ -35,7 +35,7 @@ public struct UnhandledError: FatalError {
         We received an error that we couldn't handle:
             - Localized description: \(error.localizedDescription)
             - Error: \(error)
-        
+
         If you think it's a legit issue, please file an issue including the reproducible steps: https://github.com/tuist/tuist/issues/new
         """
     }

--- a/Sources/TuistSupport/Errors/FatalError.swift
+++ b/Sources/TuistSupport/Errors/FatalError.swift
@@ -36,7 +36,7 @@ public struct UnhandledError: FatalError {
             - Localized description: \(error.localizedDescription)
             - Error: \(error)
 
-        If you think it's a legit issue, please file an issue including the reproducible steps: https://github.com/tuist/tuist/issues/new
+        If you think it's a legit issue, please file an issue including the reproducible steps: https://github.com/tuist/tuist/issues/new/choose
         """
     }
 }

--- a/Sources/TuistSupport/Errors/FatalError.swift
+++ b/Sources/TuistSupport/Errors/FatalError.swift
@@ -34,7 +34,9 @@ public struct UnhandledError: FatalError {
         """
         We received an error that we couldn't handle:
             - Localized description: \(error.localizedDescription)
-            - Error: \(error)"
+            - Error: \(error)
+        
+        If you think it's a legit issue, please file an issue including the reproducible steps: https://github.com/tuist/tuist/issues/new
         """
     }
 }


### PR DESCRIPTION
### Short description 📝
When we print an unhandled error to the user, we don't give them instructions. around what to do next. This PR improves the developer experience by telling them to open an issue if they think it's a legit issue.