### PR TITLE
Feat: Update fourier to use system tuist whenever possible

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-./fourier lint swift
-./fourier lint ruby
+./fourier lint all

--- a/projects/fourier/lib/fourier.rb
+++ b/projects/fourier/lib/fourier.rb
@@ -46,9 +46,9 @@ module Fourier
     desc "encrypt", "Encrypt content in the repository"
     subcommand "encrypt", Commands::Encrypt
 
-    desc "focus TARGET", "Generate Tuist's project focusing on the target TARGET"
-    def focus(target = nil)
-      Services::Focus.call(target: target)
+    desc "focus TARGETS", "Generate Tuist's project focusing on the target TARGET"
+    def focus(*targets)
+      Services::Focus.call(targets: targets)
     end
 
     desc "tuist", "Runs Tuist"

--- a/projects/fourier/lib/fourier/services/build/tuist/all.rb
+++ b/projects/fourier/lib/fourier/services/build/tuist/all.rb
@@ -8,7 +8,6 @@ module Fourier
           def call
             dependencies = ["dependencies", "fetch"]
             Utilities::System.tuist(*dependencies)
-
             Utilities::System.tuist("build", "--generate")
           end
         end

--- a/projects/fourier/lib/fourier/services/focus.rb
+++ b/projects/fourier/lib/fourier/services/focus.rb
@@ -3,10 +3,10 @@
 module Fourier
   module Services
     class Focus < Base
-      attr_reader :target
+      attr_reader :targets
 
-      def initialize(target:)
-        @target = target
+      def initialize(targets:)
+        @targets = targets
       end
 
       def call
@@ -16,8 +16,7 @@ module Fourier
         cache_warm = ["cache", "warm", "--dependencies-only"]
         Utilities::System.tuist(*cache_warm)
 
-        focus = ["focus"]
-        focus << "#{target}" if target != nil
+        focus = ["focus"] + targets
         Utilities::System.tuist(*focus)
       end
     end

--- a/projects/fourier/lib/fourier/services/test/tuist/unit.rb
+++ b/projects/fourier/lib/fourier/services/test/tuist/unit.rb
@@ -8,7 +8,6 @@ module Fourier
           def call
             dependencies = ["dependencies", "fetch"]
             Utilities::System.tuist(*dependencies)
-
             Utilities::System.tuist("test")
             Dir.chdir(Constants::TUIST_DIRECTORY) do
               Utilities::System.system("swift", "test")

--- a/projects/fourier/lib/fourier/services/tuist.rb
+++ b/projects/fourier/lib/fourier/services/tuist.rb
@@ -12,7 +12,7 @@ module Fourier
       def call
         Utilities::SwiftPackageManager.build_product("ProjectAutomation")
         Utilities::SwiftPackageManager.build_product("ProjectDescription")
-        Utilities::System.tuist(*arguments)
+        Utilities::System.tuist(*arguments, from_source: true)
       end
     end
   end

--- a/projects/fourier/lib/fourier/utilities/system.rb
+++ b/projects/fourier/lib/fourier/utilities/system.rb
@@ -9,12 +9,17 @@ module Fourier
         Kernel.system(*args) || exit(1)
       end
 
-      def self.tuist(*args)
-        Dir.chdir(Constants::TUIST_DIRECTORY) do
-          self.system("swift", "build")
-          @tuist = ".build/debug/tuist"
-          self.system(@tuist, *args)
+      def self.tuist(*args, **kwargs)
+        @tuist = "/usr/local/bin/tuist"
+
+        if kwargs[:from_source] || !File.exist?(@tuist)
+          Dir.chdir(Constants::TUIST_DIRECTORY) do
+            self.system("swift", "build")
+            @tuist = ".build/debug/tuist"
+          end
         end
+
+        self.system(@tuist, *args)
       end
 
       def self.fixturegen(*args)

--- a/projects/fourier/test/fourier/services/focus_test.rb
+++ b/projects/fourier/test/fourier/services/focus_test.rb
@@ -13,13 +13,13 @@ module Fourier
         Utilities::System
           .expects(:tuist)
           .with("dependencies", "fetch")
-        target = "TuistSupport"
+        targets = ["TuistSupport", "TuistSupportTests"]
         Utilities::System
           .expects(:tuist)
-          .with("focus", target)
+          .with("focus", *targets)
 
         # Then
-        Services::Focus.call(target: target)
+        Services::Focus.call(targets: targets)
       end
     end
   end


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY
Request for comments document (if applies):

### Short description 📝

This PR makes it so that `fourier` commands which use `tuist` default to using the users installed version of tuist so they do not need to build it from source while working on the project (or be stuck if they're in-progress on some work that is failing to compile).

Note: The `fourier tuist <subcommand>` will still build tuist from source as the intention of that command is to run the source version of tuist in the current repository.

### Checklist ✅

- [X] The code architecture and patterns are consistent with the rest of the codebase.
- [X] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [X] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [X] In case the PR introduces changes that affect users, the documentation has been updated.
- [X] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
