### PR TITLE
Add "retry tests on failure" functionality for Xcode 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Use GitHub tags (via `git ls-remote`) to determine the latest Tuist version when installing/updating Tuist [#3985](https://github.com/tuist/tuist/pull/3985) by [@ezraberch](https://github.com/ezraberch)
 
 ### Added
+- Add a new test argument `--retry-count <number>` to retry failed tests <number> of times until success [#4021](https://github.com/tuist/tuist/pull/4021) by [@regularberry](https://github.com/regularberry)
 - Add support for `.docc` file types [#3982](https://github.com/tuist/tuist/pull/3982) by [@Jake Prickett](https://github.com/Jake-Prickett)
 
 - Add ability to specify as a command line argument, the Xcode version to use when bundling/releasing tuist and its libraries [#3957](https://github.com/tuist/tuist/pull/3957) by [@hisaac](https://github.com/hisaac)

--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -65,7 +65,8 @@ public final class XcodeBuildController: XcodeBuildControlling {
         destination: XcodeBuildDestination,
         derivedDataPath: AbsolutePath?,
         resultBundlePath: AbsolutePath?,
-        arguments: [XcodeBuildArgument]
+        arguments: [XcodeBuildArgument],
+        retryCount: Int
     ) -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         var command = ["/usr/bin/xcrun", "xcodebuild"]
 
@@ -83,6 +84,11 @@ public final class XcodeBuildController: XcodeBuildControlling {
 
         // Arguments
         command.append(contentsOf: arguments.flatMap(\.arguments))
+        
+        // Retry On Failure
+        if retryCount > 0 {
+            command.append(contentsOf: XcodeBuildArgument.retryCount(retryCount).arguments)
+        }
 
         // Destination
         switch destination {

--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -84,7 +84,7 @@ public final class XcodeBuildController: XcodeBuildControlling {
 
         // Arguments
         command.append(contentsOf: arguments.flatMap(\.arguments))
-        
+
         // Retry On Failure
         if retryCount > 0 {
             command.append(contentsOf: XcodeBuildArgument.retryCount(retryCount).arguments)

--- a/Sources/TuistCore/Automation/XcodeBuildArgument.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildArgument.swift
@@ -33,7 +33,7 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
         case let .derivedDataPath(path):
             return ["-derivedDataPath", path.pathString]
         case let .retryCount(count):
-            return ["-retry-tests-on-failure", "-test-iterations", "\(count+1)"]
+            return ["-retry-tests-on-failure", "-test-iterations", "\(count + 1)"]
         case let .xcarg(key, value):
             return ["\(key)=\(value.spm_shellEscaped())"]
         }
@@ -51,7 +51,7 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
         case let .derivedDataPath(path):
             return "Xcodebuild's derivedDataPath argument: \(path.pathString)"
         case let .retryCount(count):
-            return "Xcodebuild's retry-tests-on-failure argument combined with test-iterations: \(count+1)"
+            return "Xcodebuild's retry-tests-on-failure argument combined with test-iterations: \(count + 1)"
         case let .xcarg(key, value):
             return "Xcodebuild's additional argument: \(key)=\(value)"
         }

--- a/Sources/TuistCore/Automation/XcodeBuildArgument.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildArgument.swift
@@ -15,11 +15,11 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
     /// Specifies the directory where build products and other derived data will go.
     case derivedDataPath(AbsolutePath)
 
+    /// Specifies number of retry attempts on failure for testing
+    case retryCount(Int)
+
     /// To pass additional arguments
     case xcarg(String, String)
-    
-    /// To pass additional flags
-    case xcflag(String)
 
     /// It returns the bash arguments that represent this xcodebuild argument.
     public var arguments: [String] {
@@ -32,10 +32,10 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
             return ["-destination", "\(destination)"]
         case let .derivedDataPath(path):
             return ["-derivedDataPath", path.pathString]
+        case let .retryCount(count):
+            return ["-retry-tests-on-failure", "-test-iterations", "\(count)"]
         case let .xcarg(key, value):
             return ["\(key)=\(value.spm_shellEscaped())"]
-        case let .xcflag(flag):
-            return [flag]
         }
     }
 
@@ -50,10 +50,10 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
             return "Xcodebuild's destination argument: \(destination)"
         case let .derivedDataPath(path):
             return "Xcodebuild's derivedDataPath argument: \(path.pathString)"
+        case let .retryCount(count):
+            return "Xcodebuild's retry-tests-on-failure argument combined with test-iterations: \(count)"
         case let .xcarg(key, value):
             return "Xcodebuild's additional argument: \(key)=\(value)"
-        case let .xcflag(flag):
-            return "Xcodebuild's additional flag: \(flag)"
         }
     }
 }

--- a/Sources/TuistCore/Automation/XcodeBuildArgument.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildArgument.swift
@@ -33,7 +33,7 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
         case let .derivedDataPath(path):
             return ["-derivedDataPath", path.pathString]
         case let .retryCount(count):
-            return ["-retry-tests-on-failure", "-test-iterations", "\(count)"]
+            return ["-retry-tests-on-failure", "-test-iterations", "\(count+1)"]
         case let .xcarg(key, value):
             return ["\(key)=\(value.spm_shellEscaped())"]
         }
@@ -51,7 +51,7 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
         case let .derivedDataPath(path):
             return "Xcodebuild's derivedDataPath argument: \(path.pathString)"
         case let .retryCount(count):
-            return "Xcodebuild's retry-tests-on-failure argument combined with test-iterations: \(count)"
+            return "Xcodebuild's retry-tests-on-failure argument combined with test-iterations: \(count+1)"
         case let .xcarg(key, value):
             return "Xcodebuild's additional argument: \(key)=\(value)"
         }

