### PR TITLE
Apply appropriate hackery to fix dyld error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Fix dependencies not fetching using Swift Package Manager 5.6 [#4078](https://github.com/tuist/tuist/pull/4078) by [mikchmie](https://github.com/mikchmie)
 - Fix clean `tuist test` for project with resources [#4091](https://github.com/tuist/tuist/pull/4091) by [@adellibovi](https://github.com/adellibovi)
+- Fix running `tuist` on macOS 11.6.2. [#4108](https://github.com/tuist/tuist/pull/4108) by [@kalkwarf](https://github.com/kalkwarf)
 
 ## 2.7.2
 
@@ -86,7 +87,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Changed
 
 - Remove duplicate bundle identifier lint warning [#3914](https://github.com/tuist/tuist/pull/3914) by [@danyf90](https://github.com/danyf90)
-- Update version requirement for `swift-argument-parser` package from `.upToNextMajor(from: "0.4.3")` to `.upToNextMajor(from: "1.0.0")` [#3949](https://github.com/tuist/tuist/pull/3949) by [@laxmorek](https://github.com/laxmorek) 
+- Update version requirement for `swift-argument-parser` package from `.upToNextMajor(from: "0.4.3")` to `.upToNextMajor(from: "1.0.0")` [#3949](https://github.com/tuist/tuist/pull/3949) by [@laxmorek](https://github.com/laxmorek)
 
 ### Added
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,5 @@
 // swift-tools-version:5.5.0
-
+import Foundation
 import PackageDescription
 
 let swiftToolsSupportDependency: Target.Dependency = .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core")
@@ -660,3 +660,66 @@ let package = Package(
         ),
     ]
 )
+
+hookInternalSwiftConcurrency()
+func hookInternalSwiftConcurrency() {
+    let isFromTerminal = ProcessInfo.processInfo.environment.values.contains("/usr/bin/swift")
+    if !isFromTerminal {
+        package.targets.first?.addLinkerSettingUnsafeFlagRunpathSearchPath()
+    }
+}
+
+extension PackageDescription.Target {
+    func addLinkerSettingUnsafeFlagRunpathSearchPath() {
+        linkerSettings = [linkerSetting]
+    }
+
+    private var linkerSetting: LinkerSetting {
+        guard let xcodeFolder = Executable("/usr/bin/xcode-select")("-p") else {
+            fatalError("Could not run `xcode-select -p`")
+        }
+
+        let toolchainFolder = "\(xcodeFolder.trimmed)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx"
+
+        return .unsafeFlags(["-rpath", toolchainFolder])
+    }
+}
+
+extension String {
+    var trimmed: String { trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) }
+}
+
+private struct Executable {
+    private let url: URL
+
+    init(_ filePath: String) {
+        url = URL(fileURLWithPath: filePath)
+    }
+
+    func callAsFunction(_ arguments: String...) -> String? {
+        let process = Process()
+        process.executableURL = url
+        process.arguments = arguments
+
+        let stdout = Pipe()
+        process.standardOutput = stdout
+
+        process.launch()
+        process.waitUntilExit()
+
+        return stdout.readStringToEndOfFile()
+    }
+}
+
+extension Pipe {
+    func readStringToEndOfFile() -> String? {
+        let data: Data
+        if #available(OSX 10.15.4, *) {
+            data = (try? fileHandleForReading.readToEnd()) ?? Data()
+        } else {
+            data = fileHandleForReading.readDataToEndOfFile()
+        }
+
+        return String(data: data, encoding: .utf8)
+    }
+}


### PR DESCRIPTION

Resolves https://github.com/tuist/tuist/issues/4107

### Short description 📝

As discussed in Slack, copied a workaround to the
```
dyld: Library not loaded: @rpath/libswift_Concurrency.dylib
```
error

### How to test the changes locally 🧐

Try to run tuist in the Xcode 13.2.1 debugger on macOS 11.6.2 before this patch, and it will fail to launch.

After this patch, it will launch and run correctly.
### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
