### PR TITLE
print-hashes absolute path is fixed

### DIFF
--- a/Sources/TuistKit/Commands/Cache/CachePrintHashesCommand.swift
+++ b/Sources/TuistKit/Commands/Cache/CachePrintHashesCommand.swift
@@ -17,7 +17,7 @@ struct CachePrintHashesCommand: ParsableCommand {
 
     func run() throws {
         try CachePrintHashesService().run(
-            path: options.path.map { AbsolutePath($0) } ?? FileHandler.shared.currentPath,
+            path: options.path,
             xcframeworks: options.xcframeworks,
             profile: options.profile
         )

--- a/Sources/TuistKit/Services/Cache/CachePrintHashesService.swift
+++ b/Sources/TuistKit/Services/Cache/CachePrintHashesService.swift
@@ -33,11 +33,20 @@ final class CachePrintHashesService {
         self.configLoader = configLoader
     }
 
-    func run(path: AbsolutePath, xcframeworks: Bool, profile: String?) throws {
+    private func absolutePath(_ path: String?) -> AbsolutePath {
+        if let path = path {
+            return AbsolutePath(path, relativeTo: FileHandler.shared.currentPath)
+        } else {
+            return FileHandler.shared.currentPath
+        }
+    }
+
+    func run(path: String?, xcframeworks: Bool, profile: String?) throws {
+        let absolutePath = absolutePath(path)
         let timer = clock.startTimer()
-        let config = try configLoader.loadConfig(path: path)
+        let config = try configLoader.loadConfig(path: absolutePath)
         let generator = generatorFactory.default(config: config)
-        let graph = try generator.load(path: path)
+        let graph = try generator.load(path: absolutePath)
         let cacheOutputType: CacheOutputType = xcframeworks ? .xcframework : .framework
         let cacheProfile = try CacheProfileResolver().resolveCacheProfile(named: profile, from: config)
         let hashes = try cacheGraphContentHasher.contentHashes(

--- a/Tests/TuistKitTests/Services/Cache/CachePrintHashesServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cache/CachePrintHashesServiceTests.swift
@@ -16,12 +16,12 @@ final class CachePrintHashesServiceTests: TuistUnitTestCase {
     var generatorFactory: MockGeneratorFactory!
     var cacheGraphContentHasher: MockCacheGraphContentHasher!
     var clock: Clock!
-    var path: AbsolutePath!
+    var path: String!
     var configLoader: MockConfigLoader!
 
     override func setUp() {
         super.setUp()
-        path = AbsolutePath("/Test")
+        path = "/Test"
         generatorFactory = MockGeneratorFactory()
         generator = MockGenerator()
         generatorFactory.stubbedDefaultResult = generator
@@ -51,6 +51,57 @@ final class CachePrintHashesServiceTests: TuistUnitTestCase {
         super.tearDown()
     }
 
+    func test_run_withFullPath_loads_the_graph() throws {
+        // Given
+        subject = CachePrintHashesService(
+            generatorFactory: generatorFactory,
+            cacheGraphContentHasher: cacheGraphContentHasher,
+            clock: clock,
+            configLoader: configLoader
+        )
+        let fullPath = FileHandler.shared.currentPath.pathString + "/full/path"
+        // When
+        _ = try subject.run(path: fullPath, xcframeworks: false, profile: nil)
+
+        // Then
+        XCTAssertEqual(generator.invokedLoadParameterPath, AbsolutePath(fullPath))
+    }
+
+    func test_run_withoutPath_loads_the_graph() throws {
+        // Given
+        subject = CachePrintHashesService(
+            generatorFactory: generatorFactory,
+            cacheGraphContentHasher: cacheGraphContentHasher,
+            clock: clock,
+            configLoader: configLoader
+        )
+
+        // When
+        _ = try subject.run(path: nil, xcframeworks: false, profile: nil)
+
+        // Then
+        XCTAssertEqual(generator.invokedLoadParameterPath, FileHandler.shared.currentPath)
+    }
+
+    func test_run_withRelativePath__loads_the_graph() throws {
+        // Given
+        subject = CachePrintHashesService(
+            generatorFactory: generatorFactory,
+            cacheGraphContentHasher: cacheGraphContentHasher,
+            clock: clock,
+            configLoader: configLoader
+        )
+
+        // When
+        _ = try subject.run(path: "RelativePath", xcframeworks: false, profile: nil)
+
+        // Then
+        XCTAssertEqual(
+            generator.invokedLoadParameterPath,
+            AbsolutePath("RelativePath", relativeTo: FileHandler.shared.currentPath)
+        )
+    }
+
     func test_run_loads_the_graph() throws {
         // Given
         subject = CachePrintHashesService(
@@ -64,7 +115,7 @@ final class CachePrintHashesServiceTests: TuistUnitTestCase {
         _ = try subject.run(path: path, xcframeworks: false, profile: nil)
 
         // Then
-        XCTAssertEqual(generator.invokedLoadParameterPath, path)
+        XCTAssertEqual(generator.invokedLoadParameterPath, "/Test")
     }
 
     func test_run_content_hasher_gets_correct_graph() throws {


### PR DESCRIPTION
### Short description 📝

`print-hashes` subcommand of `tuist cache` accepts path argument but that argument had to be the full path to the folder. This PR fixes this issue by converting the passed path to a relative path to the main project folder.

### How to test the changes locally 🧐

`tuist cache print-hashes -p Project`

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
