### PR TITLE
Add missing logic for non-iOS platforms

### DIFF
--- a/.github/workflows/meta-tuist.yml
+++ b/.github/workflows/meta-tuist.yml
@@ -6,15 +6,17 @@ on:
       - main
   pull_request:
     paths:
-      - Tuist/Dependencies/Lockfiles/Package.resolved
+      - Tuist/**
       - Package.resolved
       - Gemfile*
       - Package.swift
+      - Project.swift
       - Sources/**
       - Tests/**
       - projects/tuist/features/**
-      - Project.swift
+      - projects/tuist/fixtures/**
       - .github/workflows/meta-tuist.yml
+      - .package.resolved
 
 concurrency:
   group: meta-tuist-${{ github.head_ref }}
@@ -30,7 +32,7 @@ jobs:
     runs-on: macOS-11
     strategy:
       matrix:
-        xcode: ['12.5.1']
+        xcode: ['12.5.1', "13.0"]
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
@@ -51,12 +53,38 @@ jobs:
       - name: Build
         run: |
           ./fourier build tuist all
+  generate:
+    name: Generate with Xcode ${{ matrix.xcode }}
+    runs-on: macOS-11
+    strategy:
+      matrix:
+        xcode: ['12.5.1', "13.0"]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
+      - name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Build
+        run: |
+          ./fourier generate tuist
   test:
     name: Test with Xcode ${{ matrix.xcode }}
     runs-on: macOS-11
     strategy:
       matrix:
-        xcode: ['12.5.1']
+        xcode: ['12.5.1', "13.0"]
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/meta-tuist.yml
+++ b/.github/workflows/meta-tuist.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: macOS-11
     strategy:
       matrix:
-        xcode: ['12.5.1', "13.0"]
+        xcode: ['13.0']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
@@ -58,7 +58,7 @@ jobs:
     runs-on: macOS-11
     strategy:
       matrix:
-        xcode: ['12.5.1', "13.0"]
+        xcode: ['13.0']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
@@ -84,7 +84,7 @@ jobs:
     runs-on: macOS-11
     strategy:
       matrix:
-        xcode: ['12.5.1', "13.0"]
+        xcode: ['13.0']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -425,7 +425,16 @@ extension ProjectDescription.DeploymentTarget {
         packageName _: String
     ) throws -> Self {
         if let packagePlatform = package.first(where: { $0.platformName == platform.rawValue }) {
-            return .iOS(targetVersion: packagePlatform.version, devices: [.iphone, .ipad])
+            switch platform {
+            case .iOS:
+                return .iOS(targetVersion: packagePlatform.version, devices: [.iphone, .ipad])
+            case .macOS:
+                return .macOS(targetVersion: packagePlatform.version)
+            case .watchOS:
+                return .watchOS(targetVersion: packagePlatform.version)
+            case .tvOS:
+                return .tvOS(targetVersion: packagePlatform.version)
+            }
         } else {
             return minDeploymentTargets[platform]!
         }


### PR DESCRIPTION
Since #3602, tuist will not generate properly using [these instructions](https://docs.tuist.io/contributors/get-started#set-up-the-project-locally). Running `./fourier generate tuist --open` gives the following error:

```
Found an inconsistency between a platform `macOS` and deployment target `iOS`
```
(above line repeats many times)
```
Fatal linting issues found
Consider creating an issue using the following link: https://github.com/tuist/tuist/issues/new/choose
````

The cause of this is a method which only has logic for iOS. Adding logic to handle the other platforms fixes this problem.