### PR TITLE
[WIP] Testing Process Live Publishers

### DIFF
--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -173,7 +173,7 @@ public final class XcodeBuildController: XcodeBuildControlling {
             // can sometimes hang indefinitely on projects that don't
             // share any schemes, so automatically bail out if it looks
             // like that's happening.
-            .timeout(.seconds(20), scheduler: DispatchQueue.global())
+            .timeout(.seconds(20), scheduler: DispatchQueue.global(), customError: { PublisherError.timeout })
             .retry(5)
             .values
         var buildSettingsByTargetName = [String: XcodeBuildSettings]()


### PR DESCRIPTION
### Short description 📝

This PR wants to test a better live stream of the output for command like `xcodebuild`, which currently seems to be buffering resulting, for some cases, to appear as if tuist is stuck.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
