### PR TITLE
fix: add missing linkable framework

### DIFF
--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -463,11 +463,13 @@ public class GraphLinter: GraphLinting {
         LintableTarget(platform: .tvOS, product: .staticLibrary): [
             LintableTarget(platform: .tvOS, product: .staticLibrary),
             LintableTarget(platform: .tvOS, product: .staticFramework),
+            LintableTarget(platform: .tvOS, product: .framework),
             LintableTarget(platform: .tvOS, product: .bundle),
         ],
         LintableTarget(platform: .tvOS, product: .staticFramework): [
             LintableTarget(platform: .tvOS, product: .staticLibrary),
             LintableTarget(platform: .tvOS, product: .staticFramework),
+            LintableTarget(platform: .tvOS, product: .framework),
             LintableTarget(platform: .tvOS, product: .bundle),
         ],
         LintableTarget(platform: .tvOS, product: .dynamicLibrary): [


### PR DESCRIPTION
Resolves #4154

### Short description 📝

add framework as valid linkable product to tvOS products

### How to test the changes locally 🧐

1. create Dependencies.swift from SPM with nested SPM dependencies that build as framework
2. add them to target
3. generate project

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
