### PR TITLE
feat: update manifest load error messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Changed
 
 - **Breaking** the used tuist version and the manifests compilation times are no longer printed at default log level. Use the `--verbose` flag to print them. [#4052](https://github.com/tuist/tuist/pull/4052) by [@danyf90](https://github.com/danyf90)
+- Add more detailed messaging for errors during manifest loading [#4076](https://github.com/tuist/tuist/pull/4076) by [@luispadron](https://github.com/luispadron)
 
 ## 2.7.2
 

--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -10,6 +10,7 @@ public enum ManifestLoaderError: FatalError, Equatable {
     case unexpectedOutput(AbsolutePath)
     case manifestNotFound(Manifest?, AbsolutePath)
     case manifestCachingFailed(Manifest?, AbsolutePath)
+    case manifestLoadingFailed(path: AbsolutePath, context: String)
 
     public static func manifestNotFound(_ path: AbsolutePath) -> ManifestLoaderError {
         .manifestNotFound(nil, path)
@@ -25,6 +26,11 @@ public enum ManifestLoaderError: FatalError, Equatable {
             return "\(manifest?.fileName(path) ?? "Manifest") not found at path \(path.pathString)"
         case let .manifestCachingFailed(manifest, path):
             return "Could not cache \(manifest?.fileName(path) ?? "Manifest") at path \(path.pathString)"
+        case let .manifestLoadingFailed(path, context):
+            return """
+            Unable to load manifest at \(path.pathString.bold())
+            \(context)
+            """
         }
     }
 
@@ -38,21 +44,8 @@ public enum ManifestLoaderError: FatalError, Equatable {
             return .abort
         case .manifestCachingFailed:
             return .abort
-        }
-    }
-
-    // MARK: - Equatable
-
-    public static func == (lhs: ManifestLoaderError, rhs: ManifestLoaderError) -> Bool {
-        switch (lhs, rhs) {
-        case let (.projectDescriptionNotFound(lhsPath), .projectDescriptionNotFound(rhsPath)):
-            return lhsPath == rhsPath
-        case let (.unexpectedOutput(lhsPath), .unexpectedOutput(rhsPath)):
-            return lhsPath == rhsPath
-        case let (.manifestNotFound(lhsManifest, lhsPath), .manifestNotFound(rhsManifest, rhsPath)):
-            return lhsManifest == rhsManifest && lhsPath == rhsPath
-        default:
-            return false
+        case .manifestLoadingFailed:
+            return .abort
         }
     }
 }
@@ -180,12 +173,63 @@ public class ManifestLoader: ManifestLoading {
             manifest,
             at: path
         )
+
         let data = try loadDataForManifest(manifest, at: manifestPath)
-        if Environment.shared.isVerbose {
-            let string = String(data: data, encoding: .utf8)
-            logger.debug("Trying to load the manifest represented by the following JSON representation:\n\(string ?? "")")
+
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            guard let error = error as? DecodingError else {
+                throw ManifestLoaderError.manifestLoadingFailed(
+                    path: manifestPath, context: error.localizedDescription
+                )
+            }
+
+            let json = (String(data: data, encoding: .utf8) ?? "nil")
+
+            switch error {
+            case let .typeMismatch(type, context):
+                throw ManifestLoaderError.manifestLoadingFailed(
+                    path: manifestPath,
+                    context: """
+                    The content of the manifest did not match the expected type of: \(String(describing: type).bold())
+                    \(context.debugDescription)
+                    """
+                )
+            case let .valueNotFound(value, _):
+                throw ManifestLoaderError.manifestLoadingFailed(
+                    path: manifestPath,
+                    context: """
+                    Expected a non-optional value for property of type \(String(describing: value).bold()) but found a nil value.
+                    \(json.bold())
+                    """
+                )
+            case let .keyNotFound(codingKey, _):
+                throw ManifestLoaderError.manifestLoadingFailed(
+                    path: manifestPath,
+                    context: """
+                    Did not find property with name \(codingKey.stringValue.bold()) in the JSON represented by:
+                    \(json.bold())
+                    """
+                )
+            case let .dataCorrupted(context):
+                throw ManifestLoaderError.manifestLoadingFailed(
+                    path: manifestPath,
+                    context: """
+                    The encoded data for the manifest is corrupted.
+                    \(context.debugDescription)
+                    """
+                )
+            @unknown default:
+                throw ManifestLoaderError.manifestLoadingFailed(
+                    path: manifestPath,
+                    context: """
+                    Unable to decode the manifest for an unknown reason.
+                    \(error.localizedDescription)
+                    """
+                )
+            }
         }
-        return try decoder.decode(T.self, from: data)
     }
 
     private func manifestPath(

--- a/Tests/TuistLoaderIntegrationTests/Loaders/ManifestLoaderTests.swift
+++ b/Tests/TuistLoaderIntegrationTests/Loaders/ManifestLoaderTests.swift
@@ -170,4 +170,27 @@ final class ManifestLoaderTests: TuistTestCase {
         XCTAssertTrue(got.contains(.workspace))
         XCTAssertTrue(got.contains(.config))
     }
+
+    func test_manifestLoadError() throws {
+        // Given
+        let fileHandler = FileHandler()
+        let temporaryPath = try temporaryPath()
+        try fileHandler.touch(temporaryPath.appending(component: "Config.swift"))
+
+        // When
+        XCTAssertThrowsError(
+            try subject.loadConfig(at: temporaryPath)
+        ) { error in
+            XCTAssertEqual(
+                error as? ManifestLoaderError,
+                .manifestLoadingFailed(
+                    path: temporaryPath.appending(component: "Config.swift"),
+                    context: """
+                    The encoded data for the manifest is corrupted.
+                    The given data was not valid JSON.
+                    """
+                )
+            )
+        }
+    }
 }

