### PR TITLE
fix: fix SwiftPackageManager local xcframework mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- Fix SwiftPackageManager local xcframework mapping [#3533](https://github.com/tuist/tuist/pull/3533) by [@danyf90](https://github.com/danyf90)
+
 ## 2.0.1 - Tarifa
 
 ### Fixed

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -131,11 +131,11 @@ public final class PackageInfoMapper: PackageInfoMapping {
     ) {
         let targetDependencyToFramework: [String: Path] = packageInfos.reduce(into: [:]) { result, packageInfo in
             let artifactsFolderForPackage = artifactsFolder.appending(component: packageInfo.key)
-            packageInfos[packageInfo.key]?.targets.forEach { target in
+            packageInfo.value.targets.forEach { target in
                 guard target.type == .binary else { return }
                 if let path = target.path {
                     // local binary
-                    result[target.name] = Path(RelativePath(path).pathString)
+                    result[target.name] = Path(packageToFolder[packageInfo.key]!.appending(RelativePath(path)).pathString)
                 } else {
                     // remote binaries are checked out by SPM in artifacts/<Package>/<Target>.xcframework
                     result[target.name] = Path(artifactsFolderForPackage.appending(component: "\(target.name).xcframework").pathString)

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -1494,7 +1494,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             .test(
                 name: "Package",
                 targets: [
-                    .test("Target1", dependencies: [.xcframework(path: "Dependency1/Dependency1.xcframework")]),
+                    .test("Target1", dependencies: [.xcframework(path: "/Package/Dependency1/Dependency1.xcframework")]),
                 ]
             )
         )


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3484

### Short description 📝

package path was missing in local framework path

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
