### PR TITLE
feat: allow to pass Cloud authentication token via environment even when not CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Added
+
+- Allow to pass Cloud authentication token via TUIST_CLOUD_TOKEN even when not CI [#3380](https://github.com/tuist/tuist/pull/3380) by [@danyf90](https://github.com/danyf90)
 ## 1.49.2
 
 ### Fixed

--- a/Sources/TuistCloud/Utilities/CloudHTTPRequestAuthenticator.swift
+++ b/Sources/TuistCloud/Utilities/CloudHTTPRequestAuthenticator.swift
@@ -46,11 +46,12 @@ public final class CloudHTTPRequestAuthenticator: CloudHTTPRequestAuthenticating
         urlComponents.queryItems = nil
         let serverURL = urlComponents.url!
 
+        let tokenFromEnvironment = environmentVariables()[Constants.EnvironmentVariables.cloudToken]
         let token: String?
         if ciChecker.isCI() {
-            token = environmentVariables()[Constants.EnvironmentVariables.cloudToken]
+            token = tokenFromEnvironment
         } else {
-            token = try credentialsStore.read(serverURL: serverURL)?.token
+            token = tokenFromEnvironment ?? try credentialsStore.read(serverURL: serverURL)?.token
         }
 
         var request = request

--- a/Sources/TuistCloud/Utilities/CloudHTTPRequestAuthenticator.swift
+++ b/Sources/TuistCloud/Utilities/CloudHTTPRequestAuthenticator.swift
@@ -51,7 +51,7 @@ public final class CloudHTTPRequestAuthenticator: CloudHTTPRequestAuthenticating
         if ciChecker.isCI() {
             token = tokenFromEnvironment
         } else {
-            token = tokenFromEnvironment ?? try credentialsStore.read(serverURL: serverURL)?.token
+            token = try tokenFromEnvironment ?? credentialsStore.read(serverURL: serverURL)?.token
         }
 
         var request = request

--- a/Tests/TuistCloudTests/Utilities/CloudHTTPRequestAuthenticatorTests.swift
+++ b/Tests/TuistCloudTests/Utilities/CloudHTTPRequestAuthenticatorTests.swift
@@ -58,4 +58,18 @@ final class CloudHTTPRequestAuthenticatorTests: TuistUnitTestCase {
         // Then
         XCTAssertEqual(got.allHTTPHeaderFields?["Authorization"], "Bearer \(token)")
     }
+
+    func test_authenticate_from_environment_when_not_CI() throws {
+        // Given
+        ciChecker.isCIStub = false
+        let token = "TOKEN"
+        environmentVariables[Constants.EnvironmentVariables.cloudToken] = token
+        let request = URLRequest(url: URL(string: "https://cloud.tuist.io/path")!)
+
+        // When
+        let got = try subject.authenticate(request: request)
+
+        // Then
+        XCTAssertEqual(got.allHTTPHeaderFields?["Authorization"], "Bearer \(token)")
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY
Request for comments document (if applies):

### Short description 📝

In some scenario, you might want to delegate the authentication part to other tools, and just pass the token to be used to tuist

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
