### PR TITLE
Add Support for SPM Dependencies with `.` and `-` in the Target Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 - settings-to-xcconfig migration command produces correct string format. [#3260](https://github.com/tuist/tuist/3260) by [@saim80](https://github.com/saim80)
 - Fix caching of manifests that use plugins [#3370](https://github.com/tuist/tuist/pull/3370) by [@luispadron](https://github.com/luispadron)
+- Add support for SPM dependencies with `.` and `-` in the target name. [#3449](https://github.com/tuist/tuist/3449) by [@moritzsternemann](https://github.com/moritzsternemann)
 
 ### Added
 

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -308,7 +308,7 @@ extension ProjectDescription.Target {
         )
 
         return ProjectDescription.Target(
-            name: target.name.replacingOccurrences(of: ".", with: "_").replacingOccurrences(of: "-", with: "_"),
+            name: target.name.replacingOccurrences(of: ".", with: "_"),
             platform: platform,
             product: product,
             bundleId: target.name.replacingOccurrences(of: "_", with: "-"),
@@ -893,7 +893,7 @@ extension PackageInfoMapper {
             if let framework = targetDependencyToFramework[name] {
                 return .xcframework(path: framework)
             } else {
-                return .target(name: name.replacingOccurrences(of: ".", with: "_").replacingOccurrences(of: "-", with: "_"))
+                return .target(name: name.replacingOccurrences(of: ".", with: "_"))
             }
         }
 

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -244,6 +244,10 @@ public final class PackageInfoMapper: PackageInfoMapping {
             resourceSynthesizers: []
         )
     }
+
+    fileprivate class func sanitize(targetName: String) -> String {
+        targetName.replacingOccurrences(of: ".", with: "_")
+    }
 }
 
 extension ProjectDescription.Target {
@@ -308,7 +312,7 @@ extension ProjectDescription.Target {
         )
 
         return ProjectDescription.Target(
-            name: target.name.replacingOccurrences(of: ".", with: "_"),
+            name: PackageInfoMapper.sanitize(targetName: target.name),
             platform: platform,
             product: product,
             bundleId: target.name.replacingOccurrences(of: "_", with: "-"),
@@ -893,7 +897,7 @@ extension PackageInfoMapper {
             if let framework = targetDependencyToFramework[name] {
                 return .xcframework(path: framework)
             } else {
-                return .target(name: name.replacingOccurrences(of: ".", with: "_"))
+                return .target(name: PackageInfoMapper.sanitize(targetName: name))
             }
         }
 

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -308,7 +308,7 @@ extension ProjectDescription.Target {
         )
 
         return ProjectDescription.Target(
-            name: target.name,
+            name: target.name.replacingOccurrences(of: ".", with: "_").replacingOccurrences(of: "-", with: "_"),
             platform: platform,
             product: product,
             bundleId: target.name.replacingOccurrences(of: "_", with: "-"),
@@ -893,7 +893,7 @@ extension PackageInfoMapper {
             if let framework = targetDependencyToFramework[name] {
                 return .xcframework(path: framework)
             } else {
-                return .target(name: name)
+                return .target(name: name.replacingOccurrences(of: ".", with: "_").replacingOccurrences(of: "-", with: "_"))
             }
         }
 

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -438,16 +438,21 @@ extension SourceFilesList {
     fileprivate static func from(sources: [String]?, path: AbsolutePath, excluding: [String]) -> Self? {
         let sourcesPaths: [AbsolutePath]
         if let customSources = sources {
-            sourcesPaths = customSources.map { path.appending(RelativePath($0)) }
+            sourcesPaths = customSources.map { source in
+                let absolutePath = path.appending(RelativePath(source))
+                if absolutePath.extension == nil {
+                    return absolutePath.appending(component: "**")
+                }
+                return absolutePath
+            }
         } else {
-            sourcesPaths = [path]
+            sourcesPaths = [path.appending(component: "**")]
         }
         guard !sourcesPaths.isEmpty else { return nil }
         return .init(
             globs: sourcesPaths.map { absolutePath -> ProjectDescription.SourceFileGlob in
-                let glob = absolutePath.extension != nil ? absolutePath : absolutePath.appending(component: "**")
-                return .init(
-                    Path(glob.pathString),
+                .init(
+                    Path(absolutePath.pathString),
                     excluding: excluding.map {
                         let excludePath = path.appending(RelativePath($0))
                         let excludeGlob = excludePath.extension != nil ? excludePath : excludePath.appending(component: "**")

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -146,6 +146,39 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         )
     }
 
+    func testMap_whenNameContainsDotOrDash_mapsToUnderscodeInTargetName() throws {
+        let project = try subject.map(
+            package: "Package",
+            packageInfos: [
+                "Package": .init(
+                    products: [
+                        .init(name: "com.example.product-1", type: .library(.automatic), targets: ["com.example.target-1"]),
+                    ],
+                    targets: [
+                        .test(name: "com.example.target-1"),
+                    ],
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+        XCTAssertEqual(
+            project,
+            .test(
+                name: "Package",
+                targets: [
+                    .test(
+                        "com_example_target_1",
+                        customBundleID: "com.example.target-1",
+                        customSources: .init(globs: [AbsolutePath("/").appending(RelativePath("Package/Path/Sources/com.example.target-1/**")).pathString])
+                    ),
+                ]
+            )
+        )
+    }
+
     func testMap_whenTargetNotInProduct_ignoresIt() throws {
         let project = try subject.map(
             package: "Package",

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -170,7 +170,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 name: "Package",
                 targets: [
                     .test(
-                        "com_example_target_1",
+                        "com_example_target-1",
                         customBundleID: "com.example.target-1",
                         customSources: .init(globs: [AbsolutePath("/").appending(RelativePath("Package/Path/Sources/com.example.target-1/**")).pathString])
                     ),


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3432

### Short description 📝

As explained in the linked issue, Tuist's dependency management system currently doesn't support SPM dependencies where targets contain `.` or `-` characters (these occur e.g. in reverse-domain-name style names: `com.example.target-1`).

This PR solves the issue by replacing `.` and `-` with `_` in the appropriate places in the target name. Also the logic for building source code globs is adapted to handle paths that contain `.` correctly.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
