### PR TITLE
Fix redirecting after sign in

### DIFF
--- a/projects/cloud/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/projects/cloud/app/controllers/users/omniauth_callbacks_controller.rb
@@ -14,6 +14,10 @@ module Users
       redirect_to(root_path)
     end
 
+    def after_sign_in_path_for(resource)
+      root_path
+    end
+
     def find_or_create_and_redirect_user
       @user = UserCreateService.call(email: auth_email, skip_confirmation: true)
       if @user.persisted?

--- a/projects/cloud/app/controllers/users/registrations_controller.rb
+++ b/projects/cloud/app/controllers/users/registrations_controller.rb
@@ -6,5 +6,9 @@ module Users
       @user = UserCreateService.call(email: params[:email], password: params[:password])
       super
     end
+
+    def after_sign_in_path_for(resource)
+      root_path
+    end
   end
 end

--- a/projects/cloud/app/controllers/users/sessions_controller.rb
+++ b/projects/cloud/app/controllers/users/sessions_controller.rb
@@ -2,6 +2,10 @@
 
 module Users
   class SessionsController < Devise::SessionsController
+    def after_sign_in_path_for(resource)
+      root_path
+    end
+
     protected
       def respond_to_on_destroy
         head(:no_content)


### PR DESCRIPTION
### Short description 📝

Currently, after sign in the url stays `base_url/user/sign_in` but the user is already authenticated - leading the frontend application to assume there is an organization `user` with project `sign_in`. It understandably fails to find it.

Let's force the sessions controller to use the `root_path` instead.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
