### PR TITLE
Remove requirement for `TUIST_` prefix when reading environments variables in manifests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Add default `Release` caching profile [#3304](https://github.com/tuist/tuist/pull/3304) by [@danyf90](https://github.com/danyf90)
 
+### Changed
+
+- Environment variables now support keys with and without `TUIST_` prefix [#3337](https://github.com/tuist/tuist/pull/3337) by [@wattson12](https://github.com/wattson12)
+
 ### Fixed
 
 - Fix Dependency.swift binary path's with `path` instead of `url`. [#3269](https://github.com/tuist/tuist/pull/3269) by [@apps4everyone](https://github.com/apps4everyone)

--- a/Sources/ProjectDescription/Environment.swift
+++ b/Sources/ProjectDescription/Environment.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @dynamicMemberLookup
 public struct Environment {
-    public enum Value {
+    public enum Value: Equatable {
         case boolean(Bool)
         case string(String)
 

--- a/Sources/ProjectDescription/Environment.swift
+++ b/Sources/ProjectDescription/Environment.swift
@@ -28,16 +28,12 @@ public struct Environment {
     }
 
     public static subscript(dynamicMember member: String) -> Value? {
-        let snakeCaseMember = "TUIST_\(member.camelCaseToSnakeCase().uppercased())"
-        return value(for: snakeCaseMember)
+        value(for: member, environment: ProcessInfo.processInfo.environment)
     }
 
-    public static func value(for key: String) -> Value? {
-        value(for: key, environment: ProcessInfo.processInfo.environment)
-    }
-
-    static func value(for key: String, environment: [String: String]) -> Value? {
-        guard let value = environment[key] else { return nil }
+    static func value(for key: String, environment: [String: String] = ProcessInfo.processInfo.environment) -> Value? {
+        let formattedName = key.camelCaseToSnakeCase().uppercased()
+        guard let value = environment["TUIST_\(formattedName)"] ?? environment[formattedName] else { return nil }
         let trueValues = ["1", "true", "TRUE", "yes", "YES"]
         let falseValues = ["0", "false", "FALSE", "no", "NO"]
         if trueValues.contains(value) {

--- a/Sources/ProjectDescription/Environment.swift
+++ b/Sources/ProjectDescription/Environment.swift
@@ -29,7 +29,15 @@ public struct Environment {
 
     public static subscript(dynamicMember member: String) -> Value? {
         let snakeCaseMember = "TUIST_\(member.camelCaseToSnakeCase().uppercased())"
-        guard let value = ProcessInfo.processInfo.environment[snakeCaseMember] else { return nil }
+        return value(for: snakeCaseMember)
+    }
+
+    public static func value(for key: String) -> Value? {
+        value(for: key, environment: ProcessInfo.processInfo.environment)
+    }
+
+    static func value(for key: String, environment: [String: String]) -> Value? {
+        guard let value = environment[key] else { return nil }
         let trueValues = ["1", "true", "TRUE", "yes", "YES"]
         let falseValues = ["0", "false", "FALSE", "no", "NO"]
         if trueValues.contains(value) {
@@ -42,12 +50,12 @@ public struct Environment {
     }
 }
 
-extension Optional where Wrapped == Environment.Value {
+public extension Optional where Wrapped == Environment.Value {
     /// Retrieve the Environment value as a string or return the specified default string value
     /// - Parameters:
     ///   - default: default String value to be returned
     /// - Returns: String
-    public func getString(default defaultString: String) -> String {
+    func getString(default defaultString: String) -> String {
         if case let .string(value) = self { return value }
         return defaultString
     }
@@ -56,7 +64,7 @@ extension Optional where Wrapped == Environment.Value {
     /// - Parameters:
     ///   - default: default Boolean value to be returned
     /// - Returns: Bool
-    public func getBoolean(default defaultBoolean: Bool) -> Bool {
+    func getBoolean(default defaultBoolean: Bool) -> Bool {
         if case let .boolean(value) = self { return value }
         return defaultBoolean
     }

--- a/Tests/ProjectDescriptionTests/EnvironmentTests.swift
+++ b/Tests/ProjectDescriptionTests/EnvironmentTests.swift
@@ -42,6 +42,20 @@ final class EnvironmentTests: XCTestCase {
         }
     }
 
+    func test_stringValue() {
+        let stringValue = UUID().uuidString
+        let environment: [String: String] = [
+            "0": stringValue,
+        ]
+        let value = Environment.value(for: "0", environment: environment)
+        switch value {
+        case .string(stringValue):
+            break
+        default:
+            XCTFail("Unexpected value. Got: \(String(describing: value)), expected: .boolean(_)")
+        }
+    }
+
     func test_unknownKeysReturnNil() {
         let environment: [String: String] = [
             "0": "0",

--- a/Tests/ProjectDescriptionTests/EnvironmentTests.swift
+++ b/Tests/ProjectDescriptionTests/EnvironmentTests.swift
@@ -63,4 +63,35 @@ final class EnvironmentTests: XCTestCase {
         let value = Environment.value(for: "1", environment: environment)
         XCTAssertNil(value)
     }
+
+    func testValueChecksForTuistPrefixedValuesFirst() {
+        let environment: [String: String] = [
+            "TUIST_NAME_SUFFIX": "0",
+            "NAME_SUFFIX": "1",
+        ]
+
+        // mimicing the camel cased dynamic member format
+        let value = Environment.value(for: "nameSuffix", environment: environment)
+        switch value {
+        case .boolean(false):
+            break
+        default:
+            XCTFail("Unexpected value. Got: \(String(describing: value)), expected: .boolean(false)")
+        }
+    }
+
+    func testNonPrefixedKeysAreFetchedIfPrefixedValueDoesNotExist() {
+        let environment: [String: String] = [
+            "NAME_SUFFIX": "1",
+        ]
+
+        // mimicing the camel cased dynamic member format
+        let value = Environment.value(for: "nameSuffix", environment: environment)
+        switch value {
+        case .boolean(true):
+            break
+        default:
+            XCTFail("Unexpected value. Got: \(String(describing: value)), expected: .boolean(true)")
+        }
+    }
 }

--- a/Tests/ProjectDescriptionTests/EnvironmentTests.swift
+++ b/Tests/ProjectDescriptionTests/EnvironmentTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import XCTest
+
+@testable import ProjectDescription
+
+final class EnvironmentTests: XCTestCase {
+    func test_booleanTrueValues() throws {
+        let environment: [String: String] = [
+            "0": "1",
+            "1": "true",
+            "2": "TRUE",
+            "3": "yes",
+            "4": "YES",
+        ]
+        try environment.keys.forEach { key in
+            let value = try XCTUnwrap(Environment.value(for: key, environment: environment))
+            switch value {
+            case .boolean(true):
+                break
+            default:
+                XCTFail("Unexpected value. Got: \(value), expected: .boolean(true)")
+            }
+        }
+    }
+
+    func test_booleanFalseValues() throws {
+        let environment: [String: String] = [
+            "0": "0",
+            "1": "false",
+            "2": "FALSE",
+            "3": "no",
+            "4": "NO",
+        ]
+        try environment.keys.forEach { key in
+            let value = try XCTUnwrap(Environment.value(for: key, environment: environment))
+            switch value {
+            case .boolean(false):
+                break
+            default:
+                XCTFail("Unexpected value. Got: \(value), expected: .boolean(false)")
+            }
+        }
+    }
+
+    func test_unknownKeysReturnNil() {
+        let environment: [String: String] = [
+            "0": "0",
+        ]
+        let value = Environment.value(for: "1", environment: environment)
+        XCTAssertNil(value)
+    }
+}

--- a/Tests/ProjectDescriptionTests/EnvironmentTests.swift
+++ b/Tests/ProjectDescriptionTests/EnvironmentTests.swift
@@ -70,7 +70,7 @@ final class EnvironmentTests: XCTestCase {
             "NAME_SUFFIX": "1",
         ]
 
-        // mimicing the camel cased dynamic member format
+        // mimicking the camel cased dynamic member format
         let value = Environment.value(for: "nameSuffix", environment: environment)
         switch value {
         case .boolean(false):
@@ -85,7 +85,7 @@ final class EnvironmentTests: XCTestCase {
             "NAME_SUFFIX": "1",
         ]
 
-        // mimicing the camel cased dynamic member format
+        // mimicking the camel cased dynamic member format
         let value = Environment.value(for: "nameSuffix", environment: environment)
         switch value {
         case .boolean(true):

--- a/Tests/ProjectDescriptionTests/EnvironmentTests.swift
+++ b/Tests/ProjectDescriptionTests/EnvironmentTests.swift
@@ -14,12 +14,7 @@ final class EnvironmentTests: XCTestCase {
         ]
         try environment.keys.forEach { key in
             let value = try XCTUnwrap(Environment.value(for: key, environment: environment))
-            switch value {
-            case .boolean(true):
-                break
-            default:
-                XCTFail("Unexpected value. Got: \(value), expected: .boolean(true)")
-            }
+            XCTAssertEqual(value, .boolean(true))
         }
     }
 
@@ -33,12 +28,7 @@ final class EnvironmentTests: XCTestCase {
         ]
         try environment.keys.forEach { key in
             let value = try XCTUnwrap(Environment.value(for: key, environment: environment))
-            switch value {
-            case .boolean(false):
-                break
-            default:
-                XCTFail("Unexpected value. Got: \(value), expected: .boolean(false)")
-            }
+            XCTAssertEqual(value, .boolean(false))
         }
     }
 
@@ -48,12 +38,7 @@ final class EnvironmentTests: XCTestCase {
             "0": stringValue,
         ]
         let value = Environment.value(for: "0", environment: environment)
-        switch value {
-        case .string(stringValue):
-            break
-        default:
-            XCTFail("Unexpected value. Got: \(String(describing: value)), expected: .boolean(_)")
-        }
+        XCTAssertEqual(value, .string(stringValue))
     }
 
     func test_unknownKeysReturnNil() {
@@ -72,12 +57,7 @@ final class EnvironmentTests: XCTestCase {
 
         // mimicking the camel cased dynamic member format
         let value = Environment.value(for: "nameSuffix", environment: environment)
-        switch value {
-        case .boolean(false):
-            break
-        default:
-            XCTFail("Unexpected value. Got: \(String(describing: value)), expected: .boolean(false)")
-        }
+        XCTAssertEqual(value, .boolean(false))
     }
 
     func testNonPrefixedKeysAreFetchedIfPrefixedValueDoesNotExist() {
@@ -87,11 +67,6 @@ final class EnvironmentTests: XCTestCase {
 
         // mimicking the camel cased dynamic member format
         let value = Environment.value(for: "nameSuffix", environment: environment)
-        switch value {
-        case .boolean(true):
-            break
-        default:
-            XCTFail("Unexpected value. Got: \(String(describing: value)), expected: .boolean(true)")
-        }
+        XCTAssertEqual(value, .boolean(true))
     }
 }

--- a/projects/docs/docs/guides/environment.md
+++ b/projects/docs/docs/guides/environment.md
@@ -18,8 +18,7 @@ If you want to pass multiple environment variables just separate them with a spa
 TUIST_APP_NAME=MyApp TUIST_APP_LOCALE=pl tuist focus
 ```
 
-Variables can be accesed using the `Environment` type. Any variables following the convention `TUIST_XXX` defined in the environment or passed to Tuist when running commands will be accessible using the `Environment` type.
-The following example shows how we access the `TUIST_APP_NAME` variable:
+Variables can be accessed using the `Environment` type. Variables accessed via the `Environment` type can be in the format `TUIST_XYZ` or `XYZ`. The following example works for either of the `TUIST_APP_NAME` or `APP_NAME` variables:
 
 ```swift
 func appName() -> String {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY
Request for comments document (if applies):

### Short description 📝

When using `tuist` (especially on CI) I've found the requirement of a `TUIST_` prefix to be an awkward part of the API. As a concrete example when running on a gitlab CI there are various env vars which we may want to access (the obvious ones like `CI` indicating this is a CI environment, as well as incrementing identifiers we use for build numbers, e.g. `CI_PIPELINE_IID`)

We can currently use these only if we re-export them with the `TUIST_` prefix. ~~This PR leaves the existing dynamic member subscript in place to avoid this being a breaking change, but adds an extra public `value(for:` function which accesses env var values directly.~~ Following feedback below this leaves the same dynamic member lookup, and adds a fallback to check for the non prefixed value if the prefixed key is not found

I have also refactored slightly to allow testing the value fetching + boolean mapping. 

This change should update docs + changelog but wanted to see if people were happy with this change before updating those.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
