### PR TITLE
Add local tuist plugin to `tuist init` generated project

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -12,6 +12,7 @@ on:
       - Package.swift
       - Project.swift
       - Sources/**
+      - Templates/**
       - Tests/**
       - projects/tuist/features/**
       - projects/tuist/fixtures/**

--- a/Templates/AppProject.stencil
+++ b/Templates/AppProject.stencil
@@ -1,5 +1,6 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
+import MyPlugin
 
 /*
                 +-------------+
@@ -18,6 +19,9 @@ import ProjectDescriptionHelpers
  */
 
 // MARK: - Project
+
+// Local plugin loaded
+let localHelper = LocalHelper(name: "MyPlugin")
 
 // Creates our project using a helper function defined in ProjectDescriptionHelpers
 let project = Project.app(name: "{{ name }}",

--- a/Templates/Config.stencil
+++ b/Templates/Config.stencil
@@ -1,3 +1,7 @@
 import ProjectDescription
 
-let config = Config()
+let config = Config(
+    plugins: [
+        .local(path: .relativeToManifest("../../Plugins/{{ name }}")),
+    ]
+)

--- a/Templates/LocalHelper.stencil
+++ b/Templates/LocalHelper.stencil
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct LocalHelper {
+    let name: String
+
+    public init(name: String) {
+        self.name = name
+    }
+}

--- a/Templates/Package.stencil
+++ b/Templates/Package.stencil
@@ -1,0 +1,15 @@
+// swift-tools-version: 5.4
+
+import PackageDescription
+
+let package = Package(
+    name: "MyPlugin",
+    products: [
+        .executable(name: "tuist-my-cli", targets: ["tuist-my-cli"]),
+    ],
+    targets: [
+        .executableTarget(
+            name: "tuist-my-cli"
+        ),
+    ]
+)

--- a/Templates/Plugin.stencil
+++ b/Templates/Plugin.stencil
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let plugin = Plugin(name: "MyPlugin")

--- a/Templates/default/default.swift
+++ b/Templates/default/default.swift
@@ -6,6 +6,7 @@ let projectPath = "."
 let appPath = "Targets/\(nameAttribute)"
 let kitFrameworkPath = "Targets/\(nameAttribute)Kit"
 let uiFrameworkPath = "Targets/\(nameAttribute)UI"
+let taskPath = "Plugins/\(nameAttribute)"
 
 func templatePath(_ path: String) -> Path {
     "../\(path)"
@@ -53,6 +54,18 @@ let template = Template(
         .file(
             path: uiFrameworkPath + "/Tests/\(nameAttribute)UITests.swift",
             templatePath: templatePath("/UITests.stencil")
+        ),
+        .file(
+            path: taskPath + "/Sources/tuist-my-cli/main.swift",
+            templatePath: templatePath("/main.stencil")
+        ),
+        .file(
+            path: taskPath + "/Package.swift",
+            templatePath: templatePath("/Package.stencil")
+        ),
+        .file(
+            path: taskPath + "/Plugin.swift",
+            templatePath: templatePath("/Plugin.stencil")
         ),
         .file(
             path: ".gitignore",

--- a/Templates/default/default.swift
+++ b/Templates/default/default.swift
@@ -60,6 +60,10 @@ let template = Template(
             templatePath: templatePath("/main.stencil")
         ),
         .file(
+            path: taskPath + "/ProjectDescriptionHelpers/LocalHelper.swift",
+            templatePath: templatePath("/LocalHelper.stencil")
+        ),
+        .file(
             path: taskPath + "/Package.swift",
             templatePath: templatePath("/Package.stencil")
         ),

--- a/Templates/main.stencil
+++ b/Templates/main.stencil
@@ -1,0 +1,1 @@
+print("Hello, from your Tuist Task")

--- a/Templates/swiftui/swiftui.swift
+++ b/Templates/swiftui/swiftui.swift
@@ -6,6 +6,7 @@ let projectPath = "."
 let appPath = "Targets/\(nameAttribute)"
 let kitFrameworkPath = "Targets/\(nameAttribute)Kit"
 let uiFrameworkPath = "Targets/\(nameAttribute)UI"
+let taskPath = "Plugins/\(nameAttribute)"
 
 func templatePath(_ path: String) -> Path {
     "../\(path)"
@@ -57,6 +58,22 @@ let template = Template(
         .file(
             path: uiFrameworkPath + "/Tests/\(nameAttribute)UITests.swift",
             templatePath: templatePath("/UITests.stencil")
+        ),
+        .file(
+            path: taskPath + "/Sources/tuist-my-cli/main.swift",
+            templatePath: templatePath("/main.stencil")
+        ),
+        .file(
+            path: taskPath + "/ProjectDescriptionHelpers/LocalHelper.swift",
+            templatePath: templatePath("/LocalHelper.stencil")
+        ),
+        .file(
+            path: taskPath + "/Package.swift",
+            templatePath: templatePath("/Package.stencil")
+        ),
+        .file(
+            path: taskPath + "/Plugin.swift",
+            templatePath: templatePath("/Plugin.stencil")
         ),
         .file(
             path: ".gitignore",


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/2996

### Short description 📝

Hi folks!
I've been discovering plugins/tasks functionality recently and I found this issue. Is this enough to resolve @fortmarek requirement?
> provide a "foo" task by default in the project generated by that command

### How to test the changes locally 🧐

- run `tuist init` command in empty directory

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
