### PR TITLE
Fix `tuist generate` and `tuist cache warm` performance when no parameter is passed

### DIFF
--- a/Sources/TuistCache/Mappers/Graph/FocusTargetsGraphMappers.swift
+++ b/Sources/TuistCache/Mappers/Graph/FocusTargetsGraphMappers.swift
@@ -15,16 +15,12 @@ public final class FocusTargetsGraphMappers: GraphMapping {
     public func map(graph: Graph) throws -> (Graph, [SideEffectDescriptor]) {
         let graphTraverser = GraphTraverser(graph: graph)
         var graph = graph
-        let filteredTargets: Set<GraphTarget>
-        if !includedTargets.isEmpty {
-            let userSpecifiedSourceTargets = graphTraverser.allTargets().filter { includedTargets.contains($0.target.name) }
-            filteredTargets = Set(try topologicalSort(
-                Array(userSpecifiedSourceTargets),
-                successors: { Array(graphTraverser.directTargetDependencies(path: $0.path, name: $0.target.name)) }
-            ))
-        } else {
-            filteredTargets = graphTraverser.allInternalTargets()
-        }
+        let includedTargets = includedTargets.isEmpty ? Set(graphTraverser.allInternalTargets().map { $0.target.name }) : includedTargets
+        let userSpecifiedSourceTargets = graphTraverser.allTargets().filter { includedTargets.contains($0.target.name) }
+        let filteredTargets = Set(try topologicalSort(
+            Array(userSpecifiedSourceTargets),
+            successors: { Array(graphTraverser.directTargetDependencies(path: $0.path, name: $0.target.name)) }
+        ))
 
         graphTraverser.allTargets().forEach { graphTarget in
             if !filteredTargets.contains(graphTarget) {

--- a/Sources/TuistCache/Mappers/Graph/FocusTargetsGraphMappers.swift
+++ b/Sources/TuistCache/Mappers/Graph/FocusTargetsGraphMappers.swift
@@ -15,7 +15,8 @@ public final class FocusTargetsGraphMappers: GraphMapping {
     public func map(graph: Graph) throws -> (Graph, [SideEffectDescriptor]) {
         let graphTraverser = GraphTraverser(graph: graph)
         var graph = graph
-        let includedTargets = includedTargets.isEmpty ? Set(graphTraverser.allInternalTargets().map { $0.target.name }) : includedTargets
+        let includedTargets = includedTargets
+            .isEmpty ? Set(graphTraverser.allInternalTargets().map(\.target.name)) : includedTargets
         let userSpecifiedSourceTargets = graphTraverser.allTargets().filter { includedTargets.contains($0.target.name) }
         let filteredTargets = Set(try topologicalSort(
             Array(userSpecifiedSourceTargets),

--- a/Sources/TuistCache/Mappers/Graph/FocusTargetsGraphMappers.swift
+++ b/Sources/TuistCache/Mappers/Graph/FocusTargetsGraphMappers.swift
@@ -6,9 +6,9 @@ import TuistGraph
 /// `FocusTargetsGraphMappers` is used to filter out some targets and their dependencies and tests targets.
 public final class FocusTargetsGraphMappers: GraphMapping {
     /// The targets name to be kept as non prunable with their respective dependencies and tests targets
-    let includedTargets: Set<String>?
+    let includedTargets: Set<String>
 
-    public init(includedTargets: Set<String>?) {
+    public init(includedTargets: Set<String>) {
         self.includedTargets = includedTargets
     }
 
@@ -16,14 +16,14 @@ public final class FocusTargetsGraphMappers: GraphMapping {
         let graphTraverser = GraphTraverser(graph: graph)
         var graph = graph
         let filteredTargets: Set<GraphTarget>
-        if let includedTargets = includedTargets {
+        if !includedTargets.isEmpty {
             let userSpecifiedSourceTargets = graphTraverser.allTargets().filter { includedTargets.contains($0.target.name) }
             filteredTargets = Set(try topologicalSort(
                 Array(userSpecifiedSourceTargets),
                 successors: { Array(graphTraverser.directTargetDependencies(path: $0.path, name: $0.target.name)) }
             ))
         } else {
-            filteredTargets = graphTraverser.allTargets()
+            filteredTargets = graphTraverser.allInternalTargets()
         }
 
         graphTraverser.allTargets().forEach { graphTarget in

--- a/Sources/TuistCache/Mappers/Graph/TargetsToCacheBinariesGraphMapper.swift
+++ b/Sources/TuistCache/Mappers/Graph/TargetsToCacheBinariesGraphMapper.swift
@@ -89,6 +89,10 @@ public final class TargetsToCacheBinariesGraphMapper: GraphMapping {
         let availableTargets = Set(
             graphTraverser.allTargets().map(\.target.name)
         )
+        let allInternalTargets = Set(
+            graphTraverser.allInternalTargets().map(\.target.name)
+        )
+        let sources = sources.isEmpty ? Set(allInternalTargets) : sources
         let missingTargets = sources.subtracting(availableTargets)
         guard
             missingTargets.isEmpty

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -44,6 +44,12 @@ public class GraphTraverser: GraphTraversing {
         })
     }
 
+    public func allInternalTargets() -> Set<GraphTarget> {
+        allTargets()
+            .filter { !$0.path.pathString.contains("\(Constants.tuistDirectoryName)/\(Constants.DependenciesDirectory.name)")
+            }
+    }
+
     public func rootProjects() -> Set<Project> {
         Set(graph.workspace.projects.compactMap {
             projects[$0]

--- a/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
+++ b/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
@@ -39,6 +39,9 @@ public protocol GraphTraversing {
     /// Returns all the targets of the project.
     func allTargets() -> Set<GraphTarget>
 
+    /// Returns all the internal targets, that is, excluding `Dependencies`.
+    func allInternalTargets() -> Set<GraphTarget>
+
     /// Returns the project from which the graph has been loaded.
     func rootProjects() -> Set<Project>
 

--- a/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
+++ b/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
@@ -125,6 +125,16 @@ final class MockGraphTraverser: GraphTraversing {
         return stubbedAllTargetsResult
     }
 
+    var invokedAllInternalTargets = false
+    var invokedAllInternalTargetsCount = 0
+    var stubbedAllInternalTargetsResult: Set<GraphTarget>! = []
+
+    func allInternalTargets() -> Set<GraphTarget> {
+        invokedAllInternalTargets = true
+        invokedAllInternalTargetsCount += 1
+        return stubbedAllInternalTargetsResult
+    }
+
     var invokedPrecompiledFrameworksPaths = false
     var invokedPrecompiledFrameworksPathsCount = 0
     var stubbedPrecompiledFrameworksPathsResult: Set<AbsolutePath>! = []

--- a/Sources/TuistKit/Cache/CacheController.swift
+++ b/Sources/TuistKit/Cache/CacheController.swift
@@ -86,7 +86,7 @@ final class CacheController: CacheControlling {
         let xcframeworks = artifactBuilder.cacheOutputType == .xcframework
         let generator = generatorFactory.cache(
             config: config,
-            includedTargets: includedTargets.isEmpty ? nil : Set(includedTargets),
+            includedTargets: includedTargets,
             focusedTargets: nil,
             xcframeworks: xcframeworks,
             cacheProfile: cacheProfile

--- a/Sources/TuistKit/Cache/CacheController.swift
+++ b/Sources/TuistKit/Cache/CacheController.swift
@@ -215,6 +215,9 @@ final class CacheController: CacheControlling {
         includedTargets: Set<String>,
         dependenciesOnly: Bool
     ) async throws -> [(GraphTarget, String)] {
+        let graphTraverser = GraphTraverser(graph: graph)
+        let includedTargets = includedTargets
+            .isEmpty ? Set(graphTraverser.allInternalTargets().map(\.target.name)) : includedTargets
         // When `dependenciesOnly` is true, there is no need to compute `includedTargets` hashes
         let excludedTargets = dependenciesOnly ? includedTargets : []
         let hashesByCacheableTarget = try cacheGraphContentHasher.contentHashes(
@@ -223,8 +226,6 @@ final class CacheController: CacheControlling {
             cacheOutputType: cacheOutputType,
             excludedTargets: excludedTargets
         )
-
-        let graphTraverser = GraphTraverser(graph: graph)
 
         let graph = try topologicalSort(
             Array(graphTraverser.allTargets()),

--- a/Sources/TuistKit/Generator/GeneratorFactory.swift
+++ b/Sources/TuistKit/Generator/GeneratorFactory.swift
@@ -49,7 +49,7 @@ protocol GeneratorFactorying {
     /// - Returns: A Generator instance.
     func cache(
         config: Config,
-        includedTargets: Set<String>?,
+        includedTargets: Set<String>,
         focusedTargets: Set<String>?,
         xcframeworks: Bool,
         cacheProfile: TuistGraph.Cache.Profile
@@ -122,7 +122,7 @@ class GeneratorFactory: GeneratorFactorying {
 
     func cache(
         config: Config,
-        includedTargets: Set<String>?,
+        includedTargets: Set<String>,
         focusedTargets: Set<String>?,
         xcframeworks: Bool,
         cacheProfile: TuistGraph.Cache.Profile
@@ -146,7 +146,7 @@ class GeneratorFactory: GeneratorFactorying {
             graphMappers = graphMapperFactory.cache(includedTargets: includedTargets)
         }
 
-        let workspaceMappers = workspaceMapperFactory.cache(config: config, includedTargets: includedTargets ?? [])
+        let workspaceMappers = workspaceMapperFactory.cache(config: config, includedTargets: includedTargets)
         return Generator(
             projectMapper: SequentialProjectMapper(mappers: projectMappers),
             graphMapper: SequentialGraphMapper(graphMappers),

--- a/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
+++ b/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
@@ -25,7 +25,7 @@ protocol GraphMapperFactorying {
 
     /// Returns the graph mapper whose output project is a cacheable graph.
     /// - Returns: A graph mapper.
-    func cache(includedTargets: Set<String>?) -> [GraphMapping]
+    func cache(includedTargets: Set<String>) -> [GraphMapping]
 
     /// Returns the default graph mapper that should be used from all the commands that require loading and processing the graph.
     /// - Returns: The default mapper.
@@ -75,7 +75,7 @@ final class GraphMapperFactory: GraphMapperFactorying {
         return mappers
     }
 
-    func cache(includedTargets: Set<String>?) -> [GraphMapping] {
+    func cache(includedTargets: Set<String>) -> [GraphMapping] {
         var mappers: [GraphMapping] = [
             FocusTargetsGraphMappers(includedTargets: includedTargets),
             TreeShakePrunedTargetsGraphMapper(),

--- a/Sources/TuistKit/Mappers/Workspace/GenerateCacheableSchemesWorkspaceMapper.swift
+++ b/Sources/TuistKit/Mappers/Workspace/GenerateCacheableSchemesWorkspaceMapper.swift
@@ -34,12 +34,19 @@ final class GenerateCacheableSchemesWorkspaceMapper: WorkspaceMapping {
             .projects
             .flatMap { project in project.targets.map { (project, $0) } }
             .filter { $0.1.platform == platform }
+
+        let allInternalTargets = projectsWithTargets
+            .filter { !$0.0.path.pathString.contains("\(Constants.tuistDirectoryName)/\(Constants.DependenciesDirectory.name)") }
+            .map(\.1.name)
+        let includedTargets = includedTargets.isEmpty ? Set(allInternalTargets) : includedTargets
+
+        let filteredProjectsWithTargets = projectsWithTargets
             .filter { _, target in includedTargets.contains(target.name) }
 
-        let bundleTargets = projectsWithTargets
+        let bundleTargets = filteredProjectsWithTargets
             .filter { $0.1.product == .bundle }
 
-        let binariesTargets = projectsWithTargets
+        let binariesTargets = filteredProjectsWithTargets
             .filter(\.1.product.isFramework)
 
         let bundleTargetReferences = bundleTargets

--- a/Sources/TuistKit/Services/GenerateService.swift
+++ b/Sources/TuistKit/Services/GenerateService.swift
@@ -49,7 +49,7 @@ final class GenerateService {
         let cacheProfile = try CacheProfileResolver().resolveCacheProfile(named: profile, from: config)
         let generator = generatorFactory.focus(
             config: config,
-            sources: sources.isEmpty ? try projectTargets(at: path, config: config) : sources,
+            sources: sources,
             xcframeworks: xcframeworks,
             cacheProfile: cacheProfile,
             ignoreCache: ignoreCache
@@ -70,27 +70,5 @@ final class GenerateService {
         } else {
             return FileHandler.shared.currentPath
         }
-    }
-
-    private func projectTargets(at path: AbsolutePath, config: Config) throws -> Set<String> {
-        let plugins = try pluginService.loadPlugins(using: config)
-        try manifestLoader.register(plugins: plugins)
-        let manifests = manifestLoader.manifests(at: path)
-
-        let projects: [AbsolutePath]
-        if manifests.contains(.workspace) {
-            let workspace = try manifestLoader.loadWorkspace(at: path)
-            projects = workspace.projects.flatMap { project in
-                FileHandler.shared.glob(path, glob: project.pathString).filter {
-                    FileHandler.shared.isFolder($0) && manifestLoader.manifests(at: $0).contains(.project)
-                }
-            }
-        } else if manifests.contains(.project) {
-            projects = [path]
-        } else {
-            throw ManifestLoaderError.manifestNotFound(path)
-        }
-
-        return try Set(projects.flatMap { try manifestLoader.loadProject(at: $0).targets.map(\.name) })
     }
 }

--- a/Tests/TuistKitTests/Generator/Mocks/MockGeneratorFactory.swift
+++ b/Tests/TuistKitTests/Generator/Mocks/MockGeneratorFactory.swift
@@ -74,14 +74,14 @@ final class MockGeneratorFactory: GeneratorFactorying {
     var invokedCacheCount = 0
     var invokedCacheParameters: (
         config: Config,
-        includedTargets: Set<String>?,
+        includedTargets: Set<String>,
         focusedTargets: Set<String>?,
         xcframeworks: Bool,
         cacheProfile: Cache.Profile
     )?
     var invokedCacheParametersList = [(
         config: Config,
-        includedTargets: Set<String>?,
+        includedTargets: Set<String>,
         focusedTargets: Set<String>?,
         xcframeworks: Bool,
         cacheProfile: Cache.Profile
@@ -90,7 +90,7 @@ final class MockGeneratorFactory: GeneratorFactorying {
 
     func cache(
         config: Config,
-        includedTargets: Set<String>?,
+        includedTargets: Set<String>,
         focusedTargets: Set<String>?,
         xcframeworks: Bool,
         cacheProfile: Cache.Profile


### PR DESCRIPTION
### Short description 📝

Currently (in 3.0), we were loading the target names by loading each manifest synchronously, this revert the change and loads the total list of target from the graph.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
