### PR TITLE
Fix TrackableCommandTests' test

### DIFF
--- a/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
+++ b/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import TuistKit
 @testable import TuistSupportTesting
 
-final class TrackableCommandTests: TuistUnitTestCase {
+final class TrackableCommandTests: TuistTestCase {
     private var subject: TrackableCommand!
     private var mockAsyncQueue: MockAsyncQueuer!
 

--- a/Tests/TuistKitTests/Services/DumpServiceTests.swift
+++ b/Tests/TuistKitTests/Services/DumpServiceTests.swift
@@ -30,9 +30,13 @@ final class DumpServiceTests: TuistUnitTestCase {
     func test_run_throws_when_file_doesnt_exist() throws {
         for manifest in DumpableManifest.allCases {
             let tmpDir = try temporaryPath()
+            var expectedDirectory = tmpDir
+            if manifest == .config {
+                expectedDirectory = expectedDirectory.appending(component: Constants.tuistDirectoryName)
+            }
             XCTAssertThrowsSpecific(
                 try subject.run(path: tmpDir.pathString, manifest: manifest),
-                ManifestLoaderError.manifestNotFound(manifest.manifest, tmpDir)
+                ManifestLoaderError.manifestNotFound(manifest.manifest, expectedDirectory)
             )
         }
     }


### PR DESCRIPTION
### Short description 📝
One of the tests fails because an inner component tries to get the Swift version from the environment and because our test subclasses `TuistUnitTestCase`, the mock instance of `System` returns that the command hasn't been stubbed. Because the interaction is to get the Swift version, I think it's safe to turn the test into a `TuistTestCase` and get the real version.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
