### PR TITLE
Fix/error parsing remote url init command

### DIFF
--- a/Sources/TuistSupport/Extensions/String+Extras.swift
+++ b/Sources/TuistSupport/Extensions/String+Extras.swift
@@ -4,6 +4,8 @@ import struct TSCUtility.Version
 extension String {
     // swiftlint:disable:next force_try
     private static let whitespaceRegularExpression = try! NSRegularExpression(pattern: "\\s")
+    static let httpRegularExpression = "(\\w+://)(.+@)*([\\w\\d\\.]+)(:[\\d]+){0,1}/*(.*)"
+    static let sshRegularExpression = "(.+@)*([\\w\\d\\.]+):(.*)"
 
     public var escapingWhitespaces: String {
         String.whitespaceRegularExpression.stringByReplacingMatches(
@@ -105,9 +107,7 @@ extension String {
     }
 
     public var isGitURL: Bool {
-        let httpPattern = "(\\w+://)(.+@)*([\\w\\d\\.]+)(:[\\d]+){0,1}/*(.*)"
-        let sshPattern = "(.+@)*([\\w\\d\\.]+):(.*)"
-        return self.matches(pattern: httpPattern) || self.matches(pattern: sshPattern)
+        self.matches(pattern: String.httpRegularExpression) || self.matches(pattern: String.sshRegularExpression)
     }
 
     /// A collection of all the words in the string by separating out any punctuation and spaces.

--- a/Sources/TuistSupport/Utils/TemplateLocationParser.swift
+++ b/Sources/TuistSupport/Utils/TemplateLocationParser.swift
@@ -26,8 +26,13 @@ public final class TemplateLocationParser: TemplateLocationParsing {
             .split(separator: "@")
         guard
             let branch = splittedURL.last,
-            splittedURL.count >= 2 else { return nil }
-        if splittedURL.count == 2, !templateURL.contains("http") {
+            splittedURL.count >= 2
+        else {
+            return nil
+        }
+        if let url = splittedURL.first, splittedURL.count == 2,
+           !String(url).matches(pattern: String.httpRegularExpression)
+        {
             return nil
         } else {
             return String(branch)
@@ -37,21 +42,28 @@ public final class TemplateLocationParser: TemplateLocationParsing {
     public func parseRepositoryURL(from templateURL: String) -> String {
         let splittedURL = templateURL
             .split(separator: "@")
+
         if splittedURL.count < 2, !splittedURL.isEmpty {
             return templateURL
+        } else if splittedURL.count == 2 {
+            if let remoteURl = splittedURL.first,
+               String(remoteURl).matches(pattern: String.httpRegularExpression)
+            {
+                return String(remoteURl)
+            } else {
+                return String(
+                    splittedURL
+                        .reduce("") { $0 + "@" + $1 }
+                        .dropFirst()
+                )
+            }
         } else {
-            return splittedURL.count > 2 ?
-                String(
-                    splittedURL
-                        .dropLast()
-                        .reduce("") { $0 + "@" + $1 }
-                        .dropFirst()
-                )
-                : String(
-                    splittedURL
-                        .reduce("") { $0 + "@" + $1 }
-                        .dropFirst()
-                )
+            return String(
+                splittedURL
+                    .dropLast()
+                    .reduce("") { $0 + "@" + $1 }
+                    .dropFirst()
+            )
         }
     }
 }

--- a/Sources/TuistSupport/Utils/TemplateLocationParser.swift
+++ b/Sources/TuistSupport/Utils/TemplateLocationParser.swift
@@ -27,7 +27,11 @@ public final class TemplateLocationParser: TemplateLocationParsing {
         guard
             let branch = splittedURL.last,
             splittedURL.count >= 2 else { return nil }
-        return String(branch)
+        if splittedURL.count == 2, !templateURL.contains("http") {
+            return nil
+        } else {
+            return String(branch)
+        }
     }
 
     public func parseRepositoryURL(from templateURL: String) -> String {
@@ -36,12 +40,18 @@ public final class TemplateLocationParser: TemplateLocationParsing {
         if splittedURL.count < 2, !splittedURL.isEmpty {
             return templateURL
         } else {
-            return String(
-                splittedURL
-                    .dropLast()
-                    .reduce("") { $0 + "@" + $1 }
-                    .dropFirst()
-            )
+            return splittedURL.count > 2 ?
+                String(
+                    splittedURL
+                        .dropLast()
+                        .reduce("") { $0 + "@" + $1 }
+                        .dropFirst()
+                )
+                : String(
+                    splittedURL
+                        .reduce("") { $0 + "@" + $1 }
+                        .dropFirst()
+                )
         }
     }
 }

--- a/Tests/TuistSupportTests/Utils/TemplateLocationParserTests.swift
+++ b/Tests/TuistSupportTests/Utils/TemplateLocationParserTests.swift
@@ -29,9 +29,32 @@ final class TemplateLocationParserTests: TuistUnitTestCase {
         XCTAssertEqual("develop", branch)
     }
 
+    func test_parse_branch_name_for_given_ssh_url_template() {
+        // Given
+        let urlTemplate = "git@github.com:tuist/ExampleTuistTemplate.git@develop"
+
+        // When
+        let branch = subject.parseRepositoryBranch(from: urlTemplate)
+
+        // Then
+        XCTAssertNotNil(branch)
+        XCTAssertEqual("develop", branch)
+    }
+
     func test_nil_branch_when_not_branch_found_in_template_url() {
         // Given
         let urlTemplate = "https://github.com/tuist/ExampleTuistTemplate"
+
+        // When
+        let branch = subject.parseRepositoryBranch(from: urlTemplate)
+
+        // Then
+        XCTAssertNil(branch)
+    }
+
+    func test_nil_branch_when_not_branch_found_in_template_ssh_url() {
+        // Given
+        let urlTemplate = "git@github.com:tuist/ExampleTuistTemplate.git"
 
         // When
         let branch = subject.parseRepositoryBranch(from: urlTemplate)
@@ -48,7 +71,18 @@ final class TemplateLocationParserTests: TuistUnitTestCase {
         let repositoryURL = subject.parseRepositoryURL(from: urlTemplate)
 
         // Then
-        XCTAssertEqual("https://github.com/tuist/ExampleTuistTemplate", repositoryURL)
+        XCTAssertEqual("https://github.com/tuist/ExampleTuistTemplate@develop", repositoryURL)
+    }
+
+    func test_parse_template_url_when_template_ssh_url_has_branch_name_on_it() {
+        // Given
+        let urlTemplate = "git@github.com:tuist/ExampleTuistTemplate.git@develop"
+
+        // When
+        let repositoryURL = subject.parseRepositoryURL(from: urlTemplate)
+
+        // Then
+        XCTAssertEqual("git@github.com:tuist/ExampleTuistTemplate.git", repositoryURL)
     }
 
     func test_parse_template_url_when_template_url_has_not_branch_name_on_it() {
@@ -60,5 +94,16 @@ final class TemplateLocationParserTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual("https://github.com/tuist/ExampleTuistTemplate", repositoryURL)
+    }
+
+    func test_parse_template_url_when_template_ssh_url_has_not_branch_name_on_it() {
+        // Given
+        let urlTemplate = "git@github.com:tuist/ExampleTuistTemplate.git"
+
+        // When
+        let repositoryURL = subject.parseRepositoryURL(from: urlTemplate)
+
+        // Then
+        XCTAssertEqual("git@github.com:tuist/ExampleTuistTemplate.git", repositoryURL)
     }
 }

--- a/Tests/TuistSupportTests/Utils/TemplateLocationParserTests.swift
+++ b/Tests/TuistSupportTests/Utils/TemplateLocationParserTests.swift
@@ -71,7 +71,7 @@ final class TemplateLocationParserTests: TuistUnitTestCase {
         let repositoryURL = subject.parseRepositoryURL(from: urlTemplate)
 
         // Then
-        XCTAssertEqual("https://github.com/tuist/ExampleTuistTemplate@develop", repositoryURL)
+        XCTAssertEqual("https://github.com/tuist/ExampleTuistTemplate", repositoryURL)
     }
 
     func test_parse_template_url_when_template_ssh_url_has_branch_name_on_it() {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3922
Request for comments document (if applies):

### Short description 📝

It will fix the problem when trying to init a ssh URL without a specific branch

### How to test the changes locally 🧐

run:

`tuist init -t git@github.com:tuist/ExampleTuistTemplate.git`

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
