### PR TITLE
Fetch project only if necessary for verifying upload

### DIFF
--- a/projects/cloud/app/services/cache_service.rb
+++ b/projects/cloud/app/services/cache_service.rb
@@ -59,11 +59,7 @@ class CacheService < ApplicationService
   end
 
   def verify_upload
-    project = ProjectFetchService.call(
-      name: project_name,
-      account_name: account_name,
-      user: user
-    )
+    fetch_project_if_necessary
     s3_client = s3_client(s3_bucket: project.remote_cache_storage)
     object = s3_client.get_object(
       bucket: project.remote_cache_storage.name,


### PR DESCRIPTION
### Short description 📝

Storing artifacts with a project cloud token was failing because we were not using the passed project for the `verify_upload` method.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
