### PR TITLE
Replace RxSwift for `ManifestLoader`

### DIFF
--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -228,8 +228,11 @@ public class ManifestLoader: ManifestLoading {
         do {
             let string = try System.shared.capture(arguments, verbose: false, environment: environment.manifestLoadingVariables)
 
-            guard let startTokenRange = string.range(of: ManifestLoader.startManifestToken) else { return string.data(using: .utf8)! }
-            guard let endTokenRange = string.range(of: ManifestLoader.endManifestToken) else { return string.data(using: .utf8)! }
+            guard let startTokenRange = string.range(of: ManifestLoader.startManifestToken),
+                  let endTokenRange = string.range(of: ManifestLoader.endManifestToken)
+            else {
+                return string.data(using: .utf8)!
+            }
 
             let preManifestLogs = String(string[string.startIndex ..< startTokenRange.lowerBound]).chomp()
             let postManifestLogs = String(string[endTokenRange.upperBound ..< string.endIndex]).chomp()

--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -1,7 +1,5 @@
 import Foundation
 import ProjectDescription
-import RxBlocking
-import RxSwift
 import TSCBasic
 import TuistCore
 import TuistGraph
@@ -227,18 +225,12 @@ public class ManifestLoader: ManifestLoading {
             at: path
         ) + ["--tuist-dump"]
 
-        let result = System.shared
-            .observable(arguments, verbose: false, environment: environment.manifestLoadingVariables)
-            .toBlocking()
-            .materialize()
+        do {
+            let string = try System.shared.capture(arguments, verbose: false, environment: environment.manifestLoadingVariables)
 
-        switch result {
-        case let .completed(elements):
-            let output = elements.filter(\.isStandardOutput).map(\.value).reduce(into: Data()) { $0.append($1) }
-            guard let string = String(data: output, encoding: .utf8) else { return output }
-
-            guard let startTokenRange = string.range(of: ManifestLoader.startManifestToken) else { return output }
-            guard let endTokenRange = string.range(of: ManifestLoader.endManifestToken) else { return output }
+            guard let startTokenRange = string.range(of: ManifestLoader.startManifestToken)
+            else { return string.data(using: .utf8)! }
+            guard let endTokenRange = string.range(of: ManifestLoader.endManifestToken) else { return string.data(using: .utf8)! }
 
             let preManifestLogs = String(string[string.startIndex ..< startTokenRange.lowerBound]).chomp()
             let postManifestLogs = String(string[endTokenRange.upperBound ..< string.endIndex]).chomp()
@@ -248,7 +240,7 @@ public class ManifestLoader: ManifestLoading {
 
             let manifest = string[startTokenRange.upperBound ..< endTokenRange.lowerBound]
             return manifest.data(using: .utf8)!
-        case let .failed(_, error):
+        } catch {
             logUnexpectedImportErrorIfNeeded(in: path, error: error, manifest: manifest)
             logPluginHelperBuildErrorIfNeeded(in: path, error: error, manifest: manifest)
             throw error

--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -228,8 +228,7 @@ public class ManifestLoader: ManifestLoading {
         do {
             let string = try System.shared.capture(arguments, verbose: false, environment: environment.manifestLoadingVariables)
 
-            guard let startTokenRange = string.range(of: ManifestLoader.startManifestToken)
-            else { return string.data(using: .utf8)! }
+            guard let startTokenRange = string.range(of: ManifestLoader.startManifestToken) else { return string.data(using: .utf8)! }
             guard let endTokenRange = string.range(of: ManifestLoader.endManifestToken) else { return string.data(using: .utf8)! }
 
             let preManifestLogs = String(string[string.startIndex ..< startTokenRange.lowerBound]).chomp()


### PR DESCRIPTION
Part of #4004

### Short description 📝

Not much to do for this one, since RxSwift isn't used in an asynchronous manner here.

### How to test the changes locally 🧐

Covered by existing tests

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
