### PR TITLE
Add `--skip-cache` parameter to `tuist test`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Add default `Release` caching profile [#3304](https://github.com/tuist/tuist/pull/3304) by [@danyf90](https://github.com/danyf90)
 - Add `--dependencies-only` parameter to `tuist cache warm` command [#3334](https://github.com/tuist/tuist/pull/3334) by [@danyf90](https://github.com/danyf90)
+- Add `--skip-cache` parameter to `tuist test` command [#3262](https://github.com/tuist/tuist/pull/3262) by [@olejnjak](https://github.com/olejnjak)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Add default `Release` caching profile [#3304](https://github.com/tuist/tuist/pull/3304) by [@danyf90](https://github.com/danyf90)
 - Add `--dependencies-only` parameter to `tuist cache warm` command [#3334](https://github.com/tuist/tuist/pull/3334) by [@danyf90](https://github.com/danyf90)
-- Add `--skip-cache` parameter to `tuist test` command [#3262](https://github.com/tuist/tuist/pull/3262) by [@olejnjak](https://github.com/olejnjak)
+- Add `--skip-cache` parameter to `tuist test` command [#3362](https://github.com/tuist/tuist/pull/3362) by [@olejnjak](https://github.com/olejnjak)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Add default `Release` caching profile [#3304](https://github.com/tuist/tuist/pull/3304) by [@danyf90](https://github.com/danyf90)
 - Add `--dependencies-only` parameter to `tuist cache warm` command [#3334](https://github.com/tuist/tuist/pull/3334) by [@danyf90](https://github.com/danyf90)
-- Add `--skip-cache` parameter to `tuist test` command [#3362](https://github.com/tuist/tuist/pull/3362) by [@olejnjak](https://github.com/olejnjak)
+- Add `--all-tests` parameter to `tuist test` command [#3362](https://github.com/tuist/tuist/pull/3362) by [@olejnjak](https://github.com/olejnjak)
 
 ### Fixed
 

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -59,6 +59,12 @@ struct TestCommand: ParsableCommand {
     )
     var resultBundlePath: String?
 
+    @Flag(
+        name: .long,
+        help: "Skip Tuist cache and run all tests"
+    )
+    var skipCache = false
+
     func run() throws {
         let absolutePath: AbsolutePath
 
@@ -81,7 +87,8 @@ struct TestCommand: ParsableCommand {
                     $0,
                     relativeTo: FileHandler.shared.currentPath
                 )
-            }
+            },
+            skipCache: skipCache
         )
     }
 }

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -61,9 +61,9 @@ struct TestCommand: ParsableCommand {
 
     @Flag(
         name: .long,
-        help: "Skip Tuist cache and run all tests"
+        help: "Run all tests, do not skip tests for targets that haven't changed since last test run"
     )
-    var skipCache = false
+    var allTests = false
 
     func run() throws {
         let absolutePath: AbsolutePath
@@ -88,7 +88,7 @@ struct TestCommand: ParsableCommand {
                     relativeTo: FileHandler.shared.currentPath
                 )
             },
-            skipCache: skipCache
+            skipCache: allTests
         )
     }
 }

--- a/Sources/TuistKit/Generator/TestServiceGeneratorFactory.swift
+++ b/Sources/TuistKit/Generator/TestServiceGeneratorFactory.swift
@@ -9,7 +9,8 @@ protocol TestServiceGeneratorFactorying {
     func generator(
         automationPath: AbsolutePath,
         testsCacheDirectory: AbsolutePath,
-        skipUITests: Bool
+        skipUITests: Bool,
+        skipCache: Bool
     ) -> Generating
 }
 
@@ -17,12 +18,14 @@ final class TestServiceGeneratorFactory: TestServiceGeneratorFactorying {
     func generator(
         automationPath: AbsolutePath,
         testsCacheDirectory: AbsolutePath,
-        skipUITests: Bool
+        skipUITests: Bool,
+        skipCache: Bool
     ) -> Generating {
         Generator(
             projectMapperProvider: AutomationProjectMapperProvider(skipUITests: skipUITests),
             graphMapperProvider: AutomationGraphMapperProvider(
-                testsCacheDirectory: testsCacheDirectory
+                testsCacheDirectory: testsCacheDirectory,
+                skipTestsCache: skipCache
             ),
             workspaceMapperProvider: AutomationWorkspaceMapperProvider(
                 workspaceDirectory: FileHandler.shared.resolveSymlinks(automationPath),

--- a/Sources/TuistKit/GraphMappers/AutomationGraphMapperProvider.swift
+++ b/Sources/TuistKit/GraphMappers/AutomationGraphMapperProvider.swift
@@ -7,22 +7,28 @@ import TuistGraph
 final class AutomationGraphMapperProvider: GraphMapperProviding {
     private let testsCacheDirectory: AbsolutePath
     private let graphMapperProvider: GraphMapperProviding
+    private let skipTestsCache: Bool
 
     init(
         testsCacheDirectory: AbsolutePath,
-        graphMapperProvider: GraphMapperProviding = GraphMapperProvider()
+        graphMapperProvider: GraphMapperProviding = GraphMapperProvider(),
+        skipTestsCache: Bool
     ) {
         self.testsCacheDirectory = testsCacheDirectory
         self.graphMapperProvider = graphMapperProvider
+        self.skipTestsCache = skipTestsCache
     }
 
     func mapper(config: Config) -> GraphMapping {
         var mappers: [GraphMapping] = []
         mappers.append(graphMapperProvider.mapper(config: config))
-        mappers.append(
-            TestsCacheGraphMapper(hashesCacheDirectory: testsCacheDirectory, config: config)
-        )
-        mappers.append(CacheTreeShakingGraphMapper())
+
+        if !skipTestsCache {
+            mappers.append(
+                TestsCacheGraphMapper(hashesCacheDirectory: testsCacheDirectory, config: config)
+            )
+            mappers.append(CacheTreeShakingGraphMapper())
+        }
         return SequentialGraphMapper(mappers)
     }
 }

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -78,7 +78,8 @@ final class TestService {
         deviceName: String?,
         osVersion: String?,
         skipUITests: Bool,
-        resultBundlePath: AbsolutePath?
+        resultBundlePath: AbsolutePath?,
+        skipCache: Bool
     ) throws {
         // Load config
         let manifestLoaderFactory = ManifestLoaderFactory()
@@ -96,7 +97,8 @@ final class TestService {
         let generator = testServiceGeneratorFactory.generator(
             automationPath: Environment.shared.automationPath ?? projectDirectory,
             testsCacheDirectory: testsCacheTemporaryDirectory.path,
-            skipUITests: skipUITests
+            skipUITests: skipUITests,
+            skipCache: skipCache
         )
         logger.notice("Generating project for testing", metadata: .section)
         let graph = try generator.generateWithGraph(

--- a/Tests/TuistKitTests/Generator/Mocks/MockTestServiceGeneratorFactory.swift
+++ b/Tests/TuistKitTests/Generator/Mocks/MockTestServiceGeneratorFactory.swift
@@ -4,12 +4,13 @@ import TSCBasic
 @testable import TuistKit
 
 final class MockTestServiceGeneratorFactory: TestServiceGeneratorFactorying {
-    var generatorStub: ((AbsolutePath, AbsolutePath, Bool) -> Generating)?
+    var generatorStub: ((AbsolutePath, AbsolutePath, Bool, Bool) -> Generating)?
     func generator(
         automationPath: AbsolutePath,
         testsCacheDirectory: AbsolutePath,
-        skipUITests: Bool
+        skipUITests: Bool,
+        skipCache: Bool
     ) -> Generating {
-        generatorStub?(automationPath, testsCacheDirectory, skipUITests) ?? MockGenerator()
+        generatorStub?(automationPath, testsCacheDirectory, skipUITests, skipCache) ?? MockGenerator()
     }
 }

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -332,7 +332,7 @@ private extension TestService {
         osVersion: String? = nil,
         skipUiTests: Bool = false,
         resultBundlePath: AbsolutePath? = nil,
-        skipCache: Bool = true
+        skipCache: Bool = false
     ) throws {
         try run(
             schemeName: schemeName,

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -33,7 +33,7 @@ final class TestServiceTests: TuistUnitTestCase {
         contentHasher = .init()
         testsCacheTemporaryDirectory = try TemporaryDirectory(removeTreeOnDeinit: true)
         testServiceGeneratorFactory = .init()
-        testServiceGeneratorFactory.generatorStub = { _, _, _ in
+        testServiceGeneratorFactory.generatorStub = { _, _, _, _ in
             self.generator
         }
         let mockCacheDirectoriesProvider = try MockCacheDirectoriesProvider()
@@ -70,7 +70,7 @@ final class TestServiceTests: TuistUnitTestCase {
         // Given
         var automationPath: AbsolutePath?
 
-        testServiceGeneratorFactory.generatorStub = { gotAutomationPath, _, _ in
+        testServiceGeneratorFactory.generatorStub = { gotAutomationPath, _, _, _ in
             automationPath = gotAutomationPath
             return self.generator
         }
@@ -331,7 +331,8 @@ private extension TestService {
         deviceName: String? = nil,
         osVersion: String? = nil,
         skipUiTests: Bool = false,
-        resultBundlePath: AbsolutePath? = nil
+        resultBundlePath: AbsolutePath? = nil,
+        skipCache: Bool = true
     ) throws {
         try run(
             schemeName: schemeName,
@@ -341,7 +342,8 @@ private extension TestService {
             deviceName: deviceName,
             osVersion: osVersion,
             skipUITests: skipUiTests,
-            resultBundlePath: resultBundlePath
+            resultBundlePath: resultBundlePath,
+            skipCache: skipCache
         )
     }
 }

--- a/projects/docs/docs/commands/test.md
+++ b/projects/docs/docs/commands/test.md
@@ -59,3 +59,4 @@ One of the benefits of using Tuist over other automation tools is that developer
 | `--configuration`      | `-C`  | `The configuration to be used when building the scheme.`            |                   | No       |
 | `--skip-ui-tests`      | n/a   | `When passed, it skips testing UI Tests targets.`                   | False             | No       |
 | `--result-bundle-path` | `-T`  | `Path where test result bundle will be saved`                       |                   | No       |
+| `--skip-cache` | n/a  | `Run tests without using tuist cache`                       | False                  | No       |

--- a/projects/docs/docs/commands/test.md
+++ b/projects/docs/docs/commands/test.md
@@ -59,4 +59,4 @@ One of the benefits of using Tuist over other automation tools is that developer
 | `--configuration`      | `-C`  | `The configuration to be used when building the scheme.`            |                   | No       |
 | `--skip-ui-tests`      | n/a   | `When passed, it skips testing UI Tests targets.`                   | False             | No       |
 | `--result-bundle-path` | `-T`  | `Path where test result bundle will be saved`                       |                   | No       |
-| `--skip-cache` | n/a  | `Run tests without using tuist cache`                       | False                  | No       |
+| `--all-tests` | n/a  | `Run all tests, do not skip tests for targets that haven't changed since last test run`                       | False                  | No       |


### PR DESCRIPTION
### Short description 📝

Add `--skip-cache` parameter to `tuist test` so we have explicit option to run all tests without using caching.

Maybe I would rather discuss how to test it as I don't get failed tests when I use `skipCache = true` as default in `TestServiceTests.testRun(...)`. Any ideas?

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
