### PR TITLE
Fix missing embedded dependencies in App Clip targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fix SPM mapping for `GCC_PREPROCESSOR_DEFINITIONS` definitions [#3995](https://github.com/tuist/tuist/pull/3995) by [@adellibovi](https://github.com/adellibovi)
 - Fix archiving iOS target for Mac Catalyst [#3990](https://github.com/tuist/tuist/pull/3990) by [@orbitekk](https://github.com/orbitekk)
 - Mark libraries depending on XCTest through `ENABLE_TESTING_SEARCH_PATHS` setting as not cacheable [#4012](https://github.com/tuist/tuist/pull/4012) by [@danyf90](https://github.com/danyf90)
+- Fix missing embedded dependencies in App Clip targets [#4033](https://github.com/tuist/tuist/pull/4033) by [@kwridan](https://github.com/kwridan)
 
 ## 2.6.0 - Havana
 

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -659,6 +659,7 @@ public class GraphTraverser: GraphTraversing {
     func canEmbedProducts(target: Target) -> Bool {
         let validProducts: [Product] = [
             .app,
+            .appClip,
             .unitTests,
             .uiTests,
             .watch2Extension,

--- a/projects/tuist/features/generate-6.feature
+++ b/projects/tuist/features/generate-6.feature
@@ -28,6 +28,7 @@ Scenario: The project is an iOS application with appclip (ios_app_with_appclip)
     Then I should be able to build for iOS the scheme App
     Then the product 'App.app' with destination 'Debug-iphonesimulator' contains the appClip 'AppClip1' with architecture 'x86_64'
     Then the product 'App.app' with destination 'Debug-iphonesimulator' contains the appClip 'AppClip1' without architecture 'armv7'
+    Then AppClip1 embeds the framework Framework
     Then I should be able to build for iOS the scheme AppClip1
     Then I should be able to test for iOS the scheme AppClip1Tests
     Then I should be able to test for iOS the scheme AppClip1UITests

--- a/projects/tuist/features/step_definitions/cache.rb
+++ b/projects/tuist/features/step_definitions/cache.rb
@@ -18,7 +18,7 @@ Then(/^tuist warms the cache with ([a-zA-Z]+) profile$/) do |cache_profile|
   system(@tuist, "cache", "warm", "--path", @dir, "--profile", cache_profile)
 end
 
-Then(/^([a-zA-Z]+) links the framework ([a-zA-Z]+) from the cache/) do |target_name, framework_name|
+Then(/^([a-zA-Z0-9]+) links the framework ([a-zA-Z0-9]+) from the cache/) do |target_name, framework_name|
   projects = Xcode.projects(@workspace_path)
   target = projects.flat_map(&:targets).detect { |t| t.name == target_name }
   flunk("Target #{target_name} doesn't exist in any of the projects' targets of the workspace") if target.nil?
@@ -37,7 +37,7 @@ Then(/^([a-zA-Z]+) links the framework ([a-zA-Z]+) from the cache/) do |target_n
   end
 end
 
-Then(/^([a-zA-Z]+) copies the bundle ([a-zA-Z]+) from the cache/) do |target_name, bundle_name|
+Then(/^([a-zA-Z0-9]+) copies the bundle ([a-zA-Z0-9]+) from the cache/) do |target_name, bundle_name|
   projects = Xcode.projects(@workspace_path)
   target = projects.flat_map(&:targets).detect { |t| t.name == target_name }
   flunk("Target #{target_name} doesn't exist in any of the projects' targets of the workspace") if target.nil?
@@ -56,7 +56,7 @@ Then(/^([a-zA-Z]+) copies the bundle ([a-zA-Z]+) from the cache/) do |target_nam
   end
 end
 
-Then(/^([a-zA-Z]+) copies the bundle ([a-zA-Z]+) from the build directory/) do |target_name, bundle_name|
+Then(/^([a-zA-Z0-9]+) copies the bundle ([a-zA-Z0-9]+) from the build directory/) do |target_name, bundle_name|
   projects = Xcode.projects(@workspace_path)
   target = projects.flat_map(&:targets).detect { |t| t.name == target_name }
   flunk("Target #{target_name} doesn't exist in any of the projects' targets of the workspace") if target.nil?
@@ -75,7 +75,7 @@ Then(/^([a-zA-Z]+) copies the bundle ([a-zA-Z]+) from the build directory/) do |
   end
 end
 
-Then(/^([a-zA-Z]+) links the xcframework ([a-zA-Z]+)$/) do |target_name, xcframework|
+Then(/^([a-zA-Z0-9]+) links the xcframework ([a-zA-Z0-9]+)$/) do |target_name, xcframework|
   projects = Xcode.projects(@workspace_path)
   target = projects.flat_map(&:targets).detect { |t| t.name == target_name }
   flunk("Target #{target_name} doesn't exist in any of the projects' targets of the workspace") if target.nil?
@@ -88,7 +88,7 @@ Then(/^([a-zA-Z]+) links the xcframework ([a-zA-Z]+)$/) do |target_name, xcframe
   end
 end
 
-Then(/^([a-zA-Z]+) links the framework ([a-zA-Z]+)$/) do |target_name, framework|
+Then(/^([a-zA-Z0-9]+) links the framework ([a-zA-Z0-9]+)$/) do |target_name, framework|
   projects = Xcode.projects(@workspace_path)
   target = projects.flat_map(&:targets).detect { |t| t.name == target_name }
   flunk("Target #{target_name} doesn't exist in any of the projects' targets of the workspace") if target.nil?
@@ -99,7 +99,7 @@ Then(/^([a-zA-Z]+) links the framework ([a-zA-Z]+)$/) do |target_name, framework
   end
 end
 
-Then(/^([a-zA-Z]+) embeds the xcframework ([a-zA-Z]+)$/) do |target_name, xcframework|
+Then(/^([a-zA-Z0-9]+) embeds the xcframework ([a-zA-Z0-9]+)$/) do |target_name, xcframework|
   projects = Xcode.projects(@workspace_path)
   target = projects.flat_map(&:targets).detect { |t| t.name == target_name }
   flunk("Target #{target_name} in any of the projects of the workspace") if target.nil?
@@ -114,7 +114,7 @@ Then(/^([a-zA-Z]+) embeds the xcframework ([a-zA-Z]+)$/) do |target_name, xcfram
   end
 end
 
-Then(/^([a-zA-Z]+) embeds the framework ([a-zA-Z]+)$/) do |target_name, framework|
+Then(/^([a-zA-Z0-9]+) embeds the framework ([a-zA-Z0-9]+)$/) do |target_name, framework|
   projects = Xcode.projects(@workspace_path)
   target = projects.flat_map(&:targets).detect { |t| t.name == target_name }
   flunk("Target #{target_name} in any of the projects of the workspace") if target.nil?
@@ -129,7 +129,7 @@ Then(/^([a-zA-Z]+) embeds the framework ([a-zA-Z]+)$/) do |target_name, framewor
   end
 end
 
-Then(/^([a-zA-Z]+) doesn't embed the xcframework ([a-zA-Z]+)$/) do |target_name, xcframework|
+Then(/^([a-zA-Z0-9]+) doesn't embed the xcframework ([a-zA-Z0-9]+)$/) do |target_name, xcframework|
   projects = Xcode.projects(@workspace_path)
   target = projects.flat_map(&:targets).detect { |t| t.name == target_name }
   flunk("Target #{target_name} in any of the projects of the workspace") if target.nil?
@@ -143,7 +143,7 @@ Then(/^([a-zA-Z]+) doesn't embed the xcframework ([a-zA-Z]+)$/) do |target_name,
   end
 end
 
-Then(/^([a-zA-Z]+) does not embed any xcframeworks$/) do |target_name|
+Then(/^([a-zA-Z0-9]+) does not embed any xcframeworks$/) do |target_name|
   projects = Xcode.projects(@workspace_path)
   target = projects.flat_map(&:targets).detect { |t| t.name == target_name }
   flunk("Target #{target_name} in any of the projects of the workspace") if target.nil?


### PR DESCRIPTION

Resolves https://github.com/tuist/tuist/issues/4032

### Short description 📝

- App clips are stand-alone applications that can embed frameworks they depend on
- App clips have now been added to the list of product types that can embed frameworks to support this
- Tests and fixtures have been updated accordingly to verify this behaviour

### How to test the changes locally 🧐

- Generate the `ios_app_with_appclip` fixture and verify `Framework` is included in the list of embeded targets

```sh
swift build
swift run tuist generate --path projects/tuist/fixtures/ios_app_with_appclip
open projects/tuist/fixtures/ios_app_with_appclip/App.xcworkspace
```

### Notes 📝

- A small update to the fixture definitions was needed to support product names that contain numbers (e.g. `AppClip1`)

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- ~In case the PR introduces changes that affect users, the documentation has been updated.~
- ~In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.~
