### PR TITLE
Add generation time to focus command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 - Add support for `exclusionRule` parameter to `Headers` [#3793](https://github.com/tuist/tuist/pull/3793) by [@pavel-trafimuk](https://github.com/pavel-trafimuk)
+- Add generation time for `tuist focus` command [#3872](https://github.com/tuist/tuist/pull/3872) by [@adellibovi](https://github.com/adellibovi)
 
 ## 2.4.0 - Lune
 

--- a/Sources/TuistKit/Services/FocusService.swift
+++ b/Sources/TuistKit/Services/FocusService.swift
@@ -12,18 +12,21 @@ import TuistSupport
 
 final class FocusService {
     private let opener: Opening
+    private let clock: Clock
     private let generatorFactory: GeneratorFactorying
     private let configLoader: ConfigLoading
     private let manifestLoader: ManifestLoading
     private let pluginService: PluginServicing
 
     init(
+        clock: Clock = WallClock(),
         configLoader: ConfigLoading = ConfigLoader(manifestLoader: ManifestLoader()),
         manifestLoader: ManifestLoading = ManifestLoader(),
         opener: Opening = Opener(),
         generatorFactory: GeneratorFactorying = GeneratorFactory(),
         pluginService: PluginServicing = PluginService()
     ) {
+        self.clock = clock
         self.configLoader = configLoader
         self.manifestLoader = manifestLoader
         self.opener = opener
@@ -32,6 +35,7 @@ final class FocusService {
     }
 
     func run(path: String?, sources: Set<String>, noOpen: Bool, xcframeworks: Bool, profile: String?, ignoreCache: Bool) throws {
+        let timer = clock.startTimer()
         let path = self.path(path)
         let config = try configLoader.loadConfig(path: path)
         let cacheProfile = try CacheProfileResolver().resolveCacheProfile(named: profile, from: config)
@@ -46,6 +50,10 @@ final class FocusService {
         if !noOpen {
             try opener.open(path: workspacePath)
         }
+        let time = String(format: "%.3f", timer.stop())
+
+        logger.notice("Project generated.", metadata: .success)
+        logger.notice("Total time taken: \(time)s")
     }
 
     // MARK: - Helpers

--- a/Sources/TuistKit/Services/FocusService.swift
+++ b/Sources/TuistKit/Services/FocusService.swift
@@ -13,6 +13,7 @@ import TuistSupport
 final class FocusService {
     private let opener: Opening
     private let clock: Clock
+    private let timeTakenLoggerFormatter: TimeTakenLoggerFormatting
     private let generatorFactory: GeneratorFactorying
     private let configLoader: ConfigLoading
     private let manifestLoader: ManifestLoading
@@ -20,6 +21,7 @@ final class FocusService {
 
     init(
         clock: Clock = WallClock(),
+        timeTakenLoggerFormatter: TimeTakenLoggerFormatting = TimeTakenLoggerFormatter(),
         configLoader: ConfigLoading = ConfigLoader(manifestLoader: ManifestLoader()),
         manifestLoader: ManifestLoading = ManifestLoader(),
         opener: Opening = Opener(),
@@ -27,6 +29,7 @@ final class FocusService {
         pluginService: PluginServicing = PluginService()
     ) {
         self.clock = clock
+        self.timeTakenLoggerFormatter = timeTakenLoggerFormatter
         self.configLoader = configLoader
         self.manifestLoader = manifestLoader
         self.opener = opener
@@ -50,10 +53,8 @@ final class FocusService {
         if !noOpen {
             try opener.open(path: workspacePath)
         }
-        let time = String(format: "%.3f", timer.stop())
-
         logger.notice("Project generated.", metadata: .success)
-        logger.notice("Total time taken: \(time)s")
+        logger.notice(timeTakenLoggerFormatter.timeTakenMessage(for: timer))
     }
 
     // MARK: - Helpers

--- a/Sources/TuistKit/Services/GenerateService.swift
+++ b/Sources/TuistKit/Services/GenerateService.swift
@@ -10,17 +10,20 @@ final class GenerateService {
 
     private let opener: Opening
     private let clock: Clock
+    private let timeTakenLoggerFormatter: TimeTakenLoggerFormatting
     private let generatorFactory: GeneratorFactorying
     private let configLoader: ConfigLoading
 
     // MARK: - Init
 
     init(clock: Clock = WallClock(),
+         timeTakenLoggerFormatter: TimeTakenLoggerFormatting = TimeTakenLoggerFormatter(),
          opener: Opening = Opener(),
          generatorFactory: GeneratorFactorying = GeneratorFactory(),
          configLoader: ConfigLoading = ConfigLoader(manifestLoader: ManifestLoader()))
     {
         self.clock = clock
+        self.timeTakenLoggerFormatter = timeTakenLoggerFormatter
         self.opener = opener
         self.generatorFactory = generatorFactory
         self.configLoader = configLoader
@@ -40,10 +43,8 @@ final class GenerateService {
             try opener.open(path: generatedProjectPath, wait: false)
         }
 
-        let time = String(format: "%.3f", timer.stop())
-
         logger.notice("Project generated.", metadata: .success)
-        logger.notice("Total time taken: \(time)s")
+        logger.notice(timeTakenLoggerFormatter.timeTakenMessage(for: timer))
     }
 
     // MARK: - Helpers

--- a/Sources/TuistSupport/Utils/TimeTakenLoggerFormatter.swift
+++ b/Sources/TuistSupport/Utils/TimeTakenLoggerFormatter.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public protocol TimeTakenLoggerFormatting {
+    func timeTakenMessage(for timer: ClockTimer) -> Logger.Message
+}
+
+public class TimeTakenLoggerFormatter: TimeTakenLoggerFormatting {
+    public init() {}
+
+    public func timeTakenMessage(for timer: ClockTimer) -> Logger.Message {
+        let time = String(format: "%.3f", timer.stop())
+        return "Total time taken: \(time)s"
+    }
+}


### PR DESCRIPTION
### Short description 📝

Currently, we show how long it takes for `tuist generate` to generate the project, I was wondering if it could be a good idea to apply the same behavior to `tuist focus`, personally I find myself wanting to quickly see if there is any regression between new versions. Also, it works as confirmation feedback of "completion" of the command.
What do you think?

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
