### PR TITLE
chore: disable xcode 13.0 in CI

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: macOS-11
     strategy:
       matrix:
-        xcode: ['12.4', '12.5.1', '13.0'] # keep 12.4 to ensure backwards compatibility
+        xcode: ['12.4', '12.5.1'] # keep 12.4 to ensure backwards compatibility
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode


### PR DESCRIPTION
### Short description 📝

Disable to unblock CI until dependencies are fixed

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
