### PR TITLE
[docs] Add commandLineTool to Product types

### DIFF
--- a/projects/docs/docs/manifests/project.md
+++ b/projects/docs/docs/manifests/project.md
@@ -273,6 +273,7 @@ The type of build product this target will output. It can be any of the followin
 | `.watch2Extension`      | A Watch application extension. (watchOS platform only).               |
 | `.messagesExtension`    | An iMessage extension. (iOS platform only)                            |
 | `.appClip`              | An appClip. (iOS platform only).                                      |
+| `.commandLineTool`      | A command line tool (macOS platform only).                            |
 
 ### InfoPlist
 


### PR DESCRIPTION
The Product type `.commandLineTool` seems to be missing from the documentation.
