### PR TITLE
Binary SPM dependencies with different library names are not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- Fixed handling of SPM binary dependencies with custom library names [#3718](https://github.com/tuist/tuist/issues/3718) by [@wattson12](https://github.com/wattson12)
+
 ## 2.3.0 - Bender
 
 ### Changed
@@ -27,7 +31,6 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Fixed caching of targets with `sdk` dependencies [#3681](https://github.com/tuist/tuist/pull/3681) by [@danyf90](https://github.com/danyf90)
-- Fixed handling of SPM binary dependencies with custom library names [#3718](https://github.com/tuist/tuist/issues/3718) by [@wattson12](https://github.com/wattson12)
 
 ## 2.2.1 - Weg
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Fixed caching of targets with `sdk` dependencies [#3681](https://github.com/tuist/tuist/pull/3681) by [@danyf90](https://github.com/danyf90)
+- Fixed handling of SPM binary dependencies with custom library names [#3718](https://github.com/tuist/tuist/issues/3718) by [@wattson12](https://github.com/wattson12)
 
 ## 2.2.1 - Weg
 

--- a/Sources/TuistCore/MetadataProviders/XCFrameworkMetadataProvider.swift
+++ b/Sources/TuistCore/MetadataProviders/XCFrameworkMetadataProvider.swift
@@ -92,7 +92,9 @@ public final class XCFrameworkMetadataProvider: PrecompiledMetadataProvider, XCF
 
         guard let library = libraries.first(where: {
             let hasValidArchitectures = !$0.architectures.filter(archs.contains).isEmpty
-            guard hasValidArchitectures, let binaryPath = try? path(for: $0, binaryName: $0.path.basenameWithoutExt, xcframeworkPath: xcframeworkPath) else {
+            guard hasValidArchitectures,
+                let binaryPath = try? path(for: $0, binaryName: $0.path.basenameWithoutExt, xcframeworkPath: xcframeworkPath)
+            else {
                 return false
             }
             guard FileHandler.shared.exists(binaryPath) else {

--- a/Sources/TuistCore/MetadataProviders/XCFrameworkMetadataProvider.swift
+++ b/Sources/TuistCore/MetadataProviders/XCFrameworkMetadataProvider.swift
@@ -89,11 +89,10 @@ public final class XCFrameworkMetadataProvider: PrecompiledMetadataProvider, XCF
 
     public func binaryPath(xcframeworkPath: AbsolutePath, libraries: [XCFrameworkInfoPlist.Library]) throws -> AbsolutePath {
         let archs: [BinaryArchitecture] = [.arm64, .x8664]
-        let binaryName = xcframeworkPath.basenameWithoutExt
 
         guard let library = libraries.first(where: {
             let hasValidArchitectures = !$0.architectures.filter(archs.contains).isEmpty
-            guard hasValidArchitectures, let binaryPath = try? path(for: $0, binaryName: binaryName, xcframeworkPath: xcframeworkPath) else {
+            guard hasValidArchitectures, let binaryPath = try? path(for: $0, binaryName: $0.path.basenameWithoutExt, xcframeworkPath: xcframeworkPath) else {
                 return false
             }
             guard FileHandler.shared.exists(binaryPath) else {
@@ -107,7 +106,7 @@ public final class XCFrameworkMetadataProvider: PrecompiledMetadataProvider, XCF
             throw XCFrameworkMetadataProviderError.supportedArchitectureReferencesNotFound(xcframeworkPath)
         }
 
-        return try path(for: library, binaryName: binaryName, xcframeworkPath: xcframeworkPath)
+        return try path(for: library, binaryName: library.path.basenameWithoutExt, xcframeworkPath: xcframeworkPath)
     }
 
     private func path(for library: XCFrameworkInfoPlist.Library, binaryName: String, xcframeworkPath: AbsolutePath) throws -> AbsolutePath {

--- a/projects/tuist/fixtures/app_with_spm_dependencies/App/AppDelegate.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/App/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Adjust
 import Alamofire
+import AppboyPushStory
 import Charts
 import ComposableArchitecture
 import FBSDKCoreKit
@@ -26,6 +27,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Use Alamofire to make sure it links fine
         _ = AF.download("http://www.tuist.io")
+        
+        // Use AppboyPushStory to make sure it links fine
+        _ = ABKStoriesView(frame: .zero)
 
         // Use Charts to make sure it links fine
         _ = BarChartView()

--- a/projects/tuist/fixtures/app_with_spm_dependencies/Project.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/Project.swift
@@ -14,6 +14,7 @@ let project = Project(
                 .sdk(name: "libc++.tbd", status: .required),
                 .external(name: "Adjust"),
                 .external(name: "Alamofire"),
+                .external(name: "AppboyPushStory"),
                 .external(name: "Charts"),
                 .external(name: "ComposableArchitecture"),
                 .external(name: "FacebookCore"),

--- a/projects/tuist/fixtures/app_with_spm_dependencies/Tuist/Dependencies.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/Tuist/Dependencies.swift
@@ -12,6 +12,7 @@ let dependencies = Dependencies(
             .package(url: "https://github.com/pointfreeco/swift-composable-architecture", .upToNextMinor(from: "0.22.0")),
             .package(url: "https://github.com/Quick/Quick", .upToNextMajor(from: "4.0.0")),
             .package(url: "https://github.com/Quick/Nimble", .upToNextMajor(from: "9.0.0")),
+            .package(url: "https://github.com/braze-inc/braze-ios-sdk", .upToNextMajor(from: "4.4.0")),
         ],
         targetSettings: [
             "Quick": ["ENABLE_TESTING_SEARCH_PATHS": "YES"],


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3718
Request for comments document (if applies):

### Short description 📝

This adds a potential fix (needs more testing) for an issue where SPM packages with binary targets where the library name does not match the framework name cause errors

More details are here https://github.com/tuist/tuist/issues/3718

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
