### PR TITLE
add macOS bundle support in GraphLinter

### DIFF
--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -330,6 +330,7 @@ public class GraphLinter: GraphLinting {
     static let validLinks: [LintableTarget: [LintableTarget]] = [
         // iOS products
         LintableTarget(platform: .iOS, product: .app): [
+            LintableTarget(platform: .macOS, product: .bundle),
             LintableTarget(platform: .iOS, product: .staticLibrary),
             LintableTarget(platform: .iOS, product: .dynamicLibrary),
             LintableTarget(platform: .iOS, product: .framework),
@@ -411,6 +412,7 @@ public class GraphLinter: GraphLinting {
         ],
         // macOS
         LintableTarget(platform: .macOS, product: .app): [
+            LintableTarget(platform: .macOS, product: .bundle),
             LintableTarget(platform: .macOS, product: .staticLibrary),
             LintableTarget(platform: .macOS, product: .dynamicLibrary),
             LintableTarget(platform: .macOS, product: .framework),


### PR DESCRIPTION
to support catalyst target import macOS bundle

Resolves https://github.com/tuist/tuist/issues/YYY
Request for comments document (if applies):

### Short description 📝

> Describe here the purpose of your PR.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
