### PR TITLE
Fix release process to make Tuist compatible again with Xcode 12.5 and above

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
         xcode: ['12.5.1']
     steps:
     - uses: actions/checkout@v2
+    - name: Select Xcode
+      run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ env.RUBY_VERSION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
-- Fix release process to make Tuist compatible again with Xcode < 12.5 and above [#3731](https://github.com/tuist/tuist/pull/3731) by [@mikchmie](https://github.com/mikchmie)
+- Fix release process to make Tuist compatible again with Xcode 12.5 and above [#3731](https://github.com/tuist/tuist/pull/3731) by [@mikchmie](https://github.com/mikchmie)
 
 ## 2.3.0 - Bender
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- Add missing "Select Xcode" step to "Tuist release" GitHub action [#3731](https://github.com/tuist/tuist/pull/3731) by [@mikchmie](https://github.com/mikchmie)
+
 ## 2.3.0 - Bender
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
-- Add missing "Select Xcode" step to "Tuist release" GitHub action [#3731](https://github.com/tuist/tuist/pull/3731) by [@mikchmie](https://github.com/mikchmie)
+- Fix release process to make Tuist compatible again with Xcode < 12.5 and above [#3731](https://github.com/tuist/tuist/pull/3731) by [@mikchmie](https://github.com/mikchmie)
 
 ## 2.3.0 - Bender
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3676

### Short description 📝

Run `xcode-select` in release pipeline with Xcode version provided as matrix parameter. 

This should resolve issues with missing `_Concurrency` module when using Xcode 12. E.g.:
```
$ tuist generate

[...] error: no such module '_Concurrency'
import _Concurrency
       ^
```

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
