### PR TITLE
fixing issue #3811 related with inconsistency with tuist init command

### DIFF
--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -95,7 +95,8 @@ extension InitCommand {
     static func preprocess(_ arguments: [String]? = nil) throws {
         guard
             let arguments = arguments,
-            arguments.contains("--template")
+            arguments.contains("--template"),
+            arguments.contains("-t")
         else { return }
 
         // We want to parse only the name of template, not its arguments which will be dynamically added


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3811

### Short description 📝

After debugging, I did found that in `InitCommand.swift` at the `preprocess(_ arguments:` function is making a `guard` evaluating if `arguments` contians `"--template"` but not evaluating `"-t"` aswell. I added this and all the cases described above works like a charm.

### How to test the changes locally 🧐

check this init command's variants:
`tuist init`
`tuist init --template default`
`tuist init -t default`
`tuist init --template swiftui` (`Error: Missing expected argument '--name <name>'`)
`tuist init -t swiftui`

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
