### PR TITLE
Remove mentions of AGPL in tuist cloud

### DIFF
--- a/projects/cloud/README.md
+++ b/projects/cloud/README.md
@@ -3,7 +3,7 @@
 [![Tuist Cloud](https://github.com/tuist/cloud/actions/workflows/tuistcloud.yml/badge.svg)](https://github.com/tuist/cloud/actions/workflows/tuistcloud.yml)
 
 Tuist Cloud is a server-side extension for Tuist Projects that provides new **integrations** and **workflows**.
-It's a web app powered by [Ruby on Rails](https://rubyonrails.org/) and licensed under [AGPL-3.0](LICENSEd).
+It's a web app powered by [Ruby on Rails](https://rubyonrails.org/) and licensed under the MIT license.
 You can read more about Tuist Cloud and the motivations behind it on the [documentation website](https://docs.tuist.io/cloud/get-started)
 
 ## Set up for development

--- a/projects/docs/docs/cloud/get-started.md
+++ b/projects/docs/docs/cloud/get-started.md
@@ -33,7 +33,7 @@ What if **Tuist Cloud** is the solution?
 That's what we are aiming to achieve, 
 taking inspiration from tools like [Plausible](https://plausible.io/) and [Ghost](https://ghost.org/).
 
-The project is an [open-source](https://github.com/tuist/cloud) Rails app licensed under AGPL-3.0.
+The project is an [open-source](https://github.com/tuist/cloud) Rails app licensed under MIT.
 Teams can self-host it themselves.
 However, 
 we document the process to self-host the project and design it for easy hosting.
@@ -42,7 +42,3 @@ It provides benefits like support, monitoring, and continuous updates,
 and you support a project your project depends on.
 You can also take the adventurous path of building your backend.
 The [specification](/cloud/specification) documents the contract and designs it to be platform-agnostic.
-
-:::info APGPL-3.0
-Note that the AGPL-3.0 license under which Tuist Cloud is licensed allows you to host the code yourself, but modifications of the project need to be contributed upstream.
-:::


### PR DESCRIPTION
### Short description 📝

AGPL is unnecessarily restrictive and there are some legal questions when it comes to having multiple licenses in a single repo. To simplify things, cloud will now be licensed under the MIT license as the rest of the repo.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
