### PR TITLE
Update `Package.resolved` to point to newest fortmarek/SwiftGen commit

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -213,7 +213,7 @@
         "repositoryURL": "https://github.com/fortmarek/SwiftGen",
         "state": {
           "branch": "stable",
-          "revision": "5514d331d8ff1273b5c88747d646edcb63e13d69",
+          "revision": "4b365316b079c2aeb38396f3294739e7deeee3a5",
           "version": null
         }
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Changed
+
+- Update SwiftGen to support generating custom SF Symbols (a.k.a. `symbolset`). [#3521](https://github.com/tuist/tuist/pull/3521) by [@hisaac](https://github.com/hisaac)
+
 ### 1.51.1
 
 ### Added

--- a/Package.resolved
+++ b/Package.resolved
@@ -213,7 +213,7 @@
         "repositoryURL": "https://github.com/fortmarek/SwiftGen",
         "state": {
           "branch": "stable",
-          "revision": "5514d331d8ff1273b5c88747d646edcb63e13d69",
+          "revision": "4b365316b079c2aeb38396f3294739e7deeee3a5",
           "version": null
         }
       },


### PR DESCRIPTION
### Short description 📝

We recently updated @fortmarek's fork of SwiftGen to include changes that add support for custom SF Symbols (aka `symbolset`s) (https://github.com/fortmarek/SwiftGen/pull/1). We need to point the `Package.resolved` file to that newest commit in order for the next release of Tuist to include those changes.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] ~~In case the PR introduces changes that affect users, the documentation has been updated.~~