### PR TITLE
Fix the building of products when running acceptance tests locally

### DIFF
--- a/projects/tuist/features/step_definitions/shared/tuist.rb
+++ b/projects/tuist/features/step_definitions/shared/tuist.rb
@@ -1,28 +1,30 @@
 # frozen_string_literal: true
 require "open3"
 Given(/tuist is available/) do
+  project_root = File.expand_path("../../../../..", __dir__)
   # On CI we expect tuist to be built already by the previous job `release_build`, so we skip `swift build`
+
   if ENV["CI"].nil?
-    system(
-      "swift",
-      "build",
-      "-c",
-      "release",
-      "--product",
-      "tuist",
-      "--product",
-      "tuistenv",
-      "--product",
-      "ProjectDescription",
-      "--product",
-      "ProjectAutomation"
-    )
+    ["tuist", "ProjectDescription", "ProjectAutomation"].each do |product|
+      system(
+        "swift",
+        "build",
+        "-c",
+        "release",
+        "--product",
+        product,
+        "--package-path",
+        project_root
+      )
+    end
+
   end
+
   # `tuist` release build expect to have `vendor` and `Templates` in the same directory where the executable is
-  FileUtils.cp_r("projects/tuist/vendor", ".build/release/vendor")
-  FileUtils.cp_r("Templates", ".build/release/Templates")
-  @tuist = ".build/release/tuist"
-  @tuistenv = ".build/release/tuistenv"
+  FileUtils.cp_r(File.join(project_root, "projects/tuist/vendor"), File.join(project_root, ".build/release/vendor"))
+  FileUtils.cp_r(File.join(project_root, "Templates"), File.join(project_root, ".build/release/Templates"))
+  @tuist = File.join(project_root, ".build/release/tuist")
+  @tuistenv = File.join(project_root, ".build/release/tuistenv")
 end
 
 Then(/^tuist generates the project$/) do


### PR DESCRIPTION
### Short description 📝
When running acceptance tests locally, we built Tuist and its dependent frameworks passing multiple option `--product` arguments. However, that's not supported by the Swift CLI, and that causes acceptance tests to fail because there are missing products (e.g. the `tuist binary`). This issue didn't surface on CI because there we build the binary in a pre-step.

I've also taken the opportunity to remove some assumptions on the acceptance tests being executed from the working directory.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
