### PR TITLE
chore: bump target Xcode to 12.5 and remove redundant checks on 12.2

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        xcode: ['12.2', '12.4']
+        xcode: ['12.5']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        xcode: ['12.2', '12.4']
+        xcode: ['12.5']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode ${{ matrix.xcode }}
@@ -54,7 +54,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        xcode: ['12.2', '12.4']
+        xcode: ['12.5']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
@@ -81,7 +81,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        xcode: ['12.4']
+        xcode: ['12.5']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/fixture-generator.yml
+++ b/.github/workflows/fixture-generator.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        xcode: ['12.2', '12.4']
+        xcode: ['12.5']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/meta-tuist.yml
+++ b/.github/workflows/meta-tuist.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        xcode: ['12.2', '12.4']
+        xcode: ['12.5']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
@@ -55,7 +55,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        xcode: ['12.2', '12.4']
+        xcode: ['12.5']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        xcode: ['12.2']
+        xcode: ['12.5']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        xcode: ['12.2', '12.4']
+        xcode: ['12.5']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
@@ -62,7 +62,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        xcode: ['12.2', '12.4']
+        xcode: ['12.2', '12.5'] # keep 12.2 to ensure backwards compatibility
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
@@ -82,7 +82,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        xcode: ['12.4']
+        xcode: ['12.5']
         feature:
           [
             'build',


### PR DESCRIPTION
### Short description 📝

Bump target Xcode to 12.5
Reduce number of jobs running on older versions, keeping the minimum to ensure backward compatibility

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
