### PR TITLE
feature: add targetSettings for packages in Dependencies.swift

### DIFF
--- a/Sources/ProjectDescription/Dependencies/SwiftPackageManagerDependencies.swift
+++ b/Sources/ProjectDescription/Dependencies/SwiftPackageManagerDependencies.swift
@@ -8,12 +8,19 @@ public struct SwiftPackageManagerDependencies: Codable, Equatable {
     /// The custom `Product` type to be used for SPM targets.
     public let productTypes: [String: Product]
 
+    // Additional settings to be added to targets generated from SwiftPackageManager.
+    public let targetSettings: [String: SettingsDictionary]
+
     /// Creates `SwiftPackageManagerDependencies` instance.
     /// - Parameter packages: List of packages that will be installed using Swift Package Manager.
     /// - Parameter productTypes: The custom `Product` types to be used for SPM targets.
-    public init(_ packages: [Package], productTypes: [String: Product] = [:]) {
+    /// - Parameter targetSettings: Additional settings to be added to targets generated from SwiftPackageManager.
+    public init(_ packages: [Package],
+                productTypes: [String: Product] = [:],
+                targetSettings: [String: SettingsDictionary] = [:]) {
         self.packages = packages
         self.productTypes = productTypes
+        self.targetSettings = targetSettings
     }
 }
 
@@ -23,5 +30,6 @@ extension SwiftPackageManagerDependencies: ExpressibleByArrayLiteral {
     public init(arrayLiteral elements: Package...) {
         packages = elements
         productTypes = [:]
+        targetSettings = [:]
     }
 }

--- a/Sources/TuistDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
@@ -103,6 +103,7 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
             at: pathsProvider.destinationBuildDirectory,
             productTypes: dependencies.productTypes,
             platforms: platforms,
+            targetSettings: dependencies.targetSettings,
             swiftToolsVersion: swiftToolsVersion
         )
 

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -96,6 +96,7 @@ public protocol PackageInfoMapping {
     ///   - name: Name of the package
     ///   - path: Path of the package
     ///   - productTypes: Product type mapping
+    ///   - targetSettings: Settings to apply to denoted targets
     ///   - minDeploymentTargets: Minimum support deployment target per platform
     ///   - targetToPlatform: Mapping from a target name to its platform
     ///   - targetToProducts: Mapping from a target name to its products
@@ -109,6 +110,7 @@ public protocol PackageInfoMapping {
         name: String,
         path: AbsolutePath,
         productTypes: [String: TuistGraph.Product],
+        targetSettings: [String: TuistGraph.SettingsDictionary],
         minDeploymentTargets: [ProjectDescription.Platform: ProjectDescription.DeploymentTarget],
         targetToPlatform: [String: ProjectDescription.Platform],
         targetToProducts: [String: Set<PackageInfo.Product>],
@@ -258,6 +260,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
         name: String,
         path: AbsolutePath,
         productTypes: [String: TuistGraph.Product],
+        targetSettings: [String: TuistGraph.SettingsDictionary],
         minDeploymentTargets: [ProjectDescription.Platform: ProjectDescription.DeploymentTarget],
         targetToPlatform: [String: ProjectDescription.Platform],
         targetToProducts: [String: Set<PackageInfo.Product>],
@@ -276,6 +279,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
                 packageFolder: path,
                 packageToProject: packageToProject,
                 productTypes: productTypes,
+                targetSettings: targetSettings,
                 platforms: targetToPlatform,
                 minDeploymentTargets: minDeploymentTargets,
                 targetToResolvedDependencies: targetToResolvedDependencies,
@@ -311,6 +315,7 @@ extension ProjectDescription.Target {
         packageFolder: AbsolutePath,
         packageToProject: [String: AbsolutePath],
         productTypes: [String: TuistGraph.Product],
+        targetSettings: [String: TuistGraph.SettingsDictionary],
         platforms: [String: ProjectDescription.Platform],
         minDeploymentTargets: [ProjectDescription.Platform: ProjectDescription.DeploymentTarget],
         targetToResolvedDependencies: [String: [PackageInfoMapper.ResolvedDependency]],
@@ -358,7 +363,8 @@ extension ProjectDescription.Target {
             targetToResolvedDependencies: targetToResolvedDependencies,
             settings: target.settings,
             platform: platform,
-            moduleMap: moduleMap
+            moduleMap: moduleMap,
+            targetSettings: targetSettings
         )
 
         return ProjectDescription.Target(
@@ -587,7 +593,8 @@ extension ProjectDescription.Settings {
         targetToResolvedDependencies: [String: [PackageInfoMapper.ResolvedDependency]],
         settings: [PackageInfo.Target.TargetBuildSettingDescription.Setting],
         platform: ProjectDescription.Platform,
-        moduleMap: (type: ModuleMapType, path: AbsolutePath?)
+        moduleMap: (type: ModuleMapType, path: AbsolutePath?),
+        targetSettings: [String: TuistGraph.SettingsDictionary]
     ) throws -> Self? {
         var headerSearchPaths: [String] = []
         var defines: [String: String] = ["SWIFT_PACKAGE": "1"]
@@ -703,7 +710,12 @@ extension ProjectDescription.Settings {
         if !linkerFlags.isEmpty {
             settingsDictionary["OTHER_LDFLAGS"] = .array(["$(inherited)"] + linkerFlags)
         }
-
+        
+        if let settingsToOverride = targetSettings[target.name] {
+            let projectDescriptionSettingsToOverride = ProjectDescription.SettingsDictionary.from(settingsDictionary: settingsToOverride)
+            settingsDictionary.merge(projectDescriptionSettingsToOverride)
+        }
+        
         return .settings(base: settingsDictionary)
     }
 
@@ -826,6 +838,19 @@ extension ProjectDescription.Product {
             return .stickerPackExtension
         case .appClip:
             return .appClip
+        }
+    }
+}
+
+extension ProjectDescription.SettingsDictionary {
+    fileprivate static func from(settingsDictionary: TuistGraph.SettingsDictionary) -> Self {
+        return settingsDictionary.mapValues { value in
+            switch value {
+            case .string(let stringValue):
+                return ProjectDescription.SettingValue.string(stringValue)
+            case .array(let arrayValue):
+                return ProjectDescription.SettingValue.array(arrayValue)
+            }
         }
     }
 }

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerGraphGenerator.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerGraphGenerator.swift
@@ -41,11 +41,13 @@ public protocol SwiftPackageManagerGraphGenerating {
     /// - Parameter path: The path to the directory that contains the `checkouts` directory where `SwiftPackageManager` installed dependencies.
     /// - Parameter productTypes: The custom `Product` types to be used for SPM targets.
     /// - Parameter platforms: The supported platforms.
+    /// - Parameter targetSettings: `SettingsDictionary` overrides for targets.
     /// - Parameter swiftToolsVersion: The version of Swift tools that will be used to generate dependencies.
     func generate(
         at path: AbsolutePath,
         productTypes: [String: TuistGraph.Product],
         platforms: Set<TuistGraph.Platform>,
+        targetSettings: [String: TuistGraph.SettingsDictionary],
         swiftToolsVersion: TSCUtility.Version?
     ) throws -> TuistCore.DependenciesGraph
 }
@@ -67,6 +69,7 @@ public final class SwiftPackageManagerGraphGenerator: SwiftPackageManagerGraphGe
         at path: AbsolutePath,
         productTypes: [String: TuistGraph.Product],
         platforms: Set<TuistGraph.Platform>,
+        targetSettings: [String: TuistGraph.SettingsDictionary],
         swiftToolsVersion: TSCUtility.Version?
     ) throws -> TuistCore.DependenciesGraph {
         let artifactsFolder = path.appending(component: "artifacts")
@@ -122,6 +125,7 @@ public final class SwiftPackageManagerGraphGenerator: SwiftPackageManagerGraphGe
                 name: packageInfo.name,
                 path: packageInfo.folder,
                 productTypes: productTypes,
+                targetSettings: targetSettings,
                 minDeploymentTargets: preprocessInfo.platformToMinDeploymentTarget,
                 targetToPlatform: preprocessInfo.targetToPlatform,
                 targetToProducts: preprocessInfo.targetToProducts,

--- a/Sources/TuistDependenciesTesting/SwiftPackageManager/Utils/MockSwiftPackageManagerGraphGenerator.swift
+++ b/Sources/TuistDependenciesTesting/SwiftPackageManager/Utils/MockSwiftPackageManagerGraphGenerator.swift
@@ -15,6 +15,7 @@ public final class MockSwiftPackageManagerGraphGenerator: SwiftPackageManagerGra
             AbsolutePath,
             [String: TuistGraph.Product],
             Set<TuistGraph.Platform>,
+            [String: TuistGraph.SettingsDictionary],
             TSCUtility.Version?
         ) throws -> TuistCore.DependenciesGraph
     )?
@@ -23,9 +24,10 @@ public final class MockSwiftPackageManagerGraphGenerator: SwiftPackageManagerGra
         at path: AbsolutePath,
         productTypes: [String: TuistGraph.Product],
         platforms: Set<TuistGraph.Platform>,
+        targetSettings: [String : TuistGraph.SettingsDictionary],
         swiftToolsVersion: TSCUtility.Version?
     ) throws -> TuistCore.DependenciesGraph {
         invokedGenerate = true
-        return try generateStub?(path, productTypes, platforms, swiftToolsVersion) ?? .test()
+        return try generateStub?(path, productTypes, platforms, targetSettings, swiftToolsVersion) ?? .test()
     }
 }

