### PR TITLE
Update Target initializer to use InfoPlist.default as default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - **Breaking** Update logic to calculate deployment target for SwiftPackageManager packages not specifying it, and remove no longer used `SwiftPackageManagerDependencies.deploymentTargets` property [#3602](https://github.com/tuist/tuist/pull/3602) by [@danyf90](https://github.com/danyf90)
 - **Breaking** Update logic to calculate client ID starting from UUID instead of hostname, to avoid collisions [#3632](https://github.com/tuist/tuist/pull/3632) by [@danyf90](https://github.com/danyf90)
+- `Target`'s initializer now has `InfoPlist.default` set as the default value for the `infoPlist` argument [#3644](https://github.com/tuist/tuist/pull/3644) by [@hisaac](https://github.com/hisaac)
 
 ### Added
 
@@ -124,12 +125,12 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - **Breaking** Specifying custom build settings files for default configurations via `Settings(base:debug:release:)` has changed.
   - **Motivation:** To support the `CustomConfiguration` API simplification.
-  - **Migration:** 
-    Replace 
+  - **Migration:**
+    Replace
 
     ```swift
     let settings = Settings(
-        debug: Configuration(settings: ["setting": "debug"]), 
+        debug: Configuration(settings: ["setting": "debug"]),
         release: Configuration(settings: ["setting": "release"])
     )
     ```
@@ -138,19 +139,19 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
     ```swift
     let settings: Settings = .settings(
-        debug: ["setting": "debug"], 
+        debug: ["setting": "debug"],
         release: ["setting": "release"]
     )
     ```
 
 - **Breaking** Specifying xcconfig files for default configurations via `Settings(base:debug:release:)` has changed.
   - **Motivation:** To support the `CustomConfiguration` API simplification.
-  - **Migration:** 
-    Replace 
+  - **Migration:**
+    Replace
 
     ```swift
     let settings = Settings(
-        debug: Configuration(xcconfig: "configs/debug.xcconfig"), 
+        debug: Configuration(xcconfig: "configs/debug.xcconfig"),
         release: Configuration(xcconfig: "configs/release.xcconfig")
     )
     ```

--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -111,7 +111,7 @@ public struct Target: Codable, Equatable {
         productName: String? = nil,
         bundleId: String,
         deploymentTarget: DeploymentTarget? = nil,
-        infoPlist: InfoPlist,
+        infoPlist: InfoPlist = .default,
         sources: SourceFilesList? = nil,
         resources: ResourceFileElements? = nil,
         copyFiles: [CopyFilesAction]? = nil,

--- a/projects/docs/docs/manifests/project.md
+++ b/projects/docs/docs/manifests/project.md
@@ -134,7 +134,7 @@ Each target in the list of project targets can be initialized with the following
 | `productName`      | The built product name.                                                                                                                                                                            | `String`                                        | No       | `$(TARGET_NAME)` |
 | `deploymentTarget` | The minimum iOS version your product will support.                                                                                                                                                 | [#deployment-target](#deployment-target)        | No       |                  |
 | `bundleId`         | The product bundle identifier.                                                                                                                                                                     | `String`                                        | Yes      |                  |
-| `infoPlist`        | Relative path to the `Info.plist`                                                                                                                                                                  | [`InfoPlist`](#infoplist)                       | Yes      |                  |
+| `infoPlist`        | Relative path to the `Info.plist`                                                                                                                                                                  | [`InfoPlist`](#infoplist)                       | No       | `.default`       |
 | `resources`        | List of files to include in the resources build phase. Note that localizable files, `*.lproj`, are supported.                                                                                      | [`ResourceFileElements`](#resourcefileelements) | No       |                  |
 | `copyFiles`        | Copy files actions allow defining copy files build phases.                                                                                                                                         | [`[CopyFilesAction]`](#copy-files-action)       | No       |                  |
 | `headers`          | The target headers.                                                                                                                                                                                | [`Headers`](#headers)                           | No       |                  |
@@ -283,7 +283,8 @@ The `InfoPlist` model represents a target `Info.plist` file. It can have any of 
 | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `.file(path: Path)`                                  | The path to an existing Info.plist file.                                                                                        |
 | `.dictionary([String: InfoPlist.Value])`             | A dictionary with the Info.plist content. Tuist generates the Info.plist file at the generation time.                           |
-| `.extendingDefault(with: [String: InfoPlist.Value])` | It indicates Tuist to provide the default content for the target the InfoPlist belongs to, and extend it with the given values. |
+| `.default`                                           | Tells Tuist to provide the default content for the target the InfoPlist belongs to.                                             |
+| `.extendingDefault(with: [String: InfoPlist.Value])` | Tells Tuist to provide the default content for the target the InfoPlist belongs to, and extend it with the given values.        |
 
 :::note ExpressibleByStringLiteral
 The InfoPlist model conforms the ExpressibleByStringLiteral protocol, which means that it can be initialized with a String. In that case, the string is the path to the Info.plist file.
@@ -421,7 +422,7 @@ It represents the scheme action that runs the built products on the supported pl
 
 #### Test Action
 
-You can create a test action with either a set of test targets or test plans using the `.targets` or `.testPlans` static methods respectively. 
+You can create a test action with either a set of test targets or test plans using the `.targets` or `.testPlans` static methods respectively.
 
 When initializing it with a **set of targets**, the attributes you can pass to those methods are documented below:
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/discussions/3635

### Short description 📝

This change updates `Target`'s initializer to use `InfoPlist.default` as the default value for the `infoPlist` argument. Many of the other arguments have default values, so this seems like an appropriate change.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/). (Currently running in CI)
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
