### PR TITLE
Fix `current_xcode_version` in `xcode.rb`

### DIFF
--- a/projects/fourier/lib/fourier/utilities/xcode.rb
+++ b/projects/fourier/lib/fourier/utilities/xcode.rb
@@ -44,7 +44,7 @@ module Fourier
         attr_accessor :libraries
 
         def initialize(default:, libraries:)
-          @default   = Xcode.path_to_xcode(default)   || current_xcode_version
+          @default   = Xcode.path_to_xcode(default)   || Xcode.current_xcode_version
           @libraries = Xcode.path_to_xcode(libraries) || @default
         end
       end


### PR DESCRIPTION
### Short description 📝

I accidentally snuck a little bug into #3957 🤦‍♂️

If you called `fourier bundle` _without_ providing an Xcode version or path, it would crash because it couldn't resolve the `current_xcode_version` reference within the `Paths` class.

Adding `Xcode.` to namespace it fixes the problem.

### How to test the changes locally 🧐

Run `./fourier bundle tuist`, and observe that bundling starts as expected.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.