### PR TITLE
Extend the template to include test steps

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,10 @@ Request for comments document (if applies):
 
 > Describe here the purpose of your PR.
 
+### How to test the changes locally 🧐
+
+> Include a set of steps for the reviewer to test the changes locally.
+
 ### Checklist ✅
 
 - [ ] The code architecture and patterns are consistent with the rest of the codebase.


### PR DESCRIPTION
### Short description 📝
I'm extending the PR template to ask contributors to include a set of steps that reviewers can use to test the changes locally.

