### PR TITLE
fix: use cloud session with no redirect to prevent redirects to be interpreted as success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Add swift version to the target hash computation. [#3455](https://github.com/tuist/tuist/3455) by [@danyf90](https://github.com/danyf90)
 - Add tuist version to the target hash computation. [#3455](https://github.com/tuist/tuist/3455) by [@danyf90](https://github.com/danyf90)
+- Fix unauthenticated cache exists responses interpreted as existing build artifact. [#3480](https://github.com/tuist/tuist/3480) by [@danyf90](https://github.com/danyf90)
 
 ## 1.50.0 - Nature
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3476

### Short description 📝

use cloud session with no redirect to prevent redirects to be interpreted as success

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
