### PR TITLE
docs: fix `tuist graph --skip-external-dependencies` for `Dependencies.swift` dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Fix dependencies not fetching using Swift Package Manager 5.6 [#4078](https://github.com/tuist/tuist/pull/4078) by [mikchmie](https://github.com/mikchmie)
 - Fix clean `tuist test` for project with resources [#4091](https://github.com/tuist/tuist/pull/4091) by [@adellibovi](https://github.com/adellibovi)
+- Fix `tuist graph --skip-external-dependencies` for `Dependencies.swift` dependencies [#4115](https://github.com/tuist/tuist/pull/4115) by [@danyf90](https://github.com/danyf90)
 
 ## 2.7.2
 

--- a/Tests/TuistGeneratorTests/GraphViz/GraphToGraphVizMapperTests.swift
+++ b/Tests/TuistGeneratorTests/GraphViz/GraphToGraphVizMapperTests.swift
@@ -109,6 +109,7 @@ final class GraphToGraphVizMapperTests: XCTestCase {
         let core = GraphViz.Node("Core")
         let coreTests = GraphViz.Node("CoreTests")
         let watchOS = GraphViz.Node("Tuist watchOS")
+        let externalDependency = GraphViz.Node("External dependency")
 
         graph.append(contentsOf: [tuist, core])
         if !onlyiOS {
@@ -122,13 +123,14 @@ final class GraphToGraphVizMapperTests: XCTestCase {
         if includeExternalDependencies {
             graph.append(
                 contentsOf: [
-                    coreData, rxSwift, xcodeProj,
+                    coreData, rxSwift, xcodeProj, externalDependency,
                 ]
             )
             graph.append(contentsOf: [
                 GraphViz.Edge(from: core, to: xcodeProj),
                 GraphViz.Edge(from: core, to: rxSwift),
                 GraphViz.Edge(from: core, to: coreData),
+                GraphViz.Edge(from: core, to: externalDependency),
             ])
         }
 
@@ -161,6 +163,10 @@ final class GraphToGraphVizMapperTests: XCTestCase {
                 product: .unitTests
             )
         )
+        let externalDependency = GraphDependency.target(
+            name: "External dependency",
+            path: project.path.appending(components: "Tuist", "Dependencies")
+        )
         let iOSApp = GraphTarget.test(target: Target.test(name: "Tuist iOS"))
         let watchApp = GraphTarget.test(target: Target.test(name: "Tuist watchOS"))
 
@@ -184,6 +190,7 @@ final class GraphToGraphVizMapperTests: XCTestCase {
                     framework,
                     library,
                     sdk,
+                    externalDependency,
                 ],
                 .target(name: coreTests.target.name, path: coreTests.path): [coreDependency],
                 .target(name: iOSApp.target.name, path: iOSApp.path): [coreDependency],


### PR DESCRIPTION
Dependencies.swift dependencies were not considered external
### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
