### PR TITLE
Fix for duplicated settings (for example, `-Xcc`) incorrectly removed

### DIFF
--- a/Sources/TuistGenerator/Extensions/Array+Extras.swift
+++ b/Sources/TuistGenerator/Extensions/Array+Extras.swift
@@ -2,4 +2,24 @@ extension Array where Element == String {
     func uniqued() -> [String] {
         Set(self).sorted { $0.compare($1, options: .caseInsensitive) == .orderedAscending }
     }
+    
+    func sortAndTrim(element: String) -> [String] {
+        guard contains(where: { $0.starts(with: element) }) else { return self }
+        // move items that contain `element` to the top of the array
+        return self.sorted { first, second in
+            first.contains(element)
+        }.enumerated().compactMap { (index, item) in
+            //Remove duplicate `element`
+            if index > 0 && item == element {
+                return nil
+            } else if index > 0 && item.contains(element) {
+                // "$(inherited) flag" -> "flag"
+                return item
+                    .replacingOccurrences(of: element, with: "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            } else {
+                return item
+            }
+        }
+    }
 }

--- a/Sources/TuistGenerator/Extensions/Array+Extras.swift
+++ b/Sources/TuistGenerator/Extensions/Array+Extras.swift
@@ -2,17 +2,19 @@ extension Array where Element == String {
     func uniqued() -> [String] {
         Set(self).sorted { $0.compare($1, options: .caseInsensitive) == .orderedAscending }
     }
-    
+
     func sortAndTrim(element: String) -> [String] {
         guard contains(where: { $0.starts(with: element) }) else { return self }
-        // move items that contain `element` to the top of the array
-        return self.sorted { first, second in
+        // Move items that contain `element` to the top of the array
+        return sorted { first, _ in
             first.contains(element)
-        }.enumerated().compactMap { (index, item) in
-            //Remove duplicate `element`
-            if index > 0 && item == element {
+        }.enumerated().compactMap { index, item in
+            // Remove duplicate `element`
+            if index > 0,
+               item == element
+            {
                 return nil
-            } else if index > 0 && item.contains(element) {
+            } else if index > 0, item.contains(element) {
                 // "$(inherited) flag" -> "flag"
                 return item
                     .replacingOccurrences(of: element, with: "")

--- a/Sources/TuistGenerator/Extensions/Array+Extras.swift
+++ b/Sources/TuistGenerator/Extensions/Array+Extras.swift
@@ -2,26 +2,4 @@ extension Array where Element == String {
     func uniqued() -> [String] {
         Set(self).sorted { $0.compare($1, options: .caseInsensitive) == .orderedAscending }
     }
-
-    func sortAndTrim(element: String) -> [String] {
-        guard contains(where: { $0.starts(with: element) }) else { return self }
-        // Move items that contain `element` to the top of the array
-        return sorted { first, _ in
-            first.contains(element)
-        }.enumerated().compactMap { index, item in
-            // Remove duplicate `element`
-            if index > 0,
-               item == element
-            {
-                return nil
-            } else if index > 0, item.contains(element) {
-                // "$(inherited) flag" -> "flag"
-                return item
-                    .replacingOccurrences(of: element, with: "")
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-            } else {
-                return item
-            }
-        }
-    }
 }

--- a/Sources/TuistGenerator/Utils/SettingsHelper.swift
+++ b/Sources/TuistGenerator/Utils/SettingsHelper.swift
@@ -85,20 +85,20 @@ final class SettingsHelper {
         case let (.string(old), .string(new)) where new.contains(inherited):
             // Example: ("OLD", "$(inherited) NEW") -> ["$(inherited) NEW", "OLD"]
             // This case shouldn't happen as all default multi-value settings are defined as NSArray<NSString>
-            return .array(sortAndTrim(array: [old, new], element: inherited))
+            return .array(Self.sortAndTrim(array: [old, new], element: inherited))
 
         case let (.string(old), .array(new)) where new.contains(inherited):
             // Example: ("OLD", ["$(inherited)", "NEW"]) -> ["$(inherited)", "NEW", "OLD"]
-            return .array(sortAndTrim(array: [old] + new, element: inherited))
+            return .array(Self.sortAndTrim(array: [old] + new, element: inherited))
 
         case let (.array(old), .string(new)) where new.contains(inherited):
             // Example: (["OLD", "OLD_2"], "$(inherited) NEW") -> ["$(inherited) NEW", "OLD", "OLD_2"]
             // This case shouldn't happen as all default multi-value settings are defined as NSArray<NSString>
-            return .array(sortAndTrim(array: old + [new], element: inherited))
+            return .array(Self.sortAndTrim(array: old + [new], element: inherited))
 
         case let (.array(old), .array(new)) where new.contains(inherited):
             // Example: (["OLD", "OLD_2"], ["$(inherited)", "NEW"]) -> ["$(inherited)", "NEW", "OLD", OLD_2"]
-            return .array(sortAndTrim(array: old + new, element: inherited))
+            return .array(Self.sortAndTrim(array: old + new, element: inherited))
 
         default:
             // The newValue does not contain $(inherited) so the oldValue should be omitted
@@ -106,7 +106,7 @@ final class SettingsHelper {
         }
     }
 
-    private func sortAndTrim(array: [String], element: String) -> [String] {
+    private static func sortAndTrim(array: [String], element: String) -> [String] {
         guard array.contains(where: { $0.starts(with: element) }) else { return array }
         // Move items that contain `element` to the top of the array
         return array

--- a/Sources/TuistGenerator/Utils/SettingsHelper.swift
+++ b/Sources/TuistGenerator/Utils/SettingsHelper.swift
@@ -75,29 +75,30 @@ final class SettingsHelper {
         // it will need to be merged with the oldValue, otherwise the oldValue will be discarded
         // and the newValue returned without merging.
         //
-        // The .uniqued() method ensures the result of merging does not contain duplicates
-        // and all the elements are sorted, i.e. merging the following values:
+        // The .sortAndTrim() method ensures the result of merging does not contain duplicate "$(inherited)" and that "$(inherited)" is the first element
+        // i.e. merging the following values:
         // oldValue = ["$(inherited)", "VALUE_1"]
         // newValue = ["$(inherited)", "VALUE_2"]
-        // would result in ["$(inherited)", "$(inherited)", "VALUE_1", "VALUE_2"] if .uniqued() was not used.
+        // would result in ["$(inherited)", "$(inherited)", "VALUE_1", "VALUE_2"] if .sortAndTrim() was not used.
+        let inherited = "$(inherited)"
         switch (oldValue, newValue) {
-        case let (.string(old), .string(new)) where new.contains("$(inherited)"):
+        case let (.string(old), .string(new)) where new.contains(inherited):
             // Example: ("OLD", "$(inherited) NEW") -> ["$(inherited) NEW", "OLD"]
             // This case shouldn't happen as all default multi-value settings are defined as NSArray<NSString>
-            return .array([old, new].uniqued())
+            return .array([old, new].sortAndTrim(element: inherited))
 
-        case let (.string(old), .array(new)) where new.contains("$(inherited)"):
+        case let (.string(old), .array(new)) where new.contains(inherited):
             // Example: ("OLD", ["$(inherited)", "NEW"]) -> ["$(inherited)", "NEW", "OLD"]
-            return .array(([old] + new).uniqued())
+            return .array(([old] + new).sortAndTrim(element: inherited))
 
-        case let (.array(old), .string(new)) where new.contains("$(inherited)"):
+        case let (.array(old), .string(new)) where new.contains(inherited):
             // Example: (["OLD", "OLD_2"], "$(inherited) NEW") -> ["$(inherited) NEW", "OLD", "OLD_2"]
             // This case shouldn't happen as all default multi-value settings are defined as NSArray<NSString>
-            return .array((old + [new]).uniqued())
+            return .array((old + [new]).sortAndTrim(element: inherited))
 
-        case let (.array(old), .array(new)) where new.contains("$(inherited)"):
+        case let (.array(old), .array(new)) where new.contains(inherited):
             // Example: (["OLD", "OLD_2"], ["$(inherited)", "NEW"]) -> ["$(inherited)", "NEW", "OLD", OLD_2"]
-            return .array((old + new).uniqued())
+            return .array((old + new).sortAndTrim(element: inherited))
 
         default:
             // The newValue does not contain $(inherited) so the oldValue should be omitted

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -524,26 +524,33 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         let result = pbxTarget.buildConfigurationList
         XCTAssertEqual(result?.defaultConfigurationName, "AnotherDebug")
     }
-    
+
     func test_generateTargetConfigWithDuplicateValues() throws {
         // Given
         let projectSettings = Settings(configurations: [
             .debug("CustomDebug"): nil,
             .debug("AnotherDebug"): nil,
         ])
-        
+
         let targetSettings = Settings.test(
-            base: ["OTHER_SWIFT_FLAGS": SettingValue.array(["$(inherited)",
-                                                            "CUSTOM_SWIFT_FLAG1"])],
-            debug: .test(settings: ["OTHER_SWIFT_FLAGS": SettingValue.array(["$(inherited)",
-                                                                             "-Xcc", "-fmodule-map-file=$(SRCROOT)/B1",
-                                                                             "-Xcc", "-fmodule-map-file=$(SRCROOT)/B2"])]),
-            release: .test())
+            base: ["OTHER_SWIFT_FLAGS": SettingValue.array([
+                "$(inherited)",
+                "CUSTOM_SWIFT_FLAG1",
+            ])],
+            debug: .test(settings: ["OTHER_SWIFT_FLAGS": SettingValue.array([
+                "$(inherited)",
+                "-Xcc",
+                "-fmodule-map-file=$(SRCROOT)/B1",
+                "-Xcc",
+                "-fmodule-map-file=$(SRCROOT)/B2",
+            ])]),
+            release: .test()
+        )
         let target = Target.test(settings: targetSettings)
         let project = Project.test()
         let graph = Graph.test(path: project.path)
         let graphTraverser = GraphTraverser(graph: graph)
-        
+
         // When
         try subject.generateTargetConfig(
             target,
@@ -555,7 +562,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             graphTraverser: graphTraverser,
             sourceRootPath: AbsolutePath("/project")
         )
-        
+
         // Then
         let targetSettingsResult = try pbxTarget
             .buildConfigurationList?
@@ -563,13 +570,15 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             .first { $0.name == "Debug" }?
             .buildSettings
             .toSettings()["OTHER_SWIFT_FLAGS"]
-        
-        XCTAssertEqual(targetSettingsResult, ["$(inherited)",
-                                              "CUSTOM_SWIFT_FLAG1",
-                                              "-Xcc",
-                                              "-fmodule-map-file=$(SRCROOT)/B1",
-                                              "-Xcc",
-                                              "-fmodule-map-file=$(SRCROOT)/B2"])
+
+        XCTAssertEqual(targetSettingsResult, [
+            "$(inherited)",
+            "CUSTOM_SWIFT_FLAG1",
+            "-Xcc",
+            "-fmodule-map-file=$(SRCROOT)/B1",
+            "-Xcc",
+            "-fmodule-map-file=$(SRCROOT)/B2",
+        ])
     }
 
     // MARK: - Helpers

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -524,6 +524,53 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         let result = pbxTarget.buildConfigurationList
         XCTAssertEqual(result?.defaultConfigurationName, "AnotherDebug")
     }
+    
+    func test_generateTargetConfigWithDuplicateValues() throws {
+        // Given
+        let projectSettings = Settings(configurations: [
+            .debug("CustomDebug"): nil,
+            .debug("AnotherDebug"): nil,
+        ])
+        
+        let targetSettings = Settings.test(
+            base: ["OTHER_SWIFT_FLAGS": SettingValue.array(["$(inherited)",
+                                                            "CUSTOM_SWIFT_FLAG1"])],
+            debug: .test(settings: ["OTHER_SWIFT_FLAGS": SettingValue.array(["$(inherited)",
+                                                                             "-Xcc", "-fmodule-map-file=$(SRCROOT)/B1",
+                                                                             "-Xcc", "-fmodule-map-file=$(SRCROOT)/B2"])]),
+            release: .test())
+        let target = Target.test(settings: targetSettings)
+        let project = Project.test()
+        let graph = Graph.test(path: project.path)
+        let graphTraverser = GraphTraverser(graph: graph)
+        
+        // When
+        try subject.generateTargetConfig(
+            target,
+            project: project,
+            pbxTarget: pbxTarget,
+            pbxproj: pbxproj,
+            projectSettings: projectSettings,
+            fileElements: ProjectFileElements(),
+            graphTraverser: graphTraverser,
+            sourceRootPath: AbsolutePath("/project")
+        )
+        
+        // Then
+        let targetSettingsResult = try pbxTarget
+            .buildConfigurationList?
+            .buildConfigurations
+            .first { $0.name == "Debug" }?
+            .buildSettings
+            .toSettings()["OTHER_SWIFT_FLAGS"]
+        
+        XCTAssertEqual(targetSettingsResult, ["$(inherited)",
+                                              "CUSTOM_SWIFT_FLAG1",
+                                              "-Xcc",
+                                              "-fmodule-map-file=$(SRCROOT)/B1",
+                                              "-Xcc",
+                                              "-fmodule-map-file=$(SRCROOT)/B2"])
+    }
 
     // MARK: - Helpers
 

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -323,9 +323,9 @@ final class LinkGeneratorTests: XCTestCase {
         let config = xcodeprojElements.config
         XCTAssertEqual(config.buildSettings["LD_RUNPATH_SEARCH_PATHS"] as? [String], [
             "$(inherited)",
+            "my/custom/path",
             "$(SRCROOT)/Dependencies/Frameworks",
             "$(SRCROOT)/Dependencies/XCFrameworks",
-            "my/custom/path",
         ])
     }
 
@@ -362,11 +362,11 @@ final class LinkGeneratorTests: XCTestCase {
         let config = xcodeprojElements.config
         XCTAssertEqual(config.buildSettings["FRAMEWORK_SEARCH_PATHS"] as? [String], [
             "$(inherited)",
+            "my/custom/path",
             "$(PLATFORM_DIR)/Developer/Library/Frameworks",
             "$(SRCROOT)/Dependencies/Frameworks",
             "$(SRCROOT)/Dependencies/Libraries",
             "$(SRCROOT)/Dependencies/XCFrameworks",
-            "my/custom/path",
         ])
     }
 
@@ -430,9 +430,9 @@ final class LinkGeneratorTests: XCTestCase {
         let config = xcodeprojElements.config
         XCTAssertEqual(config.buildSettings["HEADER_SEARCH_PATHS"] as? [String], [
             "$(inherited)",
+            "my/custom/path",
             "$(SRCROOT)/to/libraries",
             "$(SRCROOT)/to/other/libraries",
-            "my/custom/path",
         ])
     }
 

--- a/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
@@ -166,6 +166,34 @@ final class SettingsHelpersTests: XCTestCase {
         // Then
         XCTAssertEqual(settings, ["A": ["$(inherited)", "A_VALUE", "A_VALUE_2", "A_VALUE_3"]])
     }
+    
+    func testExtend_whenExistingSettingsArrayWithDuplicatesAndNewWithInheritedDeclaration() {
+        // Given
+        settings["A"] = ["$(inherited)", "A_VALUE", "B_VALUE", "A_VALUE", "C_VALUE"]
+        
+        // When
+        subject.extend(buildSettings: &settings, with: ["A": ["$(inherited)", "A_VALUE_1"]])
+        
+        // Then
+        XCTAssertEqual(settings, ["A": ["$(inherited)",
+                                        "A_VALUE",
+                                        "B_VALUE",
+                                        "A_VALUE",
+                                        "C_VALUE",
+                                        "A_VALUE_1"]])
+    }
+    
+    func testExtend_whenExistingSettingsStringWithDuplicatesAndNewWithInheritedDeclaration() {
+        // Given
+        settings["A"] = "$(inherited) A_VALUE B_VALUE A_VALUE C_VALUE"
+        
+        // When
+        subject.extend(buildSettings: &settings, with: ["A": "$(inherited) A_VALUE_1"])
+        
+        // Then
+        XCTAssertEqual(settings, ["A": ["$(inherited) A_VALUE_1",
+                                        "A_VALUE B_VALUE A_VALUE C_VALUE"]])
+    }
 
     func testSettingsProviderPlatform() {
         XCTAssertEqual(subject.settingsProviderPlatform(.test(platform: .iOS)), .iOS)

--- a/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
@@ -175,24 +175,28 @@ final class SettingsHelpersTests: XCTestCase {
         subject.extend(buildSettings: &settings, with: ["A": ["$(inherited)", "A_VALUE_1"]])
 
         // Then
-        XCTAssertEqual(settings, ["A": ["$(inherited)",
-                                        "A_VALUE",
-                                        "B_VALUE",
-                                        "A_VALUE",
-                                        "C_VALUE",
-                                        "A_VALUE_1"]])
+        XCTAssertEqual(settings, ["A": [
+            "$(inherited)",
+            "A_VALUE",
+            "B_VALUE",
+            "A_VALUE",
+            "C_VALUE",
+            "A_VALUE_1",
+        ]])
     }
 
     func testExtend_whenExistingSettingsStringWithDuplicatesAndNewWithInheritedDeclaration() {
         // Given
         settings["A"] = "$(inherited) A_VALUE B_VALUE A_VALUE C_VALUE"
-        
+
         // When
         subject.extend(buildSettings: &settings, with: ["A": "$(inherited) A_VALUE_1"])
-        
+
         // Then
-        XCTAssertEqual(settings, ["A": ["$(inherited) A_VALUE_1",
-                                        "A_VALUE B_VALUE A_VALUE C_VALUE"]])
+        XCTAssertEqual(settings, ["A": [
+            "$(inherited) A_VALUE_1",
+            "A_VALUE B_VALUE A_VALUE C_VALUE",
+        ]])
     }
 
     func testSettingsProviderPlatform() {

--- a/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
+++ b/Tests/TuistGeneratorTests/Utils/SettingsHelperTests.swift
@@ -166,14 +166,14 @@ final class SettingsHelpersTests: XCTestCase {
         // Then
         XCTAssertEqual(settings, ["A": ["$(inherited)", "A_VALUE", "A_VALUE_2", "A_VALUE_3"]])
     }
-    
+
     func testExtend_whenExistingSettingsArrayWithDuplicatesAndNewWithInheritedDeclaration() {
         // Given
         settings["A"] = ["$(inherited)", "A_VALUE", "B_VALUE", "A_VALUE", "C_VALUE"]
-        
+
         // When
         subject.extend(buildSettings: &settings, with: ["A": ["$(inherited)", "A_VALUE_1"]])
-        
+
         // Then
         XCTAssertEqual(settings, ["A": ["$(inherited)",
                                         "A_VALUE",
@@ -182,7 +182,7 @@ final class SettingsHelpersTests: XCTestCase {
                                         "C_VALUE",
                                         "A_VALUE_1"]])
     }
-    
+
     func testExtend_whenExistingSettingsStringWithDuplicatesAndNewWithInheritedDeclaration() {
         // Given
         settings["A"] = "$(inherited) A_VALUE B_VALUE A_VALUE C_VALUE"


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4315
Request for comments document (if applies):

### Short description 📝

Fix merging of settings when settings require duplicate flags with preserved order.

With limited codebase experience, this is something to get the conversation started and maybe find an even better solution.

### How to test the changes locally 🧐

https://github.com/tuist/tuist/issues/4315 has a unit test that describes the issue

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
