### PR TITLE
Fix `.xcFramework` breaking change

### DIFF
--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -65,7 +65,6 @@ public enum TargetDependency: Codable, Equatable {
     ///
     /// - Parameters:
     ///   - path: Relative path to the xcframework
-
     case xcframework(path: Path)
 
     /// Dependency on XCTest.
@@ -83,6 +82,15 @@ public enum TargetDependency: Codable, Equatable {
     /// Note: Defaults to using a `required` dependency status
     public static func sdk(name: String) -> TargetDependency {
         .sdk(name: name, status: .required)
+    }
+
+    /// Dependency on a xcframework
+    ///
+    /// - Parameters:
+    ///   - path: Relative path to the xcframework
+    @available(*, deprecated, message: "Use `.xcframework(path:)` (all lower case) instead")
+    public static func xcFramework(path: Path) -> TargetDependency {
+        .xcframework(path: path)
     }
 
     public var typeName: String {

--- a/Tests/ProjectDescriptionTests/TargetDependencyTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetDependencyTests.swift
@@ -57,9 +57,19 @@ final class TargetDependencyTests: XCTestCase {
 
     func test_xcframework_codable() {
         // Given
-        let subject = TargetDependency.xcframework(path: "/path/framework.xcframework")
+        let subject: [TargetDependency] = [
+            .xcFramework(path: "/path/framework.xcframework"),
+            .xcframework(path: "/path/framework.xcframework"),
+        ]
 
         // Then
         XCTAssertCodable(subject)
+    }
+
+    func test_xcframework_migration() {
+        XCTAssertEqual(
+            TargetDependency.xcFramework(path: "/path/framework.xcframework"),
+            TargetDependency.xcframework(path: "/path/framework.xcframework")
+        )
     }
 }

--- a/projects/tuist/fixtures/ios_app_with_xcframeworks/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_xcframeworks/Project.swift
@@ -13,7 +13,8 @@ let project = Project(name: "App",
                                        // "Resources/**"
                                ],
                                dependencies: [
-                                    .xcframework(path: "Frameworks/MyFramework/prebuilt/MyFramework.xcframework"),
+                                    // .xcFramework is deprecated, .xcframework (all lower case) is the repalcement
+                                    .xcFramework(path: "Frameworks/MyFramework/prebuilt/MyFramework.xcframework"),
                                     .xcframework(path: "Frameworks/MyStaticLibrary/prebuilt/MyStaticLibrary.xcframework")
                                 ]),
                         Target(name: "AppTests",


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3280

### Short description 📝

- The `.xcFramework` target dependency was accidentally renamed to `.xcframework` _(all lower case)_ in a recent PR
- To ensure backwards compatibility we are re-introducing `.xcFramework` which internally maps to `.xcframework`
- This has also been marked as deprecated with a message to migrate to `.xcframework`
- Tests and fixtures have been updated to support this change

### Test Plan 🛠

- Verify all tests pass
- Run

```sh
swift build
wift run tuist generate --path projects/tuist/fixtures/ios_app_with_xcframeworks`
``

- Verify generation succeeds without any errors

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- ~In case the PR introduces changes that affect users, the documentation has been updated.~
