### PR TITLE
chore: suppress warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Fix dependencies not fetching using Swift Package Manager 5.6 [#4078](https://github.com/tuist/tuist/pull/4078) by [mikchmie](https://github.com/mikchmie)
 - Fix clean `tuist test` for project with resources [#4091](https://github.com/tuist/tuist/pull/4091) by [@adellibovi](https://github.com/adellibovi)
+- Fix `tuist graph --skip-external-dependencies` for `Dependencies.swift` dependencies [#4115](https://github.com/tuist/tuist/pull/4115) by [@danyf90](https://github.com/danyf90)
 
 ## 2.7.2
 

--- a/Sources/TuistSupport/Logging/DetailedLogHandler.swift
+++ b/Sources/TuistSupport/Logging/DetailedLogHandler.swift
@@ -35,7 +35,8 @@ public struct DetailedLogHandler: LogHandler {
 
         log.append(message.description)
 
-        output(for: level).log(level: level, message: message, metadata: metadata, file: file, function: function, line: line)
+        (output(for: level) as? SuppressedWarningLogHandler)?
+            .log(level: level, message: message, metadata: metadata, file: file, function: function, line: line)
     }
 
     func output(for level: Logger.Level) -> LogHandler {
@@ -73,3 +74,17 @@ func timestamp() -> String {
         }
     }
 }
+
+// MARK: - Protocol needed to suppress the warning because we don't have a valid `source` to pass to the `log` method
+protocol SuppressedWarningLogHandler {
+    func log(
+        level: Logging.Logger.Level,
+        message: Logging.Logger.Message,
+        metadata: Logging.Logger.Metadata?,
+        file: String,
+        function: String,
+        line: UInt
+    )
+}
+
+extension StreamLogHandler: SuppressedWarningLogHandler {}

--- a/Sources/TuistSupport/Logging/DetailedLogHandler.swift
+++ b/Sources/TuistSupport/Logging/DetailedLogHandler.swift
@@ -75,8 +75,7 @@ func timestamp() -> String {
     }
 }
 
-// MARK: - Protocol needed to suppress the warning because we don't have a valid `source` to pass to the `log` method
-
+// Protocol needed to suppress the warning because we don't have a valid `source` to pass to the `log` method
 protocol SuppressedWarningLogHandler {
     func log(
         level: Logging.Logger.Level,

--- a/Sources/TuistSupport/Logging/DetailedLogHandler.swift
+++ b/Sources/TuistSupport/Logging/DetailedLogHandler.swift
@@ -76,6 +76,7 @@ func timestamp() -> String {
 }
 
 // MARK: - Protocol needed to suppress the warning because we don't have a valid `source` to pass to the `log` method
+
 protocol SuppressedWarningLogHandler {
     func log(
         level: Logging.Logger.Level,

--- a/Sources/TuistSupport/Utils/FileHandler.swift
+++ b/Sources/TuistSupport/Utils/FileHandler.swift
@@ -1,4 +1,4 @@
-import CommonCrypto
+import CryptoKit
 import Foundation
 import TSCBasic
 
@@ -293,20 +293,7 @@ public class FileHandler: FileHandling {
 
     public func urlSafeBase64MD5(path: AbsolutePath) throws -> String {
         let data = try Data(contentsOf: path.url)
-        let length = Int(CC_MD5_DIGEST_LENGTH)
-        var digestData = Data(count: length)
-
-        _ = digestData.withUnsafeMutableBytes { digestBytes -> UInt8 in
-            data.withUnsafeBytes { messageBytes -> UInt8 in
-                if let messageBytesBaseAddress = messageBytes.baseAddress,
-                   let digestBytesBlindMemory = digestBytes.bindMemory(to: UInt8.self).baseAddress
-                {
-                    let messageLength = CC_LONG(data.count)
-                    CC_MD5(messageBytesBaseAddress, messageLength, digestBytesBlindMemory)
-                }
-                return 0
-            }
-        }
+        let digestData = Data(Insecure.MD5.hash(data: data))
         return digestData.base64EncodedString()
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "+", with: "-")

--- a/Tests/TuistGeneratorTests/GraphViz/GraphToGraphVizMapperTests.swift
+++ b/Tests/TuistGeneratorTests/GraphViz/GraphToGraphVizMapperTests.swift
@@ -109,6 +109,7 @@ final class GraphToGraphVizMapperTests: XCTestCase {
         let core = GraphViz.Node("Core")
         let coreTests = GraphViz.Node("CoreTests")
         let watchOS = GraphViz.Node("Tuist watchOS")
+        let externalDependency = GraphViz.Node("External dependency")
 
         graph.append(contentsOf: [tuist, core])
         if !onlyiOS {
@@ -122,13 +123,14 @@ final class GraphToGraphVizMapperTests: XCTestCase {
         if includeExternalDependencies {
             graph.append(
                 contentsOf: [
-                    coreData, rxSwift, xcodeProj,
+                    coreData, rxSwift, xcodeProj, externalDependency,
                 ]
             )
             graph.append(contentsOf: [
                 GraphViz.Edge(from: core, to: xcodeProj),
                 GraphViz.Edge(from: core, to: rxSwift),
                 GraphViz.Edge(from: core, to: coreData),
+                GraphViz.Edge(from: core, to: externalDependency),
             ])
         }
 
@@ -161,6 +163,10 @@ final class GraphToGraphVizMapperTests: XCTestCase {
                 product: .unitTests
             )
         )
+        let externalDependency = GraphDependency.target(
+            name: "External dependency",
+            path: project.path.appending(components: "Tuist", "Dependencies")
+        )
         let iOSApp = GraphTarget.test(target: Target.test(name: "Tuist iOS"))
         let watchApp = GraphTarget.test(target: Target.test(name: "Tuist watchOS"))
 
@@ -184,6 +190,7 @@ final class GraphToGraphVizMapperTests: XCTestCase {
                     framework,
                     library,
                     sdk,
+                    externalDependency,
                 ],
                 .target(name: coreTests.target.name, path: coreTests.path): [coreDependency],
                 .target(name: iOSApp.target.name, path: iOSApp.path): [coreDependency],


### PR DESCRIPTION
Suppress 2 warnings:
- usage of CC_MD5
- usage of logger without `source` parameter