### PR TITLE
Fix: Make `curl` command fail install if it fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Fix default template to work with `tvos` platform [#3759](https://github.com/tuist/tuist/pull/3759) by [@ezraberch](https://github.com/ezraberch)
+- Fix curl in the installer script so that it fails if unable to download the Tuist release assets. [#3803](https://github.com/tuist/tuist/pull/3803) by [@luispadron](https://github.com/luispadron)
 
 ## 2.3.2 - Discoteque
 

--- a/script/install
+++ b/script/install
@@ -28,7 +28,7 @@ LATEST_VERSION=$(curl --silent "https://raw.githubusercontent.com/tuist/tuist/ma
 ohai "Downloading tuistenv..."
 [ -f /tmp/tuistenv.zip ] && rm /tmp/tuistenv.zip
 [ -f /tmp/tuistenv ] && rm /tmp/tuistenv
-curl -LSs --output /tmp/tuistenv.zip https://github.com/tuist/tuist/releases/download/${LATEST_VERSION}/tuistenv.zip
+curl -LSsf --output /tmp/tuistenv.zip https://github.com/tuist/tuist/releases/download/${LATEST_VERSION}/tuistenv.zip
 ohai "Unzipping tuistenv..."
 unzip -o /tmp/tuistenv.zip -d /tmp/tuistenv > /dev/null
 ohai "Installing tuistenv..."


### PR DESCRIPTION
### Short description 📝

From discussion: https://tuistapp.slack.com/archives/CTB0DBVD2/p1638954911147500

We've seen some failures when installing Tuist where the unzip command cannot find the zip file. My thinking is the `curl` command is failing but since it doesn't terminate the installer were getting an unrelated error which is confusing.

### Checklist ✅

- [X] The code architecture and patterns are consistent with the rest of the codebase.
- [X] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [X] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [X] In case the PR introduces changes that affect users, the documentation has been updated.
- [X] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
