### PR TITLE
Add configuration option to control location of SPM clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Schemes can be hidden from the dropdown menu `Scheme(hidden: true)` [#3598](https://github.com/tuist/tuist/pull/3598) by [@pepibumur](https://github.com/pepibumur)
 - Sort schemes alphabetically by default [#3598](https://github.com/tuist/tuist/pull/3598) by [@pepibumur](https://github.com/pepibumur)
 - Add automation to release [#3603](https://github.com/tuist/tuist/pull/3603/) by [@luispadron](https://github.com/luispadron)
+- Custom `clonedSourcePackagesDirPath` can be set for Xcode managed SPM dependencies [#3628](https://github.com/tuist/tuist/pull/3628) by [@wattson12](https://github.com/wattson12)
 
 ## 2.1.1 - Patenipat
 

--- a/Sources/ProjectDescription/Config.swift
+++ b/Sources/ProjectDescription/Config.swift
@@ -53,6 +53,8 @@ public struct Config: Codable, Equatable {
         /// It is recommended to set the version option to Xcode's version that is used for development of a project, for example `.lastUpgradeCheck(Version(13, 0, 0))` for Xcode 13.0.0.
         case lastXcodeUpgradeCheck(Version)
 
+        /// Allows setting a custom directory to be used when resolving package dependencies
+        /// This path is passed to `xcodebuild` via the `-clonedSourcePackagesDirPath` argument
         case clonedSourcePackagesDirPath(Path)
     }
 

--- a/Sources/ProjectDescription/Config.swift
+++ b/Sources/ProjectDescription/Config.swift
@@ -52,6 +52,8 @@ public struct Config: Codable, Equatable {
         /// Allows to suppress warnings in Xcode about updates to recommended settings added in or below the specified Xcode version. The warnings appear when Xcode version has been upgraded.
         /// It is recommended to set the version option to Xcode's version that is used for development of a project, for example `.lastUpgradeCheck(Version(13, 0, 0))` for Xcode 13.0.0.
         case lastXcodeUpgradeCheck(Version)
+
+        case clonedSourcePackagesDirPath(Path)
     }
 
     /// Generation options.
@@ -113,6 +115,7 @@ extension Config.GenerationOptions {
         case disablePackageVersionLocking
         case disableBundleAccessors
         case lastXcodeUpgradeCheck
+        case clonedSourcePackagesDirPath
     }
 
     public init(from decoder: Decoder) throws {
@@ -157,6 +160,12 @@ extension Config.GenerationOptions {
             var associatedValues = try container.nestedUnkeyedContainer(forKey: .lastXcodeUpgradeCheck)
             let version = try associatedValues.decode(Version.self)
             self = .lastXcodeUpgradeCheck(version)
+        } else if
+            container.allKeys.contains(.clonedSourcePackagesDirPath), try container.decodeNil(forKey: .clonedSourcePackagesDirPath) == false
+        {
+            var associatedValues = try container.nestedUnkeyedContainer(forKey: .clonedSourcePackagesDirPath)
+            let path = try associatedValues.decode(Path.self)
+            self = .clonedSourcePackagesDirPath(path)
         } else {
             throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Unknown enum case"))
         }
@@ -192,6 +201,9 @@ extension Config.GenerationOptions {
         case let .lastXcodeUpgradeCheck(version):
             var associatedValues = container.nestedUnkeyedContainer(forKey: .lastXcodeUpgradeCheck)
             try associatedValues.encode(version)
+        case let .clonedSourcePackagesDirPath(path):
+            var associatedValues = container.nestedUnkeyedContainer(forKey: .clonedSourcePackagesDirPath)
+            try associatedValues.encode(path)
         }
     }
 }

--- a/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
+++ b/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
@@ -76,6 +76,17 @@ public class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting {
             arguments.append(contentsOf: ["-scmProvider", "system"])
         }
 
+        // Set specific clone directory for Xcode managed SPM dependencies
+        let clonedSourcePackagesDirPath = config.generationOptions
+            .compactMap { option -> AbsolutePath? in
+                guard case let .clonedSourcePackagesDirPath(path) = option else { return nil }
+                return path
+            }
+            .first
+        if let clonedSourcePackagesDirPath = clonedSourcePackagesDirPath {
+            arguments.append(contentsOf: ["-clonedSourcePackagesDirPath", clonedSourcePackagesDirPath.pathString])
+        }
+
         arguments.append(contentsOf: ["-workspace", workspacePath.pathString, "-list"])
 
         _ = try System.shared.observable(arguments)

--- a/Sources/TuistGraph/Models/Config.swift
+++ b/Sources/TuistGraph/Models/Config.swift
@@ -23,6 +23,7 @@ public struct Config: Equatable, Hashable {
         case disableBundleAccessors
         /// Allows to suppress warnings in Xcode about updates to recommended settings.
         case lastUpgradeCheck(Version)
+        case clonedSourcePackagesDirPath(AbsolutePath)
     }
 
     /// List of `Plugin`s used to extend Tuist.

--- a/Sources/TuistLoader/Models+ManifestMappers/Config+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Config+ManifestMapper.swift
@@ -88,6 +88,8 @@ extension TuistGraph.Config.GenerationOption {
             return .disableBundleAccessors
         case let .lastXcodeUpgradeCheck(version):
             return .lastUpgradeCheck(.init(version.major, version.minor, version.patch))
+        case let .clonedSourcePackagesDirPath(path):
+            return .clonedSourcePackagesDirPath(try generatorPaths.resolve(path: path))
         }
     }
 }

--- a/Tests/ProjectDescriptionTests/ConfigTests.swift
+++ b/Tests/ProjectDescriptionTests/ConfigTests.swift
@@ -17,6 +17,7 @@ final class ConfigTests: XCTestCase {
                 .disablePackageVersionLocking,
                 .disableBundleAccessors,
                 .lastXcodeUpgradeCheck(.init(12, 5, 1)),
+                .clonedSourcePackagesDirPath(.relativeToRoot("spm")),
             ]
         )
 