--- a/Sources/TuistCore/Automation/XcodeBuildArgument.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildArgument.swift
@@ -17,6 +17,9 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
 
     /// To pass additional arguments
     case xcarg(String, String)
+    
+    /// To pass additional flags
+    case xcflag(String)
 
     /// It returns the bash arguments that represent this xcodebuild argument.
     public var arguments: [String] {
@@ -31,6 +34,8 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
             return ["-derivedDataPath", path.pathString]
         case let .xcarg(key, value):
             return ["\(key)=\(value.spm_shellEscaped())"]
+        case let .xcflag(flag):
+            return [flag]
         }
     }
 
@@ -47,6 +52,8 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
             return "Xcodebuild's derivedDataPath argument: \(path.pathString)"
         case let .xcarg(key, value):
             return "Xcodebuild's additional argument: \(key)=\(value)"
+        case let .xcflag(flag):
+            return "Xcodebuild's additional flag: \(flag)"
         }
     }
 }

--- a/Sources/TuistCore/Automation/XcodeBuildControlling.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildControlling.swift
@@ -28,6 +28,7 @@ public protocol XcodeBuildControlling {
     ///   - destination: Destination to run the tests on
     ///   - derivedDataPath: Custom location for derived data. Use `xcodebuild`'s default if `nil`
     ///   - arguments: Extra xcodebuild arguments.
+    ///   - retryCount: Number of times to retry the test on failure
     func test(
         _ target: XcodeBuildTarget,
         scheme: String,
@@ -35,7 +36,8 @@ public protocol XcodeBuildControlling {
         destination: XcodeBuildDestination,
         derivedDataPath: AbsolutePath?,
         resultBundlePath: AbsolutePath?,
-        arguments: [XcodeBuildArgument]
+        arguments: [XcodeBuildArgument],
+        retryCount: Int
     ) -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error>
 
     /// Returns an observable that archives the given project using xcodebuild.

--- a/Sources/TuistCoreTesting/Automation/MockXcodeBuildController.swift
+++ b/Sources/TuistCoreTesting/Automation/MockXcodeBuildController.swift
@@ -23,7 +23,7 @@ final class MockXcodeBuildController: XcodeBuildControlling {
     }
 
     var testStub: (
-        (XcodeBuildTarget, String, Bool, XcodeBuildDestination, AbsolutePath?, AbsolutePath?, [XcodeBuildArgument])
+        (XcodeBuildTarget, String, Bool, XcodeBuildDestination, AbsolutePath?, AbsolutePath?, [XcodeBuildArgument], Int)
             -> [SystemEvent<XcodeBuildOutput>]
     )?
     var testErrorStub: Error?
@@ -34,10 +34,11 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         destination: XcodeBuildDestination,
         derivedDataPath: AbsolutePath?,
         resultBundlePath: AbsolutePath?,
-        arguments: [XcodeBuildArgument]
+        arguments: [XcodeBuildArgument],
+        retryCount: Int
     ) -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         if let testStub = testStub {
-            let results = testStub(target, scheme, clean, destination, derivedDataPath, resultBundlePath, arguments)
+            let results = testStub(target, scheme, clean, destination, derivedDataPath, resultBundlePath, arguments, retryCount)
             if let testErrorStub = testErrorStub {
                 return AsyncThrowingStream {
                     throw testErrorStub

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -61,15 +61,9 @@ struct TestCommand: AsyncParsableCommand {
     
     @Option(
         name: .long,
-        help: "Tests will run <number> of times."
+        help: "Tests will run <number> of times until they succeed."
     )
-    var testIterations: Int?
-    
-    @Flag(
-        name: .long,
-        help: "Tests will retry on failure. May be used in conjunction with -test-iterations <number>, in which case <number> will be the maximum number of iterations. Otherwise, a maximum of 3 is assumed."
-    )
-    var retryTestsOnFailure: Bool = false
+    var retryCount: Int = 0
 
     func runAsync() async throws {
         let absolutePath: AbsolutePath
@@ -94,8 +88,7 @@ struct TestCommand: AsyncParsableCommand {
                     relativeTo: FileHandler.shared.currentPath
                 )
             },
-            testIterations: testIterations,
-            retryTestsOnFailure: retryTestsOnFailure
+            retryCount: retryCount
         )
     }
 }

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -58,7 +58,7 @@ struct TestCommand: AsyncParsableCommand {
         help: "Path where test result bundle will be saved."
     )
     var resultBundlePath: String?
-    
+
     @Option(
         name: .long,
         help: "Tests will retry <number> of times until success. Example: if 1 is specified, the test will be retried at most once, hence it will run up to 2 times."

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -61,7 +61,7 @@ struct TestCommand: AsyncParsableCommand {
     
     @Option(
         name: .long,
-        help: "Tests will retry <number> of times until they succeed. For example, if 1 is specified, the test will be retried at most once, hence it will run up to 2 times."
+        help: "Tests will retry <number> of times until success. Example: if 1 is specified, the test will be retried at most once, hence it will run up to 2 times."
     )
     var retryCount: Int = 0
 

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -58,6 +58,18 @@ struct TestCommand: AsyncParsableCommand {
         help: "Path where test result bundle will be saved."
     )
     var resultBundlePath: String?
+    
+    @Option(
+        name: .long,
+        help: "Tests will run <number> of times."
+    )
+    var testIterations: Int?
+    
+    @Flag(
+        name: .long,
+        help: "Tests will retry on failure. May be used in conjunction with -test-iterations <number>, in which case <number> will be the maximum number of iterations. Otherwise, a maximum of 3 is assumed."
+    )
+    var retryTestsOnFailure: Bool = false
 
     func runAsync() async throws {
         let absolutePath: AbsolutePath
@@ -81,7 +93,9 @@ struct TestCommand: AsyncParsableCommand {
                     $0,
                     relativeTo: FileHandler.shared.currentPath
                 )
-            }
+            },
+            testIterations: testIterations,
+            retryTestsOnFailure: retryTestsOnFailure
         )
     }
 }

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -61,7 +61,7 @@ struct TestCommand: AsyncParsableCommand {
     
     @Option(
         name: .long,
-        help: "Tests will run <number> of times until they succeed."
+        help: "Tests will retry <number> of times until they succeed."
     )
     var retryCount: Int = 0
 

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -61,7 +61,7 @@ struct TestCommand: AsyncParsableCommand {
     
     @Option(
         name: .long,
-        help: "Tests will retry <number> of times until they succeed."
+        help: "Tests will retry <number> of times until they succeed. For example, if 1 is specified, the test will be retried at most once, hence it will run up to 2 times."
     )
     var retryCount: Int = 0
 

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -77,8 +77,7 @@ final class TestService {
         osVersion: String?,
         skipUITests: Bool,
         resultBundlePath: AbsolutePath?,
-        testIterations: Int? = nil,
-        retryTestsOnFailure: Bool
+        retryCount: Int
     ) async throws {
         // Load config
         let manifestLoaderFactory = ManifestLoaderFactory()
@@ -140,8 +139,7 @@ final class TestService {
                     version: version,
                     deviceName: deviceName,
                     resultBundlePath: resultBundlePath,
-                    testIterations: testIterations,
-                    retryTestsOnFailure: retryTestsOnFailure
+                    retryCount: retryCount
                 )
             }
         } else {
@@ -164,8 +162,7 @@ final class TestService {
                     version: version,
                     deviceName: deviceName,
                     resultBundlePath: resultBundlePath,
-                    testIterations: testIterations,
-                    retryTestsOnFailure: retryTestsOnFailure
+                    retryCount: retryCount
                 )
             }
         }
