### PR TITLE
[Cache] Add Release profile to default profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Added
+
+- Add default `Release` caching profile [#3304](https://github.com/tuist/tuist/pull/3304) by [@danyf90](https://github.com/danyf90)
+
 ### Fixed
 
 - Fix Dependency.swift binary path's with `path` instead of `url`. [#3269](https://github.com/tuist/tuist/pull/3269) by [@apps4everyone](https://github.com/apps4everyone)

--- a/Sources/TuistGraph/Models/Cache.swift
+++ b/Sources/TuistGraph/Models/Cache.swift
@@ -28,5 +28,11 @@ public struct Cache: Equatable, Hashable {
         self.path = path
     }
 
-    public static let `default` = Cache(profiles: [Profile(name: "Development", configuration: "Debug")], path: nil)
+    public static let `default` = Cache(
+        profiles: [
+            Profile(name: "Development", configuration: "Debug"),
+            Profile(name: "Release", configuration: "Release"),
+        ],
+        path: nil
+    )
 }

--- a/Sources/TuistKit/Services/FocusService.swift
+++ b/Sources/TuistKit/Services/FocusService.swift
@@ -54,9 +54,7 @@ final class FocusService {
         let path = self.path(path)
         let config = try configLoader.loadConfig(path: path)
 
-        let cacheProfile = ignoreCache
-            ? CacheProfileResolver.defaultCacheProfileFromTuist
-            : try CacheProfileResolver().resolveCacheProfile(named: profile, from: config)
+        let cacheProfile = try CacheProfileResolver().resolveCacheProfile(named: profile, from: config)
 
         let generator = projectGeneratorFactory.generator(
             sources: sources,

--- a/Tests/TuistKitTests/Services/Cache/CacheProfileResolverTests.swift
+++ b/Tests/TuistKitTests/Services/Cache/CacheProfileResolverTests.swift
@@ -32,11 +32,11 @@ final class CacheProfileResolverTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(
+            resolvedProfile,
             CacheProfile(
                 name: "Development",
                 configuration: "Debug"
-            ),
-            resolvedProfile
+            )
         )
     }
 
@@ -49,11 +49,11 @@ final class CacheProfileResolverTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(
+            resolvedProfile,
             CacheProfile(
                 name: "Development",
                 configuration: "Debug"
-            ),
-            resolvedProfile
+            )
         )
     }
 
@@ -66,11 +66,11 @@ final class CacheProfileResolverTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(
+            resolvedProfile,
             CacheProfile(
                 name: "foo",
                 configuration: "configuration"
-            ),
-            resolvedProfile
+            )
         )
     }
 
@@ -90,11 +90,79 @@ final class CacheProfileResolverTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(
+            resolvedProfile,
             CacheProfile(
                 name: "bar",
                 configuration: "release"
-            ),
-            resolvedProfile
+            )
+        )
+    }
+
+    func test_resolves_selected_release_profile_from_tuist_defaults_when_cache_config_is_nil() throws {
+        // When
+        let resolvedProfile = try subject.resolveCacheProfile(
+            named: "Release",
+            from: .test(cache: nil)
+        )
+
+        // Then
+        XCTAssertEqual(
+            resolvedProfile,
+            CacheProfile(
+                name: "Release",
+                configuration: "Release"
+            )
+        )
+    }
+
+    func test_resolves_selected_release_profile_from_tuist_defaults_when_profiles_list_is_empty() throws {
+        // When
+        let resolvedProfile = try subject.resolveCacheProfile(
+            named: "Release",
+            from: .test(cache: .test(profiles: []))
+        )
+
+        // Then
+        XCTAssertEqual(
+            resolvedProfile,
+            CacheProfile(
+                name: "Release",
+                configuration: "Release"
+            )
+        )
+    }
+
+    func test_resolves_selected_development_profile_from_tuist_defaults_when_cache_config_is_nil() throws {
+        // When
+        let resolvedProfile = try subject.resolveCacheProfile(
+            named: "Development",
+            from: .test(cache: nil)
+        )
+
+        // Then
+        XCTAssertEqual(
+            resolvedProfile,
+            CacheProfile(
+                name: "Development",
+                configuration: "Debug"
+            )
+        )
+    }
+
+    func test_resolves_selected_development_profile_from_tuist_defaults_when_profiles_list_is_empty() throws {
+        // When
+        let resolvedProfile = try subject.resolveCacheProfile(
+            named: "Development",
+            from: .test(cache: .test(profiles: []))
+        )
+
+        // Then
+        XCTAssertEqual(
+            resolvedProfile,
+            CacheProfile(
+                name: "Development",
+                configuration: "Debug"
+            )
         )
     }
 


### PR DESCRIPTION
https://tuistapp.slack.com/archives/C01FMS8L72L/p1628849841002100

### Short description 📝

Given Tuist automatically generates `Release` and `Debug` configuration, it could be helpful to allow to use the caching features for both of them, without the need to configure custom caching profiles.
The PR add the `Release` profile to the default ones, so you can do `tuist cache warm --profile Release` without having to define it in the `Config.cache`.

If instead we think having to explicitly specify the profiles in the Config is the way to go, maybe we should reconsider having a default for the debug configuration 🤔 

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
