### PR TITLE
Fix: tuist config coloured output was ignored in some outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Sort schemes alphabetically by default [#3598](https://github.com/tuist/tuist/pull/3598) by [@pepibumur](https://github.com/pepibumur)
 - Add automation to release [#3603](https://github.com/tuist/tuist/pull/3603/) by [@luispadron](https://github.com/luispadron)
 
+### Fixed
+
+- Fix handling of `TUIST_CONFIG_COLOURED_OUTPUT` environment variable [#3631](https://github.com/tuist/tuist/pull/3631) by [@danyf90](https://github.com/danyf90)
+
 ## 2.1.1 - Patenipat
 
 ### Fixed

--- a/Sources/TuistEnvKit/Commands/CommandRunner.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRunner.swift
@@ -116,7 +116,6 @@ class CommandRunner: CommandRunning {
         args.append(contentsOf: Array(arguments().dropFirst()))
 
         var environment = ProcessInfo.processInfo.environment
-        environment[Constants.EnvironmentVariables.colouredOutput] = "\(self.environment.shouldOutputBeColoured)"
         if CommandLine.arguments.contains("--verbose") {
             environment[Constants.EnvironmentVariables.verbose] = "true"
         }

--- a/Sources/TuistSupport/Logging/StandardLogHandler.swift
+++ b/Sources/TuistSupport/Logging/StandardLogHandler.swift
@@ -26,26 +26,28 @@ public struct StandardLogHandler: LogHandler {
         }
 
         let string: String
-
-        switch metadata?[Logger.Metadata.tuist] {
-        case Logger.Metadata.successKey?:
-            string = message.description.green().bold()
-        case Logger.Metadata.sectionKey?:
-            string = message.description.cyan().bold()
-        case Logger.Metadata.subsectionKey?:
-            string = message.description.cyan()
-        default:
-
-            switch level {
-            case .critical:
-                string = message.description.red().bold()
-            case .error:
-                string = message.description.red()
-            case .warning:
-                string = message.description.yellow()
-            case .notice, .info, .debug, .trace:
-                string = message.description
+        if Environment.shared.shouldOutputBeColoured {
+            switch metadata?[Logger.Metadata.tuist] {
+            case Logger.Metadata.successKey?:
+                string = message.description.green().bold()
+            case Logger.Metadata.sectionKey?:
+                string = message.description.cyan().bold()
+            case Logger.Metadata.subsectionKey?:
+                string = message.description.cyan()
+            default:
+                switch level {
+                case .critical:
+                    string = message.description.red().bold()
+                case .error:
+                    string = message.description.red()
+                case .warning:
+                    string = message.description.yellow()
+                case .notice, .info, .debug, .trace:
+                    string = message.description
+                }
             }
+        } else {
+            string = message.description
         }
 
         output(for: level).print(string)

--- a/Sources/TuistSupport/Utils/PrintableString.swift
+++ b/Sources/TuistSupport/Utils/PrintableString.swift
@@ -97,23 +97,25 @@ extension PrintableString {
         }
 
         public var description: String {
-            switch self {
+          guard Environment.shared.shouldOutputBeColoured else {
+            return unformatted
+          }
+
+          switch self {
             case let .raw(string):
                 return string
-            case let .command(token):
-                return Environment.shared.shouldOutputBeColoured ? token.description.cyan() : token.description
-            case let .keystroke(token):
-                return Environment.shared.shouldOutputBeColoured ? token.description.cyan() : token.description
+            case let .command(token), let .keystroke(token):
+                return token.description.cyan()
             case let .bold(token):
-                return Environment.shared.shouldOutputBeColoured ? token.description.bold() : token.description
+                return token.description.bold()
             case let .error(token):
-                return Environment.shared.shouldOutputBeColoured ? token.description.red() : token.description
+                return token.description.red()
             case let .success(token):
-                return Environment.shared.shouldOutputBeColoured ? token.description.green() : token.description
+                return token.description.green()
             case let .warning(token):
-                return Environment.shared.shouldOutputBeColoured ? token.description.yellow() : token.description
+                return token.description.yellow()
             case let .info(token):
-                return Environment.shared.shouldOutputBeColoured ? token.description.lightBlue() : token.description
+                return token.description.lightBlue()
             }
         }
     }

--- a/Sources/TuistSupport/Utils/PrintableString.swift
+++ b/Sources/TuistSupport/Utils/PrintableString.swift
@@ -97,11 +97,11 @@ extension PrintableString {
         }
 
         public var description: String {
-          guard Environment.shared.shouldOutputBeColoured else {
-            return unformatted
-          }
+            guard Environment.shared.shouldOutputBeColoured else {
+                return unformatted
+            }
 
-          switch self {
+            switch self {
             case let .raw(string):
                 return string
             case let .command(token), let .keystroke(token):


### PR DESCRIPTION
### Short description 📝

As per title.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
