### PR TITLE
Fix throwing errors for System Publishers - DO NOT MERGE

### DIFF
--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -232,28 +232,15 @@ public final class XcodeBuildController: XcodeBuildControlling {
 extension AsyncThrowingStream where Element == SystemEvent<Data> {
     fileprivate func mapAsXcodeBuildOutput() -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         var iterator = makeAsyncIterator()
-        var subIterator: IndexingIterator<[SystemEvent<XcodeBuildOutput>]>?
         return AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
-            if let output = subIterator?.next() {
-                return output
-            }
-
             guard let event = try await iterator.next() else { return nil }
             switch event {
             case let .standardError(errorData):
                 guard let line = String(data: errorData, encoding: .utf8) else { return nil }
-                let output = line.split(separator: "\n").map { line -> SystemEvent<XcodeBuildOutput> in
-                    SystemEvent.standardError(XcodeBuildOutput(raw: "\(String(line))\n"))
-                }
-                subIterator = output.makeIterator()
-                return subIterator?.next()
+                return SystemEvent.standardError(XcodeBuildOutput(raw: "\(String(line))\n"))
             case let .standardOutput(outputData):
                 guard let line = String(data: outputData, encoding: .utf8) else { return nil }
-                let output = line.split(separator: "\n").map { line -> SystemEvent<XcodeBuildOutput> in
-                    SystemEvent.standardOutput(XcodeBuildOutput(raw: "\(String(line))\n"))
-                }
-                subIterator = output.makeIterator()
-                return subIterator?.next()
+                return SystemEvent.standardOutput(XcodeBuildOutput(raw: "\(String(line))\n"))
             }
         }
     }

--- a/Sources/TuistSupport/System/System.swift
+++ b/Sources/TuistSupport/System/System.swift
@@ -195,7 +195,7 @@ public final class System: Systeming {
                     process.signal(9) // SIGKILL
                 }
             }
-        }.subscribe(on: DispatchQueue.global()).eraseToAnyPublisher()
+        }.subscribe(on: DispatchQueue.global(qos: .background)).eraseToAnyPublisher()
     }
 
     public func publisher(_ arguments: [String],
@@ -378,6 +378,6 @@ public final class System: Systeming {
                     processOne.terminate()
                 }
             }
-        }.subscribe(on: DispatchQueue.global()).eraseToAnyPublisher()
+        }.subscribe(on: DispatchQueue.global(qos: .background)).eraseToAnyPublisher()
     }
 }

