### PR TITLE
fix: persist Cartfile and Package.swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
+- Fixed persisting generated `Package.swift` and `Cartfile` [#3729](https://github.com/tuist/tuist/pull/3729) by [@thedavidharris](https://github.com/thedavidharris)
 - Improve error message in case `ModuleMapMapper` fails to retrieve a dependency [#3733](https://github.com/tuist/tuist/pull/3733) by [@danyf90](https://github.com/danyf90)
 - Fix resolution of external dependencies with products including binary targets [#3737](https://github.com/tuist/tuist/pull/3737) by [@danyf90](https://github.com/danyf90)
 

--- a/Sources/TuistDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
@@ -144,7 +144,7 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
         }
 
         // create `Package.swift`
-        let packageManifestPath = pathsProvider.temporaryPackageSwiftPath
+        let packageManifestPath = pathsProvider.destinationPackageSwiftPath
         try fileHandler.createFolder(packageManifestPath.removingLastComponent())
         try fileHandler.write(dependencies.manifestValue(), path: packageManifestPath, atomically: true)
 
@@ -164,18 +164,11 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
         guard !hasRemoteDependencies || fileHandler.exists(pathsProvider.temporaryPackageResolvedPath) else {
             throw SwiftPackageManagerInteractorError.packageResolvedNotFound
         }
-        guard fileHandler.exists(pathsProvider.temporaryPackageSwiftPath) else {
+        guard fileHandler.exists(pathsProvider.destinationPackageSwiftPath) else {
             throw SwiftPackageManagerInteractorError.packageSwiftNotFound
         }
         guard fileHandler.exists(pathsProvider.destinationBuildDirectory) else {
             throw SwiftPackageManagerInteractorError.buildDirectoryNotFound
-        }
-
-        if fileHandler.exists(pathsProvider.temporaryPackageSwiftPath) {
-            try copy(
-                from: pathsProvider.temporaryPackageSwiftPath,
-                to: pathsProvider.destinationPackageSwiftPath
-            )
         }
 
         if fileHandler.exists(pathsProvider.temporaryPackageResolvedPath) {
@@ -186,7 +179,6 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
         }
 
         // remove temporary files
-        try? FileHandler.shared.delete(pathsProvider.temporaryPackageSwiftPath)
         try? FileHandler.shared.delete(pathsProvider.temporaryPackageResolvedPath)
     }
 
@@ -211,7 +203,6 @@ private struct SwiftPackageManagerPathsProvider {
     let destinationBuildDirectory: AbsolutePath
 
     let temporaryPackageResolvedPath: AbsolutePath
-    let temporaryPackageSwiftPath: AbsolutePath
 
     init(dependenciesDirectory: AbsolutePath) {
         destinationPackageSwiftPath = dependenciesDirectory
@@ -226,7 +217,5 @@ private struct SwiftPackageManagerPathsProvider {
 
         temporaryPackageResolvedPath = destinationSwiftPackageManagerDirectory
             .appending(component: Constants.DependenciesDirectory.packageResolvedName)
-        temporaryPackageSwiftPath = destinationSwiftPackageManagerDirectory
-            .appending(component: Constants.DependenciesDirectory.packageSwiftName)
     }
 }

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
@@ -102,6 +102,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
             swiftPackageManagerDirectory,
             [
                 ".build",
+                "Package.swift",
             ]
         )
         try XCTAssertDirectoryContentEqual(
@@ -193,6 +194,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
             swiftPackageManagerDirectory,
             [
                 ".build",
+                "Package.swift",
             ]
         )
         try XCTAssertDirectoryContentEqual(
@@ -280,6 +282,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
             swiftPackageManagerDirectory,
             [
                 ".build",
+                "Package.swift",
             ]
         )
         try XCTAssertDirectoryContentEqual(


### PR DESCRIPTION
### Short description 📝

This is kind of a silly one, but some of the path logic on this was wrong + the "temporary" place where those files are staying is actually the permanent place, so naming it as such and just not deleting it should actually give the right behavior.

### Checklist ✅

- [ x] The code architecture and patterns are consistent with the rest of the codebase.
- [ x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ x] In case the PR introduces changes that affect users, the documentation has been updated.
- [ x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
