### PR TITLE
[2.0] Move test action options from `TestAction` to `TestActionOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
   - **Motivation:** provisioning environments for working with Xcode projects was outside of the scope of the project. Moreover, it added up to our triaging and maintenace work because errors that bubbled up from underlying commands made people think that they were Tuist bugs.
   - **Migration:** as suggested [here](https://github.com/tuist/tuist-up), turn your `Setup.swift` into a `up.toml` and use `tuist-up` instead.
 
+- **Breaking** Scheme `TestAction` options have been consolidated together under a new type `TestActionOptions`.
+  - **Motivation:** This makes the API consistent with some of the other Scheme actions as well as how it appears in the Scheme editor.
+  - **Migration:** Use `TestAction.targets(options: .options(language:region:codeCoverage:codeCoverageTargets))`
+    - `TestAction.language` > `TestActionOptions.language`
+    - `TestAction.region` > `TestActionOptions.region`
+    - `TestAction.codeCoverage` > `TestActionOptions.codeCoverage`
+    - `TestAction.codeCoverageTargets` > `TestActionOptions.codeCoverageTargets`
+
 ## Next
 
 ### Added

--- a/Sources/ProjectDescription/TestAction.swift
+++ b/Sources/ProjectDescription/TestAction.swift
@@ -86,18 +86,13 @@ public struct TestAction: Equatable, Codable {
     /// Initializes a test action using a list of test plans.
     /// - Parameters:
     ///   - testPlans: List of test plans to run.
-    ///   - arguments: Arguments passed when running the tests.
     ///   - configuration: Configuration to be used.
-    ///   - expandVariableFromTarget: A target that will be used to expand the variables defined inside Environment Variables definition
     ///   - preActions: Actions to execute before running the tests.
     ///   - postActions: Actions to execute after running the tests.
-    ///   - options: Test options.
-    ///   - diagnosticsOptions: Diagnostics options.
     /// - Returns: An initialized test action.
     public static func testPlans(_ testPlans: [Path],
                                  configuration: ConfigurationName = .debug,
                                  preActions: [ExecutionAction] = [],
-                                 options: TestActionOptions = .options(),
                                  postActions: [ExecutionAction] = []) -> Self
     {
         Self(
@@ -108,8 +103,8 @@ public struct TestAction: Equatable, Codable {
             expandVariableFromTarget: nil,
             preActions: preActions,
             postActions: postActions,
-            options: options,
-            diagnosticsOptions: [.mainThreadChecker]
+            options: .options(),
+            diagnosticsOptions: []
         )
     }
 }

--- a/Sources/ProjectDescription/TestAction.swift
+++ b/Sources/ProjectDescription/TestAction.swift
@@ -14,12 +14,6 @@ public struct TestAction: Equatable, Codable {
     /// Name of the configuration that should be used for building the test targets.
     public let configuration: ConfigurationName
 
-    /// True to collect the test coverage results.
-    public let coverage: Bool
-
-    /// List of targets for which Xcode will collect the coverage results.
-    public let codeCoverageTargets: [TargetReference]
-
     /// Set the target that will expand the variables for
     public let expandVariableFromTarget: TargetReference?
 
@@ -28,12 +22,9 @@ public struct TestAction: Equatable, Codable {
 
     /// List of actions to be executed after running the tests.
     public let postActions: [ExecutionAction]
-
-    /// Language.
-    public let language: SchemeLanguage?
-
-    /// Region.
-    public let region: String?
+    
+    /// Options.
+    public let options: TestActionOptions
 
     /// Diagnostics options.
     public let diagnosticsOptions: [SchemeDiagnosticsOption]
@@ -42,27 +33,21 @@ public struct TestAction: Equatable, Codable {
                  targets: [TestableTarget],
                  arguments: Arguments?,
                  configuration: ConfigurationName,
-                 coverage: Bool,
-                 codeCoverageTargets: [TargetReference],
                  expandVariableFromTarget: TargetReference?,
                  preActions: [ExecutionAction],
                  postActions: [ExecutionAction],
-                 diagnosticsOptions: [SchemeDiagnosticsOption],
-                 language: SchemeLanguage?,
-                 region: String?)
+                 options: TestActionOptions,
+                 diagnosticsOptions: [SchemeDiagnosticsOption])
     {
         self.testPlans = testPlans
         self.targets = targets
         self.arguments = arguments
         self.configuration = configuration
-        self.coverage = coverage
         self.preActions = preActions
         self.postActions = postActions
-        self.codeCoverageTargets = codeCoverageTargets
         self.expandVariableFromTarget = expandVariableFromTarget
+        self.options = options
         self.diagnosticsOptions = diagnosticsOptions
-        self.language = language
-        self.region = region
     }
 
     /// Initializes a test action using a list of targets.
@@ -70,40 +55,31 @@ public struct TestAction: Equatable, Codable {
     ///   - targets: List of targets to be tested.
     ///   - arguments: Arguments passed when running the tests.
     ///   - configuration: Configuration to be used.
-    ///   - coverage: Whether test coverage should be collected.
-    ///   - codeCoverageTargets: The targets the test coverage should be collected from.
     ///   - expandVariableFromTarget: A target that will be used to expand the variables defined inside Environment Variables definition
     ///   - preActions: Actions to execute before running the tests.
     ///   - postActions: Actions to execute after running the tests.
+    ///   - options: Test options.
     ///   - diagnosticsOptions: Diagnostics options.
-    ///   - language: The language to be used.
-    ///   - region: The region to be used.
     /// - Returns: An initialized test action.
     public static func targets(_ targets: [TestableTarget],
                                arguments: Arguments? = nil,
                                configuration: ConfigurationName = .debug,
-                               coverage: Bool = false,
-                               codeCoverageTargets: [TargetReference] = [],
                                expandVariableFromTarget: TargetReference? = nil,
                                preActions: [ExecutionAction] = [],
                                postActions: [ExecutionAction] = [],
-                               diagnosticsOptions: [SchemeDiagnosticsOption] = [.mainThreadChecker],
-                               language: SchemeLanguage? = nil,
-                               region: String? = nil) -> Self
+                               options: TestActionOptions = .options(),
+                               diagnosticsOptions: [SchemeDiagnosticsOption] = [.mainThreadChecker]) -> Self
     {
         Self(
             testPlans: nil,
             targets: targets,
             arguments: arguments,
             configuration: configuration,
-            coverage: coverage,
-            codeCoverageTargets: codeCoverageTargets,
             expandVariableFromTarget: expandVariableFromTarget,
             preActions: preActions,
             postActions: postActions,
-            diagnosticsOptions: diagnosticsOptions,
-            language: language,
-            region: region
+            options: options,
+            diagnosticsOptions: diagnosticsOptions
         )
     }
 
@@ -112,18 +88,16 @@ public struct TestAction: Equatable, Codable {
     ///   - testPlans: List of test plans to run.
     ///   - arguments: Arguments passed when running the tests.
     ///   - configuration: Configuration to be used.
-    ///   - coverage: Whether test coverage should be collected.
-    ///   - codeCoverageTargets: The targets the test coverage should be collected from.
     ///   - expandVariableFromTarget: A target that will be used to expand the variables defined inside Environment Variables definition
     ///   - preActions: Actions to execute before running the tests.
     ///   - postActions: Actions to execute after running the tests.
+    ///   - options: Test options.
     ///   - diagnosticsOptions: Diagnostics options.
-    ///   - language: The language to be used.
-    ///   - region: The region to be used.
     /// - Returns: An initialized test action.
     public static func testPlans(_ testPlans: [Path],
                                  configuration: ConfigurationName = .debug,
                                  preActions: [ExecutionAction] = [],
+                                 options: TestActionOptions = .options(),
                                  postActions: [ExecutionAction] = []) -> Self
     {
         Self(
@@ -131,14 +105,11 @@ public struct TestAction: Equatable, Codable {
             targets: [],
             arguments: nil,
             configuration: configuration,
-            coverage: false,
-            codeCoverageTargets: [],
             expandVariableFromTarget: nil,
             preActions: preActions,
             postActions: postActions,
-            diagnosticsOptions: [.mainThreadChecker],
-            language: nil,
-            region: nil
+            options: options,
+            diagnosticsOptions: [.mainThreadChecker]
         )
     }
 }

--- a/Sources/ProjectDescription/TestActionOptions.swift
+++ b/Sources/ProjectDescription/TestActionOptions.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Options for the `TestAction` action
+public struct TestActionOptions: Equatable, Codable {
+    /// App Language.
+    public let language: SchemeLanguage?
+    
+    /// Region.
+    public let region: String?
+    
+    /// True to collect the test coverage results.
+    public let coverage: Bool
+    
+    /// List of targets for which Xcode will collect the coverage results.
+    public let codeCoverageTargets: [TargetReference]
+    
+    init(language: SchemeLanguage?,
+         region: String?,
+         coverage: Bool,
+         codeCoverageTargets: [TargetReference]) {
+        self.language = language
+        self.region = region
+        self.coverage = coverage
+        self.codeCoverageTargets = codeCoverageTargets
+    }
+    
+    /// Initializes set of options for a test action.
+    /// - Parameters:
+    ///   - language: Language used for running the tests.
+    ///   - region: Region used for running the tests.
+    ///   - coverage: Whether test coverage should be collected.
+    ///   - codeCoverageTargets: List of tests whose code coverage information should be collected.
+    /// - Returns: Initialized set of options.
+    public static func options(language: SchemeLanguage? = nil,
+                               region: String? = nil,
+                               coverage: Bool = false,
+                               codeCoverageTargets: [TargetReference] = []) -> TestActionOptions {
+        return TestActionOptions(language: language,
+                                 region: region,
+                                 coverage: coverage,
+                                 codeCoverageTargets: codeCoverageTargets)
+    }
+}

--- a/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
@@ -39,8 +39,8 @@ extension TuistGraph.TestAction {
         } else {
             targets = try manifest.targets.map { try TuistGraph.TestableTarget.from(manifest: $0, generatorPaths: generatorPaths) }
             arguments = manifest.arguments.map { TuistGraph.Arguments.from(manifest: $0) }
-            coverage = manifest.coverage
-            codeCoverageTargets = try manifest.codeCoverageTargets.map {
+            coverage = manifest.options.coverage
+            codeCoverageTargets = try manifest.options.codeCoverageTargets.map {
                 TuistGraph.TargetReference(
                     projectPath: try generatorPaths.resolveSchemeActionProjectPath($0.projectPath),
                     name: $0.targetName
@@ -54,8 +54,8 @@ extension TuistGraph.TestAction {
             }
 
             diagnosticsOptions = Set(manifest.diagnosticsOptions.map { TuistGraph.SchemeDiagnosticsOption.from(manifest: $0) })
-            language = manifest.language
-            region = manifest.region
+            language = manifest.options.language
+            region = manifest.options.region
 
             // not used when using targets
             testPlans = nil

--- a/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
+++ b/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
@@ -148,9 +148,9 @@ extension TestAction {
             targets,
             arguments: arguments,
             configuration: configuration,
-            coverage: coverage,
             preActions: [ExecutionAction.test()],
-            postActions: [ExecutionAction.test()]
+            postActions: [ExecutionAction.test()],
+            options: .options(coverage: true)
         )
     }
 }

--- a/Tests/ProjectDescriptionTests/SchemeTests.swift
+++ b/Tests/ProjectDescriptionTests/SchemeTests.swift
@@ -27,9 +27,9 @@ final class SchemeTests: XCTestCase {
                     launchArguments: [LaunchArgument(name: "test", isEnabled: true)]
                 ),
                 configuration: .debug,
-                coverage: true,
                 preActions: testAction,
-                postActions: testAction
+                postActions: testAction,
+                options: .options(coverage: true)
             ),
             runAction: RunAction(
                 configuration: .debug,
@@ -68,9 +68,9 @@ final class SchemeTests: XCTestCase {
                     launchArguments: [LaunchArgument(name: "test", isEnabled: true)]
                 ),
                 configuration: .debug,
-                coverage: true,
                 preActions: testAction,
-                postActions: testAction
+                postActions: testAction,
+                options: .options(coverage: true)
             ),
             runAction: RunAction(
                 configuration: .release,

--- a/Tests/TuistLoaderTests/Extensions/TuistTestCase+ManifestMappers.swift
+++ b/Tests/TuistLoaderTests/Extensions/TuistTestCase+ManifestMappers.swift
@@ -137,7 +137,7 @@ extension TuistTestCase {
         let targets = try manifest.targets.map { try TestableTarget.from(manifest: $0, generatorPaths: generatorPaths) }
         XCTAssertEqual(testAction.targets, targets, file: file, line: line)
         XCTAssertTrue(testAction.configurationName == manifest.configuration.rawValue, file: file, line: line)
-        XCTAssertEqual(testAction.coverage, manifest.coverage, file: file, line: line)
+        XCTAssertEqual(testAction.coverage, manifest.options.coverage, file: file, line: line)
         try optionalAssert(testAction.arguments, manifest.arguments) {
             assert(arguments: $0, matches: $1, file: file, line: line)
         }


### PR DESCRIPTION
Related https://github.com/tuist/tuist/issues/2981

### Short description 📝

As suggested [here](https://github.com/tuist/tuist/issues/2981#issuecomment-886844973) to be consistent with Xcode's UI, I'm moving the options from test actions into its own model, `TestActionOptions`.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
