### PR TITLE
Bundle cocoapods-interactor and add CocoaPods interactor utility

### DIFF
--- a/Sources/TuistCore/Utils/BinaryLocator.swift
+++ b/Sources/TuistCore/Utils/BinaryLocator.swift
@@ -5,6 +5,7 @@ import TuistSupport
 enum BinaryLocatorError: FatalError, Equatable {
     case swiftLintNotFound
     case xcbeautifyNotFound
+    case cocoapodsInteractorNotFound
 
     var description: String {
         switch self {
@@ -12,13 +13,16 @@ enum BinaryLocatorError: FatalError, Equatable {
             return "Couldn't find the swift-lint binary."
         case .xcbeautifyNotFound:
             return "Couldn't find the xcbeautify binary."
+        case .cocoapodsInteractorNotFound:
+            return "Couldn't find the cocoapods-interactor executable."
         }
     }
 
     var type: ErrorType {
         switch self {
         case .swiftLintNotFound,
-             .xcbeautifyNotFound:
+             .xcbeautifyNotFound,
+             .cocoapodsInteractorNotFound:
             return .bug
         }
     }
@@ -31,6 +35,9 @@ public protocol BinaryLocating {
 
     /// Returns the path to the xcbeautify binary.
     func xcbeautifyPath() throws -> AbsolutePath
+
+    /// Returns the path to the cocoapods-interactor executable
+    func cocoapodsInteractorPath() throws -> AbsolutePath
 }
 
 public final class BinaryLocator: BinaryLocating {
@@ -53,6 +60,24 @@ public final class BinaryLocator: BinaryLocating {
             bundlePath.parentDirectory,
             bundlePath.appending(RelativePath("vendor")),
         ]
+    }
+
+    public func cocoapodsInteractorPath() throws -> AbsolutePath {
+        #if DEBUG
+            // Used only for debug purposes
+            let path = AbsolutePath(#file.replacingOccurrences(of: "file://", with: ""))
+                .removingLastComponent()
+                .removingLastComponent()
+                .removingLastComponent()
+                .removingLastComponent()
+                .appending(RelativePath("projects/cocoapods-interactor/bin/cocoapods-interactor"))
+        #else
+            let path = AbsolutePath(Bundle(for: BinaryLocator.self).bundleURL.path).appending(RelativePath("cocoapods-interactor/bin/cocoapods-interactor"))
+        #endif
+        guard FileHandler.shared.exists(path) else {
+            throw BinaryLocatorError.cocoapodsInteractorNotFound
+        }
+        return path
     }
 
     public func swiftLintPath() throws -> AbsolutePath {

--- a/Sources/TuistCoreTesting/Utils/MockBinaryLocator.swift
+++ b/Sources/TuistCoreTesting/Utils/MockBinaryLocator.swift
@@ -3,12 +3,10 @@ import TSCBasic
 @testable import TuistCore
 
 public final class MockBinaryLocator: BinaryLocating {
-    var invokedSwiftLintPath = false
-    var invokedSwiftLintPathCount = 0
-    var stubbedSwiftLintPathError: Error?
-    var stubbedSwiftLintPathResult: AbsolutePath!
-
-    public init() {}
+    public var invokedSwiftLintPath = false
+    public var invokedSwiftLintPathCount = 0
+    public var stubbedSwiftLintPathError: Error?
+    public var stubbedSwiftLintPathResult: AbsolutePath!
 
     public func swiftLintPath() throws -> AbsolutePath {
         invokedSwiftLintPath = true
@@ -20,11 +18,31 @@ public final class MockBinaryLocator: BinaryLocating {
     }
 
     public var xcbeautifyStub: (() throws -> AbsolutePath)?
+    public var invokedXcbeautifyPath = false
+    public var invokedXcbeautifyPathCount = 0
+    public var stubbedXcbeautifyPathError: Error?
+    public var stubbedXcbeautifyPathResult: AbsolutePath!
+
     public func xcbeautifyPath() throws -> AbsolutePath {
-        if let xcbeautifyPath = xcbeautifyStub {
-            return try xcbeautifyPath()
-        } else {
-            throw BinaryLocatorError.xcbeautifyNotFound
+        invokedXcbeautifyPath = true
+        invokedXcbeautifyPathCount += 1
+        if let error = stubbedXcbeautifyPathError {
+            throw error
         }
+        return stubbedXcbeautifyPathResult
+    }
+
+    public var invokedCocoapodsInteractorPath = false
+    public var invokedCocoapodsInteractorPathCount = 0
+    public var stubbedCocoapodsInteractorPathError: Error?
+    public var stubbedCocoapodsInteractorPathResult: AbsolutePath!
+
+    public func cocoapodsInteractorPath() throws -> AbsolutePath {
+        invokedCocoapodsInteractorPath = true
+        invokedCocoapodsInteractorPathCount += 1
+        if let error = stubbedCocoapodsInteractorPathError {
+            throw error
+        }
+        return stubbedCocoapodsInteractorPathResult
     }
 }

--- a/Sources/TuistDependencies/Cocoapods/CocoaPodsInteractor.swift
+++ b/Sources/TuistDependencies/Cocoapods/CocoaPodsInteractor.swift
@@ -14,7 +14,6 @@ final class CocoaPodsInteractor {
 
     func run() throws {
         let path = try binaryLocator.cocoapodsInteractorPath()
-        print(path)
         try System.shared.runAndPrint(path.pathString)
     }
 }

--- a/Sources/TuistDependencies/Cocoapods/CocoaPodsInteractor.swift
+++ b/Sources/TuistDependencies/Cocoapods/CocoaPodsInteractor.swift
@@ -1,0 +1,20 @@
+import Foundation
+import TSCBasic
+import TuistCore
+import TuistSupport
+
+protocol CocoaPodsInteracting {}
+
+final class CocoaPodsInteractor {
+    private let binaryLocator: BinaryLocating
+
+    init(binaryLocator: BinaryLocating = BinaryLocator()) {
+        self.binaryLocator = binaryLocator
+    }
+
+    func run() throws {
+        let path = try binaryLocator.cocoapodsInteractorPath()
+        print(path)
+        try System.shared.runAndPrint(path.pathString)
+    }
+}

--- a/Tests/TuistDependenciesTests/Cocoapods/CocoaPodsInteractorTests.swift
+++ b/Tests/TuistDependenciesTests/Cocoapods/CocoaPodsInteractorTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import TuistDependenciesTesting
 @testable import TuistSupportTesting
 
-final class CocoaPodsInteractorTests: TuistUnitTestCase {
+final class CocoaPodsInteractorTests: TuistTestCase {
     var subject: CocoaPodsInteractor!
 
     override func setUp() {

--- a/Tests/TuistDependenciesTests/Cocoapods/CocoaPodsInteractorTests.swift
+++ b/Tests/TuistDependenciesTests/Cocoapods/CocoaPodsInteractorTests.swift
@@ -1,0 +1,29 @@
+import ProjectDescription
+import TSCBasic
+import TSCUtility
+import TuistCore
+import TuistGraph
+import TuistSupport
+import XCTest
+
+@testable import TuistDependencies
+@testable import TuistDependenciesTesting
+@testable import TuistSupportTesting
+
+final class CocoaPodsInteractorTests: TuistUnitTestCase {
+    var subject: CocoaPodsInteractor!
+
+    override func setUp() {
+        super.setUp()
+        subject = CocoaPodsInteractor()
+    }
+
+    override func tearDown() {
+        subject = nil
+        super.tearDown()
+    }
+
+    func test_it_runs() throws {
+        try subject.run()
+    }
+}

--- a/projects/cocoapods-interactor/lib/cocoapods_interactor.rb
+++ b/projects/cocoapods-interactor/lib/cocoapods_interactor.rb
@@ -2,3 +2,5 @@
 
 module CocoaPodsInteractor
 end
+
+puts "hello world"

--- a/projects/fourier/lib/fourier/services/bundle/tuist.rb
+++ b/projects/fourier/lib/fourier/services/bundle/tuist.rb
@@ -31,6 +31,10 @@ module Fourier
               build_tuist(output_directory: build_directory, swift_build_directory: swift_build_directory)
 
               FileUtils.cp_r(
+                File.expand_path("projects/cocoapods-interactor", Constants::ROOT_DIRECTORY),
+                File.expand_path("cocoapods-interactor", build_directory)
+              )
+              FileUtils.cp_r(
                 File.expand_path("projects/tuist/vendor", Constants::ROOT_DIRECTORY),
                 File.expand_path("vendor", build_directory)
               )
@@ -52,7 +56,8 @@ module Fourier
                   "ProjectAutomation.framework",
                   "ProjectAutomation.framework.dSYM",
                   "Templates",
-                  "vendor"
+                  "vendor",
+                  "cocoapods-interactor"
                 )
               end
             end

--- a/projects/fourier/lib/fourier/services/bundle/tuist.rb
+++ b/projects/fourier/lib/fourier/services/bundle/tuist.rb
@@ -34,6 +34,7 @@ module Fourier
                 File.expand_path("projects/cocoapods-interactor", Constants::ROOT_DIRECTORY),
                 File.expand_path("cocoapods-interactor", build_directory)
               )
+              FileUtils.rm_r(File.expand_path("cocoapods-interactor/test", build_directory))
               FileUtils.cp_r(
                 File.expand_path("projects/tuist/vendor", Constants::ROOT_DIRECTORY),
                 File.expand_path("vendor", build_directory)


### PR DESCRIPTION
### Short description 📝
This PR extends the `bundle` step of the release process to include the `/projects/cocoapods-interactor` directory (with the exception of `test`), and adds a new `CocoaPodsInteractor` utility in `TuistDependencies` to proxy with the Ruby process that will take care of resolving the dependencies and exporting the graph in a Tuist-compatible format.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