--- a/Tests/TuistGeneratorIntegrationTests/Generator/SwiftPackageManagerInteractorTests.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Generator/SwiftPackageManagerInteractorTests.swift
@@ -162,6 +162,41 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         XCTAssertFalse(FileHandler.shared.exists(temporaryPath.appending(component: ".package.resolved")))
     }
 
+    func test_generate_sets_cloned_source_packages_dir_path() throws {
+        // Given
+        let temporaryPath = try self.temporaryPath()
+        let spmPath = temporaryPath.appending(component: "spm")
+        let config = Config(compatibleXcodeVersions: .all, cloud: nil, cache: nil, swiftVersion: nil, plugins: [], generationOptions: [.clonedSourcePackagesDirPath(spmPath)], path: nil)
+
+        let target = anyTarget(dependencies: [
+            .package(product: "Example"),
+        ])
+        let package = Package.remote(url: "http://some.remote/repo.git", requirement: .exact("branch"))
+        let project = Project.test(
+            path: temporaryPath,
+            name: "Test",
+            settings: .default,
+            targets: [target],
+            packages: [package]
+        )
+        let graph = Graph.test(
+            path: project.path,
+            packages: [project.path: ["Test": package]],
+            dependencies: [GraphDependency.packageProduct(path: project.path, product: "Test"): Set()]
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        let workspacePath = temporaryPath.appending(component: "\(project.name).xcworkspace")
+        system.succeedCommand(["xcodebuild", "-resolvePackageDependencies", "-clonedSourcePackagesDirPath", spmPath.pathString, "-workspace", workspacePath.pathString, "-list"])
+        try createFiles(["\(workspacePath.basename)/xcshareddata/swiftpm/Package.resolved"])
+
+        // When
+        try subject.install(graphTraverser: graphTraverser, workspaceName: workspacePath.basename, config: config)
+
+        // Then
+        XCTAssertTrue(FileHandler.shared.exists(temporaryPath.appending(component: ".package.resolved")))
+    }
+
     // MARK: - Helpers
 
     func anyTarget(dependencies: [TargetDependency] = []) -> Target {


### PR DESCRIPTION
Resolves: no ticket yet, was briefly discussed in slack [here](https://tuistapp.slack.com/archives/C018QG7U7SN/p1635789271063000)
Request for comments document (if applies):

### Short description 📝

I have added a new configuration option `clonedSourcePackagesDirPath` to allow users to set a custom directory tuist runs `xcodebuild -resolvePackageDependencies ...`

The motivation for this is to have a predictable location for these clones, which can be cached on CI (useful for those dependencies which don't _yet_ work when added via `Tuist/Dependencies.swift`)

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