@@ -202,8 +199,7 @@ final class TestService {
         version: Version?,
         deviceName: String?,
         resultBundlePath: AbsolutePath?,
-        testIterations: Int?,
-        retryTestsOnFailure: Bool
+        retryCount: Int
     ) async throws {
         logger.log(level: .notice, "Testing scheme \(scheme.name)", metadata: .section)
         guard let buildableTarget = buildGraphInspector.testableTarget(scheme: scheme, graphTraverser: graphTraverser) else {
@@ -218,10 +214,7 @@ final class TestService {
             deviceName: deviceName
         )
         
-        let extraTestArguments: [XcodeBuildArgument] = [
-            retryTestsOnFailure ? .xcflag("-retry-tests-on-failure") : nil,
-            testIterations.flatMap { .xcarg("-test-iterations", "\($0)") },
-        ].compactMap { $0 }
+        let extraTestArguments: [XcodeBuildArgument] = retryCount > 0 ? [.retryCount(retryCount)] : []
 
         try await xcodebuildController.test(
             .workspace(graphTraverser.workspace.xcWorkspacePath),

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -214,8 +214,6 @@ final class TestService {
             deviceName: deviceName
         )
 
-        let extraTestArguments: [XcodeBuildArgument] = retryCount > 0 ? [.retryCount(retryCount)] : []
-
         try await xcodebuildController.test(
             .workspace(graphTraverser.workspace.xcWorkspacePath),
             scheme: scheme.name,
@@ -228,7 +226,8 @@ final class TestService {
                 target: buildableTarget.target,
                 configuration: configuration,
                 skipSigning: false
-            ) + extraTestArguments
+            ),
+            retryCount: retryCount
         )
         .printFormattedOutput()
     }

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -213,7 +213,7 @@ final class TestService {
             version: version,
             deviceName: deviceName
         )
-        
+
         let extraTestArguments: [XcodeBuildArgument] = retryCount > 0 ? [.retryCount(retryCount)] : []
 
         try await xcodebuildController.test(

--- a/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildControllerTests.swift
+++ b/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildControllerTests.swift
@@ -71,7 +71,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             destination: .device("device-id"),
             derivedDataPath: nil,
             resultBundlePath: nil,
-            arguments: []
+            arguments: [],
+            retryCount: 0
         )
 
         let result = try await events.toArray()
@@ -107,7 +108,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             destination: .mac,
             derivedDataPath: nil,
             resultBundlePath: nil,
-            arguments: []
+            arguments: [],
+            retryCount: 0
         )
 
         let result = try await events.toArray()