--- a/Sources/TuistGraph/Models/Dependencies/SwiftPackageManagerDependencies.swift
+++ b/Sources/TuistGraph/Models/Dependencies/SwiftPackageManagerDependencies.swift
@@ -8,16 +8,22 @@ public struct SwiftPackageManagerDependencies: Equatable {
     /// The custom `Product` types to be used for SPM targets.
     public let productTypes: [String: Product]
 
+    /// The custom `Settings` to be applied to SPM targets
+    public let targetSettings: [String: SettingsDictionary]
+
     /// Initializes a new `SwiftPackageManagerDependencies` instance.
     /// - Parameters:
     ///    - packages: List of packages that will be installed using Swift Package Manager.
     ///    - productTypes: The custom `Product` types to be used for SPM targets.
+    ///    - targetSettings: The custom `SettingsDictionary` to be applied to denoted targets
     public init(
         _ packages: [Package],
-        productTypes: [String: Product]
+        productTypes: [String: Product],
+        targetSettings: [String: SettingsDictionary]
     ) {
         self.packages = packages
         self.productTypes = productTypes
+        self.targetSettings = targetSettings
     }
 }
 

--- a/Sources/TuistLoader/Models+ManifestMappers/SettingsDictionary+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/SettingsDictionary+ManifestMapper.swift
@@ -1,0 +1,19 @@
+import Foundation
+import ProjectDescription
+import TuistGraph
+
+extension TuistGraph.SettingsDictionary {
+    /// Maps a ProjectDescription.SettingsDictionary instance into a TuistGraph.SettingsDictionary instance.
+    /// - Parameters:
+    ///   - manifest: Manifest representation of deployment target model.
+    static func from(manifest: ProjectDescription.SettingsDictionary) -> TuistGraph.SettingsDictionary {
+        return manifest.mapValues { value in
+            switch value {
+            case .string(let stringValue):
+                return TuistGraph.SettingValue.string(stringValue)
+            case .array(let arrayValue):
+                return TuistGraph.SettingValue.array(arrayValue)
+            }
+        }
+    }
+}

