### PR TITLE
Defer the display of warnings untill after project generation

### DIFF
--- a/Sources/TuistCore/Models/LintingIssue.swift
+++ b/Sources/TuistCore/Models/LintingIssue.swift
@@ -36,20 +36,26 @@ public struct LintingIssue: CustomStringConvertible, Equatable {
 // MARK: - Array Extension (Linting issues)
 
 extension Array where Element == LintingIssue {
-    public func printAndThrowIfNeeded() throws {
+    public func printAndThrowErrorsIfNeeded() throws {
         if count == 0 { return }
 
         let errorIssues = filter { $0.severity == .error }
-        let warningIssues = filter { $0.severity == .warning }
-
-        for issue in warningIssues {
-            logger.warning("\(issue.description)")
-        }
 
         for issue in errorIssues {
             logger.error("\(issue.description)")
         }
 
         if !errorIssues.isEmpty { throw LintingError() }
+    }
+
+    public func printWarningsIfNeeded() {
+        if count == 0 { return }
+
+        let warningIssues = filter { $0.severity == .warning }
+        logger.warning("")
+        for issue in warningIssues {
+            logger.warning("Warning: \(issue.description)")
+        }
+        logger.warning("")
     }
 }

--- a/Sources/TuistKit/Services/GraphService.swift
+++ b/Sources/TuistKit/Services/GraphService.swift
@@ -46,7 +46,7 @@ final class GraphService {
         path: AbsolutePath,
         outputPath: AbsolutePath
     ) async throws {
-        let (graph, _) = try await manifestGraphLoader.load(path: path)
+        let (graph, _, _) = try await manifestGraphLoader.load(path: path)
 
         let filePath = outputPath.appending(component: "graph.\(format.rawValue)")
         if FileHandler.shared.exists(filePath) {

--- a/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
+++ b/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
@@ -162,8 +162,16 @@ open class TuistTestCase: XCTestCase {
         XCTAssertPrinterContains(expected, at: .warning, >=, file: file, line: line)
     }
 
+    public func XCTAssertPrinterOutputNotContains(_ notExpected: String, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertPrinterNotContains(notExpected, at: .warning, >=, file: file, line: line)
+    }
+
     public func XCTAssertPrinterErrorContains(_ expected: String, file: StaticString = #file, line: UInt = #line) {
         XCTAssertPrinterContains(expected, at: .error, <=, file: file, line: line)
+    }
+
+    public func XCTAssertPrinterErrorNotContains(_ notExpected: String, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertPrinterNotContains(notExpected, at: .error, <=, file: file, line: line)
     }
 
     public func XCTAssertPrinterContains(

--- a/Tests/TuistGraphTests/Models/LintingIssueTests.swift
+++ b/Tests/TuistGraphTests/Models/LintingIssueTests.swift
@@ -11,13 +11,13 @@ final class LintingIssueTests: TuistUnitTestCase {
         XCTAssertEqual(subject.description, "whatever")
     }
 
-    func test_printAndThrowIfNeeded() throws {
+    func test_printAndThrowErrorsIfNeeded() throws {
         let first = LintingIssue(reason: "error", severity: .error)
         let second = LintingIssue(reason: "warning", severity: .warning)
 
-        XCTAssertThrowsError(try [first, second].printAndThrowIfNeeded())
+        XCTAssertThrowsError(try [first, second].printAndThrowErrorsIfNeeded())
 
-        XCTAssertPrinterOutputContains(
+        XCTAssertPrinterOutputNotContains(
             """
             warning
             """
@@ -29,14 +29,26 @@ final class LintingIssueTests: TuistUnitTestCase {
         )
     }
 
-    func test_printAndThrowIfNeeded_whenErrorsOnly() throws {
+    func test_printAndThrowErrorsIfNeeded_whenErrorsOnly() throws {
         let first = LintingIssue(reason: "error", severity: .error)
 
-        XCTAssertThrowsError(try [first].printAndThrowIfNeeded())
+        XCTAssertThrowsError(try [first].printAndThrowErrorsIfNeeded())
 
         XCTAssertPrinterErrorContains(
             """
             error
+            """
+        )
+    }
+
+    func test_printWarningsIfNeeded() throws {
+        let first = LintingIssue(reason: "warning", severity: .warning)
+
+        XCTAssertNoThrow(try [first].printWarningsIfNeeded())
+
+        XCTAssertPrinterOutputContains(
+            """
+            warning
             """
         )
     }

--- a/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -340,7 +340,7 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
 
         let graph = try graphLoader.loadWorkspace(workspace: models.workspace, projects: models.projects)
         let graphTraverser = GraphTraverser(graph: graph)
-        try linter.lint(graphTraverser: graphTraverser).printAndThrowIfNeeded()
+        try linter.lint(graphTraverser: graphTraverser).printAndThrowErrorsIfNeeded()
         let descriptor = try subject.generateWorkspace(graphTraverser: graphTraverser)
         try writer.write(workspace: descriptor)
     }

--- a/Tests/TuistKitIntegrationTests/Utils/ManifestGraphLoaderIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Utils/ManifestGraphLoaderIntegrationTests.swift
@@ -36,7 +36,7 @@ final class ManifestGraphLoaderIntegrationTests: TuistTestCase {
         let path = try temporaryFixture("WorkspaceWithPlugins")
 
         // When
-        let (result, _) = try await subject.load(path: path)
+        let (result, _, _) = try await subject.load(path: path)
 
         // Then
         XCTAssertEqual(result.workspace.name, "Workspace")
@@ -53,7 +53,7 @@ final class ManifestGraphLoaderIntegrationTests: TuistTestCase {
             .appending(component: "App")
 
         // When
-        let (result, _) = try await subject.load(path: path)
+        let (result, _, _) = try await subject.load(path: path)
 
         // Then
         XCTAssertEqual(result.workspace.name, "App")

--- a/Tests/TuistKitTests/Mocks/MockManifestGraphLoader.swift
+++ b/Tests/TuistKitTests/Mocks/MockManifestGraphLoader.swift
@@ -7,7 +7,7 @@ import TuistGraphTesting
 
 final class MockManifestGraphLoader: ManifestGraphLoading {
     var stubLoadGraph: Graph?
-    func load(path _: AbsolutePath) async throws -> (Graph, [SideEffectDescriptor]) {
-        (stubLoadGraph ?? .test(), [])
+    func load(path _: AbsolutePath) async throws -> (Graph, [SideEffectDescriptor], [LintingIssue]) {
+        (stubLoadGraph ?? .test(), [], [])
     }
 }


### PR DESCRIPTION
Resolves part of the discussion in https://github.com/tuist/tuist/issues/4376

### Short description 📝
Logs generated by the generate command tends to follow the whole workspace size, so it's easy to miss the linting warnings generated by the linters, and therefore lead to potential errors.
This PR defers the display of the warnings generated by the generate command until after the generation has finished.

### How to test the changes locally 🧐
Make a sample project and trigger a lint warning (e.g., `target doesn't contain source files`) and generate the project.

### Output
Before change
```
Resolved cache profile 'Development' from Tuist's defaults
The target ModuleSampleUI doesn't contain source files.
Generating workspace ModuleSample.xcworkspace
Generating project ModuleSample
Project generated.
Total time taken: 0.960s
```
After changes
```
Resolved cache profile 'Development' from Tuist's defaults
Generating workspace ModuleSample.xcworkspace
Generating project ModuleSample

Warning: The target ModuleSampleUI doesn't contain source files.

Project generated.
Total time taken: 0.950s
```

### Thoughts
- I've changed the `LintingIssue` type from structs to classes to leverage inheritnace and therefore rely on types to do the warning checking. 
- Any feedback would be appreciated. Thanks.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
