### PR TITLE
Add docs for tuist task plugins

### DIFF
--- a/Sources/TuistDependencies/DependenciesGraph/DependenciesGraphController.swift
+++ b/Sources/TuistDependencies/DependenciesGraph/DependenciesGraphController.swift
@@ -21,7 +21,7 @@ enum DependenciesGraphControllerError: FatalError, Equatable {
     var description: String {
         switch self {
         case .failedToDecodeDependenciesGraph:
-            return "Couldn't decode the DependenciesGraph from the serialized JSON file. Running `tuist dependencies fetch` should solve the problem."
+            return "Couldn't decode the DependenciesGraph from the serialized JSON file. Running `tuist fetch dependencies` should solve the problem."
         case .failedToEncodeDependenciesGraph:
             return "Couldn't encode the DependenciesGraph as a JSON file."
         }
@@ -80,7 +80,7 @@ public final class DependenciesGraphController: DependenciesGraphControlling {
         } catch {
             logger
                 .debug(
-                    "Failed to load dependencies graph, running `tuist dependencies fetch` should solve the problem.\nError: \(error)"
+                    "Failed to load dependencies graph, running `tuist fetch dependencies` should solve the problem.\nError: \(error)"
                 )
             throw DependenciesGraphControllerError.failedToDecodeDependenciesGraph
         }

--- a/projects/docs/docs/commands/dependencies.md
+++ b/projects/docs/docs/commands/dependencies.md
@@ -6,7 +6,7 @@ description: "Learn how to use Tuist's dependencies commands to manage external 
 
 ### Context
 
-External dependencies are represented by another graph. Dependency managers like [CocoaPods](https://cocoapods.org) integrate it when running `pod install` leveraging Xcode workspaces, and Swift Package Manager does it at build time leveraging Xcode's closed build system. Both approaches might lead to integration issues that can cause compilation issues down the road. We are aware that's not a great developer experience and thus we take a different approach to managing external dependencies that allows leverating Tuist features such as linting and caching. The idea is simple, developers define their Carthage and Package dependencies in a `Dependencies.swift` file. They are fetched by running `tuist dependencies fetch` and integrated into the generated Xcode project at generation time. Because we merge your project and the external dependencies' graph into a single graph, we validate and fail early if the resulting graph is invalid.
+External dependencies are represented by another graph. Dependency managers like [CocoaPods](https://cocoapods.org) integrate it when running `pod install` leveraging Xcode workspaces, and Swift Package Manager does it at build time leveraging Xcode's closed build system. Both approaches might lead to integration issues that can cause compilation issues down the road. We are aware that's not a great developer experience and thus we take a different approach to managing external dependencies that allows leverating Tuist features such as linting and caching. The idea is simple, developers define their Carthage and Package dependencies in a `Dependencies.swift` file. They are fetched by running `tuist fetch dependencies` and integrated into the generated Xcode project at generation time. Because we merge your project and the external dependencies' graph into a single graph, we validate and fail early if the resulting graph is invalid.
 
 Check out [this page](/guides/third-party-dependencies/) for the API reference of `Dependencies.swift`.
 
@@ -17,7 +17,7 @@ Check out [this page](/guides/third-party-dependencies/) for the API reference o
 Dependencies can be fetched by running the following command. They are stored in your project's `Tuist/Dependencies` directory:
 
 ```bash
-tuist dependencies fetch
+tuist fetch dependencies
 ```
 
 | Argument | Short | Description                                                                                          | Default           | Required |

--- a/projects/docs/docs/commands/plugin.md
+++ b/projects/docs/docs/commands/plugin.md
@@ -1,7 +1,7 @@
 ---
 slug: '/commands/plugin'
-title: Interact with plugins
-description: 'Learn how to use plugin commands for developing and publishing tuist plugins.'
+title: Sharing via plugins
+description: 'Learn how to use plugin commands for developing and publishing Tuist plugins.'
 ---
 
 To help developers with the process of [creating plugins](/plugins/creating-plugins/),
@@ -16,7 +16,7 @@ we provide a set of commands under `tuist plugin`. These plugin commands are aim
 | Argument | Short | Description | Default | Required |
 | ------------------ | ----- | ------------------------- | ------- | -------- |
 | `--configuration` | `-c`  | Choose configuration | `debug` | No |
-| `--path`  | `-p`  | Path to the directory that contains the definition of the plugin |  | No |
+| `--path`  | `-p`  | Path to the directory that contains the definition of the plugin | Current directory | No |
 | `--build-tests` | n/a | Build both source and test targets | No | No |
 | `--show-bin-path` | n/a | Print the binary output path | No | No |
 | `--targets` | n/a | Build the specificed targets |  | No |
@@ -31,7 +31,7 @@ we provide a set of commands under `tuist plugin`. These plugin commands are aim
 | Argument | Short | Description | Default | Required |
 | ------------------ | ----- | ------------------------- | ------- | -------- |
 | `--configuration` | `-c`  | Choose configuration | `debug` | No |
-| `--path`  | `-p`  | Path to the directory that contains the definition of the plugin |  | No |
+| `--path`  | `-p`  | Path to the directory that contains the definition of the plugin | Current directory | No |
 | `--build-tests` | n/a | Build both source and test targets | No | No |
 | `--test-products` | n/a | Test the specified products | No | No |
 
@@ -43,4 +43,4 @@ Archives a plugin into a `NameOfPlugin.tuist-plugin.zip`. This file is then used
 
 | Argument | Short | Description | Default | Required |
 | ------------------ | ----- | ------------------------- | ------- | -------- |
-| `--path`  | `-p`  | Path to the directory that contains the definition of the plugin |  | No |
+| `--path`  | `-p`  | Path to the directory that contains the definition of the plugin | Current directory | No |

--- a/projects/docs/docs/commands/plugin.md
+++ b/projects/docs/docs/commands/plugin.md
@@ -1,0 +1,46 @@
+---
+slug: '/commands/plugin'
+title: Interact with plugins
+description: 'Learn how to use plugin commands for developing and publishing tuist plugins.'
+---
+
+To help developers with the process of [creating plugins](/plugins/creating-plugins/),
+we provide a set of commands under `tuist plugin`. These plugin commands are aimed at parts of the plugin defined in `Package.swift`.
+
+### Build
+
+`tuist plugin build` will build the plugin.
+
+#### Arguments
+
+| Argument | Short | Description | Default | Required |
+| ------------------ | ----- | ------------------------- | ------- | -------- |
+| `--configuration` | `-c`  | Choose configuration | `debug` | No |
+| `--path`  | `-p`  | Path to the directory that contains the definition of the plugin |  | No |
+| `--build-tests` | n/a | Build both source and test targets | No | No |
+| `--show-bin-path` | n/a | Print the binary output path | No | No |
+| `--targets` | n/a | Build the specificed targets |  | No |
+| `--products` | n/a | Build the specified products | | No |
+
+### Test
+
+`test` subcommand is used for testing the plugin.
+
+#### Arguments
+
+| Argument | Short | Description | Default | Required |
+| ------------------ | ----- | ------------------------- | ------- | -------- |
+| `--configuration` | `-c`  | Choose configuration | `debug` | No |
+| `--path`  | `-p`  | Path to the directory that contains the definition of the plugin |  | No |
+| `--build-tests` | n/a | Build both source and test targets | No | No |
+| `--test-products` | n/a | Test the specified products | No | No |
+
+### Archive
+
+Archives a plugin into a `NameOfPlugin.tuist-plugin.zip`. This file is then used for publishing the plugin as described [here](/plugins/creating-plugins).
+
+#### Arguments
+
+| Argument | Short | Description | Default | Required |
+| ------------------ | ----- | ------------------------- | ------- | -------- |
+| `--path`  | `-p`  | Path to the directory that contains the definition of the plugin |  | No |

--- a/projects/docs/docs/commands/task.md
+++ b/projects/docs/docs/commands/task.md
@@ -11,6 +11,102 @@ These are often written in Shell or Ruby which only a handful of developers on y
 This means that these files are edited by an exclusive group and they are sort of "magical" for others.
 We try to fix that by introducing a concept of "Tasks" where you can define custom commands - in Swift!
 
+Not only that, we will provide you with an easy integration with tuist, so you can for example inspect your project's graph.
+
+:::warning Alpha
+Tasks and the `ProjectAutomation` package are in alpha.
+Be aware some APIs might change as we iterate the functionality with the feedback we get from users.
+:::
+
 ### Defining a task
 
 You can prepend any executable with `tuist-` and add it to your `PATH`. If you for example add `tuist-my-command` to your `PATH`, you will be able to run `tuist my-command` and `tuist-my-command` will automatically be executed.
+
+You can also create a task as a tuist plugin - learn how to do that [here](/plugins/creating-plugins#Tasks).
+
+## ProjectAutomation
+
+`ProjectAutomation` is a framework for interacting with tuist which can be integrated as Swift package.
+
+Your `Package.swift` for your CLI then may look as the following:
+```swift
+let package = Package(
+    name: "my-cli",
+    products: [
+        .executable(name: "my-cli", targets: ["my-cli"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/tuist/tuist", .upToNextMajor(from: "x.y.z")), // Add tuist as a package
+    ],
+    targets: [
+        .target(
+            name: "my-cli",
+            dependencies: [
+                .product(name: "ProjectAutomation", package: "tuist") // Integrate ProjectAutomation framework
+            ]
+        ),
+    ]
+)
+```
+
+### Graph
+
+To get your project's graph, you can leverage `Tuist`'s `graph` method. Here is an example how you might use this method:
+
+```swift
+import ProjectAutomation
+
+let graph = try Tuist.graph()
+
+let targets = graph.projects.values.flatMap(\.targets)
+print("These are the current project's targets: \(targets))"
+```
+
+You might wonder what the return value of `Tuist.graph()` is - the method returns a Swift model `Graph`. Below you will find the exact specification.
+
+#### Graph
+
+| Property       | Description                                                   | Type    |
+| ---------- | ------------------------------------------------------------- | ------- |
+| `name`| Name of the graph | `String` |
+| `path` | Absolute path of the graph | `String` |
+| `projects` | Projects which are a part of the graph | `[String: Project]` |
+
+#### Project
+
+| Property       | Description                                                   | Type    |
+| ---------- | ------------------------------------------------------------- | ------- |
+| `name`| Name of the project | `String` |
+| `path` | Absolute path of the project | `String` |
+| `packages` | Swift packages that this project depends on | `[Package]` |
+| `targets` | Targets of this projects | `[Target]` |
+| `schemes` | Defined schemes for this project | `[Scheme]` |
+
+#### Target
+
+| Property       | Description                                                   | Type    |
+| ---------- | ------------------------------------------------------------- | ------- |
+| `name`| Name of the target | `String` |
+| `product` | Product type the target produces | `String` |
+
+#### Package
+
+| Property       | Description                                                   | Type    |
+| ---------- | ------------------------------------------------------------- | ------- |
+| `kind`| The type of the package | `PackageKind` |
+| `path` | The path of the package. For a local package, the path is an absolute path to the package directory. For a remote package, it it value of the URL of the package. | `String` |
+
+#### PackageKind
+
+| Case       | Description                                                   |
+| ---------- | ------------------------------------------------------------- |
+| `remote` | Represents a remote package
+| `local` | Represents a local package |
+
+
+#### Scheme
+
+| Property       | Description                                                   | Type    |
+| ---------- | ------------------------------------------------------------- | ------- |
+| `name` | Name of the scheme | `String` |
+| `testActionTargets` | Targets which can be tested via this scheme | `[String]?`

--- a/projects/docs/docs/plugins/creating-plugins.md
+++ b/projects/docs/docs/plugins/creating-plugins.md
@@ -55,7 +55,26 @@ In order for Tuist to locate the templates for a plugin, they must be placed in 
 
 ### Tasks
 
-<!-- TODO: Write documentation for tasks -->
+Tasks represent arbitrary tasks which can be run via tuist. For more context, continue [here](/commands/task) where you will also find documentation for the `ProjectAutomation` framework.
+
+To create a task plugin, start by adding a `Package.swift` and adding your CLI executable with `tuist` prefix, such as:
+```swift
+let package = Package(
+    name: "MyPlugin",
+    products: [
+        .executable(name: "tuist-my-cli", targets: ["tuist-my-cli"]),
+    ],
+    targets: [
+        .target(
+            name: "tuist-my-cli",
+        ),
+    ]
+)
+```
+
+For easier development and help with publishing your plugin, use `tuist plugin` - you can read more about it [here](/commands/plugin.md).
+
+To publish a plugin with tasks, you will need to run `tuist plugin archive` and then create a Github release with the created `.zip` as an artifact.
 
 ## ResourceSynthesizers
 

--- a/projects/docs/sidebars.js
+++ b/projects/docs/sidebars.js
@@ -39,6 +39,7 @@ module.exports = {
         'commands/migration',
         'commands/clean',
         'commands/dependencies',
+        'commands/plugin',
       ],
     },
     {


### PR DESCRIPTION
### Short description 📝

This PR adds documentation for how to use the new tasks plugins. 

Once this is merged, we should be close to merging the new plugins architecture to `main` 🎉 

### How to test the changes locally 🧐

Read the docs 🙂 

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
