### PR TITLE
Revert Xcode version for release to 12.5.1

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: macOS-11
     strategy:
       matrix:
-        xcode: ['13.2']
+        xcode: ['12.5.1']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macOS-11
     strategy:
       matrix:
-        xcode: ['13.2']
+        xcode: ['12.5.1']
     steps:
     - uses: actions/checkout@v2
     - name: Select Xcode

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: macOS-11
     strategy:
       matrix:
-        xcode: ['13.2']
+        xcode: ['12.5.1', '13.2'] # keep 12.5.1 to ensure backwards compatibility
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/Sources/ProjectDescription/CompatibleXcodeVersions.swift
+++ b/Sources/ProjectDescription/CompatibleXcodeVersions.swift
@@ -32,4 +32,61 @@ public enum CompatibleXcodeVersions: ExpressibleByArrayLiteral, ExpressibleByStr
     public init(stringLiteral value: String) {
         self = .exact(Version(stringLiteral: value))
     }
+
+    // MARK: - Codable
+
+    private enum Kind: String, Codable {
+        case all
+        case exact
+        case upToNextMajor
+        case upToNextMinor
+        case list
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case version
+        case compatibleXcodeVersions
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .all:
+            self = .all
+        case .exact:
+            let version = try container.decode(Version.self, forKey: .version)
+            self = .exact(version)
+        case .upToNextMajor:
+            let version = try container.decode(Version.self, forKey: .version)
+            self = .upToNextMajor(version)
+        case .upToNextMinor:
+            let version = try container.decode(Version.self, forKey: .version)
+            self = .upToNextMinor(version)
+        case .list:
+            let compatibleXcodeVersions = try container.decode([CompatibleXcodeVersions].self, forKey: .compatibleXcodeVersions)
+            self = .list(compatibleXcodeVersions)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .all:
+            try container.encode(Kind.all.self, forKey: .kind)
+        case let .exact(version):
+            try container.encode(Kind.exact.self, forKey: .kind)
+            try container.encode(version, forKey: .version)
+        case let .upToNextMajor(version):
+            try container.encode(Kind.upToNextMajor.self, forKey: .kind)
+            try container.encode(version, forKey: .version)
+        case let .upToNextMinor(version):
+            try container.encode(Kind.upToNextMinor.self, forKey: .kind)
+            try container.encode(version, forKey: .version)
+        case let .list(compatibleXcodeVersions):
+            try container.encode(Kind.list.self, forKey: .kind)
+            try container.encode(compatibleXcodeVersions, forKey: .compatibleXcodeVersions)
+        }
+    }
 }

--- a/Tests/TuistKitIntegrationTests/Commands/DumpServiceIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Commands/DumpServiceIntegrationTests.swift
@@ -130,9 +130,7 @@ final class DumpServiceTests: TuistTestCase {
         let expected = """
         {
           "compatibleXcodeVersions": {
-            "all": {
-
-            }
+            "kind": "all"
           },
           "generationOptions": [
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3938
Request for comments document (if applies):

### Short description 📝

Because of the new Swift compiler, frameworks as `ProjectDescription` and `ProjectAutomation` are no longer compatible with the previous Xcode version if built with Xcode 13.0+.
This PR reverts the Xcode version for release to 12.5.1 so that `tuist` can work correctly with previous Xcode versions.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
