### PR TITLE
Update install command to be shell agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ It's open source and written in Swift.
 
 ### Running script (Recommended)
 
-```bash
-bash <(curl -Ls https://install.tuist.io)
+```shell
+curl -Ls http://server/path/script.sh | bash
 ```
 
 ## Bootstrap your first project 🌀


### PR DESCRIPTION
### Short description 📝

I noticed that the shell command in the README fails when run using the `fish` shell. I've tested this updated install command, and it works with `fish`, and continues to work with `bash` and `zsh`.

A little extra context, when run using `fish`, the command fails with the following error:

```
fish: Invalid redirection target:
bash <(curl -Ls https://install.tuist.io)
     ^
```

`fish` doesn't support the `<(...)` syntax, so instead I'm piping the downloaded script to bash.