### PR TITLE
Fix ignored Workspace generation when Project exists on the same directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Fix linking of staticFramework in messagesExtensions [#4211](https://github.com/tuist/tuist/pull/4211) by [paulsamuels](https://github.com/paulsamuels).
-- Fix ignored Workspace generation when Project with the same name exist [#4236](https://github.com/tuist/tuist/pull/4236) by [adellibovi](https://github.com/adellibovi).
+- Fix ignored Workspace generation when Project exists on the same directory [#4236](https://github.com/tuist/tuist/pull/4236) by [adellibovi](https://github.com/adellibovi).
 
 ## 3.0.1 - Bravissimo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
 - Fix linking of staticFramework in messagesExtensions [#4211](https://github.com/tuist/tuist/pull/4211) by [paulsamuels](https://github.com/paulsamuels).
+- Fix ignored Workspace generation when Project with the same name exist [#4236](https://github.com/tuist/tuist/pull/4236) by [adellibovi](https://github.com/adellibovi).
 
 ## 3.0.1 - Bravissimo
 

--- a/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
+++ b/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
@@ -28,11 +28,13 @@ extension Workspace {
     public static func test(
         name: String = "Workspace",
         projects: [Path] = [],
+        schemes: [Scheme] = [],
         additionalFiles: [FileElement] = []
     ) -> Workspace {
         Workspace(
             name: name,
             projects: projects,
+            schemes: schemes,
             additionalFiles: additionalFiles
         )
     }

--- a/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
@@ -266,7 +266,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
                 ".",
             ],
             schemes: [
-                Scheme(name: "CustomWorkspaceScheme")
+                Scheme(name: "CustomWorkspaceScheme"),
             ]
         )
 

--- a/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
@@ -258,6 +258,36 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         ])
     }
 
+    func test_loadWorkspace_withSameProjectName() throws {
+        // Given
+        let workspace = Workspace.test(
+            name: "ProjectA",
+            projects: [
+                ".",
+            ]
+        )
+
+        let projectA = createProject(
+            name: "ProjectA",
+            targets: [
+                "TargetA": [],
+            ]
+        )
+
+        try stub(manifest: projectA, at: RelativePath("Some/Path"))
+        try stub(manifest: workspace, at: RelativePath("Some/Path"))
+
+        // When
+        let manifests = try subject.loadWorkspace(at: path.appending(RelativePath("Some/Path")))
+
+        // Then
+        XCTAssertEqual(manifests.path, path.appending(RelativePath("Some/Path")))
+        XCTAssertEqual(manifests.workspace, workspace)
+        XCTAssertEqual(withRelativePaths(manifests.projects), [
+            "Some/Path": projectA,
+        ])
+    }
+
     // MARK: - Helpers
 
     private func createProject(

--- a/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
@@ -261,9 +261,12 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
     func test_loadWorkspace_withSameProjectName() throws {
         // Given
         let workspace = Workspace.test(
-            name: "ProjectA",
+            name: "MyWorkspace",
             projects: [
                 ".",
+            ],
+            schemes: [
+                Scheme(name: "CustomWorkspaceScheme")
             ]
         )
 


### PR DESCRIPTION
Resolves #4206

### Short description 📝

This PR resolves a conflicts where Workspace was ignored when having a Project with the same name.

### How to test the changes locally 🧐

There is an example in #4206

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
