### PR TITLE
Fix supported platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Fix issue where test results were not being cached if a scheme was specified in the `tuist test` command [#3952](https://github.com/tuist/tuist/pull/3952) by [@hisaac](https://github.com/hisaac)
 - Fix for target references within workspace scheme pre/post actions [#3954](https://github.com/tuist/tuist/pull/3954) by [@kwridan](https://github.com/kwridan)
+- Fix archiving iOS target for Mac Catalyst [#3990](https://github.com/tuist/tuist/pull/3990) by [@orbitekk](https://github.com/orbitekk)
 
 ## 2.6.0 - Havana
 

--- a/Sources/TuistCache/Utilities/CacheFrameworkBuilder.swift
+++ b/Sources/TuistCache/Utilities/CacheFrameworkBuilder.swift
@@ -92,7 +92,6 @@ public final class CacheFrameworkBuilder: CacheArtifactBuilding {
         try destination(platform: platform, version: version, deviceName: deviceName)
             .map { (destination: String) -> [XcodeBuildArgument] in
                 [
-                    .sdk(platform == .macOS ? platform.xcodeDeviceSDK : platform.xcodeSimulatorSDK!),
                     .configuration(configuration),
                     .xcarg("DEBUG_INFORMATION_FORMAT", "dwarf-with-dsym"),
                     .xcarg("GCC_GENERATE_DEBUGGING_SYMBOLS", "YES"),
@@ -111,7 +110,7 @@ public final class CacheFrameworkBuilder: CacheArtifactBuilding {
         case .iOS: mappedPlatform = .iOS
         case .watchOS: mappedPlatform = .watchOS
         case .tvOS: mappedPlatform = .tvOS
-        case .macOS: return .just("platform=OS X,arch=x86_64")
+        case .macOS: return .just("generic/platform=macOS")
         }
 
         return simulatorController.findAvailableDevice(

--- a/Sources/TuistCache/Utilities/CacheFrameworkBuilder.swift
+++ b/Sources/TuistCache/Utilities/CacheFrameworkBuilder.swift
@@ -110,7 +110,7 @@ public final class CacheFrameworkBuilder: CacheArtifactBuilding {
         case .iOS: mappedPlatform = .iOS
         case .watchOS: mappedPlatform = .watchOS
         case .tvOS: mappedPlatform = .tvOS
-        case .macOS: return .just("generic/platform=macOS")
+        case .macOS: return .just("platform=macOS,arch=x86_64")
         }
 
         return simulatorController.findAvailableDevice(

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -231,7 +231,6 @@ final class ConfigGenerator: ConfigGenerating {
             settings["CODE_SIGN_ENTITLEMENTS"] = .string("$(SRCROOT)/\(entitlements.relative(to: sourceRootPath).pathString)")
         }
         settings["SDKROOT"] = .string(target.platform.xcodeSdkRoot)
-        settings["SUPPORTED_PLATFORMS"] = .string(target.platform.xcodeSupportedPlatforms)
 
         if target.product == .staticFramework {
             settings["MACH_O_TYPE"] = "staticlib"

--- a/Sources/TuistGraph/Models/Platform.swift
+++ b/Sources/TuistGraph/Models/Platform.swift
@@ -81,19 +81,6 @@ extension Platform {
         }
     }
 
-    public var xcodeSupportedPlatforms: String {
-        switch self {
-        case .tvOS:
-            return "appletvsimulator appletvos"
-        case .iOS:
-            return "iphonesimulator iphoneos"
-        case .macOS:
-            return "macosx"
-        case .watchOS:
-            return "watchsimulator watchos"
-        }
-    }
-
     /// The SDK Root Path within Xcode's developer directory
     public var xcodeSdkRootPath: String {
         switch self {

--- a/Tests/TuistGraphTests/Models/PlatformTests.swift
+++ b/Tests/TuistGraphTests/Models/PlatformTests.swift
@@ -60,7 +60,7 @@ final class PlatformTests: XCTestCase {
             .iOS,
             .macOS,
             .tvOS,
-            .watchOS
+            .watchOS,
         ]
 
         // When
@@ -71,7 +71,7 @@ final class PlatformTests: XCTestCase {
             "Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk",
             "Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk",
             "Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk",
-            "Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk"
+            "Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk",
         ])
     }
 }

--- a/Tests/TuistGraphTests/Models/PlatformTests.swift
+++ b/Tests/TuistGraphTests/Models/PlatformTests.swift
@@ -23,12 +23,7 @@ final class PlatformTests: XCTestCase {
         XCTAssertEqual(Platform.macOS.xcodeSdkRoot, "macosx")
         XCTAssertEqual(Platform.iOS.xcodeSdkRoot, "iphoneos")
         XCTAssertEqual(Platform.tvOS.xcodeSdkRoot, "appletvos")
-    }
-
-    func test_xcodeSupportedPLatforms_returns_the_right_value() {
-        XCTAssertEqual(Platform.macOS.xcodeSupportedPlatforms, "macosx")
-        XCTAssertEqual(Platform.iOS.xcodeSupportedPlatforms, "iphonesimulator iphoneos")
-        XCTAssertEqual(Platform.tvOS.xcodeSupportedPlatforms, "appletvsimulator appletvos")
+        XCTAssertEqual(Platform.watchOS.xcodeSdkRoot, "watchos")
     }
 
     func test_xcodeSimulatorSDK() {
@@ -65,6 +60,7 @@ final class PlatformTests: XCTestCase {
             .iOS,
             .macOS,
             .tvOS,
+            .watchOS
         ]
 
         // When
@@ -75,6 +71,7 @@ final class PlatformTests: XCTestCase {
             "Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk",
             "Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk",
             "Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk",
+            "Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk"
         ])
     }
 }


### PR DESCRIPTION
Resolves #3989
Request for comments document (if applies):

Short description 📝

It is not possible to archive iOS project for Mac Catalyst. `Any Mac (Mac Catalyst)` destination is missing because `SUPPORTED_PLATFORMS` is set to `iOS`.

I have removed the `SUPPORTED_PLATFORM` setting.

How to test the changes locally 🧐

To test this feature you need to create a project for iOS like below:

```swift
import ProjectDescription

let project = Project(
    name: "Search",
    targets: [
        Target(
            name: "Search-ios",
            platform: .iOS,
            product: .framework,
            bundleId: "my.bundle.Search",
            deploymentTarget: .iOS(
                targetVersion: "13.0",
                devices: [
                    .iphone,
                    .ipad,
                    .mac
                ]
            ),
            infoPlist: "Info.plist",
            sources: ["Sources/**"]
        )
    ]
)
```


### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
