### PR TITLE
Revert "Feat: Update fourier to use system tuist whenever possible

### DIFF
--- a/projects/fourier/lib/fourier/services/build/tuist/all.rb
+++ b/projects/fourier/lib/fourier/services/build/tuist/all.rb
@@ -8,6 +8,7 @@ module Fourier
           def call
             dependencies = ["dependencies", "fetch"]
             Utilities::System.tuist(*dependencies)
+
             Utilities::System.tuist("build", "--generate")
           end
         end

--- a/projects/fourier/lib/fourier/services/test/tuist/unit.rb
+++ b/projects/fourier/lib/fourier/services/test/tuist/unit.rb
@@ -8,6 +8,7 @@ module Fourier
           def call
             dependencies = ["dependencies", "fetch"]
             Utilities::System.tuist(*dependencies)
+
             Utilities::System.tuist("test")
             Dir.chdir(Constants::TUIST_DIRECTORY) do
               Utilities::System.system("swift", "test")

--- a/projects/fourier/lib/fourier/services/tuist.rb
+++ b/projects/fourier/lib/fourier/services/tuist.rb
@@ -12,7 +12,7 @@ module Fourier
       def call
         Utilities::SwiftPackageManager.build_product("ProjectAutomation")
         Utilities::SwiftPackageManager.build_product("ProjectDescription")
-        Utilities::System.tuist(*arguments, from_source: true)
+        Utilities::System.tuist(*arguments)
       end
     end
   end

--- a/projects/fourier/lib/fourier/utilities/system.rb
+++ b/projects/fourier/lib/fourier/utilities/system.rb
@@ -9,17 +9,12 @@ module Fourier
         Kernel.system(*args) || exit(1)
       end
 
-      def self.tuist(*args, **kwargs)
-        @tuist = "/usr/local/bin/tuist"
-
-        if kwargs[:from_source] || !File.exist?(@tuist)
-          Dir.chdir(Constants::TUIST_DIRECTORY) do
-            self.system("swift", "build")
-            @tuist = ".build/debug/tuist"
-          end
+      def self.tuist(*args)
+        Dir.chdir(Constants::TUIST_DIRECTORY) do
+          self.system("swift", "build")
+          @tuist = ".build/debug/tuist"
+          self.system(@tuist, *args)
         end
-
-        self.system(@tuist, *args)
       end
 
       def self.fixturegen(*args)


### PR DESCRIPTION
This reverts (part of) commit 722206ebac5cd90bd463ce1711b0ae649f85714b.

### Short description 📝

Undoing this PR after some discussion that it may be overcomplicating our build processes.

### Checklist ✅

- [X] The code architecture and patterns are consistent with the rest of the codebase.
- [X] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [X] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [X] In case the PR introduces changes that affect users, the documentation has been updated.
- [X] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
