### PR TITLE
Fix timeout() for showBuildSettings

### DIFF
--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -177,7 +177,7 @@ public final class XcodeBuildController: XcodeBuildControlling {
             // can sometimes hang indefinitely on projects that don't
             // share any schemes, so automatically bail out if it looks
             // like that's happening.
-            .timeout(.seconds(20), scheduler: DispatchQueue.global(), customError: { ShowBuildSettingsError.timeout })
+            .timeout(.seconds(20), scheduler: DispatchQueue.main, customError: { ShowBuildSettingsError.timeout })
             .retry(5)
             .values
         var buildSettingsByTargetName = [String: XcodeBuildSettings]()


### PR DESCRIPTION
https://tuistapp.slack.com/archives/CTB0DBVD2/p1643738995695189

For some reason using the global queue causes the test to fail ~5% of the time. When using the main queue this does not happen.

This can be tested using Xcode's run test repeatedly feature.