### PR TITLE
DO NOT MERGE: Test adding symbolset support to SwiftGen

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -210,10 +210,10 @@
       },
       {
         "package": "SwiftGen",
-        "repositoryURL": "https://github.com/fortmarek/SwiftGen",
+        "repositoryURL": "https://github.com/hisaac/SwiftGen",
         "state": {
-          "branch": "stable",
-          "revision": "5514d331d8ff1273b5c88747d646edcb63e13d69",
+          "branch": "add-symbolset-support",
+          "revision": "0d8d974dadbed1b6baa9c0752be9c70ff48239df",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/tid-kijyun/Kanna.git",
         "state": {
           "branch": null,
-          "revision": "126bdc9600e30b4a8aeb8d14088953c16aebf495",
-          "version": "5.2.6"
+          "revision": "f9e4922223dd0d3dfbf02ca70812cf5531fc0593",
+          "version": "5.2.7"
         }
       },
       {
@@ -210,10 +210,10 @@
       },
       {
         "package": "SwiftGen",
-        "repositoryURL": "https://github.com/fortmarek/SwiftGen",
+        "repositoryURL": "https://github.com/hisaac/SwiftGen",
         "state": {
-          "branch": "stable",
-          "revision": "5514d331d8ff1273b5c88747d646edcb63e13d69",
+          "branch": "add-symbolset-support",
+          "revision": "0d8d974dadbed1b6baa9c0752be9c70ff48239df",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "0.4.3")),
         .package(url: "https://github.com/marmelroy/Zip.git", .upToNextMinor(from: "2.1.1")),
         .package(url: "https://github.com/tuist/GraphViz.git", .branch("tuist")),
-        .package(url: "https://github.com/fortmarek/SwiftGen", .branch("stable")),
+        .package(url: "https://github.com/hisaac/SwiftGen", .branch("add-symbolset-support")),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .upToNextMajor(from: "2.8.0")),
         .package(url: "https://github.com/FabrizioBrancati/Queuer.git", .upToNextMajor(from: "2.1.1")),
         .package(url: "https://github.com/CombineCommunity/CombineExt.git", .upToNextMajor(from: "1.3.0")),

--- a/Project.swift
+++ b/Project.swift
@@ -30,7 +30,7 @@ let packages: [Package] = [
     .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMajor(from: "1.4.1")),
     .package(url: "https://github.com/tuist/GraphViz.git", .branch("tuist")),
     .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "0.4.3")),
-    .package(url: "https://github.com/fortmarek/SwiftGen", .branch("stable")),
+    .package(url: "https://github.com/hisaac/SwiftGen", .branch("add-symbolset-support")),
     .package(url: "https://github.com/kylef/PathKit.git", .upToNextMajor(from: "1.0.0")),
 ]
 


### PR DESCRIPTION
### Short description 📝

**DO NOT MERGE THIS. I am opening this pull request to the Tuist repo just to run CI builds and tests, to verify nothing breaks with the changes to that dependency.**

I've opened a pull request to @fortmarek's fork of SwiftGen that is used in this project, which pulls in changes from SwiftGen's develop branch that add support for symbolset assets (https://github.com/fortmarek/SwiftGen/pull/1).

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/). (in progress)
- [ ] ~~The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.~~ (changes not intended to be merged)
- [ ] ~~In case the PR introduces changes that affect users, the documentation has been updated.~~ (changes not intended to be merged)