### PR TITLE
3️⃣ Added `sources` property to `ProjectAutomation.Target` model.

### DIFF
--- a/Sources/ProjectAutomation/Target.swift
+++ b/Sources/ProjectAutomation/Target.swift
@@ -7,7 +7,7 @@ public struct Target: Codable, Equatable {
 
     /// The product type the target produces.
     public let product: String
-    
+
     /// List of file paths that are the target's sources.
     public let sources: [String]
 

--- a/Sources/ProjectAutomation/Target.swift
+++ b/Sources/ProjectAutomation/Target.swift
@@ -1,15 +1,23 @@
 import Foundation
 
-/// The structure defining the output schema of an target.
+/// The structure defining the output schema of a target.
 public struct Target: Codable, Equatable {
     /// The name of the target.
     public let name: String
 
     /// The product type the target produces.
     public let product: String
+    
+    /// List of file paths that are the target's sources.
+    public let sources: [String]
 
-    public init(name: String, product: String) {
+    public init(
+        name: String,
+        product: String,
+        sources: [String]
+    ) {
         self.name = name
         self.product = product
+        self.sources = sources
     }
 }

--- a/Sources/TuistKit/Services/GraphService.swift
+++ b/Sources/TuistKit/Services/GraphService.swift
@@ -188,7 +188,11 @@ extension ProjectAutomation.Package {
 
 extension ProjectAutomation.Target {
     fileprivate static func from(_ target: TuistGraph.Target) -> ProjectAutomation.Target {
-        ProjectAutomation.Target(name: target.name, product: target.product.rawValue)
+        ProjectAutomation.Target(
+            name: target.name,
+            product: target.product.rawValue,
+            sources: target.sources.map(\.path.pathString)
+        )
     }
 }
 

--- a/projects/docs/docs/commands/task.md
+++ b/projects/docs/docs/commands/task.md
@@ -86,6 +86,7 @@ You might wonder what the return value of `Tuist.graph()` is - the method return
 | ---------- | ------------------------------------------------------------- | ------- |
 | `name`| Name of the target | `String` |
 | `product` | Product type the target produces | `String` |
+| `sources` | List of file paths that are the target's sources. | `[String]` |
 
 #### Package
 


### PR DESCRIPTION
### Short description 📝

This PR adds `sources` property to `ProjectAutomation.Target` model. 

- I haven't found any unit tests for `ProjectAutomation`'s mappers. Let me know if I should init them in this PR. 
- I did not update `CHANGELOG` file because because it already contains unreleased `Tuist plugins 2.0` entry and this PR is a part of it. Let me know if it should be mentioned anyway. 

Im getting familiar myself with Plugins 2.0. If I miss something in this small addition please hint me. 