### PR TITLE
fix: meta tuist project description

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -540,9 +540,11 @@ let project = Project(
         )
     ],
     packages: packages,
-    settings: Settings(configurations: [
-        .debug(name: "Debug", settings: debugSettings(), xcconfig: nil),
-        .release(name: "Release", settings: releaseSettings(), xcconfig: nil),
-    ]),
+    settings: .settings(
+        configurations: [
+            .debug(name: "Debug", settings: debugSettings(), xcconfig: nil),
+            .release(name: "Release", settings: releaseSettings(), xcconfig: nil),
+        ]
+    ),
     targets: targets()
 )

--- a/Tuist/ProjectDescriptionHelpers/Target+Helpers.swift
+++ b/Tuist/ProjectDescriptionHelpers/Target+Helpers.swift
@@ -27,7 +27,7 @@ extension Target {
             infoPlist: .default,
             sources: ["\(rootFolder)/\(name)/**/*.swift"],
             dependencies: dependencies,
-            settings: Settings(
+            settings: .settings(
                 configurations: [
                     .debug(name: "Debug", settings: [:], xcconfig: nil),
                     .release(name: "Release", settings: [:], xcconfig: nil),


### PR DESCRIPTION
### Short description 📝

You'll get errors currently when you run `./fourier generate tuist` due to some changes in `ProjectDescription`. I am not sure why this was not caught in some of the acceptance tests, I'm presuming due to caching? I have not investigated this thoroughly.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
