### PR TITLE
Add support for `.framework`s to Carthage

### DIFF
--- a/Sources/TuistDependencies/Carthage/CarthageInteractor.swift
+++ b/Sources/TuistDependencies/Carthage/CarthageInteractor.swift
@@ -123,7 +123,7 @@ public final class CarthageInteractor: CarthageInteracting {
 
                 // generate dependencies graph
                 return try carthageGraphGenerator
-                    .generate(at: pathsProvider.temporaryCarthageBuildDirectory)
+                    .generate(at: pathsProvider.temporaryCarthageBuildDirectory, for: platforms)
             }
 
         logger.info("Carthage dependencies installed successfully.", metadata: .subsection)

--- a/Sources/TuistDependencies/Carthage/Utils/CarthageGraphGenerator.swift
+++ b/Sources/TuistDependencies/Carthage/Utils/CarthageGraphGenerator.swift
@@ -3,19 +3,21 @@ import ProjectDescription
 import TSCBasic
 import TSCUtility
 import TuistCore
+import TuistGraph
 import TuistSupport
 
 /// A protocol that defines an interface to generate the `DependenciesGraph` for the `Carthage` dependencies.
 public protocol CarthageGraphGenerating {
     /// Generates the `DependenciesGraph` for the `Carthage` dependencies.
     /// - Parameter path: The path to the directory that contains the `Carthage/Build` directory where `Carthage` installed dependencies.
-    func generate(at path: AbsolutePath) throws -> DependenciesGraph
+    /// - Parameter platforms: A list of platforms to generate for
+    func generate(at path: AbsolutePath, for platforms: Set<TuistGraph.Platform>?) throws -> TuistCore.DependenciesGraph
 }
 
 public final class CarthageGraphGenerator: CarthageGraphGenerating {
     public init() {}
 
-    public func generate(at path: AbsolutePath) throws -> DependenciesGraph {
+    public func generate(at path: AbsolutePath, for platforms: Set<TuistGraph.Platform>?) throws -> TuistCore.DependenciesGraph {
         let versionFilePaths = try FileHandler.shared
             .contentsOfDirectory(path)
             .filter { $0.extension == "version" }
@@ -26,14 +28,9 @@ public final class CarthageGraphGenerator: CarthageGraphGenerating {
             .map { try jsonDecoder.decode(CarthageVersionFile.self, from: $0) }
             .flatMap { $0.allProducts }
 
-        let externalDependencies: [String: [TargetDependency]] = Dictionary(grouping: products, by: \.name)
+        let externalDependencies: [String: [ProjectDescription.TargetDependency]] = Dictionary(grouping: products, by: \.name)
             .compactMapValues { products in
                 guard let product = products.first else { return nil }
-
-                guard let xcFrameworkName = product.container else {
-                    logger.warning("\(product.name) was not added to the DependenciesGraph", metadata: .subsection)
-                    return nil
-                }
 
                 var pathString = ""
                 pathString += Constants.tuistDirectoryName
@@ -42,9 +39,26 @@ public final class CarthageGraphGenerator: CarthageGraphGenerating {
                 pathString += "/"
                 pathString += Constants.DependenciesDirectory.carthageDirectoryName
                 pathString += "/"
-                pathString += xcFrameworkName
 
-                return [.xcframework(path: Path(pathString))]
+                if let xcFrameworkName = product.container {
+                    pathString += xcFrameworkName
+                    return [.xcframework(path: Path(pathString))]
+                }
+
+                if let platforms = platforms {
+                    let paths = platforms.map { $0.carthageDirectory }
+                    let frameworks = paths.map { path -> ProjectDescription.TargetDependency in
+                        pathString += path
+                        pathString += "/"
+                        pathString += product.name
+                        pathString += ".framework"
+                        return .framework(path: Path(pathString))
+                    }
+                    return frameworks
+                }
+
+                logger.warning("\(product.name) was not added to the DependenciesGraph", metadata: .subsection)
+                return nil
             }
 
         return DependenciesGraph(externalDependencies: externalDependencies, externalProjects: [:])

--- a/Sources/TuistDependenciesTesting/Carthage/Utils/MockCarthageGraphGenerator.swift
+++ b/Sources/TuistDependenciesTesting/Carthage/Utils/MockCarthageGraphGenerator.swift
@@ -2,6 +2,7 @@ import ProjectDescription
 import TSCBasic
 import TSCUtility
 import TuistCore
+import TuistGraph
 
 @testable import TuistDependencies
 
@@ -11,7 +12,7 @@ public final class MockCarthageGraphGenerator: CarthageGraphGenerating {
     var invokedGenerate = false
     var generateStub: ((AbsolutePath) throws -> TuistCore.DependenciesGraph)?
 
-    public func generate(at path: AbsolutePath) throws -> TuistCore.DependenciesGraph {
+    public func generate(at path: AbsolutePath, for _: Set<TuistGraph.Platform>?) throws -> TuistCore.DependenciesGraph {
         invokedGenerate = true
         return try generateStub?(path) ?? .test()
     }

--- a/Tests/TuistDependenciesTests/Carthage/Utils/CarthageGraphGeneratorTests.swift
+++ b/Tests/TuistDependenciesTests/Carthage/Utils/CarthageGraphGeneratorTests.swift
@@ -2,6 +2,7 @@ import ProjectDescription
 import TSCBasic
 import TSCUtility
 import TuistCore
+import TuistGraph
 import TuistSupport
 import XCTest
 
@@ -37,7 +38,7 @@ final class CarthageGraphGeneratorTests: TuistUnitTestCase {
         try fileHandler.write(CarthageVersionFile.testAlamofireJson, path: alamofireVersionFilePath, atomically: true)
 
         // When
-        let got = try subject.generate(at: path)
+        let got = try subject.generate(at: path, for: [.iOS])
 
         // Then
         let expected = DependenciesGraph(


### PR DESCRIPTION
Resolves #3174

### Short description 📝

This change adds support for older `.framework` libraries to be added to the dependency graph when imported via Carthage.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
    - It passes linting, so I assume it's fine 🤷‍♂️
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
    - Haven't done any testing yet, beyond testing it with my individual project.
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
    - I'll do this once this pull request is out of draft status.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
    - I'll do this once this pull request is out of draft status.