@@ -143,7 +145,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             destination: .mac,
             derivedDataPath: derivedDataPath,
             resultBundlePath: nil,
-            arguments: []
+            arguments: [],
+            retryCount: 0
         )
 
         let result = try await events.toArray()
@@ -179,7 +182,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             destination: .mac,
             derivedDataPath: nil,
             resultBundlePath: resultBundlePath,
-            arguments: []
+            arguments: [],
+            retryCount: 0
         )
 
         let result = try await events.toArray()

--- a/Tests/TuistCoreTests/Automation/XcodeBuildArgumentTests.swift
+++ b/Tests/TuistCoreTests/Automation/XcodeBuildArgumentTests.swift
@@ -60,7 +60,7 @@ final class XcodeBuildArgumentTests: TuistUnitTestCase {
         // Then
         XCTAssertEqual(got, ["key=\'value with spaces\'"])
     }
-    
+
     func test_arguments_returns_the_right_value_when_retry_count() {
         // Given
         let subject = XcodeBuildArgument.retryCount(5)

--- a/Tests/TuistCoreTests/Automation/XcodeBuildArgumentTests.swift
+++ b/Tests/TuistCoreTests/Automation/XcodeBuildArgumentTests.swift
@@ -60,4 +60,15 @@ final class XcodeBuildArgumentTests: TuistUnitTestCase {
         // Then
         XCTAssertEqual(got, ["key=\'value with spaces\'"])
     }
+    
+    func test_arguments_returns_the_right_value_when_xcflag() {
+        // Given
+        let subject = XcodeBuildArgument.xcflag("flag")
+
+        // When
+        let got = subject.arguments
+
+        // Then
+        XCTAssertEqual(got, ["flag"])
+    }
 }

