### PR TITLE
feat: add --source arguments for fourier tuist commands

### DIFF
--- a/.github/workflows/meta-tuist.yml
+++ b/.github/workflows/meta-tuist.yml
@@ -73,7 +73,7 @@ jobs:
           bundle install --jobs 4 --retry 3
       - name: Build
         run: |
-          ./fourier focus
+          ./fourier focus --source
   test:
     name: Test with Xcode
     runs-on: macOS-11
@@ -96,7 +96,7 @@ jobs:
           bundle install --jobs 4 --retry 3
       - name: Test
         run: |
-          ./fourier test tuist unit
+          ./fourier test tuist unit --source
   
   lint-lockfiles:
     name: Lint lockfiles

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -57,7 +57,7 @@ jobs:
           bundle install --jobs 4 --retry 3
       - name: Run tests
         run: |
-          ./fourier test tuist unit
+          ./fourier test tuist unit --source
   release_build:
     name: Release build with Xcode
     runs-on: macOS-11
@@ -144,7 +144,7 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
       - name: Run tests
-        run: ./fourier test tuist acceptance projects/tuist/features/${{ matrix.feature }}.feature
+        run: ./fourier test tuist acceptance projects/tuist/features/${{ matrix.feature }}.feature --source
   
   lint:
     name: Lint

--- a/projects/docs/docs/contributors/fourier.md
+++ b/projects/docs/docs/contributors/fourier.md
@@ -15,10 +15,41 @@ By implementing our CLI tool within the repository we can better ensure the inte
 Before running Fourier, make sure that you have the Ruby version specified in the `.ruby-version` file, and that you have fetched the [Bundler](https://bundler.io) dependencies specified in the `Gemfile` by running `bundle install`. Then, you can run the following command:
 
 ```bash
-./fourier --help
+./fourier
 ```
 
-It'll output the list of available commands that you can run.
+#### Fourier Commands
+
+Commands typically have subcommands to reduce the number of options for a command.
+
+```bash
+./fourier lint tuist
+./fourier lint all --fix
+```
+
+You can checkout the help text for any command (or subcommand) with `--help`.
+
+```bash
+./fourier lint --help
+Commands:
+  fourier lint all                   # Lint all the code in the repository
+  fourier lint backbone              # Lint the Ruby code of the Backbone project
+  fourier lint cloud                 # Lint the Ruby code of the Cloud project
+  fourier lint cocoapods-interactor  # Lint the Ruby code of the CocoaPods interactor project
+  fourier lint fixturegen            # Lint the Swift code of the fixturegen project
+  fourier lint fourier               # Lint the Ruby code of the fixturegen project
+  fourier lint help [COMMAND]        # Describe subcommands or one specific subcommand
+  fourier lint lockfiles             # Ensures SPM and Tuist's generated lockfiles are consistent
+  fourier lint tuist                 # Lint the Swift code of the Tuist CLI
+  fourier lint tuistbench            # Lint the Swift code of the tuistbench project
+```
+
+#### Source build tools
+
+When using some commands like `./fourier test tuist` we use `tuist` to generate the project and test it.
+By default, `fourier` will attempt to use the installed version of `tuist` on the host machine. If no such version exists, it will build the `tuist` binary from the sources of the checked out repository.
+
+You may also override this behavior if you explicitly want to build from source when using the build tools with `--source` on commands that support this option.
 
 ### Shadowenv
 

--- a/projects/fourier/lib/fourier.rb
+++ b/projects/fourier/lib/fourier.rb
@@ -46,9 +46,21 @@ module Fourier
     desc "encrypt", "Encrypt content in the repository"
     subcommand "encrypt", Commands::Encrypt
 
-    desc "focus TARGETS", "Generate Tuist's project focusing on the target TARGET"
-    def focus(*targets)
-      Services::Focus.call(targets: targets)
+    desc "focus TARGETS", "Generate Tuist's project focusing on the targets TARGETS"
+    option(
+      :source,
+      desc: "Builds Tuist from source and uses that to focus on the targets.",
+      type: :boolean,
+      default: false
+    )
+    option(
+      :targets,
+      desc: "The targets to focus on. (Default = all targets)",
+      type: :array,
+      default: []
+    )
+    def focus
+      Services::Focus.call(targets: options[:targets], source: options[:source])
     end
 
     desc "tuist", "Runs Tuist"

--- a/projects/fourier/lib/fourier/commands/build/tuist.rb
+++ b/projects/fourier/lib/fourier/commands/build/tuist.rb
@@ -5,13 +5,25 @@ module Fourier
     class Build < Base
       class Tuist < Base
         desc "support", "Build TuistSupport"
+        option(
+          :source,
+          desc: "Builds Tuist from source and uses that to focus on the targets.",
+          type: :boolean,
+          required: false
+        )
         def support
-          Services::Build::Tuist::Support.call
+          Services::Build::Tuist::Support.call(source: options[:source])
         end
 
         desc "all", "Build all targets"
+        option(
+          :source,
+          desc: "Builds Tuist from source and uses that to focus on the targets.",
+          type: :boolean,
+          required: false
+        )
         def all
-          Services::Build::Tuist::All.call
+          Services::Build::Tuist::All.call(source: options[:source])
         end
       end
     end

--- a/projects/fourier/lib/fourier/commands/edit.rb
+++ b/projects/fourier/lib/fourier/commands/edit.rb
@@ -4,8 +4,14 @@ module Fourier
   module Commands
     class Edit < Base
       desc "tuist", "Edit the Tuist's project manifest"
+      option(
+        :source,
+        desc: "Builds Tuist from source and uses that binary to edit the project's manifest",
+        default: false,
+        type: :boolean
+      )
       def tuist
-        Services::Edit::Tuist.call
+        Services::Edit::Tuist.call(source: options[:source])
       end
     end
   end

--- a/projects/fourier/lib/fourier/commands/generate.rb
+++ b/projects/fourier/lib/fourier/commands/generate.rb
@@ -11,8 +11,14 @@ module Fourier
         type: :boolean,
         aliases: :o
       )