--- a/Tests/TuistLoaderTests/Loaders/ManifestLoaderErrorTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/ManifestLoaderErrorTests.swift
@@ -24,11 +24,19 @@ final class ManifestLoaderErrorTests: TuistUnitTestCase {
             ManifestLoaderError.manifestNotFound(nil, AbsolutePath("/test/")).description,
             "Manifest not found at path /test"
         )
+        XCTAssertEqual(
+            ManifestLoaderError.manifestLoadingFailed(path: AbsolutePath("/test/"), context: "Context").description,
+            """
+            Unable to load manifest at \("/test".bold())
+            Context
+            """
+        )
     }
 
     func test_type() {
         XCTAssertEqual(ManifestLoaderError.projectDescriptionNotFound(AbsolutePath("/test")).type, .bug)
         XCTAssertEqual(ManifestLoaderError.unexpectedOutput(AbsolutePath("/test/")).type, .bug)
         XCTAssertEqual(ManifestLoaderError.manifestNotFound(.project, AbsolutePath("/test/")).type, .abort)
+        XCTAssertEqual(ManifestLoaderError.manifestLoadingFailed(path: AbsolutePath("/test/"), context: "Context").type, .abort)
     }
 }


### PR DESCRIPTION
### Short description 📝

Updates the messaging for errors when loading manifests. Previously, the errors weren't very helpful and would typically just print the underlying error without much context.

This PR updates error messaging for manifest loading to be more detailed.

#### Before

```sh
We received an error that we couldn't handle:
    - Localized description: The data couldn’t be read because it isn’t in the correct format.
    - Error: dataCorrupted(Swift.DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid JSON.", underlyingError: Optional(Error Domain=NSCocoaErrorDomain Code=3840 "Unable to parse empty data." UserInfo={NSDebugDescription=Unable to parse empty data.})))

If you think it's a legit issue, please file an issue including the reproducible steps: https://github.com/tuist/tuist/issues/new/choose
Consider creating an issue using the following link: https://github.com/tuist/tuist/issues/new/choose
```

```sh
We received an error that we couldn't handle:
    - Localized description: The data couldn’t be read because it is missing.
    - Error: keyNotFound(CodingKeys(stringValue: "generationOptions", intValue: nil), Swift.DecodingError.Context(codingPath: [], debugDescription: "No value associated with key CodingKeys(stringValue: \"generationOptions\", intValue: nil) (\"generationOptions\").", underlyingError: nil))

If you think it's a legit issue, please file an issue including the reproducible steps: https://github.com/tuist/tuist/issues/new/choose
Consider creating an issue using the following link: https://github.com/tuist/tuist/issues/new/choose
```

#### After

```sh
Unable to load manifest at /Users/luispadron/Development/tuist/projects/tuist/fixtures/app_with_plugins/Tuist/Config.swift
The encoded data for the manifest is corrupted.
The given data was not valid JSON.
Consider creating an issue using the following link: https://github.com/tuist/tuist/issues/new/choose
```

```sh
Unable to load manifest at /Users/luispadron/Development/tuist/projects/tuist/fixtures/app_with_plugins/Tuist/Config.swift
Did not find property with name generationOptions in the JSON represented by:

{"swiftPackageManager":{"baseSettings":{"base":{},"configurations":[{"name":{"rawValue":"Debug"},"variant":"debug","settings":{}},{"name":{"rawValue":"Release"},"variant":"release","settings":{}}],"defaultSettings":{"recommended":{"excluding":[]}}},"productTypes":{},"targetSettings":{},"packages":[]},"platforms":["ios","macos"]}

Consider creating an issue using the following link: https://github.com/tuist/tuist/issues/new/choose
```

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

### Checklist ✅

- [X] The code architecture and patterns are consistent with the rest of the codebase.
- [X] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [X] In case the PR introduces changes that affect users, the documentation has been updated.
- [X] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