--- a/Sources/TuistSupport/Utils/FileHandler.swift
+++ b/Sources/TuistSupport/Utils/FileHandler.swift
@@ -142,15 +142,8 @@ public class FileHandler: FileHandling {
     }
 
     public func inTemporaryDirectory(_ closure: @escaping (AbsolutePath) async throws -> Void) async throws {
-        try withTemporaryDirectory(removeTreeOnDeinit: true) { path in
-            let dispatchGroup = DispatchGroup()
-            dispatchGroup.enter()
-            Task.detached {
-                try await closure(path)
-                dispatchGroup.leave()
-            }
-            dispatchGroup.wait()
-        }
+        let directory = try TemporaryDirectory(removeTreeOnDeinit: true)
+        try await closure(directory.path)
     }
 
     public func inTemporaryDirectory<Result>(removeOnCompletion: Bool,

--- a/Tests/Fixtures/Frameworks/Failing/Failing.h
+++ b/Tests/Fixtures/Frameworks/Failing/Failing.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+//! Project version number for Failing.
+FOUNDATION_EXPORT double FailingVersionNumber;
+
+//! Project version string for Failing.
+FOUNDATION_EXPORT const unsigned char FailingVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Failing/PublicHeader.h>
+
+

--- a/Tests/Fixtures/Frameworks/Failing/Failing.swift
+++ b/Tests/Fixtures/Frameworks/Failing/Failing.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public enum Failing {
+    public init {}
+}

--- a/Tests/Fixtures/Frameworks/Failing/Info.plist
+++ b/Tests/Fixtures/Frameworks/Failing/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/Tests/Fixtures/Frameworks/Frameworks.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/Frameworks/Frameworks.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		71981E36279EE17100E0E770 /* Failing.h in Headers */ = {isa = PBXBuildFile; fileRef = 71981E1F279EE08700E0E770 /* Failing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		71981E39279EE26C00E0E770 /* Failing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71981E24279EE0AA00E0E770 /* Failing.swift */; };
 		B9023E07239BCDA200666BE6 /* iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = B9023E05239BCDA200666BE6 /* iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B9023E0E239BCDBE00666BE6 /* iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9023E0D239BCDBE00666BE6 /* iOS.swift */; };
 		B9023E18239BCDE900666BE6 /* watchOS.h in Headers */ = {isa = PBXBuildFile; fileRef = B9023E16239BCDE900666BE6 /* watchOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -18,6 +20,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		71981E1F279EE08700E0E770 /* Failing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Failing.h; sourceTree = "<group>"; };
+		71981E24279EE0AA00E0E770 /* Failing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Failing.swift; sourceTree = "<group>"; };
+		71981E31279EE0C300E0E770 /* Failing.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Failing.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		71981E32279EE0C400E0E770 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = /Users/adellibovi/Repositories/tuist/Tests/Fixtures/Frameworks/Failing/Info.plist; sourceTree = "<absolute>"; };
 		B9023E02239BCDA200666BE6 /* iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B9023E05239BCDA200666BE6 /* iOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iOS.h; sourceTree = "<group>"; };
 		B9023E06239BCDA200666BE6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -37,6 +43,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		71981E2B279EE0C300E0E770 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B9023DFF239BCDA200666BE6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -68,6 +81,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		71981E1E279EE08700E0E770 /* Failing */ = {
+			isa = PBXGroup;
+			children = (
+				71981E1F279EE08700E0E770 /* Failing.h */,
+				71981E32279EE0C400E0E770 /* Info.plist */,
+				71981E24279EE0AA00E0E770 /* Failing.swift */,
+			);
+			path = Failing;
+			sourceTree = "<group>";
+		};
 		B9023DF8239BCDA200666BE6 = {
 			isa = PBXGroup;
 			children = (
@@ -75,6 +98,7 @@
 				B9023E15239BCDE900666BE6 /* watchOS */,
 				B9023E24239BCE1000666BE6 /* tvOS */,
 				B9023E33239BCE2D00666BE6 /* macOS */,
+				71981E1E279EE08700E0E770 /* Failing */,
 				B9023E03239BCDA200666BE6 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -86,6 +110,7 @@
 				B9023E14239BCDE900666BE6 /* watchOS.framework */,
 				B9023E23239BCE1000666BE6 /* tvOS.framework */,
 				B9023E32239BCE2D00666BE6 /* macOS.framework */,
+				71981E31279EE0C300E0E770 /* Failing.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -133,6 +158,14 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		71981E27279EE0C300E0E770 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				71981E36279EE17100E0E770 /* Failing.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B9023DFD239BCDA200666BE6 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -168,6 +201,25 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		71981E26279EE0C300E0E770 /* Failing */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 71981E2E279EE0C300E0E770 /* Build configuration list for PBXNativeTarget "Failing" */;
+			buildPhases = (
+				71981E27279EE0C300E0E770 /* Headers */,
+				71981E29279EE0C300E0E770 /* Sources */,
+				71981E2B279EE0C300E0E770 /* Frameworks */,
+				71981E2C279EE0C300E0E770 /* Resources */,
+				71981E2D279EE0C300E0E770 /* [Tuist] Create file to locate the built products directory */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Failing;
+			productName = iOS;
+			productReference = 71981E31279EE0C300E0E770 /* Failing.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		B9023E01239BCDA200666BE6 /* iOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B9023E0A239BCDA200666BE6 /* Build configuration list for PBXNativeTarget "iOS" */;
@@ -288,11 +340,19 @@
 				B9023E13239BCDE900666BE6 /* watchOS */,
 				B9023E22239BCE1000666BE6 /* tvOS */,
 				B9023E31239BCE2D00666BE6 /* macOS */,
+				71981E26279EE0C300E0E770 /* Failing */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		71981E2C279EE0C300E0E770 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B9023E00239BCDA200666BE6 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -324,6 +384,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		71981E2D279EE0C300E0E770 /* [Tuist] Create file to locate the built products directory */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "[Tuist] Create file to locate the built products directory";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ -n \"$I_OS_LOCATE_HASH\" ]; then\n    touch $BUILT_PRODUCTS_DIR/.$I_OS_LOCATE_HASH.tuist\nfi\n";
+		};
 		B93A85442542E4EE003EA8C2 /* [Tuist] Create file to locate the built products directory */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -399,6 +477,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		71981E29279EE0C300E0E770 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				71981E39279EE26C00E0E770 /* Failing.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B9023DFE239BCDA200666BE6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -434,6 +520,57 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		71981E2F279EE0C300E0E770 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Failing/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.tuist.Failing;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		71981E30279EE0C300E0E770 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Failing/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.tuist.Failing;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		B9023E08239BCDA200666BE6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -769,6 +906,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		71981E2E279EE0C300E0E770 /* Build configuration list for PBXNativeTarget "Failing" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				71981E2F279EE0C300E0E770 /* Debug */,
+				71981E30279EE0C300E0E770 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		B9023DFC239BCDA200666BE6 /* Build configuration list for PBXProject "Frameworks" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Tests/Fixtures/Frameworks/Frameworks.xcodeproj/xcshareddata/xcschemes/Failing.xcscheme
+++ b/Tests/Fixtures/Frameworks/Frameworks.xcodeproj/xcshareddata/xcschemes/Failing.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1320"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "71981E26279EE0C300E0E770"
+               BuildableName = "Failing.framework"
+               BlueprintName = "Failing"
+               ReferencedContainer = "container:Frameworks.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "71981E26279EE0C300E0E770"
+            BuildableName = "Failing.framework"
+            BlueprintName = "Failing"
+            ReferencedContainer = "container:Frameworks.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/TuistAutomationIntegrationTests/XcodeBuild/XcodeBuildControllerIntegrationTests.swift
+++ b/Tests/TuistAutomationIntegrationTests/XcodeBuild/XcodeBuildControllerIntegrationTests.swift
@@ -32,4 +32,18 @@ final class XcodeBuildControllerIntegrationTests: TuistTestCase {
         let buildSettings = try XCTUnwrap(got["iOS"])
         XCTAssertEqual(buildSettings.productName, "iOS")
     }
+
+    func test_build_must_throw() async throws {
+        // Given
+        let target = XcodeBuildTarget.project(fixturePath(path: RelativePath("Frameworks/Frameworks.xcodeproj")))
+
+        do {
+            // When
+            try await subject.build(target, scheme: "Failing", arguments: []).printFormattedOutput()
+            XCTFail("must throw")
+        } catch {
+            // Then
+            XCTAssertTrue(error is TuistSupport.SystemError)
+        }
+    }
 }


### PR DESCRIPTION
### Short description 📝

During #4004 we introduced:
* a deadlock in `inTemporaryDirectory`. When the closure was throwing an error, the queue is kept waiting as `dispatchGroup.leave()` is not called.
* an issue with `mapAsXcodeBuildOutput` which would result in missing to throw errors.

### How to test the changes locally 🧐

Added an integration test for the throwing error.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
