### PR TITLE
Fix: Release workflow now creates PR instead of direct commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,8 @@ jobs:
         files: build/*
         name: ${{ github.event.inputs.version }} - ${{ github.event.inputs.title }}
         tag_name: ${{ github.event.inputs.version }}
-    - name: Commit CHANGELOG and Constants update
-      uses: stefanzweifel/git-auto-commit-action@v4
+    - name: Create pull-request for release changes
+      uses: peter-evans/create-pull-request@v3
       with:
-        commit_message: "[CI] Update CHANGELOG and version for release ${{ github.event.inputs.version }}"
-        branch: main
-        file_pattern: CHANGELOG.md Sources/TuistSupport/Constants.swift
+        commit-message: "[Release] Tuist ${{ github.event.inputs.version }} - ${{ github.event.inputs.title }}"
+        base: main


### PR DESCRIPTION
### Short description 📝

We have tried unsuccessfully to commit changes from the action back to the `main` branch. Instead we can simply create a PR from the action and have someone manually commit those back into `main`.

This might be nice as it allows us to control when the `CHANGELOG.md` changes go through as that defines when `tuist update` will update users.

The action used: https://github.com/peter-evans/create-pull-request#usage

### Checklist ✅

- [X] The code architecture and patterns are consistent with the rest of the codebase.
- [X] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [X] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [X] In case the PR introduces changes that affect users, the documentation has been updated.
- [X] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
