### PR TITLE
Fix installation of Tuist when files under /tmp exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- Installation failing when intermediate files are present in `/tmp/` [#3502](https://github.com/tuist/tuist/pull/3502) by [@pepibumur](https://github.com/pepibumur).
 ## 1.51.0 - Switch
 
 ### Changed

--- a/script/install
+++ b/script/install
@@ -26,6 +26,8 @@ warn() {
 LATEST_VERSION=$(curl --silent "https://raw.githubusercontent.com/tuist/tuist/main/Sources/TuistSupport/Constants.swift" | grep 'version =' | sed -E 's/.*"([^"]+)".*/\1/')
 
 ohai "Downloading tuistenv..."
+[ -f /tmp/tuistenv.zip ] && rm /tmp/tuistenv.zip
+[ -f /tmp/tuistenv ] && rm /tmp/tuistenv
 curl -LSs --output /tmp/tuistenv.zip https://github.com/tuist/tuist/releases/download/${LATEST_VERSION}/tuistenv.zip
 ohai "Unzipping tuistenv..."
 unzip -o /tmp/tuistenv.zip -d /tmp/tuistenv > /dev/null


### PR DESCRIPTION
### Short description 📝
It was reported on Slack that the installation might if `/tmp/tuistenv` and `/tmp/tuistenv.zip` exist. To prevent that from happening, I'm extending the installation logic to delete those files if they are present in the environment. Since those are intermediate files generated by our installation script, it's a safe deletion.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
