### PR TITLE
Fix zipping and unzipping cached frameworks with symlinks

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -237,11 +237,11 @@
       },
       {
         "package": "ZIPFoundation",
-        "repositoryURL": "https://github.com/weichsel/ZIPFoundation.git",
+        "repositoryURL": "https://github.com/fortmarek/ZIPFoundation.git",
         "state": {
           "branch": null,
-          "revision": "7254c74b49cec2cb81520523ba993c671f71b066",
-          "version": "0.9.14"
+          "revision": "9dbe729b90202c19d0fe1010f1430fa75a576cd3",
+          "version": null
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -236,12 +236,12 @@
         }
       },
       {
-        "package": "Zip",
-        "repositoryURL": "https://github.com/marmelroy/Zip.git",
+        "package": "ZIPFoundation",
+        "repositoryURL": "https://github.com/weichsel/ZIPFoundation.git",
         "state": {
           "branch": null,
-          "revision": "bd19d974e8a38cc8d3a88c90c8a107386c3b8ccf",
-          "version": "2.1.1"
+          "revision": "7254c74b49cec2cb81520523ba993c671f71b066",
+          "version": "0.9.14"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -58,7 +58,7 @@ let package = Package(
         ),
         .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.2.5")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/weichsel/ZIPFoundation.git", .upToNextMajor(from: "0.9.0")),
+        .package(url: "https://github.com/fortmarek/ZIPFoundation.git", .revision("9dbe729b90202c19d0fe1010f1430fa75a576cd3")),
         .package(url: "https://github.com/tuist/GraphViz.git", .branch("tuist")),
         .package(url: "https://github.com/SwiftGen/SwiftGen", .exact("6.5.0")),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .upToNextMajor(from: "2.8.0")),

--- a/Package.swift
+++ b/Package.swift
@@ -58,7 +58,7 @@ let package = Package(
         ),
         .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.2.5")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/marmelroy/Zip.git", .upToNextMajor(from: "2.1.1")),
+        .package(url: "https://github.com/weichsel/ZIPFoundation.git", .upToNextMajor(from: "0.9.0")),
         .package(url: "https://github.com/tuist/GraphViz.git", .branch("tuist")),
         .package(url: "https://github.com/SwiftGen/SwiftGen", .exact("6.5.0")),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .upToNextMajor(from: "2.8.0")),
@@ -220,7 +220,7 @@ let package = Package(
                 loggingDependency,
                 "KeychainAccess",
                 swifterDependency,
-                "Zip",
+                "ZIPFoundation",
                 "Checksum",
                 "ProjectDescription",
             ]

