### PR TITLE
Fix lint issues

### DIFF
--- a/projects/cocoapods-interactor/lib/cocoapods_interactor/utilities/output.rb
+++ b/projects/cocoapods-interactor/lib/cocoapods_interactor/utilities/output.rb
@@ -4,7 +4,7 @@ module CocoaPodsInteractor
   module Utilities
     class Output
       def self.error(message)
-        STDERR.puts(message)
+        $stderr.puts(message)
       end
     end
   end

--- a/projects/fourier/lib/fourier/services/lint/lockfiles.rb
+++ b/projects/fourier/lib/fourier/services/lint/lockfiles.rb
@@ -24,6 +24,7 @@ module Fourier
         private
           def assert_same_packages_count(spm_lockfile:, tuist_lockfile:)
             return true if spm_lockfile.count == tuist_lockfile.count
+
             message = "The number of packages in the Package.resolved files don't match."
             Utilities::Output.error(message)
             false

--- a/projects/fourier/lib/fourier/utilities/output.rb
+++ b/projects/fourier/lib/fourier/utilities/output.rb
@@ -6,23 +6,23 @@ module Fourier
   module Utilities
     class Output
       def self.section(message)
-        STDERR.puts(message.cyan.bold)
+        $stderr.puts(message.cyan.bold)
       end
 
       def self.subsection(message)
-        STDERR.puts(message.cyan)
+        $stderr.puts(message.cyan)
       end
 
       def self.error(message)
-        STDERR.puts(message.red.bold)
+        $stderr.puts(message.red.bold)
       end
 
       def self.warning(message)
-        STDOUT.puts(message.yellow.bold)
+        $stdout.puts(message.yellow.bold)
       end
 
       def self.success(message)
-        STDOUT.puts(message.green.bold)
+        $stdout.puts(message.green.bold)
       end
     end
   end


### PR DESCRIPTION
### Short description 📝

main builds were failing for quite some time due to minor lint issues in `cocoapods-interactor` and `fourier`

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The `CHANGELOG.md` has been updated to reflect the changes. In case of a breaking change, it's been flagged as such.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
