### PR TITLE
Improve `tuist focus` execution time by avoiding redundant hashing for target dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
+- Improve tuist focus execution time by avoiding redundant hashing for target dependencies [#3947](https://github.com/tuist/tuist/pull/3947) by [@adellibovi](https://github.com/adellibovi)
 - Avoid building dependent test target when not needed during `tuist cache warm` [#3917](https://github.com/tuist/tuist/pull/3917) by [@danyf90](https://github.com/danyf90)
 - Fix unit test failures when test host requires codesigning [#3924](https://github.com/tuist/tuist/pull/3924) by [@hisaac](https://github.com/hisaac)
 - Fix circular dependency lint [#3876](https://github.com/tuist/tuist/pull/3876) by [@adellibovi](https://github.com/adellibovi)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
-- Improve tuist focus execution time by avoiding redundant hashing for target dependencies [#3947](https://github.com/tuist/tuist/pull/3947) by [@adellibovi](https://github.com/adellibovi)
+- Improve `tuist focus` execution time by avoiding redundant hashing for target dependencies [#3947](https://github.com/tuist/tuist/pull/3947) by [@adellibovi](https://github.com/adellibovi)
 - Avoid building dependent test target when not needed during `tuist cache warm` [#3917](https://github.com/tuist/tuist/pull/3917) by [@danyf90](https://github.com/danyf90)
 - Fix unit test failures when test host requires codesigning [#3924](https://github.com/tuist/tuist/pull/3924) by [@hisaac](https://github.com/hisaac)
 - Fix circular dependency lint [#3876](https://github.com/tuist/tuist/pull/3876) by [@adellibovi](https://github.com/adellibovi)

--- a/Sources/TuistCache/ContentHashing/DependenciesContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/DependenciesContentHasher.swift
@@ -5,7 +5,11 @@ import TuistGraph
 import TuistSupport
 
 public protocol DependenciesContentHashing {
-    func hash(graphTarget: GraphTarget, hashedTargets: inout [GraphHashedTarget: String], hashedPaths: inout [AbsolutePath : String]) throws -> String
+    func hash(
+        graphTarget: GraphTarget,
+        hashedTargets: inout [GraphHashedTarget: String],
+        hashedPaths: inout [AbsolutePath: String]
+    ) throws -> String
 }
 
 enum DependenciesContentHasherError: FatalError, Equatable {
@@ -51,7 +55,11 @@ public final class DependenciesContentHasher: DependenciesContentHashing {
 
     // MARK: - DependenciesContentHashing
 
-    public func hash(graphTarget: GraphTarget, hashedTargets: inout [GraphHashedTarget: String], hashedPaths: inout [AbsolutePath : String]) throws -> String {
+    public func hash(
+        graphTarget: GraphTarget,
+        hashedTargets: inout [GraphHashedTarget: String],
+        hashedPaths: inout [AbsolutePath: String]
+    ) throws -> String {
         let hashes = try graphTarget.target.dependencies
             .map { try hash(graphTarget: graphTarget, dependency: $0, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths) }
         return hashes.compactMap { $0 }.joined()

--- a/Sources/TuistCache/ContentHashing/DependenciesContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/DependenciesContentHasher.swift
@@ -5,7 +5,7 @@ import TuistGraph
 import TuistSupport
 
 public protocol DependenciesContentHashing {
-    func hash(graphTarget: GraphTarget, hashedTargets: inout [GraphHashedTarget: String]) throws -> String
+    func hash(graphTarget: GraphTarget, hashedTargets: inout [GraphHashedTarget: String], hashedPaths: inout [AbsolutePath : String]) throws -> String
 }
 
 enum DependenciesContentHasherError: FatalError, Equatable {
@@ -51,16 +51,17 @@ public final class DependenciesContentHasher: DependenciesContentHashing {
 
     // MARK: - DependenciesContentHashing
 
-    public func hash(graphTarget: GraphTarget, hashedTargets: inout [GraphHashedTarget: String]) throws -> String {
+    public func hash(graphTarget: GraphTarget, hashedTargets: inout [GraphHashedTarget: String], hashedPaths: inout [AbsolutePath : String]) throws -> String {
         let hashes = try graphTarget.target.dependencies
-            .map { try hash(graphTarget: graphTarget, dependency: $0, hashedTargets: &hashedTargets) }
+            .map { try hash(graphTarget: graphTarget, dependency: $0, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths) }
         return hashes.compactMap { $0 }.joined()
     }
 
     // MARK: - Private
 
     private func hash(graphTarget: GraphTarget, dependency: TargetDependency,
-                      hashedTargets: inout [GraphHashedTarget: String]) throws -> String
+                      hashedTargets: inout [GraphHashedTarget: String],
+                      hashedPaths: inout [AbsolutePath: String]) throws -> String
     {
         switch dependency {
         case let .target(targetName):
@@ -83,12 +84,10 @@ public final class DependenciesContentHasher: DependenciesContentHashing {
                 )
             }
             return dependencyHash
-        case let .framework(path):
-            return try contentHasher.hash(path: path)
-        case let .xcframework(path):
-            return try contentHasher.hash(path: path)
+        case let .framework(path), let .xcframework(path):
+            return try cachedHash(path: path, hashedPaths: &hashedPaths)
         case let .library(path, publicHeaders, swiftModuleMap):
-            let libraryHash = try contentHasher.hash(path: path)
+            let libraryHash = try cachedHash(path: path, hashedPaths: &hashedPaths)
             let publicHeadersHash = try contentHasher.hash(path: publicHeaders)
             if let swiftModuleMap = swiftModuleMap {
                 let swiftModuleHash = try contentHasher.hash(path: swiftModuleMap)
@@ -102,6 +101,16 @@ public final class DependenciesContentHasher: DependenciesContentHashing {
             return try contentHasher.hash("sdk-\(name)-\(status)")
         case .xctest:
             return try contentHasher.hash("xctest")
+        }
+    }
+
+    private func cachedHash(path: AbsolutePath, hashedPaths: inout [AbsolutePath: String]) throws -> String {
+        if let pathHash = hashedPaths[path] {
+            return pathHash
+        } else {
+            let pathHash = try contentHasher.hash(path: path)
+            hashedPaths[path] = pathHash
+            return pathHash
         }
     }
 }

--- a/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/GraphContentHasher.swift
@@ -63,6 +63,7 @@ public final class GraphContentHasher: GraphContentHashing {
         let graphTraverser = GraphTraverser(graph: graph)
         var visitedIsHasheableNodes: [GraphTarget: Bool] = [:]
         var hashedTargets: [GraphHashedTarget: String] = [:]
+        var hashedPaths: [AbsolutePath: String] = [:]
 
         let sortedCacheableTargets = try topologicalSort(
             Array(graphTraverser.allTargets()),
@@ -87,6 +88,7 @@ public final class GraphContentHasher: GraphContentHashing {
             let hash = try targetContentHasher.contentHash(
                 for: target,
                 hashedTargets: &hashedTargets,
+                hashedPaths: &hashedPaths,
                 additionalStrings: additionalStrings
             )
             hashedTargets[GraphHashedTarget(projectPath: target.path, targetName: target.target.name)] = hash

--- a/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
@@ -6,9 +6,9 @@ import TuistSupport
 
 public protocol TargetContentHashing {
     func contentHash(for target: GraphTarget, hashedTargets: inout [GraphHashedTarget: String],
-                     hashedPaths: inout [AbsolutePath : String]) throws -> String
+                     hashedPaths: inout [AbsolutePath: String]) throws -> String
     func contentHash(for target: GraphTarget, hashedTargets: inout [GraphHashedTarget: String],
-                     hashedPaths: inout [AbsolutePath : String],
+                     hashedPaths: inout [AbsolutePath: String],
                      additionalStrings: [String]) throws -> String
 }
 
@@ -73,7 +73,11 @@ public final class TargetContentHasher: TargetContentHashing {
 
     // MARK: - TargetContentHashing
 
-    public func contentHash(for target: GraphTarget, hashedTargets: inout [GraphHashedTarget: String], hashedPaths: inout [AbsolutePath : String]) throws -> String {
+    public func contentHash(
+        for target: GraphTarget,
+        hashedTargets: inout [GraphHashedTarget: String],
+        hashedPaths: inout [AbsolutePath: String]
+    ) throws -> String {
         try contentHash(for: target, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths, additionalStrings: [])
     }
 
@@ -91,7 +95,8 @@ public final class TargetContentHasher: TargetContentHashing {
         let dependenciesHash = try dependenciesContentHasher.hash(
             graphTarget: graphTarget,
             hashedTargets: &hashedTargets,
-            hashedPaths: &hashedPaths)
+            hashedPaths: &hashedPaths
+        )
         let environmentHash = try contentHasher.hash(graphTarget.target.environment)
         var stringsToHash = [
             graphTarget.target.name,

--- a/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
@@ -5,8 +5,10 @@ import TuistGraph
 import TuistSupport
 
 public protocol TargetContentHashing {
-    func contentHash(for target: GraphTarget, hashedTargets: inout [GraphHashedTarget: String]) throws -> String
     func contentHash(for target: GraphTarget, hashedTargets: inout [GraphHashedTarget: String],
+                     hashedPaths: inout [AbsolutePath : String]) throws -> String
+    func contentHash(for target: GraphTarget, hashedTargets: inout [GraphHashedTarget: String],
+                     hashedPaths: inout [AbsolutePath : String],
                      additionalStrings: [String]) throws -> String
 }
 
@@ -71,13 +73,14 @@ public final class TargetContentHasher: TargetContentHashing {
 
     // MARK: - TargetContentHashing
 
-    public func contentHash(for target: GraphTarget, hashedTargets: inout [GraphHashedTarget: String]) throws -> String {
-        try contentHash(for: target, hashedTargets: &hashedTargets, additionalStrings: [])
+    public func contentHash(for target: GraphTarget, hashedTargets: inout [GraphHashedTarget: String], hashedPaths: inout [AbsolutePath : String]) throws -> String {
+        try contentHash(for: target, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths, additionalStrings: [])
     }
 
     public func contentHash(
         for graphTarget: GraphTarget,
         hashedTargets: inout [GraphHashedTarget: String],
+        hashedPaths: inout [AbsolutePath: String],
         additionalStrings: [String]
     ) throws -> String {
         let sourcesHash = try sourceFilesContentHasher.hash(sources: graphTarget.target.sources)
@@ -85,7 +88,10 @@ public final class TargetContentHasher: TargetContentHashing {
         let copyFilesHash = try copyFilesContentHasher.hash(copyFiles: graphTarget.target.copyFiles)
         let coreDataModelHash = try coreDataModelsContentHasher.hash(coreDataModels: graphTarget.target.coreDataModels)
         let targetScriptsHash = try targetScriptsContentHasher.hash(targetScripts: graphTarget.target.scripts)
-        let dependenciesHash = try dependenciesContentHasher.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
+        let dependenciesHash = try dependenciesContentHasher.hash(
+            graphTarget: graphTarget,
+            hashedTargets: &hashedTargets,
+            hashedPaths: &hashedPaths)
         let environmentHash = try contentHasher.hash(graphTarget.target.environment)
         var stringsToHash = [
             graphTarget.target.name,

--- a/Tests/TuistCacheTests/ContentHashing/DependenciesContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/DependenciesContentHasherTests.swift
@@ -17,11 +17,13 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
     private var filePath3: AbsolutePath! = AbsolutePath("/file3")
     private var graphTarget: GraphTarget!
     private var hashedTargets: [GraphHashedTarget: String]!
+    private var hashedPaths: [AbsolutePath: String]!
 
     override func setUp() {
         super.setUp()
         mockContentHasher = MockContentHasher()
         hashedTargets = [:]
+        hashedPaths = [:]
         subject = DependenciesContentHasher(contentHasher: mockContentHasher)
     }
 
@@ -29,6 +31,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         subject = nil
         mockContentHasher = nil
         hashedTargets = nil
+        hashedPaths = nil
         graphTarget = nil
         filePath1 = nil
         filePath2 = nil
@@ -43,7 +46,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
         hashedTargets[GraphHashedTarget(projectPath: graphTarget.path, targetName: "foo")] = "target-foo-hash"
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
 
         // Then
         XCTAssertEqual(hash, "target-foo-hash")
@@ -60,7 +63,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
             dependencyProjectPath: graphTarget.path,
             dependencyTargetName: "foo"
         )
-        XCTAssertThrowsSpecific(try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets), expectedError)
+        XCTAssertThrowsSpecific(try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths), expectedError)
     }
 
     func test_hash_whenDependencyIsProject_returnsTheRightHash() throws {
@@ -70,7 +73,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
         hashedTargets[GraphHashedTarget(projectPath: filePath1, targetName: "foo")] = "project-file-hashed-foo-hash"
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
 
         // Then
         XCTAssertEqual(hash, "project-file-hashed-foo-hash")
@@ -88,7 +91,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
             dependencyProjectPath: filePath1,
             dependencyTargetName: "foo"
         )
-        XCTAssertThrowsSpecific(try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets), expectedError)
+        XCTAssertThrowsSpecific(try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths), expectedError)
     }
 
     func test_hash_whenDependencyIsFramework_callsContentHasherAsExpected() throws {
@@ -98,7 +101,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
 
         // Then
         XCTAssertEqual(hash, "file-hashed")
@@ -112,7 +115,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
 
         // Then
         XCTAssertEqual(hash, "file-hashed")
@@ -132,7 +135,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
 
         // Then
         XCTAssertEqual(hash, "library-file1-hashed-file2-hashed-file3-hashed-hash")
@@ -152,7 +155,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
 
         // Then
         XCTAssertEqual(hash, "library-file1-hashed-file2-hashed-hash")
@@ -166,7 +169,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
 
         // Then
         XCTAssertEqual(hash, "package-foo-hash")
@@ -179,7 +182,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
 
         // Then
         XCTAssertEqual(hash, "sdk-foo-optional-hash")
@@ -192,7 +195,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
 
         // Then
         XCTAssertEqual(hash, "sdk-foo-required-hash")
@@ -205,7 +208,7 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
 
         // When
         let graphTarget = GraphTarget.test(target: Target.test(dependencies: [dependency]))
-        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets)
+        let hash = try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths)
 
         // Then
         XCTAssertEqual(hash, "xctest-hash")

--- a/Tests/TuistCacheTests/ContentHashing/DependenciesContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/DependenciesContentHasherTests.swift
@@ -63,7 +63,10 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
             dependencyProjectPath: graphTarget.path,
             dependencyTargetName: "foo"
         )
-        XCTAssertThrowsSpecific(try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths), expectedError)
+        XCTAssertThrowsSpecific(
+            try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths),
+            expectedError
+        )
     }
 
     func test_hash_whenDependencyIsProject_returnsTheRightHash() throws {
@@ -91,7 +94,10 @@ final class DependenciesContentHasherTests: TuistUnitTestCase {
             dependencyProjectPath: filePath1,
             dependencyTargetName: "foo"
         )
-        XCTAssertThrowsSpecific(try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths), expectedError)
+        XCTAssertThrowsSpecific(
+            try subject.hash(graphTarget: graphTarget, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths),
+            expectedError
+        )
     }
 
     func test_hash_whenDependencyIsFramework_callsContentHasherAsExpected() throws {


### PR DESCRIPTION
### Short description 📝

This PR improves `tuist focus` generation time, in particular when having precompiled frameworks as dependencies.
For example, in test projects having ~10 precompiled frameworks shared for different targets, the generation time before this PR was ~20seconds, now it is ~8seconds.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
