### PR TITLE
Remove leftovers and CI fix cache key for `.xcode-version`

### DIFF
--- a/.github/workflows/backbone.yml
+++ b/.github/workflows/backbone.yml
@@ -69,13 +69,10 @@ jobs:
   lint:
     name: Lint
     runs-on: macOS-11
-    strategy:
-      matrix:
-        xcode: ['13.2']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}

--- a/.github/workflows/backbone.yml
+++ b/.github/workflows/backbone.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Install dependencies
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Install dependencies

--- a/.github/workflows/backbone.yml
+++ b/.github/workflows/backbone.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('project/backbone/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Install dependencies
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('project/backbone/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('project/backbone/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Install dependencies

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -28,13 +28,10 @@ jobs:
   lint_lockfiles:
     name: Lint lockfiles
     runs-on: macOS-11
-    strategy:
-      matrix:
-        xcode: ['13.2']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -71,13 +71,10 @@ jobs:
   lint:
     name: Lint
     runs-on: macOS-11
-    strategy:
-      matrix:
-        xcode: ['13.2']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Install dependencies
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - uses: actions/setup-node@v2
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - uses: actions/setup-node@v2
@@ -183,7 +183,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - uses: actions/setup-node@v2
@@ -221,7 +221,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - uses: actions/setup-node@v2
@@ -259,7 +259,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - uses: actions/setup-node@v2

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('project/cloud/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Install dependencies
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('project/cloud/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('project/cloud/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - uses: actions/setup-node@v2
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('project/cloud/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - uses: actions/setup-node@v2
@@ -183,7 +183,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('project/cloud/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - uses: actions/setup-node@v2
@@ -221,7 +221,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('project/cloud/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - uses: actions/setup-node@v2
@@ -259,7 +259,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('project/cloud/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - uses: actions/setup-node@v2

--- a/.github/workflows/cocoapods-interactor.yml
+++ b/.github/workflows/cocoapods-interactor.yml
@@ -44,13 +44,10 @@ jobs:
   lint:
     name: Lint
     runs-on: macOS-11
-    strategy:
-      matrix:
-        xcode: ['13.2']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}

--- a/.github/workflows/cocoapods-interactor.yml
+++ b/.github/workflows/cocoapods-interactor.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Install Bundler dependencies

--- a/.github/workflows/fixturegen.yml
+++ b/.github/workflows/fixturegen.yml
@@ -22,15 +22,12 @@ env:
 
 jobs:
   test:
-    name: Test the fixture generator with Xcode ${{ matrix.xcode }}
+    name: Test the fixture generator with Xcode
     runs-on: macOS-11
-    strategy:
-      matrix:
-        xcode: ['13.2']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
@@ -51,13 +48,10 @@ jobs:
   lint:
     name: Lint
     runs-on: macOS-11
-    strategy:
-      matrix:
-        xcode: ['13.2']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}

--- a/.github/workflows/fixturegen.yml
+++ b/.github/workflows/fixturegen.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install

--- a/.github/workflows/fourier.yml
+++ b/.github/workflows/fourier.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install

--- a/.github/workflows/fourier.yml
+++ b/.github/workflows/fourier.yml
@@ -43,13 +43,10 @@ jobs:
   lint:
     name: Lint
     runs-on: macOS-11
-    strategy:
-      matrix:
-        xcode: ['13.2']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}

--- a/.github/workflows/meta-tuist.yml
+++ b/.github/workflows/meta-tuist.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install

--- a/.github/workflows/meta-tuist.yml
+++ b/.github/workflows/meta-tuist.yml
@@ -29,15 +29,12 @@ env:
 
 jobs:
   build:
-    name: Build with Xcode ${{ matrix.xcode }}
+    name: Build with Xcode
     runs-on: macOS-11
-    strategy:
-      matrix:
-        xcode: ['13.2']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
@@ -55,15 +52,12 @@ jobs:
         run: |
           ./fourier build tuist all
   generate:
-    name: Generate with Xcode ${{ matrix.xcode }}
+    name: Generate with Xcode
     runs-on: macOS-11
-    strategy:
-      matrix:
-        xcode: ['13.2']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
@@ -81,15 +75,12 @@ jobs:
         run: |
           ./fourier focus
   test:
-    name: Test with Xcode ${{ matrix.xcode }}
+    name: Test with Xcode
     runs-on: macOS-11
-    strategy:
-      matrix:
-        xcode: ['13.2']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
@@ -110,13 +101,10 @@ jobs:
   lint-lockfiles:
     name: Lint lockfiles
     runs-on: macOS-11
-    strategy:
-      matrix:
-        xcode: ['13.2']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -25,8 +25,6 @@ jobs:
     runs-on: macOS-11
     steps:
       - uses: actions/checkout@v1
-      - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
@@ -42,4 +40,4 @@ jobs:
           bundle install --jobs 4 --retry 3
       - name: Build
         run: |
-          ./fourier bundle all
+          ./fourier bundle all --xcode_version=$(cat .xcode-version) --xcode_version_libraries=$(cat .xcode-version-libraries)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
     - name: Bundle install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
     runs-on: macOS-11
     steps:
     - uses: actions/checkout@v2
-    - name: Select Xcode
-      run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ env.RUBY_VERSION }}
@@ -41,7 +39,7 @@ jobs:
         sed -i '' -e "s/version = \".*\"/version = \"${{ github.event.inputs.version }}\"/g" Sources/TuistSupport/Constants.swift
         sed -i '' -e "s/## Next/## ${{ github.event.inputs.version }} - ${{ github.event.inputs.title }}\"/g" CHANGELOG.md
     - name: Fourier releae
-      run: ./fourier release tuist ${{ github.event.inputs.version }}
+      run: ./fourier release tuist ${{ github.event.inputs.version }} $(cat .xcode-version) $(cat .xcode-version-libraries)
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v1
       with:

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -63,8 +63,6 @@ jobs:
     runs-on: macOS-11
     steps:
       - uses: actions/checkout@v1
-      - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - uses: actions/cache@v2
         name: 'Cache Tuist Build'
         with:
@@ -73,10 +71,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm-${{ hashFiles('Package.resolved') }}
             ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm
+      - name: Select Xcode for Tuist and Tuistenv
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - name: Build Tuist for release
         run: swift build -c release --product tuist
       - name: Build Tuistenv for release
         run: swift build -c release --product tuistenv
+      - name: Select Xcode for Tuist libraries
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version-libraries).app
       - name: Build ProjectDescription for release
         run: swift build -c release --product ProjectDescription
       - name: Build ProjectAutomation for release

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -77,8 +77,6 @@ jobs:
         run: swift build -c release --product tuist
       - name: Build Tuistenv for release
         run: swift build -c release --product tuistenv
-      - name: Select Xcode for Tuist libraries
-        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version-libraries).app
       - name: Build ProjectDescription for release
         run: swift build -c release --product ProjectDescription
       - name: Build ProjectAutomation for release

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -39,9 +39,9 @@ jobs:
         name: 'Cache SPM dependencies'
         with:
           path: .build
-          key: ${{ runner.os }}-${{ matrix.xcode }}-spm-${{ hashFiles('**/Package.resolved') }}
+          key: ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.xcode }}-spm-
+            ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm-
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
@@ -68,10 +68,10 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: .build
-          key: ${{ runner.os }}-${{ matrix.xcode }}-spm-${{ hashFiles('**/Package.resolved') }}-git-${{ github.sha }}
+          key: ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm-${{ hashFiles('**/Package.resolved') }}-git-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.xcode }}-spm-${{ hashFiles('**/Package.resolved') }}
-            ${{ runner.os }}-${{ matrix.xcode }}-spm
+            ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm-${{ hashFiles('**/Package.resolved') }}
+            ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm
       - name: Build Tuist for release
         run: swift build -c release --product tuist
       - name: Build Tuistenv for release
