### PR TITLE
Feat: Add logging when helpers are built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Added
+
+- Add logging when helpers modules are being built [#3913](https://github.com/tuist/tuist/pull/3913) by [@luispadron](https://github.com/luispadron)
+
 ## 2.5.0 - Gestalt
 
 ### Changed


### PR DESCRIPTION
### Short description 📝

Simply adds extra logging to the `tuist` commands. Previously, when building a helper module we wouldn't log anything, this adds logging information for what module is being built and how long it took.

I believe this will let users better understand what is happening and also informs users that we cache building of these helpers (since it won't log if the helper is already built).

Before:

```sh
Cloning plugin from https://github.com/tuist/ExampleTuistPlugin.git @ 6fa42ca
Generating workspace TuistPluginTest.xcworkspace
Generating project TuistPluginTest
Project generated.
Total time taken: 2.366s
```

After:

```sh
Cloning plugin from https://github.com/tuist/ExampleTuistPlugin.git @ 6fa42ca
Building LocalPlugin (0.210s)
Building ExampleTuistPlugin (0.215s)
Building ProjectDescriptionHelpers (0.233s)
Generating workspace TuistPluginTest.xcworkspace
Generating project TuistPluginTest
Project generated.
Total time taken: 1.717s
```

### How to test the changes locally 🧐

```sh
swift run tuist generate --path projects/tuist/fixtures/app_with_plugins
```

### Checklist ✅

- [X] The code architecture and patterns are consistent with the rest of the codebase.
- [X] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [X] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [X] In case the PR introduces changes that affect users, the documentation has been updated.
- [X] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
