### PR TITLE
fix: Remove default support for MacCatalyst in Framework projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 - Use GitHub tags (via `git ls-remote`) to determine the latest Tuist version when installing/updating Tuist [#3985](https://github.com/tuist/tuist/pull/3985) by [@ezraberch](https://github.com/ezraberch)
 
+- Remove default MacCatalyst support when framework deployment target is set to iOS and/or iPad [#4134](https://github.com/tuist/tuist/pull/4134) by [@TheInkedEngineer](https://github.com/TheInkedEngineer)  
+
 ### Added
 - Add a new test argument `--retry-count <number>` to retry failed tests <number> of times until success [#4021](https://github.com/tuist/tuist/pull/4021) by [@regularberry](https://github.com/regularberry)
 - Add support for `.docc` file types [#3982](https://github.com/tuist/tuist/pull/3982) by [@Jake Prickett](https://github.com/Jake-Prickett)

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -294,7 +294,6 @@ final class ConfigGenerator: ConfigGenerating {
             } else {
                 // Unless explicitly specified, when the platform the Product is a framework, these default to YES.
                 settings["SUPPORTS_MACCATALYST"] = "NO"
-                settings["DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER"] = "NO"
             }
         case let .macOS(version):
             settings["MACOSX_DEPLOYMENT_TARGET"] = .string(version)

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -291,6 +291,10 @@ final class ConfigGenerator: ConfigGenerating {
             if devices.contains(.ipad), devices.contains(.mac) {
                 settings["SUPPORTS_MACCATALYST"] = "YES"
                 settings["DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER"] = "YES"
+            } else {
+                // Unless explicitly specified, when the platform the Product is a framework, these default to YES.
+                settings["SUPPORTS_MACCATALYST"] = "NO"
+                settings["DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER"] = "NO"
             }
         case let .macOS(version):
             settings["MACOSX_DEPLOYMENT_TARGET"] = .string(version)

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -263,7 +263,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         assert(config: debugConfig, contains: expectedSettings)
         assert(config: releaseConfig, contains: expectedSettings)
     }
-    
+
     func test_generateTargetWithDeploymentTarget_whenIOS_for_framework() throws {
         // Given
         let target = Target.test(product: .framework, deploymentTarget: .iOS("13.0", [.iphone, .ipad]))
@@ -292,7 +292,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             "TARGETED_DEVICE_FAMILY": "1,2",
             "IPHONEOS_DEPLOYMENT_TARGET": "13.0",
             "SUPPORTS_MACCATALYST": "NO",
-            "DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER": "NO"
+            "DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER": "NO",
         ]
 
         assert(config: debugConfig, contains: expectedSettings)

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -292,7 +292,6 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             "TARGETED_DEVICE_FAMILY": "1,2",
             "IPHONEOS_DEPLOYMENT_TARGET": "13.0",
             "SUPPORTS_MACCATALYST": "NO",
-            "DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER": "NO",
         ]
 
         assert(config: debugConfig, contains: expectedSettings)

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -263,6 +263,41 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         assert(config: debugConfig, contains: expectedSettings)
         assert(config: releaseConfig, contains: expectedSettings)
     }
+    
+    func test_generateTargetWithDeploymentTarget_whenIOS_for_framework() throws {
+        // Given
+        let target = Target.test(product: .framework, deploymentTarget: .iOS("13.0", [.iphone, .ipad]))
+        let project = Project.test(targets: [target])
+        let graph = Graph.test(path: project.path)
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        try subject.generateTargetConfig(
+            target,
+            project: project,
+            pbxTarget: pbxTarget,
+            pbxproj: pbxproj,
+            projectSettings: .default,
+            fileElements: ProjectFileElements(),
+            graphTraverser: graphTraverser,
+            sourceRootPath: AbsolutePath("/project")
+        )
+
+        // Then
+        let configurationList = pbxTarget.buildConfigurationList
+        let debugConfig = configurationList?.configuration(name: "Debug")
+        let releaseConfig = configurationList?.configuration(name: "Release")
+
+        let expectedSettings = [
+            "TARGETED_DEVICE_FAMILY": "1,2",
+            "IPHONEOS_DEPLOYMENT_TARGET": "13.0",
+            "SUPPORTS_MACCATALYST": "NO",
+            "DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER": "NO"
+        ]
+
+        assert(config: debugConfig, contains: expectedSettings)
+        assert(config: releaseConfig, contains: expectedSettings)
+    }
 
     func test_generateTargetWithDeploymentTarget_whenMac() throws {
         // Given


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4133
Request for comments document (if applies):

### Short description 📝

After a short [discussion on slack](https://tuistapp.slack.com/archives/CCXC295QS/p1644275914684129) it was agreed then when the deployment target is explicitly specified to iOS and/or iPad, framework projects should not support the default behaviour of Xcode of including Mac Catalyst by default.

### How to test the changes locally 🧐

A unit test has been added to make sure the modifications are properly working.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
