### PR TITLE
Add support for generating per-configuration Info.plist

### DIFF
--- a/Sources/ProjectDescription/Settings.swift
+++ b/Sources/ProjectDescription/Settings.swift
@@ -46,12 +46,14 @@ public struct Configuration: Equatable, Codable {
     public let name: ConfigurationName
     public let variant: Variant
     public let settings: SettingsDictionary
+    public let infoPlist: InfoPlist?
     public let xcconfig: Path?
 
-    init(name: ConfigurationName, variant: Variant, settings: SettingsDictionary, xcconfig: Path?) {
+    init(name: ConfigurationName, variant: Variant, settings: SettingsDictionary, infoPlist: InfoPlist?, xcconfig: Path?) {
         self.name = name
         self.variant = variant
         self.settings = settings
+        self.infoPlist = infoPlist
         self.xcconfig = xcconfig
     }
 
@@ -63,12 +65,13 @@ public struct Configuration: Equatable, Codable {
     ///   - xcconfig: The xcconfig file to associate with this configuration
     /// - Returns: A debug `CustomConfiguration`
     public static func debug(name: ConfigurationName, settings: SettingsDictionary = [:],
-                             xcconfig: Path? = nil) -> Configuration
+                             infoPlist: InfoPlist? = nil, xcconfig: Path? = nil) -> Configuration
     {
         Configuration(
             name: name,
             variant: .debug,
             settings: settings,
+            infoPlist: infoPlist,
             xcconfig: xcconfig
         )
     }
@@ -81,12 +84,13 @@ public struct Configuration: Equatable, Codable {
     ///   - xcconfig: The xcconfig file to associate with this configuration
     /// - Returns: A release `CustomConfiguration`
     public static func release(name: ConfigurationName, settings: SettingsDictionary = [:],
-                               xcconfig: Path? = nil) -> Configuration
+                               infoPlist: InfoPlist? = nil, xcconfig: Path? = nil) -> Configuration
     {
         Configuration(
             name: name,
             variant: .release,
             settings: settings,
+            infoPlist: infoPlist,
             xcconfig: xcconfig
         )
     }

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -166,7 +166,8 @@ final class ConfigGenerator: ConfigGenerating {
             target: target,
             graphTraverser: graphTraverser,
             project: project,
-            sourceRootPath: sourceRootPath
+            sourceRootPath: sourceRootPath,
+            configuration: configuration
         )
 
         settingsHelper.extend(buildSettings: &settings, with: target.settings?.base ?? [:])
@@ -191,13 +192,15 @@ final class ConfigGenerator: ConfigGenerating {
                                      target: Target,
                                      graphTraverser: GraphTraversing,
                                      project: Project,
-                                     sourceRootPath: AbsolutePath)
+                                     sourceRootPath: AbsolutePath,
+                                     configuration: Configuration?)
     {
         settings.merge(
             generalTargetDerivedSettings(
                 target: target,
                 sourceRootPath: sourceRootPath,
-                project: project
+                project: project,
+                configuration: configuration
             )
         ) { $1 }
         settings
@@ -212,14 +215,15 @@ final class ConfigGenerator: ConfigGenerating {
     private func generalTargetDerivedSettings(
         target: Target,
         sourceRootPath: AbsolutePath,
-        project: Project
+        project: Project,
+        configuration: Configuration?
     ) -> SettingsDictionary {
         var settings: SettingsDictionary = [:]
         settings["PRODUCT_BUNDLE_IDENTIFIER"] = .string(target.bundleId)
 
         // Info.plist
-        if let infoPlist = target.infoPlist, let path = infoPlist.path {
-            let relativePath = path.relative(to: sourceRootPath).pathString
+        if let infoPlistPath = configuration?.infoPlist?.path ?? target.infoPlist?.path {
+            let relativePath = infoPlistPath.relative(to: sourceRootPath).pathString
             if project.xcodeProjPath.parentDirectory == sourceRootPath {
                 settings["INFOPLIST_FILE"] = .string(relativePath)
             } else {

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -161,6 +161,10 @@ class ProjectFileElements {
             files.insert(configFilePath)
         }
 
+        target.settings?.configurations.infoPlists().compactMap(\.path).forEach { infoPlistPath in
+            files.insert(infoPlistPath)
+        }
+
         // Additional files
         files.formUnion(target.additionalFiles.map(\.path))
 

--- a/Sources/TuistGraph/Models/Settings.swift
+++ b/Sources/TuistGraph/Models/Settings.swift
@@ -32,12 +32,14 @@ public struct Configuration: Equatable, Codable {
     // MARK: - Attributes
 
     public let settings: SettingsDictionary
+    public let infoPlist: InfoPlist?
     public let xcconfig: AbsolutePath?
 
     // MARK: - Init
 
-    public init(settings: SettingsDictionary = [:], xcconfig: AbsolutePath? = nil) {
+    public init(settings: SettingsDictionary = [:], infoPlist: InfoPlist? = nil, xcconfig: AbsolutePath? = nil) {
         self.settings = settings
+        self.infoPlist = infoPlist
         self.xcconfig = xcconfig
     }
 
@@ -48,6 +50,7 @@ public struct Configuration: Equatable, Codable {
     public func with(settings: SettingsDictionary) -> Configuration {
         Configuration(
             settings: settings,
+            infoPlist: infoPlist,
             xcconfig: xcconfig
         )
     }
@@ -135,6 +138,12 @@ extension Dictionary where Key == BuildConfiguration, Value == Configuration? {
         sortedByBuildConfigurationName()
             .map(\.value)
             .compactMap { $0?.xcconfig }
+    }
+
+    public func infoPlists() -> [InfoPlist] {
+        sortedByBuildConfigurationName()
+            .map(\.value)
+            .compactMap(\.?.infoPlist)
     }
 }
 

--- a/Sources/TuistLoader/Models+ManifestMappers/Configuration+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Configuration+ManifestMapper.swift
@@ -15,7 +15,8 @@ extension TuistGraph.Configuration {
     {
         guard let manifest = manifest else { return nil }
         let settings = manifest.settings.mapValues(TuistGraph.SettingValue.from)
+        let infoPlist = try manifest.infoPlist.map { try TuistGraph.InfoPlist.from(manifest: $0, generatorPaths: generatorPaths) }
         let xcconfig = try manifest.xcconfig.flatMap { try generatorPaths.resolve(path: $0) }
-        return Configuration(settings: settings, xcconfig: xcconfig)
+        return Configuration(settings: settings, infoPlist: infoPlist, xcconfig: xcconfig)
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/1157

### example of Project.swift with different info.plist files

```
import ProjectDescription

let project = Project(
    name: "TestApp",
    targets: [
        Target(
            name: "TestApp",
            platform: .iOS,
            product: .app,
            bundleId: "com.test.app",
            infoPlist: "Info.plist", // will be used by default if configuration doesn't have infoPlist
            sources: ["Classes/**"],
            settings: .settings(configurations: [
                .release(name: "Release", settings: [:], infoPlist: "Info.plist", xcconfig: nil),
                .debug(name: "Debug", settings: [:], infoPlist: "Info-debug.plist", xcconfig: nil)
            ])
        )
    ]
)
```

### TODO list

- [ ] Support all possible cases of InfoPlist (now supports only InfoPlist.file)
- [ ] Create tests for new functionality

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