+      option(
+        :source,
+        desc: "Builds Tuist from source to generate the project",
+        default: false,
+        type: :boolean
+      )
       def tuist
-        Services::Generate::Tuist.call(open: options[:open])
+        Services::Generate::Tuist.call(open: options[:open], source: options[:source])
       end
     end
   end

--- a/projects/fourier/lib/fourier/commands/test/tuist.rb
+++ b/projects/fourier/lib/fourier/commands/test/tuist.rb
@@ -5,13 +5,25 @@ module Fourier
     class Test < Base
       class Tuist < Base
         desc "unit", "Run Tuist unit tests"
+        option(
+          :source,
+          desc: "Builds Tuist from source and uses that to run the Tuist project unit tests.",
+          type: :boolean,
+          required: false
+        )
         def unit
-          Services::Test::Tuist::Unit.call
+          Services::Test::Tuist::Unit.call(source: options[:source])
         end
 
         desc "support", "Run TuistSupport unit tests"
+        option(
+          :source,
+          desc: "Builds Tuist from source and uses that to run the TuistSupport unit tests.",
+          type: :boolean,
+          required: false
+        )
         def support
-          Services::Test::Tuist::Support.call
+          Services::Test::Tuist::Support.call(source: options[:source])
         end
 
         desc "acceptance FEATURE", "Runs the acceptance tests for a given feature."\

--- a/projects/fourier/lib/fourier/services/build/tuist/all.rb
+++ b/projects/fourier/lib/fourier/services/build/tuist/all.rb
@@ -5,10 +5,16 @@ module Fourier
     module Build
       module Tuist
         class All < Base
+          attr_reader :source
+
+          def initialize(source: false)
+            @source = source
+          end
+
           def call
             dependencies = ["dependencies", "fetch"]
-            Utilities::System.tuist(*dependencies)
-            Utilities::System.tuist("build", "--generate")
+            Utilities::System.tuist(*dependencies, source: @source)
+            Utilities::System.tuist("build", "--generate", source: @source)
           end
         end
       end

--- a/projects/fourier/lib/fourier/services/build/tuist/support.rb
+++ b/projects/fourier/lib/fourier/services/build/tuist/support.rb
@@ -5,8 +5,14 @@ module Fourier
     module Build
       module Tuist
         class Support < Base
+          attr_reader :source
+
+          def initialize(source: false)
+            @source = source
+          end
+
           def call
-            Utilities::System.tuist("build", "TuistSupport")
+            Utilities::System.tuist("build", "TuistSupport", source: source)
           end
         end
       end

--- a/projects/fourier/lib/fourier/services/edit/tuist.rb
+++ b/projects/fourier/lib/fourier/services/edit/tuist.rb
@@ -4,8 +4,14 @@ module Fourier
   module Services
     module Edit
       class Tuist < Base
+        attr_reader :source
+
+        def initialize(source: false)
+          @source = source
+        end
+
         def call
-          Utilities::System.tuist("edit", "--only-current-directory")
+          Utilities::System.tuist("edit", "--only-current-directory", source: @source)
         end
       end
     end

--- a/projects/fourier/lib/fourier/services/focus.rb
+++ b/projects/fourier/lib/fourier/services/focus.rb
@@ -3,21 +3,31 @@
 module Fourier
   module Services
     class Focus < Base
