### PR TITLE
Allow overriding `SWIFT_VERSION`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - **Breaking** Update logic to calculate client ID starting from UUID instead of hostname, to avoid collisions [#3632](https://github.com/tuist/tuist/pull/3632) by [@danyf90](https://github.com/danyf90)
 - **Breaking** Removed value for `ENABLE_TESTING_SEARCH_PATHS` in SPM dependencies. If a target requires a non-default value, you can set it using the `targetSettings` property in the `Dependencies.swift` file [#3632](https://github.com/tuist/tuist/pull/3653) by [@wattson12](https://github.com/wattson12)
 - `Target`'s initializer now has `InfoPlist.default` set as the default value for the `infoPlist` argument [#3644](https://github.com/tuist/tuist/pull/3644) by [@hisaac](https://github.com/hisaac)
+- Allow overriding `SWIFT_VERSION` [#3644](https://github.com/tuist/tuist/pull/3666) by [@kwridan](https://github.com/kwridan)
+  - The `SWIFT_VERSION` build setting is now part of the `.essential` [`DefaultSettings`](https://docs.tuist.io/manifests/project#defaultsettings)
+  - This algins its behavior with the rest of the default settings, and allows excluding it if necessary via:
+    - Specifying `DefaultSettings.none` for cases where `xcconfig` files are used to control all build settings
+    - Explicitly excluding it via:
+      - `DefaultSettings.recommended(excluding: ["SWIFT_VERSION])` 
+      - `DefaultSettings.essential(excluding: ["SWIFT_VERSION])`
+  - Additionally for convenience, Tuist will not set a `SWIFT_VERSION` target level setting if a project level setting already exists for it
 
 ### Added
 

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -97,7 +97,6 @@ final class ConfigGenerator: ConfigGenerating {
         let configurations = Dictionary(uniqueKeysWithValues: configurationsTuples)
         let nonEmptyConfigurations = !configurations.isEmpty ? configurations : Settings.default.configurations
         let orderedConfigurations = nonEmptyConfigurations.sortedByBuildConfigurationName()
-        let swiftVersion = try System.shared.swiftVersion()
         try orderedConfigurations.forEach {
             try generateTargetSettingsFor(
                 target: target,
@@ -108,7 +107,6 @@ final class ConfigGenerator: ConfigGenerating {
                 graphTraverser: graphTraverser,
                 pbxproj: pbxproj,
                 configurationList: configurationList,
-                swiftVersion: swiftVersion,
                 sourceRootPath: sourceRootPath
             )
         }
@@ -155,7 +153,6 @@ final class ConfigGenerator: ConfigGenerating {
                                            graphTraverser: GraphTraversing,
                                            pbxproj: PBXProj,
                                            configurationList: XCConfigurationList,
-                                           swiftVersion: String,
                                            sourceRootPath: AbsolutePath) throws
     {
         let settingsHelper = SettingsHelper()
@@ -168,7 +165,6 @@ final class ConfigGenerator: ConfigGenerating {
             buildSettings: &settings,
             target: target,
             graphTraverser: graphTraverser,
-            swiftVersion: swiftVersion,
             project: project,
             sourceRootPath: sourceRootPath
         )
@@ -194,14 +190,12 @@ final class ConfigGenerator: ConfigGenerating {
     private func updateTargetDerived(buildSettings settings: inout SettingsDictionary,
                                      target: Target,
                                      graphTraverser: GraphTraversing,
-                                     swiftVersion: String,
                                      project: Project,
                                      sourceRootPath: AbsolutePath)
     {
         settings.merge(
             generalTargetDerivedSettings(
                 target: target,
-                swiftVersion: swiftVersion,
                 sourceRootPath: sourceRootPath,
                 project: project
             )
@@ -213,7 +207,6 @@ final class ConfigGenerator: ConfigGenerating {
 
     private func generalTargetDerivedSettings(
         target: Target,
-        swiftVersion: String,
         sourceRootPath: AbsolutePath,
         project: Project
     ) -> SettingsDictionary {
@@ -235,10 +228,6 @@ final class ConfigGenerator: ConfigGenerating {
         }
         settings["SDKROOT"] = .string(target.platform.xcodeSdkRoot)
         settings["SUPPORTED_PLATFORMS"] = .string(target.platform.xcodeSupportedPlatforms)
-
-        if settings["SWIFT_VERSION"] == nil {
-            settings["SWIFT_VERSION"] = .string(swiftVersion)
-        }
 
         if target.product == .staticFramework {
             settings["MACH_O_TYPE"] = "staticlib"

--- a/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
+++ b/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
@@ -70,7 +70,23 @@ public final class DefaultSettingsProvider: DefaultSettingsProviding {
         ],
     ]
 
-    public init() {}
+    private let system: Systeming
+    private let xcodeController: XcodeControlling
+
+    public convenience init() {
+        self.init(
+            system: System.shared,
+            xcodeController: XcodeController.shared
+        )
+    }
+
+    public init(
+        system: Systeming,
+        xcodeController: XcodeControlling
+    ) {
+        self.system = system
+        self.xcodeController = xcodeController
+    }
 
     // MARK: - DefaultSettingsProviding
 
@@ -114,6 +130,7 @@ public final class DefaultSettingsProvider: DefaultSettingsProviding {
             product: product,
             swift: true
         ).toSettings()
+        let targetSystemInferred = try systemInferredTargetSettings(for: project)
         let filter = try createFilter(
             defaultSettings: defaultSettings,
             essentialKeys: DefaultSettingsProvider.essentialTargetSettings,
@@ -123,6 +140,7 @@ public final class DefaultSettingsProvider: DefaultSettingsProviding {
         var settings: SettingsDictionary = [:]
         settingsHelper.extend(buildSettings: &settings, with: targetDefaultAll)
         settingsHelper.extend(buildSettings: &settings, with: targetDefaultVariant)
+        settingsHelper.extend(buildSettings: &settings, with: targetSystemInferred)
         return settings.filter(filter)
     }
 
@@ -136,7 +154,7 @@ public final class DefaultSettingsProvider: DefaultSettingsProviding {
         case let .essential(excludedKeys):
             return { key, _ in essentialKeys.contains(key) && !excludedKeys.contains(key) }
         case let .recommended(excludedKeys):
-            let xcodeVersion = try XcodeController.shared.selectedVersion()
+            let xcodeVersion = try xcodeController.selectedVersion()
             return { key, _ in
                 // Filter keys that are from higher Xcode version than current (otherwise return true)
                 !newXcodeKeys
@@ -147,6 +165,18 @@ public final class DefaultSettingsProvider: DefaultSettingsProviding {
         case .none:
             return { _, _ in false }
         }
+    }
+
+    private func systemInferredTargetSettings(for project: Project) throws -> SettingsDictionary {
+        var systemInferredSettings = SettingsDictionary()
+        // If swift version is already specified at the project level settings, there is no need to
+        // override it with an inferred version. This allows users to set `SWIFT_VERSION`
+        // at the project level and it automatically applying to all targets without it getting
+        // overwritten with an inferred version.
+        if project.settings.base["SWIFT_VERSION"] == nil {
+            systemInferredSettings["SWIFT_VERSION"] = .string(try system.swiftVersion())
+        }
+        return systemInferredSettings
     }
 }
 

--- a/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
+++ b/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
@@ -61,6 +61,7 @@ public final class DefaultSettingsProvider: DefaultSettingsProviding {
         "COMBINE_HIDPI_IMAGES",
         "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES",
         "WRAPPER_EXTENSION",
+        "SWIFT_VERSION",
     ]
 
     /// Key is `Version` which describes from which version of Xcode are values available for

--- a/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -60,6 +60,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         "CODE_SIGN_IDENTITY": "iPhone Developer",
         "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
         "TARGETED_DEVICE_FAMILY": "1,2",
+        "SWIFT_VERSION": "5.5",
     ]
 
     private let appTargetEssentialReleaseSettings: [String: SettingValue] = [
@@ -70,6 +71,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         "SDKROOT": "iphoneos",
         "CODE_SIGN_IDENTITY": "iPhone Developer",
         "SWIFT_OPTIMIZATION_LEVEL": "-Owholemodule",
+        "SWIFT_VERSION": "5.5",
     ]
 
     private let frameworkTargetEssentialDebugSettings: [String: SettingValue] = [
@@ -89,6 +91,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         "INSTALL_PATH": "$(LOCAL_LIBRARY_DIR)/Frameworks",
         "DYLIB_CURRENT_VERSION": "1",
         "DYLIB_COMPATIBILITY_VERSION": "1",
+        "SWIFT_VERSION": "5.5",
     ]
 
     private let frameworkTargetEssentialReleaseSettings: [String: SettingValue] = [
@@ -107,6 +110,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         "CODE_SIGN_IDENTITY": "",
         "SKIP_INSTALL": "YES",
         "DYLIB_CURRENT_VERSION": "1",
+        "SWIFT_VERSION": "5.5",
     ]
 
     private let testTargetEssentialDebugSettings: [String: SettingValue] = [
@@ -116,6 +120,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         "CODE_SIGN_IDENTITY": "iPhone Developer",
         "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
         "TARGETED_DEVICE_FAMILY": "1,2",
+        "SWIFT_VERSION": "5.5",
     ]
 
     override func setUp() {
@@ -480,7 +485,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         XCTAssertNil(got["SWIFT_VERSION"])
     }
 
-    func testTargetSettings_whenEssentials_doesNotContainsSystemInferredSettings() throws {
+    func testTargetSettings_whenEssential_containsSystemInferredSettings() throws {
         // Given
         let buildConfiguration: BuildConfiguration = .release
         let settings = Settings(
@@ -500,7 +505,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertNil(got["SWIFT_VERSION"])
+        XCTAssertEqual(got["SWIFT_VERSION"], .string("5.0"))
     }
 
     func testTargetSettings_whenNone_doesNotContainsSystemInferredSettings() throws {

--- a/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -120,7 +120,11 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
 
     override func setUp() {
         super.setUp()
-        subject = DefaultSettingsProvider()
+        system.swiftVersionStub = { "5.5" }
+        subject = DefaultSettingsProvider(
+            system: system,
+            xcodeController: xcodeController
+        )
     }
 
     override func tearDown() {
@@ -359,7 +363,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
 
         // Then
         XCTAssertSettings(got, containsAll: appTargetEssentialDebugSettings)
-        XCTAssertEqual(got.count, 9)
+        XCTAssertEqual(got.count, 10)
     }
 
     func testTargetSettings_inheritsProjectDefaultSettings_when_targetBuildSettings_are_nil() throws {
@@ -424,6 +428,104 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
         XCTAssertTrue(got.keys.contains(where: { $0 == "ENABLE_PREVIEWS" }))
     }
 
+    func testTargetSettings_whenRecommended_containsSystemInferredSettings() throws {
+        // Given
+        let buildConfiguration: BuildConfiguration = .release
+        let settings = Settings(
+            base: [:],
+            configurations: [buildConfiguration: nil],
+            defaultSettings: .recommended
+        )
+        let target = Target.test(product: .app, settings: settings)
+        let project = Project.test()
+        system.swiftVersionStub = { "5.0" }
+
+        // When
+        let got = try subject.targetSettings(
+            target: target,
+            project: project,
+            buildConfiguration: buildConfiguration
+        )
+
+        // Then
+        XCTAssertEqual(got["SWIFT_VERSION"], .string("5.0"))
+    }
+
+    func testTargetSettings_whenRecommendedAndSpecifiedInProject_doesNotContainsSystemInferredSettings() throws {
+        // Given
+        let buildConfiguration: BuildConfiguration = .release
+        let settings = Settings(
+            base: [:],
+            configurations: [buildConfiguration: nil],
+            defaultSettings: .essential
+        )
+        let target = Target.test(product: .app, settings: settings)
+        let project = Project.test(
+            settings: .test(
+                base: [
+                    "SWIFT_VERSION": "5.1",
+                ]
+            )
+        )
+        system.swiftVersionStub = { "5.0" }
+
+        // When
+        let got = try subject.targetSettings(
+            target: target,
+            project: project,
+            buildConfiguration: buildConfiguration
+        )
+
+        // Then
+        XCTAssertNil(got["SWIFT_VERSION"])
+    }
+
+    func testTargetSettings_whenEssentials_doesNotContainsSystemInferredSettings() throws {
+        // Given
+        let buildConfiguration: BuildConfiguration = .release
+        let settings = Settings(
+            base: [:],
+            configurations: [buildConfiguration: nil],
+            defaultSettings: .essential
+        )
+        let target = Target.test(product: .app, settings: settings)
+        let project = Project.test()
+        system.swiftVersionStub = { "5.0" }
+
+        // When
+        let got = try subject.targetSettings(
+            target: target,
+            project: project,
+            buildConfiguration: buildConfiguration
+        )
+
+        // Then
+        XCTAssertNil(got["SWIFT_VERSION"])
+    }
+
+    func testTargetSettings_whenNone_doesNotContainsSystemInferredSettings() throws {
+        // Given
+        let buildConfiguration: BuildConfiguration = .release
+        let settings = Settings(
+            base: [:],
+            configurations: [buildConfiguration: nil],
+            defaultSettings: .none
+        )
+        let target = Target.test(product: .app, settings: settings)
+        let project = Project.test()
+        system.swiftVersionStub = { "5.0" }
+
+        // When
+        let got = try subject.targetSettings(
+            target: target,
+            project: project,
+            buildConfiguration: buildConfiguration
+        )
+
+        // Then
+        XCTAssertNil(got["SWIFT_VERSION"])
+    }
+
     func testTargetSettings_whenRecommendedRelease_App() throws {
         // Given
         let buildConfiguration: BuildConfiguration = .release
@@ -445,7 +547,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
 
         // Then
         XCTAssertSettings(got, containsAll: appTargetEssentialReleaseSettings)
-        XCTAssertEqual(got.count, 8)
+        XCTAssertEqual(got.count, 9)
     }
 
     func testTargetSettings_whenRecommendedDebug_Framework() throws {
@@ -468,7 +570,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
 
         // Then
         XCTAssertSettings(got, containsAll: frameworkTargetEssentialDebugSettings)
-        XCTAssertEqual(got.count, 17)
+        XCTAssertEqual(got.count, 18)
     }
 
     func testTargetSettings_whenRecommendedRelease_Framework() throws {
@@ -491,7 +593,7 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
 
         // Then
         XCTAssertSettings(got, containsAll: frameworkTargetEssentialReleaseSettings)
-        XCTAssertEqual(got.count, 16)
+        XCTAssertEqual(got.count, 17)
     }
 
     func testTargetSettings_whenNoneDebug_Framework() throws {


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/920

### Description 📝

- The `SWIFT_VERSION` has historically been automatically inferred for generated projects by obtaining the current system's Swift version
- This ensured all generated projects worked out of the box without further configuration
- Many common use-cases developers have is setting the `SWIFT_VERSION` in an `xcconfig` file to share among all of their projects / targets
- The automatic inferred `SWIFT_VERSION` was set as a target level setting and didn't offer a way to opt out of it easily
  - Developers needed to explicitly define target level settings for each of their targets to override this default
- To fix this the `SWIFT_VERSION` is now being set within the `DefaultSettingsProvider` instead of the `ConfigGenerator` directly
  - This allows users to opt-out of having this value in one of several ways
  - The first is by choosing `defaultSettings: .none`
  - Another is by using the exclusion API `defaultSettings: .recommended(excluding: ["SWIFT_VERSION"])`
- The `SWIFT_VERSION` is no longer set if a project level setting exists
  - This will enable developers to set the `SWIFT_VERSION` as a project level setting that will apply to all targets within it without the automatic inferred value overriding it
- Lastly, while in the area a few small dependency injection improvements were made
  - When using `TuistGenerator` as a library, we were unable to provide our own implementations of `System` and `XcodeController` to the `DefaultSettingsProvider`
  - For our generation purposes, we didn't need any system calls for this, stubbing values was suffice

### Test Plan 🛠

- Verify `SWIFT_VERSION` is still automatically added as a target setting like before by generating an existing fixture

e.g.

```sh
swift build
swift run tuist generate --path projects/tuist/fixtures/ios_app_with_multi_configs
```

- Change the `defaultSettings` for one of the fixtures to `.none`, and verify `SWIFT_VERSION` is no longer set

e.g.

```swift
let settings: Settings = .settings(
    base: [
        "PROJECT_BASE": "PROJECT_BASE",
    ],
    configurations: [
        .debug(name: "Debug", xcconfig: "../ConfigurationFiles/Debug.xcconfig"),
        .release(name: "Beta", xcconfig: "../ConfigurationFiles/Beta.xcconfig"),
        .release(name: "Release", xcconfig: "../ConfigurationFiles/Release.xcconfig"),
    ],
    defaultSettings: .none
)
```

- Change the `defaultSettings` for one of the fixtures to `.recommended(excluding: ["SWIFT_VERSION"])` and verify the setting is no longer set

e.g.

```swift
let settings: Settings = .settings(
    base: [
        "PROJECT_BASE": "PROJECT_BASE",
    ],
    configurations: [
        .debug(name: "Debug", xcconfig: "../ConfigurationFiles/Debug.xcconfig"),
        .release(name: "Beta", xcconfig: "../ConfigurationFiles/Beta.xcconfig"),
        .release(name: "Release", xcconfig: "../ConfigurationFiles/Release.xcconfig"),
    ],
    defaultSettings: .recommended(excluding: ["SWIFT_VERSION"])
)
```

- Add `SWIFT_VERSION` as a project level setting and verify it is not overridden by any target level settings

e.g.

```swift
let settings: Settings = .settings(
    base: [
        "PROJECT_BASE": "PROJECT_BASE",
        "SWIFT_VERSION": "5.0"
    ],
    configurations: [
        .debug(name: "Debug", xcconfig: "../ConfigurationFiles/Debug.xcconfig"),
        .release(name: "Beta", xcconfig: "../ConfigurationFiles/Beta.xcconfig"),
        .release(name: "Release", xcconfig: "../ConfigurationFiles/Release.xcconfig"),
    ]
)
```

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] ~In case the PR introduces changes that affect users, the documentation has been updated.~
- [ ] ~In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.~
