### PR TITLE
Loading public headers from Umbrella file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fix clean `tuist test` for project with resources [#4091](https://github.com/tuist/tuist/pull/4091) by [@adellibovi](https://github.com/adellibovi)
 - Fix `tuist graph --skip-external-dependencies` for `Dependencies.swift` dependencies [#4115](https://github.com/tuist/tuist/pull/4115) by [@danyf90](https://github.com/danyf90)
 
+### Added
+
+- Add support for `umbrellaHeader` parameter to `Headers` to get list of public headers automatically. Also added new static functions in `Headers` for most popular cases with umbrella header [#3884](https://github.com/tuist/tuist/pull/3884) by [@pavel-trafimuk](https://github.com/pavel-trafimuk)
+
 ## 2.7.2
 
 - Fix download of binary artifacts from the remote cache [#4073](https://github.com/tuist/tuist/pull/4073) by [@adellibovi](https://github.com/adellibovi)

--- a/Sources/TuistLoader/Loaders/UmbrellaHeaderHeadersExtractor.swift
+++ b/Sources/TuistLoader/Loaders/UmbrellaHeaderHeadersExtractor.swift
@@ -1,0 +1,48 @@
+import Foundation
+import TSCBasic
+import TuistSupport
+
+public enum UmbrellaHeaderHeadersExtractor {
+    public static func headers(
+        from path: AbsolutePath,
+        for productName: String?
+    ) throws -> [String] {
+        let umbrellaContent = try FileHandler.shared.readTextFile(path)
+        let lines = umbrellaContent.components(separatedBy: .newlines)
+        let expectedPrefixes = [
+            "#import \"",
+            "#import <",
+        ]
+
+        return lines.compactMap { line in
+            let stripped = line.trimmingCharacters(in: .whitespaces)
+            guard let matchingPrefix = expectedPrefixes.first(where: { line.hasPrefix($0) }) else {
+                return nil
+            }
+            // also we need drop comments and spaces before comments
+            guard let stripedWithoutComments = stripped.components(separatedBy: "//")
+                .first?
+                .trimmingCharacters(in: .whitespaces)
+            else {
+                return nil
+            }
+            let headerReference = stripedWithoutComments.dropFirst(matchingPrefix.count).dropLast()
+            let headerComponents = headerReference.components(separatedBy: "/")
+
+            // <ProductName/Header.h>
+            // "ProductName/Header.h"
+            let isValidProductPrefixedHeader = headerComponents.count == 2 &&
+                productName != nil &&
+                headerComponents[0] == productName
+
+            // "Header.h"
+            let isValidSingleHeader = headerComponents.count == 1
+
+            guard isValidProductPrefixedHeader || isValidSingleHeader else {
+                return nil
+            }
+
+            return headerComponents.last
+        }
+    }
+}

--- a/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
@@ -71,7 +71,11 @@ extension TuistGraph.Target {
             try TuistGraph.CopyFilesAction.from(manifest: $0, generatorPaths: generatorPaths)
         }
 
-        let headers = try manifest.headers.map { try TuistGraph.Headers.from(manifest: $0, generatorPaths: generatorPaths) }
+        let headers = try manifest.headers.map { try TuistGraph.Headers.from(
+            manifest: $0,
+            generatorPaths: generatorPaths,
+            productName: manifest.productName
+        ) }
 
         let coreDataModels = try manifest.coreDataModels.map {
             try TuistGraph.CoreDataModel.from(manifest: $0, generatorPaths: generatorPaths)

--- a/Sources/TuistLoader/Models/FileListGlob+Unfold.swift
+++ b/Sources/TuistLoader/Models/FileListGlob+Unfold.swift
@@ -1,0 +1,36 @@
+import Foundation
+import ProjectDescription
+import TSCBasic
+import TuistGraph
+import TuistSupport
+
+extension FileListGlob {
+    func unfold(
+        generatorPaths: GeneratorPaths,
+        filter: ((AbsolutePath) -> Bool)? = nil
+    ) throws -> [AbsolutePath] {
+        let resolvedPath = try generatorPaths.resolve(path: glob)
+        let resolvedExcluding = try resolvedExcluding(generatorPaths: generatorPaths)
+        let pattern = String(resolvedPath.pathString.dropFirst())
+        return FileHandler.shared.glob(AbsolutePath.root, glob: pattern).filter { path in
+            guard !resolvedExcluding.contains(path) else {
+                return false
+            }
+            if let filter = filter {
+                return filter(path)
+            }
+            return true
+        }
+    }
+
+    private func resolvedExcluding(generatorPaths: GeneratorPaths) throws -> Set<AbsolutePath> {
+        guard !excluding.isEmpty else { return [] }
+        var result: Set<AbsolutePath> = []
+        try excluding.forEach { path in
+            let resolved = try generatorPaths.resolve(path: path)
+            let globs = AbsolutePath(resolved.dirname).glob(resolved.basename)
+            result.formUnion(globs)
+        }
+        return result
+    }
+}

--- a/projects/docs/docs/manifests/project.md
+++ b/projects/docs/docs/manifests/project.md
@@ -297,10 +297,10 @@ The following example shows classic way with manual declaring list for each kind
 
 ```swift
 .headers(
-            public: "Sources/public/**",
-            private: "Sources/private/**",
-            project: "Sources/project/**"
-        )
+    public: "Sources/public/**",
+    private: "Sources/private/**",
+    project: "Sources/project/**"
+)
 ```
 
 ### File List

--- a/projects/docs/docs/manifests/project.md
+++ b/projects/docs/docs/manifests/project.md
@@ -260,9 +260,48 @@ It represents the target headers:
 | Property           | Description                                                                           | Type                                                     | Required | Default |
 | ------------------ | ---------------------------------------------------------------------------------------- | ----------------------------------------------------- | -------- | ------- |
 | `public`           | Relative glob pattern that points to the public headers.                                 | [`FileList`](#file-list)                              | No       |         |
+| `umbrellaHeader`   | Path to an umbrella header, which will be used to get list of public headers             | [`Path`](#path)                                       | No       |         |
 | `private`          | Relative glob pattern that points to the private headers.                                | [`FileList`](#file-list)                              | No       |         |
 | `project`          | Relative glob pattern that points to the project headers.                                | [`FileList`](#file-list)                              | No       |         |
 | `exclusionRule`    | Rule, which determines how to resolve found duplicates in public/private/project scopes  | [`AutomaticExclusionRule`](#automatic-exclusion-rule) | No       | `.none` |
+
+The following example shows creating Header by using umbrealla header as source of truth for public headers, all others will be with `project` visibility:
+
+```swift
+.allHeaders(from: "Classes/**", umbrella: "MyModuleName.h")
+```
+
+The following example shows creating Header by using umbrealla header as source of truth for public headers, specific list of private headers and all others will be with `project` visibility:
+
+```swift
+.allHeaders(from: "Classes/**", umbrella: "MyModuleName.h", private: "Sources/**/*+Private.h")
+```
+
+The following example shows creating Header by using umbrealla header as source of truth for public headers, specific list of private headers and all others will be with skipped:
+
+```swift
+.onlyHeaders(from: "Classes/**", umbrella: "MyModuleName.h", private: "Sources/**/*+Private.h")
+```
+
+Don't forget, that you can add exceptions for the each list, e.g. to remove unit-tests headers
+
+```swift
+.allHeaders(
+    from: .list([.glob("Sources/group/**", excluding: ["Sources/**/*+Mock.h"])]),
+    umbrella: "Sources/Umbrella.h",
+    private: "Sources/**/*+Private.h"
+    )
+```
+
+The following example shows classic way with manual declaring list for each kind of vibisility
+
+```swift
+.headers(
+            public: "Sources/public/**",
+            private: "Sources/private/**",
+            project: "Sources/project/**"
+        )
+```
 
 ### File List
 

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/App/Config/App-Info.plist
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/App/Config/App-Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright Tuist©. All rights reserved.</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/App/Config/AppTests-Info.plist
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/App/Config/AppTests-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/App/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/App/Project.swift
@@ -1,0 +1,33 @@
+import ProjectDescription
+
+let settings: Settings = .settings(base: [
+    "HEADER_SEARCH_PATHS": "path/to/lib/include",
+])
+let project = Project(
+    name: "MainApp",
+    settings: settings,
+    targets: [
+        Target(
+            name: "App",
+            platform: .iOS,
+            product: .app,
+            bundleId: "io.tuist.App",
+            infoPlist: "Config/App-Info.plist",
+            sources: "Sources/**",
+            dependencies: [
+                .project(target: "Framework1-iOS", path: "../Framework1"),
+            ]
+        ),
+        Target(
+            name: "AppTests",
+            platform: .iOS,
+            product: .unitTests,
+            bundleId: "io.tuist.AppTests",
+            infoPlist: "Config/AppTests-Info.plist",
+            sources: "Tests/**",
+            dependencies: [
+                .target(name: "App"),
+            ]
+        ),
+    ]
+)

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/App/Sources/AppDelegate.swift
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/App/Sources/AppDelegate.swift
@@ -1,0 +1,20 @@
+import Framework1
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func applicationDidFinishLaunching(_: UIApplication) {
+        let framework1 = Framework1File()
+        let framework1Objc = MyPublicClass()
+
+        print(hello())
+        print("AppDelegate -> \(framework1.hello())")
+        print("AppDelegate -> \(framework1Objc.hello())")
+    }
+
+    func hello() -> String {
+        "AppDelegate.hello()"
+    }
+}

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/App/Tests/AppDelegateTests.swift
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/App/Tests/AppDelegateTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import App
+
+class AppDelegateTests: XCTestCase {
+    func testHello() {
+        let sut = AppDelegate()
+
+        XCTAssertEqual("AppDelegate.hello()", sut.hello())
+    }
+}

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Config/Framework1-Info.plist
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Config/Framework1-Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright Tuist©. All rights reserved.</string>
+</dict>
+</plist>

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Config/Framework1Tests-Info.plist
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Config/Framework1Tests-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Project.swift
@@ -1,0 +1,48 @@
+import ProjectDescription
+
+let project = Project(
+    name: "Framework1",
+    targets: [
+        Target(
+            name: "Framework1-iOS",
+            platform: .iOS,
+            product: .framework,
+            productName: "Framework1",
+            bundleId: "io.tuist.Framework1",
+            infoPlist: "Config/Framework1-Info.plist",
+            sources: "Sources/**",
+            headers: .allHeaders(
+                from: "Sources/**",
+                umbrella: "Sources/Framework1.h",
+                private: "Sources/MyPrivateClass.h"
+            ),
+            dependencies: []
+        ),
+        Target(
+            name: "Framework1-macOS",
+            platform: .macOS,
+            product: .framework,
+            productName: "Framework1",
+            bundleId: "io.tuist.Framework1",
+            infoPlist: "Config/Framework1-Info.plist",
+            sources: "Sources/**",
+            headers: .allHeaders(
+                from: "Sources/**",
+                umbrella: "Sources/Framework1.h",
+                private: "Sources/MyPrivateClass.h"
+            ),
+            dependencies: []
+        ),
+        Target(
+            name: "Framework1Tests",
+            platform: .iOS,
+            product: .unitTests,
+            bundleId: "io.tuist.Framework1Tests",
+            infoPlist: "Config/Framework1Tests-Info.plist",
+            sources: "Tests/**",
+            dependencies: [
+                .target(name: "Framework1-iOS"),
+            ]
+        ),
+    ]
+)

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Sources/Framework1.h
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Sources/Framework1.h
@@ -1,0 +1,2 @@
+
+#import <Framework1/MyPublicClass.h>

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Sources/Framework1File.swift
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Sources/Framework1File.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public class Framework1File {
+    public init() {}
+
+    public func hello() -> String {
+        "Framework1File.hello()"
+    }
+}

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Sources/MyPrivateClass.h
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Sources/MyPrivateClass.h
@@ -1,0 +1,12 @@
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MyPrivateClass : NSObject
+
+- (NSString *)hello;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Sources/MyPrivateClass.m
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Sources/MyPrivateClass.m
@@ -1,0 +1,11 @@
+
+#import "MyPrivateClass.h"
+
+@implementation MyPrivateClass
+
+- (NSString *)hello
+{
+    return @"MyPrivateClass.hello";
+}
+
+@end

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Sources/MyProjectClass.h
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Sources/MyProjectClass.h
@@ -1,0 +1,12 @@
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MyProjectClass : NSObject
+
+- (NSString *)hello;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Sources/MyProjectClass.m
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Sources/MyProjectClass.m
@@ -1,0 +1,11 @@
+
+#import "MyProjectClass.h"
+
+@implementation MyProjectClass
+
+- (NSString *)hello
+{
+    return @"MyProjectClass.hello";
+}
+
+@end

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Sources/MyPublicClass.h
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Sources/MyPublicClass.h
@@ -1,0 +1,12 @@
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MyPublicClass : NSObject
+
+- (NSString *)hello;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Sources/MyPublicClass.m
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Sources/MyPublicClass.m
@@ -1,0 +1,11 @@
+
+#import "MyPublicClass.h"
+
+@implementation MyPublicClass
+
+- (NSString *)hello
+{
+    return @"MyPublicClass.hello";
+}
+
+@end

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Tests/Framework1FileTests.swift
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Tests/Framework1FileTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import Framework1
+
+class Framework1Tests: XCTestCase {
+    func testHello() {
+        let sut = Framework1File()
+
+        XCTAssertEqual("Framework1File.hello()", sut.hello())
+    }
+}

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Tests/MyPublicClassTests.swift
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Framework1/Tests/MyPublicClassTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import Framework1
+
+class MyPublicClassTests: XCTestCase {
+    func testHello() {
+        let sut = MyPublicClass()
+
+        XCTAssertEqual("MyPublicClass.hello", sut.hello())
+    }
+}

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Tuist/Config.swift
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Tuist/Config.swift
@@ -1,0 +1,6 @@
+import ProjectDescription
+
+let config = Config(
+    generationOptions: [
+    ]
+)

--- a/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Workspace.swift
+++ b/projects/tuist/fixtures/ios_app_with_headers_in_one_dir/Workspace.swift
@@ -1,0 +1,6 @@
+import ProjectDescription
+
+let workspace = Workspace(
+    name: "Workspace",
+    projects: ["App", "Framework1"]
+)


### PR DESCRIPTION
Resolves discussing https://github.com/tuist/tuist/discussions/3784

### Short description 📝

Add support to use an umbrella file as list of public headers.
It will allow automatically change the lists of public/project headers 
just by adding needed h-file to the umbrella and re-generate project.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
