### PR TITLE
fix: remove .swiftsourceinfo files from release archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fix clean `tuist test` for project with resources [#4091](https://github.com/tuist/tuist/pull/4091) by [@adellibovi](https://github.com/adellibovi)
 - Fix `tuist graph --skip-external-dependencies` for `Dependencies.swift` dependencies [#4115](https://github.com/tuist/tuist/pull/4115) by [@danyf90](https://github.com/danyf90) & [#4124](https://github.com/tuist/tuist/pull/4124) by [@laxmorek](https://github.com/laxmorek)
 - Fix `envversion` command not printing the tuist env version [#4126](https://github.com/tuist/tuist/pull/4126) by [@takinwande](https://github.com/takinwande)
+- Fix `.swiftsourceinfo` files from being added to the release artifact [#4132](https://github.com/tuist/tuist/pull/4132) by [@luispadron](https://github.com/luispadron)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fix clean `tuist test` for project with resources [#4091](https://github.com/tuist/tuist/pull/4091) by [@adellibovi](https://github.com/adellibovi)
 - Fix `tuist graph --skip-external-dependencies` for `Dependencies.swift` dependencies [#4115](https://github.com/tuist/tuist/pull/4115) by [@danyf90](https://github.com/danyf90) & [#4124](https://github.com/tuist/tuist/pull/4124) by [@laxmorek](https://github.com/laxmorek)
 - Fix `envversion` command not printing the tuist env version [#4126](https://github.com/tuist/tuist/pull/4126) by [@takinwande](https://github.com/takinwande)
-- Fix `.swiftsourceinfo` files from being added to the release artifact [#4132](https://github.com/tuist/tuist/pull/4132) by [@luispadron](https://github.com/luispadron)
+- Fix warning when importing `ProjectDescription` during `tuist edit`. It was caused by `.swiftsourceinfo` files  being added to the release artifact [#4132](https://github.com/tuist/tuist/pull/4132) by [@luispadron](https://github.com/luispadron)
 
 ### Added
 

--- a/projects/fourier/lib/fourier.rb
+++ b/projects/fourier/lib/fourier.rb
@@ -106,7 +106,7 @@ module Fourier
       Services::Check.call
     end
 
-    desc "release", "Release the Tuist"
+    desc "release", "Prepares the Tuist binary and dependencies for release"
     subcommand "release", Commands::Release
 
     def self.exit_on_failure?

--- a/projects/fourier/lib/fourier/commands/release.rb
+++ b/projects/fourier/lib/fourier/commands/release.rb
@@ -3,7 +3,7 @@
 module Fourier
   module Commands
     class Release < Base
-      desc "tuist VERSION", "Bundles and uploads Tuist to GCS"
+      desc "tuist VERSION", "Configures and bundles Tuist for release"
       def tuist(
         version,
         xcode_version = nil,
@@ -26,7 +26,7 @@ module Fourier
           xcode_paths: xcode_paths
         )
 
-        Utilities::Output.success("tuist and tuistenv were built successfully")
+        Utilities::Output.success("tuist and tuistenv were bundled successfully to #{output_directory}")
       end
     end
   end

--- a/projects/fourier/lib/fourier/utilities/swift_package_manager.rb
+++ b/projects/fourier/lib/fourier/utilities/swift_package_manager.rb
@@ -36,11 +36,21 @@ module Fourier
             "clean", "build"
           )
 
+          FileUtils.mkdir_p(
+            File.join(output_directory, "#{product}.framework/Modules")
+          )
+
+          # NOTE: We remove the PRODUCT.swiftmodule/Project directory because
+          # this directory contains objects that are not stable across Swift releases.
+          # If left in here they manifest as warnings when compiling.
+          FileUtils.rm_rf(
+            File.join(swift_build_directory, "Release/#{product}.swiftmodule/Project")
+          )
+
           FileUtils.cp_r(
             File.join(swift_build_directory, "Release/PackageFrameworks/#{product}.framework"),
             File.join(output_directory, "#{product}.framework")
           )
-          FileUtils.mkdir_p(File.join(output_directory, "#{product}.framework/Modules"))
           FileUtils.cp_r(
             File.join(swift_build_directory, "Release/#{product}.swiftmodule"),
             File.join(output_directory, "#{product}.framework/Modules/#{product}.swiftmodule")


### PR DESCRIPTION
Closes #3543

### Short description 📝

When releasing Tuist we copy over the `.swiftmodule` directory as-is. This directory includes `.swiftsourceinfo` files which are unstable across Swift versions, so when end-users go to compile the `ProjectDescription` framework they receive warnings about this file being included. This PR fixes those warnings by removing the files from the archive. 

### Checklist ✅

- [X] The code architecture and patterns are consistent with the rest of the codebase.
- [X] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [X] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [X] In case the PR introduces changes that affect users, the documentation has been updated.
- [X] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
