### PR TITLE
Set up CocoaPods interactor project

### DIFF
--- a/.github/workflows/cocoapods-interactor.yml
+++ b/.github/workflows/cocoapods-interactor.yml
@@ -1,0 +1,45 @@
+name: CocoaPods Interactor
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - projects/cocoapods-interactor/**
+      - .github/workflows/cocoapods-interactor.yml
+
+concurrency:
+  group: cocoapods-interactor-${{ github.head_ref }}
+  cancel-in-progress: true
+
+env:
+  RUBY_VERSION: '3.0.2'
+
+jobs:
+  tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [ '2.6.8', '2.7.4', '3.0.2']
+    steps:
+      - uses: actions/checkout@v1
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Install Bundler 2.1.4
+        run: gem install bundler --version 2.1.4
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
+      - name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Unit tests
+        run: |
+          ./fourier test cocoapods-interactor

--- a/.github/workflows/cocoapods-interactor.yml
+++ b/.github/workflows/cocoapods-interactor.yml
@@ -13,9 +13,6 @@ concurrency:
   group: cocoapods-interactor-${{ github.head_ref }}
   cancel-in-progress: true
 
-env:
-  RUBY_VERSION: '3.0.2'
-
 jobs:
   tests:
     name: Unit tests

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@
 
 source "https://rubygems.org"
 
-ruby "3.0.2"
-
 gem "cucumber", "~> 6.0"
 gem "rake", "~> 13.0"
 gem "simctl", "~> 1.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,8 +352,5 @@ DEPENDENCIES
   xcodeproj (~> 1.19)
   zeitwerk (~> 2.4)
 
-RUBY VERSION
-   ruby 3.0.2p107
-
 BUNDLED WITH
    2.2.25

--- a/projects/cocoapods-interactor/.rubocop.yml
+++ b/projects/cocoapods-interactor/.rubocop.yml
@@ -1,0 +1,22 @@
+inherit_from: ../../.rubocop.yml
+inherit_gem:
+  rubocop-rails_config:
+    - config/rails.yml
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/RedundantBegin:
+  Enabled: false
+
+Layout/LineLength:
+  Max: 200
+
+AllCops:
+  TargetRubyVersion: 3.0.2
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+  Exclude:
+    - node_modules/**/*
+    - vendor/**/*
+    - db/schema.rb
+    - bin/**/*

--- a/projects/cocoapods-interactor/bin/cocoapods-interactor
+++ b/projects/cocoapods-interactor/bin/cocoapods-interactor
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+lib_path = File.expand_path("../lib", File.dirname(__FILE__))
+$LOAD_PATH.unshift(lib_path) unless $LOAD_PATH.include?(lib_path)
+
+require "cocoapods_interactor"

--- a/projects/cocoapods-interactor/lib/cocoapods_interactor.rb
+++ b/projects/cocoapods-interactor/lib/cocoapods_interactor.rb
@@ -1,0 +1,3 @@
+module CocoaPodsInteractor
+
+end

--- a/projects/cocoapods-interactor/test/cocoapods_interactor/example_test.rb
+++ b/projects/cocoapods-interactor/test/cocoapods_interactor/example_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+module CocoaPodsInteractor
+  class ExampleTest < MiniTest::Test
+    def test_it_passes
+      assert true
+    end
+  end
+end

--- a/projects/cocoapods-interactor/test/test_helper.rb
+++ b/projects/cocoapods-interactor/test/test_helper.rb
@@ -1,0 +1,11 @@
+$LOAD_PATH.unshift(File.expand_path("../../lib", __FILE__))
+
+ENV["TEST"] = "true"
+
+require "cocoapods_interactor"
+
+require "minitest/autorun"
+require "mocha/minitest"
+require "byebug"
+require "minitest/reporters"
+Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new)

--- a/projects/fourier/lib/fourier/commands/test.rb
+++ b/projects/fourier/lib/fourier/commands/test.rb
@@ -10,6 +10,11 @@ module Fourier
       def fourier(test = nil)
         Services::Test::Fourier.call(test: test)
       end
+
+      desc "cocoapods-interactor TEST", "Run all the unit tests from the CocoaPods Interactor"
+      def cocoapods_interactor(test = nil)
+        Services::Test::CocoapodsInteractor.call(test: test)
+      end
     end
   end
 end

--- a/projects/fourier/lib/fourier/constants.rb
+++ b/projects/fourier/lib/fourier/constants.rb
@@ -9,6 +9,7 @@ module Fourier
     TUIST_VENDOR_DIRECTORY = File.expand_path("projects/tuist/vendor", ROOT_DIRECTORY)
     FIXTUREGEN_DIRECTORY = File.expand_path("projects/fixturegen", ROOT_DIRECTORY)
     FOURIER_DIRECTORY = File.expand_path("projects/fourier", ROOT_DIRECTORY)
+    COCOAPODS_INTERACTOR_DIRECTORY = File.expand_path("projects/cocoapods-interactor", ROOT_DIRECTORY)
     TUISTBENCH_DIRECTORY = File.expand_path("projects/tuistbench", ROOT_DIRECTORY)
     WEBSITE_DIRECTORY = File.expand_path("projects/website", ROOT_DIRECTORY)
     DOCS_DIRECTORY = File.expand_path("projects/docs", ROOT_DIRECTORY)

--- a/projects/fourier/lib/fourier/services/test/cocoapods_interactor.rb
+++ b/projects/fourier/lib/fourier/services/test/cocoapods_interactor.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rake/testtask"
+
+module Fourier
+  module Services
+    module Test
+      class CocoapodsInteractor < Base
+        attr_reader :test
+
+        def initialize(test:)
+          @test = test
+        end
+
+        def call
+          Dir.chdir(Constants::ROOT_DIRECTORY) do
+            lib_directory = File.expand_path("lib", Constants::COCOAPODS_INTERACTOR_DIRECTORY)
+            test_directory = File.expand_path("test", Constants::COCOAPODS_INTERACTOR_DIRECTORY)
+
+            test_paths = if @test.nil?
+              Dir.glob(File.join(Constants::COCOAPODS_INTERACTOR_DIRECTORY, "test/**/*_test.rb"))
+            else
+              @test
+            end
+
+            arguments = [
+              "ruby",
+              "-I#{lib_directory}",
+              "-I#{test_directory}",
+              "-e \"ARGV.each {|f| require f}\"",
+              *test_paths,
+            ].join(" ")
+            Utilities::System.system(arguments)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Short description 📝
There are some users that need to use CocoaPods with their Tuist-generated projects. The solution most of them resort to is running a post-generation `pod install` command. However, this is not ideal because they can't benefit from Tuist generation-time optimization because Tuist is not aware of the graph that CocoaPods generates and integrates into their projects.
To solve that, I'll extend the `Dependencies.swift` API to have support for declaring Pods too. The process will be similar to the SPM's. We'll run the `pod install/update` command to resolve the graph and fetch the dependencies. Because those commands don't output the graph in a format that's easy to read from `tuist`, we'll delegate the logic to a Ruby process that can load `CocoaPods` in memory and map the graph into a JSON format that will contract with what Tuist expects.

This PR adds the Ruby project, sets up a CI pipeline to run the unit tests and ensure it's compatible with several Ruby versions, and adjusts the release process to vendor the `cocoapods-interactor` directory.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
