### PR TITLE
Persist Package.swift file along with resolved file

### DIFF
--- a/Sources/ProjectDescription/Dependencies/SwiftPackageManagerDependencies.swift
+++ b/Sources/ProjectDescription/Dependencies/SwiftPackageManagerDependencies.swift
@@ -17,7 +17,8 @@ public struct SwiftPackageManagerDependencies: Codable, Equatable {
     /// - Parameter targetSettings: Additional settings to be added to targets generated from SwiftPackageManager.
     public init(_ packages: [Package],
                 productTypes: [String: Product] = [:],
-                targetSettings: [String: SettingsDictionary] = [:]) {
+                targetSettings: [String: SettingsDictionary] = [:])
+    {
         self.packages = packages
         self.productTypes = productTypes
         self.targetSettings = targetSettings

--- a/Sources/TuistDependencies/Carthage/CarthageInteractor.swift
+++ b/Sources/TuistDependencies/Carthage/CarthageInteractor.swift
@@ -129,7 +129,7 @@ public final class CarthageInteractor: CarthageInteracting {
         let cartfileResolvedPath = dependenciesDirectory
             .appending(component: Constants.DependenciesDirectory.lockfilesDirectoryName)
             .appending(component: Constants.DependenciesDirectory.cartfileResolvedName)
-        
+
         try FileHandler.shared.delete(carthageDirectory)
         try FileHandler.shared.delete(cartfileResolvedPath)
     }
@@ -161,14 +161,14 @@ public final class CarthageInteractor: CarthageInteracting {
         guard FileHandler.shared.exists(pathsProvider.temporaryCartfilePath) else {
             throw CarthageInteractorError.cartfileNotFound
         }
-        
+
         guard FileHandler.shared.exists(pathsProvider.temporaryCartfileResolvedPath) else {
             throw CarthageInteractorError.cartfileResolvedNotFound
         }
         guard FileHandler.shared.exists(pathsProvider.destinationCarthageBuildDirectory) else {
             throw CarthageInteractorError.buildDirectoryNotFound
         }
-        
+
         try copy(
             from: pathsProvider.temporaryCartfilePath,
             to: pathsProvider.destinationCartfilePath

--- a/Sources/TuistDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
@@ -204,7 +204,7 @@ private struct SwiftPackageManagerPathsProvider {
 
     init(dependenciesDirectory: AbsolutePath) {
         destinationPackageSwiftPath = dependenciesDirectory
-            .appending(component: Constants.DependenciesDirectory.lockfilesDirectoryName)
+            .appending(component: Constants.DependenciesDirectory.swiftPackageManagerDirectoryName)
             .appending(component: Constants.DependenciesDirectory.packageSwiftName)
         destinationPackageResolvedPath = dependenciesDirectory
             .appending(component: Constants.DependenciesDirectory.lockfilesDirectoryName)

--- a/Sources/TuistDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
@@ -159,7 +159,7 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
         guard fileHandler.exists(pathsProvider.destinationBuildDirectory) else {
             throw SwiftPackageManagerInteractorError.buildDirectoryNotFound
         }
-        
+
         if fileHandler.exists(pathsProvider.temporaryPackageSwiftPath) {
             try copy(
                 from: pathsProvider.temporaryPackageSwiftPath,

--- a/Sources/TuistDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
@@ -115,6 +115,7 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
     public func clean(dependenciesDirectory: AbsolutePath) throws {
         let pathsProvider = SwiftPackageManagerPathsProvider(dependenciesDirectory: dependenciesDirectory)
         try fileHandler.delete(pathsProvider.destinationSwiftPackageManagerDirectory)
+        try fileHandler.delete(pathsProvider.destinationPackageSwiftPath)
         try fileHandler.delete(pathsProvider.destinationPackageResolvedPath)
     }
 
@@ -158,6 +159,13 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
         guard fileHandler.exists(pathsProvider.destinationBuildDirectory) else {
             throw SwiftPackageManagerInteractorError.buildDirectoryNotFound
         }
+        
+        if fileHandler.exists(pathsProvider.temporaryPackageSwiftPath) {
+            try copy(
+                from: pathsProvider.temporaryPackageSwiftPath,
+                to: pathsProvider.destinationPackageSwiftPath
+            )
+        }
 
         if fileHandler.exists(pathsProvider.temporaryPackageResolvedPath) {
             try copy(
@@ -187,6 +195,7 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
 
 private struct SwiftPackageManagerPathsProvider {
     let destinationSwiftPackageManagerDirectory: AbsolutePath
+    let destinationPackageSwiftPath: AbsolutePath
     let destinationPackageResolvedPath: AbsolutePath
     let destinationBuildDirectory: AbsolutePath
 
@@ -194,6 +203,9 @@ private struct SwiftPackageManagerPathsProvider {
     let temporaryPackageSwiftPath: AbsolutePath
 
     init(dependenciesDirectory: AbsolutePath) {
+        destinationPackageSwiftPath = dependenciesDirectory
+            .appending(component: Constants.DependenciesDirectory.lockfilesDirectoryName)
+            .appending(component: Constants.DependenciesDirectory.packageSwiftName)
         destinationPackageResolvedPath = dependenciesDirectory
             .appending(component: Constants.DependenciesDirectory.lockfilesDirectoryName)
             .appending(component: Constants.DependenciesDirectory.packageResolvedName)

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -710,12 +710,12 @@ extension ProjectDescription.Settings {
         if !linkerFlags.isEmpty {
             settingsDictionary["OTHER_LDFLAGS"] = .array(["$(inherited)"] + linkerFlags)
         }
-        
+
         if let settingsToOverride = targetSettings[target.name] {
             let projectDescriptionSettingsToOverride = ProjectDescription.SettingsDictionary.from(settingsDictionary: settingsToOverride)
             settingsDictionary.merge(projectDescriptionSettingsToOverride)
         }
-        
+
         return .settings(base: settingsDictionary)
     }
 
@@ -846,9 +846,9 @@ extension ProjectDescription.SettingsDictionary {
     fileprivate static func from(settingsDictionary: TuistGraph.SettingsDictionary) -> Self {
         return settingsDictionary.mapValues { value in
             switch value {
-            case .string(let stringValue):
+            case let .string(stringValue):
                 return ProjectDescription.SettingValue.string(stringValue)
-            case .array(let arrayValue):
+            case let .array(arrayValue):
                 return ProjectDescription.SettingValue.array(arrayValue)
             }
         }

--- a/Sources/TuistDependenciesTesting/SwiftPackageManager/Utils/MockSwiftPackageManagerGraphGenerator.swift
+++ b/Sources/TuistDependenciesTesting/SwiftPackageManager/Utils/MockSwiftPackageManagerGraphGenerator.swift
@@ -24,7 +24,7 @@ public final class MockSwiftPackageManagerGraphGenerator: SwiftPackageManagerGra
         at path: AbsolutePath,
         productTypes: [String: TuistGraph.Product],
         platforms: Set<TuistGraph.Platform>,
-        targetSettings: [String : TuistGraph.SettingsDictionary],
+        targetSettings: [String: TuistGraph.SettingsDictionary],
         swiftToolsVersion: TSCUtility.Version?
     ) throws -> TuistCore.DependenciesGraph {
         invokedGenerate = true

--- a/Sources/TuistLoader/Models+ManifestMappers/SettingsDictionary+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/SettingsDictionary+ManifestMapper.swift
@@ -9,9 +9,9 @@ extension TuistGraph.SettingsDictionary {
     static func from(manifest: ProjectDescription.SettingsDictionary) -> TuistGraph.SettingsDictionary {
         return manifest.mapValues { value in
             switch value {
-            case .string(let stringValue):
+            case let .string(stringValue):
                 return TuistGraph.SettingValue.string(stringValue)
-            case .array(let arrayValue):
+            case let .array(arrayValue):
                 return TuistGraph.SettingValue.array(arrayValue)
             }
         }

--- a/Tests/TuistDependenciesTests/Carthage/CarthageInteractorTests.swift
+++ b/Tests/TuistDependenciesTests/Carthage/CarthageInteractorTests.swift
@@ -94,7 +94,7 @@ final class CarthageInteractorTests: TuistUnitTestCase {
             carthageDirectory,
             [
                 "Build",
-                "Cartfile"
+                "Cartfile",
             ]
         )
         try XCTAssertDirectoryContentEqual(
@@ -202,7 +202,7 @@ final class CarthageInteractorTests: TuistUnitTestCase {
             carthageDirectory,
             [
                 "Build",
-                "Cartfile"
+                "Cartfile",
             ]
         )
         try XCTAssertDirectoryContentEqual(

--- a/Tests/TuistDependenciesTests/Carthage/CarthageInteractorTests.swift
+++ b/Tests/TuistDependenciesTests/Carthage/CarthageInteractorTests.swift
@@ -94,6 +94,7 @@ final class CarthageInteractorTests: TuistUnitTestCase {
             carthageDirectory,
             [
                 "Build",
+                "Cartfile"
             ]
         )
         try XCTAssertDirectoryContentEqual(
@@ -201,6 +202,7 @@ final class CarthageInteractorTests: TuistUnitTestCase {
             carthageDirectory,
             [
                 "Build",
+                "Cartfile"
             ]
         )
         try XCTAssertDirectoryContentEqual(
@@ -313,6 +315,7 @@ private extension CarthageInteractorTests {
     func simulateCarthageOutput(at path: AbsolutePath) throws {
         try [
             "Cartfile.resolved",
+            "Carthage/Cartfile",
             "Carthage/Build/iOS/Moya.framework/Info.plist",
             "Carthage/Build/iOS/ReactiveMoya.framework/Info.plist",
             "Carthage/Build/iOS/RxMoya.framework/Info.plist",

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
@@ -295,7 +295,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
             .appending(component: Constants.DependenciesDirectory.lockfilesDirectoryName)
 
         try createFiles([
-            "Dependencies/Lockfiles/Package.swift",
+            "Dependencies/SwiftPackageManager/Package.swift",
             "Dependencies/Lockfiles/Package.resolved",
             "Dependencies/Lockfiles/OtherLockfile.lock",
             "Dependencies/SwiftPackageManager/Info.plist",

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
@@ -295,6 +295,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
             .appending(component: Constants.DependenciesDirectory.lockfilesDirectoryName)
 
         try createFiles([
+            "Dependencies/Lockfiles/Package.swift",
             "Dependencies/Lockfiles/Package.resolved",
             "Dependencies/Lockfiles/OtherLockfile.lock",
             "Dependencies/SwiftPackageManager/Info.plist",
@@ -330,6 +331,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
 private extension SwiftPackageManagerInteractorTests {
     func simulateSPMOutput(at path: AbsolutePath) throws {
         try [
+            "Package.swift",
             "Package.resolved",
             ".build/manifest.db",
             ".build/workspace-state.json",

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -1456,14 +1456,14 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             )
         )
     }
-    
+
     func testMap_whenSettingsContainsCustomSettingsDictionary_mapsToCustomSettings() throws {
         let basePath = try temporaryPath()
         let sourcesPath = basePath.appending(RelativePath("Package/Path/Sources/Target1"))
         try fileHandler.createFolder(sourcesPath)
-        
+
         let customSettings: TuistGraph.SettingsDictionary = ["CUSTOM_SETTING": .string("CUSTOM_VALUE")]
-        
+
         let targetSettings = ["Target1": customSettings]
 
         let project = try subject.map(
@@ -1489,19 +1489,21 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     swiftLanguageVersions: nil
                 ),
             ],
-            targetSettings:  targetSettings
+            targetSettings: targetSettings
         )
         XCTAssertEqual(
             project,
             .test(
                 name: "Package",
                 targets: [
-                    .test("Target1",
-                          basePath: basePath,
-                          customSettings: [
+                    .test(
+                        "Target1",
+                        basePath: basePath,
+                        customSettings: [
                             "OTHER_LDFLAGS": ["key1", "key2", "key3"],
-                            "CUSTOM_SETTING": "CUSTOM_VALUE"
-                          ]),
+                            "CUSTOM_SETTING": "CUSTOM_VALUE",
+                        ]
+                    ),
                 ]
             )
         )


### PR DESCRIPTION
### Short description 📝

This also persists the generated Package.swift file alongside the Package.resolved; for various bits of open source tooling, both files are required.

### Checklist ✅

- [ ✅] The code architecture and patterns are consistent with the rest of the codebase.
- [ ✅] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ✅] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ✅] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
