### PR TITLE
Use only SwiftFormat for line length linting

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,11 +7,7 @@ disabled_rules:
   - todo
   - function_parameter_count
   - opening_brace
-line_length:
-  ignores_interpolated_strings: true
-  ignores_comments: true
-  warning: 150
-  error: 170
+  - line_length
 identifier_name:
   min_length:
     error: 1

--- a/Sources/TuistCoreTesting/Simulator/SimulatorRuntime+TestData.swift
+++ b/Sources/TuistCoreTesting/Simulator/SimulatorRuntime+TestData.swift
@@ -8,7 +8,6 @@ extension SimulatorRuntime {
             "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime",
         buildVersion: String = "17F61",
         runtimeRoot: AbsolutePath =
-            // swiftformat:disable:next wrap
             "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot",
         identifier: String = "com.apple.CoreSimulator.SimRuntime.iOS-13-5",
         version: SimulatorRuntimeVersion = "13.5",

--- a/Sources/TuistCoreTesting/Simulator/SimulatorRuntime+TestData.swift
+++ b/Sources/TuistCoreTesting/Simulator/SimulatorRuntime+TestData.swift
@@ -8,7 +8,7 @@ extension SimulatorRuntime {
             "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime",
         buildVersion: String = "17F61",
         runtimeRoot: AbsolutePath =
-            // swiftlint:disable:next line_length
+            // swiftformat:disable:next wrap
             "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot",
         identifier: String = "com.apple.CoreSimulator.SimRuntime.iOS-13-5",
         version: SimulatorRuntimeVersion = "13.5",

--- a/Sources/TuistEnvKit/Commands/LocalCommand.swift
+++ b/Sources/TuistEnvKit/Commands/LocalCommand.swift
@@ -7,7 +7,6 @@ struct LocalCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "local",
-            // swiftformat:disable:next wrap
             abstract: "Creates a .tuist-version file to pin the tuist version that should be used in the current directory. If the version is not specified, it prints the local versions"
         )
     }

--- a/Sources/TuistEnvKit/Commands/LocalCommand.swift
+++ b/Sources/TuistEnvKit/Commands/LocalCommand.swift
@@ -7,7 +7,7 @@ struct LocalCommand: ParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "local",
-            // swiftlint:disable:next line_length
+            // swiftformat:disable:next wrap
             abstract: "Creates a .tuist-version file to pin the tuist version that should be used in the current directory. If the version is not specified, it prints the local versions"
         )
     }

--- a/Sources/TuistGenerator/Templates/AssetsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/AssetsTemplate.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable line_length
+// swiftformat:disable wrap
 extension SynthesizedResourceInterfaceTemplates {
     static let assetsTemplate = """
     // swiftlint:disable all

--- a/Sources/TuistGenerator/Templates/FilesTemplate.swift
+++ b/Sources/TuistGenerator/Templates/FilesTemplate.swift
@@ -1,4 +1,3 @@
-// swiftformat:disable wrap
 extension SynthesizedResourceInterfaceTemplates {
     static let filesTemplate = """
     // swiftlint:disable all

--- a/Sources/TuistGenerator/Templates/FilesTemplate.swift
+++ b/Sources/TuistGenerator/Templates/FilesTemplate.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable line_length
+// swiftformat:disable wrap
 extension SynthesizedResourceInterfaceTemplates {
     static let filesTemplate = """
     // swiftlint:disable all

--- a/Sources/TuistGenerator/Templates/FontsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/FontsTemplate.swift
@@ -1,4 +1,3 @@
-// swiftformat:disable wrap
 extension SynthesizedResourceInterfaceTemplates {
     static let fontsTemplate = """
     // swiftlint:disable all

--- a/Sources/TuistGenerator/Templates/FontsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/FontsTemplate.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable line_length
+// swiftformat:disable wrap
 extension SynthesizedResourceInterfaceTemplates {
     static let fontsTemplate = """
     // swiftlint:disable all

--- a/Sources/TuistGenerator/Templates/StringsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/StringsTemplate.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable line_length
+// swiftformat:disable wrap
 extension SynthesizedResourceInterfaceTemplates {
     static let stringsTemplate = """
     // swiftlint:disable all

--- a/Sources/TuistGenerator/Templates/StringsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/StringsTemplate.swift
@@ -1,4 +1,3 @@
-// swiftformat:disable wrap
 extension SynthesizedResourceInterfaceTemplates {
     static let stringsTemplate = """
     // swiftlint:disable all

--- a/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
+++ b/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
@@ -105,7 +105,7 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
     }
 
     // swiftlint:disable function_body_length
-    // swiftlint:disable line_length
+    // swiftformat:disable wrap
     fileprivate func baseScript() -> String {
         """
         #!/bin/sh
@@ -252,7 +252,7 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
     }
 
     // swiftlint:enable function_body_length
-    // swiftlint:enable line_length
+    // swiftformat:enable wrap
 }
 
 extension RelativePath {

--- a/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
+++ b/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
@@ -105,7 +105,6 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
     }
 
     // swiftlint:disable function_body_length
-    // swiftformat:disable wrap
     fileprivate func baseScript() -> String {
         """
         #!/bin/sh
@@ -252,7 +251,6 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
     }
 
     // swiftlint:enable function_body_length
-    // swiftformat:enable wrap
 }
 
 extension RelativePath {

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -21,7 +21,6 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             stdout: "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform\n",
             exitstatus: 0
         )
-        // swiftformat:disable wrap
         system
             .stubs[
                 "/usr/bin/xcrun vtool -show-build /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest"
@@ -60,7 +59,6 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 """,
                 exitstatus: 0
             )
-        // swiftformat:enable wrap
         subject = PackageInfoMapper()
     }
 
@@ -1101,7 +1099,6 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             stdout: "/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform\n",
             exitstatus: 0
         )
