### PR TITLE
Fix broken link in get-started.md

### DIFF
--- a/projects/docs/docs/tutorial/get-started.md
+++ b/projects/docs/docs/tutorial/get-started.md
@@ -81,7 +81,7 @@ let project = Project(
 )
 ```
 
-Since we are defining an Xcode project, most of the properties might be familiar to you. There are some that are available which are not used from the manifest that you've got generated. You can [check out](../manifests/project) the project reference to see all the public models that are available in the `ProjectDescription` framework.
+Since we are defining an Xcode project, most of the properties might be familiar to you. There are some that are available which are not used from the manifest that you've got generated. You can [check out](../manifests/project.md) the project reference to see all the public models that are available in the `ProjectDescription` framework.
 
 ### Generating project
 

--- a/projects/docs/versioned_docs/version-1/tutorial/get-started.md
+++ b/projects/docs/versioned_docs/version-1/tutorial/get-started.md
@@ -81,7 +81,7 @@ let project = Project(
 )
 ```
 
-Since we are defining an Xcode project, most of the properties might be familiar to you. There are some that are available which are not used from the manifest that you've got generated. You can [check out](../manifests/project) the project reference to see all the public models that are available in the `ProjectDescription` framework.
+Since we are defining an Xcode project, most of the properties might be familiar to you. There are some that are available which are not used from the manifest that you've got generated. You can [check out](../manifests/project.md) the project reference to see all the public models that are available in the `ProjectDescription` framework.
 
 ### Generating project
 


### PR DESCRIPTION
### Short description 📝

Hi, I'm going through the tutorial and noticed that there's a broken link. I'm assuming it's supposed to link to the `Manifest Reference` doc.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
