### PR TITLE
Fix: Release version should use version number and not title

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,8 @@ jobs:
     - name: Update Tuist version
       # This step updates the version in the Constants.swift file by replacing the current tag in Constants.swift with the tagged release.
       # This step also updates the CHANGELOG.md to rename the Next section to the proper release version.
-      # We use a Regex from https://semver.org/ to replace the current version with the new one
       run: |
-        VERSION_REGEX="(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
-        perl -pi -e 's/version = \"${ VERSION_REGEX }\"/version = \"${{ github.event.inputs.title }}\"/g' Sources/TuistSupport/Constants.swift
+        sed -i '' -e "s/version = \".*\"/version = \"${{ github.event.inputs.version }}\"/g" Sources/TuistSupport/Constants.swift
         sed -i '' -e "s/## Next/## ${{ github.event.inputs.version }} - ${{ github.event.inputs.title }}\"/g" CHANGELOG.md
     - name: Fourier releae
       run: ./fourier release tuist ${{ github.event.inputs.version }}


### PR DESCRIPTION
### Short description 📝

When I added the release action I accidentally used the release title for the `Constants.swift` version but this should be the tag version not the title 🤦🏼 

### Checklist ✅

- [X] The code architecture and patterns are consistent with the rest of the codebase.
- [X] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [X] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [X] In case the PR introduces changes that affect users, the documentation has been updated.
- [X] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
