### PR TITLE
Fix crash when running tuist build with verbose config variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fix shell completion script generated in directory containing `.tuist_version` file [#3804](https://github.com/tuist/tuist/pull/3804) by [@mikchmie](https://github.com/mikchmie)
 - `tuist cache print-hashes` not working with relative paths [#3892](https://github.com/tuist/tuist/pull/3892) by [@erkekin](https://github.com/erkekin)
 - Fix argument parsing errors handling in `tuistenv` [#3905](https://github.com/tuist/tuist/pull/3905) by [@pepicrft](https://github.com/pepicrft).
+- Fix crash when running `tuist build` with `TUIST_CONFIG_VERBOSE=1` [#3752](https://github.com/tuist/tuist/pull/3752) by [@fortmarek](https://github.com/fortmarek)
 
 ## 2.4.0 - Lune
 
@@ -33,7 +34,6 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
-- Fix crash when running `tuist build` with `TUIST_CONFIG_VERBOSE=1` [#3752](https://github.com/tuist/tuist/pull/3752) by [@fortmarek](https://github.com/fortmarek)
 - Fix default template to work with `tvos` platform [#3759](https://github.com/tuist/tuist/pull/3759) by [@ezraberch](https://github.com/ezraberch)
 - Fix curl in the installer script so that it fails if unable to download the Tuist release assets. [#3803](https://github.com/tuist/tuist/pull/3803) by [@luispadron](https://github.com/luispadron)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
+- Crash when running `tuist build` with `TUIST_CONFIG_VERBOSE=1` [#3752](https://github.com/tuist/tuist/pull/3752) by [@fortmarek](https://github.com/fortmarek)
 - Fix default template to work with `tvos` platform [#3759](https://github.com/tuist/tuist/pull/3759) by [@ezraberch](https://github.com/ezraberch)
 - Fix curl in the installer script so that it fails if unable to download the Tuist release assets. [#3803](https://github.com/tuist/tuist/pull/3803) by [@luispadron](https://github.com/luispadron)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
-- Crash when running `tuist build` with `TUIST_CONFIG_VERBOSE=1` [#3752](https://github.com/tuist/tuist/pull/3752) by [@fortmarek](https://github.com/fortmarek)
+- Fix crash when running `tuist build` with `TUIST_CONFIG_VERBOSE=1` [#3752](https://github.com/tuist/tuist/pull/3752) by [@fortmarek](https://github.com/fortmarek)
 - Fix default template to work with `tvos` platform [#3759](https://github.com/tuist/tuist/pull/3759) by [@ezraberch](https://github.com/ezraberch)
 - Fix curl in the installer script so that it fails if unable to download the Tuist release assets. [#3803](https://github.com/tuist/tuist/pull/3803) by [@luispadron](https://github.com/luispadron)
 

--- a/Sources/TuistSupport/Utils/Environment.swift
+++ b/Sources/TuistSupport/Utils/Environment.swift
@@ -35,12 +35,14 @@ public protocol Environmenting: AnyObject {
 
     /// Returns true unless the user specifically opted out from stats
     var isStatsEnabled: Bool { get }
+
+    /// Sets up the local environment.
+    func bootstrap() throws
 }
 
 /// Local environment controller.
 public class Environment: Environmenting {
-    public static var shared: Environmenting { environment }
-    private static let environment = Environment()
+    public static var shared: Environmenting = Environment()
 
     /// Returns the default local directory.
     static let defaultDirectory = AbsolutePath(URL(fileURLWithPath: NSHomeDirectory()).path).appending(component: ".tuist")
@@ -61,7 +63,7 @@ public class Environment: Environmenting {
         )
     }
 
-    /// Default environment constroller constructor.
+    /// Default environment constructor.
     ///
     /// - Parameters:
     ///   - directory: Directory where the Tuist environment files will be stored.
@@ -74,10 +76,10 @@ public class Environment: Environmenting {
     // MARK: - EnvironmentControlling
 
     /// Sets up the local environment.
-    public static func bootstrap() throws {
-        try [environment.directory, environment.versionsDirectory].forEach {
-            if !environment.fileHandler.exists($0) {
-                try environment.fileHandler.createFolder($0)
+    public func bootstrap() throws {
+        try [directory, versionsDirectory].forEach {
+            if !fileHandler.exists($0) {
+                try fileHandler.createFolder($0)
             }
         }
     }

--- a/Sources/TuistSupport/Utils/Environment.swift
+++ b/Sources/TuistSupport/Utils/Environment.swift
@@ -39,7 +39,8 @@ public protocol Environmenting: AnyObject {
 
 /// Local environment controller.
 public class Environment: Environmenting {
-    public static var shared: Environmenting = Environment()
+    public static var shared: Environmenting { environment }
+    private static let environment = Environment()
 
     /// Returns the default local directory.
     static let defaultDirectory = AbsolutePath(URL(fileURLWithPath: NSHomeDirectory()).path).appending(component: ".tuist")
@@ -68,17 +69,15 @@ public class Environment: Environmenting {
     init(directory: AbsolutePath, fileHandler: FileHandling) {
         self.directory = directory
         self.fileHandler = fileHandler
-        setup()
     }
 
     // MARK: - EnvironmentControlling
 
     /// Sets up the local environment.
-    private func setup() {
-        [directory, versionsDirectory].forEach {
-            if !fileHandler.exists($0) {
-                // swiftlint:disable:next force_try
-                try! fileHandler.createFolder($0)
+    public static func bootstrap() throws {
+        try [environment.directory, environment.versionsDirectory].forEach {
+            if !environment.fileHandler.exists($0) {
+                try environment.fileHandler.createFolder($0)
             }
         }
     }

--- a/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
+++ b/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
@@ -45,4 +45,6 @@ public class MockEnvironment: Environmenting {
     func path(version: String) -> AbsolutePath {
         versionsDirectory.appending(component: version)
     }
+
+    public func bootstrap() throws {}
 }

--- a/Sources/tuist/main.swift
+++ b/Sources/tuist/main.swift
@@ -18,7 +18,7 @@ if let argumentIndex = CommandLine.arguments.firstIndex(of: "--path") {
     path = .current
 }
 
-try TuistSupport.Environment.bootstrap()
+try TuistSupport.Environment.shared.bootstrap()
 try TuistAnalytics.bootstrap(config: ConfigLoader().loadConfig(path: path))
 
 import TuistKit

--- a/Sources/tuist/main.swift
+++ b/Sources/tuist/main.swift
@@ -18,6 +18,7 @@ if let argumentIndex = CommandLine.arguments.firstIndex(of: "--path") {
     path = .current
 }
 
+try TuistSupport.Environment.bootstrap()
 try TuistAnalytics.bootstrap(config: ConfigLoader().loadConfig(path: path))
 
 import TuistKit

--- a/Sources/tuistenv/main.swift
+++ b/Sources/tuistenv/main.swift
@@ -7,6 +7,7 @@ if CommandLine.arguments.contains("--generate-completion-script") {
     try? ProcessEnv.setVar(Constants.EnvironmentVariables.silent, value: "true")
 }
 
+try TuistSupport.Environment.shared.bootstrap()
 LogOutput.bootstrap()
 
 TuistCommand.main()

--- a/projects/tuist/features/step_definitions/shared/tuist.rb
+++ b/projects/tuist/features/step_definitions/shared/tuist.rb
@@ -6,7 +6,7 @@ Given(/tuist is available/) do
   # On CI we expect tuist to be built already by the previous job `release_build`, so we skip `swift build`
 
   if ENV["CI"].nil?
-    ["tuist", "ProjectDescription", "ProjectAutomation"].each do |product|
+    ["tuist", "ProjectDescription", "ProjectAutomation", "tuistenv"].each do |product|
       system(
         "swift",
         "build",


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3684

### Short description 📝

We were executing [business logic](https://github.com/tuist/tuist/compare/fix-crash-environment?expand=1#diff-c10d893a0d13a5433625b2ea899cb54210648ccd49e3de2301be7245ad471abdL77) when initializing `Environment` which could lead to accessing `Environment` while the `Environment` was being initalized (leading to a crash as described in the [attached issue](https://github.com/tuist/tuist/issues/3684)).

To remedy this, I have added `bootstrap` method that will be executed in `main.swift` to execute the business logic only _after_ `Environment.shared` is initialized. 

cc @kikeenrique

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
