### PR TITLE
📦 [SPM] Add `LastUpgradeCheck` to SwiftPackageManager generated projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,18 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
-### Fixed
-
-- Fix `tuist generate` performance regression [#3562](https://github.com/tuist/tuist/pull/3562) by [@adellibovi](https://github.com/adellibovi)
-
 ### Added
 
 - Perform remote cache download and upload concurrently [#3549](https://github.com/tuist/tuist/pull/3549) by [@danyf90](https://github.com/danyf90)
 - Add optional `manifest` argument to `tuist dump` command, to allow to dump other kinds of manifests [#3551](https://github.com/tuist/tuist/pull/3551) by [@danyf90](https://github.com/danyf90)
-- Xcode LastUpgradeCheck [#3561](https://github.com/tuist/tuist/pull/3561) by [@mollyIV](https://github.com/mollyIV).
+- Add support for configuring the `LastUpgradeCheck` of the `Xcode` project [#3561](https://github.com/tuist/tuist/pull/3561) by [@mollyIV](https://github.com/mollyIV)
+- Add arbitrarily high `LastUpgradeCheck` to SwiftPackageManager generated projects to disable warnings [#3569](https://github.com/tuist/tuist/pull/3569) by [@danyf90](https://github.com/danyf90)
 
 ### Fixed
 
 - Fix Swift Package Manager default resource handling [#3295](https://github.com/tuist/tuist/pull/3295) by [@mstfy](https://github.com/mstfy)
 - If present, use coloured output configuration from environment even if it's false [#3550](https://github.com/tuist/tuist/pull/3550) by [@danyf90](https://github.com/danyf90)
+- Fix `tuist generate` performance regression [#3562](https://github.com/tuist/tuist/pull/3562) by [@adellibovi](https://github.com/adellibovi)
 
 ## 2.0.2 - Wald
 

--- a/Sources/TuistLoader/Loaders/ManifestModelConverter.swift
+++ b/Sources/TuistLoader/Loaders/ManifestModelConverter.swift
@@ -1,6 +1,7 @@
 import Foundation
 import ProjectDescription
 import TSCBasic
+import TSCUtility
 import TuistCore
 import TuistGraph
 import TuistSupport
@@ -88,21 +89,19 @@ public final class ManifestModelConverter: ManifestModelConverting {
             }
         }
 
-        return .init(
-            externalDependencies: externalDependencies,
-            externalProjects: try Dictionary(uniqueKeysWithValues: manifest.externalProjects.map { project in
-                let projectPath = AbsolutePath(project.key.pathString)
-                return (
-                    projectPath,
-                    try convert(
-                        manifest: project.value,
-                        path: projectPath,
-                        plugins: .none,
-                        externalDependencies: externalDependencies
-                    )
-                )
+        let externalProjects = try Dictionary<AbsolutePath, TuistGraph.Project>(uniqueKeysWithValues: manifest.externalProjects.map { project in
+            let projectPath = AbsolutePath(project.key.pathString)
+            var project = try convert(
+                manifest: project.value,
+                path: projectPath,
+                plugins: .none,
+                externalDependencies: externalDependencies
+            )
+            // Disable all lastUpgradeCheck related warnings on projects generated from dependencies
+            project.lastUpgradeCheck = Version(99, 9, 9)
+            return (projectPath, project)
+        })
 
-            })
-        )
+        return .init(externalDependencies: externalDependencies, externalProjects: externalProjects)
     }
 }


### PR DESCRIPTION
Wire LastUpgradeCheck to avoid warnings in SwiftPackageManager generated projects