### PR TITLE
Fix hashFiles timeout

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock projects/*/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install


### PR DESCRIPTION
### Short description 📝

There's a `hashFiles` [timeout](https://github.com/tuist/tuist/runs/4731480456?check_suite_focus=true) for `Gemfile.lock` pattern - it's causing issues on main.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