--- a/Tests/TuistCoreTests/Automation/XcodeBuildArgumentTests.swift
+++ b/Tests/TuistCoreTests/Automation/XcodeBuildArgumentTests.swift
@@ -69,6 +69,6 @@ final class XcodeBuildArgumentTests: TuistUnitTestCase {
         let got = subject.arguments
 
         // Then
-        XCTAssertEqual(got, ["-retry-tests-on-failure", "-test-iterations", "5"])
+        XCTAssertEqual(got, ["-retry-tests-on-failure", "-test-iterations", "6"])
     }
 }

--- a/Tests/TuistCoreTests/Automation/XcodeBuildArgumentTests.swift
+++ b/Tests/TuistCoreTests/Automation/XcodeBuildArgumentTests.swift
@@ -61,14 +61,14 @@ final class XcodeBuildArgumentTests: TuistUnitTestCase {
         XCTAssertEqual(got, ["key=\'value with spaces\'"])
     }
     
-    func test_arguments_returns_the_right_value_when_xcflag() {
+    func test_arguments_returns_the_right_value_when_retry_count() {
         // Given
-        let subject = XcodeBuildArgument.xcflag("flag")
+        let subject = XcodeBuildArgument.retryCount(5)
 
         // When
         let got = subject.arguments
 
         // Then
-        XCTAssertEqual(got, ["flag"])
+        XCTAssertEqual(got, ["-retry-tests-until-failure", "-test-iterations", "5"])
     }
 }

--- a/Tests/TuistCoreTests/Automation/XcodeBuildArgumentTests.swift
+++ b/Tests/TuistCoreTests/Automation/XcodeBuildArgumentTests.swift
@@ -69,6 +69,6 @@ final class XcodeBuildArgumentTests: TuistUnitTestCase {
         let got = subject.arguments
 
         // Then
-        XCTAssertEqual(got, ["-retry-tests-until-failure", "-test-iterations", "5"])
+        XCTAssertEqual(got, ["-retry-tests-on-failure", "-test-iterations", "5"])
     }
 }

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -355,7 +355,7 @@ final class TestServiceTests: TuistUnitTestCase {
             expectedResourceBundlePath
         )
     }
