### PR TITLE
🚨 Suppress swift warnings for SPM dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ## Next
 
 ### Changed
-- Suppressed swift warnings in SPM packages added via Dependencies.swift [#3852](https://github.com/tuist/tuist/pull/3852) by [@wattson12](https://github.com/wattson12)
+- Add `SWIFT_SUPPRESS_WARNINGS` setting to SwiftPackageManager generated project to suppress warnings from dependencies defined in Dependencies.swift [#3852](https://github.com/tuist/tuist/pull/3852) by [@wattson12](https://github.com/wattson12)
 
 ## 2.4.0 - Lune
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Changed
+- Suppressed swift warnings in SPM packages added via Dependencies.swift [#3852](https://github.com/tuist/tuist/pull/3852) by [@wattson12](https://github.com/wattson12)
+
 ## 2.4.0 - Lune
 
 ### Added

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -707,6 +707,7 @@ extension ProjectDescription.Settings {
             "USE_HEADERMAP": "NO",
             // Disable warnings in generated projects
             "GCC_WARN_INHIBIT_ALL_WARNINGS": "YES",
+            "SWIFT_SUPPRESS_WARNINGS": "YES",
         ]
 
         if let moduleMapPath = moduleMap.path {

--- a/Sources/TuistDependenciesTesting/DependenciesGraph/DependenciesGraph+TestData.swift
+++ b/Sources/TuistDependenciesTesting/DependenciesGraph/DependenciesGraph+TestData.swift
@@ -456,6 +456,7 @@ extension DependenciesGraph {
         let defaultSpmSettings: SettingsDictionary = [
             "ALWAYS_SEARCH_USER_PATHS": "YES",
             "GCC_WARN_INHIBIT_ALL_WARNINGS": "YES",
+            "SWIFT_SUPPRESS_WARNINGS": "YES",
             "CLANG_ENABLE_OBJC_WEAK": "NO",
             "CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER": "NO",
             "ENABLE_STRICT_OBJC_MSGSEND": "NO",


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY
Request for comments document (if applies):

### Short description 📝

This adds the `SWIFT_SUPPRESS_WARNINGS` flag to targets created for SPM dependencies to silence swift warnings (some warnings are already silenced via `GCC_WARN_INHIBIT_ALL_WARNINGS`)

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
