### PR TITLE
Print a helpful message if swiftformat linting fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Added
+
+- Add more helpful output when `./fourier swift format` command fails. [#3451](https://github.com/tuist/tuist/pull/3451) by [@hisaac](https://github.com/hisaac)
+
 ## 1.50.0 - Nature
 
 ### Changed
@@ -27,7 +31,6 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Add `tuist dependencies clean` command [#3417](https://github.com/tuist/tuist/pull/3417) by [@danyf90](https://github.com/danyf90).
 - Support for floating number (`real`) value for `InfoPlist` [#3377](https://github.com/tuist/tuist/pull/3377) by [@MarvinNazari](https://github.com/MarvinNazari)
 - Support for `shellPath` parameter in `TargetAction` and `TargetScript` to enable `/bin/zsh` as shell. [#3384](https://github.com/tuist/tuist/pull/3384) by [@DarkoDamjanovic](https://github.com/DarkoDamjanovic)
-- Add more helpful output when `./fourier swift format` command fails. [#3451](https://github.com/tuist/tuist/pull/3451) by [@hisaac](https://github.com/hisaac)
 
 ## 1.49.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Improve speed of `tuist generate` by updating Xcodeproj [#3444](https://github.com/tuist/tuist/pull/3444) by [@adellibovi](https://github.com/adellibovi).
 
 ### Fixed
+
 - settings-to-xcconfig migration command produces correct string format. [#3260](https://github.com/tuist/tuist/3260) by [@saim80](https://github.com/saim80)
 - Fix caching of manifests that use plugins [#3370](https://github.com/tuist/tuist/pull/3370) by [@luispadron](https://github.com/luispadron)
 - Add support for SPM dependencies with `.` and `-` in the target name. [#3449](https://github.com/tuist/tuist/3449) by [@moritzsternemann](https://github.com/moritzsternemann)
@@ -26,6 +27,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Add `tuist dependencies clean` command [#3417](https://github.com/tuist/tuist/pull/3417) by [@danyf90](https://github.com/danyf90).
 - Support for floating number (`real`) value for `InfoPlist` [#3377](https://github.com/tuist/tuist/pull/3377) by [@MarvinNazari](https://github.com/MarvinNazari)
 - Support for `shellPath` parameter in `TargetAction` and `TargetScript` to enable `/bin/zsh` as shell. [#3384](https://github.com/tuist/tuist/pull/3384) by [@DarkoDamjanovic](https://github.com/DarkoDamjanovic)
+- Add more helpful output when `./fourier swift format` command fails. [#3451](https://github.com/tuist/tuist/pull/3451) by [@hisaac](https://github.com/hisaac)
 
 ## 1.49.2
 

--- a/projects/fourier/lib/fourier/commands/format.rb
+++ b/projects/fourier/lib/fourier/commands/format.rb
@@ -5,7 +5,10 @@ module Fourier
       desc "swift", "Format the Swift code of the repo"
       option :fix, desc: "When passed, it fixes the issues", type: :boolean, default: false
       def swift
-        Services::Format::Swift.call(fix: options[:fix])
+        exit_status = Services::Format::Swift.call(fix: options[:fix])
+        if !options[:fix] && !exit_status
+          puts(::CLI::UI.fmt("{{red:Please run `./fourier format swift --fix` to address Swift formatting issues.}}"))
+        end
       end
     end
   end

--- a/projects/fourier/lib/fourier/utilities/system.rb
+++ b/projects/fourier/lib/fourier/utilities/system.rb
@@ -5,7 +5,7 @@ module Fourier
   module Utilities
     module System
       def self.system(*args)
-        Kernel.system(*args) || Kernel.abort
+        Kernel.system(*args)
       end
 
       def self.tuist(*args)


### PR DESCRIPTION
### Short description 📝

The `./fourier format swift` command is run on every commit. If it detects issues, the only output is:

```shell
Source input did not pass lint check.
```

For someone new to the project (like myself), that output isn't very helpful to know how to address the issues.

This change adds the following line to the output:

```shell
Please run `./fourier format swift --fix` to address Swift formatting issues
```

I'm not very familiar with Ruby, so I'm very open to suggestions here. I also have one question which I'll add as an inline comment below.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
	- Not sure on this one, so please let me know if things need to be changed to be more consistent.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
	- Any suggestions on if/how `fourier` commands should be tested?
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
