### PR TITLE
Fix missing source files when file extension is not lowercase

### DIFF
--- a/Sources/TuistCore/Graph/ModelExtensions/Target+Core.swift
+++ b/Sources/TuistCore/Graph/ModelExtensions/Target+Core.swift
@@ -78,7 +78,7 @@ extension Target {
             Set(paths)
                 .subtracting(excluded)
                 .filter { path in
-                    if let `extension` = path.extension, Target.validSourceExtensions.contains(`extension`) {
+                    if let `extension` = path.extension, Target.validSourceExtensions.contains(where: { $0.caseInsensitiveCompare(`extension`) == .orderedSame }) {
                         return true
                     }
                     return false

--- a/Sources/TuistCore/Graph/ModelExtensions/Target+Core.swift
+++ b/Sources/TuistCore/Graph/ModelExtensions/Target+Core.swift
@@ -78,10 +78,9 @@ extension Target {
             Set(paths)
                 .subtracting(excluded)
                 .filter { path in
-                    if let `extension` = path.extension, Target.validSourceExtensions.contains(where: { $0.caseInsensitiveCompare(`extension`) == .orderedSame }) {
-                        return true
-                    }
-                    return false
+                    guard let `extension` = path.extension else { return false }
+                    return Target.validSourceExtensions
+                        .contains(where: { $0.caseInsensitiveCompare(`extension`) == .orderedSame })
                 }
                 .forEach { sourceFiles[$0] = SourceFile(path: $0, compilerFlags: source.compilerFlags, codeGen: source.codeGen) }
         }

--- a/Tests/TuistGraphTests/Models/TargetTests.swift
+++ b/Tests/TuistGraphTests/Models/TargetTests.swift
@@ -114,6 +114,7 @@ final class TargetTests: TuistUnitTestCase {
             "sources/d.c",
             "sources/e.cpp",
             "sources/f.s",
+            "sources/g.S",
             "sources/k.kt",
             "sources/n.metal",
         ])
@@ -141,6 +142,7 @@ final class TargetTests: TuistUnitTestCase {
             "sources/c.mm",
             "sources/d.c",
             "sources/f.s",
+            "sources/g.S",
             "sources/e.cpp",
             "sources/n.metal",
         ]))


### PR DESCRIPTION
Resolves #4341 
Resolves #3371

### Short description 📝

This PR will switch to `caseInsensitiveCompare` when comparing the extensions of source files with the [`Target.validSourceExtensions`](https://github.com/tuist/tuist/blob/c5ace8fba137e38975c1ddf7384b87a01ac6d598/Sources/TuistGraph/Models/Target.swift#L9-L12).

Discussion on Slack: https://tuistapp.slack.com/archives/C018QG7U7SN/p1649262979568319?thread_ts=1649254949.140979&cid=C018QG7U7SN

### How to test the changes locally 🧐

Same steps as in #4341, but with the modifications of this PR applied before running `tuist fetch`.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
