### PR TITLE
[Cloud] Add a strategy to be able to authenticate using tokens

### DIFF
--- a/projects/cloud/app/controllers/application_controller.rb
+++ b/projects/cloud/app/controllers/application_controller.rb
@@ -5,12 +5,6 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate_user!
 
-  def create_project
-  end
-
-  def show_project
-  end
-
   def app
     render(layout: "app")
   end

--- a/projects/cloud/app/models/concerns/token_authenticatable.rb
+++ b/projects/cloud/app/models/concerns/token_authenticatable.rb
@@ -15,7 +15,7 @@ module TokenAuthenticatable
     end
   end
 
-  def encoded_authentication_token
+  def encoded_token
     return if self.class.token_property.nil?
     APITokenStrategy::Token.new(
       self.class.name,

--- a/projects/cloud/app/models/concerns/token_authenticatable.rb
+++ b/projects/cloud/app/models/concerns/token_authenticatable.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module TokenAuthenticatable
+  extend ActiveSupport::Concern
+
+  included do
+    before_save :ensure_token_presence
+  end
+
+  class_methods do
+    attr_reader :token_property
+
+    def autogenerates_token(token_property)
+      @token_property = token_property
+    end
+  end
+
+  def encoded_authentication_token
+    return if self.class.token_property.nil?
+    APITokenStrategy::Token.new(
+      self.class.name,
+      id,
+      self.send(self.class.token_property),
+    ).encode
+  end
+
+  private
+    def ensure_token_presence
+      return if self.class.token_property.nil?
+      token = self.send(self.class.token_property)
+      if token.blank?
+        self.send("#{self.class.token_property}=", generate_token)
+      end
+    end
+
+    def generate_token
+      loop do
+        token = Devise.friendly_token(30)
+        query = { self.class.token_property => token }
+        break token unless self.class.exists?(**query)
+      end
+    end
+end

--- a/projects/cloud/app/models/project.rb
+++ b/projects/cloud/app/models/project.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class Project < ApplicationRecord
+  include TokenAuthenticatable
+
+  # Token authenticatable
+  autogenerates_token :token
+
   # Associations
   belongs_to :account, optional: false
 

--- a/projects/cloud/app/strategies/api_token_strategy.rb
+++ b/projects/cloud/app/strategies/api_token_strategy.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+class APITokenStrategy < Devise::Strategies::Base
+  Token = Struct.new(:model_name, :id, :token) do
+    def self.decode(encoded)
+      decoded = Base64.urlsafe_decode64(encoded)
+      model_name, id, token = decoded.split(":")
+
+      new(model_name, id, token)
+    end
+
+    def valid?
+      [model_name, id, token].all?(&:present?)
+    end
+
+    def encode
+      Base64.urlsafe_encode64(to_a.join(":"), padding: false)
+    end
+  end
+
+  def valid?
+    encoded_token.present?
+  end
+
+  def authenticate!
+    return fail! unless token_format_valid?
+    return fail! unless scope_match?
+    return fail! unless token_match?
+
+    skip_trackable
+
+    success!(model_object)
+  end
+
+  def store?
+    false
+  end
+
+  def clean_up_csrf?
+    false
+  end
+
+  private
+    def skip_trackable
+      env["devise.skip_trackable"] = true
+    end
+
+    def fail!
+      super("invalid token")
+    end
+
+    def token_format_valid?
+      decoded_token.valid?
+    rescue ArgumentError
+      false
+    end
+
+    def scope_match?
+      model.name == decoded_token.model_name
+    end
+
+    def model_object
+      @model_object ||= model.find(decoded_token.id)
+    end
+
+    def token_match?
+      Devise.secure_compare(model_object&.authentication_token, decoded_token.token)
+    end
+
+    def model
+      mapping.to
+    end
+
+    def decoded_token
+      @decoded_token ||= Token.decode(encoded_token)
+    end
+
+    def encoded_token
+      request.headers["Authorization"].to_s.remove("Bearer ")
+    end
+end

--- a/projects/cloud/config/initializers/inflections.rb
+++ b/projects/cloud/config/initializers/inflections.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections
@@ -12,6 +13,6 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym "RESTful"
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym("API")
+end

--- a/projects/cloud/config/initializers/warden.rb
+++ b/projects/cloud/config/initializers/warden.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "api_token_strategy"
+
+Warden::Strategies.add(:api_token, APITokenStrategy)

--- a/projects/cloud/test/models/concerns/token_authenticatable_test.rb
+++ b/projects/cloud/test/models/concerns/token_authenticatable_test.rb
@@ -40,7 +40,7 @@ class TokenAuthenticatableTest < ActiveSupport::TestCase
     assert subject.token
   end
 
-  test "encoded_authentication_token returns the encoded token value" do
+  test "encoded_token returns the encoded token value" do
     # Given
     subject = AuthenticatableTestModel.new(name: "name")
 
@@ -48,6 +48,6 @@ class TokenAuthenticatableTest < ActiveSupport::TestCase
     subject.save
 
     # Then
-    assert subject.encoded_authentication_token
+    assert subject.encoded_token
   end
 end

--- a/projects/cloud/test/models/concerns/token_authenticatable_test.rb
+++ b/projects/cloud/test/models/concerns/token_authenticatable_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TokenAuthenticatableTest < ActiveSupport::TestCase
+  class AuthenticatableTestModel
+    include ActiveModel::API
+    extend ActiveModel::Callbacks
+
+    define_model_callbacks :save
+    attr_accessor :token, :name
+
+    include TokenAuthenticatable
+
+    autogenerates_token :token
+
+    def save
+      run_callbacks(:save) do
+        # noop
+      end
+    end
+
+    def id
+      "123"
+    end
+
+    def self.exists?(*)
+      false
+    end
+  end
+
+  test "it generates the token when saving the model" do
+    # Given
+    subject = AuthenticatableTestModel.new(name: "name")
+
+    # When
+    subject.save
+
+    # Then
+    assert subject.token
+  end
+
+  test "encoded_authentication_token returns the encoded token value" do
+    # Given
+    subject = AuthenticatableTestModel.new(name: "name")
+
+    # When
+    subject.save
+
+    # Then
+    assert subject.encoded_authentication_token
+  end
+end

--- a/projects/cloud/test/strategies/api_token_strategy_test.rb
+++ b/projects/cloud/test/strategies/api_token_strategy_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class APITokenStrategyTest < ActiveSupport::TestCase
+  test "token's valid? method returns true when all the attributes are present" do
+    # Given
+    subject = APITokenStrategy::Token.new(
+      "Project",
+      "123",
+      "token",
+    )
+
+    # Then
+    assert subject.valid?
+  end
+
+  test "token's valid? method returns false when any of the attributes is missing" do
+   # Given
+   subject = APITokenStrategy::Token.new(
+     "",
+     "123",
+     "token",
+   )
+
+   # Then
+   assert_not subject.valid?
+ end
+
+  test "token's encoding/decoding" do
+     # Given
+     subject = APITokenStrategy::Token.new(
+       "Project",
+       "123",
+       "token",
+     )
+
+     # Then
+     encoded_token = subject.encode
+     assert encoded_token
+     decoded_token = APITokenStrategy::Token.decode(encoded_token)
+     assert_equal subject.model_name, decoded_token.model_name
+     assert_equal subject.id, decoded_token.id
+     assert_equal subject.token, decoded_token.token
+   end
+end


### PR DESCRIPTION
### Short description 📝
I'm adding a Warden strategy to allow authenticating using a token through the `Authorization` header of HTTP requests. Moreover, I'm adding a new concern, `TokenAuthenticatable`, that models can use to mark themselves as token-authenticatable. The concern takes care of ensuring the model has a token before persisting it, and provides a `encoded_token` method that returns the token that should be used in requests.
