### PR TITLE
docs: mention tuist fetch on using-plugins.md

### DIFF
--- a/projects/docs/docs/plugins/using-plugins.md
+++ b/projects/docs/docs/plugins/using-plugins.md
@@ -7,7 +7,7 @@ description: Learn how to extend Tuist with plugins.
 ### Plugins
 
 Plugins are meant to be separate and isolated directories, each containing code used to extend existing Tuist functionality.
-You may use plugins that exist at a path local to your machine or at a git source URL to enable sharing and version control across multiple projects.
+You may use plugins that exist at a path local to your machine or at a git source URL to enable sharing and version control across multiple projects. They are fetched by running `tuist fetch`. If you add plugin to your project you can not generate it without fetching. 
 
 ### Adding plugins
 
@@ -62,6 +62,10 @@ PluginLocation.git(url: "https://url/to/plugin.git", sha: "e34c5ba")
 ```
 
 The [`Plugin.swift`](plugins/creating-plugins.md) manifest in a git repository should be located at the root of the repository.
+
+### Fetching plugins
+
+After plugins have been declared in `Config.swift`, you need to fetch them by running [`tuist fetch`](commands/dependencies.md#fetching). 
 
 ### Example
 

--- a/projects/docs/docs/plugins/using-plugins.md
+++ b/projects/docs/docs/plugins/using-plugins.md
@@ -63,10 +63,6 @@ PluginLocation.git(url: "https://url/to/plugin.git", sha: "e34c5ba")
 
 The [`Plugin.swift`](plugins/creating-plugins.md) manifest in a git repository should be located at the root of the repository.
 
-### Fetching plugins
-
-After plugins have been declared in `Config.swift`, you need to fetch them by running [`tuist fetch`](commands/dependencies.md#fetching). 
-
 ### Example
 
 Let's say we have a plugin called `MyTuistPlugin`. This plugin is designed to add functionality to `ProjectDescription`, in this example the plugin will add a new method to `Project` which allow us to define an application.
@@ -83,6 +79,8 @@ let config = Config(
     ]
 )
 ```
+
+After plugins have been declared in `Config.swift`, you need to fetch them by running [`tuist fetch`](commands/dependencies.md#fetching). 
 
 #### Tasks
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4276

### Short description 📝

Currently, if a user does a tuist generate without fetching plugins tuist will fail (see [#4269](https://github.com/tuist/tuist/issues/4269)).
Documentation for "Using plugins" mentions that tuist fetch is required.

### How to test the changes locally 🧐

* cd to `projects/docs/docs/plugins` folder
* open using-plugins.md
* you can see it mentions the turist fetch

