### PR TITLE
Revert using Github artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Changed
 
+- Revert using Github artifacts [#3342](https://github.com/tuist/tuist/pull/3342) by [@fortmarek](https://github.com/fortmarek)
 - Get the latest available version from GitHub releases instead of the Google Cloud Storage bucket [#3335](https://github.com/tuist/tuist/pull/3335) by [@pepibumur](https://github.com/pepibumur).
 - The `install` script has been updated to pull the `tuistenv` binary from the latest GitHub release's assets [#3336](https://github.com/tuist/tuist/pull/3336) by [@pepibumur](https://github.com/pepibumur).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Changed
 
-- Revert using Github artifacts [#3342](https://github.com/tuist/tuist/pull/3342) by [@fortmarek](https://github.com/fortmarek)
+- Skip making API call for latest Github artifact [#3342](https://github.com/tuist/tuist/pull/3342) by [@fortmarek](https://github.com/fortmarek)
 - Get the latest available version from GitHub releases instead of the Google Cloud Storage bucket [#3335](https://github.com/tuist/tuist/pull/3335) by [@pepibumur](https://github.com/pepibumur).
 - The `install` script has been updated to pull the `tuistenv` binary from the latest GitHub release's assets [#3336](https://github.com/tuist/tuist/pull/3336) by [@pepibumur](https://github.com/pepibumur).
 

--- a/script/install
+++ b/script/install
@@ -21,7 +21,7 @@ warn() {
 }
 
 ohai "Downloading tuistenv..."
-curl -LSs --output /tmp/tuistenv.zip https://storage.googleapis.com/tuist-releases/latest/tuistenv.zip
+curl -LSs --output /tmp/tuistenv.zip https://github.com/tuist/tuist/releases/download/1.48.1/tuistenv.zip
 ohai "Unzipping tuistenv..."
 unzip -o /tmp/tuistenv.zip -d /tmp/tuistenv > /dev/null
 ohai "Installing tuistenv..."

--- a/script/install
+++ b/script/install
@@ -20,10 +20,8 @@ warn() {
   printf "${tty_red}Warning${tty_reset}: %s\n" "$(chomp "$1")"
 }
 
-LATEST_VERSION=$(curl --silent "https://api.github.com/repos/tuist/tuist/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-
 ohai "Downloading tuistenv..."
-curl -LSs --output /tmp/tuistenv.zip https://github.com/tuist/tuist/releases/download/${LATEST_VERSION}/tuistenv.zip
+curl -LSs --output /tmp/tuistenv.zip https://storage.googleapis.com/tuist-releases/latest/tuistenv.zip
 ohai "Unzipping tuistenv..."
 unzip -o /tmp/tuistenv.zip -d /tmp/tuistenv > /dev/null
 ohai "Installing tuistenv..."


### PR DESCRIPTION
### Short description 📝

As reported [here](https://github.com/tuist/tuist/issues/3341), the amount of unauthenticated Github API requests is limited to 60 per hour. This reverts the logic of install script to using GCS.

However, this does not fix the issue as we still want to migrate from GCS. But we do need to ensure that tuist is not broken for our users.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
