### PR TITLE
fix: dont filter out xcframeworks with static libs

### DIFF
--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -201,7 +201,7 @@ public class GraphTraverser: GraphTraversing {
         /// Precompiled frameworks
         let precompiledFrameworks = filterDependencies(
             from: .target(name: name, path: path),
-            test: isDependencyPrecompiledDynamicAndLinkable,
+            test: isDependencyPrecompiledAndLinkable,
             skip: canDependencyEmbedProducts
         )
         .lazy
@@ -408,7 +408,7 @@ public class GraphTraverser: GraphTraversing {
         let from = GraphDependency.target(name: name, path: path)
         let precompiledFramewoksPaths = filterDependencies(
             from: from,
-            test: isDependencyPrecompiledDynamicAndLinkable,
+            test: isDependencyPrecompiledAndLinkable,
             skip: canDependencyEmbedProducts
         )
         .lazy
@@ -633,10 +633,11 @@ public class GraphTraverser: GraphTraversing {
         }
     }
 
-    func isDependencyPrecompiledDynamicAndLinkable(dependency: GraphDependency) -> Bool {
+    func isDependencyPrecompiledAndLinkable(dependency: GraphDependency) -> Bool {
         switch dependency {
-        case let .xcframework(_, _, _, linking),
-             let .framework(_, _, _, _, linking, _, _),
+        case .xcframework(_, _, _, _):
+            return true
+        case let .framework(_, _, _, _, linking, _, _),
              let .library(path: _, publicHeaders: _, linking: linking, architectures: _, swiftModuleMap: _):
             return linking == .dynamic
         case .bundle: return false


### PR DESCRIPTION
Closes #3621

Resolves https://github.com/tuist/tuist/issues/3621
Request for comments document (if applies):

### Short description 📝

Please see #3621 for details.

The problem seems to be, as far as I understand it, that:
- while static libraries should not be embedded.
- xcframeworks have to be embedded, even if they contain static librararies <- this is what Tuist does wrong

> Describe here the purpose of your PR.

Fixes integration of xcframeworks which contain static libraries.

### How to test the changes locally 🧐

Problem can be reproduced when trying to integrate Firebase xcframeworks.

Created demo project https://github.com/pokryfka/tuist-demo

> Include a set of steps for the reviewer to test the changes locally.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