@@ -125,10 +125,10 @@ jobs:
         name: 'Cache SPM dependencies'
         with:
           path: .build
-          key: ${{ runner.os }}-${{ matrix.xcode }}-spm-${{ hashFiles('**/Package.resolved') }}-git-${{ github.sha }}
+          key: ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm-${{ hashFiles('**/Package.resolved') }}-git-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.xcode }}-spm-${{ hashFiles('**/Package.resolved') }}
-            ${{ runner.os }}-${{ matrix.xcode }}-spm
+            ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm-${{ hashFiles('**/Package.resolved') }}
+            ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -39,7 +39,7 @@ jobs:
         name: 'Cache SPM dependencies'
         with:
           path: .build
-          key: ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm-${{ hashFiles('**/Package.resolved') }}
+          key: ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm-${{ hashFiles('Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm-
       - uses: ruby/setup-ruby@v1
@@ -66,11 +66,12 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - uses: actions/cache@v2
+        name: 'Cache Tuist Build'
         with:
           path: .build
-          key: ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm-${{ hashFiles('**/Package.resolved') }}-git-${{ github.sha }}
+          key: ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm-${{ hashFiles('Package.resolved') }}-git-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm-${{ hashFiles('**/Package.resolved') }}
+            ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm-${{ hashFiles('Package.resolved') }}
             ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm
       - name: Build Tuist for release
         run: swift build -c release --product tuist
@@ -122,12 +123,12 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - uses: actions/cache@v2
-        name: 'Cache SPM dependencies'
+        name: 'Cache Tuist Build'
         with:
           path: .build
-          key: ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm-${{ hashFiles('**/Package.resolved') }}-git-${{ github.sha }}
+          key: ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm-${{ hashFiles('Package.resolved') }}-git-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm-${{ hashFiles('**/Package.resolved') }}
+            ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm-${{ hashFiles('Package.resolved') }}
             ${{ runner.os }}-${{ hashFiles('.xcode-version') }}-spm
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install
@@ -159,7 +159,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install
@@ -184,7 +184,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install

--- a/.github/workflows/tuistbench.yml
+++ b/.github/workflows/tuistbench.yml
@@ -20,15 +20,12 @@ env:
 
 jobs:
   test:
-    name: Build benchmarking tooling with Xcode ${{ matrix.xcode }}
+    name: Build benchmarking tooling with Xcode
     runs-on: macOS-11
-    strategy:
-      matrix:
-        xcode: ['13.2']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
@@ -48,13 +45,10 @@ jobs:
   lint:
     name: Lint
     runs-on: macOS-11
-    strategy:
-      matrix:
-        xcode: ['13.2']
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}

--- a/.github/workflows/tuistbench.yml
+++ b/.github/workflows/tuistbench.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Bundle install

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-${{ hashFiles('Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
       - name: Install Bundler dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Added
 
+- Add ability to specify as a command line argument, the Xcode version to use when bundling/releasing tuist and its libraries [#3957](https://github.com/tuist/tuist/pull/3957) by [@hisaac](https://github.com/hisaac)
+
 ### Fixed
 
 - Fix issue where test results were not being cached if a scheme was specified in the `tuist test` command [#3952](https://github.com/tuist/tuist/pull/3952) by [@hisaac](https://github.com/hisaac)
@@ -17,7 +19,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Changed
 
 - Remove duplicate bundle identifier lint warning [#3914](https://github.com/tuist/tuist/pull/3914) by [@danyf90](https://github.com/danyf90)
-- Upadate version requirement for `swift-argument-parser` package from `.upToNextMajor(from: "0.4.3")` to `.upToNextMajor(from: "1.0.0")` [#3949](https://github.com/tuist/tuist/pull/3949) by [@laxmorek](https://github.com/laxmorek) 
+- Update version requirement for `swift-argument-parser` package from `.upToNextMajor(from: "0.4.3")` to `.upToNextMajor(from: "1.0.0")` [#3949](https://github.com/tuist/tuist/pull/3949) by [@laxmorek](https://github.com/laxmorek)
 
 ### Added
 

--- a/projects/fourier/lib/fourier/commands/bundle.rb
+++ b/projects/fourier/lib/fourier/commands/bundle.rb
@@ -13,10 +13,41 @@ module Fourier
         required: false,
         aliases: :p,
       )
+      option(
+        :xcode_version,
+        desc: %(
+          The version of Xcode to use to build tuist.
+          Can be either a version number (e.g. `--xcode_version="13.2.1"`)
+          or a file path pointing to the Xcode app bundle to use. (e.g. `--xcode_version="/path/to/Xcode.app"`)
+          Defaults to the currently selected Xcode on the system.
+        ),
+        type: :string,
+        required: false
+      )
+      option(
+        :xcode_version_libraries,
+        desc: %(
+          The version of Xcode to use to build tuist's library dependencies.
+          Can be either a version number (e.g. `--xcode_version="13.2.1"`)
+          or a file path pointing to the Xcode app bundle to use. (e.g. `--xcode_version="/path/to/Xcode.app"`)
+          Defaults to the currently selected Xcode on the system.
+        ),
+        type: :string,
+        required: false
+      )
       def tuist
         output_directory = options[:output]
         output_directory ||= File.expand_path("build", Constants::ROOT_DIRECTORY)
-        Services::Bundle::Tuist.call(output_directory: output_directory)
+
+        xcode_paths = Utilities::Xcode::Paths.new(
+          default: options[:xcode_version],
+          libraries: options[:xcode_version_libraries]
+        )
+
+        Services::Bundle::Tuist.call(
+          output_directory: output_directory,
+          xcode_paths: xcode_paths
+        )
       end
 
       desc "tuistenv", "Bundle tuistenv"
@@ -27,10 +58,41 @@ module Fourier
         required: false,
         aliases: :p,
       )
+      option(
+        :xcode_version,
+        desc: %(
+          The version of Xcode to use to build tuistenv.
+          Can be either a version number (e.g. `--xcode_version="13.2.1"`)
+          or a file path pointing to the Xcode app bundle to use. (e.g. `--xcode_version="/path/to/Xcode.app"`)
+          Defaults to the currently selected Xcode on the system.
+        ),
+        type: :string,
+        required: false
+      )
+      option(
+        :xcode_version_libraries,
+        desc: %(
+          The version of Xcode to use to build tuistenv's library dependencies.
+          Can be either a version number (e.g. `--xcode_version="13.2.1"`)
+          or a file path pointing to the Xcode app bundle to use. (e.g. `--xcode_version="/path/to/Xcode.app"`)
+          Defaults to the currently selected Xcode on the system.
+        ),
+        type: :string,
+        required: false
+      )
       def tuistenv
         output_directory = options[:output]
         output_directory ||= File.expand_path("build", Constants::ROOT_DIRECTORY)
-        Services::Bundle::Tuistenv.call(output_directory: output_directory)
+
+        xcode_paths = Utilities::Xcode::Paths.new(
+          default: options[:xcode_version],
+          libraries: options[:xcode_version_libraries]
+        )
+
+        Services::Bundle::Tuistenv.call(
+          output_directory: output_directory,
+          xcode_paths: xcode_paths
+        )
       end
 
       desc "all", "Bundle tuistenv and tuist"
@@ -48,19 +110,55 @@ module Fourier
         required: false,
         aliases: :b,
       )
+      option(
+        :xcode_version,
+        desc: %(
+          The version of Xcode to use to build tuist and tuistenv.
+          Can be either a version number (e.g. `--xcode_version="13.2.1"`)
+          or a file path pointing to the Xcode app bundle to use. (e.g. `--xcode_version="/path/to/Xcode.app"`)
+          Defaults to the currently selected Xcode on the system.
+        ),
+        type: :string,
+        required: false
+      )
+      option(
+        :xcode_version_libraries,
+        desc: %(
+          The version of Xcode to use to build tuist and tuistenv's library dependencies.
+          Can be either a version number (e.g. `--xcode_version="13.2.1"`)
+          or a file path pointing to the Xcode app bundle to use. (e.g. `--xcode_version="/path/to/Xcode.app"`)
+          Defaults to the currently selected Xcode on the system.
+        ),
+        type: :string,
+        required: false
+      )
       def all
         output_directory = options[:output]
         output_directory ||= File.expand_path("build", Constants::ROOT_DIRECTORY)
 
-        bundle_all(output_directory: output_directory)
+        xcode_paths = Utilities::Xcode::Paths.new(
+          default: options[:xcode_version],
+          libraries: options[:xcode_version_libraries]
+        )
+
+        bundle_all(
+          output_directory: output_directory,
+          xcode_paths: xcode_paths
+        )
       end
+
       no_commands {
-        def bundle_all(output_directory:)
+        def bundle_all(
+          output_directory:,
+          xcode_paths:
+        )
           Services::Bundle::Tuist.call(
-            output_directory: output_directory
+            output_directory: output_directory,
+            xcode_paths: xcode_paths
           )
           Services::Bundle::Tuistenv.call(
-            output_directory: output_directory
+            output_directory: output_directory,
+            xcode_paths: xcode_paths
           )
         end
       }

--- a/projects/fourier/lib/fourier/commands/release.rb
+++ b/projects/fourier/lib/fourier/commands/release.rb
@@ -4,10 +4,28 @@ module Fourier
   module Commands
     class Release < Base
       desc "tuist VERSION", "Bundles and uploads Tuist to GCS"
-      def tuist(version)
+      def tuist(
+        version,
+        xcode_version = nil,
+        xcode_version_libraries = nil
+      )
         output_directory ||= File.expand_path("build", Constants::ROOT_DIRECTORY)
-        Services::Bundle::Tuist.call(output_directory: output_directory)
-        Services::Bundle::Tuistenv.call(output_directory: output_directory)
+
+        xcode_paths = Utilities::Xcode::Paths.new(
+          default: xcode_version,
+          libraries: xcode_version_libraries
+        )
+
+        Services::Bundle::Tuist.call(
+          output_directory: output_directory,
+          xcode_paths: xcode_paths
+        )
+
+        Services::Bundle::Tuistenv.call(
+          output_directory: output_directory,
+          xcode_paths: xcode_paths
+        )
+
         Utilities::Output.success("tuist and tuistenv were built successfully")
       end
     end

--- a/projects/fourier/lib/fourier/services/bundle/tuist.rb
+++ b/projects/fourier/lib/fourier/services/bundle/tuist.rb
@@ -8,9 +8,14 @@ module Fourier
     module Bundle
       class Tuist < Base
         attr_reader :output_directory
+        attr_reader :xcode_paths
 
-        def initialize(output_directory:)
+        def initialize(
+          output_directory:,
+          xcode_paths:
+        )
           @output_directory = output_directory
+          @xcode_paths = xcode_paths
         end
 
         def call
@@ -22,13 +27,25 @@ module Fourier
 
           Dir.mktmpdir do |build_directory|
             Dir.mktmpdir do |swift_build_directory|
-              build_project_library(name: "ProjectDescription", output_directory: build_directory,
-                swift_build_directory: swift_build_directory)
-              build_project_library(name: "ProjectAutomation", output_directory: build_directory,
-                swift_build_directory: swift_build_directory)
+              build_project_library(
+                name: "ProjectDescription",
+                output_directory: build_directory,
+                swift_build_directory: swift_build_directory,
+                xcode_paths: xcode_paths
+              )
+              build_project_library(
+                name: "ProjectAutomation",
+                output_directory: build_directory,
+                swift_build_directory: swift_build_directory,
+                xcode_paths: xcode_paths
+              )
 
               Utilities::Output.section("Building Tuist...")
-              build_tuist(output_directory: build_directory, swift_build_directory: swift_build_directory)
+              build_tuist(
+                output_directory: build_directory,
+                swift_build_directory: swift_build_directory,
+                xcode_paths: xcode_paths
+              )
 
               FileUtils.cp_r(
                 File.expand_path("projects/cocoapods-interactor", Constants::ROOT_DIRECTORY),
@@ -66,23 +83,34 @@ module Fourier
         end
 
         private
-          def build_tuist(output_directory:, swift_build_directory:)
+          def build_tuist(
+            output_directory:,
+            swift_build_directory:,
+            xcode_paths:
+          )
             Utilities::SwiftPackageManager.build_fat_release_binary(
               path: Constants::ROOT_DIRECTORY,
               product: "tuist",
               binary_name: "tuist",
               output_directory: output_directory,
-              swift_build_directory: swift_build_directory
+              swift_build_directory: swift_build_directory,
+              xcode_paths: xcode_paths
             )
           end
 
-          def build_project_library(name:, output_directory:, swift_build_directory:)
+          def build_project_library(
+            name:,
+            output_directory:,
+            swift_build_directory:,
+            xcode_paths:
+          )
             Utilities::Output.section("Building #{name}...")
             Utilities::SwiftPackageManager.build_fat_release_library(
               path: Constants::ROOT_DIRECTORY,
               product: name,
               output_directory: output_directory,
-              swift_build_directory: swift_build_directory
+              swift_build_directory: swift_build_directory,
+              xcode_paths: xcode_paths
             )
           end
       end

--- a/projects/fourier/lib/fourier/services/bundle/tuistenv.rb
+++ b/projects/fourier/lib/fourier/services/bundle/tuistenv.rb
@@ -9,10 +9,16 @@ module Fourier
       class Tuistenv < Base
         attr_reader :output_directory
         attr_reader :build_directory
+        attr_reader :xcode_paths
 
-        def initialize(output_directory:, build_directory: nil)
+        def initialize(
+          output_directory:,
+          build_directory: nil,
+          xcode_paths:
+        )
           @output_directory = output_directory
           @build_directory = build_directory
+          @xcode_paths = xcode_paths
         end
 
         def call
@@ -27,7 +33,8 @@ module Fourier
               Utilities::Output.section("Building Tuistenv...")
               build_tuistenv(
                 output_directory: build_directory,
-                swift_build_directory: swift_build_directory
+                swift_build_directory: swift_build_directory,
+                xcode_paths: xcode_paths
               )
 
               Dir.chdir(build_directory) do
@@ -45,13 +52,18 @@ module Fourier
         end
 
         private
-          def build_tuistenv(output_directory:, swift_build_directory:)
+          def build_tuistenv(
+            output_directory:,
+            swift_build_directory:,
+            xcode_paths:
+          )
             Utilities::SwiftPackageManager.build_fat_release_binary(
               path: Constants::ROOT_DIRECTORY,
               product: "tuistenv",
               binary_name: "tuistenv",
               output_directory: output_directory,
-              swift_build_directory: swift_build_directory
+              swift_build_directory: swift_build_directory,
+              xcode_paths: xcode_paths
             )
           end
       end

--- a/projects/fourier/lib/fourier/utilities/xcode.rb
+++ b/projects/fourier/lib/fourier/utilities/xcode.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Fourier
+  module Utilities
+    module Xcode
+      def self.current_xcode_version
+        %x{ xcode-select -p }.split(/(?<=app)/).first
+      end
+
+      def self.path_to_xcode(version)
+        if version.nil?
+          nil
+        elsif !(version =~ /.app/).nil?
+          # If the version contains ".app", we can safely assume it's a path
+          # to an Xcode app bundle, so we return it.
+          version
+        else
+          # If the version string provided does not contain ".app", it's most likely
+          # a version number. We then find the path to the app bundle by parsing the
+          # output of the the `system_profiler` binary.
+          xcode_infos_json = %x{ system_profiler -json SPDeveloperToolsDataType }
+          parsed_xcode_infos = JSON.parse(xcode_infos_json)
+          xcode_infos = parsed_xcode_infos&.dig("SPDeveloperToolsDataType")
+
+          desired_xcode = xcode_infos.find { |info|
+            xcode_version = info&.dig("spdevtools_version").split(" (").first
+            SemVer.new(xcode_version) == SemVer.new(version)
+          }
+          desired_xcode_path = desired_xcode&.dig("spdevtools_path")
+
+          if desired_xcode_path.nil?
+            Output.error("The requested Xcode version '#{version}' is not available")
+            exit(1)
+          else
+            desired_xcode_path
+          end
+        end
+      end
+
+      class Paths
+        attr_accessor :default
+        attr_accessor :libraries
+
+        def initialize(default:, libraries:)
+          @default   = Xcode.path_to_xcode(default)   || current_xcode_version
+          @libraries = Xcode.path_to_xcode(libraries) || @default
+        end
+      end
+
+      class SemVer
+        attr_accessor :major
+        attr_accessor :minor
+        attr_accessor :patch
+
+        def initialize(version)
+          sem_version = version.strip.split(".")
+          @major = sem_version[0]
+          @minor = sem_version[1] || 0
+          @patch = sem_version[2] || 0
+        end
+
+        def ==(other)
+          self.major == other.major &&
+            self.minor == other.minor &&
+            self.patch == other.patch
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Short description 📝

We had some left-overs for the `.xcode-version` and the cache key configuration.

I took the opportunity to fix it and include the following changes:
* Hash `.xcode-version` where previously we used the input value from `strategy/matrix/xcode`
* Hash root `Packaged.resolved`, where previously we used the list all `**/Packaged.resolved`, this is not needed since we only need to cache the root manifest, which is what we use for building tuist and cloning its dependencies, plus it was failing randomly since `hashFiles` of Github action currently does not respect order, resulting in non-determinist hashes and may cause CI to fail.
* Hash root `Gemfile.lock` for tuist related jobs, hash `project/backbone/Gemfile.lock` for backbone related builds, and `project/cloud/Gemfile.lock` for cloud-related jobs, where previously we were using `**/Gemfile.lock` resulting in timeouts. (#3969)
* Includes the configurable Xcode paths by #3957

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
