### PR TITLE
fix: fix tuistignore when local path are specified

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: macOS-11
     strategy:
       matrix:
-        xcode: ['12.4', '12.5.1', '13.0'] # keep 12.4 to ensure backwards compatibility
+        xcode: ['12.4', '12.5.1'] # keep 12.4 to ensure backwards compatibility
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
@@ -99,8 +99,19 @@ final class ProjectEditor: ProjectEditing {
         onlyCurrentDirectory: Bool,
         plugins: Plugins
     ) throws -> AbsolutePath {
-        let tuistIgnoreEntries =
-            (try? FileHandler.shared.readTextFile(editingPath.appending(component: ".tuistignore")).split(separator: "\n").map(String.init)) ?? []
+        let tuistIgnoreContent = (try? FileHandler.shared.readTextFile(editingPath.appending(component: ".tuistignore"))) ?? ""
+        let tuistIgnoreEntries = tuistIgnoreContent
+            .split(separator: "\n")
+            .map(String.init)
+            .map { entry -> String in
+                guard !entry.starts(with: "**") else { return entry }
+                let path = editingPath.appending(RelativePath(entry))
+                if FileHandler.shared.isFolder(path) {
+                    return path.appending(component: "**").pathString
+                } else {
+                    return path.pathString
+                }
+            }
 
         let pathsToExclude = [
             "**/\(Constants.tuistDirectoryName)/\(Constants.DependenciesDirectory.name)/**",

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
@@ -103,8 +103,10 @@ final class ProjectEditorTests: TuistUnitTestCase {
             directory.appending(components: "Tuist", "Tasks", "TaskOne.swift"),
             directory.appending(components: "Tuist", "Tasks", "TaskTwo.swift"),
         ]
+        try FileHandler.shared.createFolder(directory.appending(component: "a folder"))
         try FileHandler.shared.write(
             """
+            a folder
             B.swift
             """,
             path: directory.appending(component: ".tuistignore"),
@@ -118,7 +120,8 @@ final class ProjectEditorTests: TuistUnitTestCase {
                 excluding,
                 [
                     "**/Tuist/Dependencies/**",
-                    "B.swift",
+                    "\(directory.pathString)/a folder/**",
+                    "\(directory.pathString)/B.swift",
                 ]
             )
             return manifests


### PR DESCRIPTION
### Short description 📝

relative path (as the one we are specifying in Tuist own .tuistignore) were not matched correctly

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
