### PR TITLE
Make getting started more "universal"

### DIFF
--- a/projects/docs/docs/tutorial/get-started.md
+++ b/projects/docs/docs/tutorial/get-started.md
@@ -11,7 +11,7 @@ Tuist is a command line tool \(CLI\) that aims to facilitate the generation, mai
 The first thing that we need to do to get started is installing the tool. To do so, you can run the following commands in your terminal:
 
 ```bash
-bash <(curl -Ls https://install.tuist.io)
+curl -Ls https://install.tuist.io | bash
 ```
 
 The process is relatively fast because we are actually not installing the tool. We are installing `tuistenv` \(which gets renamed to `tuist`\) when you install it.


### PR DESCRIPTION
Hi! I'm a fish shell user, and that installation command doesn't really work on fish. While there's a ["recommended"](https://github.com/fish-shell/fish-shell/issues/5181) way to do it, turns out the README already has a pretty universal way to install tuist. This PR thus has two benefits: docs are now consistent with the README, and the install method now should work on more shells 😄

Resolves https://github.com/tuist/tuist/issues/YYY
Request for comments document (if applies):

### Short description 📝

> Describe here the purpose of your PR.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
