### PR TITLE
Version verification before runVersion(_)

### DIFF
--- a/Sources/TuistEnvKit/Commands/CommandRunner.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRunner.swift
@@ -1,6 +1,6 @@
 import Foundation
 import TSCBasic
-import struct TSCUtility.Version
+import TSCUtility
 import TuistSupport
 
 protocol CommandRunning: AnyObject {

--- a/Sources/TuistEnvKit/Commands/CommandRunner.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRunner.swift
@@ -105,6 +105,7 @@ class CommandRunner: CommandRunning {
         guard Version(string: version) != nil else {
             logger.error("\(version) is not a valid version")
             exiter(1)
+            return
         }
 
         if !versionsController.versions().contains(where: { $0.description == version }) {

--- a/Sources/TuistEnvKit/Commands/CommandRunner.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRunner.swift
@@ -101,7 +101,7 @@ class CommandRunner: CommandRunning {
     }
 
     func runVersion(_ version: String) throws {
-        guard Version(version) != nil else {
+        guard Version(string: version) != nil else {
             logger.error("\(version) is not a valid version")
             exiter(1)
         }

--- a/Sources/TuistEnvKit/Commands/CommandRunner.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRunner.swift
@@ -101,6 +101,8 @@ class CommandRunner: CommandRunning {
     }
 
     func runVersion(_ version: String) throws {
+        _ = Version(stringLiteral: version)
+
         if !versionsController.versions().contains(where: { $0.description == version }) {
             logger.notice("Version \(version) not found locally. Installing...")
             try installer.install(version: version)

--- a/Sources/TuistEnvKit/Commands/CommandRunner.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRunner.swift
@@ -101,7 +101,10 @@ class CommandRunner: CommandRunning {
     }
 
     func runVersion(_ version: String) throws {
-        _ = Version(stringLiteral: version)
+        guard Version(string: version) != nil else {
+            logger.error("\(version) is not a valid version")
+            exiter(1)
+        }
 
         if !versionsController.versions().contains(where: { $0.description == version }) {
             logger.notice("Version \(version) not found locally. Installing...")

--- a/Sources/TuistEnvKit/Commands/CommandRunner.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRunner.swift
@@ -1,5 +1,6 @@
 import Foundation
 import TSCBasic
+import struct TSCUtility.Version
 import TuistSupport
 
 protocol CommandRunning: AnyObject {

--- a/Sources/TuistEnvKit/Commands/CommandRunner.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRunner.swift
@@ -101,7 +101,7 @@ class CommandRunner: CommandRunning {
     }
 
     func runVersion(_ version: String) throws {
-        guard Version(string: version) != nil else {
+        guard Version(version) != nil else {
             logger.error("\(version) is not a valid version")
             exiter(1)
         }


### PR DESCRIPTION
### Short description 📝

> Version verification before runVersion(_)

### How to test the changes locally 🧐

> 1. Put not vaild version in `.tuist-version`
> 2. Generate project
> 3. It will be occurs fatalError with "\(notVaildVersion) is not a valid version" message

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.