### PR TITLE
Fix the installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Changed
 
-- Skip making API call for latest Github artifact [#3342](https://github.com/tuist/tuist/pull/3342) by [@fortmarek](https://github.com/fortmarek)
 - Get the latest available version from GitHub releases instead of the Google Cloud Storage bucket [#3335](https://github.com/tuist/tuist/pull/3335) by [@pepibumur](https://github.com/pepibumur).
 - The `install` script has been updated to pull the `tuistenv` binary from the latest GitHub release's assets [#3336](https://github.com/tuist/tuist/pull/3336) by [@pepibumur](https://github.com/pepibumur).
 

--- a/script/install
+++ b/script/install
@@ -20,7 +20,10 @@ warn() {
   printf "${tty_red}Warning${tty_reset}: %s\n" "$(chomp "$1")"
 }
 
-LATEST_VERSION=$(curl --silent "https://api.github.com/repos/tuist/tuist/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+# The line below extracts the version from the Constants.swift file by parsing the line:
+# public static let version = "1.48.1"
+# Note: We can't hit the API from this script because it has limits that might cause the installation to fail.
+LATEST_VERSION=$(curl --silent "https://raw.githubusercontent.com/tuist/tuist/main/Sources/TuistSupport/Constants.swift" | grep 'version =' | sed -E 's/.*"([^"]+)".*/\1/')
 
 ohai "Downloading tuistenv..."
 curl -LSs --output /tmp/tuistenv.zip https://github.com/tuist/tuist/releases/download/${LATEST_VERSION}/tuistenv.zip

--- a/script/install
+++ b/script/install
@@ -20,8 +20,10 @@ warn() {
   printf "${tty_red}Warning${tty_reset}: %s\n" "$(chomp "$1")"
 }
 
+LATEST_VERSION=$(curl --silent "https://api.github.com/repos/tuist/tuist/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+
 ohai "Downloading tuistenv..."
-curl -LSs --output /tmp/tuistenv.zip https://github.com/tuist/tuist/releases/download/1.48.1/tuistenv.zip
+curl -LSs --output /tmp/tuistenv.zip https://github.com/tuist/tuist/releases/download/${LATEST_VERSION}/tuistenv.zip
 ohai "Unzipping tuistenv..."
 unzip -o /tmp/tuistenv.zip -d /tmp/tuistenv > /dev/null
 ohai "Installing tuistenv..."


### PR DESCRIPTION
Reverts https://github.com/tuist/tuist/pull/3342

### Short description 📝

We had to ship a [hotfix](https://github.com/tuist/tuist/pull/3342) to fix the installation script that was failing for some users due to GitHub API limits. This PR reverts the hotfix and fixes the issue by reading the version from the `Constants.swift` raw file without hitting the API.