### PR TITLE
Fix SPM mapping of GCC_PREPROCESSOR_DEFINITIONS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Fix issue where test results were not being cached if a scheme was specified in the `tuist test` command [#3952](https://github.com/tuist/tuist/pull/3952) by [@hisaac](https://github.com/hisaac)
 - Fix for target references within workspace scheme pre/post actions [#3954](https://github.com/tuist/tuist/pull/3954) by [@kwridan](https://github.com/kwridan)
+- Fix SPM mapping for `GCC_PREPROCESSOR_DEFINITIONS` definitions [#3995](https://github.com/tuist/tuist/pull/3995) by [@adellibovi](https://github.com/adellibovi)
 
 ## 2.6.0 - Havana
 

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -722,7 +722,7 @@ extension ProjectDescription.Settings {
         if !defines.isEmpty {
             let sortedDefines = defines.sorted { $0.key < $1.key }
             settingsDictionary["GCC_PREPROCESSOR_DEFINITIONS"] = .array(["$(inherited)"] + sortedDefines.map { key, value in
-                "\(key)=\(value)"
+                "\(key)=\(value.spm_shellEscaped())"
             })
         }
 

--- a/projects/tuist/fixtures/app_with_spm_dependencies/Project.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/Project.swift
@@ -21,6 +21,7 @@ let project = Project(
                 .external(name: "FirebaseDatabase"),
                 .external(name: "FirebaseFirestore"),
                 .external(name: "GoogleSignIn"),
+                .external(name: "Realm"),
             ]
         ),
         Target(

--- a/projects/tuist/fixtures/app_with_spm_dependencies/Tuist/Dependencies.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/Tuist/Dependencies.swift
@@ -12,6 +12,7 @@ let dependencies = Dependencies(
             .package(url: "https://github.com/pointfreeco/swift-composable-architecture", .upToNextMinor(from: "0.22.0")),
             .package(url: "https://github.com/Quick/Quick", .upToNextMajor(from: "4.0.0")),
             .package(url: "https://github.com/Quick/Nimble", .upToNextMajor(from: "9.0.0")),
+            .package(url: "https://github.com/realm/realm-cocoa.git", .upToNextMajor(from: "10.7.2")),
         ],
         targetSettings: [
             "Quick": ["ENABLE_TESTING_SEARCH_PATHS": "YES"],


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3928
Request for comments document (if applies):

### Short description 📝

When having a manifest that includes a GCC definition like `FOO="BAR"`, SPM successfully maintains the quotes and it will convert it to a compiler parameter like `-DFOO=\"BAR\"`.
Xcode configuration, instead, treats the quotes as value assignment, resulting in `-DFOO=BAR`, which has a different meaning in GCC macros, building packages incorrectly.
Tuist needs to escape those definitions for SPM manifests, as SPM is doing, so they can be built the same way.

### How to test the changes locally 🧐

The fixture `app_with_spm_dependencies` has been updated to include Realm which was not compiling because of the error.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
