### PR TITLE
Add `--reinstall-app` parameter for test command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Add default `Release` caching profile [#3304](https://github.com/tuist/tuist/pull/3304) by [@danyf90](https://github.com/danyf90)
 - Add `--dependencies-only` parameter to `tuist cache warm` command [#3334](https://github.com/tuist/tuist/pull/3334) by [@danyf90](https://github.com/danyf90)
+- Add `--reinstall-app` parameter to `tuist test` [#3367](https://github.com/tuist/tuist/pull/3367) by [@olejnjak](https://github.com/olejnjak)
 
 ### Fixed
 

--- a/Sources/TuistCore/Simulator/SimulatorController.swift
+++ b/Sources/TuistCore/Simulator/SimulatorController.swift
@@ -200,7 +200,8 @@ public final class SimulatorController: SimulatorControlling {
 
     public func uninstallApp(bundleId: String, deviceUdid: String) throws {
         logger.debug("Uninstalling app \(bundleId) from simulator device with id \(deviceUdid)")
-        try System.shared.run(["/usr/bin/xcrun", "simctl", "uninstall", deviceUdid, bundleId])
+        let device = try devices().toBlocking().last()?.filter { $0.udid == deviceUdid }.first?.booted()
+        try System.shared.run(["/usr/bin/xcrun", "simctl", "uninstall", device?.udid ?? deviceUdid, bundleId])
     }
 
     public func launchApp(bundleId: String, device: SimulatorDevice, arguments: [String]) throws {

--- a/Sources/TuistCore/Simulator/SimulatorController.swift
+++ b/Sources/TuistCore/Simulator/SimulatorController.swift
@@ -44,6 +44,12 @@ public protocol SimulatorControlling {
     ///   - device: The simulator device to install the app on.
     func installApp(at path: AbsolutePath, device: SimulatorDevice) throws
 
+    /// Uninstalls app with given `bundleId` from given simulator.
+    /// - Parameters:
+    ///   - bundleId: Bundle identifier of app to be uninstalled.
+    ///   - device: The simulator device to uninstall the app from.
+    func uninstallApp(bundleId: String, device: SimulatorDevice) throws
+
     /// Opens the simulator application & launches app on the given simulator.
     /// - Parameters:
     ///   - bundleId: The bundle id of the app to launch.
@@ -190,6 +196,11 @@ public final class SimulatorController: SimulatorControlling {
         logger.debug("Installing app at \(path) on simulator device with id \(device.udid)")
         let device = try device.booted()
         try System.shared.run(["/usr/bin/xcrun", "simctl", "install", device.udid, path.pathString])
+    }
+
+    public func uninstallApp(bundleId: String, device: SimulatorDevice) throws {
+        logger.debug("Uninstalling app \(bundleId) from simulator device with id \(device.udid)")
+        try System.shared.run(["/usr/bin/xcrun", "simctl", "uninstall", device.udid, bundleId])
     }
 
     public func launchApp(bundleId: String, device: SimulatorDevice, arguments: [String]) throws {

--- a/Sources/TuistCore/Simulator/SimulatorController.swift
+++ b/Sources/TuistCore/Simulator/SimulatorController.swift
@@ -48,7 +48,7 @@ public protocol SimulatorControlling {
     /// - Parameters:
     ///   - bundleId: Bundle identifier of app to be uninstalled.
     ///   - device: The simulator device to uninstall the app from.
-    func uninstallApp(bundleId: String, deviceUdid: String) throws
+    func uninstallApp(bundleId: String, device: SimulatorDevice) throws
 
     /// Opens the simulator application & launches app on the given simulator.
     /// - Parameters:
@@ -198,10 +198,10 @@ public final class SimulatorController: SimulatorControlling {
         try System.shared.run(["/usr/bin/xcrun", "simctl", "install", device.udid, path.pathString])
     }
 
-    public func uninstallApp(bundleId: String, deviceUdid: String) throws {
-        logger.debug("Uninstalling app \(bundleId) from simulator device with id \(deviceUdid)")
-        let device = try devices().toBlocking().last()?.filter { $0.udid == deviceUdid }.first?.booted()
-        try System.shared.run(["/usr/bin/xcrun", "simctl", "uninstall", device?.udid ?? deviceUdid, bundleId])
+    public func uninstallApp(bundleId: String, device: SimulatorDevice) throws {
+        logger.debug("Uninstalling app \(bundleId) from simulator device with id \(device.udid)")
+        let device = try device.booted()
+        try System.shared.run(["/usr/bin/xcrun", "simctl", "uninstall", device.udid, bundleId])
     }
 
     public func launchApp(bundleId: String, device: SimulatorDevice, arguments: [String]) throws {

--- a/Sources/TuistCore/Simulator/SimulatorController.swift
+++ b/Sources/TuistCore/Simulator/SimulatorController.swift
@@ -48,7 +48,7 @@ public protocol SimulatorControlling {
     /// - Parameters:
     ///   - bundleId: Bundle identifier of app to be uninstalled.
     ///   - device: The simulator device to uninstall the app from.
-    func uninstallApp(bundleId: String, device: SimulatorDevice) throws
+    func uninstallApp(bundleId: String, deviceUdid: String) throws
 
     /// Opens the simulator application & launches app on the given simulator.
     /// - Parameters:
@@ -198,9 +198,9 @@ public final class SimulatorController: SimulatorControlling {
         try System.shared.run(["/usr/bin/xcrun", "simctl", "install", device.udid, path.pathString])
     }
 
-    public func uninstallApp(bundleId: String, device: SimulatorDevice) throws {
-        logger.debug("Uninstalling app \(bundleId) from simulator device with id \(device.udid)")
-        try System.shared.run(["/usr/bin/xcrun", "simctl", "uninstall", device.udid, bundleId])
+    public func uninstallApp(bundleId: String, deviceUdid: String) throws {
+        logger.debug("Uninstalling app \(bundleId) from simulator device with id \(deviceUdid)")
+        try System.shared.run(["/usr/bin/xcrun", "simctl", "uninstall", deviceUdid, bundleId])
     }
 
     public func launchApp(bundleId: String, device: SimulatorDevice, arguments: [String]) throws {

--- a/Sources/TuistCoreTesting/Simulator/MockSimulatorController.swift
+++ b/Sources/TuistCoreTesting/Simulator/MockSimulatorController.swift
@@ -70,9 +70,9 @@ public final class MockSimulatorController: SimulatorControlling {
         try installAppStub?(path, device)
     }
 
-    public var uninstallAppStub: ((String, String) throws -> Void)?
-    public func uninstallApp(bundleId: String, deviceUdid: String) throws {
-        try uninstallAppStub?(bundleId, deviceUdid)
+    public var uninstallAppStub: ((String, SimulatorDevice) throws -> Void)?
+    public func uninstallApp(bundleId: String, device: SimulatorDevice) throws {
+        try uninstallAppStub?(bundleId, device)
     }
 
     public var launchAppStub: ((String, SimulatorDevice, [String]) throws -> Void)?

--- a/Sources/TuistCoreTesting/Simulator/MockSimulatorController.swift
+++ b/Sources/TuistCoreTesting/Simulator/MockSimulatorController.swift
@@ -70,9 +70,9 @@ public final class MockSimulatorController: SimulatorControlling {
         try installAppStub?(path, device)
     }
 
-    public var uninstallAppStub: ((String, SimulatorDevice) throws -> Void)?
-    public func uninstallApp(bundleId: String, device: SimulatorDevice) throws {
-        try uninstallAppStub?(bundleId, device)
+    public var uninstallAppStub: ((String, String) throws -> Void)?
+    public func uninstallApp(bundleId: String, deviceUdid: String) throws {
+        try uninstallAppStub?(bundleId, deviceUdid)
     }
 
     public var launchAppStub: ((String, SimulatorDevice, [String]) throws -> Void)?

--- a/Sources/TuistCoreTesting/Simulator/MockSimulatorController.swift
+++ b/Sources/TuistCoreTesting/Simulator/MockSimulatorController.swift
@@ -70,6 +70,11 @@ public final class MockSimulatorController: SimulatorControlling {
         try installAppStub?(path, device)
     }
 
+    public var uninstallAppStub: ((String, SimulatorDevice) throws -> Void)?
+    public func uninstallApp(bundleId: String, device: SimulatorDevice) throws {
+        try uninstallAppStub?(bundleId, device)
+    }
+
     public var launchAppStub: ((String, SimulatorDevice, [String]) throws -> Void)?
     public func launchApp(bundleId: String, device: SimulatorDevice, arguments: [String]) throws {
         try launchAppStub?(bundleId, device, arguments)

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -59,6 +59,12 @@ struct TestCommand: ParsableCommand {
     )
     var resultBundlePath: String?
 
+    @Flag(
+        name: .shortAndLong,
+        help: "Reinstall app (if any) when running runnable target tests"
+    )
+    var reinstallApp = false
+
     func run() throws {
         let absolutePath: AbsolutePath
 
@@ -81,7 +87,8 @@ struct TestCommand: ParsableCommand {
                     $0,
                     relativeTo: FileHandler.shared.currentPath
                 )
-            }
+            },
+            reinstallApp: reinstallApp
         )
     }
 }

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -61,7 +61,7 @@ struct TestCommand: ParsableCommand {
 
     @Flag(
         name: .shortAndLong,
-        help: "Reinstall app (if any) when running runnable target tests"
+        help: "Uninstall app (if any) before running tests"
     )
     var reinstallApp = false
 

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -214,7 +214,7 @@ final class TestService {
             deviceName: deviceName
         )
 
-        if reinstallApp, case let .device(udid) = destination {
+        if reinstallApp, let device = destination.1 {
             let appTargets = scheme.buildAction?.targets
                 .compactMap { graphTraverser.target(path: $0.projectPath, name: $0.name) }
                 .filter { $0.target.product == .app }
@@ -222,7 +222,7 @@ final class TestService {
             try appTargets?.forEach { target in
                 try simulatorController.uninstallApp(
                     bundleId: target.target.bundleId,
-                    deviceUdid: udid
+                    device: device
                 )
             }
         }
@@ -231,7 +231,7 @@ final class TestService {
             .workspace(graphTraverser.workspace.xcWorkspacePath),
             scheme: scheme.name,
             clean: clean,
-            destination: destination,
+            destination: destination.0,
             derivedDataPath: nil,
             resultBundlePath: resultBundlePath,
             arguments: buildGraphInspector.buildArguments(
@@ -252,7 +252,7 @@ final class TestService {
         graphTraverser: GraphTraversing,
         version: Version?,
         deviceName: String?
-    ) throws -> XcodeBuildDestination {
+    ) throws -> (XcodeBuildDestination, SimulatorDevice?) {
         switch target.platform {
         case .iOS, .tvOS, .watchOS:
             let minVersion: Version?
@@ -278,9 +278,9 @@ final class TestService {
             )
             .toBlocking()
             .single()
-            return .device(deviceAndRuntime.device.udid)
+            return (.device(deviceAndRuntime.device.udid), deviceAndRuntime.device)
         case .macOS:
-            return .mac
+            return (.mac, nil)
         }
     }
 }

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -78,10 +78,9 @@ final class TestService {
         deviceName: String?,
         osVersion: String?,
         skipUITests: Bool,
-        resultBundlePath: AbsolutePath?
+        resultBundlePath: AbsolutePath?,
+        reinstallApp: Bool
     ) throws {
-        let reinstallApp = true
-
         // Load config
         let manifestLoaderFactory = ManifestLoaderFactory()
         let manifestLoader = manifestLoaderFactory.createManifestLoader()

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -214,16 +214,17 @@ final class TestService {
             deviceName: deviceName
         )
 
-        if reinstallApp, case let .device(udid) = destination,
-            let runnableTarget = buildGraphInspector.runnableTarget(
-                scheme: scheme,
-                graphTraverser: graphTraverser
-            )
-        {
-            try simulatorController.uninstallApp(
-                bundleId: runnableTarget.target.bundleId,
-                deviceUdid: udid
-            )
+        if reinstallApp, case let .device(udid) = destination {
+            let appTargets = scheme.buildAction?.targets
+                .compactMap { graphTraverser.target(path: $0.projectPath, name: $0.name) }
+                .filter { $0.target.product == .app }
+
+            try appTargets?.forEach { target in
+                try simulatorController.uninstallApp(
+                    bundleId: target.target.bundleId,
+                    deviceUdid: udid
+                )
+            }
         }
 
         _ = try xcodebuildController.test(

--- a/Tests/TuistCoreTests/Simulator/SimulatorControllerTests.swift
+++ b/Tests/TuistCoreTests/Simulator/SimulatorControllerTests.swift
@@ -192,9 +192,11 @@ final class SimulatorControllerTests: TuistUnitTestCase {
         let udid = deviceAndRuntime.device.udid
         let uninstallCommand = ["/usr/bin/xcrun", "simctl", "uninstall", udid, bundleId]
         system.succeedCommand(uninstallCommand)
+        let bootCommand = ["/usr/bin/xcrun", "simctl", "boot", udid]
+        system.succeedCommand(bootCommand)
 
         // When
-        try subject.uninstallApp(bundleId: bundleId, deviceUdid: udid)
+        try subject.uninstallApp(bundleId: bundleId, device: deviceAndRuntime.device)
 
         // Then
         XCTAssertTrue(system.called(uninstallCommand))

--- a/Tests/TuistCoreTests/Simulator/SimulatorControllerTests.swift
+++ b/Tests/TuistCoreTests/Simulator/SimulatorControllerTests.swift
@@ -194,7 +194,7 @@ final class SimulatorControllerTests: TuistUnitTestCase {
         system.succeedCommand(uninstallCommand)
 
         // When
-        try subject.uninstallApp(bundleId: bundleId, device: deviceAndRuntime.device)
+        try subject.uninstallApp(bundleId: bundleId, deviceUdid: udid)
 
         // Then
         XCTAssertTrue(system.called(uninstallCommand))

--- a/Tests/TuistCoreTests/Simulator/SimulatorControllerTests.swift
+++ b/Tests/TuistCoreTests/Simulator/SimulatorControllerTests.swift
@@ -185,6 +185,21 @@ final class SimulatorControllerTests: TuistUnitTestCase {
         XCTAssertTrue(system.called(installCommand))
     }
 
+    func test_uninstallApp_should_uninstallAppOnSimulatorWithUdid() throws {
+        // Given
+        let deviceAndRuntime = createSystemStubs(devices: true, runtimes: true)
+        let bundleId = "io.tuist.app"
+        let udid = deviceAndRuntime.device.udid
+        let uninstallCommand = ["/usr/bin/xcrun", "simctl", "uninstall", udid, bundleId]
+        system.succeedCommand(uninstallCommand)
+
+        // When
+        try subject.uninstallApp(bundleId: bundleId, device: deviceAndRuntime.device)
+
+        // Then
+        XCTAssertTrue(system.called(uninstallCommand))
+    }
+
     func test_launchApp_should_bootSimulatorIfNotBooted() throws {
         // Given
         let deviceAndRuntime = createSystemStubs(devices: true, runtimes: true)

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -331,7 +331,8 @@ private extension TestService {
         deviceName: String? = nil,
         osVersion: String? = nil,
         skipUiTests: Bool = false,
-        resultBundlePath: AbsolutePath? = nil
+        resultBundlePath: AbsolutePath? = nil,
+        reinstallApp: Bool = false
     ) throws {
         try run(
             schemeName: schemeName,
@@ -341,7 +342,8 @@ private extension TestService {
             deviceName: deviceName,
             osVersion: osVersion,
             skipUITests: skipUiTests,
-            resultBundlePath: resultBundlePath
+            resultBundlePath: resultBundlePath,
+            reinstallApp: reinstallApp
         )
     }
 }

--- a/projects/docs/docs/commands/test.md
+++ b/projects/docs/docs/commands/test.md
@@ -59,4 +59,4 @@ One of the benefits of using Tuist over other automation tools is that developer
 | `--configuration`      | `-C`  | `The configuration to be used when building the scheme.`            |                   | No       |
 | `--skip-ui-tests`      | n/a   | `When passed, it skips testing UI Tests targets.`                   | False             | No       |
 | `--result-bundle-path` | `-T`  | `Path where test result bundle will be saved`                       |                   | No       |
-| `--reinstall-app`      | `-r`  | `Uninstall app before running tests`                                | False             | No       |
+| `--reinstall-app`      | `-r`  | `Uninstall app (if any) before running tests`                       | False             | No       |

--- a/projects/docs/docs/commands/test.md
+++ b/projects/docs/docs/commands/test.md
@@ -59,3 +59,4 @@ One of the benefits of using Tuist over other automation tools is that developer
 | `--configuration`      | `-C`  | `The configuration to be used when building the scheme.`            |                   | No       |
 | `--skip-ui-tests`      | n/a   | `When passed, it skips testing UI Tests targets.`                   | False             | No       |
 | `--result-bundle-path` | `-T`  | `Path where test result bundle will be saved`                       |                   | No       |
+| `--reinstall-app`      | `-r`  | `Uninstall app before running tests`                                | False             | No       |


### PR DESCRIPTION
### Short description 📝

Sometimes it is useful to make sure that we have clean app target when running app tests (e.g. in case of database migrations).

This PR adds `--reinstall-app` parameter to test command that uninstalls apps before running tests.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
