### PR TITLE
fix: tuistenv not running tuist

### DIFF
--- a/Sources/TuistEnvKit/Commands/TuistCommand.swift
+++ b/Sources/TuistEnvKit/Commands/TuistCommand.swift
@@ -20,7 +20,7 @@ public struct TuistCommand: ParsableCommand {
         )
     }
 
-    public static func main(_: [String]? = nil) async {
+    public static func main(_: [String]? = nil) {
         let errorHandler = ErrorHandler()
         let processedArguments = processArguments()
 


### PR DESCRIPTION
### Short description 📝

We released version `2.7.0` which introduced a bug in `tuistenv` due to some `async/await` API changes. Currently swift-argument-parser commands [don't support](https://github.com/apple/swift-argument-parser/issues/326) async/await. 

When we updated the `static main` to add `async` it broke the command parsing for `tuistenv` so any `tuist` commands would not fall through and you'd see an error like:

```
Error: Unexpected argument 'generate'
Usage: tuist <subcommand>
  See 'tuist --help' for more information.
```

### How to test the changes locally 🧐

```
swift run tuistenv generate // Should generate (:
```

### Checklist ✅

- [X] The code architecture and patterns are consistent with the rest of the codebase.
- [X] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [X] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [X] In case the PR introduces changes that affect users, the documentation has been updated.
- [X] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