--- a/Project.swift
+++ b/Project.swift
@@ -63,7 +63,7 @@ func targets() -> [Target] {
                     .external(name: "Swifter"),
                     .external(name: "SwiftToolsSupport-auto"),
                     .external(name: "XcodeProj"),
-                    .external(name: "Zip"),
+                    .external(name: "ZIPFoundation"),
                     .target(name: "ProjectDescription"),
                 ],
                 testingDependencies: [

--- a/Sources/TuistCache/Cache/CacheRemoteStorage.swift
+++ b/Sources/TuistCache/Cache/CacheRemoteStorage.swift
@@ -79,7 +79,6 @@ public final class CacheRemoteStorage: CacheStoring {
     }
 
     public func fetch(name: String, hash: String) async throws -> AbsolutePath {
-        print("Changing something in this framework to make the cache dirty")
         let resource = try cloudCacheResourceFactory.fetchResource(name: name, hash: hash)
         let url = try await cloudClient.request(resource).object.data.url
 

--- a/Sources/TuistCache/Cache/CacheRemoteStorage.swift
+++ b/Sources/TuistCache/Cache/CacheRemoteStorage.swift
@@ -90,14 +90,8 @@ public final class CacheRemoteStorage: CacheStoring {
 
     public func store(name: String, hash: String, paths: [AbsolutePath]) async throws {
         let archiver = try fileArchiverFactory.makeFileArchiver(for: paths)
-        var temporaryDirectoryToDelete: AbsolutePath?
         do {
-            let (destinationZipPath, temporaryDirectory) = try FileHandler.shared.inTemporaryDirectory(removeOnCompletion: false) { temporaryDirectory -> (AbsolutePath, AbsolutePath) in
-                let destinationZipPath = temporaryDirectory.appending(component: "\(name).zip")
-                try System.shared.run(["zip", "--symlinks", "-r", destinationZipPath.pathString] + paths.map(\.pathString))
-                return (destinationZipPath, temporaryDirectory)
-            }
-            temporaryDirectoryToDelete = temporaryDirectory
+            let destinationZipPath = try archiver.zip(name: hash)
             let md5 = try FileHandler.shared.urlSafeBase64MD5(path: destinationZipPath)
             let storeResource = try cloudCacheResourceFactory.storeResource(
                 name: name,
@@ -117,7 +111,6 @@ public final class CacheRemoteStorage: CacheStoring {
 
             _ = try await cloudClient.request(verifyUploadResource)
         } catch {
-            try temporaryDirectoryToDelete.map(FileHandler.shared.delete)
             try archiver.delete()
             throw error
         }

--- a/Sources/TuistCache/Cache/CacheRemoteStorage.swift
+++ b/Sources/TuistCache/Cache/CacheRemoteStorage.swift
@@ -79,6 +79,7 @@ public final class CacheRemoteStorage: CacheStoring {
     }
 
     public func fetch(name: String, hash: String) async throws -> AbsolutePath {
+        print("Changing something in this framework to make the cache dirty")
         let resource = try cloudCacheResourceFactory.fetchResource(name: name, hash: hash)
         let url = try await cloudClient.request(resource).object.data.url
 

--- a/Sources/TuistSupport/Utils/FileArchiver.swift
+++ b/Sources/TuistSupport/Utils/FileArchiver.swift
@@ -27,13 +27,13 @@ public class FileArchiver: FileArchiving {
 
     public func zip(name: String) throws -> AbsolutePath {
         let destinationZipPath = temporaryDirectory.appending(component: "\(name).zip")
-        // ZIPFoundation does not support zipping array of items, we instead copy them all to a single directory
-        let pathsPath = temporaryDirectory.appending(component: "\(name)-paths")
-        try FileHandler.shared.createFolder(pathsPath)
+        /// ZIPFoundation does not support zipping array of items, we instead copy them all to a single directory
+        let pathsDirectoryPath = temporaryDirectory.appending(component: "\(name)-paths")
+        try FileHandler.shared.createFolder(pathsDirectoryPath)
         try paths.forEach {
-            try FileHandler.shared.copy(from: $0, to: pathsPath.appending(component: $0.basename))
+            try FileHandler.shared.copy(from: $0, to: pathsDirectoryPath.appending(component: $0.basename))
         }
-        try FileHandler.shared.zipItem(at: pathsPath, to: destinationZipPath)
+        try FileHandler.shared.zipItem(at: pathsDirectoryPath, to: destinationZipPath)
         return destinationZipPath
     }
 

--- a/Sources/TuistSupport/Utils/FileArchiver.swift
+++ b/Sources/TuistSupport/Utils/FileArchiver.swift
@@ -28,7 +28,7 @@ public class FileArchiver: FileArchiving {
 
     public func zip(name: String) throws -> AbsolutePath {
         let destinationZipPath = temporaryDirectory.appending(component: "\(name).zip")
-        try Zip.zipFiles(paths: paths.map(\.url), zipFilePath: destinationZipPath.url, password: nil, progress: nil)
+        try System.shared.run(["zip", "--symlinks", "-r", destinationZipPath.pathString] + paths.map(\.pathString))
         return destinationZipPath
     }
 

--- a/Sources/TuistSupport/Utils/FileArchiver.swift
+++ b/Sources/TuistSupport/Utils/FileArchiver.swift
@@ -26,7 +26,6 @@ public class FileArchiver: FileArchiving {
     }
 
     public func zip(name: String) throws -> AbsolutePath {
-        print("Dirty cache")
         let destinationZipPath = temporaryDirectory.appending(component: "\(name).zip")
         // ZIPFoundation does not support zipping array of items, we instead copy them all to a single directory
         let pathsPath = temporaryDirectory.appending(component: "\(name)-paths")

--- a/Sources/TuistSupport/Utils/FileArchiver.swift
+++ b/Sources/TuistSupport/Utils/FileArchiver.swift
@@ -26,6 +26,7 @@ public class FileArchiver: FileArchiving {
     }
 
     public func zip(name: String) throws -> AbsolutePath {
+        print("Dirty cache")
         let destinationZipPath = temporaryDirectory.appending(component: "\(name).zip")
         // ZIPFoundation does not support zipping array of items, we instead copy them all to a single directory
         let pathsPath = temporaryDirectory.appending(component: "\(name)-paths")

--- a/Sources/TuistSupport/Utils/FileHandler.swift
+++ b/Sources/TuistSupport/Utils/FileHandler.swift
@@ -1,6 +1,7 @@
 import CryptoKit
 import Foundation
 import TSCBasic
+import ZIPFoundation
 
 public enum FileHandlerError: FatalError, Equatable {
     case invalidTextEncoding(AbsolutePath)
@@ -75,6 +76,8 @@ public protocol FileHandling: AnyObject {
     func resolveSymlinks(_ path: AbsolutePath) -> AbsolutePath
     func fileAttributes(at path: AbsolutePath) throws -> [FileAttributeKey: Any]
     func filesAndDirectoriesContained(in path: AbsolutePath) -> [AbsolutePath]?
+    func zipItem(at sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws
+    func unzipItem(at sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws
 }
 
 public class FileHandler: FileHandling {
@@ -318,5 +321,13 @@ public class FileHandler: FileHandling {
         let newPath = path.removingLastComponent().appending(component: "\(path.basenameWithoutExt).\(sanitizedExtension)")
         try move(from: path, to: newPath)
         return newPath
+    }
+
+    public func zipItem(at sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
+        try fileManager.zipItem(at: sourcePath.asURL, to: destinationPath.asURL, shouldKeepParent: false)
+    }
+
+    public func unzipItem(at sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
+        try fileManager.unzipItem(at: sourcePath.asURL, to: destinationPath.asURL)
     }
 }

--- a/Sources/TuistSupport/Utils/FileUnarchiver.swift
+++ b/Sources/TuistSupport/Utils/FileUnarchiver.swift
@@ -1,6 +1,5 @@
 import Foundation
 import TSCBasic
-import Zip
 
 /// An interface to unarchive files from a zip file.
 public protocol FileUnarchiving {
@@ -26,7 +25,7 @@ public class FileUnarchiver: FileUnarchiving {
     }
 
     public func unzip() throws -> AbsolutePath {
-        try Zip.unzipFile(path.url, destination: temporaryDirectory.url, overwrite: true, password: nil)
+        try FileHandler.shared.unzipItem(at: path, to: temporaryDirectory)
         return temporaryDirectory
     }
 

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
@@ -438,6 +438,10 @@ final class WorkspaceStructureGeneratorTests: XCTestCase {
         func changeExtension(path: AbsolutePath, to newExtension: String) throws -> AbsolutePath {
             path.removingLastComponent().appending(component: "\(path.basenameWithoutExt).\(newExtension)")
         }
+
+        func zipItem(at _: AbsolutePath, to _: AbsolutePath) throws {}
+
+        func unzipItem(at _: AbsolutePath, to _: AbsolutePath) throws {}
     }
 }
 

--- a/Tuist/Config.swift
+++ b/Tuist/Config.swift
@@ -1,5 +1,5 @@
 import ProjectDescription
 
 let config = Config(
-    // cloud: .cloud(projectId: "tuist/tuist", url: "https://cloud.tuist.io", options: [.optional])
+    cloud: .cloud(projectId: "tuist/tuist", url: "https://cloud.tuist.io", options: [.optional])
 )

--- a/Tuist/Config.swift
+++ b/Tuist/Config.swift
@@ -1,5 +1,5 @@
 import ProjectDescription
 
 let config = Config(
-    cloud: .cloud(projectId: "tuist/tuist", url: "https://cloud.tuist.io", options: [.optional])
+    cloud: .cloud(projectId: "tuist/tuist", url: "https://cloud.tuist.io", options: [.optional, .analytics])
 )

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -9,7 +9,10 @@ let dependencies = Dependencies(
             .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.2")),
             .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", .upToNextMajor(from: "4.2.2")),
             .package(url: "https://github.com/httpswift/swifter.git", .revision("1e4f51c92d7ca486242d8bf0722b99de2c3531aa")),
-            .package(url: "https://github.com/fortmarek/ZIPFoundation.git", .revision("9dbe729b90202c19d0fe1010f1430fa75a576cd3")),
+            .package(
+                url: "https://github.com/fortmarek/ZIPFoundation.git",
+                .revision("9dbe729b90202c19d0fe1010f1430fa75a576cd3")
+            ),
             .package(url: "https://github.com/rnine/Checksum.git", .upToNextMajor(from: "1.0.2")),
             .package(url: "https://github.com/stencilproject/Stencil.git", .upToNextMajor(from: "0.14.1")),
             .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .upToNextMajor(from: "2.8.0")),

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -9,7 +9,7 @@ let dependencies = Dependencies(
             .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.2")),
             .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", .upToNextMajor(from: "4.2.2")),
             .package(url: "https://github.com/httpswift/swifter.git", .revision("1e4f51c92d7ca486242d8bf0722b99de2c3531aa")),
-            .package(url: "https://github.com/marmelroy/Zip.git", .upToNextMajor(from: "2.1.1")),
+            .package(url: "https://github.com/weichsel/ZIPFoundation.git", .upToNextMajor(from: "0.9.14")),
             .package(url: "https://github.com/rnine/Checksum.git", .upToNextMajor(from: "1.0.2")),
             .package(url: "https://github.com/stencilproject/Stencil.git", .upToNextMajor(from: "0.14.1")),
             .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .upToNextMajor(from: "2.8.0")),

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -9,7 +9,7 @@ let dependencies = Dependencies(
             .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.2")),
             .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", .upToNextMajor(from: "4.2.2")),
             .package(url: "https://github.com/httpswift/swifter.git", .revision("1e4f51c92d7ca486242d8bf0722b99de2c3531aa")),
-            .package(url: "https://github.com/weichsel/ZIPFoundation.git", .upToNextMajor(from: "0.9.14")),
+            .package(url: "https://github.com/fortmarek/ZIPFoundation.git", .revision("9dbe729b90202c19d0fe1010f1430fa75a576cd3")),
             .package(url: "https://github.com/rnine/Checksum.git", .upToNextMajor(from: "1.0.2")),
             .package(url: "https://github.com/stencilproject/Stencil.git", .upToNextMajor(from: "0.14.1")),
             .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .upToNextMajor(from: "2.8.0")),

--- a/Tuist/Dependencies/Lockfiles/Package.resolved
+++ b/Tuist/Dependencies/Lockfiles/Package.resolved
@@ -237,11 +237,11 @@
       },
       {
         "package": "ZIPFoundation",
-        "repositoryURL": "https://github.com/weichsel/ZIPFoundation.git",
+        "repositoryURL": "https://github.com/fortmarek/ZIPFoundation.git",
         "state": {
           "branch": null,
-          "revision": "7254c74b49cec2cb81520523ba993c671f71b066",
-          "version": "0.9.14"
+          "revision": "9dbe729b90202c19d0fe1010f1430fa75a576cd3",
+          "version": null
         }
       }
     ]

--- a/Tuist/Dependencies/Lockfiles/Package.resolved
+++ b/Tuist/Dependencies/Lockfiles/Package.resolved
@@ -236,12 +236,12 @@
         }
       },
       {
-        "package": "Zip",
-        "repositoryURL": "https://github.com/marmelroy/Zip.git",
+        "package": "ZIPFoundation",
+        "repositoryURL": "https://github.com/weichsel/ZIPFoundation.git",
         "state": {
           "branch": null,
-          "revision": "bd19d974e8a38cc8d3a88c90c8a107386c3b8ccf",
-          "version": "2.1.1"
+          "revision": "7254c74b49cec2cb81520523ba993c671f71b066",
+          "version": "0.9.14"
         }
       }
     ]

--- a/projects/fourier/lib/fourier/services/generate/tuist.rb
+++ b/projects/fourier/lib/fourier/services/generate/tuist.rb
@@ -16,10 +16,10 @@ module Fourier
           fetch = ["fetch"]
           Utilities::System.tuist(*fetch)
 
-          cache_warm = ["cache", "warm", "--dependencies-only"] + targets
+          cache_warm = ["cache", "warm", "--dependencies-only", "--xcframeworks"] + targets
           Utilities::System.tuist(*cache_warm)
 
-          generate = ["generate"] + targets
+          generate = ["generate", "--xcframeworks"] + targets
           generate << "--no-open" if no_open
           Utilities::System.tuist(*generate)
         end

--- a/projects/fourier/test/fourier/services/generate/tuist_test.rb
+++ b/projects/fourier/test/fourier/services/generate/tuist_test.rb
@@ -9,7 +9,8 @@ module Fourier
         def test_calls_tuist_with_the_right_arguments
           # Given
           Utilities::System.expects(:tuist).with("fetch")
-          Utilities::System.expects(:tuist).with("cache", "warm", "--dependencies-only", "--xcframeworks", "Target1", "Target2")
+          Utilities::System.expects(:tuist).with("cache", "warm", "--dependencies-only", "--xcframeworks", "Target1",
+            "Target2")
           Utilities::System.expects(:tuist).with("generate", "--xcframeworks", "Target1", "Target2")
 
           # When/Then
@@ -20,7 +21,8 @@ module Fourier
         def test_calls_tuist_with_the_right_arguments_when_no_open_is_true
           # Given
           Utilities::System.expects(:tuist).with("fetch")
-          Utilities::System.expects(:tuist).with("cache", "warm", "--dependencies-only", "--xcframeworks", "Target1", "Target2")
+          Utilities::System.expects(:tuist).with("cache", "warm", "--dependencies-only", "--xcframeworks", "Target1",
+            "Target2")
           Utilities::System.expects(:tuist).with("generate", "--xcframeworks", "Target1", "Target2", "--no-open")
 
           # When/Then

--- a/projects/fourier/test/fourier/services/generate/tuist_test.rb
+++ b/projects/fourier/test/fourier/services/generate/tuist_test.rb
@@ -9,8 +9,8 @@ module Fourier
         def test_calls_tuist_with_the_right_arguments
           # Given
           Utilities::System.expects(:tuist).with("fetch")
-          Utilities::System.expects(:tuist).with("cache", "warm", "--dependencies-only", "Target1", "Target2")
-          Utilities::System.expects(:tuist).with("generate", "Target1", "Target2")
+          Utilities::System.expects(:tuist).with("cache", "warm", "--dependencies-only", "--xcframeworks", "Target1", "Target2")
+          Utilities::System.expects(:tuist).with("generate", "--xcframeworks", "Target1", "Target2")
 
           # When/Then
           Fourier::Services::Generate::Tuist.call(no_open: false, targets: ["Target1", "Target2"])
@@ -20,8 +20,8 @@ module Fourier
         def test_calls_tuist_with_the_right_arguments_when_no_open_is_true
           # Given
           Utilities::System.expects(:tuist).with("fetch")
-          Utilities::System.expects(:tuist).with("cache", "warm", "--dependencies-only", "Target1", "Target2")
-          Utilities::System.expects(:tuist).with("generate", "Target1", "Target2", "--no-open")
+          Utilities::System.expects(:tuist).with("cache", "warm", "--dependencies-only", "--xcframeworks", "Target1", "Target2")
+          Utilities::System.expects(:tuist).with("generate", "--xcframeworks", "Target1", "Target2", "--no-open")
 
           # When/Then
           Fourier::Services::Generate::Tuist.call(no_open: true, targets: ["Target1", "Target2"])


### PR DESCRIPTION
### Short description 📝

This PR contains two things:
- turning on the cloud in `Config.swift`
- fixing the issue of using mac frameworks which were missing symlink -> that then resulted into `Module not found` errors

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