-    
+
     func test_run_passes_retry_count_as_argument() async throws {
         // Given
         buildGraphInspector.testableSchemesStub = { _ in
@@ -371,24 +371,24 @@ final class TestServiceTests: TuistUnitTestCase {
         generator.generateWithGraphStub = { path, _ in
             (path, Graph.test())
         }
-        
+
         var passedArguments: [XcodeBuildArgument] = []
         xcodebuildController.testStub = { _, _, _, _, _, _, arguments in
             passedArguments = arguments
             return [.standardOutput(.init(raw: "success"))]
         }
-        
+
         // When
         try await subject.testRun(
             schemeName: "ProjectSchemeOne",
             path: try temporaryPath(),
             retryCount: 3
         )
-        
+
         // Then
         XCTAssertTrue(passedArguments.contains(XcodeBuildArgument.retryCount(3)))
     }
-    
+
     func test_run_does_not_pass_retry_count_as_argument() async throws {
         // Given
         buildGraphInspector.testableSchemesStub = { _ in
@@ -404,19 +404,19 @@ final class TestServiceTests: TuistUnitTestCase {
         generator.generateWithGraphStub = { path, _ in
             (path, Graph.test())
         }
-        
+
         var passedArguments: [XcodeBuildArgument] = []
         xcodebuildController.testStub = { _, _, _, _, _, _, arguments in
             passedArguments = arguments
             return [.standardOutput(.init(raw: "success"))]
         }
-        
+
         // When
         try await subject.testRun(
             schemeName: "ProjectSchemeOne",
             path: try temporaryPath()
         )
-        
+
         // Then
         XCTAssertTrue(!passedArguments.contains(XcodeBuildArgument.retryCount(3)))
     }

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -356,7 +356,7 @@ final class TestServiceTests: TuistUnitTestCase {
         )
     }
     
-    func test_run_passes_test_iterations_as_argument() async throws {
+    func test_run_passes_retry_count_as_argument() async throws {
         // Given
         buildGraphInspector.testableSchemesStub = { _ in
             [
@@ -382,14 +382,14 @@ final class TestServiceTests: TuistUnitTestCase {
         try await subject.testRun(
             schemeName: "ProjectSchemeOne",
             path: try temporaryPath(),
-            testIterations: 3
+            retryCount: 3
         )
         
         // Then
-        XCTAssertTrue(passedArguments.contains(XcodeBuildArgument.xcarg("-test-iterations", "3")))
+        XCTAssertTrue(passedArguments.contains(XcodeBuildArgument.retryCount(3)))
     }
     
-    func test_run_does_not_pass_test_iterations_as_argument() async throws {
+    func test_run_does_not_pass_retry_count_as_argument() async throws {
         // Given
         buildGraphInspector.testableSchemesStub = { _ in
             [
@@ -418,107 +418,7 @@ final class TestServiceTests: TuistUnitTestCase {
         )
         
         // Then
-        XCTAssertTrue(!passedArguments.contains(XcodeBuildArgument.xcarg("-test-iterations", "3")))
-    }
-    
-    func test_run_does_pass_retry_on_failure_as_flag() async throws {
-        // Given
-        buildGraphInspector.testableSchemesStub = { _ in
-            [
-                Scheme.test(name: "TestScheme"),
-            ]
-        }
-        buildGraphInspector.projectSchemesStub = { _ in
-            [
-                Scheme.test(name: "ProjectSchemeOne"),
-            ]
-        }
-        generator.generateWithGraphStub = { path, _ in
-            (path, Graph.test())
-        }
-        
-        var passedArguments: [XcodeBuildArgument] = []
-        xcodebuildController.testStub = { _, _, _, _, _, _, arguments in
-            passedArguments = arguments
-            return [.standardOutput(.init(raw: "success"))]
-        }
-        
-        // When
-        try await subject.testRun(
-            schemeName: "ProjectSchemeOne",
-            path: try temporaryPath(),
-            retryTestsOnFailure: true
-        )
-        
-        // Then
-        XCTAssertTrue(passedArguments.contains(XcodeBuildArgument.xcflag("-retry-tests-on-failure")))
-    }
-    
-    func test_run_does_not_pass_retry_on_failure_as_flag() async throws {
-        // Given
-        buildGraphInspector.testableSchemesStub = { _ in
-            [
-                Scheme.test(name: "TestScheme"),
-            ]
-        }
-        buildGraphInspector.projectSchemesStub = { _ in
-            [
-                Scheme.test(name: "ProjectSchemeOne"),
-            ]
-        }
-        generator.generateWithGraphStub = { path, _ in
-            (path, Graph.test())
-        }
-        
-        var passedArguments: [XcodeBuildArgument] = []
-        xcodebuildController.testStub = { _, _, _, _, _, _, arguments in
-            passedArguments = arguments
-            return [.standardOutput(.init(raw: "success"))]
-        }
-        
-        // When
-        try await subject.testRun(
-            schemeName: "ProjectSchemeOne",
-            path: try temporaryPath()
-        )
-        
-        // Then
-        XCTAssertTrue(!passedArguments.contains(XcodeBuildArgument.xcflag("-retry-tests-on-failure")))
-    }
-    
-    func test_run_passes_both_retry_and_iterations_as_arguments() async throws {
-        // Given
-        buildGraphInspector.testableSchemesStub = { _ in
-            [
-                Scheme.test(name: "TestScheme"),
-            ]
-        }
-        buildGraphInspector.projectSchemesStub = { _ in
-            [
-                Scheme.test(name: "ProjectSchemeOne"),
-            ]
-        }
-        generator.generateWithGraphStub = { path, _ in
-            (path, Graph.test())
-        }
-        
-        var passedArguments: [XcodeBuildArgument] = []
-        xcodebuildController.testStub = { _, _, _, _, _, _, arguments in
-            passedArguments = arguments
-            return [.standardOutput(.init(raw: "success"))]
-        }
-        
-        // When
-        try await subject.testRun(
-            schemeName: "ProjectSchemeOne",
-            path: try temporaryPath(),
-            testIterations: 5,
-            retryTestsOnFailure: true
-        )
-        
-        // Then
-        XCTAssertTrue(passedArguments.contains(XcodeBuildArgument.xcflag("-retry-tests-on-failure")))
-        XCTAssertTrue(passedArguments.contains(XcodeBuildArgument.xcarg("-test-iterations", "5")))
+        XCTAssertTrue(!passedArguments.contains(XcodeBuildArgument.retryCount(3)))
     }
 }
 
@@ -534,8 +434,7 @@ extension TestService {
         osVersion: String? = nil,
         skipUiTests: Bool = false,
         resultBundlePath: AbsolutePath? = nil,
-        testIterations: Int? = nil,
-        retryTestsOnFailure: Bool = false
+        retryCount: Int = 0
     ) async throws {
         try await run(
             schemeName: schemeName,
@@ -546,8 +445,7 @@ extension TestService {
             osVersion: osVersion,
             skipUITests: skipUiTests,
             resultBundlePath: resultBundlePath,
-            testIterations: testIterations,
-            retryTestsOnFailure: retryTestsOnFailure
+            retryCount: retryCount
         )
     }
 }

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -122,7 +122,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -154,7 +154,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -203,7 +203,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -242,7 +242,7 @@ final class TestServiceTests: TuistUnitTestCase {
         }
         var testedSchemes: [String] = []
         xcodebuildController.testErrorStub = NSError.test()
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return []
         }
@@ -277,7 +277,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -297,7 +297,7 @@ final class TestServiceTests: TuistUnitTestCase {
         let expectedResourceBundlePath = AbsolutePath("/test")
         var resourceBundlePath: AbsolutePath?
 
-        xcodebuildController.testStub = { _, _, _, _, _, gotResourceBundlePath, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, gotResourceBundlePath, _, _ in
             resourceBundlePath = gotResourceBundlePath
             return []
         }
@@ -328,7 +328,7 @@ final class TestServiceTests: TuistUnitTestCase {
         let expectedResourceBundlePath = AbsolutePath("/test")
         var resourceBundlePath: AbsolutePath?
 
-        xcodebuildController.testStub = { _, _, _, _, _, gotResourceBundlePath, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, gotResourceBundlePath, _, _ in
             resourceBundlePath = gotResourceBundlePath
             return []
         }
@@ -372,9 +372,9 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
 
-        var passedArguments: [XcodeBuildArgument] = []
-        xcodebuildController.testStub = { _, _, _, _, _, _, arguments in
-            passedArguments = arguments
+        var passedRetryCount = 0
+        xcodebuildController.testStub = { _, _, _, _, _, _, _, retryCount in
+            passedRetryCount = retryCount
             return [.standardOutput(.init(raw: "success"))]
         }
 
@@ -386,10 +386,10 @@ final class TestServiceTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertTrue(passedArguments.contains(XcodeBuildArgument.retryCount(3)))
+        XCTAssertEqual(passedRetryCount, 3)
     }
 
-    func test_run_does_not_pass_retry_count_as_argument() async throws {
+    func test_run_defaults_retry_count_to_zero() async throws {
         // Given
         buildGraphInspector.testableSchemesStub = { _ in
             [
@@ -405,9 +405,9 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
 
-        var passedArguments: [XcodeBuildArgument] = []
-        xcodebuildController.testStub = { _, _, _, _, _, _, arguments in
-            passedArguments = arguments
+        var passedRetryCount = -1
+        xcodebuildController.testStub = { _, _, _, _, _, _, _, retryCount in
+            passedRetryCount = retryCount
             return [.standardOutput(.init(raw: "success"))]
         }
 
@@ -418,7 +418,7 @@ final class TestServiceTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertTrue(!passedArguments.contains(XcodeBuildArgument.retryCount(3)))
+        XCTAssertEqual(passedRetryCount, 0)
     }
 }
 

--- a/projects/docs/docs/commands/test.md
+++ b/projects/docs/docs/commands/test.md
@@ -50,12 +50,11 @@ One of the benefits of using Tuist over other automation tools is that developer
 
 | Argument               | Short | Description                                                         | Default           | Required |
 | ---------------------- | ----- | ------------------------------------------------------------------- | ----------------- | -------- |
-| `--clean`                  | `-c`  | `When passed, it cleans the project before testing it.`             | False             | No       |
-| `--path`                   | `-p`  | `The path to the directory that contains the project to be tested.` | Current directory | No       |
-| `--device`                 | `-d`  | `Test on a specific device.`                                        |                   | No       |
-| `--os`                     | `-o`  | `Test with a specific version of the OS.`                           |                   | No       |
-| `--configuration`          | `-C`  | `The configuration to be used when building the scheme.`            |                   | No       |
-| `--skip-ui-tests`          | n/a   | `When passed, it skips testing UI Tests targets.`                   | False             | No       |
-| `--result-bundle-path`     | `-T`  | `Path where test result bundle will be saved`                       |                   | No       |
-| `--test-iterations`        | n/a   | `Tests will run <number> of times.`                                 |                   | No       |
-| `--retry-tests-on-failure` | n/a   | `Tests will retry on failure.`                                      |                   | No       |
+| `--clean`              | `-c`  | `When passed, it cleans the project before testing it.`             | False             | No       |
+| `--path`               | `-p`  | `The path to the directory that contains the project to be tested.` | Current directory | No       |
+| `--device`             | `-d`  | `Test on a specific device.`                                        |                   | No       |
+| `--os`                 | `-o`  | `Test with a specific version of the OS.`                           |                   | No       |
+| `--configuration`      | `-C`  | `The configuration to be used when building the scheme.`            |                   | No       |
+| `--skip-ui-tests`      | n/a   | `When passed, it skips testing UI Tests targets.`                   | False             | No       |
+| `--result-bundle-path` | `-T`  | `Path where test result bundle will be saved`                       |                   | No       |
+| `--retry-count`        | n/a   | `Tests will run <number> of times until they succeed.`              | 0                 | No       |

--- a/projects/docs/docs/commands/test.md
+++ b/projects/docs/docs/commands/test.md
@@ -50,10 +50,12 @@ One of the benefits of using Tuist over other automation tools is that developer
 
 | Argument               | Short | Description                                                         | Default           | Required |
 | ---------------------- | ----- | ------------------------------------------------------------------- | ----------------- | -------- |
-| `--clean`              | `-c`  | `When passed, it cleans the project before testing it.`             | False             | No       |
-| `--path`               | `-p`  | `The path to the directory that contains the project to be tested.` | Current directory | No       |
-| `--device`             | `-d`  | `Test on a specific device.`                                        |                   | No       |
-| `--os`                 | `-o`  | `Test with a specific version of the OS.`                           |                   | No       |
-| `--configuration`      | `-C`  | `The configuration to be used when building the scheme.`            |                   | No       |
-| `--skip-ui-tests`      | n/a   | `When passed, it skips testing UI Tests targets.`                   | False             | No       |
-| `--result-bundle-path` | `-T`  | `Path where test result bundle will be saved`                       |                   | No       |
+| `--clean`                  | `-c`  | `When passed, it cleans the project before testing it.`             | False             | No       |
+| `--path`                   | `-p`  | `The path to the directory that contains the project to be tested.` | Current directory | No       |
+| `--device`                 | `-d`  | `Test on a specific device.`                                        |                   | No       |
+| `--os`                     | `-o`  | `Test with a specific version of the OS.`                           |                   | No       |
+| `--configuration`          | `-C`  | `The configuration to be used when building the scheme.`            |                   | No       |
+| `--skip-ui-tests`          | n/a   | `When passed, it skips testing UI Tests targets.`                   | False             | No       |
+| `--result-bundle-path`     | `-T`  | `Path where test result bundle will be saved`                       |                   | No       |
+| `--test-iterations`        | n/a   | `Tests will run <number> of times.`                                 |                   | No       |
+| `--retry-tests-on-failure` | n/a   | `Tests will retry on failure.`                                      |                   | No       |

--- a/projects/docs/docs/commands/test.md
+++ b/projects/docs/docs/commands/test.md
@@ -57,4 +57,4 @@ One of the benefits of using Tuist over other automation tools is that developer
 | `--configuration`      | `-C`  | `The configuration to be used when building the scheme.`            |                   | No       |
 | `--skip-ui-tests`      | n/a   | `When passed, it skips testing UI Tests targets.`                   | False             | No       |
 | `--result-bundle-path` | `-T`  | `Path where test result bundle will be saved`                       |                   | No       |
-| `--retry-count`        | n/a   | `Tests will run <number> of times until they succeed.`              | 0                 | No       |
+| `--retry-count`        | n/a   | `Tests will retry <number> of times until they succeed.`              | 0                 | No       |


### PR DESCRIPTION
### Short description 📝

While building out Tuist at work, we came across the need to use the new "retry tests on failure" functionality in Xcode 13. Reference: https://emptytheory.com/2021/11/28/retrying-failed-tests-with-xcode-13-and-continuous-integration/

This adds `retry-tests-on-failure` and `test-iterations` to the `TestCommand` as arguments, and passes them to the underlying xcodebuild command.

It was discussed in Slack about the possibility of passing in any arbitrary argument/flag into the underlying xcodebuild command, but I wasn't sure how that would affect caching, or if the project as a whole wants to go down that route. Definitely willing to discuss if that's something you'd prefer!

I also updated the documentation. Not sure if this is automatic though somewhere?

### How to test the changes locally 🧐

I included Unit Tests for the new functionality.

Additionally, I tested this out in a sample project with the following test:

```Swift
import XCTest

var val = 0

class MyAppTests: XCTestCase {

    override func setUpWithError() throws {
        val += 1
    }

    func testExample() throws {
        XCTAssert(val == 2)
    }
}
```
This test will fail the first time, but succeed the second.


### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
