### PR TITLE
Bundle inside a framework bug

### DIFF
--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -115,6 +115,41 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         ])
     }
 
+    func test_addElement_bundleInsideFrameworkReference() throws {
+        // Given
+        let bundle = GroupFileElement(
+            path: "/path/vendor/abc.framework/resources/abc.bundle",
+            group: .group(name: "Project"),
+            isReference: true
+        )
+        let framework = GroupFileElement(
+            path: "/path/vendor/abc.framework",
+            group: .group(name: "Project"),
+            isReference: true
+        )
+
+        // When
+        try subject.generate(
+            fileElement: bundle,
+            groups: groups,
+            pbxproj: pbxproj,
+            sourceRootPath: "/path"
+        )
+        try subject.generate(
+            fileElement: framework,
+            groups: groups,
+            pbxproj: pbxproj,
+            sourceRootPath: "/path"
+        )
+
+        // Then
+        let projectGroup = groups.sortedMain.group(named: "Project")
+        XCTAssertEqual(projectGroup?.flattenedChildren, [
+            "vendor/abc.framework/resources/abc.bundle",
+            "vendor/abc.framework",
+        ])
+    }
+
     func test_addElement_fileReference() throws {
         // Given
         let element = GroupFileElement(


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4130, https://github.com/tuist/tuist/issues/3730, https://github.com/tuist/tuist/issues/1779

### Short description 📝

Can't add a bundle which is inside a framework if we add that framework as a dependency.

### How to test the changes locally 🧐

to reproduce it please see the https://github.com/tuist/tuist/issues/4130

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
