### PR TITLE
Fix: Use Xcode 12.5.1 for release

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: macOS-11
     strategy:
       matrix:
-        xcode: ['13.0']
+        xcode: ['12.5.1']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macOS-11
     strategy:
       matrix:
-        xcode: ['13.0']
+        xcode: ['12.5.1']
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION

### Short description 📝

Update to use Xcode 12.5.1 because of issue reported in: https://tuistapp.slack.com/archives/CTB0DBVD2/p1637251492070400