### PR TITLE
Make cache hashes of SwiftPackageManager dependencies with modulemap independent from the absolute path of the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Installation failing when intermediate files are present in `/tmp/` [#3502](https://github.com/tuist/tuist/pull/3502) by [@pepibumur](https://github.com/pepibumur).
+- Make cache hashes of SwiftPackageManager dependencies with modulemap independent from the absolute path of the project [#3505](https://github.com/tuist/tuist/pull/3505) by [@danyf90](https://github.com/danyf90).
+
 ## 1.51.0 - Switch
 
 ### Changed

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -634,7 +634,7 @@ extension ProjectDescription.Settings {
         ]
 
         if let moduleMapPath = moduleMap.path {
-            settingsDictionary["MODULEMAP_FILE"] = .string(moduleMapPath.pathString)
+          settingsDictionary["MODULEMAP_FILE"] = .string("$(SRCROOT)/\(moduleMapPath.relative(to: packageFolder))")
         }
 
         if !headerSearchPaths.isEmpty {

--- a/Sources/TuistDependenciesTesting/DependenciesGraph/DependenciesGraph+TestData.swift
+++ b/Sources/TuistDependenciesTesting/DependenciesGraph/DependenciesGraph+TestData.swift
@@ -418,7 +418,7 @@ extension DependenciesGraph {
 
     static func spmSettings(
         with customSettings: SettingsDictionary = [:],
-        moduleMap: AbsolutePath? = nil
+        moduleMap: String? = nil
     ) -> Settings {
         let defaultSpmSettings: SettingsDictionary = [
             "ALWAYS_SEARCH_USER_PATHS": "YES",
@@ -434,7 +434,7 @@ extension DependenciesGraph {
         var settingsDictionary = customSettings.merging(defaultSpmSettings, uniquingKeysWith: { custom, _ in custom })
 
         if let moduleMap = moduleMap {
-            settingsDictionary["MODULEMAP_FILE"] = .string(moduleMap.pathString)
+            settingsDictionary["MODULEMAP_FILE"] = .string(moduleMap)
         }
 
         if case let .array(headerSearchPaths) = settingsDictionary["HEADER_SEARCH_PATHS"] {

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -464,7 +464,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         customSettings: [
                             "HEADER_SEARCH_PATHS": ["$(SRCROOT)/Sources/Target1/include"],
                         ],
-                        moduleMap: moduleMapPath
+                        moduleMap: "$(SRCROOT)/Sources/Target1/include/module.modulemap"
                     ),
                 ]
             )
@@ -575,7 +575,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                 "$(SRCROOT)/Sources/Dependency2/include",
                             ],
                         ],
-                        moduleMap: target1ModuleMapPath
+                        moduleMap: "$(SRCROOT)/Sources/Target1/include/module.modulemap"
                     ),
                     .test(
                         "Dependency1",
@@ -587,7 +587,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                 "$(SRCROOT)/Sources/Dependency2/include",
                             ],
                         ],
-                        moduleMap: dependency1ModuleMapPath
+                        moduleMap: "$(SRCROOT)/Sources/Dependency1/include/module.modulemap"
                     ),
                     .test(
                         "Dependency2",
@@ -595,7 +595,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         customSettings: [
                             "HEADER_SEARCH_PATHS": ["$(SRCROOT)/Sources/Dependency2/include"],
                         ],
-                        moduleMap: dependency2ModuleMapPath
+                        moduleMap: "$(SRCROOT)/Sources/Dependency2/include/module.modulemap"
                     ),
                 ]
             )
@@ -683,7 +683,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                 "$(SRCROOT)/../../Package3/Path/Sources/Dependency2/include",
                             ],
                         ],
-                        moduleMap: target1ModuleMapPath
+                        moduleMap: "$(SRCROOT)/Sources/Target1/include/module.modulemap"
                     ),
                 ]
             )
@@ -693,7 +693,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
     func testMap_whenCustomPath() throws {
         let basePath = try temporaryPath()
         let headersPath = basePath.appending(RelativePath("Package/Path/Custom/Path/Headers"))
-        let headerPath = headersPath.appending(component: "module.modulemap")
+        let headerPath = headersPath.appending(component: "module.h")
         let moduleMapPath = headersPath.appending(component: "module.modulemap")
         try fileHandler.createFolder(headersPath)
         try fileHandler.write("", path: headerPath, atomically: true)
@@ -740,7 +740,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         customSettings: [
                             "HEADER_SEARCH_PATHS": ["$(SRCROOT)/Custom/Path/Headers"],
                         ],
-                        moduleMap: moduleMapPath
+                        moduleMap: "$(SRCROOT)/Custom/Path/Headers/module.modulemap"
                     ),
                 ]
             )
@@ -792,7 +792,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         customSettings: [
                             "HEADER_SEARCH_PATHS": ["$(SRCROOT)/Sources/Dependency1/include"],
                         ],
-                        moduleMap: dependencyHeadersPath.appending(RelativePath("Dependency1.modulemap"))
+                        moduleMap: "$(SRCROOT)/Sources/Dependency1/include/Dependency1.modulemap"
                     ),
                 ]
             )
@@ -1857,7 +1857,7 @@ extension ProjectDescription.Target {
         headers: ProjectDescription.Headers? = nil,
         dependencies: [ProjectDescription.TargetDependency] = [],
         customSettings: ProjectDescription.SettingsDictionary = [:],
-        moduleMap: AbsolutePath? = nil
+        moduleMap: String? = nil
     ) -> Self {
         return .init(
             name: name,


### PR DESCRIPTION
### Short description 📝

The MODULEMAP path was using absolut instead of relative, which causes different hashes to be generated depending on the project path

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