-        // swiftformat:disable wrap
         system
             .stubs[
                 "/usr/bin/xcrun vtool -show-build /Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest"
@@ -1128,7 +1125,6 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 """,
                 exitstatus: 0
             )
-        // swiftformat:enable wrap
         let basePath = try temporaryPath()
         let sourcesPath = basePath.appending(RelativePath("Package/Path/Sources/Target1"))
         try fileHandler.createFolder(sourcesPath)

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -21,7 +21,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             stdout: "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform\n",
             exitstatus: 0
         )
-        // swiftlint:disable line_length
+        // swiftformat:disable wrap
         system
             .stubs[
                 "/usr/bin/xcrun vtool -show-build /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest"
@@ -60,7 +60,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 """,
                 exitstatus: 0
             )
-        // swiftlint:enable line_length
+        // swiftformat:enable wrap
         subject = PackageInfoMapper()
     }
 
@@ -1101,7 +1101,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             stdout: "/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform\n",
             exitstatus: 0
         )
-        // swiftlint:disable line_length
+        // swiftformat:disable wrap
         system
             .stubs[
                 "/usr/bin/xcrun vtool -show-build /Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest"
@@ -1128,7 +1128,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 """,
                 exitstatus: 0
             )
-        // swiftlint:enable line_length
+        // swiftformat:enable wrap
         let basePath = try temporaryPath()
         let sourcesPath = basePath.appending(RelativePath("Package/Path/Sources/Target1"))
         try fileHandler.createFolder(sourcesPath)

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
@@ -25,7 +25,7 @@ class SwiftPackageManagerGraphGeneratorTests: TuistUnitTestCase {
             stdout: "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform\n",
             exitstatus: 0
         )
-        // swiftlint:disable line_length
+        // swiftformat:disable wrap
         system
             .stubs[
                 "/usr/bin/xcrun vtool -show-build /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest"
@@ -64,7 +64,7 @@ class SwiftPackageManagerGraphGeneratorTests: TuistUnitTestCase {
                 """,
                 exitstatus: 0
             )
-        // swiftlint:enable line_length
+        // swiftformat:enable wrap
 
         subject = SwiftPackageManagerGraphGenerator(swiftPackageManagerController: swiftPackageManagerController)
     }

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
@@ -25,7 +25,6 @@ class SwiftPackageManagerGraphGeneratorTests: TuistUnitTestCase {
             stdout: "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform\n",
             exitstatus: 0
         )
-        // swiftformat:disable wrap
         system
             .stubs[
                 "/usr/bin/xcrun vtool -show-build /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest"
@@ -64,7 +63,6 @@ class SwiftPackageManagerGraphGeneratorTests: TuistUnitTestCase {
                 """,
                 exitstatus: 0
             )
-        // swiftformat:enable wrap
 
         subject = SwiftPackageManagerGraphGenerator(swiftPackageManagerController: swiftPackageManagerController)
     }


### PR DESCRIPTION
### Short description 📝

Disable SwiftLint's `line_length` rule in favor of SwiftFormat's `wrap` rule, according to [discussion on Slack](https://tuistapp.slack.com/archives/CTB0DBVD2/p1643623166767399?thread_ts=1643623009.493989&cid=CTB0DBVD2).

### How to test the changes locally 🧐

`./fourier lint all`

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
