### PR TITLE
[Plugins] Fix manifest caching logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 - Allow to pass Cloud authentication token via TUIST_CLOUD_TOKEN even when not CI [#3380](https://github.com/tuist/tuist/pull/3380) by [@danyf90](https://github.com/danyf90)
+
+### Fixed
+
+- Fix caching of manifests that use plugins [#3370](https://github.com/tuist/tuist/pull/3370) by [@luispadron](https://github.com/luispadron)
+
 ## 1.49.2
 
 ### Fixed


### PR DESCRIPTION
## Summary

The `CachedManifestLoader` is the loader used in Tuist to load manifests like `Project.swift`. This caching loader would take into account the contents of the `Tuist/ProjectDescriptionHelpers` sources (thus invalidating the cache and triggering a full reload when loading the `Project.swift` manifest).

However, in the current implementation the `CachedManifestLoader` does **not** take into account the contents of the helpers defined in plugins. This means: If you had a plugin `PluginA` which was imported by project `ProjectA`, and the project had been generated and cached, changing the sources for `PluginA` would not cause a full re-generation of `ProjectA` on the next time `ProjectA` was generated. 


## Changes

- Updates `CachedManifestLoader` to account for the contents of the
  helpers in the projects plugins
- Adds a test case to assert cache works for plugins

### Checklist ✅

- [X] The code architecture and patterns are consistent with the rest of the codebase.
- [X] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [X] In case the PR introduces changes that affect users, the documentation has been updated.
