### PR TITLE
Fix Retry for showBuildSettings

### DIFF
--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -150,6 +150,10 @@ public final class XcodeBuildController: XcodeBuildControlling {
         return run(command: command, isVerbose: environment.isVerbose)
     }
 
+    enum ShowBuildSettingsError: Error {
+        case timeout
+    }
+
     public func showBuildSettings(
         _ target: XcodeBuildTarget,
         scheme: String,
@@ -173,7 +177,7 @@ public final class XcodeBuildController: XcodeBuildControlling {
             // can sometimes hang indefinitely on projects that don't
             // share any schemes, so automatically bail out if it looks
             // like that's happening.
-            .timeout(.seconds(20), scheduler: DispatchQueue.global())
+            .timeout(.seconds(20), scheduler: DispatchQueue.global(), customError: { ShowBuildSettingsError.timeout })
             .retry(5)
             .values
         var buildSettingsByTargetName = [String: XcodeBuildSettings]()


### PR DESCRIPTION
### Short description 📝

There was an issue with the retry logic when we moved from RxSwift to Combine. The `timeout` operator, if it does not have an error define it will simply end the stream, while when defining an error it will propagate downstream, correctly passing it to the `retry` operator and therefore behaving as before.

### How to test the changes locally 🧐

`XcodeBuildControllerIntegrationTests.test_showBuildSettings`

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
