### PR TITLE
Set `ENABLE_TESTING_SEARCH_PATHS` for appropriate dependencies

### DIFF
--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -22,7 +22,8 @@ let dependencies = Dependencies(
             .package(url: "https://github.com/SwiftGen/SwiftGen", .exact("6.5.0")),
             .package(url: "https://github.com/kylef/PathKit.git", .upToNextMajor(from: "1.0.0")),
         ],
-        productTypes: ["RxSwift": .framework, "Checksum": .framework]
+        productTypes: ["RxSwift": .framework, "Checksum": .framework],
+        targetSettings: ["TSCTestSupport": ["ENABLE_TESTING_SEARCH_PATHS": "YES"], "RxTest": ["ENABLE_TESTING_SEARCH_PATHS": "YES"]]
     ),
     platforms: [.macOS]
 )


### PR DESCRIPTION
The change to no longer automatically set `ENABLE_TESTING_SEARCH_PATHS` has broken the build on `main`. This is fixed by setting the flag for the necessary dependencies.

This plus #3665 should allow all tests to pass again.