--- a/Sources/TuistLoader/Models+ManifestMappers/SwiftPackageManagerDependencies+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/SwiftPackageManagerDependencies+ManifestMapper.swift
@@ -13,6 +13,8 @@ extension TuistGraph.SwiftPackageManagerDependencies {
     ) throws -> Self {
         let packages = try manifest.packages.map { try TuistGraph.Package.from(manifest: $0, generatorPaths: generatorPaths) }
         let productTypes = manifest.productTypes.mapValues { TuistGraph.Product.from(manifest: $0) }
-        return .init(packages, productTypes: productTypes)
+        let productSettings = manifest.targetSettings.mapValues { TuistGraph.SettingsDictionary.from(manifest: $0) }
+
+        return .init(packages, productTypes: productTypes, targetSettings: productSettings)
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/SwiftPackageManagerDependencies+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/SwiftPackageManagerDependencies+ManifestMapper.swift
@@ -13,8 +13,8 @@ extension TuistGraph.SwiftPackageManagerDependencies {
     ) throws -> Self {
         let packages = try manifest.packages.map { try TuistGraph.Package.from(manifest: $0, generatorPaths: generatorPaths) }
         let productTypes = manifest.productTypes.mapValues { TuistGraph.Product.from(manifest: $0) }
-        let productSettings = manifest.targetSettings.mapValues { TuistGraph.SettingsDictionary.from(manifest: $0) }
+        let targetSettings = manifest.targetSettings.mapValues { TuistGraph.SettingsDictionary.from(manifest: $0) }
 
-        return .init(packages, productTypes: productTypes, targetSettings: productSettings)
+        return .init(packages, productTypes: productTypes, targetSettings: targetSettings)
     }
 }

