### PR TITLE
Exclude `**/Tuist/Dependencies/**` when run `tuist edit`. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fix for `./fourier bundle` command when `xcodeproj` or `xcworkspace` files are present [#3331](https://github.com/tuist/tuist/pull/3331) by [@danyf90](https://github.com/danyf90)
 - Fix for filtering logic for caching dependencies to include dependencies of filtered non-cacheable targets [#3333](https://github.com/tuist/tuist/pull/3333) by [@adellibovi](https://github.com/adellibovi)
 - Fix for importing Swift Package Manager binary targets from Dependency.swift [#3352](https://github.com/tuist/tuist/pull/3352) by [@danyf90](https://github.com/danyf90)
+- Fix for the `tuist edit`  command when the `Tuist/Dependencies` directory contains "manifest-like" files (`Project.swift` or `Plugin.swift`).  [#3359](https://github.com/tuist/tuist/pull/3300) by [@laxmorek](https://github.com/laxmorek)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fix for `./fourier bundle` command when `xcodeproj` or `xcworkspace` files are present [#3331](https://github.com/tuist/tuist/pull/3331) by [@danyf90](https://github.com/danyf90)
 - Fix for filtering logic for caching dependencies to include dependencies of filtered non-cacheable targets [#3333](https://github.com/tuist/tuist/pull/3333) by [@adellibovi](https://github.com/adellibovi)
 - Fix for importing Swift Package Manager binary targets from Dependency.swift [#3352](https://github.com/tuist/tuist/pull/3352) by [@danyf90](https://github.com/danyf90)
-- Fix for the `tuist edit`  command when the `Tuist/Dependencies` directory contains "manifest-like" files (`Project.swift` or `Plugin.swift`).  [#3359](https://github.com/tuist/tuist/pull/3300) by [@laxmorek](https://github.com/laxmorek)
+- Fix for the `tuist edit`  command when the `Tuist/Dependencies` directory contains "manifest-like" files (`Project.swift` or `Plugin.swift`).  [#3359](https://github.com/tuist/tuist/pull/3359) by [@laxmorek](https://github.com/laxmorek)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fix for `./fourier bundle` command when `xcodeproj` or `xcworkspace` files are present [#3331](https://github.com/tuist/tuist/pull/3331) by [@danyf90](https://github.com/danyf90)
 - Fix for filtering logic for caching dependencies to include dependencies of filtered non-cacheable targets [#3333](https://github.com/tuist/tuist/pull/3333) by [@adellibovi](https://github.com/adellibovi)
 - Fix for importing Swift Package Manager binary targets from Dependency.swift [#3352](https://github.com/tuist/tuist/pull/3352) by [@danyf90](https://github.com/danyf90)
-- Fix for the `tuist edit`  command when the `Tuist/Dependencies` directory contains "manifest-like" files (`Project.swift` or `Plugin.swift`).  [#3359](https://github.com/tuist/tuist/pull/3359) by [@laxmorek](https://github.com/laxmorek)
+- Fix for the `tuist edit` command when the `Tuist/Dependencies` directory contains "manifest-like" files (`Project.swift` or `Plugin.swift`). [#3359](https://github.com/tuist/tuist/pull/3359) by [@laxmorek](https://github.com/laxmorek)
 
 ### Changed
 

--- a/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
@@ -102,7 +102,7 @@ final class ProjectEditor: ProjectEditing {
         let pathsToExclude = [
             "**/\(Constants.tuistDirectoryName)/\(Constants.DependenciesDirectory.name)/**",
         ]
-        
+
         let projectDescriptionPath = try resourceLocator.projectDescription()
         let projectManifests = manifestFilesLocator.locateProjectManifests(at: editingPath, excluding: pathsToExclude, onlyCurrentDirectory: onlyCurrentDirectory)
         let configPath = manifestFilesLocator.locateConfig(at: editingPath)

--- a/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
@@ -30,14 +30,12 @@ protocol ProjectEditing: AnyObject {
     /// Generates an Xcode project to edit the Project defined in the given directory.
     /// - Parameters:
     ///   - editingPath: Directory whose project will be edited.
-    ///   - excluding: Relative glob patterns for excluded files.
     ///   - destinationDirectory: Directory in which the Xcode project will be generated.
     ///   - onlyCurrentDirectory: True if only the manifest in the current directory should be included.
     ///   - plugins: The plugins to load as part of the edit project.
     /// - Returns: The path to the generated Xcode project.
     func edit(
         at editingPath: AbsolutePath,
-        excluding: [String],
         in destinationDirectory: AbsolutePath,
         onlyCurrentDirectory: Bool,
         plugins: Plugins
@@ -97,13 +95,16 @@ final class ProjectEditor: ProjectEditing {
     // swiftlint:disable:next function_body_length
     func edit(
         at editingPath: AbsolutePath,
-        excluding: [String],
         in destinationDirectory: AbsolutePath,
         onlyCurrentDirectory: Bool,
         plugins: Plugins
     ) throws -> AbsolutePath {
+        let pathsToExclude = [
+            "**/\(Constants.tuistDirectoryName)/\(Constants.DependenciesDirectory.name)/**",
+        ]
+        
         let projectDescriptionPath = try resourceLocator.projectDescription()
-        let projectManifests = manifestFilesLocator.locateProjectManifests(at: editingPath, excluding: excluding, onlyCurrentDirectory: onlyCurrentDirectory)
+        let projectManifests = manifestFilesLocator.locateProjectManifests(at: editingPath, excluding: pathsToExclude, onlyCurrentDirectory: onlyCurrentDirectory)
         let configPath = manifestFilesLocator.locateConfig(at: editingPath)
         let cacheDirectory = try cacheDirectoryProviderFactory.cacheDirectories(config: nil)
         let projectDescriptionHelpersBuilder = projectDescriptionHelpersBuilderFactory.projectDescriptionHelpersBuilder(
@@ -123,7 +124,7 @@ final class ProjectEditor: ProjectEditing {
 
         let editablePluginManifests = locateEditablePluginManifests(
             at: editingPath,
-            excluding: excluding,
+            excluding: pathsToExclude,
             plugins: plugins,
             onlyCurrentDirectory: onlyCurrentDirectory
         )

--- a/Sources/TuistKit/Services/EditService.swift
+++ b/Sources/TuistKit/Services/EditService.swift
@@ -52,10 +52,6 @@ final class EditService {
     ) throws {
         let path = self.path(path)
 
-        let pathsToExclude = [
-            "**/\(Constants.tuistDirectoryName)/\(Constants.DependenciesDirectory.name)/**",
-        ]
-
         if !permanent {
             try withTemporaryDirectory(removeTreeOnDeinit: true) { generationDirectory in
                 EditService.temporaryDirectory = generationDirectory
@@ -73,7 +69,6 @@ final class EditService {
                 let plugins = loadPlugins(at: path)
                 let workspacePath = try projectEditor.edit(
                     at: path,
-                    excluding: pathsToExclude,
                     in: generationDirectory,
                     onlyCurrentDirectory: onlyCurrentDirectory,
                     plugins: plugins
@@ -85,7 +80,6 @@ final class EditService {
             let plugins = loadPlugins(at: path)
             let workspacePath = try projectEditor.edit(
                 at: path,
-                excluding: pathsToExclude,
                 in: path,
                 onlyCurrentDirectory: onlyCurrentDirectory,
                 plugins: plugins

--- a/Sources/TuistKit/Services/EditService.swift
+++ b/Sources/TuistKit/Services/EditService.swift
@@ -51,6 +51,10 @@ final class EditService {
         onlyCurrentDirectory: Bool
     ) throws {
         let path = self.path(path)
+        
+        let pathsToExclude = [
+            "**/\(Constants.tuistDirectoryName)/\(Constants.DependenciesDirectory.name)/**"
+        ]
 
         if !permanent {
             try withTemporaryDirectory(removeTreeOnDeinit: true) { generationDirectory in
@@ -69,6 +73,7 @@ final class EditService {
                 let plugins = loadPlugins(at: path)
                 let workspacePath = try projectEditor.edit(
                     at: path,
+                    excluding: pathsToExclude,
                     in: generationDirectory,
                     onlyCurrentDirectory: onlyCurrentDirectory,
                     plugins: plugins
@@ -80,6 +85,7 @@ final class EditService {
             let plugins = loadPlugins(at: path)
             let workspacePath = try projectEditor.edit(
                 at: path,
+                excluding: pathsToExclude,
                 in: path,
                 onlyCurrentDirectory: onlyCurrentDirectory,
                 plugins: plugins

--- a/Sources/TuistKit/Services/EditService.swift
+++ b/Sources/TuistKit/Services/EditService.swift
@@ -51,9 +51,9 @@ final class EditService {
         onlyCurrentDirectory: Bool
     ) throws {
         let path = self.path(path)
-        
+
         let pathsToExclude = [
-            "**/\(Constants.tuistDirectoryName)/\(Constants.DependenciesDirectory.name)/**"
+            "**/\(Constants.tuistDirectoryName)/\(Constants.DependenciesDirectory.name)/**",
         ]
 
         if !permanent {

--- a/Sources/TuistLoader/Utils/ManifestFilesLocator.swift
+++ b/Sources/TuistLoader/Utils/ManifestFilesLocator.swift
@@ -128,16 +128,14 @@ public final class ManifestFilesLocator: ManifestFilesLocating {
                     FileHandler.shared.glob(path, glob: $0)
                 }
 
-            let projectsPaths = Set(FileHandler.shared.glob(path, glob: "**/\(Manifest.project.fileName(path))"))
-                .subtracting(excludedPaths)
+            let projectsPaths = FileHandler.shared.glob(path, glob: "**/\(Manifest.project.fileName(path))")
                 .map {
                     ProjectManifest(
                         manifest: Manifest.project,
                         path: $0
                     )
                 }
-            let workspacesPaths = Set(FileHandler.shared.glob(path, glob: "**/\(Manifest.workspace.fileName(path))"))
-                .subtracting(excludedPaths)
+            let workspacesPaths = FileHandler.shared.glob(path, glob: "**/\(Manifest.workspace.fileName(path))")
                 .map {
                     ProjectManifest(
                         manifest: Manifest.workspace,
@@ -145,7 +143,8 @@ public final class ManifestFilesLocator: ManifestFilesLocating {
                     )
                 }
 
-            return projectsPaths + workspacesPaths
+            return (projectsPaths + workspacesPaths)
+                .filter { !excludedPaths.contains($0.path) }
         }
     }
 

--- a/Sources/TuistLoader/Utils/ManifestFilesLocator.swift
+++ b/Sources/TuistLoader/Utils/ManifestFilesLocator.swift
@@ -72,15 +72,15 @@ public final class ManifestFilesLocator: ManifestFilesLocating {
             return [pluginPath]
         } else {
             let path = rootDirectoryLocator.locate(from: locatingPath) ?? locatingPath
-            
+
             let excludedPaths = excluding
                 .flatMap {
                     FileHandler.shared.glob(path, glob: $0)
                 }
-            
+
             let pluginsPaths = Set(FileHandler.shared.glob(path, glob: "**/\(Manifest.plugin.fileName(path))"))
                 .subtracting(excludedPaths)
-            
+
             return Array(pluginsPaths)
         }
     }
@@ -122,13 +122,12 @@ public final class ManifestFilesLocator: ManifestFilesLocating {
             .filter { FileHandler.shared.exists($0.path) }
         } else {
             let path = rootDirectoryLocator.locate(from: locatingPath) ?? locatingPath
-            
+
             let excludedPaths = excluding
                 .flatMap {
                     FileHandler.shared.glob(path, glob: $0)
                 }
-            
-            
+
             let projectsPaths = Set(FileHandler.shared.glob(path, glob: "**/\(Manifest.project.fileName(path))"))
                 .subtracting(excludedPaths)
                 .map {
@@ -145,7 +144,7 @@ public final class ManifestFilesLocator: ManifestFilesLocating {
                         path: $0
                     )
                 }
-            
+
             return projectsPaths + workspacesPaths
         }
     }

--- a/Sources/TuistLoader/Utils/ManifestFilesLocator.swift
+++ b/Sources/TuistLoader/Utils/ManifestFilesLocator.swift
@@ -11,18 +11,22 @@ public protocol ManifestFilesLocating: AnyObject {
     /// It locates all plugin manifest files under the the root directory (as defined in `RootDirectoryLocator`).
     /// - Parameters:
     ///     - locatingPath: Directory for which the **plugin** manifest files will be obtained.
+    ///     - excluding: Relative glob patterns for excluded files.
     ///     - onlyCurrentDirectory: If true, search for plugin manifests only in the directory of `locatingPath`
     func locatePluginManifests(
         at locatingPath: AbsolutePath,
+        excluding: [String],
         onlyCurrentDirectory: Bool
     ) -> [AbsolutePath]
 
     /// It locates all project and workspace manifest files under the root directory (as defined in `RootDirectoryLocator`).
     /// - Parameters:
     ///     - locatingPath: Directory for which the **project** and **workspace** manifest files will be obtained.
+    ///     - excluding: Relative glob patterns for excluded files.
     ///     - onlyCurrentDirectory: If true, search for manifests only in the directory of `locatingPath`
     func locateProjectManifests(
         at locatingPath: AbsolutePath,
+        excluding: [String],
         onlyCurrentDirectory: Bool
     ) -> [ManifestFilesLocator.ProjectManifest]
 
@@ -57,6 +61,7 @@ public final class ManifestFilesLocator: ManifestFilesLocating {
 
     public func locatePluginManifests(
         at locatingPath: AbsolutePath,
+        excluding: [String],
         onlyCurrentDirectory: Bool
     ) -> [AbsolutePath] {
         if onlyCurrentDirectory {
@@ -66,10 +71,17 @@ public final class ManifestFilesLocator: ManifestFilesLocating {
             guard FileHandler.shared.exists(pluginPath) else { return [] }
             return [pluginPath]
         } else {
-            guard let rootPath = rootDirectoryLocator.locate(from: locatingPath) else {
-                return FileHandler.shared.glob(locatingPath, glob: "**/\(Manifest.plugin.fileName(locatingPath))")
-            }
-            return FileHandler.shared.glob(rootPath, glob: "**/\(Manifest.plugin.fileName(rootPath))")
+            let path = rootDirectoryLocator.locate(from: locatingPath) ?? locatingPath
+            
+            let excludedPaths = excluding
+                .flatMap {
+                    FileHandler.shared.glob(path, glob: $0)
+                }
+            
+            let pluginsPaths = Set(FileHandler.shared.glob(path, glob: "**/\(Manifest.plugin.fileName(path))"))
+                .subtracting(excludedPaths)
+            
+            return Array(pluginsPaths)
         }
     }
 
@@ -89,6 +101,7 @@ public final class ManifestFilesLocator: ManifestFilesLocating {
 
     public func locateProjectManifests(
         at locatingPath: AbsolutePath,
+        excluding: [String],
         onlyCurrentDirectory: Bool
     ) -> [ProjectManifest] {
         if onlyCurrentDirectory {
@@ -108,38 +121,31 @@ public final class ManifestFilesLocator: ManifestFilesLocating {
             ]
             .filter { FileHandler.shared.exists($0.path) }
         } else {
-            guard let rootPath = rootDirectoryLocator.locate(from: locatingPath) else {
-                let projectsPaths = FileHandler.shared.glob(locatingPath, glob: "**/\(Manifest.project.fileName(locatingPath))")
-                    .map {
-                        ProjectManifest(
-                            manifest: Manifest.project,
-                            path: $0
-                        )
-                    }
-                let workspacesPaths = FileHandler.shared.glob(locatingPath, glob: "**/\(Manifest.workspace.fileName(locatingPath))")
-                    .map {
-                        ProjectManifest(
-                            manifest: Manifest.workspace,
-                            path: $0
-                        )
-                    }
-                return projectsPaths + workspacesPaths
-            }
-
-            let projectsPaths = FileHandler.shared.glob(rootPath, glob: "**/\(Manifest.project.fileName(rootPath))")
+            let path = rootDirectoryLocator.locate(from: locatingPath) ?? locatingPath
+            
+            let excludedPaths = excluding
+                .flatMap {
+                    FileHandler.shared.glob(path, glob: $0)
+                }
+            
+            
+            let projectsPaths = Set(FileHandler.shared.glob(path, glob: "**/\(Manifest.project.fileName(path))"))
+                .subtracting(excludedPaths)
                 .map {
                     ProjectManifest(
                         manifest: Manifest.project,
                         path: $0
                     )
                 }
-            let workspacesPaths = FileHandler.shared.glob(rootPath, glob: "**/\(Manifest.workspace.fileName(rootPath))")
+            let workspacesPaths = Set(FileHandler.shared.glob(path, glob: "**/\(Manifest.workspace.fileName(path))"))
+                .subtracting(excludedPaths)
                 .map {
                     ProjectManifest(
                         manifest: Manifest.workspace,
                         path: $0
                     )
                 }
+            
             return projectsPaths + workspacesPaths
         }
     }

--- a/Sources/TuistLoaderTesting/Utils/Mocks/MockManifestFilesLocator.swift
+++ b/Sources/TuistLoaderTesting/Utils/Mocks/MockManifestFilesLocator.swift
@@ -5,7 +5,7 @@ import TSCBasic
 public final class MockManifestFilesLocator: ManifestFilesLocating {
     public var locateManifestsArgs: [AbsolutePath] = []
     public var locateManifestsStub: [(Manifest, AbsolutePath)]?
-    public var locateProjectManifestsStub: ((AbsolutePath, Bool) -> [ManifestFilesLocator.ProjectManifest])?
+    public var locateProjectManifestsStub: ((AbsolutePath, [String], Bool) -> [ManifestFilesLocator.ProjectManifest])?
     public var locatePluginManifestsStub: [AbsolutePath]?
     public var locatePluginManifestsArgs: [AbsolutePath] = []
     public var locateConfigStub: AbsolutePath?
@@ -22,16 +22,21 @@ public final class MockManifestFilesLocator: ManifestFilesLocating {
         return locateManifestsStub ?? [(.project, at.appending(component: "Project.swift"))]
     }
 
-    public func locatePluginManifests(at: AbsolutePath, onlyCurrentDirectory _: Bool) -> [AbsolutePath] {
+    public func locatePluginManifests(
+        at: AbsolutePath,
+        excluding: [String],
+        onlyCurrentDirectory _: Bool
+    ) -> [AbsolutePath] {
         locatePluginManifestsArgs.append(at)
         return locatePluginManifestsStub ?? [at.appending(component: "Plugin.swift")]
     }
 
     public func locateProjectManifests(
         at locatingPath: AbsolutePath,
+        excluding: [String],
         onlyCurrentDirectory: Bool
     ) -> [ManifestFilesLocator.ProjectManifest] {
-        return locateProjectManifestsStub?(locatingPath, onlyCurrentDirectory) ?? [
+        return locateProjectManifestsStub?(locatingPath, excluding, onlyCurrentDirectory) ?? [
             ManifestFilesLocator.ProjectManifest(
                 manifest: .project,
                 path: locatingPath.appending(component: "Project.swift")

--- a/Sources/TuistLoaderTesting/Utils/Mocks/MockManifestFilesLocator.swift
+++ b/Sources/TuistLoaderTesting/Utils/Mocks/MockManifestFilesLocator.swift
@@ -24,7 +24,7 @@ public final class MockManifestFilesLocator: ManifestFilesLocating {
 
     public func locatePluginManifests(
         at: AbsolutePath,
-        excluding: [String],
+        excluding _: [String],
         onlyCurrentDirectory _: Bool
     ) -> [AbsolutePath] {
         locatePluginManifestsArgs.append(at)

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
@@ -122,7 +122,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         }
 
         // When
-        try _ = subject.edit(at: directory, excluding: [], in: directory, onlyCurrentDirectory: false, plugins: .test())
+        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test())
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -160,7 +160,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         // Then
         XCTAssertThrowsSpecific(
             // When
-            try subject.edit(at: directory, excluding: [], in: directory, onlyCurrentDirectory: false, plugins: .test()), ProjectEditorError.noEditableFiles(directory)
+            try subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test()), ProjectEditorError.noEditableFiles(directory)
         )
     }
 
@@ -182,7 +182,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         }
 
         // When
-        try _ = subject.edit(at: directory, excluding: [], in: directory, onlyCurrentDirectory: false, plugins: .test())
+        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test())
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -217,7 +217,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         }
 
         // When
-        try _ = subject.edit(at: directory, excluding: [], in: directory, onlyCurrentDirectory: false, plugins: .test())
+        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test())
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -267,7 +267,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         let plugins = Plugins.test(projectDescriptionHelpers: [
             .init(name: "LocalPlugin", path: pluginManifestPath, location: .local),
         ])
-        try _ = subject.edit(at: directory, excluding: [], in: directory, onlyCurrentDirectory: false, plugins: plugins)
+        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: plugins)
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -315,7 +315,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
             .init(name: "LocalPlugin", path: pluginManifestPath, location: .local),
         ])
 
-        try _ = subject.edit(at: editingPath, excluding: [], in: editingPath, onlyCurrentDirectory: false, plugins: plugins)
+        try _ = subject.edit(at: editingPath, in: editingPath, onlyCurrentDirectory: false, plugins: plugins)
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -361,7 +361,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         let plugins = Plugins.test(projectDescriptionHelpers: [
             .init(name: "RemotePlugin", path: AbsolutePath("/Some/Path/To/Plugin"), location: .remote),
         ])
-        try _ = subject.edit(at: directory, excluding: [], in: directory, onlyCurrentDirectory: false, plugins: plugins)
+        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: plugins)
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
@@ -106,7 +106,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
 
         resourceLocator.projectDescriptionStub = { projectDescriptionPath }
         resourceLocator.projectAutomationStub = { projectAutomationPath }
-        manifestFilesLocator.locateProjectManifestsStub = { _, _ in
+        manifestFilesLocator.locateProjectManifestsStub = { _, _, _ in
             manifests
         }
         manifestFilesLocator.locateConfigStub = configPath
@@ -122,7 +122,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         }
 
         // When
-        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test())
+        try _ = subject.edit(at: directory, excluding: [], in: directory, onlyCurrentDirectory: false, plugins: .test())
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -147,7 +147,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         try FileHandler.shared.createFolder(helpersDirectory)
 
         resourceLocator.projectDescriptionStub = { projectDescriptionPath }
-        manifestFilesLocator.locateProjectManifestsStub = { _, _ in
+        manifestFilesLocator.locateProjectManifestsStub = { _, _, _ in
             []
         }
         manifestFilesLocator.locatePluginManifestsStub = []
@@ -160,7 +160,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         // Then
         XCTAssertThrowsSpecific(
             // When
-            try subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test()), ProjectEditorError.noEditableFiles(directory)
+            try subject.edit(at: directory, excluding: [], in: directory, onlyCurrentDirectory: false, plugins: .test()), ProjectEditorError.noEditableFiles(directory)
         )
     }
 
@@ -182,7 +182,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         }
 
         // When
-        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test())
+        try _ = subject.edit(at: directory, excluding: [], in: directory, onlyCurrentDirectory: false, plugins: .test())
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -217,7 +217,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         }
 
         // When
-        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: .test())
+        try _ = subject.edit(at: directory, excluding: [], in: directory, onlyCurrentDirectory: false, plugins: .test())
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -254,7 +254,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         let tuistPath = AbsolutePath(ProcessInfo.processInfo.arguments.first!)
 
         resourceLocator.projectDescriptionStub = { projectDescriptionPath }
-        manifestFilesLocator.locateProjectManifestsStub = { _, _ in
+        manifestFilesLocator.locateProjectManifestsStub = { _, _, _ in
             manifests
         }
         manifestFilesLocator.locatePluginManifestsStub = [pluginManifestPath]
@@ -267,7 +267,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         let plugins = Plugins.test(projectDescriptionHelpers: [
             .init(name: "LocalPlugin", path: pluginManifestPath, location: .local),
         ])
-        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: plugins)
+        try _ = subject.edit(at: directory, excluding: [], in: directory, onlyCurrentDirectory: false, plugins: plugins)
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -301,7 +301,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         let tuistPath = AbsolutePath(ProcessInfo.processInfo.arguments.first!)
 
         resourceLocator.projectDescriptionStub = { projectDescriptionPath }
-        manifestFilesLocator.locateProjectManifestsStub = { _, _ in
+        manifestFilesLocator.locateProjectManifestsStub = { _, _, _ in
             manifests
         }
         manifestFilesLocator.locatePluginManifestsStub = [pluginManifestPath]
@@ -315,7 +315,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
             .init(name: "LocalPlugin", path: pluginManifestPath, location: .local),
         ])
 
-        try _ = subject.edit(at: editingPath, in: editingPath, onlyCurrentDirectory: false, plugins: plugins)
+        try _ = subject.edit(at: editingPath, excluding: [], in: editingPath, onlyCurrentDirectory: false, plugins: plugins)
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)
@@ -344,7 +344,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         let tuistPath = AbsolutePath(ProcessInfo.processInfo.arguments.first!)
 
         resourceLocator.projectDescriptionStub = { projectDescriptionPath }
-        manifestFilesLocator.locateProjectManifestsStub = { _, _ in
+        manifestFilesLocator.locateProjectManifestsStub = { _, _, _ in
             manifests
         }
         manifestFilesLocator.locatePluginManifestsStub = []
@@ -361,7 +361,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
         let plugins = Plugins.test(projectDescriptionHelpers: [
             .init(name: "RemotePlugin", path: AbsolutePath("/Some/Path/To/Plugin"), location: .remote),
         ])
-        try _ = subject.edit(at: directory, in: directory, onlyCurrentDirectory: false, plugins: plugins)
+        try _ = subject.edit(at: directory, excluding: [], in: directory, onlyCurrentDirectory: false, plugins: plugins)
 
         // Then
         XCTAssertEqual(projectEditorMapper.mapArgs.count, 1)

--- a/Tests/TuistLoaderTests/Utils/ManifestFilesLocatorTests.swift
+++ b/Tests/TuistLoaderTests/Utils/ManifestFilesLocatorTests.swift
@@ -135,7 +135,7 @@ final class ManifestFilesLocatorTests: TuistUnitTestCase {
             ]
         )
     }
-    
+
     func test_locateProjectManifests_excludes_paths() throws {
         // Given
         let paths = try createFiles([
@@ -148,12 +148,12 @@ final class ManifestFilesLocatorTests: TuistUnitTestCase {
         let excluding = [
             "**/ExcludeMe/**",
         ]
-        
+
         // When
         let manifests = subject
             .locateProjectManifests(at: try temporaryPath(), excluding: excluding, onlyCurrentDirectory: false)
             .sorted(by: { $0.path < $1.path })
-        
+
         // Then
         XCTAssertEqual(
             manifests,
@@ -173,7 +173,7 @@ final class ManifestFilesLocatorTests: TuistUnitTestCase {
             ]
         )
     }
-    
+
     func test_locateProjectManifests_excludes_paths_when_fell_back_to_locatingPath_given_no_root_path() throws {
         // Given
         let paths = try createFiles([
@@ -310,7 +310,7 @@ final class ManifestFilesLocatorTests: TuistUnitTestCase {
             ]
         )
     }
-    
+
     func test_locatePluginManifests_excludes_paths() throws {
         // Given
         let paths = try createFiles([
@@ -345,7 +345,7 @@ final class ManifestFilesLocatorTests: TuistUnitTestCase {
             ]
         )
     }
-    
+
     func test_locatePluginManifests_excludes_paths_when_fell_back_to_locatingPath_when_no_root_path() throws {
         // Given
         let paths = try createFiles([

--- a/Tests/TuistLoaderTests/Utils/ManifestFilesLocatorTests.swift
+++ b/Tests/TuistLoaderTests/Utils/ManifestFilesLocatorTests.swift
@@ -29,7 +29,9 @@ final class ManifestFilesLocatorTests: TuistUnitTestCase {
         ])
 
         // When
-        let manifests = subject.locateProjectManifests(at: paths.first!, onlyCurrentDirectory: false)
+        let manifests = subject
+            .locateProjectManifests(at: paths.first!, excluding: [], onlyCurrentDirectory: false)
+            .sorted(by: { $0.path < $1.path })
 
         // Then
         XCTAssertEqual(
@@ -56,7 +58,9 @@ final class ManifestFilesLocatorTests: TuistUnitTestCase {
         ])
 
         // When
-        let manifests = subject.locateProjectManifests(at: paths.first!, onlyCurrentDirectory: false)
+        let manifests = subject
+            .locateProjectManifests(at: paths.first!, excluding: [], onlyCurrentDirectory: false)
+            .sorted(by: { $0.path < $1.path })
 
         // Then
         XCTAssertEqual(
@@ -83,7 +87,9 @@ final class ManifestFilesLocatorTests: TuistUnitTestCase {
         ])
 
         // When
-        let manifests = subject.locateProjectManifests(at: paths.first!.parentDirectory, onlyCurrentDirectory: true)
+        let manifests = subject
+            .locateProjectManifests(at: paths.first!.parentDirectory, excluding: [], onlyCurrentDirectory: true)
+            .sorted(by: { $0.path < $1.path })
 
         // Then
         XCTAssertEqual(
@@ -107,7 +113,83 @@ final class ManifestFilesLocatorTests: TuistUnitTestCase {
 
         // When
         let manifests = subject
-            .locateProjectManifests(at: try temporaryPath(), onlyCurrentDirectory: false)
+            .locateProjectManifests(at: try temporaryPath(), excluding: [], onlyCurrentDirectory: false)
+            .sorted(by: { $0.path < $1.path })
+
+        // Then
+        XCTAssertEqual(
+            manifests,
+            [
+                ManifestFilesLocator.ProjectManifest(
+                    manifest: .project,
+                    path: paths[0]
+                ),
+                ManifestFilesLocator.ProjectManifest(
+                    manifest: .workspace,
+                    path: paths[1]
+                ),
+                ManifestFilesLocator.ProjectManifest(
+                    manifest: .project,
+                    path: paths[2]
+                ),
+            ]
+        )
+    }
+    
+    func test_locateProjectManifests_excludes_paths() throws {
+        // Given
+        let paths = try createFiles([
+            "A/Project.swift",
+            "B/Workspace.swift",
+            "C/Project.swift",
+            "DirName/ExcludeMe/D/Project.swift",
+            "ExcludeMe/Workspace.swift",
+        ])
+        let excluding = [
+            "**/ExcludeMe/**",
+        ]
+        
+        // When
+        let manifests = subject
+            .locateProjectManifests(at: try temporaryPath(), excluding: excluding, onlyCurrentDirectory: false)
+            .sorted(by: { $0.path < $1.path })
+        
+        // Then
+        XCTAssertEqual(
+            manifests,
+            [
+                ManifestFilesLocator.ProjectManifest(
+                    manifest: .project,
+                    path: paths[0]
+                ),
+                ManifestFilesLocator.ProjectManifest(
+                    manifest: .workspace,
+                    path: paths[1]
+                ),
+                ManifestFilesLocator.ProjectManifest(
+                    manifest: .project,
+                    path: paths[2]
+                ),
+            ]
+        )
+    }
+    
+    func test_locateProjectManifests_excludes_paths_when_fell_back_to_locatingPath_given_no_root_path() throws {
+        // Given
+        let paths = try createFiles([
+            "A/Project.swift",
+            "B/Workspace.swift",
+            "C/Project.swift",
+            "DirName/ExcludeMe/D/Project.swift",
+            "ExcludeMe/Workspace.swift",
+        ])
+        let excluding = [
+            "**/ExcludeMe/**",
+        ]
+
+        // When
+        let manifests = subject
+            .locateProjectManifests(at: try temporaryPath(), excluding: excluding, onlyCurrentDirectory: false)
             .sorted(by: { $0.path < $1.path })
 
         // Then
@@ -140,16 +222,24 @@ final class ManifestFilesLocatorTests: TuistUnitTestCase {
         ])
 
         // When
-        let manifests = subject.locatePluginManifests(
-            at: paths[0], // Plugin.swift
-            onlyCurrentDirectory: false
-        )
+        let manifests = subject
+            .locatePluginManifests(
+                at: paths[0], // Plugin.swift
+                excluding: [],
+                onlyCurrentDirectory: false
+            )
+            .sorted()
 
         // Then
-        XCTAssertEqual(manifests[0], paths[1]) // A/Plugin.swift
-        XCTAssertEqual(manifests[1], paths[3]) // B/C/Plugin.swift
-        XCTAssertEqual(manifests[2], paths[2]) // B/Plugin.swift
-        XCTAssertEqual(manifests[3], paths[0]) // Plugin.swift
+        XCTAssertEqual(
+            manifests,
+            [
+                paths[1], // A/Plugin.swift
+                paths[3], // B/C/Plugin.swift
+                paths[2], // B/Plugin.swift
+                paths[0], // Plugin.swift
+            ]
+        )
     }
 
     func test_locatePluginManifests_returns_only_plugin_in_cwdir_when_only_current_directory() throws {
@@ -164,6 +254,7 @@ final class ManifestFilesLocatorTests: TuistUnitTestCase {
         // When
         let manifests = subject.locatePluginManifests(
             at: paths[0].parentDirectory, // Plugin.swift's parent directory
+            excluding: [],
             onlyCurrentDirectory: true
         )
 
@@ -186,6 +277,7 @@ final class ManifestFilesLocatorTests: TuistUnitTestCase {
         // When
         let manifests = subject.locatePluginManifests(
             at: paths[1], // A/Helpers/Helper.swift
+            excluding: [],
             onlyCurrentDirectory: false
         )
 
@@ -201,14 +293,88 @@ final class ManifestFilesLocatorTests: TuistUnitTestCase {
         ])
 
         // When
-        let manifests = subject.locatePluginManifests(
-            at: try temporaryPath(),
-            onlyCurrentDirectory: false
-        )
+        let manifests = subject
+            .locatePluginManifests(
+                at: try temporaryPath(),
+                excluding: [],
+                onlyCurrentDirectory: false
+            )
+            .sorted()
 
         // Then
-        XCTAssertEqual(manifests[0], paths[0])
-        XCTAssertEqual(manifests[1], paths[1])
+        XCTAssertEqual(
+            manifests,
+            [
+                paths[0],
+                paths[1],
+            ]
+        )
+    }
+    
+    func test_locatePluginManifests_excludes_paths() throws {
+        // Given
+        let paths = try createFiles([
+            "Plugin.swift",
+            "A/Plugin.swift",
+            "B/Plugin.swift",
+            "B/C/Plugin.swift",
+            "DirName/ExcludeMe/D/Plugin.swift",
+            "ExcludeMe/Plugin.swift",
+        ])
+        let excluding = [
+            "**/ExcludeMe/**",
+        ]
+
+        // When
+        let manifests = subject
+            .locatePluginManifests(
+                at: paths[0], // Plugin.swift
+                excluding: excluding,
+                onlyCurrentDirectory: false
+            )
+            .sorted()
+
+        // Then
+        XCTAssertEqual(
+            manifests,
+            [
+                paths[1], // A/Plugin.swift
+                paths[3], // B/C/Plugin.swift
+                paths[2], // B/Plugin.swift
+                paths[0], // Plugin.swift
+            ]
+        )
+    }
+    
+    func test_locatePluginManifests_excludes_paths_when_fell_back_to_locatingPath_when_no_root_path() throws {
+        // Given
+        let paths = try createFiles([
+            "A/Plugin.swift",
+            "B/Plugin.swift",
+            "DirName/ExcludeMe/D/Plugin.swift",
+            "ExcludeMe/Plugin.swift",
+        ])
+        let excluding = [
+            "**/ExcludeMe/**",
+        ]
+
+        // When
+        let manifests = subject
+            .locatePluginManifests(
+                at: try temporaryPath(),
+                excluding: excluding,
+                onlyCurrentDirectory: false
+            )
+            .sorted()
+
+        // Then
+        XCTAssertEqual(
+            manifests,
+            [
+                paths[0],
+                paths[1],
+            ]
+        )
     }
 
     func test_locateConfig() throws {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3353

### Short description 📝

"Manifest-like" files (`Project.swift` and `Plugin.swift`) from the `Dependencies` are no longer added to the project generated using the `tuist edit` command.

### Testing 👨‍💻

The solution was being tested with project that was attached to #3353. 

`Dependencies.swift`:

```swift
import ProjectDescription

let dependencies = Dependencies(
    swiftPackageManager: [
        .package(url: "https://github.com/optimizely/swift-sdk", .upToNextMajor(from: "3.8.0")),
        .package(url: "https://github.com/Moya/Moya", .exact("14.0.1")),
    ],
    platforms: [.iOS]
)
```

- `https://github.com/optimizely/swift-sdk`has [Project.swift](https://github.com/optimizely/swift-sdk/blob/master/Sources/Data%20Model/Project.swift) file 
- `https://github.com/Moya/Moya` has [Plugin.swift](https://github.com/Moya/Moya/blob/master/Sources/Moya/Plugin.swift) file

The project that was generated using the `tuist edit` command **before** fix:

<img width="1258" alt="Zrzut ekranu 2021-08-26 o 17 35 45" src="https://user-images.githubusercontent.com/4774319/130994659-cb4c1ffc-5c8d-450e-83d7-973470041a68.png">

The project that was generated using the `tuist edit` command **after** fix:

<img width="1405" alt="Zrzut ekranu 2021-08-26 o 17 36 54" src="https://user-images.githubusercontent.com/4774319/130994738-1c1a417b-3b11-42c1-894f-10c99ca4fa83.png">

### Questions 👨‍💻

- Should `edit.feature` be updated with a new fixture?
- Should documentation of the `tuist edit` command be updated with a tip that sources of "Tuist/Dependencies" are ignored?

