### PR TITLE
Sanitize Target Names in Resolved Dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Add tuist version to the target hash computation. [#3455](https://github.com/tuist/tuist/3455) by [@danyf90](https://github.com/danyf90)
 - Fix unauthenticated cache exists responses interpreted as existing build artifact. [#3480](https://github.com/tuist/tuist/3480) by [@danyf90](https://github.com/danyf90)
 - Fix `.tuistignore` not matching relative paths correctly [#3456](https://github.com/tuist/tuist/pull/3456) by [@danyf90](https://github.com/danyf90)
-- Sanitize target names in resolved dependencies. [#3495](https://github.com/tuist/tuist/3495) by [@moritzsternemann](https://github.com/moritzsternemann)
 
 ## 1.50.0 - Nature
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Add tuist version to the target hash computation. [#3455](https://github.com/tuist/tuist/3455) by [@danyf90](https://github.com/danyf90)
 - Fix unauthenticated cache exists responses interpreted as existing build artifact. [#3480](https://github.com/tuist/tuist/3480) by [@danyf90](https://github.com/danyf90)
 - Fix `.tuistignore` not matching relative paths correctly [#3456](https://github.com/tuist/tuist/pull/3456) by [@danyf90](https://github.com/danyf90)
+- Sanitize target names in resolved dependencies. [#3495](https://github.com/tuist/tuist/3495) by [@moritzsternemann](https://github.com/moritzsternemann)
 
 ## 1.50.0 - Nature
 

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -907,7 +907,7 @@ extension PackageInfoMapper {
             packageInfos: [String: PackageInfo]
         ) throws -> Self {
             guard
-                let targets = packageInfos[package]?.products.first(where: { $0.name == product })?.targets
+                let targets = packageInfos[package]?.products.first(where: { $0.name == product })?.targets.map(PackageInfoMapper.sanitize(targetName:))
             else {
                 throw PackageInfoMapperError.unknownProductDependency(product, package)
             }


### PR DESCRIPTION
Follow up to https://github.com/tuist/tuist/pull/3449

### Short description 📝

Testing out the changes to support SPM dependencies with reverse-domain-name-style package names (#3449) in a more complex project, I noticed that target names were not sanitized in the resolved dependencies of packages.

This PR fixes this and adds a new test to cover this case as well.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