-      attr_reader :targets
+      attr_reader :targets, :source
 
-      def initialize(targets:)
+      def initialize(targets: [], source: false)
         @targets = targets
+        @source = source
       end
 
       def call
+        targets = @targets.uniq
+
+        if targets.empty?
+          Utilities::Output.section("Focusing on all targets.")
+          Utilities::Output.subsection("Use --targets to specify targets")
+        else
+          Utilities::Output.section("Focusing on targets: #{targets.join(", ")}")
+        end
+
         dependencies = ["dependencies", "fetch"]
-        Utilities::System.tuist(*dependencies)
+        Utilities::System.tuist(*dependencies, source: @source)
 
         cache_warm = ["cache", "warm", "--dependencies-only"]
-        Utilities::System.tuist(*cache_warm)
+        Utilities::System.tuist(*cache_warm, source: @source)
 
         focus = ["focus"] + targets
-        Utilities::System.tuist(*focus)
+        Utilities::System.tuist(*focus, source: @source)
       end
     end
   end

--- a/projects/fourier/lib/fourier/services/generate/tuist.rb
+++ b/projects/fourier/lib/fourier/services/generate/tuist.rb
@@ -4,19 +4,20 @@ module Fourier
   module Services
     module Generate
       class Tuist < Base
-        attr_reader :open
+        attr_reader :open, :source
 
-        def initialize(open: false)
+        def initialize(open: false, source: false)
           @open = open
+          @source = source
         end
 
         def call
           dependencies = ["dependencies", "fetch"]
-          Utilities::System.tuist(*dependencies)
+          Utilities::System.tuist(*dependencies, source: @source)
 
           generate = ["generate"]
           generate << "--open" if open
-          Utilities::System.tuist(*generate)
+          Utilities::System.tuist(*generate, source: @source)
         end
       end
     end

--- a/projects/fourier/lib/fourier/services/test/tuist/support.rb
+++ b/projects/fourier/lib/fourier/services/test/tuist/support.rb
@@ -5,8 +5,14 @@ module Fourier
     module Test
       module Tuist
         class Support < Base
+          attr_reader :source
+
+          def initialize(source: false)
+            @source = source
+          end
+
           def call
-            Utilities::System.tuist("test", "TuistSupport")
+            Utilities::System.tuist("test", "TuistSupport", source: @source)
           end
         end
       end

--- a/projects/fourier/lib/fourier/services/test/tuist/unit.rb
+++ b/projects/fourier/lib/fourier/services/test/tuist/unit.rb
@@ -5,10 +5,16 @@ module Fourier
     module Test
       module Tuist
         class Unit < Base
+          attr_reader :source
+
+          def initialize(source: false)
+            @source = source
+          end
+
           def call
             dependencies = ["dependencies", "fetch"]
-            Utilities::System.tuist(*dependencies)
-            Utilities::System.tuist("test")
+            Utilities::System.tuist(*dependencies, source: @source)
+            Utilities::System.tuist("test", source: @source)
             Dir.chdir(Constants::TUIST_DIRECTORY) do
               Utilities::System.system("swift", "test")
             end

--- a/projects/fourier/lib/fourier/services/tuist.rb
+++ b/projects/fourier/lib/fourier/services/tuist.rb
@@ -12,7 +12,7 @@ module Fourier
       def call
         Utilities::SwiftPackageManager.build_product("ProjectAutomation")
         Utilities::SwiftPackageManager.build_product("ProjectDescription")
-        Utilities::System.tuist(*arguments, from_source: true)
+        Utilities::System.tuist(*arguments, source: true)
       end
     end
   end

--- a/projects/fourier/lib/fourier/utilities/system.rb
+++ b/projects/fourier/lib/fourier/utilities/system.rb
@@ -9,17 +9,17 @@ module Fourier
         Kernel.system(*args) || exit(1)
       end
 
-      def self.tuist(*args, **kwargs)
-        @tuist = "/usr/local/bin/tuist"
+      def self.tuist(*args, source: false)
+        tuist = "/usr/local/bin/tuist"
 
-        if kwargs[:from_source] || !File.exist?(@tuist)
+        if source || !File.exist?(tuist)
           Dir.chdir(Constants::TUIST_DIRECTORY) do
             self.system("swift", "build")
-            @tuist = ".build/debug/tuist"
+            tuist = ".build/debug/tuist"
           end
         end
 
-        self.system(@tuist, *args)
+        self.system(tuist, *args)
       end
 
       def self.fixturegen(*args)

