### PR TITLE
Avoid exposing RxSwift for Systeming

### DIFF
--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -1,5 +1,5 @@
+import Combine
 import Foundation
-import RxSwift
 import TSCBasic
 import TuistCore
 import TuistSupport
@@ -150,7 +150,6 @@ public final class XcodeBuildController: XcodeBuildControlling {
         return run(command: command, isVerbose: environment.isVerbose)
     }
 
-    // swiftlint:disable:next function_body_length
     public func showBuildSettings(
         _ target: XcodeBuildTarget,
         scheme: String,
@@ -167,97 +166,87 @@ public final class XcodeBuildController: XcodeBuildControlling {
         // Target
         command.append(contentsOf: target.xcodebuildArguments)
 
-        return try await System.shared.observable(command)
+        let values = System.shared.publisher(command)
             .mapToString()
             .collectAndMergeOutput()
             // xcodebuild has a bug where xcodebuild -showBuildSettings
             // can sometimes hang indefinitely on projects that don't
             // share any schemes, so automatically bail out if it looks
             // like that's happening.
-            .timeout(DispatchTimeInterval.seconds(20), scheduler: ConcurrentDispatchQueueScheduler(queue: .global()))
+            .timeout(.seconds(20), scheduler: DispatchQueue.global())
             .retry(5)
-            .flatMap { string -> Observable<XcodeBuildSettings> in
-                Observable.create { observer -> Disposable in
-                    var currentSettings: [String: String] = [:]
-                    var currentTarget: String?
+            .values
+        var buildSettingsByTargetName = [String: XcodeBuildSettings]()
+        for try await string in values {
+            var currentSettings: [String: String] = [:]
+            var currentTarget: String?
 
-                    let flushTarget = { () -> Void in
-                        if let currentTarget = currentTarget {
-                            let buildSettings = XcodeBuildSettings(
-                                currentSettings,
-                                target: currentTarget,
-                                configuration: configuration
-                            )
-                            observer.onNext(buildSettings)
-                        }
+            let flushTarget = { () -> Void in
+                if let currentTarget = currentTarget {
+                    let buildSettings = XcodeBuildSettings(
+                        currentSettings,
+                        target: currentTarget,
+                        configuration: configuration
+                    )
+                    buildSettingsByTargetName[buildSettings.target] = buildSettings
+                }
 
-                        currentTarget = nil
-                        currentSettings = [:]
-                    }
+                currentTarget = nil
+                currentSettings = [:]
+            }
 
-                    string.enumerateLines { line, _ in
-                        if let result = XcodeBuildController.targetSettingsRegex.firstMatch(
-                            in: line,
-                            range: NSRange(line.startIndex..., in: line)
-                        ) {
-                            let targetRange = Range(result.range(at: 1), in: line)!
-
-                            flushTarget()
-                            currentTarget = String(line[targetRange])
-                            return
-                        }
-
-                        let trimSet = CharacterSet.whitespacesAndNewlines
-                        let components = line
-                            .split(maxSplits: 1) { $0 == "=" }
-                            .map { $0.trimmingCharacters(in: trimSet) }
-
-                        if components.count == 2 {
-                            currentSettings[components[0]] = components[1]
-                        }
-                    }
+            string.enumerateLines { line, _ in
+                if let result = XcodeBuildController.targetSettingsRegex.firstMatch(
+                    in: line,
+                    range: NSRange(line.startIndex..., in: line)
+                ) {
+                    let targetRange = Range(result.range(at: 1), in: line)!
 
                     flushTarget()
-                    observer.onCompleted()
-                    return Disposables.create()
+                    currentTarget = String(line[targetRange])
+                    return
+                }
+
+                let trimSet = CharacterSet.whitespacesAndNewlines
+                let components = line
+                    .split(maxSplits: 1) { $0 == "=" }
+                    .map { $0.trimmingCharacters(in: trimSet) }
+
+                if components.count == 2 {
+                    currentSettings[components[0]] = components[1]
                 }
             }
-            .reduce([String: XcodeBuildSettings](), accumulator: { acc, buildSettings -> [String: XcodeBuildSettings] in
-                var acc = acc
-                acc[buildSettings.target] = buildSettings
-                return acc
-            })
-            .asSingle()
-            .value
+            flushTarget()
+        }
+        return buildSettingsByTargetName
     }
 
     fileprivate func run(command: [String], isVerbose: Bool) -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         run(command: command, isVerbose: isVerbose)
-            .flatMap { event -> Observable<SystemEvent<XcodeBuildOutput>> in
-                switch event {
-                case let .standardError(errorData):
-                    guard let line = String(data: errorData, encoding: .utf8) else { return Observable.empty() }
-                    let output = line.split(separator: "\n").map { line -> SystemEvent<XcodeBuildOutput> in
-                        SystemEvent.standardError(XcodeBuildOutput(raw: "\(String(line))\n"))
-                    }
-                    return Observable.from(output)
-                case let .standardOutput(outputData):
-                    guard let line = String(data: outputData, encoding: .utf8) else { return Observable.empty() }
-                    let output = line.split(separator: "\n").map { line -> SystemEvent<XcodeBuildOutput> in
-                        SystemEvent.standardOutput(XcodeBuildOutput(raw: "\(String(line))\n"))
-                    }
-                    return Observable.from(output)
-                }
-            }
-            .values
+            .mapAsXcodeBuildOutput().values
     }
 
-    fileprivate func run(command: [String], isVerbose: Bool) -> Observable<SystemEvent<Data>> {
+    fileprivate func run(command: [String], isVerbose: Bool) -> AnyPublisher<SystemEvent<Data>, Error> {
         if isVerbose {
-            return System.shared.observable(command)
+            return System.shared.publisher(command)
         } else {
             // swiftlint:disable:next force_try
-            return System.shared.observable(command, pipeTo: try! formatter.buildArguments())
+            return System.shared.publisher(command, pipeTo: try! formatter.buildArguments())
         }
+    }
+}
+
+extension Publisher where Output == SystemEvent<Data>, Failure == Error {
+    fileprivate func mapAsXcodeBuildOutput() -> AnyPublisher<SystemEvent<XcodeBuildOutput>, Error> {
+        compactMap { event -> SystemEvent<XcodeBuildOutput>? in
+            switch event {
+            case let .standardError(errorData):
+                guard let line = String(data: errorData, encoding: .utf8) else { return nil }
+                return SystemEvent.standardError(XcodeBuildOutput(raw: line))
+            case let .standardOutput(outputData):
+                guard let line = String(data: outputData, encoding: .utf8) else { return nil }
+                return SystemEvent.standardOutput(XcodeBuildOutput(raw: line))
+            }
+        }.eraseToAnyPublisher()
     }
 }

--- a/Sources/TuistCore/Automation/Extensions/AsyncThrowingStream+XcodeBuildOutput.swift
+++ b/Sources/TuistCore/Automation/Extensions/AsyncThrowingStream+XcodeBuildOutput.swift
@@ -6,9 +6,15 @@ extension AsyncThrowingStream where Element == SystemEvent<XcodeBuildOutput> {
         for try await element in self {
             switch element {
             case let .standardError(error):
-                logger.error("\(error.raw.dropLast())")
+                let lines = error.raw.split(separator: "\n")
+                for line in lines where !line.isEmpty {
+                    logger.error("\(line)")
+                }
             case let .standardOutput(output):
-                logger.notice("\(output.raw.dropLast())")
+                let lines = output.raw.split(separator: "\n")
+                for line in lines where !line.isEmpty {
+                    logger.notice("\(line)")
+                }
             }
         }
     }

--- a/Sources/TuistSupport/System/Publisher+System.swift
+++ b/Sources/TuistSupport/System/Publisher+System.swift
@@ -1,46 +1,6 @@
 import Combine
 import CombineExt
 import Foundation
-import RxSwift
-
-extension Observable where Element == SystemEvent<Data> {
-    /// Returns another observable where the standard output and error data are mapped
-    /// to a string.
-    public func mapToString() -> Observable<SystemEvent<String>> {
-        map { $0.mapToString() }
-    }
-}
-
-extension Observable where Element == SystemEvent<String> {
-    /// It collects the standard output and error into an object that is sent
-    /// as a single event when the process completes.
-    public func collectOutput() -> Observable<SystemCollectedOutput> {
-        reduce(SystemCollectedOutput()) { collected, event -> SystemCollectedOutput in
-            var collected = collected
-            switch event {
-            case let .standardError(error):
-                collected.standardError.append(error)
-            case let .standardOutput(output):
-                collected.standardOutput.append(output)
-            }
-            return collected
-        }
-    }
-
-    /// Returns an observable that collects and merges the standard output and error into a single string.
-    public func collectAndMergeOutput() -> Observable<String> {
-        reduce("") { collected, event -> String in
-            var collected = collected
-            switch event {
-            case let .standardError(error):
-                collected.append(error)
-            case let .standardOutput(output):
-                collected.append(output)
-            }
-            return collected
-        }
-    }
-}
 
 extension Publisher where Output == SystemEvent<Data>, Failure == Error {
     /// Returns another observable where the standard output and error data are mapped

--- a/Sources/TuistSupport/System/Systeming.swift
+++ b/Sources/TuistSupport/System/Systeming.swift
@@ -1,6 +1,5 @@
 import Combine
 import Foundation
-import RxSwift
 
 public protocol Systeming {
     /// System environment.
@@ -68,17 +67,6 @@ public protocol Systeming {
     ///   - arguments: Command.
     ///   - pipeTo: Second Command.
     func publisher(_ arguments: [String], pipeTo secondArguments: [String]) -> AnyPublisher<SystemEvent<Data>, Error>
-
-    /// Runs a command in the shell and wraps the standard output and error in a publisher.
-    /// - Parameters:
-    ///   - arguments: Command.
-    func observable(_ arguments: [String]) -> Observable<SystemEvent<Data>>
-
-    /// Runs a command in the shell and wraps the standard output and error in a publisher.
-    /// - Parameters:
-    ///   - arguments: Command.
-    ///   - pipeTo: Second Command.
-    func observable(_ arguments: [String], pipeTo secondArguments: [String]) -> Observable<SystemEvent<Data>>
 
     /// Runs a command in the shell asynchronously.
     /// When the process that triggers the command gets killed, the command continues its execution.

--- a/Sources/TuistSupportTesting/Utils/MockSystem.swift
+++ b/Sources/TuistSupportTesting/Utils/MockSystem.swift
@@ -1,6 +1,5 @@
 import Combine
 import Foundation
-import RxSwift
 import TSCBasic
 import XCTest
 @testable import TuistSupport
@@ -132,46 +131,6 @@ public final class MockSystem: Systeming {
             }
             subscriber.send(completion: .finished)
             return AnyCancellable {}
-        }
-    }
-
-    public func observable(_ arguments: [String]) -> Observable<SystemEvent<Data>> {
-        observable(arguments, verbose: false, environment: env)
-    }
-
-    public func observable(_ arguments: [String], verbose: Bool, environment: [String: String]) -> Observable<SystemEvent<Data>> {
-        Observable.create { observer -> Disposable in
-            let cancellable = self.publisher(arguments, verbose: verbose, environment: environment).sink { completion in
-                switch completion {
-                case .finished:
-                    observer.onCompleted()
-                case let .failure(error):
-                    observer.onError(error)
-                }
-            } receiveValue: { event in
-                observer.onNext(event)
-            }
-            return Disposables.create {
-                cancellable.cancel()
-            }
-        }
-    }
-
-    public func observable(_ arguments: [String], pipeTo secondArguments: [String]) -> Observable<SystemEvent<Data>> {
-        Observable.create { observer -> Disposable in
-            let cancellable = self.publisher(arguments, pipeTo: secondArguments).sink { completion in
-                switch completion {
-                case .finished:
-                    observer.onCompleted()
-                case let .failure(error):
-                    observer.onError(error)
-                }
-            } receiveValue: { event in
-                observer.onNext(event)
-            }
-            return Disposables.create {
-                cancellable.cancel()
-            }
         }
     }
 

--- a/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildControllerTests.swift
+++ b/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildControllerTests.swift
@@ -38,7 +38,7 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
         let events = subject.build(target, scheme: scheme, clean: true, arguments: [])
 
         let result = try await events.toArray()
-        XCTAssertEqual(result, [.standardOutput(XcodeBuildOutput(raw: "output\n"))])
+        XCTAssertEqual(result, [.standardOutput(XcodeBuildOutput(raw: "output"))])
     }
 
     func test_test_when_device() async throws {
@@ -76,7 +76,7 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
         )
 
         let result = try await events.toArray()
-        XCTAssertEqual(result, [.standardOutput(XcodeBuildOutput(raw: "output\n"))])
+        XCTAssertEqual(result, [.standardOutput(XcodeBuildOutput(raw: "output"))])
     }
 
     func test_test_when_mac() async throws {
@@ -113,7 +113,7 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
         )
 
         let result = try await events.toArray()
-        XCTAssertEqual(result, [.standardOutput(XcodeBuildOutput(raw: "output\n"))])
+        XCTAssertEqual(result, [.standardOutput(XcodeBuildOutput(raw: "output"))])
     }
 
     func test_test_with_derived_data() async throws {
@@ -150,7 +150,7 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
         )
 
         let result = try await events.toArray()
-        XCTAssertEqual(result, [.standardOutput(XcodeBuildOutput(raw: "output\n"))])
+        XCTAssertEqual(result, [.standardOutput(XcodeBuildOutput(raw: "output"))])
     }
 
     func test_test_with_result_bundle_path() async throws {
@@ -187,7 +187,7 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
         )
 
         let result = try await events.toArray()
-        XCTAssertEqual(result, [.standardOutput(XcodeBuildOutput(raw: "output\n"))])
+        XCTAssertEqual(result, [.standardOutput(XcodeBuildOutput(raw: "output"))])
     }
 }
 


### PR DESCRIPTION
### Short description 📝

This is a continuation of #4042, taken from the reverted #4040, it stop exposing RxSwift methods from Systeming without changing the implementation

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
