### PR TITLE
[2.0] Fix for missing the `coverage` test data property

### DIFF
--- a/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
+++ b/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
@@ -142,7 +142,7 @@ extension TestAction {
     public static func test(targets: [TestableTarget] = [],
                             arguments: Arguments? = nil,
                             configuration: ConfigurationName = .debug,
-                            coverage _: Bool = true) -> TestAction
+                            coverage: Bool = true) -> TestAction
     {
         TestAction.targets(
             targets,
@@ -150,7 +150,7 @@ extension TestAction {
             configuration: configuration,
             preActions: [ExecutionAction.test()],
             postActions: [ExecutionAction.test()],
-            options: .options(coverage: true)
+            options: .options(coverage: coverage)
         )
     }
 }


### PR DESCRIPTION
### Short description 📝

- During some of the 2.0 changes to schemes we accidentally stopped propagating the `coverage` flag
- This didn't impact any production functionality as it was within an unused test utility

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- ~The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.~
- ~In case the PR introduces changes that affect users, the documentation has been updated.~
