### PR TITLE
fix: default nil TestAction to empty test action

### DIFF
--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -267,7 +267,9 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
                           generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.TestAction?
     {
         // Use empty action if nil, otherwise Xcode will create it anyway
-        let testAction = scheme.testAction ?? .empty
+        let testAction = scheme.testAction ?? .empty(
+            withConfigurationName: scheme.runAction?.configurationName ?? BuildConfiguration.debug.name
+        )
 
         var testables: [XCScheme.TestableReference] = []
         var preActions: [XCScheme.ExecutionAction] = []
@@ -868,11 +870,11 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
 }
 
 extension TestAction {
-    fileprivate static var empty: Self {
+    fileprivate static func empty(withConfigurationName configurationName: String) -> Self {
         .init(
             targets: [],
             arguments: nil,
-            configurationName: "",
+            configurationName: configurationName,
             attachDebugger: true,
             coverage: false,
             codeCoverageTargets: [],
@@ -882,7 +884,7 @@ extension TestAction {
             diagnosticsOptions: [],
             language: nil,
             region: nil,
-            testPlans: []
+            testPlans: nil
         )
     }
 }

--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -865,3 +865,23 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
         }
     }
 }
+
+extension TestAction {
+    fileprivate static func empty(defaultBuildConfiguraiton: String) -> Self {
+        .init(
+            targets: [],
+            arguments: nil,
+            configurationName: "",
+            attachDebugger: true,
+            coverage: false,
+            codeCoverageTargets: [],
+            expandVariableFromTarget: nil,
+            preActions: [],
+            postActions: [],
+            diagnosticsOptions: [],
+            language: nil,
+            region: nil,
+            testPlans: []
+        )
+    }
+}

--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -266,7 +266,8 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
                           rootPath: AbsolutePath,
                           generatedProjects: [AbsolutePath: GeneratedProject]) throws -> XCScheme.TestAction?
     {
-        guard let testAction = scheme.testAction else { return nil }
+        // Use empty action if nil, otherwise Xcode will create it anyway
+        let testAction = scheme.testAction ?? .empty
 
         var testables: [XCScheme.TestableReference] = []
         var preActions: [XCScheme.ExecutionAction] = []
@@ -867,7 +868,7 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
 }
 
 extension TestAction {
-    fileprivate static func empty(defaultBuildConfiguraiton: String) -> Self {
+    fileprivate static var empty: Self {
         .init(
             targets: [],
             arguments: nil,


### PR DESCRIPTION
Address https://github.com/tuist/tuist/pull/4093#discussion_r798321114

in test action is nil, map to empty test action, to avoid that Xcode needs to create it