### PR TITLE
Fix for target references within workspace scheme pre/post actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Fix issue where test results were not being cached if a scheme was specified in the `tuist test` command [#3952](https://github.com/tuist/tuist/pull/3952) by [@hisaac](https://github.com/hisaac)
+- Fix for target references within workspace scheme pre/post actions [#3954](https://github.com/tuist/tuist/pull/3954) by [@kwridan](https://github.com/kwridan)
 
 ## 2.6.0 - Havana
 

--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -666,66 +666,35 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
         )
     }
 
-    func schemeExecutionAction(action: ExecutionAction,
-                               graphTraverser: GraphTraversing,
-                               generatedProjects: [AbsolutePath: GeneratedProject],
-                               rootPath _: AbsolutePath) throws -> XCScheme.ExecutionAction
-    {
+    func schemeExecutionAction(
+        action: ExecutionAction,
+        graphTraverser: GraphTraversing,
+        generatedProjects: [AbsolutePath: GeneratedProject],
+        rootPath: AbsolutePath
+    ) throws -> XCScheme.ExecutionAction {
         guard
             let targetReference = action.target,
-            let graphTarget = graphTraverser.target(path: targetReference.projectPath, name: targetReference.name),
-            let generatedProject = generatedProjects[graphTarget.project.xcodeProjPath]
+            let graphTarget = graphTraverser.target(path: targetReference.projectPath, name: targetReference.name)
         else {
-            return schemeExecutionAction(action: action)
-        }
-        return schemeExecutionAction(
-            action: action,
-            target: graphTarget.target,
-            generatedProject: generatedProject
-        )
-    }
-
-    private func schemeExecutionAction(action: ExecutionAction) -> XCScheme.ExecutionAction {
-        XCScheme.ExecutionAction(
-            scriptText: action.scriptText,
-            title: action.title,
-            environmentBuildable: nil
-        )
-    }
-
-    /// Returns the scheme pre/post actions.
-    ///
-    /// - Parameters:
-    ///   - action: pre/post action manifest.
-    ///   - target: Project manifest.
-    ///   - generatedProject: Generated Xcode project.
-    /// - Returns: Scheme actions.
-    private func schemeExecutionAction(action: ExecutionAction,
-                                       target: Target,
-                                       generatedProject: GeneratedProject) -> XCScheme.ExecutionAction
-    {
-        /// Return Buildable Reference for Scheme Action
-        func schemeBuildableReference(target: Target, generatedProject: GeneratedProject) -> XCScheme.BuildableReference? {
-            guard let pbxTarget = generatedProject.targets[target.name] else { return nil }
-
-            return targetBuildableReference(
-                target: target,
-                pbxTarget: pbxTarget,
-                projectPath: generatedProject.name
+            return XCScheme.ExecutionAction(
+                scriptText: action.scriptText,
+                title: action.title,
+                environmentBuildable: nil
             )
         }
 
-        let schemeAction = XCScheme.ExecutionAction(
-            scriptText: action.scriptText,
-            title: action.title,
-            environmentBuildable: nil
+        let buildableReference = try createBuildableReference(
+            graphTarget: graphTarget,
+            graphTraverser: graphTraverser,
+            rootPath: rootPath,
+            generatedProjects: generatedProjects
         )
 
-        schemeAction.environmentBuildable = schemeBuildableReference(
-            target: target,
-            generatedProject: generatedProject
+        return XCScheme.ExecutionAction(
+            scriptText: action.scriptText,
+            title: action.title,
+            environmentBuildable: buildableReference
         )
-        return schemeAction
     }
 
     // MARK: - Helpers

--- a/projects/tuist/fixtures/ios_app_with_custom_scheme/Workspace.swift
+++ b/projects/tuist/fixtures/ios_app_with_custom_scheme/Workspace.swift
@@ -7,18 +7,18 @@ let customAppScheme = Scheme(
         targets: [
             .project(path: "App", target: "App"),
             .project(path: "Frameworks/Framework1", target: "Framework1"),
-        ], 
+        ],
         preActions: [
             ExecutionAction(
-                scriptText: "echo pre-action", 
+                scriptText: "echo pre-action",
                 target: .project(path: "App", target: "App")
-            )
+            ),
         ],
         postActions: [
             ExecutionAction(
-                scriptText: "echo post-action", 
+                scriptText: "echo post-action",
                 target: .project(path: "Frameworks/Framework1", target: "Framework1")
-            )
+            ),
         ]
     ),
     testAction: TestAction.targets([

--- a/projects/tuist/fixtures/ios_app_with_custom_scheme/Workspace.swift
+++ b/projects/tuist/fixtures/ios_app_with_custom_scheme/Workspace.swift
@@ -3,7 +3,24 @@ import ProjectDescription
 let customAppScheme = Scheme(
     name: "Workspace-App",
     shared: true,
-    buildAction: .buildAction(targets: [.project(path: "App", target: "App")], preActions: []),
+    buildAction: .buildAction(
+        targets: [
+            .project(path: "App", target: "App"),
+            .project(path: "Frameworks/Framework1", target: "Framework1"),
+        ], 
+        preActions: [
+            ExecutionAction(
+                scriptText: "echo pre-action", 
+                target: .project(path: "App", target: "App")
+            )
+        ],
+        postActions: [
+            ExecutionAction(
+                scriptText: "echo post-action", 
+                target: .project(path: "Frameworks/Framework1", target: "Framework1")
+            )
+        ]
+    ),
     testAction: TestAction.targets([
         TestableTarget(target: .project(path: "App", target: "AppTests")),
         TestableTarget(target: .project(


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3941



### Short description 📝


- Schemes can define pre/post scripts (known as execution actions) that can run before/after individual actions within a scheme (such as build, test, etc...)
- Those execution actions can declare which target they'd like to inherit build settings from (such that they are accessible as environment variables within the scripts)
- There was a bug where the references to those targets in the generated schemes was not encoding the relative path the host projects - and subsequently Xcode omitting when viewed in the scheme editor

![pre-action](https://user-images.githubusercontent.com/11914919/148347546-f8350392-d883-475c-8cc2-c44d50e1c372.png)


Examining the generated scheme and manually fixing the issue in the Xcode scheme editor we can see the issue:

```diff
    <ExecutionAction
    ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
    <ActionContent
        title = "Run Script"
        scriptText = "echo pre-action">
        <EnvironmentBuildable>
            <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "8359F535E312088875AB7F4E"
                BuildableName = "App.app"
                BlueprintName = "App"
-               ReferencedContainer = "container:MainApp.xcodeproj">
+               ReferencedContainer = "container:App/MainApp.xcodeproj">
            </BuildableReference>
        </EnvironmentBuildable>
    </ActionContent>
    </ExecutionAction>
```

- To resolve this, the scheme generator now uses the correct method for resolving those targets (buildable references)
- A fixture has been updated to help replicate and show case this issue

### How to test the changes locally 🧐


- Generate the `ios_app_with_custom_scheme` fixture via:

```
swift build
swift run tuist generate --path projects/tuist/fixtures/ios_app_with_custom_scheme
```

- Open the generated workspace and examine the `Workspace-App` scheme
- Verify the build action has a pre and post action that correctly references targets

![expected](https://user-images.githubusercontent.com/11914919/148347699-fd47568e-a154-4ff2-9e32-693453bc0681.png)


### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- ~In case the PR introduces changes that affect users, the documentation has been updated.~
- ~In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.~
