### PR TITLE
Gitignore `.vscode/launch.json` + Remove VSCode colorTheme settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ node_modules
 
 Tuist/Dependencies/SwiftPackageManager
 Tuist/Dependencies/graph.json
+
+# VSCode Settings
+.vscode/launch.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,7 +27,6 @@
     "**/node_modules": true,
     "**/.DS_Store": true
   },
-  "workbench.colorTheme": "Dracula Soft",
   "spellright.language": [
     "en"
   ],


### PR DESCRIPTION
### Short description 📝

This PR fixes 2 small annoyances I've been dealing with lately.

There's a file that's been appearing in the project whenever I edit it in VSCode, at `.vscode/launch.json`. It's being added by the [new Swift plugin from the Swift Server Working Group](https://marketplace.visualstudio.com/items?itemName=sswg.swift-lang), like @danyf90 surmised [here](https://github.com/tuist/tuist/pull/3914#discussion_r776314457) in #3914. Unless there are objections, I think it's worth just ignoring it.

Also, while I was in that folder, I made a small change that's been bugging me for a while: removed the `workbench.colorTheme` setting. I have a color theme that I like to use in VSCode, and it's always bugged me that it gets switched to something else whenever I open the Tuist project. I hope it's not too much to ask that we remove that here.

### How to test the changes locally 🧐

1. Install the new Swift plugin in VS Code: https://marketplace.visualstudio.com/items?itemName=sswg.swift-lang
2. Open the Tuist project in VS Code
3. Observe that a file is created at `.vscode/launch.json`
4. Observe that it does not appear to git
5. Also observe that the color theme is not changed from your preferred defaults