--- a/Tests/TuistDependenciesTests/DependenciesControllerTests.swift
+++ b/Tests/TuistDependenciesTests/DependenciesControllerTests.swift
@@ -99,7 +99,8 @@ final class DependenciesControllerTests: TuistUnitTestCase {
                 .remote(url: "Moya", requirement: .exact("2.3.4")),
                 .remote(url: "Alamofire", requirement: .upToNextMajor("5.0.0")),
             ],
-            productTypes: [:]
+            productTypes: [:],
+            targetSettings: [:]
         )
         let dependencies = Dependencies(
             carthage: nil,
@@ -149,7 +150,8 @@ final class DependenciesControllerTests: TuistUnitTestCase {
                 .remote(url: "Moya", requirement: .exact("2.3.4")),
                 .remote(url: "Alamofire", requirement: .upToNextMajor("5.0.0")),
             ],
-            productTypes: [:]
+            productTypes: [:],
+            targetSettings: [:]
         )
         let dependencies = Dependencies(
             carthage: carthageDependencies,
@@ -212,7 +214,8 @@ final class DependenciesControllerTests: TuistUnitTestCase {
                 [
                     .remote(url: "Moya", requirement: .exact("2.3.4")),
                 ],
-                productTypes: [:]
+                productTypes: [:],
+                targetSettings: [:]
             ),
             platforms: [.iOS]
         )
