### PR TITLE
Fix fourier's focus command

### DIFF
--- a/projects/fourier/lib/fourier.rb
+++ b/projects/fourier/lib/fourier.rb
@@ -50,13 +50,8 @@ module Fourier
     subcommand "encrypt", Commands::Encrypt
 
     desc "focus TARGET", "Generate Tuist's project focusing on the target TARGET"
-    def focus(target)
+    def focus(target = nil)
       Services::Focus.call(target: target)
-    end
-
-    desc "focus", "Generate Tuist's project focusing on internal targets"
-    def focus
-      Services::Focus.call(target: nil)
     end
 
     desc "tuist", "Runs Tuist"


### PR DESCRIPTION
### Short description 📝

It is currently not possible to specify a target on which to focus when running `fourier focus` (aka you cannot run `fourier focus TuistKit`)

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
