### PR TITLE
fix: release workflow PR step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         sed -i '' -e "s/version = \".*\"/version = \"${{ github.event.inputs.version }}\"/g" Sources/TuistSupport/Constants.swift
         sed -i '' -e "s/## Next/## ${{ github.event.inputs.version }} - ${{ github.event.inputs.title }}\"/g" CHANGELOG.md
-    - name: Fourier releae
+    - name: Fourier release
       run: ./fourier release tuist ${{ github.event.inputs.version }} $(cat .xcode-version) $(cat .xcode-version-libraries)
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v1
@@ -50,5 +50,6 @@ jobs:
     - name: Create pull-request for release changes
       uses: peter-evans/create-pull-request@v3
       with:
+        title: "[Release] Tuist ${{ github.event.inputs.version }} - ${{ github.event.inputs.title }}"
         commit-message: "[Release] Tuist ${{ github.event.inputs.version }} - ${{ github.event.inputs.title }}"
         base: main

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ Tuist/Dependencies/graph.json
 
 # VSCode Settings
 .vscode/launch.json
+
+# Release artifacts
+vendor/


### PR DESCRIPTION
### Short description 📝

This fixes an issue with the release workflow PR as seen in #4054 we are committing the `vendor` folder because it gets created during release but is not `.gitignore`d.

This PR updates the gitignore to include any release artifacts and updates the title made by the action.

### How to test the changes locally 🧐

Testing my changes on my fork: https://github.com/luispadron/tuist/actions/runs/1752691574

### Checklist ✅

- [X] The code architecture and patterns are consistent with the rest of the codebase.
- [X] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [X] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [X] In case the PR introduces changes that affect users, the documentation has been updated.
- [X] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
