### PR TITLE
fix: messageExtension linking to staticFramework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
+## Next
+
+### Fixed
+
+- Fix linking of staticFramework in messagesExtensions [#4211](https://github.com/tuist/tuist/pull/4211) by [paulsamuels](https://github.com/paulsamuels).
+
 ## 3.0.1 - Bravissimo
 
 ### Fixed

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -380,6 +380,7 @@ public class GraphLinter: GraphLinting {
 //            LintableTarget(platform: .iOS, product: .framework),
 //        ],
         LintableTarget(platform: .iOS, product: .messagesExtension): [
+            LintableTarget(platform: .iOS, product: .staticFramework),
             LintableTarget(platform: .iOS, product: .staticLibrary),
             LintableTarget(platform: .iOS, product: .dynamicLibrary),
             LintableTarget(platform: .iOS, product: .framework),


### PR DESCRIPTION
### Short description 📝

The linter currently fails when trying to link a staticFramework into a
messages extension. This commit makes this a valid link.

### How to test the changes locally 🧐

1) create Dependencies.swift with SPM dependency that builds as static framework e.g. `FirebaseAnalytics`
2) add to a messages extension target
3) generate project

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