@@ -256,7 +259,7 @@ final class DependenciesControllerTests: TuistUnitTestCase {
 
         let dependencies = TuistGraph.Dependencies(
             carthage: .init([]),
-            swiftPackageManager: .init([], productTypes: [:]),
+            swiftPackageManager: .init([], productTypes: [:], targetSettings: [:]),
             platforms: []
         )
 
@@ -273,7 +276,7 @@ final class DependenciesControllerTests: TuistUnitTestCase {
 
         let dependencies = TuistGraph.Dependencies(
             carthage: .init([]),
-            swiftPackageManager: .init([], productTypes: [:]),
+            swiftPackageManager: .init([], productTypes: [:], targetSettings: [:]),
             platforms: [.iOS]
         )
 
@@ -346,7 +349,8 @@ final class DependenciesControllerTests: TuistUnitTestCase {
                 .remote(url: "Moya", requirement: .exact("2.3.4")),
                 .remote(url: "Alamofire", requirement: .upToNextMajor("5.0.0")),
             ],
-            productTypes: [:]
+            productTypes: [:],
+            targetSettings: [:]
         )
         let dependencies = Dependencies(
             carthage: nil,
@@ -395,7 +399,8 @@ final class DependenciesControllerTests: TuistUnitTestCase {
                 .remote(url: "Moya", requirement: .exact("2.3.4")),
                 .remote(url: "Alamofire", requirement: .upToNextMajor("5.0.0")),
             ],
-            productTypes: [:]
+            productTypes: [:],
+            targetSettings: [:]
         )
         let dependencies = Dependencies(
             carthage: carthageDependencies,
@@ -440,7 +445,7 @@ final class DependenciesControllerTests: TuistUnitTestCase {
 
         let dependencies = TuistGraph.Dependencies(
             carthage: .init([]),
-            swiftPackageManager: .init([], productTypes: [:]),
+            swiftPackageManager: .init([], productTypes: [:], targetSettings: [:]),
             platforms: []
         )
 
@@ -457,7 +462,7 @@ final class DependenciesControllerTests: TuistUnitTestCase {
 
         let dependencies = TuistGraph.Dependencies(
             carthage: .init([]),
-            swiftPackageManager: .init([], productTypes: [:]),
+            swiftPackageManager: .init([], productTypes: [:], targetSettings: [:]),
             platforms: [.iOS]
         )
 

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
@@ -48,7 +48,8 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
             [
                 .remote(url: "https://github.com/Alamofire/Alamofire.git", requirement: .upToNextMajor("5.2.0")),
             ],
-            productTypes: [:]
+            productTypes: [:],
+            targetSettings: [:]
         )
 
         swiftPackageManagerController.resolveStub = { path, printOutput in
@@ -61,10 +62,11 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
             XCTAssertNil(version) // swift-tools-version is not specified
         }
 
-        swiftPackageManagerGraphGenerator.generateStub = { path, automaticProductType, platforms, swiftToolsVersion in
+        swiftPackageManagerGraphGenerator.generateStub = { path, automaticProductType, platforms, productSettings, swiftToolsVersion in
             XCTAssertEqual(path, swiftPackageManagerBuildDirectory)
             XCTAssertEqual(platforms, [.iOS])
             XCTAssertEqual(automaticProductType, [:])
+            XCTAssertEqual(productSettings, [:])
             XCTAssertNil(swiftToolsVersion)
             return .test()
         }
@@ -131,7 +133,8 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
             [
                 .remote(url: "https://github.com/Alamofire/Alamofire.git", requirement: .upToNextMajor("5.2.0")),
             ],
-            productTypes: [:]
+            productTypes: [:],
+            targetSettings: [:]
         )
 
         swiftPackageManagerController.resolveStub = { path, printOutput in
@@ -144,10 +147,11 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
             XCTAssertEqual(version, swiftToolsVersion.description) // version should be equal to the version that has been specified
         }
 
-        swiftPackageManagerGraphGenerator.generateStub = { path, automaticProductType, platforms, swiftVersion in
+        swiftPackageManagerGraphGenerator.generateStub = { path, automaticProductType, platforms, productSettings, swiftVersion in
             XCTAssertEqual(path, swiftPackageManagerBuildDirectory)
             XCTAssertEqual(automaticProductType, [:])
             XCTAssertEqual(platforms, [.iOS])
+            XCTAssertEqual(productSettings, [:])
             XCTAssertEqual(swiftVersion, swiftToolsVersion)
             return .test()
         }
@@ -213,7 +217,8 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
             [
                 .remote(url: "https://github.com/Alamofire/Alamofire.git", requirement: .upToNextMajor("5.2.0")),
             ],
-            productTypes: [:]
+            productTypes: [:],
+            targetSettings: [:]
         )
 
         swiftPackageManagerController.updateStub = { path, printOutput in
@@ -226,10 +231,11 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
             XCTAssertNil(version) // swift-tools-version is not specified
         }
 
-        swiftPackageManagerGraphGenerator.generateStub = { path, automaticProductType, platforms, swiftToolsVersion in
+        swiftPackageManagerGraphGenerator.generateStub = { path, automaticProductType, platforms, productSettings, swiftToolsVersion in
             XCTAssertEqual(path, swiftPackageManagerBuildDirectory)
             XCTAssertEqual(automaticProductType, [:])
             XCTAssertEqual(platforms, [.iOS])
+            XCTAssertEqual(productSettings, [:])
             XCTAssertNil(swiftToolsVersion)
             return .test()
         }

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
@@ -62,11 +62,11 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
             XCTAssertNil(version) // swift-tools-version is not specified
         }
 
-        swiftPackageManagerGraphGenerator.generateStub = { path, automaticProductType, platforms, productSettings, swiftToolsVersion in
+        swiftPackageManagerGraphGenerator.generateStub = { path, automaticProductType, platforms, targetSettings, swiftToolsVersion in
             XCTAssertEqual(path, swiftPackageManagerBuildDirectory)
             XCTAssertEqual(platforms, [.iOS])
             XCTAssertEqual(automaticProductType, [:])
-            XCTAssertEqual(productSettings, [:])
+            XCTAssertEqual(targetSettings, [:])
             XCTAssertNil(swiftToolsVersion)
             return .test()
         }
@@ -147,11 +147,11 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
             XCTAssertEqual(version, swiftToolsVersion.description) // version should be equal to the version that has been specified
         }
 
-        swiftPackageManagerGraphGenerator.generateStub = { path, automaticProductType, platforms, productSettings, swiftVersion in
+        swiftPackageManagerGraphGenerator.generateStub = { path, automaticProductType, platforms, targetSettings, swiftVersion in
             XCTAssertEqual(path, swiftPackageManagerBuildDirectory)
             XCTAssertEqual(automaticProductType, [:])
             XCTAssertEqual(platforms, [.iOS])
-            XCTAssertEqual(productSettings, [:])
+            XCTAssertEqual(targetSettings, [:])
             XCTAssertEqual(swiftVersion, swiftToolsVersion)
             return .test()
         }
@@ -231,11 +231,11 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
             XCTAssertNil(version) // swift-tools-version is not specified
         }
 
-        swiftPackageManagerGraphGenerator.generateStub = { path, automaticProductType, platforms, productSettings, swiftToolsVersion in
+        swiftPackageManagerGraphGenerator.generateStub = { path, automaticProductType, platforms, targetSettings, swiftToolsVersion in
             XCTAssertEqual(path, swiftPackageManagerBuildDirectory)
             XCTAssertEqual(automaticProductType, [:])
             XCTAssertEqual(platforms, [.iOS])
-            XCTAssertEqual(productSettings, [:])
+            XCTAssertEqual(targetSettings, [:])
             XCTAssertNil(swiftToolsVersion)
             return .test()
         }

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
@@ -290,6 +290,7 @@ class SwiftPackageManagerGraphGeneratorTests: TuistUnitTestCase {
                 "GULNetwork": .dynamicLibrary,
             ],
             platforms: [.iOS],
+            targetSettings: [:],
             swiftToolsVersion: nil
         )
 

--- a/Tests/TuistGraphTests/Models/Dependencies/SwiftPackageManagerDependenciesTests.swift
+++ b/Tests/TuistGraphTests/Models/Dependencies/SwiftPackageManagerDependenciesTests.swift
@@ -10,7 +10,8 @@ final class SwiftPackageManagerDependenciesTests: TuistUnitTestCase {
             [
                 .remote(url: "url/url/url", requirement: .branch("branch")),
             ],
-            productTypes: [:]
+            productTypes: [:],
+            targetSettings: [:]
         )
 
         // When
@@ -42,7 +43,8 @@ final class SwiftPackageManagerDependenciesTests: TuistUnitTestCase {
                 .remote(url: "url/url/url", requirement: .range(from: "1.2.3", to: "5.2.1")),
                 .local(path: "/path/path/path"),
             ],
-            productTypes: [:]
+            productTypes: [:],
+            targetSettings: [:]
         )
 
         // When

--- a/Tests/TuistKitTests/Services/Dependencies/DependenciesFetchServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Dependencies/DependenciesFetchServiceTests.swift
@@ -56,7 +56,8 @@ final class DependenciesFetchServiceTests: TuistUnitTestCase {
                 [
                     .remote(url: "Dependency1/Dependency1", requirement: .upToNextMajor("1.2.3")),
                 ],
-                productTypes: [:]
+                productTypes: [:],
+                targetSettings: [:]
             ),
             platforms: [.iOS, .macOS]
         )

--- a/Tests/TuistKitTests/Services/Dependencies/DependenciesUpdateServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Dependencies/DependenciesUpdateServiceTests.swift
@@ -56,7 +56,8 @@ final class DependenciesUpdateServiceTests: TuistUnitTestCase {
                 [
                     .remote(url: "Dependency1/Dependency1", requirement: .upToNextMajor("1.2.3")),
                 ],
-                productTypes: [:]
+                productTypes: [:],
+                targetSettings: [:]
             ),
             platforms: [.iOS, .macOS]
         )

