### PR TITLE
Fix importing `ViewInspector` from `Dependencies.swift`

### DIFF
--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -321,6 +321,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
                     "SnapshotTesting", // https://github.com/pointfreeco/swift-snapshot-testing
                     "TempuraTesting", // https://github.com/BendingSpoons/tempura-swift
                     "TSCTestSupport", // https://github.com/apple/swift-tools-support-core
+                    "ViewInspector", // https://github.com/nalexn/ViewInspector
                 ].map {
                     ($0, ["ENABLE_TESTING_SEARCH_PATHS": "YES"])
                 }

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -2461,7 +2461,16 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
 
     func testMap_whenTargetsWithDefaultHardcodedMapping() throws {
         let basePath = try temporaryPath()
-        let testTargets = ["Nimble", "Quick", "RxTest", "RxTest-Dynamic", "SnapshotTesting", "TempuraTesting", "TSCTestSupport"]
+        let testTargets = [
+            "Nimble",
+            "Quick",
+            "RxTest",
+            "RxTest-Dynamic",
+            "SnapshotTesting",
+            "TempuraTesting",
+            "TSCTestSupport",
+            "ViewInspector",
+        ]
         let allTargets = ["RxSwift"] + testTargets
         try allTargets
             .map { basePath.appending(RelativePath("Package/Path/Sources/\($0)")) }


### PR DESCRIPTION
Resolves [https://github.com/tuist/tuist/issues/4321](https://github.com/tuist/tuist/issues/4321)
Request for comments document (if applies):

### Short description 📝

> Describe here the purpose of your PR.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