--- a/projects/fourier/test/fourier/services/build/tuist/all_test.rb
+++ b/projects/fourier/test/fourier/services/build/tuist/all_test.rb
@@ -11,13 +11,13 @@ module Fourier
             # Given
             Utilities::System
               .expects(:tuist)
-              .with("dependencies", "fetch")
+              .with("dependencies", "fetch", source: false)
             Utilities::System
               .expects(:tuist)
-              .with("build", "--generate")
+              .with("build", "--generate", source: false)
 
             # Then
-            Services::Build::Tuist::All.call
+            Services::Build::Tuist::All.call(source: false)
           end
         end
       end

--- a/projects/fourier/test/fourier/services/build/tuist/support_test.rb
+++ b/projects/fourier/test/fourier/services/build/tuist/support_test.rb
@@ -11,10 +11,10 @@ module Fourier
             # Given
             Utilities::System
               .expects(:tuist)
-              .with("build", "TuistSupport")
+              .with("build", "TuistSupport", source: false)
 
             # Then
-            Services::Build::Tuist::Support.call
+            Services::Build::Tuist::Support.call(source: false)
           end
         end
       end

--- a/projects/fourier/test/fourier/services/edit/tuist_test.rb
+++ b/projects/fourier/test/fourier/services/edit/tuist_test.rb
@@ -10,10 +10,10 @@ module Fourier
           # Given
           Utilities::System
             .expects(:tuist)
-            .with("edit", "--only-current-directory")
+            .with("edit", "--only-current-directory", source: false)
 
           # Then
-          Services::Edit::Tuist.call
+          Services::Edit::Tuist.call(source: false)
         end
       end
     end

--- a/projects/fourier/test/fourier/services/focus_test.rb
+++ b/projects/fourier/test/fourier/services/focus_test.rb
@@ -9,17 +9,17 @@ module Fourier
         # Given
         Utilities::System
           .expects(:tuist)
-          .with("cache", "warm", "--dependencies-only")
+          .with("cache", "warm", "--dependencies-only", source: false)
         Utilities::System
           .expects(:tuist)
-          .with("dependencies", "fetch")
+          .with("dependencies", "fetch", source: false)
         targets = ["TuistSupport", "TuistSupportTests"]
         Utilities::System
           .expects(:tuist)
-          .with("focus", *targets)
+          .with("focus", *targets, source: false)
 
         # Then
-        Services::Focus.call(targets: targets)
+        Services::Focus.call(targets: targets, source: false)
       end
     end
   end

--- a/projects/fourier/test/fourier/services/generate/tuist_test.rb
+++ b/projects/fourier/test/fourier/services/generate/tuist_test.rb
@@ -8,20 +8,20 @@ module Fourier
       class TuistTest < TestCase
         def test_calls_tuist_with_the_right_arguments
           # Given
-          Utilities::System.expects(:tuist).with("dependencies", "fetch")
-          Utilities::System.expects(:tuist).with("generate")
+          Utilities::System.expects(:tuist).with("dependencies", "fetch", source: false)
+          Utilities::System.expects(:tuist).with("generate", source: false)
 
           # When/Then
-          Fourier::Services::Generate::Tuist.call(open: false)
+          Fourier::Services::Generate::Tuist.call(open: false, source: false)
         end
 
         def test_calls_tuist_with_the_right_arguments_when_open_is_true
           # Given
-          Utilities::System.expects(:tuist).with("dependencies", "fetch")
-          Utilities::System.expects(:tuist).with("generate", "--open")
+          Utilities::System.expects(:tuist).with("dependencies", "fetch", source: false)
+          Utilities::System.expects(:tuist).with("generate", "--open", source: false)
 
           # When/Then
-          Fourier::Services::Generate::Tuist.call(open: true)
+          Fourier::Services::Generate::Tuist.call(open: true, source: false)
         end
       end
     end

--- a/projects/fourier/test/fourier/services/test/tuist/unit_test.rb
+++ b/projects/fourier/test/fourier/services/test/tuist/unit_test.rb
@@ -13,16 +13,16 @@ module Fourier
             # Given
             Utilities::System
               .expects(:tuist)
-              .with("dependencies", "fetch")
+              .with("dependencies", "fetch", source: false)
             Utilities::System
               .expects(:tuist)
-              .with("test")
+              .with("test", source: false)
             Utilities::System
               .expects(:system)
               .with("swift", "test")
 
             # When/Then
-            Unit.call
+            Unit.call(source: false)
           end
         end
       end


### PR DESCRIPTION
### Short description 📝

Adding `--source` argument to build Tuist from source.


### How to test the changes locally 🧐

For any commands that support it, use `--source` to build `tuist` from source when using `fourier`.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
