### PR TITLE
Add `name` parameter to remote cache API calls

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "AEXML",
-        "repositoryURL": "https://github.com/tadija/AEXML",
+        "repositoryURL": "https://github.com/tadija/AEXML.git",
         "state": {
           "branch": null,
           "revision": "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
           "branch": null,
-          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
-          "version": "1.0.0"
+          "revision": "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+          "version": "1.0.1"
         }
       },
       {
@@ -150,8 +150,8 @@
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
           "branch": null,
-          "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
-          "version": "0.9.2"
+          "revision": "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+          "version": "0.10.1"
         }
       },
       {
@@ -222,8 +222,8 @@
         "repositoryURL": "https://github.com/tuist/XcodeProj.git",
         "state": {
           "branch": null,
-          "revision": "8e83191dba8bcbfc0be4d7c48bf1e02e7fedc88c",
-          "version": "8.2.0"
+          "revision": "446f3a0db73e141c7f57e26fcdb043096b1db52c",
+          "version": "8.3.1"
         }
       },
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Added
+
+- Add `name` parameter to remote cache API calls. [#3516](https://github.com/tuist/tuist/pull/3516) by [@danyf90](https://github.com/danyf90)
+
 ### Fixed
 
 - Installation failing when intermediate files are present in `/tmp/` [#3502](https://github.com/tuist/tuist/pull/3502) by [@pepibumur](https://github.com/pepibumur).

--- a/Sources/ProjectDescription/SourceFilesList.swift
+++ b/Sources/ProjectDescription/SourceFilesList.swift
@@ -10,7 +10,7 @@ public struct SourceFileGlob: ExpressibleByStringInterpolation, Codable, Equatab
 
     /// Compiler flags.
     public let compilerFlags: String?
-    
+
     /// Source file code generation attribute
     public let codeGen: FileCodeGen?
 
@@ -24,7 +24,8 @@ public struct SourceFileGlob: ExpressibleByStringInterpolation, Codable, Equatab
     public init(_ glob: Path,
                 excluding: [Path] = [],
                 compilerFlags: String? = nil,
-                codeGen: FileCodeGen? = nil) {
+                codeGen: FileCodeGen? = nil)
+    {
         self.glob = glob
         self.excluding = excluding
         self.compilerFlags = compilerFlags
@@ -34,7 +35,8 @@ public struct SourceFileGlob: ExpressibleByStringInterpolation, Codable, Equatab
     public init(_ glob: Path,
                 excluding: Path?,
                 compilerFlags: String? = nil,
-                codeGen: FileCodeGen? = nil) {
+                codeGen: FileCodeGen? = nil)
+    {
         let paths: [Path] = excluding.flatMap { [$0] } ?? []
         self.init(glob, excluding: paths, compilerFlags: compilerFlags, codeGen: codeGen)
     }

--- a/Sources/TuistCache/Cache/Cache.swift
+++ b/Sources/TuistCache/Cache/Cache.swift
@@ -23,30 +23,30 @@ public final class Cache: CacheStoring {
 
     // MARK: - CacheStoring
 
-    public func exists(hash: String) -> Single<Bool> {
+    public func exists(name: String, hash: String) -> Single<Bool> {
         /// It calls exists sequentially until one of the storages returns true.
         return storages.reduce(Single.just(false)) { (result, next) -> Single<Bool> in
             result.flatMap { exists in
                 guard !exists else { return result }
-                return next.exists(hash: hash)
+                return next.exists(name: name, hash: hash)
             }.catchError { (_) -> Single<Bool> in
-                next.exists(hash: hash)
+                next.exists(name: name, hash: hash)
             }
         }
     }
 
-    public func fetch(hash: String) -> Single<AbsolutePath> {
+    public func fetch(name: String, hash: String) -> Single<AbsolutePath> {
         return storages
             .reduce(nil) { (result, next) -> Single<AbsolutePath> in
                 if let result = result {
-                    return result.catchError { _ in next.fetch(hash: hash) }
+                    return result.catchError { _ in next.fetch(name: name, hash: hash) }
                 } else {
-                    return next.fetch(hash: hash)
+                    return next.fetch(name: name, hash: hash)
                 }
             }!
     }
 
-    public func store(hash: String, paths: [AbsolutePath]) -> Completable {
-        return Completable.zip(storages.map { $0.store(hash: hash, paths: paths) })
+    public func store(name: String, hash: String, paths: [AbsolutePath]) -> Completable {
+        return Completable.zip(storages.map { $0.store(name: name, hash: hash, paths: paths) })
     }
 }

--- a/Sources/TuistCache/Cache/CacheLocalStorage.swift
+++ b/Sources/TuistCache/Cache/CacheLocalStorage.swift
@@ -38,14 +38,14 @@ public final class CacheLocalStorage: CacheStoring {
 
     // MARK: - CacheStoring
 
-    public func exists(hash: String) -> Single<Bool> {
+    public func exists(name _: String, hash: String) -> Single<Bool> {
         Single.create { (completed) -> Disposable in
             completed(.success(self.lookupCompiledArtifact(directory: self.cacheDirectory.appending(component: hash)) != nil))
             return Disposables.create()
         }
     }
 
-    public func fetch(hash: String) -> Single<AbsolutePath> {
+    public func fetch(name _: String, hash: String) -> Single<AbsolutePath> {
         Single.create { (completed) -> Disposable in
             if let path = self.lookupCompiledArtifact(directory: self.cacheDirectory.appending(component: hash)) {
                 completed(.success(path))
@@ -56,7 +56,7 @@ public final class CacheLocalStorage: CacheStoring {
         }
     }
 
-    public func store(hash: String, paths: [AbsolutePath]) -> Completable {
+    public func store(name _: String, hash: String, paths: [AbsolutePath]) -> Completable {
         let copy = Completable.create { (completed) -> Disposable in
             let hashFolder = self.cacheDirectory.appending(component: hash)
 

--- a/Sources/TuistCache/Cache/CacheStoring.swift
+++ b/Sources/TuistCache/Cache/CacheStoring.swift
@@ -6,21 +6,24 @@ import TuistCore
 public protocol CacheStoring {
     /// Returns if the target with the given hash exists in the cache.
     /// - Parameters:
+    ///   - name: Target's name.
     ///   - hash: Target's hash.
     /// - Returns: An observable that returns a boolean indicating whether the target is cached.
-    func exists(hash: String) -> Single<Bool>
+    func exists(name: String, hash: String) -> Single<Bool>
 
     /// For the target with the given hash, it fetches it from the cache and returns a path
     /// pointint to the .xcframework that represents it.
     ///
     /// - Parameters:
+    ///   - name: Target's name.
     ///   - hash: Target's hash.
     /// - Returns: An observable that returns a boolean indicating whether the target is cached.
-    func fetch(hash: String) -> Single<AbsolutePath>
+    func fetch(name: String, hash: String) -> Single<AbsolutePath>
 
     /// It stores the xcframework at the given path in the cache.
     /// - Parameters:
+    ///   - name: Target's name.
     ///   - hash: Hash of the target the xcframework belongs to.
     ///   - paths: Path to the files that will be stored.
-    func store(hash: String, paths: [AbsolutePath]) -> Completable
+    func store(name: String, hash: String, paths: [AbsolutePath]) -> Completable
 }

--- a/Sources/TuistCache/Cache/Resources/CloudCacheResourceFactory.swift
+++ b/Sources/TuistCache/Cache/Resources/CloudCacheResourceFactory.swift
@@ -9,10 +9,10 @@ typealias CloudVerifyUploadResource = HTTPResource<CloudResponse<CloudVerifyUplo
 
 /// Entity responsible for providing cache-related resources
 protocol CloudCacheResourceFactorying {
-    func existsResource(hash: String) throws -> CloudExistsResource
-    func fetchResource(hash: String) throws -> CloudCacheResource
-    func storeResource(hash: String, contentMD5: String) throws -> CloudCacheResource
-    func verifyUploadResource(hash: String, contentMD5: String) throws -> CloudVerifyUploadResource
+    func existsResource(name: String, hash: String) throws -> CloudExistsResource
+    func fetchResource(name: String, hash: String) throws -> CloudCacheResource
+    func storeResource(name: String, hash: String, contentMD5: String) throws -> CloudCacheResource
+    func verifyUploadResource(name: String, hash: String, contentMD5: String) throws -> CloudVerifyUploadResource
 }
 
 class CloudCacheResourceFactory: CloudCacheResourceFactorying {
@@ -22,8 +22,8 @@ class CloudCacheResourceFactory: CloudCacheResourceFactorying {
         self.cloudConfig = cloudConfig
     }
 
-    func existsResource(hash: String) throws -> CloudExistsResource {
-        let url = try apiCacheURL(hash: hash, cacheURL: cloudConfig.url, projectId: cloudConfig.projectId)
+    func existsResource(name: String, hash: String) throws -> CloudExistsResource {
+        let url = try apiCacheURL(name: name, hash: hash, cacheURL: cloudConfig.url, projectId: cloudConfig.projectId)
         var request = URLRequest(url: url)
         request.httpMethod = "HEAD"
         return HTTPResource(
@@ -33,8 +33,9 @@ class CloudCacheResourceFactory: CloudCacheResourceFactorying {
         )
     }
 
-    func fetchResource(hash: String) throws -> CloudCacheResource {
+    func fetchResource(name: String, hash: String) throws -> CloudCacheResource {
         let url = try apiCacheURL(
+            name: name,
             hash: hash,
             cacheURL: cloudConfig.url,
             projectId: cloudConfig.projectId
@@ -42,8 +43,9 @@ class CloudCacheResourceFactory: CloudCacheResourceFactorying {
         return HTTPResource.jsonResource(for: url, httpMethod: "GET")
     }
 
-    func storeResource(hash: String, contentMD5: String) throws -> CloudCacheResource {
+    func storeResource(name: String, hash: String, contentMD5: String) throws -> CloudCacheResource {
         let url = try apiCacheURL(
+            name: name,
             hash: hash,
             cacheURL: cloudConfig.url,
             projectId: cloudConfig.projectId,
@@ -52,8 +54,9 @@ class CloudCacheResourceFactory: CloudCacheResourceFactorying {
         return HTTPResource.jsonResource(for: url, httpMethod: "POST")
     }
 
-    func verifyUploadResource(hash: String, contentMD5: String) throws -> CloudVerifyUploadResource {
+    func verifyUploadResource(name: String, hash: String, contentMD5: String) throws -> CloudVerifyUploadResource {
         let url = try apiCacheVerifyUploadURL(
+            name: name,
             hash: hash,
             cacheURL: cloudConfig.url,
             projectId: cloudConfig.projectId,
@@ -64,15 +67,18 @@ class CloudCacheResourceFactory: CloudCacheResourceFactorying {
 
     // MARK: Private
 
-    private func apiCacheURL(hash: String,
-                             cacheURL: URL,
-                             projectId: String,
-                             contentMD5: String? = nil) throws -> URL
-    {
+    private func apiCacheURL(
+        name: String,
+        hash: String,
+        cacheURL: URL,
+        projectId: String,
+        contentMD5: String? = nil
+    ) throws -> URL {
         var urlComponents = URLComponents(url: cacheURL, resolvingAgainstBaseURL: false)!
         var queryItems: [URLQueryItem] = [
             URLQueryItem(name: "project_id", value: projectId),
             URLQueryItem(name: "hash", value: hash),
+            URLQueryItem(name: "name", value: name),
         ]
         if let contentMD5 = contentMD5 {
             queryItems.append(URLQueryItem(name: "content_md5", value: contentMD5))
@@ -83,17 +89,20 @@ class CloudCacheResourceFactory: CloudCacheResourceFactorying {
         return urlComponents.url!
     }
 
-    private func apiCacheVerifyUploadURL(hash: String,
-                                         cacheURL: URL,
-                                         projectId: String,
-                                         contentMD5: String) throws -> URL
-    {
+    private func apiCacheVerifyUploadURL(
+        name: String,
+        hash: String,
+        cacheURL: URL,
+        projectId: String,
+        contentMD5: String
+    ) throws -> URL {
         var urlComponents = URLComponents(url: cacheURL, resolvingAgainstBaseURL: false)!
         urlComponents.path = "/api/cache/verify_upload"
         urlComponents.queryItems = [
             URLQueryItem(name: "project_id", value: projectId),
             URLQueryItem(name: "hash", value: hash),
             URLQueryItem(name: "content_md5", value: contentMD5),
+            URLQueryItem(name: "name", value: name),
         ]
         return urlComponents.url!
     }

--- a/Sources/TuistCache/GraphMappers/CacheMapper.swift
+++ b/Sources/TuistCache/GraphMappers/CacheMapper.swift
@@ -146,10 +146,10 @@ public final class CacheMapper: GraphMapping {
 
     private func fetch(hashes: [GraphTarget: String]) -> Single<[GraphTarget: AbsolutePath]> {
         Single.zip(hashes.map { target, hash in
-            self.cache.exists(hash: hash)
+            self.cache.exists(name: target.target.name, hash: hash)
                 .flatMap { (exists) -> Single<(target: GraphTarget, path: AbsolutePath?)> in
                     guard exists else { return Single.just((target: target, path: nil)) }
-                    return self.cache.fetch(hash: hash).map { (target: target, path: $0) }
+                    return self.cache.fetch(name: target.target.name, hash: hash).map { (target: target, path: $0) }
                 }
         })
             .map { result in

--- a/Sources/TuistCacheTesting/Cache/Mocks/MockCacheStorage.swift
+++ b/Sources/TuistCacheTesting/Cache/Mocks/MockCacheStorage.swift
@@ -9,7 +9,7 @@ public final class MockCacheStorage: CacheStoring {
 
     public init() {}
 
-    public func exists(name: String,  hash: String) -> Single<Bool> {
+    public func exists(name: String, hash: String) -> Single<Bool> {
         do {
             if let existsStub = existsStub {
                 return Single.just(try existsStub(name, hash))

--- a/Sources/TuistCacheTesting/Cache/Mocks/MockCacheStorage.swift
+++ b/Sources/TuistCacheTesting/Cache/Mocks/MockCacheStorage.swift
@@ -5,14 +5,14 @@ import TuistCache
 import TuistCore
 
 public final class MockCacheStorage: CacheStoring {
-    var existsStub: ((String) throws -> Bool)?
+    var existsStub: ((String, String) throws -> Bool)?
 
     public init() {}
 
-    public func exists(hash: String) -> Single<Bool> {
+    public func exists(name: String,  hash: String) -> Single<Bool> {
         do {
             if let existsStub = existsStub {
-                return Single.just(try existsStub(hash))
+                return Single.just(try existsStub(name, hash))
             } else {
                 return Single.just(false)
             }
@@ -21,11 +21,11 @@ public final class MockCacheStorage: CacheStoring {
         }
     }
 
-    var fetchStub: ((String) throws -> AbsolutePath)?
-    public func fetch(hash: String) -> Single<AbsolutePath> {
+    var fetchStub: ((String, String) throws -> AbsolutePath)?
+    public func fetch(name: String, hash: String) -> Single<AbsolutePath> {
         if let fetchStub = fetchStub {
             do {
-                return Single.just(try fetchStub(hash))
+                return Single.just(try fetchStub(name, hash))
             } catch {
                 return Single.error(error)
             }
@@ -34,10 +34,10 @@ public final class MockCacheStorage: CacheStoring {
         }
     }
 
-    var storeStub: ((_ hash: String, _ paths: [AbsolutePath]) -> Void)?
-    public func store(hash: String, paths: [AbsolutePath]) -> Completable {
+    var storeStub: ((String, String, [AbsolutePath]) -> Void)?
+    public func store(name: String, hash: String, paths: [AbsolutePath]) -> Completable {
         if let storeStub = storeStub {
-            storeStub(hash, paths)
+            storeStub(name, hash, paths)
         }
         return Completable.empty()
     }

--- a/Sources/TuistCacheTesting/Cache/Mocks/MockCloudCacheResponseFactory.swift
+++ b/Sources/TuistCacheTesting/Cache/Mocks/MockCloudCacheResponseFactory.swift
@@ -12,7 +12,7 @@ public class MockCloudCacheResourceFactory: CloudCacheResourceFactorying {
 
     public var invokedExistsResource = false
     public var invokedExistsResourceCount = 0
-    public var invokedExistsResourceParameters: (name: String, hash: String, Void)?
+    public var invokedExistsResourceParameters: (name: String, hash: String, Void)? // swiftlint:disable:this large_tuple
     public var invokedExistsResourceParametersList = [(name: String, hash: String, Void)]()
     public var stubbedExistsResourceError: Error?
     public var stubbedExistsResourceResult: CloudExistsResource = HTTPResource(
@@ -34,7 +34,7 @@ public class MockCloudCacheResourceFactory: CloudCacheResourceFactorying {
 
     public var invokedFetchResource = false
     public var invokedFetchResourceCount = 0
-    public var invokedFetchResourceParameters: (name: String, hash: String, Void)?
+    public var invokedFetchResourceParameters: (name: String, hash: String, Void)? // swiftlint:disable:this large_tuple
     public var invokedFetchResourceParametersList = [(name: String, hash: String, Void)]()
     public var stubbedFetchResourceError: Error?
     public var stubbedFetchResourceResult: CloudCacheResource = HTTPResource(
@@ -56,7 +56,7 @@ public class MockCloudCacheResourceFactory: CloudCacheResourceFactorying {
 
     public var invokedStoreResource = false
     public var invokedStoreResourceCount = 0
-    public var invokedStoreResourceParameters: (name: String, hash: String, contentMD5: String)?
+    public var invokedStoreResourceParameters: (name: String, hash: String, contentMD5: String)? // swiftlint:disable:this large_tuple
     public var invokedStoreResourceParametersList = [(name: String, hash: String, contentMD5: String)]()
     public var stubbedStoreResourceError: Error?
     public var stubbedStoreResourceResult: CloudCacheResource = HTTPResource(
@@ -78,7 +78,7 @@ public class MockCloudCacheResourceFactory: CloudCacheResourceFactorying {
 
     public var invokedVerifyUploadResource = false
     public var invokedVerifyUploadResourceCount = 0
-    public var invokedVerifyUploadResourceParameters: (name: String, hash: String, contentMD5: String)?
+    public var invokedVerifyUploadResourceParameters: (name: String, hash: String, contentMD5: String)? // swiftlint:disable:this large_tuple
     // swiftlint:disable:next identifier_name
     public var invokedVerifyUploadResourceParametersList = [(name: String, hash: String, contentMD5: String)]()
     public var stubbedVerifyUploadResourceError: Error?

--- a/Sources/TuistCacheTesting/Cache/Mocks/MockCloudCacheResponseFactory.swift
+++ b/Sources/TuistCacheTesting/Cache/Mocks/MockCloudCacheResponseFactory.swift
@@ -12,8 +12,8 @@ public class MockCloudCacheResourceFactory: CloudCacheResourceFactorying {
 
     public var invokedExistsResource = false
     public var invokedExistsResourceCount = 0
-    public var invokedExistsResourceParameters: (hash: String, Void)?
-    public var invokedExistsResourceParametersList = [(hash: String, Void)]()
+    public var invokedExistsResourceParameters: (name: String, hash: String, Void)?
+    public var invokedExistsResourceParametersList = [(name: String, hash: String, Void)]()
     public var stubbedExistsResourceError: Error?
     public var stubbedExistsResourceResult: CloudExistsResource = HTTPResource(
         request: { URLRequest.test() },
@@ -21,11 +21,11 @@ public class MockCloudCacheResourceFactory: CloudCacheResourceFactorying {
         parseError: { _, _ in CloudHEADResponseError() }
     )
 
-    public func existsResource(hash: String) throws -> HTTPResource<CloudResponse<CloudHEADResponse>, CloudHEADResponseError> {
+    public func existsResource(name: String, hash: String) throws -> HTTPResource<CloudResponse<CloudHEADResponse>, CloudHEADResponseError> {
         invokedExistsResource = true
         invokedExistsResourceCount += 1
-        invokedExistsResourceParameters = (hash, ())
-        invokedExistsResourceParametersList.append((hash, ()))
+        invokedExistsResourceParameters = (name, hash, ())
+        invokedExistsResourceParametersList.append((name, hash, ()))
         if let error = stubbedExistsResourceError {
             throw error
         }
@@ -34,8 +34,8 @@ public class MockCloudCacheResourceFactory: CloudCacheResourceFactorying {
 
     public var invokedFetchResource = false
     public var invokedFetchResourceCount = 0
-    public var invokedFetchResourceParameters: (hash: String, Void)?
-    public var invokedFetchResourceParametersList = [(hash: String, Void)]()
+    public var invokedFetchResourceParameters: (name: String, hash: String, Void)?
+    public var invokedFetchResourceParametersList = [(name: String, hash: String, Void)]()
     public var stubbedFetchResourceError: Error?
     public var stubbedFetchResourceResult: CloudCacheResource = HTTPResource(
         request: { URLRequest.test() },
@@ -43,11 +43,11 @@ public class MockCloudCacheResourceFactory: CloudCacheResourceFactorying {
         parseError: { _, _ in CloudResponseError.test() }
     )
 
-    public func fetchResource(hash: String) throws -> CloudCacheResource {
+    public func fetchResource(name: String, hash: String) throws -> CloudCacheResource {
         invokedFetchResource = true
         invokedFetchResourceCount += 1
-        invokedFetchResourceParameters = (hash, ())
-        invokedFetchResourceParametersList.append((hash, ()))
+        invokedFetchResourceParameters = (name, hash, ())
+        invokedFetchResourceParametersList.append((name, hash, ()))
         if let error = stubbedFetchResourceError {
             throw error
         }
@@ -56,8 +56,8 @@ public class MockCloudCacheResourceFactory: CloudCacheResourceFactorying {
 
     public var invokedStoreResource = false
     public var invokedStoreResourceCount = 0
-    public var invokedStoreResourceParameters: (hash: String, contentMD5: String)?
-    public var invokedStoreResourceParametersList = [(hash: String, contentMD5: String)]()
+    public var invokedStoreResourceParameters: (name: String, hash: String, contentMD5: String)?
+    public var invokedStoreResourceParametersList = [(name: String, hash: String, contentMD5: String)]()
     public var stubbedStoreResourceError: Error?
     public var stubbedStoreResourceResult: CloudCacheResource = HTTPResource(
         request: { URLRequest.test() },
@@ -65,11 +65,11 @@ public class MockCloudCacheResourceFactory: CloudCacheResourceFactorying {
         parseError: { _, _ in CloudResponseError.test() }
     )
 
-    public func storeResource(hash: String, contentMD5: String) throws -> CloudCacheResource {
+    public func storeResource(name: String, hash: String, contentMD5: String) throws -> CloudCacheResource {
         invokedStoreResource = true
         invokedStoreResourceCount += 1
-        invokedStoreResourceParameters = (hash, contentMD5)
-        invokedStoreResourceParametersList.append((hash, contentMD5))
+        invokedStoreResourceParameters = (name, hash, contentMD5)
+        invokedStoreResourceParametersList.append((name, hash, contentMD5))
         if let error = stubbedStoreResourceError {
             throw error
         }
@@ -78,8 +78,9 @@ public class MockCloudCacheResourceFactory: CloudCacheResourceFactorying {
 
     public var invokedVerifyUploadResource = false
     public var invokedVerifyUploadResourceCount = 0
-    public var invokedVerifyUploadResourceParameters: (hash: String, contentMD5: String)?
-    public var invokedVerifyUploadResourceParametersList = [(hash: String, contentMD5: String)]() // swiftlint:disable:this identifier_name
+    public var invokedVerifyUploadResourceParameters: (name: String, hash: String, contentMD5: String)?
+    // swiftlint:disable:next identifier_name
+    public var invokedVerifyUploadResourceParametersList = [(name: String, hash: String, contentMD5: String)]()
     public var stubbedVerifyUploadResourceError: Error?
     public var stubbedVerifyUploadResourceResult: CloudVerifyUploadResource = HTTPResource(
         request: { URLRequest.test() },
@@ -87,11 +88,11 @@ public class MockCloudCacheResourceFactory: CloudCacheResourceFactorying {
         parseError: { _, _ in CloudResponseError.test() }
     )
 
-    public func verifyUploadResource(hash: String, contentMD5: String) throws -> CloudVerifyUploadResource {
+    public func verifyUploadResource(name: String, hash: String, contentMD5: String) throws -> CloudVerifyUploadResource {
         invokedVerifyUploadResource = true
         invokedVerifyUploadResourceCount += 1
-        invokedVerifyUploadResourceParameters = (hash, contentMD5)
-        invokedVerifyUploadResourceParametersList.append((hash, contentMD5))
+        invokedVerifyUploadResourceParameters = (name, hash, contentMD5)
+        invokedVerifyUploadResourceParametersList.append((name, hash, contentMD5))
         if let error = stubbedVerifyUploadResourceError {
             throw error
         }

--- a/Sources/TuistCloud/Client/CloudClient.swift
+++ b/Sources/TuistCloud/Client/CloudClient.swift
@@ -10,7 +10,7 @@ public class CloudClient: CloudClienting {
 
     // Use session without redirect to prevent redirects to be wrongly interpreted as successful responses.
     // For example, the `CacheRemoteStorage.exists` method would return true if the request is not authenticated and redirect is allowed.
-    private var noRedirectDelegate: NoRedirectDelegate?
+    private var noRedirectDelegate: NoRedirectDelegate? // swiftlint:disable:this weak_delegate
     lazy var requestDispatcher: HTTPRequestDispatching = {
         noRedirectDelegate = NoRedirectDelegate()
         return HTTPRequestDispatcher(session: URLSession(configuration: .default, delegate: noRedirectDelegate, delegateQueue: nil))
@@ -18,8 +18,7 @@ public class CloudClient: CloudClienting {
 
     // MARK: - Init
 
-    public init(cloudHTTPRequestAuthenticator: CloudHTTPRequestAuthenticating = CloudHTTPRequestAuthenticator())
-    {
+    public init(cloudHTTPRequestAuthenticator: CloudHTTPRequestAuthenticating = CloudHTTPRequestAuthenticator()) {
         self.cloudHTTPRequestAuthenticator = cloudHTTPRequestAuthenticator
     }
 

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -634,7 +634,7 @@ extension ProjectDescription.Settings {
         ]
 
         if let moduleMapPath = moduleMap.path {
-          settingsDictionary["MODULEMAP_FILE"] = .string("$(SRCROOT)/\(moduleMapPath.relative(to: packageFolder))")
+            settingsDictionary["MODULEMAP_FILE"] = .string("$(SRCROOT)/\(moduleMapPath.relative(to: packageFolder))")
         }
 
         if !headerSearchPaths.isEmpty {
@@ -906,11 +906,10 @@ extension PackageInfoMapper {
             product: String,
             packageInfos: [String: PackageInfo]
         ) throws -> Self {
-            guard
-                let targets = packageInfos[package]?.products.first(where: { $0.name == product })?.targets.map(PackageInfoMapper.sanitize(targetName:))
-            else {
+            guard let product = packageInfos[package]?.products.first(where: { $0.name == product }) else {
                 throw PackageInfoMapperError.unknownProductDependency(product, package)
             }
+            let targets = product.targets.map(PackageInfoMapper.sanitize(targetName:))
             return .externalTargets(package: package, targets: targets)
         }
     }

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -906,10 +906,10 @@ extension PackageInfoMapper {
             product: String,
             packageInfos: [String: PackageInfo]
         ) throws -> Self {
-            guard let product = packageInfos[package]?.products.first(where: { $0.name == product }) else {
+            guard let packageProduct = packageInfos[package]?.products.first(where: { $0.name == product }) else {
                 throw PackageInfoMapperError.unknownProductDependency(product, package)
             }
-            let targets = product.targets.map(PackageInfoMapper.sanitize(targetName:))
+            let targets = packageProduct.targets.map(PackageInfoMapper.sanitize(targetName:))
             return .externalTargets(package: package, targets: targets)
         }
     }

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -220,7 +220,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
                     "COMPILER_FLAGS": compilerFlags,
                 ]
             }
-            
+
             /// Source file ATTRIBUTES
             /// example: `settings = {ATTRIBUTES = (codegen, )`}
             if let codegen = buildFile.codeGen {

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -230,7 +230,7 @@ class TargetLinter: TargetLinting {
             .init(reason: "Target '\(target.name)' has duplicate \($0.element.key.typeName) dependency specified: '\($0.element.key.name)'", severity: .warning)
         }
     }
-    
+
     private func lintValidSourceFileCodeGenAttributes(target: Target) -> [LintingIssue] {
         let knownSupportedExtensions = [
             "intentdefinition",

--- a/Sources/TuistGraph/Models/SourceFile.swift
+++ b/Sources/TuistGraph/Models/SourceFile.swift
@@ -14,14 +14,15 @@ public struct SourceFile: ExpressibleByStringLiteral, Equatable, Codable {
     /// This is intended to be used by the mappers that generate files through side effects.
     /// This attribute is used by the content hasher used by the caching functionality.
     public var contentHash: String?
-    
+
     /// Source file code generation attribute
     public let codeGen: FileCodeGen?
 
     public init(path: AbsolutePath,
                 compilerFlags: String? = nil,
                 contentHash: String? = nil,
-                codeGen: FileCodeGen? = nil) {
+                codeGen: FileCodeGen? = nil)
+    {
         self.path = path
         self.compilerFlags = compilerFlags
         self.contentHash = contentHash

--- a/Sources/TuistKit/Cache/CacheController.swift
+++ b/Sources/TuistKit/Cache/CacheController.swift
@@ -221,6 +221,7 @@ final class CacheController: CacheControlling {
 
                 let productNameWithExtension = target.target.productName
                 _ = try cache.store(
+                    name: target.target.name,
                     hash: hash,
                     paths: FileHandler.shared.glob(outputDirectory.appending(component: suffix), glob: "\(productNameWithExtension).*")
                 ).toBlocking().last()
@@ -257,7 +258,7 @@ final class CacheController: CacheControlling {
             guard
                 let hash = hashesByCacheableTarget[target],
                 // if cache already exists, no need to build
-                try !self.cache.exists(hash: hash).toBlocking().single()
+                try !self.cache.exists(name: target.target.name, hash: hash).toBlocking().single()
             else {
                 return nil
             }

--- a/Sources/TuistLoader/Models+ManifestMappers/FileCodeGen+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/FileCodeGen+ManifestMapper.swift
@@ -6,7 +6,7 @@ import TuistGraph
 import TuistSupport
 
 extension TuistGraph.FileCodeGen {
-    static func from(manifest: ProjectDescription.FileCodeGen) -> TuistGraph.FileCodeGen {                
+    static func from(manifest: ProjectDescription.FileCodeGen) -> TuistGraph.FileCodeGen {
         switch manifest {
         case .public:
             return .public

--- a/Tests/ProjectDescriptionTests/TargetTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetTests.swift
@@ -61,7 +61,7 @@ final class TargetTests: XCTestCase {
                 SourceFileGlob("Intents/Public.intentdefinition", codeGen: .public),
                 SourceFileGlob("Intents/Private.intentdefinition", codeGen: .private),
                 SourceFileGlob("Intents/Project.intentdefinition", codeGen: .project),
-                SourceFileGlob("Intents/Disabled.intentdefinition", codeGen: .disabled)
+                SourceFileGlob("Intents/Disabled.intentdefinition", codeGen: .disabled),
             ]),
             resources: ["resources/*",
                         .glob(pattern: "file.type", tags: ["tag"]),

--- a/Tests/TuistCacheIntegrationTests/Cache/CacheLocalStorageIntegrationTests.swift
+++ b/Tests/TuistCacheIntegrationTests/Cache/CacheLocalStorageIntegrationTests.swift
@@ -32,7 +32,7 @@ final class CacheLocalStorageIntegrationTests: TuistTestCase {
         try FileHandler.shared.createFolder(xcframeworkPath)
 
         // When
-        let got = try subject.exists(hash: hash).toBlocking().first()
+        let got = try subject.exists(name: "ignored", hash: hash).toBlocking().first()
 
         // Then
         XCTAssertTrue(got == true)
@@ -42,7 +42,7 @@ final class CacheLocalStorageIntegrationTests: TuistTestCase {
         // When
         let hash = "abcde"
 
-        let got = try subject.exists(hash: hash).toBlocking().first()
+        let got = try subject.exists(name: "ignored", hash: hash).toBlocking().first()
 
         // Then
         XCTAssertTrue(got == false)
@@ -58,7 +58,7 @@ final class CacheLocalStorageIntegrationTests: TuistTestCase {
         try FileHandler.shared.createFolder(xcframeworkPath)
 
         // When
-        let got = try subject.fetch(hash: hash).toBlocking().first()
+        let got = try subject.fetch(name: "ignored", hash: hash).toBlocking().first()
 
         // Then
         XCTAssertTrue(got == xcframeworkPath)
@@ -68,7 +68,7 @@ final class CacheLocalStorageIntegrationTests: TuistTestCase {
         let hash = "abcde"
 
         XCTAssertThrowsSpecific(
-            try subject.fetch(hash: hash).toBlocking().first(),
+            try subject.fetch(name: "ignored", hash: hash).toBlocking().first(),
             CacheLocalStorageError.compiledArtifactNotFound(hash: hash)
         )
     }
@@ -81,7 +81,7 @@ final class CacheLocalStorageIntegrationTests: TuistTestCase {
         try FileHandler.shared.createFolder(xcframeworkPath)
 
         // When
-        _ = try subject.store(hash: hash, paths: [xcframeworkPath]).toBlocking().first()
+        _ = try subject.store(name: "ignored", hash: hash, paths: [xcframeworkPath]).toBlocking().first()
 
         // Then
         XCTAssertTrue(FileHandler.shared.exists(cacheDirectory.appending(RelativePath("\(hash)/framework.xcframework"))))

--- a/Tests/TuistCacheIntegrationTests/ContentHashing/ContentHashingIntegrationTests.swift
+++ b/Tests/TuistCacheIntegrationTests/ContentHashing/ContentHashingIntegrationTests.swift
@@ -148,8 +148,8 @@ final class ContentHashingIntegrationTests: TuistUnitTestCase {
         let contentHash = try subject.contentHashes(for: graph, cacheProfile: cacheProfile, cacheOutputType: .framework, excludedTargets: [])
 
         // Then
-        XCTAssertEqual(contentHash[framework1], "f9cfe0d4d9bff3de27aa95e2ee76de45")
-        XCTAssertEqual(contentHash[framework2], "b45fb54122d06bc991c1919517d77be3")
+        XCTAssertEqual(contentHash[framework1], "a7dc3ed1c35e5f08a69d93b07c979ffe")
+        XCTAssertEqual(contentHash[framework2], "324b4e4ec028fa01d1abc88098f3b064")
     }
 
     func test_contentHashes_hashChangesWithCacheOutputType() throws {

--- a/Tests/TuistCacheTests/Cache/CacheGraphContentHasherTests.swift
+++ b/Tests/TuistCacheTests/Cache/CacheGraphContentHasherTests.swift
@@ -20,7 +20,7 @@ final class CacheGraphContentHasherTests: TuistUnitTestCase {
         graphContentHasher = MockGraphContentHasher()
         contentHasher = MockContentHasher()
         system.swiftVersionStub = {
-            return "5.4.2"
+            "5.4.2"
         }
         subject = CacheGraphContentHasher(
             graphContentHasher: graphContentHasher,

--- a/Tests/TuistCacheTests/Cache/CacheGraphContentHasherTests.swift
+++ b/Tests/TuistCacheTests/Cache/CacheGraphContentHasherTests.swift
@@ -19,6 +19,9 @@ final class CacheGraphContentHasherTests: TuistUnitTestCase {
 
         graphContentHasher = MockGraphContentHasher()
         contentHasher = MockContentHasher()
+        system.swiftVersionStub = {
+            return "5.4.2"
+        }
         subject = CacheGraphContentHasher(
             graphContentHasher: graphContentHasher,
             cacheProfileContentHasher: CacheProfileContentHasher(contentHasher: contentHasher),

--- a/Tests/TuistCacheTests/Cache/CacheRemoteStorageTests.swift
+++ b/Tests/TuistCacheTests/Cache/CacheRemoteStorageTests.swift
@@ -72,7 +72,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         cloudClient.mock(error: CloudHEADResponseError())
 
         // When
-        let result = subject.exists(hash: "acho tio")
+        let result = subject.exists(name: "targetName", hash: "acho tio")
             .toBlocking()
             .materialize()
 
@@ -94,7 +94,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         cloudClient.mock(object: cloudResponse, response: httpResponse)
 
         // When
-        let result = try subject.exists(hash: "acho tio")
+        let result = try subject.exists(name: "targetName", hash: "acho tio")
             .toBlocking()
             .single()
 
@@ -109,7 +109,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         cloudClient.mock(object: cloudResponse, response: httpResponse)
 
         // When
-        let result = try subject.exists(hash: "acho tio")
+        let result = try subject.exists(name: "targetName", hash: "acho tio")
             .toBlocking()
             .single()
 
@@ -124,7 +124,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         cloudClient.mock(object: cloudResponse, response: httpResponse)
 
         // When
-        let result = try subject.exists(hash: "acho tio")
+        let result = try subject.exists(name: "targetName", hash: "acho tio")
             .toBlocking()
             .single()
 
@@ -140,7 +140,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         cloudClient.mock(error: expectedError)
 
         // When
-        let result = subject.fetch(hash: "acho tio")
+        let result = subject.fetch(name: "targetName", hash: "acho tio")
             .toBlocking()
             .materialize()
 
@@ -167,7 +167,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         fileUnarchiver.stubbedUnzipResult = paths.first
 
         // When
-        let result = subject.fetch(hash: hash)
+        let result = subject.fetch(name: "targetName", hash: hash)
             .toBlocking()
             .materialize()
 
@@ -194,7 +194,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         fileUnarchiver.stubbedUnzipResult = paths.first?.parentDirectory
 
         // When
-        let result = try subject.fetch(hash: hash)
+        let result = try subject.fetch(name: "targetName", hash: hash)
             .toBlocking()
             .single()
 
@@ -216,7 +216,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         fileUnarchiver.stubbedUnzipResult = paths.first!.parentDirectory
 
         // When
-        _ = try subject.fetch(hash: hash)
+        _ = try subject.fetch(name: "targetName", hash: hash)
             .toBlocking()
             .single()
 
@@ -237,7 +237,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         let hash = "foo_bar"
 
         // When
-        _ = try subject.fetch(hash: hash)
+        _ = try subject.fetch(name: "targetName", hash: hash)
             .toBlocking()
             .single()
 
@@ -253,7 +253,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         cloudClient.mock(error: expectedError)
 
         // When
-        let result = subject.store(hash: "acho tio", paths: [.root])
+        let result = subject.store(name: "targetName", hash: "acho tio", paths: [.root])
             .toBlocking()
             .materialize()
 
@@ -273,7 +273,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         configureCloudClientForSuccessfulUpload()
 
         // When
-        _ = subject.store(hash: "foo_bar", paths: [.root])
+        _ = subject.store(name: "targetName", hash: "foo_bar", paths: [.root])
             .toBlocking()
             .materialize()
 
@@ -291,7 +291,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         configureCloudClientForSuccessfulUpload()
 
         // When
-        _ = subject.store(hash: hash, paths: [.root])
+        _ = subject.store(name: "targetName", hash: hash, paths: [.root])
             .toBlocking()
             .materialize()
 
@@ -310,7 +310,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         fileArchiver.stubbedZipResult = zipPath
 
         // When
-        _ = subject.store(hash: hash, paths: [.root])
+        _ = subject.store(name: "targetName", hash: hash, paths: [.root])
             .toBlocking()
             .materialize()
 
@@ -328,7 +328,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         cloudClient.mock(error: expectedError)
 
         // When
-        _ = subject.store(hash: "acho tio", paths: [.root])
+        _ = subject.store(name: "targetName", hash: "acho tio", paths: [.root])
             .toBlocking()
             .materialize()
 
@@ -342,7 +342,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         fileClient.stubbedUploadResult = Single.error(TestError("Error uploading file"))
 
         // When
-        _ = subject.store(hash: "acho tio", paths: [.root])
+        _ = subject.store(name: "targetName", hash: "acho tio", paths: [.root])
             .toBlocking()
             .materialize()
 
@@ -356,7 +356,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         fileClient.stubbedUploadResult = Single.error(TestError("Error uploading file"))
 
         // When
-        _ = subject.store(hash: "acho tio", paths: [.root])
+        _ = subject.store(name: "targetName", hash: "acho tio", paths: [.root])
             .toBlocking()
             .materialize()
 
@@ -369,7 +369,7 @@ final class CacheRemoteStorageTests: TuistUnitTestCase {
         configureCloudClientForSuccessfulUploadAndFailedVerify()
 
         // When
-        _ = subject.store(hash: "verify fails hash", paths: [.root])
+        _ = subject.store(name: "targetName", hash: "verify fails hash", paths: [.root])
             .toBlocking()
             .materialize()
 

--- a/Tests/TuistCacheTests/Cache/CacheTests.swift
+++ b/Tests/TuistCacheTests/Cache/CacheTests.swift
@@ -30,76 +30,86 @@ final class CacheTests: TuistUnitTestCase {
     }
 
     func test_exists_when_in_first_cache_does_not_check_second_and_returns_true() {
-        firstCache.existsStub = { hash in
+        firstCache.existsStub = { name, hash in
+            XCTAssertEqual(name, "targetName")
             XCTAssertEqual(hash, "1234")
             return true
         }
-        secondCache.existsStub = { _ in
+        secondCache.existsStub = { _, _ in
             XCTFail("Second cache should not be checked if first hits")
             return false
         }
-        XCTAssertTrue(try subject.exists(hash: "1234").toBlocking().single())
+        XCTAssertTrue(try subject.exists(name: "targetName", hash: "1234").toBlocking().single())
     }
 
     func test_exists_when_in_second_cache_checks_both_and_returns_true() {
-        firstCache.existsStub = { hash in
+        firstCache.existsStub = { name, hash in
+            XCTAssertEqual(name, "targetName")
             XCTAssertEqual(hash, "1234")
             return false
         }
-        secondCache.existsStub = { hash in
+        secondCache.existsStub = { name, hash in
+            XCTAssertEqual(name, "targetName")
             XCTAssertEqual(hash, "1234")
             return true
         }
-        XCTAssertTrue(try subject.exists(hash: "1234").toBlocking().single())
+        XCTAssertTrue(try subject.exists(name: "targetName", hash: "1234").toBlocking().single())
     }
 
     func test_exists_when_not_in_cache_checks_both_and_returns_false() {
-        firstCache.existsStub = { hash in
+        firstCache.existsStub = { name, hash in
+            XCTAssertEqual(name, "targetName")
             XCTAssertEqual(hash, "1234")
             return false
         }
-        secondCache.existsStub = { hash in
+        secondCache.existsStub = { name, hash in
+            XCTAssertEqual(name, "targetName")
             XCTAssertEqual(hash, "1234")
             return false
         }
-        XCTAssertFalse(try subject.exists(hash: "1234").toBlocking().single())
+        XCTAssertFalse(try subject.exists(name: "targetName", hash: "1234").toBlocking().single())
     }
 
     func test_fetch_when_in_first_cache_does_not_check_second_and_returns_path() {
-        firstCache.fetchStub = { hash in
+        firstCache.fetchStub = { name, hash in
+            XCTAssertEqual(name, "targetName")
             XCTAssertEqual(hash, "1234")
             return "/Absolute/Path"
         }
-        secondCache.fetchStub = { _ in
+        secondCache.fetchStub = { _, _ in
             XCTFail("Second cache should not be checked if first hits")
             throw TestError("")
         }
-        XCTAssertEqual(try subject.fetch(hash: "1234").toBlocking().single(), "/Absolute/Path")
+        XCTAssertEqual(try subject.fetch(name: "targetName", hash: "1234").toBlocking().single(), "/Absolute/Path")
     }
 
     func test_fetch_when_in_second_cache_checks_both_and_returns_path() {
-        firstCache.fetchStub = { hash in
+        firstCache.fetchStub = { name, hash in
+            XCTAssertEqual(name, "targetName")
             XCTAssertEqual(hash, "1234")
             throw TestError("")
         }
-        secondCache.fetchStub = { hash in
+        secondCache.fetchStub = { name, hash in
+            XCTAssertEqual(name, "targetName")
             XCTAssertEqual(hash, "1234")
             return "/Absolute/Path"
         }
-        XCTAssertEqual(try subject.fetch(hash: "1234").toBlocking().single(), "/Absolute/Path")
+        XCTAssertEqual(try subject.fetch(name: "targetName", hash: "1234").toBlocking().single(), "/Absolute/Path")
     }
 
     func test_fetch_when_not_in_cache_checks_both_and_throws() {
-        firstCache.fetchStub = { hash in
+        firstCache.fetchStub = { name, hash in
+            XCTAssertEqual(name, "targetName")
             XCTAssertEqual(hash, "1234")
             throw TestError("")
         }
-        secondCache.fetchStub = { hash in
+        secondCache.fetchStub = { name, hash in
+            XCTAssertEqual(name, "targetName")
             XCTAssertEqual(hash, "1234")
             throw TestError("")
         }
         XCTAssertThrowsSpecific(
-            try subject.fetch(hash: "1234").toBlocking().single(),
+            try subject.fetch(name: "targetName", hash: "1234").toBlocking().single(),
             TestError("")
         )
     }

--- a/Tests/TuistCacheTests/GraphMappers/CacheMapperTests.swift
+++ b/Tests/TuistCacheTests/GraphMappers/CacheMapperTests.swift
@@ -123,16 +123,31 @@ final class CacheMapperTests: TuistUnitTestCase {
             contentHashes
         }
 
-        cache.existsStub = { hash in
-            if hash == bHash { return true }
-            if hash == cHash { return true }
-            return false
+        cache.existsStub = { name, hash in
+            switch hash {
+            case bHash:
+                XCTAssertEqual(name, "B")
+                return true
+            case cHash:
+                XCTAssertEqual(name, "C")
+                return true
+            default:
+                return false
+            }
         }
 
-        cache.fetchStub = { hash in
-            if hash == bHash { return bXCFrameworkPath }
-            if hash == cHash { return cXCFrameworkPath }
-            else { fatalError("unexpected call to fetch") }
+        cache.fetchStub = { name, hash in
+            switch hash {
+            case bHash:
+                XCTAssertEqual(name, "B")
+                return bXCFrameworkPath
+            case cHash:
+                XCTAssertEqual(name, "C")
+                return cXCFrameworkPath
+            default:
+                XCTFail("Unexpected call to fetch")
+                return "/"
+            }
         }
         cacheGraphMutator.stubbedMapResult = outputGraph
 
@@ -192,16 +207,31 @@ final class CacheMapperTests: TuistUnitTestCase {
             contentHashes
         }
 
-        cache.existsStub = { hash in
-            if hash == bHash { return true }
-            if hash == cHash { return true }
-            return false
+        cache.existsStub = { name, hash in
+            switch hash {
+            case bHash:
+                XCTAssertEqual(name, "B")
+                return true
+            case cHash:
+                XCTAssertEqual(name, "C")
+                return true
+            default:
+                return false
+            }
         }
 
-        cache.fetchStub = { hash in
-            if hash == bHash { return bXCFrameworkPath }
-            if hash == cHash { throw error }
-            else { fatalError("unexpected call to fetch") }
+        cache.fetchStub = { name, hash in
+            switch hash {
+            case bHash:
+                XCTAssertEqual(name, "B")
+                return bXCFrameworkPath
+            case cHash:
+                XCTAssertEqual(name, "C")
+                throw error
+            default:
+                XCTFail("Unexpected call to fetch")
+                return "/"
+            }
         }
         cacheGraphMutator.stubbedMapResult = outputGraph
 

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -77,7 +77,7 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
             "file3.swift",
             "file4.swift",
             "file5.swift",
-            "file6.swift"
+            "file6.swift",
         ])
 
         let buildFilesSettings = buildFiles.map {
@@ -86,10 +86,9 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
 
         XCTAssertEqual(buildFilesSettings, [
             ["COMPILER_FLAGS": "flag"],
-            nil, nil, nil, nil, nil
+            nil, nil, nil, nil, nil,
         ])
-        
-        
+
         let fileCodegenSettings = buildFiles.map {
             $0.settings as? [String: [String]]
         }
@@ -99,7 +98,7 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
             ["ATTRIBUTES": ["codegen"]],
             ["ATTRIBUTES": ["private_codegen"]],
             ["ATTRIBUTES": ["project_codegen"]],
-            ["ATTRIBUTES": ["no_codegen"]]
+            ["ATTRIBUTES": ["no_codegen"]],
         ])
     }
 

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -305,7 +305,7 @@ final class TargetLinterTests: TuistUnitTestCase {
             severity: .error
         ))
     }
-    
+
     func test_lint_when_target_has_valid_codegen_sources() throws {
         // Given
         let target = Target.empty(

--- a/Tests/TuistKitTests/Cache/CacheControllerTests.swift
+++ b/Tests/TuistKitTests/Cache/CacheControllerTests.swift
@@ -194,7 +194,7 @@ final class CacheControllerTests: TuistUnitTestCase {
         artifactBuilder.stubbedCacheOutputType = .xcframework
 
         let remoteCacheError = TestError("remote cache error")
-        cache.existsStub = { _ in throw remoteCacheError }
+        cache.existsStub = { _, _ in throw remoteCacheError }
         // When / Then
         XCTAssertThrowsSpecific(
             try subject.cache(path: path, cacheProfile: .test(configuration: "Debug"), includedTargets: [], dependenciesOnly: false),
@@ -239,7 +239,7 @@ final class CacheControllerTests: TuistUnitTestCase {
             ]
         )
 
-        cache.existsStub = { _ in
+        cache.existsStub = { _, _ in
             true
         }
         manifestLoader.manifestsAtStub = { _ in


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/discussions/3514

### Short description 📝

Add `name` parameter to remote cache API calls to provide more insights to the backend

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
