### PR TITLE
Fix package bundling on Xcode 13

### DIFF
--- a/projects/fourier/lib/fourier/utilities/swift_package_manager.rb
+++ b/projects/fourier/lib/fourier/utilities/swift_package_manager.rb
@@ -21,7 +21,7 @@ module Fourier
             "xcodebuild",
             "-scheme", product,
             "-configuration", "Release",
-            "-sdk", "macosx",
+            "-destination", "platform=macosx",
             "BUILD_LIBRARY_FOR_DISTRIBUTION=YES",
             "ARCHS=arm64 x86_64",
             "EXCLUDED_ARCHS=",


### PR DESCRIPTION
### Short description 📝

When running `./fourier release x.y.z`, you'll get an error because you have to specify `-destination` instead of `-sdk` when building a package with `xcodebuild` on Xcode 13.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
