### PR TITLE
fix: fix for SPM single resource files not excluded correctly

### DIFF
--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -591,7 +591,11 @@ extension SourceFilesList {
 }
 
 extension ResourceFileElements {
-    fileprivate static func from(resources: [PackageInfo.Target.Resource], path: AbsolutePath, excluding: [String]) -> Self? {
+    fileprivate static func from(
+        resources: [PackageInfo.Target.Resource],
+        path: AbsolutePath,
+        excluding: [String]
+    ) -> Self? {
         let resourcesPaths = resources.map { path.appending(RelativePath($0.path)) }
         guard !resourcesPaths.isEmpty else { return nil }
 

--- a/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
@@ -17,8 +17,6 @@ extension TuistGraph.ResourceFileElement {
         includeFiles: @escaping (AbsolutePath) -> Bool = { _ in true }
     ) throws -> [TuistGraph.ResourceFileElement] {
         func globFiles(_ path: AbsolutePath, excluding: [String]) throws -> [AbsolutePath] {
-            if FileHandler.shared.exists(path), !FileHandler.shared.isFolder(path) { return [path] }
-
             var excluded: Set<AbsolutePath> = []
             excluding.forEach { path in
                 let absolute = AbsolutePath(path)

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -1388,7 +1388,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         XCTAssertTrue(got.isEmpty)
     }
 
-    func test_embeddableDependencies_whenHostedTestTarget_transitiveDepndencies() throws {
+    func test_embeddableDependencies_whenHostedTestTarget_transitiveDependencies() throws {
         // Given
         let framework = Target.test(
             name: "Framework",
@@ -1439,7 +1439,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         XCTAssertTrue(got.isEmpty)
     }
 
-    func test_embeddableDependencies_whenUITest_andAppPrecompiledDepndencies() throws {
+    func test_embeddableDependencies_whenUITest_andAppPrecompiledDependencies() throws {
         // Given
         let app = Target.test(name: "App", product: .app)
         let uiTests = Target.test(name: "AppUITests", product: .uiTests)

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -632,11 +632,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                 .init(rule: .copy, path: "Resource/Folder"),
                                 .init(rule: .process, path: "Another/Resource/Folder"),
                                 .init(rule: .process, path: "AnotherOne/Resource/Folder"),
-                                .init(rule: .process, path: "YetAnotherOne/Info.plist"),
                             ],
                             exclude: [
                                 "AnotherOne/Resource",
-                                "YetAnotherOne/Info.plist",
                             ]
                         ),
                     ],

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -632,9 +632,11 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                 .init(rule: .copy, path: "Resource/Folder"),
                                 .init(rule: .process, path: "Another/Resource/Folder"),
                                 .init(rule: .process, path: "AnotherOne/Resource/Folder"),
+                                .init(rule: .process, path: "YetAnotherOne/Info.plist"),
                             ],
                             exclude: [
                                 "AnotherOne/Resource",
+                                "YetAnotherOne/Info.plist",
                             ]
                         ),
                     ],
@@ -2427,7 +2429,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         )
     }
 
-    func testMap_whenDepndenciesContainsCustomConfiguration_mapsToProjectWithCustomConfig() throws {
+    func testMap_whenDependenciesContainsCustomConfiguration_mapsToProjectWithCustomConfig() throws {
         let basePath = try temporaryPath()
         let sourcesPath = basePath.appending(RelativePath("Package/Path/Sources/Target1"))
         try fileHandler.createFolder(sourcesPath)

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceFileElementManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceFileElementManifestMapperTests.swift
@@ -86,7 +86,7 @@ final class ResourceFileElementManifestMapperTests: TuistUnitTestCase {
         )
     }
 
-    func test_excluding() throws {
+    func test_excluding_file() throws {
         // Given
         let temporaryPath = try temporaryPath()
         let generatorPaths = GeneratorPaths(manifestDirectory: temporaryPath)
@@ -148,6 +148,22 @@ final class ResourceFileElementManifestMapperTests: TuistUnitTestCase {
                 .file(path: resourcesFolder, tags: []),
                 .file(path: includedResource, tags: []),
             ]
+        )
+    }
+
+    func test_excluding_when_pattern_is_file() throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let generatorPaths = GeneratorPaths(manifestDirectory: temporaryPath)
+        let resourcesFolder = temporaryPath.appending(component: "Resources")
+        try fileHandler.createFolder(resourcesFolder)
+        try fileHandler.write("", path: resourcesFolder.appending(component: "excluded.xib"), atomically: true)
+        let manifest = ProjectDescription.ResourceFileElement.glob(pattern: "Resources/excluded.xib", excluding: ["Resources/excluded.xib"])
+
+        // Then
+        XCTAssertEqual(
+            try TuistGraph.ResourceFileElement.from(manifest: manifest, generatorPaths: generatorPaths),
+            []
         )
     }
 }

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceFileElementManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceFileElementManifestMapperTests.swift
@@ -158,7 +158,10 @@ final class ResourceFileElementManifestMapperTests: TuistUnitTestCase {
         let resourcesFolder = temporaryPath.appending(component: "Resources")
         try fileHandler.createFolder(resourcesFolder)
         try fileHandler.write("", path: resourcesFolder.appending(component: "excluded.xib"), atomically: true)
-        let manifest = ProjectDescription.ResourceFileElement.glob(pattern: "Resources/excluded.xib", excluding: ["Resources/excluded.xib"])
+        let manifest = ProjectDescription.ResourceFileElement.glob(
+            pattern: "Resources/excluded.xib",
+            excluding: ["Resources/excluded.xib"]
+        )
 
         // Then
         XCTAssertEqual(


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3597

### Short description 📝

Resource filtering was not working if the pattern is a single file

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
