### PR TITLE
fix: fix the release flow

### DIFF
--- a/projects/fourier/lib/fourier/utilities/swift_package_manager.rb
+++ b/projects/fourier/lib/fourier/utilities/swift_package_manager.rb
@@ -47,9 +47,9 @@ module Fourier
             File.join(output_directory, "#{product}.framework")
           )
 
-            FileUtils.mkdir_p(
-              File.join(output_directory, "#{product}.framework/Modules")
-            )
+          FileUtils.mkdir_p(
+            File.join(output_directory, "#{product}.framework/Modules")
+          )
           FileUtils.cp_r(
             File.join(swift_build_directory, "Release/#{product}.swiftmodule"),
             File.join(output_directory, "#{product}.framework/Modules/#{product}.swiftmodule")

--- a/projects/fourier/lib/fourier/utilities/swift_package_manager.rb
+++ b/projects/fourier/lib/fourier/utilities/swift_package_manager.rb
@@ -36,25 +36,25 @@ module Fourier
             "clean", "build"
           )
 
-          FileUtils.mkdir_p(
-            File.join(output_directory, "#{product}.framework/Modules")
-          )
-
           # NOTE: We remove the PRODUCT.swiftmodule/Project directory because
           # this directory contains objects that are not stable across Swift releases.
           # If left in here they manifest as warnings when compiling.
           FileUtils.rm_rf(
             File.join(swift_build_directory, "Release/#{product}.swiftmodule/Project")
           )
-
           FileUtils.cp_r(
             File.join(swift_build_directory, "Release/PackageFrameworks/#{product}.framework"),
             File.join(output_directory, "#{product}.framework")
           )
+
+            FileUtils.mkdir_p(
+              File.join(output_directory, "#{product}.framework/Modules")
+            )
           FileUtils.cp_r(
             File.join(swift_build_directory, "Release/#{product}.swiftmodule"),
             File.join(output_directory, "#{product}.framework/Modules/#{product}.swiftmodule")
           )
+
           FileUtils.cp_r(
             File.join(swift_build_directory, "Release/#{product}.framework.dSYM"),
             File.join(output_directory, "#{product}.framework.dSYM")


### PR DESCRIPTION
Moving the copy above was causing the framework to be structured as `ProjectDescription.framework/ProjectDescription.framework/stuff` instead of `ProjectDescription.framework/stuff`, this should fix it