### PR TITLE
Build RxSwift dependency as a dynamic framework

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -6,15 +6,17 @@ on:
       - main
   pull_request:
     paths:
-      - Tuist/Dependencies/Lockfiles/Package.resolved
+      - Tuist/**
       - Package.resolved
       - Gemfile*
       - Package.swift
+      - Project.swift
       - Sources/**
       - Tests/**
       - projects/tuist/features/**
       - projects/tuist/fixtures/**
       - .github/workflows/tuist.yml
+      - .package.resolved
 
 concurrency:
   group: tuist-${{ github.head_ref }}

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -1,25 +1,28 @@
 import ProjectDescription
 
 let dependencies = Dependencies(
-    swiftPackageManager: [
-        .package(url: "https://github.com/tuist/XcodeProj.git", .upToNextMajor(from: "8.5.0")),
-        .package(url: "https://github.com/CombineCommunity/CombineExt.git", .upToNextMajor(from: "1.3.0")),
-        .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.2.0")),
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.1.1")),
-        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.2")),
-        .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", .upToNextMajor(from: "4.2.2")),
-        .package(url: "https://github.com/fortmarek/swifter.git", .branch("stable")),
-        .package(url: "https://github.com/tuist/BlueSignals.git", .upToNextMajor(from: "1.0.21")),
-        .package(url: "https://github.com/maparoni/Zip.git", .revision("059e7346082d02de16220cd79df7db18ddeba8c3")),
-        .package(url: "https://github.com/rnine/Checksum.git", .upToNextMajor(from: "1.0.2")),
-        .package(url: "https://github.com/stencilproject/Stencil.git", .upToNextMajor(from: "0.14.1")),
-        .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .upToNextMajor(from: "2.8.0")),
-        .package(url: "https://github.com/FabrizioBrancati/Queuer.git", .upToNextMajor(from: "2.1.1")),
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMajor(from: "1.4.1")),
-        .package(url: "https://github.com/tuist/GraphViz.git", .branch("tuist")),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "0.4.3")),
-        .package(url: "https://github.com/SwiftGen/SwiftGen", .upToNextMajor(from: "6.5.1")),
-        .package(url: "https://github.com/kylef/PathKit.git", .upToNextMajor(from: "1.0.0")),
-    ],
+    swiftPackageManager: .init(
+        [
+            .package(url: "https://github.com/tuist/XcodeProj.git", .upToNextMajor(from: "8.5.0")),
+            .package(url: "https://github.com/CombineCommunity/CombineExt.git", .upToNextMajor(from: "1.3.0")),
+            .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.2.0")),
+            .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.1.1")),
+            .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.2")),
+            .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", .upToNextMajor(from: "4.2.2")),
+            .package(url: "https://github.com/fortmarek/swifter.git", .branch("stable")),
+            .package(url: "https://github.com/tuist/BlueSignals.git", .upToNextMajor(from: "1.0.21")),
+            .package(url: "https://github.com/maparoni/Zip.git", .revision("059e7346082d02de16220cd79df7db18ddeba8c3")),
+            .package(url: "https://github.com/rnine/Checksum.git", .upToNextMajor(from: "1.0.2")),
+            .package(url: "https://github.com/stencilproject/Stencil.git", .upToNextMajor(from: "0.14.1")),
+            .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .upToNextMajor(from: "2.8.0")),
+            .package(url: "https://github.com/FabrizioBrancati/Queuer.git", .upToNextMajor(from: "2.1.1")),
+            .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMajor(from: "1.4.1")),
+            .package(url: "https://github.com/tuist/GraphViz.git", .branch("tuist")),
+            .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "0.4.3")),
+            .package(url: "https://github.com/SwiftGen/SwiftGen", .upToNextMajor(from: "6.5.1")),
+            .package(url: "https://github.com/kylef/PathKit.git", .upToNextMajor(from: "1.0.0")),
+        ],
+        productTypes: ["RxSwift": .framework]
+    ),
     platforms: [.macOS]
 )


### PR DESCRIPTION
Resolves #3616.

### Short description 📝

Currently, as described in #3616 running tuist from within Xcode causes a crash. (This is a regression.) By changing the RxSwift dependency to build as a dynamic framework, this crash no longer occurs.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
