### PR TITLE
Improve execution time for Acceptance Tests on CI

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -71,13 +71,19 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: .build
-          key: ${{ runner.os }}-${{ matrix.xcode }}-spm-${{ hashFiles('**/Package.resolved') }}
+          key: ${{ runner.os }}-${{ matrix.xcode }}-spm-${{ hashFiles('**/Package.resolved') }}-git-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.xcode }}-spm-
+            ${{ runner.os }}-${{ matrix.xcode }}-spm-${{ hashFiles('**/Package.resolved') }}
+            ${{ runner.os }}-${{ matrix.xcode }}-spm
       - name: Build Tuist for release
         run: swift build -c release --product tuist
       - name: Build Tuistenv for release
         run: swift build -c release --product tuistenv
+      - name: Build ProjectDescription for release
+        run: swift build -c release --product ProjectDescription
+      - name: Build ProjectAutomation for release
+        run: swift build -c release --product ProjectAutomation
+
   acceptance_tests:
     name: ${{ matrix.feature }} acceptance tests with Xcode ${{ matrix.xcode }}
     runs-on: macOS-11
@@ -114,6 +120,7 @@ jobs:
           ]
     env:
       TUIST_GITHUB_API_TOKEN: ${{ secrets.GH_TOKEN }}
+    needs: release_build
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
@@ -122,9 +129,10 @@ jobs:
         name: 'Cache SPM dependencies'
         with:
           path: .build
-          key: ${{ runner.os }}-${{ matrix.xcode }}-spm-${{ hashFiles('**/Package.resolved') }}
+          key: ${{ runner.os }}-${{ matrix.xcode }}-spm-${{ hashFiles('**/Package.resolved') }}-git-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-spm-
+            ${{ runner.os }}-${{ matrix.xcode }}-spm-${{ hashFiles('**/Package.resolved') }}
+            ${{ runner.os }}-${{ matrix.xcode }}-spm
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}

--- a/projects/tuist/features/step_definitions/shared/tuist.rb
+++ b/projects/tuist/features/step_definitions/shared/tuist.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 require "open3"
 Given(/tuist is available/) do
-  self.system("swift", "build", "--configuration", "release", "--product", "tuist", "--product", "tuistenv", "--product", "ProjectDescription", "--product", "ProjectAutomation")
+  if ENV["CI"].nil?
+    system("swift", "build", "-c", "release", "--product", "tuist", "--product", "tuistenv", "--product", "ProjectDescription", "--product", "ProjectAutomation")
+  end
   FileUtils.cp_r("projects/tuist/vendor", ".build/release/vendor")
   FileUtils.cp_r("Templates", ".build/release/Templates")
   @tuist = ".build/release/tuist"

--- a/projects/tuist/features/step_definitions/shared/tuist.rb
+++ b/projects/tuist/features/step_definitions/shared/tuist.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 require "open3"
 Given(/tuist is available/) do
-  system("swift", "build")
-  @tuist = ".build/debug/tuist"
-  @tuistenv = ".build/debug/tuistenv"
+  self.system("swift", "build", "--configuration", "release", "--product", "tuist", "--product", "tuistenv", "--product", "ProjectDescription", "--product", "ProjectAutomation")
+  FileUtils.cp_r("projects/tuist/vendor", ".build/release/vendor")
+  FileUtils.cp_r("Templates", ".build/release/Templates")
+  @tuist = ".build/release/tuist"
+  @tuistenv = ".build/release/tuistenv"
 end
 
 Then(/^tuist generates the project$/) do

--- a/projects/tuist/features/step_definitions/shared/tuist.rb
+++ b/projects/tuist/features/step_definitions/shared/tuist.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 require "open3"
 Given(/tuist is available/) do
+  # On CI we expect tuist to be built already by the previous job `release_build`, so we skip `swift build`
   if ENV["CI"].nil?
     system("swift", "build", "-c", "release", "--product", "tuist", "--product", "tuistenv", "--product", "ProjectDescription", "--product", "ProjectAutomation")
   end
+  # `tuist` release build expect to have `vendor` and `Templates` in the same directory where the executable is
   FileUtils.cp_r("projects/tuist/vendor", ".build/release/vendor")
   FileUtils.cp_r("Templates", ".build/release/Templates")
   @tuist = ".build/release/tuist"


### PR DESCRIPTION
### Short description 📝

Hello,
This PR improves execution time for Acceptance Tests on CI.
In particular it does so by:
* Using `tuist` Release build instead of Debug build: Release build are faster at running, generating project etc.. it also makes more sense to use Release build for acceptance criteria since those are the builds end-user will use.
* Reuse Release build across the different jobs: this PR introduces a dependency on the job `release_build` for the jobs `acceptance_tests`, caching the build artefacts by modifying the already in place cache action (now taking into account commit so the release build will be reused for the `acceptance_tests`)

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
