### PR TITLE
Change stats URL

### DIFF
--- a/Sources/TuistAnalytics/CommandEvent.swift
+++ b/Sources/TuistAnalytics/CommandEvent.swift
@@ -2,7 +2,7 @@ import Foundation
 import TuistCore
 
 /// A `CommandEvent` is the analytics event to track the execution of a Tuist command
-/// Stats are public and reported at https://stats.tuist.io/
+/// Stats are public and reported at https://backbone.tuist.io/
 public struct CommandEvent: Codable, Equatable, AsyncQueueEvent {
     public let name: String
     public let subcommand: String?

--- a/Sources/TuistAnalytics/TuistAnalyticsDispatcher.swift
+++ b/Sources/TuistAnalytics/TuistAnalyticsDispatcher.swift
@@ -2,7 +2,7 @@ import Foundation
 import TuistAsyncQueue
 import TuistCore
 
-/// `TuistAnalyticsTagger` is responsible to send analytics events that gets stored and reported at https://stats.tuist.io/
+/// `TuistAnalyticsTagger` is responsible to send analytics events that gets stored and reported at https://backbone.tuist.io/
 public struct TuistAnalyticsDispatcher: AsyncQueueDispatching {
     public static let dispatcherId = "TuistAnalytics"
 
@@ -27,7 +27,7 @@ public struct TuistAnalyticsDispatcher: AsyncQueueDispatching {
     }
 
     private func send(commandEvent: CommandEvent, completion: @escaping (Data?, URLResponse?, Error?) -> Void) throws {
-        var request = URLRequest(url: URL(string: "https://stats.tuist.io/command_events.json")!)
+        var request = URLRequest(url: URL(string: "https://backbone.tuist.io/command_events.json")!)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 

--- a/projects/docs/docs/guides/stats.md
+++ b/projects/docs/docs/guides/stats.md
@@ -14,7 +14,7 @@ The implementation is open source, mainly in the [TuistAnalytics](https://github
 If you are thinking about adding another event, please remember that we would like to keep tracking minimal and unobtrusive.
 
 The data is collected on a server implemented in the [Tuist repository](https://github.com/tuist/stats) and published on the
-[Tuist Stats website](https://stats.tuist.io/).
+[Tuist Stats website](https://backbone.tuist.io/).
 
 Users can opt out from Tuist stats setting the following environment variable:
 


### PR DESCRIPTION
### Short description 📝
After renaming the stats repository to **backbone** to be more generic and include utilities for stewarding the Tuist project, I changed its domain to be `backbone.tuist.io` instead of `stats.tuist.io`. This PR updates the URL in the CLI.