### PR TITLE
fix Tuist source glob not handling nested folder symlinks

### DIFF
--- a/Sources/TuistSupport/Extensions/FileManager+Extras.swift
+++ b/Sources/TuistSupport/Extensions/FileManager+Extras.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+extension FileManager {
+    func subpathsResolvingSymbolicLinks(atPath path: String) -> [String] {
+        subpathsResolvingSymbolicLinks(atPath: path, basePath: nil)
+    }
+
+    private func subpathsResolvingSymbolicLinks(atPath path: String, basePath: String?) -> [String] {
+        let currentPath = basePath.map { "\($0)/\(path)" } ?? path
+
+        guard let shallowSubpaths = subpaths(atPath: currentPath) else {
+            return []
+        }
+
+        var resolvedSubpaths: [String] = []
+        for subpath in shallowSubpaths {
+            let completeSubpath = "\(currentPath)/\(subpath)"
+            if isDirectory(path: completeSubpath), isSymbolicLink(path: completeSubpath) {
+                resolvedSubpaths.append(contentsOf: subpathsResolvingSymbolicLinks(atPath: subpath, basePath: currentPath))
+            }
+            resolvedSubpaths.append(completeSubpath)
+        }
+
+        return resolvedSubpaths.sorted()
+    }
+
+    private func isSymbolicLink(path: String) -> Bool {
+        return (try? destinationOfSymbolicLink(atPath: path)) != nil
+    }
+
+    func isDirectory(path: String) -> Bool {
+        #if os(macOS)
+            var isDirectoryBool = ObjCBool(false)
+        #else
+            var isDirectoryBool = false
+        #endif
+        var isDirectory = fileExists(atPath: path, isDirectory: &isDirectoryBool)
+        #if os(macOS)
+            isDirectory = isDirectory && isDirectoryBool.boolValue
+        #else
+            isDirectory = isDirectory && isDirectoryBool
+        #endif
+
+        return isDirectory
+    }
+}

--- a/Sources/TuistSupport/Utils/FileHandler.swift
+++ b/Sources/TuistSupport/Utils/FileHandler.swift
@@ -265,6 +265,10 @@ public class FileHandler: FileHandling {
         try fileManager.contentsOfDirectory(atPath: path.pathString).map { AbsolutePath(path, $0) }
     }
 
+    public func createSymbolicLink(at path: AbsolutePath, destination: AbsolutePath) throws {
+        try fileManager.createSymbolicLink(atPath: path.pathString, withDestinationPath: destination.pathString)
+    }
+
     public func resolveSymlinks(_ path: AbsolutePath) -> AbsolutePath {
         TSCBasic.resolveSymlinks(path)
     }

--- a/Tests/TuistSupportTests/Extensions/FileManager+ExtrasTests.swift
+++ b/Tests/TuistSupportTests/Extensions/FileManager+ExtrasTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import TSCBasic
+import XCTest
+
+@testable import TuistSupport
+@testable import TuistSupportTesting
+
+final class FileManagerExtrasTests: TuistUnitTestCase {
+    func testSubpaths_whenNoSymbolicLinks() throws {
+        // Given
+        let fileManager = FileManager.default
+
+        // When
+
+        // - <Root>
+        //   - Folder
+        //     - File1
+        //     - Subfolder
+        //       - File2
+
+        let rootPath = try temporaryPath()
+        let folderPath = rootPath.appending(component: "Folder")
+        let file1Path = folderPath.appending(component: "File1")
+        let subfolderPath = folderPath.appending(component: "Subfolder")
+        let file2Path = subfolderPath.appending(component: "File2")
+        try fileHandler.createFolder(subfolderPath)
+        try fileHandler.write("Test", path: file1Path, atomically: true)
+        try fileHandler.write("Test", path: file2Path, atomically: true)
+
+        // Then
+        let got = fileManager.subpathsResolvingSymbolicLinks(atPath: folderPath.pathString)
+        XCTAssertEqual(got, [file1Path, subfolderPath, file2Path].map(\.pathString))
+    }
+
+    func testSubpaths_whenSymbolicLinksToFiles() throws {
+        // Given
+        let fileManager = FileManager.default
+
+        // When
+
+        // - <Root>
+        //   - OutsideFile
+        //   - Folder
+        //     - Symlink -> OutsideFile
+        //     - Subfolder
+        //       - File
+
+        let rootPath = try temporaryPath()
+        let outsideFile = rootPath.appending(component: "OutsideFile")
+        let folderPath = rootPath.appending(component: "Folder")
+        let symlinkPath = folderPath.appending(component: "Symlink")
+        let subfolderPath = folderPath.appending(component: "Subfolder")
+        let filePath = subfolderPath.appending(component: "File")
+
+        try fileHandler.createFolder(subfolderPath)
+        try fileHandler.write("Test", path: outsideFile, atomically: true)
+        try fileHandler.write("Test", path: filePath, atomically: true)
+        try fileHandler.createSymbolicLink(at: symlinkPath, destination: outsideFile)
+
+        // Then
+        let got = fileManager.subpathsResolvingSymbolicLinks(atPath: folderPath.pathString)
+        XCTAssertEqual(got, [subfolderPath, filePath, symlinkPath].map(\.pathString))
+    }
+
+    func testSubpaths_whenSymbolicLinksToDirectory() throws {
+        // Given
+        let fileManager = FileManager.default
+
+        // When
+
+        // - <Root>
+        //   - OutsideFolder
+        //     - File
+        //   - Folder
+        //     - SymlinkFolder -> OutsideFolder
+
+        let rootPath = try temporaryPath()
+        let outsideFolderPath = rootPath.appending(component: "OutsideFolder")
+        let filePath = outsideFolderPath.appending(component: "File")
+        let folderPath = rootPath.appending(component: "Folder")
+        let symlinkPath = folderPath.appending(component: "SymlinkFolder")
+
+        try fileHandler.createFolder(outsideFolderPath)
+        try fileHandler.createFolder(folderPath)
+        try fileHandler.write("Test", path: filePath, atomically: true)
+        try fileHandler.createSymbolicLink(at: symlinkPath, destination: outsideFolderPath)
+
+        // Then
+        let got = fileManager.subpathsResolvingSymbolicLinks(atPath: folderPath.pathString)
+        XCTAssertEqual(got, [symlinkPath, symlinkPath.appending(component: "File")].map(\.pathString))
+    }
+
+    func testSubpaths_whenSymbolicLinkAndOriginalInSameSubtree() throws {
+        // Given
+        let fileManager = FileManager.default
+
+        // When
+
+        // - <Root>
+        //   - Folder
+        //     - File
+        //     - Symlink -> File
+
+        let rootPath = try temporaryPath()
+        let folderPath = rootPath.appending(component: "Folder")
+        let filePath = folderPath.appending(component: "File")
+        let symlinkPath = folderPath.appending(component: "Symlink")
+
+        try fileHandler.createFolder(folderPath)
+        try fileHandler.write("Test", path: filePath, atomically: true)
+        try fileHandler.createSymbolicLink(at: symlinkPath, destination: filePath)
+
+        // Then
+        let got = fileManager.subpathsResolvingSymbolicLinks(atPath: folderPath.pathString)
+        XCTAssertEqual(got, [filePath, symlinkPath].map(\.pathString))
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3268
Request for comments document (if applies):

### Short description 📝

This PR enhances the FileManager with a version of `subpaths(atPath:)` that correctly follows symlinks.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] ~~In case the PR introduces changes that affect users, the documentation has been updated.~~
