### PR TITLE
Add LaunchScreen template for tvOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Fixed
+
+- Fix default template to work with `tvos` platform [#3759](https://github.com/tuist/tuist/pull/3759) by [@ezraberch](https://github.com/ezraberch)
+
 ## 2.3.2 - Discoteque
 
 ### Fixed

--- a/Templates/LaunchScreen+tvOS.stencil
+++ b/Templates/LaunchScreen+tvOS.stencil
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="13122.16" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0"
+                            alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/projects/tuist/features/init.feature
+++ b/projects/tuist/features/init.feature
@@ -14,6 +14,13 @@ Feature: Initialize a new project using Tuist
     Then tuist generates the project
     Then I should be able to build for iOS the scheme MyApp
 
+  Scenario: The project is a compilable tvOS application
+    Given that tuist is available
+    And I have a working directory
+    When I initialize a tvos application named TvApp
+    Then tuist generates the project
+    Then I should be able to build for tvOS the scheme TvApp
+
   Scenario: The project is a compilable SwiftUI iOS application
     Given that tuist is available
     And I have a working directory
@@ -27,3 +34,10 @@ Feature: Initialize a new project using Tuist
     When I initialize a macos application named Test with swiftui template
     Then tuist generates the project
     Then I should be able to build for macOS the scheme Test
+
+  Scenario: The project is a compilable SwiftUI tvOS application
+    Given that tuist is available
+    And I have a working directory
+    When I initialize a tvos application named TvApp with swiftui template
+    Then tuist generates the project
+    Then I should be able to build for tvOS the scheme TvApp


### PR DESCRIPTION
`tuist init --platform tvos` fails because the `LaunchScreen` stencil template is missing. This PR adds that template. Additionally, `tvos` tests have been added to the `init` acceptance tests.