--- a/Tests/TuistLoaderTests/Loaders/DependenciesModelLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/DependenciesModelLoaderTests.swift
@@ -67,7 +67,8 @@ final class DependenciesModelLoaderTests: TuistUnitTestCase {
                     .local(path: localSwiftPackagePath),
                     .remote(url: "RemoteUrl.com", requirement: .exact("1.2.3")),
                 ],
-                productTypes: [:]
+                productTypes: [:],
+                targetSettings: [:]
             ),
             platforms: [.iOS, .macOS]
         )

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/DependenciesManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/DependenciesManifestMapperTests.swift
@@ -48,7 +48,8 @@ final class DependenciesManifestMapperTests: TuistUnitTestCase {
                     .local(path: localPackagePath),
                     .remote(url: "RemotePackage.com", requirement: .exact("1.2.3")),
                 ],
-                productTypes: [:]
+                productTypes: [:],
+                targetSettings: [:]
             ),
             platforms: [.iOS, .macOS, .tvOS]
         )


### PR DESCRIPTION
### Short description 📝

Draft PR of allowing a custom SettingsDictionary to be applied to SPM targets from Dependencies.swift. Still work to be done on testing.

### Checklist ✅

- [✅] The code architecture and patterns are consistent with the rest of the codebase.
- [✅] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [✅] In case the PR introduces changes that affect users, the documentation has been updated.
- [✅] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
