### PR TITLE
[Cache] Remove unneeded `BUILD_LIBRARY_FOR_DISTRIBUTION` setting when caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Skip making API call for latest Github artifact [#3342](https://github.com/tuist/tuist/pull/3342) by [@fortmarek](https://github.com/fortmarek)
 - Get the latest available version from GitHub releases instead of the Google Cloud Storage bucket [#3335](https://github.com/tuist/tuist/pull/3335) by [@pepibumur](https://github.com/pepibumur).
 - The `install` script has been updated to pull the `tuistenv` binary from the latest GitHub release's assets [#3336](https://github.com/tuist/tuist/pull/3336) by [@pepibumur](https://github.com/pepibumur).
+- Remove unneeded `BUILD_LIBRARY_FOR_DISTRIBUTION` setting when building `xcframework` for cache [#3344](https://github.com/tuist/tuist/pull/3344) by [@danyf90](https://github.com/danyf90).
 
 ## 1.48.1
 

--- a/Sources/TuistCache/Utilities/CacheXCFrameworkBuilder.swift
+++ b/Sources/TuistCache/Utilities/CacheXCFrameworkBuilder.swift
@@ -92,7 +92,6 @@ public final class CacheXCFrameworkBuilder: CacheArtifactBuilding {
                                  configuration: String,
                                  archivePath: AbsolutePath) throws
     {
-        // Without the BUILD_LIBRARY_FOR_DISTRIBUTION argument xcodebuild doesn't generate the .swiftinterface file
         _ = try xcodeBuildController.archive(
             projectTarget,
             scheme: scheme,
@@ -101,7 +100,6 @@ public final class CacheXCFrameworkBuilder: CacheArtifactBuilding {
             arguments: [
                 .sdk(target.platform.xcodeDeviceSDK),
                 .xcarg("SKIP_INSTALL", "NO"),
-                .xcarg("BUILD_LIBRARY_FOR_DISTRIBUTION", "YES"),
                 .configuration(configuration),
             ]
         )
@@ -120,7 +118,6 @@ public final class CacheXCFrameworkBuilder: CacheArtifactBuilding {
                                     configuration: String,
                                     archivePath: AbsolutePath) throws
     {
-        // Without the BUILD_LIBRARY_FOR_DISTRIBUTION argument xcodebuild doesn't generate the .swiftinterface file
         _ = try xcodeBuildController.archive(
             projectTarget,
             scheme: scheme,
@@ -129,7 +126,6 @@ public final class CacheXCFrameworkBuilder: CacheArtifactBuilding {
             arguments: [
                 .sdk(target.platform.xcodeSimulatorSDK!),
                 .xcarg("SKIP_INSTALL", "NO"),
-                .xcarg("BUILD_LIBRARY_FOR_DISTRIBUTION", "YES"),
                 .configuration(configuration),
             ]
         )


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/2635

Request for comments document (if applies):

### Short description 📝

Enabling swift evolution makes some builds fail

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
