### PR TITLE
Pass arguments to parseAsRoot

### DIFF
--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -50,7 +50,7 @@ public struct TuistCommand: ParsableCommand {
             if processedArguments.first == InitCommand.configuration.commandName {
                 try InitCommand.preprocess(processedArguments)
             }
-            let command = try parseAsRoot()
+            let command = try parseAsRoot(processedArguments)
             executeCommand = { try await execute(command) }
         } catch {
             parsedError = error


### PR DESCRIPTION
As requested [here](https://github.com/tuist/tuist/issues/4074#issuecomment-1027678835).