### PR TITLE
fix: Fix template name validation in InitCommand preprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Add more detailed messaging for errors during manifest loading [#4076](https://github.com/tuist/tuist/pull/4076) by [@luispadron](https://github.com/luispadron)
 - Deprecate legacy SPM support via Project.packages [#4112](https://github.com/tuist/tuist/pull/4112) by [@danyf90](https://github.com/danyf90)
 - Improve performance of `tuist generate` when cache is used [#4146](https://github.com/tuist/tuist/pull/4146) by [@adellibovi](https://github.com/adellibovi)
+- `tuist init` now requires to provide the `--name` argument for custom templates [#4163](https://github.com/tuist/tuist/pull/4163) by [@austinate](https://github.com/austinate)
 
 ### Removed
 
@@ -118,7 +119,6 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fix warning when importing `ProjectDescription` during `tuist edit`. It was caused by `.swiftsourceinfo` files  being added to the release artifact [#4132](https://github.com/tuist/tuist/pull/4132) by [@luispadron](https://github.com/luispadron)
 - Remove default MacCatalyst support when framework deployment target is set to iOS and/or iPad [#4134](https://github.com/tuist/tuist/pull/4134) by [@TheInkedEngineer](https://github.com/TheInkedEngineer)
 - Fix loading of external dependencies in nested projects [#4157](https://github.com/tuist/tuist/pull/4157) by [@alexanderwe](https://github.com/alexanderwe)
-- Fix `tuist init` not validating missing `--name` argument for custom templates with the required template name [#4163](https://github.com/tuist/tuist/pull/4163) by [@austinate](https://github.com/austinate)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 - Fix warning when importing `ProjectDescription` during `tuist edit`. It was caused by `.swiftsourceinfo` files  being added to the release artifact [#4132](https://github.com/tuist/tuist/pull/4132) by [@luispadron](https://github.com/luispadron)
 - Remove default MacCatalyst support when framework deployment target is set to iOS and/or iPad [#4134](https://github.com/tuist/tuist/pull/4134) by [@TheInkedEngineer](https://github.com/TheInkedEngineer)
 - Fix loading of external dependencies in nested projects [#4157](https://github.com/tuist/tuist/pull/4157) by [@alexanderwe](https://github.com/alexanderwe)
+- Fix `tuist init` not validating missing `--name` argument for custom templates with the required template name [#4163](https://github.com/tuist/tuist/pull/4163) by [@austinate](https://github.com/austinate)
 
 ### Added
 

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -93,10 +93,7 @@ extension InitCommand {
 
     /// We do not know template's option in advance -> we need to dynamically add them
     static func preprocess(_ arguments: [String]? = nil) throws {
-        guard let arguments = arguments,
-              arguments.contains("--template"),
-              arguments.contains("-t")
-        else { return }
+        guard let arguments = arguments else { return }
 
         // We want to parse only the name of template, not its arguments which will be dynamically added
         // Plucking out path argument
@@ -110,9 +107,10 @@ extension InitCommand {
             }
             .flatMap { $0 }
 
+        let templatesWithoutValidation = ["default", "swiftui"]
         guard let command = try parseAsRoot(filteredArguments) as? InitCommand,
               let templateName = command.template,
-              templateName != "default"
+              !templatesWithoutValidation.contains(templateName)
         else { return }
 
         let (required, optional) = try InitService().loadTemplateOptions(


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3925

### Short description 📝

- Disables additional validation for `-t` and `--template` arguments in InitCommand's `preprocess` function
- Add's `swiftui` template to the list of templates which are excluded from InitCommand's validation to make sure this is a non-breaking change: running `tuist init -t swiftui` or `tuist init --template swiftui` works as before

**Before changes:**
_Assuming some `test` template with a required name:_
- `tuist init --template test`, result: validation passes
- `tuist init -t test`, result: validation passes

_default template:_
- `tuist init --template default`, result: validation passes
- `tuist init -t default`, result: validation passes

_swiftui template:_ 
- `tuist init --template swiftui`, result: validation passes
- `tuist init -t swiftui`, result: validation passes


### How to test the changes locally 🧐

Run following commands and validate the result:
_Assuming some `test` template with a required name:_
- `tuist init --template test`, result: Error: Missing expected argument '--name <name>'
- `tuist init -t test`, result: Error: Missing expected argument '--name <name>'

_default template:_
- `tuist init --template default`: validation passes
- `tuist init -t default` validation passes

_swiftui template:_ 
- `tuist init --template swiftui`: validation passes
- `tuist init -t swiftui` validation passes

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
