### PR TITLE
Tuist executable

### DIFF
--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -47,9 +47,10 @@ public struct TuistCommand: ParsableCommand {
         let executeCommand: () throws -> ()
         do {
             let processedArguments = Array(processArguments(arguments)?.dropFirst() ?? [])
+            let commandName = processedArguments.first ?? ""
             if Self.configuration.subcommands
                 .map({ $0._commandName })
-                .contains(processedArguments.first ?? "") {
+                .contains(processedArguments.first ?? "") || !System.shared.commandExists(commandName) {
                 if processedArguments.first == ScaffoldCommand.configuration.commandName {
                     try ScaffoldCommand.preprocess(processedArguments)
                 }
@@ -63,9 +64,7 @@ public struct TuistCommand: ParsableCommand {
                 executeCommand = { try execute(command) }
             } else {
                 executeCommand = {
-                    var customCommandArguments = processedArguments
-                    customCommandArguments[0] = "tuist-\(customCommandArguments[0])"
-                    try System.shared.runAndPrint(customCommandArguments)
+                    try TuistService().run(processedArguments)
                 }
             }
         } catch {

--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -51,7 +51,7 @@ public struct TuistCommand: ParsableCommand {
             let isTuistCommand = Self.configuration.subcommands
                 .map({ $0._commandName })
                 .contains(processedArguments.first ?? "")
-            if isTuistCommand || !System.shared.commandExists(commandName) {
+            if isTuistCommand || !System.shared.commandExists("tuist-" + commandName) {
                 if processedArguments.first == ScaffoldCommand.configuration.commandName {
                     try ScaffoldCommand.preprocess(processedArguments)
                 }

--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -48,9 +48,10 @@ public struct TuistCommand: ParsableCommand {
         do {
             let processedArguments = Array(processArguments(arguments)?.dropFirst() ?? [])
             let commandName = processedArguments.first ?? ""
-            if Self.configuration.subcommands
+            let isTuistCommand = Self.configuration.subcommands
                 .map({ $0._commandName })
-                .contains(processedArguments.first ?? "") || !System.shared.commandExists(commandName) {
+                .contains(processedArguments.first ?? "")
+            if isTuistCommand || !System.shared.commandExists(commandName) {
                 if processedArguments.first == ScaffoldCommand.configuration.commandName {
                     try ScaffoldCommand.preprocess(processedArguments)
                 }

--- a/Sources/TuistKit/Services/TuistService.swift
+++ b/Sources/TuistKit/Services/TuistService.swift
@@ -1,0 +1,13 @@
+import Foundation
+import TuistSupport
+
+final class TuistService: NSObject {
+    func run(_ arguments: [String]) throws {
+        var arguments = arguments
+        
+        let commandName = "tuist-\(arguments[0])"
+        arguments[0] = commandName
+        
+        try System.shared.runAndPrint(arguments)
+    }
+}

--- a/Sources/TuistSupport/System/System.swift
+++ b/Sources/TuistSupport/System/System.swift
@@ -684,6 +684,15 @@ public final class System: Systeming {
 }
 
 extension Systeming {
+    public func commandExists(_ name: String) -> Bool {
+        do {
+            _ = try which(name)
+            return true
+        } catch {
+            return false
+        }
+    }
+    
     public func publisher(_ arguments: [String], pipedToArguments: [String]) -> AnyPublisher<SystemEvent<Data>, Error> {
         AnyPublisher.create { (subscriber) -> Cancellable in
             let disposable = self.observable(arguments, pipedToArguments: pipedToArguments).subscribe { event in

--- a/Tests/TuistKitTests/Services/TuistServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TuistServiceTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+import TuistSupport
+import TuistSupportTesting
+
+@testable import TuistKit
+
+final class TuistServiceTests: TuistUnitTestCase {
+    var subject: TuistService!
+
+    override func setUp() {
+        super.setUp()
+        subject = TuistService()
+    }
+
+    override func tearDown() {
+        subject = nil
+        super.tearDown()
+    }
+    
+    func test_run() throws {
+        system.succeedCommand("tuist-my-command", "argument-one")
+        XCTAssertNoThrow(
+            try subject.run(["my-command", "argument-one"])
+        )
+    }
+}

--- a/projects/docs/docs/commands/task.md
+++ b/projects/docs/docs/commands/task.md
@@ -13,4 +13,4 @@ We try to fix that by introducing a concept of "Tasks" where you can define cust
 
 ### Defining a task
 
-You can prepend any executable with `tuist-` and add it to your `PATH`. If you for example add `tuist-my-command` to your `PATH`, you will be able to run `tuist my-command` and `my-command` will automatically be executed.
+You can prepend any executable with `tuist-` and add it to your `PATH`. If you for example add `tuist-my-command` to your `PATH`, you will be able to run `tuist my-command` and `tuist-my-command` will automatically be executed.

--- a/projects/docs/docs/commands/task.md
+++ b/projects/docs/docs/commands/task.md
@@ -1,7 +1,7 @@
 ---
 title: Run tasks
 slug: '/commands/task'
-description: 'Learn how to to automate arbitrary tasks with tuist Swift.'
+description: 'Learn how to to automate arbitrary tasks with tuist in Swift.'
 ---
 
 ### Context
@@ -13,31 +13,4 @@ We try to fix that by introducing a concept of "Tasks" where you can define cust
 
 ### Defining a task
 
-To define a task, you can run `tuist edit` and then create a file `NameOfCommand.swift` in `Tuist/Tasks` directory.
-Afterwards, you will need to define the task's options (if there are any) and the code that should be executed when the task is run.
-Below you can find an example of the `CreateFile` task:
-
-```swift
-import ProjectAutomation
-import Foundation
-
-let task = Task(
-    options: [
-         .option("file-name"),
-    ]
-) { options in
-    let fileName = options["file-name"] ?? "file"
-    try "File created with a task".write(
-        to: URL(fileURLWithPath: "\(fileName).txt"),
-        atomically: true,
-        encoding: .utf8
-    )
-    print("File created!")
-}
-```
-
-If you added this file to `Tuist/Tasks/CreateFile.swift`, you can run it by `tuist exec create-file --file-name MyFileName`.
-The `Task` accepts two parameters - `options: [Option]` which defines the possible options of the task.
-Then there is a parameter `task: ([String: String]) throws -> Void` which is a simple closure that is executed when the task is run.
-Note that the closure has input of `[String: String]` -
-this is a dictionary of options defined by the user where the key is the name of the option and value is the option's value.
+You can prepend any executable with `tuist-` and add it to your `PATH`. If you for example add `tuist-my-command` to your `PATH`, you will be able to run `tuist my-command` and `my-command` will automatically be executed.

--- a/projects/tuist/features/step_definitions/tasks.rb
+++ b/projects/tuist/features/step_definitions/tasks.rb
@@ -8,6 +8,14 @@ Then(/^tuist runs a task (.+) with attribute (.+) as (.+)$/) do |name, attribute
   system(@tuist, "exec", name, "--#{attribute}", attribute_value, "--path", @dir)
 end
 
-Then(/^content of a file named ([a-zA-Z\-_]+) should be equal to (.+)$/) do |file, content|
+Then(/^content of a file named ([a-zA-Z\-_\.]+) should be equal to (.+)$/) do |file, content|
   assert_equal File.read(File.join(@dir, file)), content
+end
+
+Then(/^tuist runs ([a-zA-Z\-_]+)$/) do |command|
+  system(@tuist, command, @dir)
+end
+
+Then(/^(.+) is added to PATH$/) do |executable_name|
+  ENV["PATH"] = ENV["PATH"] + ":#{@dir}"
 end

--- a/projects/tuist/features/tasks.feature
+++ b/projects/tuist/features/tasks.feature
@@ -13,4 +13,7 @@ Feature: Run tasks
     And I have a working directory
     Then I copy the fixture app_with_plugins into the working directory
     Then tuist runs a task create-file
-    Then content of a file named file.txt should be equal to File created with a plugin
+    Then content of a file named plugin-file.txt should be equal to File created with a plugin
+    Then tuist-create-file is added to PATH
+    Then tuist runs create-file
+    Then content of a file named create-file.txt should be equal to run_from_task

--- a/projects/tuist/fixtures/app_with_plugins/tuist-create-file
+++ b/projects/tuist/fixtures/app_with_plugins/tuist-create-file
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "run_from_task" | tr -d "\n" > "$1"/create-file.txt


### PR DESCRIPTION
### Short description 📝

In this PR I added a functionality where if you run `tuist xxx` and `xxx` is not tuist's command, tuist will automatically try to run an executable from `PATH`.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
