### PR TITLE
Adds support for parsing .env files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 - Add support for `umbrellaHeader` parameter to `Headers` to get list of public headers automatically. Also added new static functions in `Headers` for most popular cases with umbrella header [#3884](https://github.com/tuist/tuist/pull/3884) by [@pavel-trafimuk](https://github.com/pavel-trafimuk)
+- Add Support for parsing `.env` files by default [#4125](https://github.com/tuist/tuist/pull/4125) by [@jaerod95](https://github.com/jaerod95)
 
 ## 2.7.2
 

--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -14,6 +14,7 @@ public enum Constants {
     public static let envBundleName: String = "tuistenv.zip"
     public static let trueValues: [String] = ["1", "true", "TRUE", "yes", "YES"]
     public static let tuistDirectoryName: String = "Tuist"
+    public static let tuistDotEnvName: String = ".env"
 
     public static let helpersDirectoryName: String = "ProjectDescriptionHelpers"
     public static let signingDirectoryName: String = "Signing"

--- a/Sources/TuistSupport/Utils/DotEnvParser.swift
+++ b/Sources/TuistSupport/Utils/DotEnvParser.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+struct DotEnvParser {
+    /// Parse .env file at the given path
+    /// - Parameters:
+    ///   - path: path to .env file
+    func parse(path: String) -> [String: String] {
+        var results: [String: String] = [:]
+        if let contents = try? NSString(contentsOfFile: path, encoding: String.Encoding.utf8.rawValue) {
+            // DotEnv Parsing Logic pulled from https://github.com/SwiftOnTheServer/SwiftDotEnv/blob/master/Sources/DotEnv/DotEnv.swift.
+            let lines = String(describing: contents).split { $0 == "\n" || $0 == "\r\n" }.map(String.init)
+
+            for line in lines {
+                // ignore comments
+                if line[line.startIndex] == "#" {
+                    continue
+                }
+
+                // ignore lines that appear empty
+                if line.trimmingCharacters(in: NSCharacterSet.whitespacesAndNewlines).isEmpty {
+                    continue
+                }
+
+                // extract key and value which are separated by an equals sign
+                let parts = line.split(separator: "=", maxSplits: 1).map(String.init)
+
+                let key = parts[0].trimmingCharacters(in: NSCharacterSet.whitespacesAndNewlines)
+                var value = parts[1].trimmingCharacters(in: NSCharacterSet.whitespacesAndNewlines)
+
+                // remove surrounding quotes from value & convert remove escape character before any embedded quotes
+                if value[value.startIndex] == "\"", value[value.index(before: value.endIndex)] == "\"" {
+                    value.remove(at: value.startIndex)
+                    value.remove(at: value.index(before: value.endIndex))
+                    value = value.replacingOccurrences(of: "\\\"", with: "\"")
+                }
+                results[key] = value
+            }
+        }
+
+        return results
+    }
+}

--- a/projects/docs/docs/guides/environment.md
+++ b/projects/docs/docs/guides/environment.md
@@ -18,6 +18,12 @@ If you want to pass multiple environment variables just separate them with a spa
 TUIST_APP_NAME=MyApp TUIST_APP_LOCALE=pl tuist generate
 ```
 
+Tuist also supports reading from .env files located inside of the Tuist/ directory by default. Simply Create a .env file inside of the Tuist directory and add your environment varables one per line. For example:
+```bash
+TUIST_APP_NAME=MyApp
+TUIST_APP_LOCALE=pl
+```
+
 Variables can be accessed using the `Environment` type. Any variables following the convention `TUIST_XXX` defined in the environment or passed to Tuist when running commands will be accessible using the `Environment` type.
 The following example shows how we access the `TUIST_APP_NAME` variable:
 


### PR DESCRIPTION
### Short description 📝

`.env` files are now parsed from the Tuist/.env path by default. We only parse variables that begin with `TUIST_` or `TUIST_CONFIG_` and ignore the rest. Environment variables provided via the CLI take priority vs what is inside your `.env` file.

### How to test the changes locally 🧐

To test simply create a .env file inside of the Tuist Directory.
Add environment variables beginning with `TUIST_` or `TUIST_CONFIG_` and ensure the values are parsed into the appropriate environment variable groups.
Add environment variables that do not begin with `TUIST_` or `TUIST_CONFIG_` and they should be ignored.
Add environment variables to the .env, and then provide a different value in the CLI and ensure the cli value is used vs the one in the .env. For example, if `TUST_APP_NAME=MyApp` is defined in your .env and the command `TUIST_APP_NAME=SomeOtherApp tuist generate` is executed, wherever the environment variable `TUIST_APP_NAME` is used, the value should resolve to `SomeOtherApp`.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
