### PR TITLE
[WIP] Adding ability of custom groups for additional files

### DIFF
--- a/Sources/ProjectDescription/FileElement.swift
+++ b/Sources/ProjectDescription/FileElement.swift
@@ -9,11 +9,11 @@ import Foundation
 ///       `"some/pattern/**"` is the equivalent of `FileElement.glob(pattern: "some/pattern/**")`
 public enum FileElement: Codable, Equatable {
     /// A glob pattern of files to include
-    case glob(pattern: Path)
+    case glob(pattern: Path, group: String? = nil)
 
     /// Relative path to a directory to include
     /// as a folder reference
-    case folderReference(path: Path)
+    case folderReference(path: Path, group: String? = nil)
 
     private enum TypeName: String, Codable {
         case glob
@@ -33,18 +33,20 @@ public enum FileElement: Codable, Equatable {
         case type
         case pattern
         case path
+        case group
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let type = try container.decode(TypeName.self, forKey: .type)
+        let group = try container.decodeIfPresent(String.self, forKey: .group)
         switch type {
         case .glob:
             let pattern = try container.decode(Path.self, forKey: .pattern)
-            self = .glob(pattern: pattern)
+            self = .glob(pattern: pattern, group: group)
         case .folderReference:
             let path = try container.decode(Path.self, forKey: .path)
-            self = .folderReference(path: path)
+            self = .folderReference(path: path, group: group)
         }
     }
 
@@ -52,9 +54,11 @@ public enum FileElement: Codable, Equatable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(typeName, forKey: .type)
         switch self {
-        case let .glob(pattern: pattern):
+        case let .glob(pattern: pattern, group: group):
+            try container.encode(group, forKey: .group)
             try container.encode(pattern, forKey: .pattern)
-        case let .folderReference(path: path):
+        case let .folderReference(path: path, group: group):
+            try container.encode(group, forKey: .group)
             try container.encode(path, forKey: .path)
         }
     }

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -100,10 +100,22 @@ class ProjectFileElements {
         })
 
         // Additional files
+        var createdGroups = [String: ProjectGroup]()
+        
         fileElements.formUnion(project.additionalFiles.map {
-            GroupFileElement(
+            let group: ProjectGroup = $0.group.map { groupName in
+                if let alreadyCreated = createdGroups[groupName] {
+                    return alreadyCreated
+                }
+                else {
+                    let justCreated = ProjectGroup.group(name: customGroup)
+                    createdGroups[customGroup] = justCreated
+                    return justCreated
+                }
+            } ?? project.filesGroup
+            return GroupFileElement(
                 path: $0.path,
-                group: project.filesGroup,
+                group: group,
                 isReference: $0.isReference
             )
         })

--- a/Sources/TuistGraph/Models/Workspace.swift
+++ b/Sources/TuistGraph/Models/Workspace.swift
@@ -90,7 +90,7 @@ extension Workspace {
             schemes: schemes,
             generationOptions: generationOptions,
             ideTemplateMacros: ideTemplateMacros,
-            additionalFiles: additionalFiles + files.map { .file(path: $0) },
+            additionalFiles: additionalFiles + files.map { .file(path: $0, group: nil) },
             lastUpgradeCheck: lastUpgradeCheck
         )
     }

--- a/Sources/TuistLoader/Models+ManifestMappers/FileElement+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/FileElement+ManifestMapper.swift
@@ -50,12 +50,12 @@ extension TuistGraph.FileElement {
         }
 
         switch manifest {
-        case let .glob(pattern: pattern):
+        case let .glob(pattern: pattern, group: group):
             let resolvedPath = try generatorPaths.resolve(path: pattern)
-            return try globFiles(resolvedPath).map(FileElement.file)
-        case let .folderReference(path: folderReferencePath):
+            return try globFiles(resolvedPath).map { FileElement.file(path: $0, group: group) }
+        case let .folderReference(path: folderReferencePath, group: group):
             let resolvedPath = try generatorPaths.resolve(path: folderReferencePath)
-            return folderReferences(resolvedPath).map(FileElement.folderReference)
+            return folderReferences(resolvedPath).map { FileElement.folderReference(path: $0, group: group) }
         }
     }
 }


### PR DESCRIPTION
Partially resolves https://github.com/tuist/tuist/issues/268

### Short description 📝

Add ability to move additional files from "Project" group to custom, e.g. "Documentation"

It's a draft version, want to hear your suggestions. Also locally some compile issues even on clean branch. So will take care of all edge cases here bit later 
### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
