### PR TITLE
fix: remove "Bult in" and "Using version" from non-verbose standard output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## Next
 
+### Changed
+
+- **Breaking** the used tuist version and the manifests compilation times are no longer printed at default log level. Use the `--verbose` flag to print them. [#4052](https://github.com/tuist/tuist/pull/4052) by [@danyf90](https://github.com/danyf90)
+
 ### 2.7.1
 
 - Fix `tuistenv` not running `tuist` commands [#4061](https://github.com/tuist/tuist/pull/4061) by [@danyf90](https://github.com/danyf90)

--- a/Sources/TuistEnvKit/Commands/CommandRunner.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRunner.swift
@@ -64,9 +64,9 @@ class CommandRunner: CommandRunning {
 
         switch resolvedVersion {
         case let .bin(path):
-            logger.notice("Using bundled version at path \(path.pathString)")
+            logger.debug("Using bundled version at path \(path.pathString)")
         case let .versionFile(path, value):
-            logger.notice("Using version \(value) defined at \(path.pathString)")
+            logger.debug("Using version \(value) defined at \(path.pathString)")
         default:
             break
         }

--- a/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
+++ b/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
@@ -178,7 +178,7 @@ public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBu
         try System.shared.runAndPrint(command, verbose: false, environment: Environment.shared.manifestLoadingVariables)
         let duration = timer.stop()
         let time = String(format: "%.3f", duration)
-        logger.notice("Built \(name) in (\(time)s)", metadata: .success)
+        logger.debug("Built \(name) in (\(time)s)", metadata: .success)
 
         return projectDescriptionHelpersModule
     }

--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -67,7 +67,6 @@ public enum Constants {
     /// But only eg. for acceptance tests and other cases needed internally
     public enum EnvironmentVariables {
         public static let verbose = "TUIST_CONFIG_VERBOSE"
-        public static let silent = "TUIST_CONFIG_SILENT"
         public static let colouredOutput = "TUIST_CONFIG_COLOURED_OUTPUT"
         public static let versionsDirectory = "TUIST_CONFIG_VERSIONS_DIRECTORY"
         public static let forceConfigCacheDirectory = "TUIST_CONFIG_FORCE_CONFIG_CACHE_DIRECTORY"

--- a/Sources/tuist/TuistApp.swift
+++ b/Sources/tuist/TuistApp.swift
@@ -8,10 +8,8 @@ import TuistSupport
 @main
 enum TuistApp {
     static func main() async throws {
-        if CommandLine.arguments
-            .contains("--verbose") { try? ProcessEnv.setVar(Constants.EnvironmentVariables.verbose, value: "true") }
-        if CommandLine.arguments.contains("--generate-completion-script") {
-            try? ProcessEnv.unsetVar(Constants.EnvironmentVariables.silent)
+        if CommandLine.arguments.contains("--verbose") {
+            try? ProcessEnv.setVar(Constants.EnvironmentVariables.verbose, value: "true")
         }
 
         TuistSupport.LogOutput.bootstrap()

--- a/Sources/tuistenv/main.swift
+++ b/Sources/tuistenv/main.swift
@@ -1,11 +1,6 @@
 import Foundation
-import TSCBasic
 import TuistEnvKit
 import TuistSupport
-
-if CommandLine.arguments.contains("--generate-completion-script") {
-    try? ProcessEnv.setVar(Constants.EnvironmentVariables.silent, value: "true")
-}
 
 try TuistSupport.Environment.shared.bootstrap()
 LogOutput.bootstrap()

--- a/Tests/TuistEnvKitTests/Commands/CommandRunnerTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/CommandRunnerTests.swift
@@ -90,10 +90,6 @@ final class CommandRunnerTests: TuistUnitTestCase {
 
         try subject.run()
 
-        XCTAssertPrinterOutputContains("""
-        Using version 3.2.1 defined at \(temporaryPath.pathString)
-        Version 3.2.1 not found locally. Installing...
-        """)
         XCTAssertEqual(installArgs.count, 1)
         XCTAssertEqual(installArgs.first, "3.2.1")
     }


### PR DESCRIPTION
Now tuist dumps prints an actual JSON, which means it's easier to pipe it to other commands (e.g. `jq`).
It also resolves https://github.com/tuist/tuist/issues/3797 in a much simpler and less hacky way

