### PR TITLE
Fix concurrency issue on cachedmanifestloader

### DIFF
--- a/Sources/TuistKit/Generator/Generator.swift
+++ b/Sources/TuistKit/Generator/Generator.swift
@@ -112,7 +112,7 @@ class Generator: Generating {
 
         // Load Plugins
         let plugins = try pluginsService.loadPlugins(using: config)
-        manifestLoader.register(plugins: plugins)
+        try manifestLoader.register(plugins: plugins)
 
         // Load DependenciesGraph
         let dependenciesGraph = try dependenciesGraphController.load(at: path)
@@ -241,7 +241,7 @@ class Generator: Generating {
 
         // Load Plugins
         let plugins = try pluginsService.loadPlugins(using: config)
-        manifestLoader.register(plugins: plugins)
+        try manifestLoader.register(plugins: plugins)
 
         // Load DependenciesGraph
         let dependenciesGraph = try dependenciesGraphController.load(at: path)
@@ -303,7 +303,7 @@ class Generator: Generating {
 
         // Load Plugins
         let plugins = try pluginsService.loadPlugins(using: config)
-        manifestLoader.register(plugins: plugins)
+        try manifestLoader.register(plugins: plugins)
 
         // Load DependenciesGraph
         let dependenciesGraph = try dependenciesGraphController.load(at: path)

--- a/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -78,7 +78,7 @@ final class ManifestGraphLoader: ManifestGraphLoading {
     func loadPlugins(at path: AbsolutePath) throws -> Plugins {
         let config = try configLoader.loadConfig(path: path)
         let plugins = try pluginsService.loadPlugins(using: config)
-        manifestLoader.register(plugins: plugins)
+        try manifestLoader.register(plugins: plugins)
         return plugins
     }
 

--- a/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -22,10 +22,10 @@ public class CachedManifestLoader: ManifestLoading {
     private let tuistVersion: String
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()
-    private var helpersCache: [AbsolutePath: String?] = [:]
-    private var pluginsCache: [AbsolutePath: String?] = [:]
-    private var cacheDirectory: AbsolutePath!
-    private var plugins: Plugins?
+    @Atomic private var helpersCache: [AbsolutePath: String?] = [:]
+    @Atomic private var pluginsCache: [AbsolutePath: String?] = [:]
+    @Atomic private var cacheDirectory: AbsolutePath!
+    @Atomic private var plugins: Plugins?
 
     public convenience init(manifestLoader: ManifestLoading = ManifestLoader()) {
         let environment = TuistSupport.Environment.shared

--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -102,7 +102,7 @@ public protocol ManifestLoading {
 
     /// Registers plugins that will be used within the manifest loading process.
     /// - Parameter plugins: The plugins to register.
-    func register(plugins: Plugins)
+    func register(plugins: Plugins) throws
 }
 
 public class ManifestLoader: ManifestLoading {
@@ -211,7 +211,7 @@ public class ManifestLoader: ManifestLoading {
         try loadManifest(.plugin, at: path)
     }
 
-    public func register(plugins: Plugins) {
+    public func register(plugins: Plugins) throws {
         self.plugins = plugins
     }
 

--- a/Sources/TuistLoaderTesting/Loaders/Mocks/MockManifestLoader.swift
+++ b/Sources/TuistLoaderTesting/Loaders/Mocks/MockManifestLoader.swift
@@ -84,5 +84,5 @@ public final class MockManifestLoader: ManifestLoading {
         try taskLoadArgumentsStub?(path) ?? []
     }
 
-    public func register(plugins _: Plugins) {}
+    public func register(plugins _: Plugins) throws {}
 }

--- a/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
@@ -324,7 +324,7 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
         ])
 
         projectDescriptionHelpersHasher.stubHash = { _ in hash }
-        subject.register(plugins: plugins)
+        try subject.register(plugins: plugins)
     }
 
     private func corruptFiles(at path: AbsolutePath) throws {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY
Request for comments document (if applies):

### Short description 📝

Hi, we detected some issue when loading multiple project, in particular the cache value was read/set from different threads. The problem was probably already present, but since the rest of the values were accessed sporadically it was not happening as often

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
