### PR TITLE
Fix presentation of errors parsing arguments in tuistenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Fix shell completion script generated in directory containing `.tuist_version` file [#3804](https://github.com/tuist/tuist/pull/3804) by [@mikchmie](https://github.com/mikchmie)
 - `tuist cache print-hashes` not working with relative paths [#3892](https://github.com/tuist/tuist/pull/3892) by [@erkekin](https://github.com/erkekin)
- - Errors related to parsing arguments in `tuistenv` are not handled gracefully [#3905](https://github.com/tuist/tuist/pull/3905) by [@pepicrft](https://github.com/pepicrft).
+- Fix argument parsing errors handling in `tuistenv` [#3905](https://github.com/tuist/tuist/pull/3905) by [@pepicrft](https://github.com/pepicrft).
 
 ## 2.4.0 - Lune
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Fix shell completion script generated in directory containing `.tuist_version` file [#3804](https://github.com/tuist/tuist/pull/3804) by [@mikchmie](https://github.com/mikchmie)
 - `tuist cache print-hashes` not working with relative paths [#3892](https://github.com/tuist/tuist/pull/3892) by [@erkekin](https://github.com/erkekin)
- 
+ - Errors related to parsing arguments in `tuistenv` are not handled gracefully [#3905](https://github.com/tuist/tuist/pull/3905) by [@pepicrft](https://github.com/pepicrft).
+
 ## 2.4.0 - Lune
 
 ### Added

--- a/Sources/TuistDependencies/DependenciesController.swift
+++ b/Sources/TuistDependencies/DependenciesController.swift
@@ -147,13 +147,6 @@ public final class DependenciesController: DependenciesControlling {
         shouldUpdate: Bool,
         swiftVersion: TSCUtility.Version?
     ) throws -> TuistCore.DependenciesGraph {
-        logger.warning(
-            """
-            The integration of external dependencies is in alpha. \
-            Be aware some APIs might change as we iterate the functionality with the feedback we get from users.
-            """
-        )
-
         let dependenciesDirectory = path
             .appending(component: Constants.tuistDirectoryName)
             .appending(component: Constants.DependenciesDirectory.name)

--- a/Sources/TuistEnvKit/Commands/TuistCommand.swift
+++ b/Sources/TuistEnvKit/Commands/TuistCommand.swift
@@ -26,9 +26,8 @@ public struct TuistCommand: ParsableCommand {
 
         // Help env
         if processedArguments.dropFirst().first == "--help-env" {
-            let error = UnhandledError(error: CleanExit.helpRequest(self))
-            errorHandler.fatal(error: error)
-            _exit(exitCode(for: error).rawValue)
+            let error = CleanExit.helpRequest(self)
+            exit(withError: error)
         }
 
         // Parse the command

--- a/Sources/TuistEnvKit/Commands/TuistCommand.swift
+++ b/Sources/TuistEnvKit/Commands/TuistCommand.swift
@@ -22,17 +22,39 @@ public struct TuistCommand: ParsableCommand {
 
     public static func main(_: [String]? = nil) -> Never {
         let errorHandler = ErrorHandler()
+        let processedArguments = processArguments()
+
+        // Help env
+        if processedArguments.dropFirst().first == "--help-env" {
+            let error = UnhandledError(error: CleanExit.helpRequest(self))
+            errorHandler.fatal(error: error)
+            _exit(exitCode(for: error).rawValue)
+        }
+
+        // Parse the command
+        var command: ParsableCommand?
         do {
-            let processedArguments = processArguments()
-            if processedArguments.dropFirst().first == "--help-env" {
-                throw CleanExit.helpRequest(self)
-            } else if let parsedArguments = try parse() {
-                var command = try parseAsRoot(parsedArguments)
+            if let parsedArguments = try parse() {
+                command = try parseAsRoot(parsedArguments)
+            }
+        } catch {
+            let exitCode = exitCode(for: error).rawValue
+            if exitCode == 0 {
+                logger.info("\(fullMessage(for: error))")
+            } else {
+                logger.error("\(fullMessage(for: error))")
+            }
+            _exit(exitCode)
+        }
+
+        // Run the command
+        do {
+            if var command = command {
                 try command.run()
             } else {
                 try CommandRunner().run()
             }
-            exit()
+            _exit(0)
         } catch let error as FatalError {
             errorHandler.fatal(error: error)
             _exit(exitCode(for: error).rawValue)

--- a/projects/fourier/lib/fourier/services/lint/swift.rb
+++ b/projects/fourier/lib/fourier/services/lint/swift.rb
@@ -13,7 +13,7 @@ module Fourier
         def call
           Dir.chdir(Constants::ROOT_DIRECTORY) do
             arguments = [vendor_path("swiftlint"), "--quiet"]
-            arguments << "autocorrect" if fix
+            arguments << "--fix" if fix
             Utilities::System.system(*arguments)
           end
         end

--- a/projects/fourier/lib/fourier/utilities/swift_linter.rb
+++ b/projects/fourier/lib/fourier/utilities/swift_linter.rb
@@ -9,7 +9,7 @@ module Fourier
             File.join(Fourier::Constants::VENDOR_DIRECTORY, "swiftlint", "swiftlint"),
           ]
           if fix
-            arguments << "autocorrect"
+            arguments << "--fix"
           else
             arguments << "lint"
           end

--- a/projects/fourier/test/fourier/utilities/swift_linter_test.rb
+++ b/projects/fourier/test/fourier/utilities/swift_linter_test.rb
@@ -14,7 +14,7 @@ module Fourier
           File.join(Fourier::Constants::VENDOR_DIRECTORY, "swiftlint", "swiftlint"),
         ]
         if fix
-          arguments << "autocorrect" if fix
+          arguments << "--fix" if fix
         else
           arguments << "lint"
         end


### PR DESCRIPTION
### Short description 📝
I noticed errors related to parsing arguments in `tuistenv` are not handled gracefully. For example, `tuist update tuist` yields the following in the terminal:

```
We received an error that we couldn't handle:
    - Localized description: The operation couldn’t be completed. (ArgumentParser.CommandError error 1.)
    - Error: CommandError(commandStack: [TuistEnvKit.TuistCommand, TuistEnvKit.UpdateCommand], parserError: ArgumentParser.ParserError.unexpectedExtraValues([(ArgumentParser.InputOrigin(_elements: Set([ArgumentParser.InputOrigin.Element.argumentIndex(1)])), "tuis")]))

If you think it's a legit issue, please file an issue including the reproducible steps: https://github.com/tuist/tuist/issues/new/choose
Consider creating an issue using the following link: https://github.com/tuist/tuist/issues/new/choose
```

I've adjusted the logic to be consistent with how we do things on the `tuist` side and now the error that we present in that case is:

```bash
Error: Unexpected argument 'tuist'
Usage: tuist update
  See 'tuist update --help' for more information.
```

### How to test the changes locally 🧐

1. Run `tuistenv update tuist`
2. The error should be handled gracefully.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
