### PR TITLE
Support for watchOS UI test targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ### Fixed
 
-- Added support for WatchOS UITests with a Target Application [#4382](https://github.com/tuist/tuist/issues/4382) by [Smponias](https://github.com/Smponias)
+- Added support for WatchOS UITests with a Target Application [#4389](https://github.com/tuist/tuist/pull/4389) by [Smponias](https://github.com/Smponias)
 
 ## 3.2.0 - 2022-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
-## Next
-
-### Fixed
-
-- Added support for WatchOS UITests with a Target Application [#4389](https://github.com/tuist/tuist/pull/4389) by [Smponias](https://github.com/Smponias)
-
 ## 3.2.0 - 2022-04-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
+## Next
+
+### Fixed
+
+- Added support for WatchOS UITests with a Target Application [#4382](https://github.com/tuist/tuist/issues/4382) by [Smponias](https://github.com/Smponias)
+
 ## 3.2.0 - 2022-04-11
 
 ### Changed

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -533,6 +533,12 @@ public class GraphLinter: GraphLinting {
             LintableTarget(platform: .watchOS, product: .staticFramework),
             LintableTarget(platform: .watchOS, product: .watch2Extension),
         ],
+        LintableTarget(platform: .watchOS, product: .uiTests): [
+            LintableTarget(platform: .watchOS, product: .staticLibrary),
+            LintableTarget(platform: .watchOS, product: .framework),
+            LintableTarget(platform: .watchOS, product: .staticFramework),
+            LintableTarget(platform: .watchOS, product: .watch2App),
+        ],
         //        LintableTarget(platform: .watchOS, product: .watchExtension): [
 //            LintableTarget(platform: .watchOS, product: .staticLibrary),
 //            LintableTarget(platform: .watchOS, product: .dynamicLibrary),

--- a/Sources/TuistGraph/Models/Product.swift
+++ b/Sources/TuistGraph/Models/Product.swift
@@ -200,6 +200,6 @@ public enum Product: String, CustomStringConvertible, CaseIterable, Codable {
     }
 
     public func canHostTests() -> Bool {
-        [.app, .appClip].contains(self)
+        [.app, .appClip, .watch2App].contains(self)
     }
 }

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -469,7 +469,7 @@ final class GraphLinterTests: TuistUnitTestCase {
         // Then
         XCTAssertFalse(result.isEmpty)
     }
-    
+
     func test_lint_when_watchOS_UITests_depends_on_watch2App() throws {
         // Given
         let path: AbsolutePath = "/project"
@@ -506,7 +506,7 @@ final class GraphLinterTests: TuistUnitTestCase {
         // Then
         XCTAssertTrue(got.isEmpty)
     }
-    
+
     func test_lint_when_watchOS_UITests_depends_on_staticLibrary() throws {
         // Given
         let path: AbsolutePath = "/project"
@@ -543,7 +543,7 @@ final class GraphLinterTests: TuistUnitTestCase {
         // Then
         XCTAssertTrue(got.isEmpty)
     }
-    
+
     func test_lint_when_watchOS_UITests_depends_on_framework() throws {
         // Given
         let path: AbsolutePath = "/project"
@@ -580,7 +580,7 @@ final class GraphLinterTests: TuistUnitTestCase {
         // Then
         XCTAssertTrue(got.isEmpty)
     }
-    
+
     func test_lint_when_watchOS_UITests_depends_on_staticFramework() throws {
         // Given
         let path: AbsolutePath = "/project"

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -469,6 +469,154 @@ final class GraphLinterTests: TuistUnitTestCase {
         // Then
         XCTAssertFalse(result.isEmpty)
     }
+    
+    func test_lint_when_watchOS_UITests_depends_on_watch2App() throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let watchApp = Target.empty(
+            name: "WatchApp",
+            platform: .watchOS,
+            product: .watch2App
+        )
+        let watchAppTests = Target.empty(
+            name: "WatchAppUITests",
+            platform: .watchOS,
+            product: .uiTests,
+            dependencies: [.target(name: watchApp.name)]
+        )
+        let project = Project.test(path: path, targets: [watchApp, watchAppTests])
+
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: watchApp.name, path: path): Set([]),
+            .target(name: watchAppTests.name, path: path): Set([.target(name: watchApp.name, path: path)]),
+        ]
+
+        let graph = Graph.test(
+            path: path,
+            workspace: Workspace.test(projects: [path]),
+            projects: [path: project],
+            targets: [path: [watchApp.name: watchApp, watchAppTests.name: watchAppTests]],
+            dependencies: dependencies
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.lint(graphTraverser: graphTraverser)
+
+        // Then
+        XCTAssertTrue(got.isEmpty)
+    }
+    
+    func test_lint_when_watchOS_UITests_depends_on_staticLibrary() throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let staticLibrary = Target.empty(
+            name: "StaticLibrary",
+            platform: .watchOS,
+            product: .staticLibrary
+        )
+        let watchAppTests = Target.empty(
+            name: "WatchAppUITests",
+            platform: .watchOS,
+            product: .uiTests,
+            dependencies: [.target(name: staticLibrary.name)]
+        )
+        let project = Project.test(path: path, targets: [staticLibrary, watchAppTests])
+
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: staticLibrary.name, path: path): Set([]),
+            .target(name: watchAppTests.name, path: path): Set([.target(name: staticLibrary.name, path: path)]),
+        ]
+
+        let graph = Graph.test(
+            path: path,
+            workspace: Workspace.test(projects: [path]),
+            projects: [path: project],
+            targets: [path: [staticLibrary.name: staticLibrary, watchAppTests.name: watchAppTests]],
+            dependencies: dependencies
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.lint(graphTraverser: graphTraverser)
+
+        // Then
+        XCTAssertTrue(got.isEmpty)
+    }
+    
+    func test_lint_when_watchOS_UITests_depends_on_framework() throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let framework = Target.empty(
+            name: "Framework",
+            platform: .watchOS,
+            product: .framework
+        )
+        let watchAppTests = Target.empty(
+            name: "WatchAppUITests",
+            platform: .watchOS,
+            product: .uiTests,
+            dependencies: [.target(name: framework.name)]
+        )
+        let project = Project.test(path: path, targets: [framework, watchAppTests])
+
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: framework.name, path: path): Set([]),
+            .target(name: watchAppTests.name, path: path): Set([.target(name: framework.name, path: path)]),
+        ]
+
+        let graph = Graph.test(
+            path: path,
+            workspace: Workspace.test(projects: [path]),
+            projects: [path: project],
+            targets: [path: [framework.name: framework, watchAppTests.name: watchAppTests]],
+            dependencies: dependencies
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.lint(graphTraverser: graphTraverser)
+
+        // Then
+        XCTAssertTrue(got.isEmpty)
+    }
+    
+    func test_lint_when_watchOS_UITests_depends_on_staticFramework() throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let staticFramework = Target.empty(
+            name: "StaticFramework",
+            platform: .watchOS,
+            product: .watch2App
+        )
+        let watchAppTests = Target.empty(
+            name: "WatchAppUITests",
+            platform: .watchOS,
+            product: .uiTests,
+            dependencies: [.target(name: staticFramework.name)]
+        )
+        let project = Project.test(path: path, targets: [staticFramework, watchAppTests])
+
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: staticFramework.name, path: path): Set([]),
+            .target(name: watchAppTests.name, path: path): Set([.target(name: staticFramework.name, path: path)]),
+        ]
+
+        let graph = Graph.test(
+            path: path,
+            workspace: Workspace.test(projects: [path]),
+            projects: [path: project],
+            targets: [path: [staticFramework.name: staticFramework, watchAppTests.name: watchAppTests]],
+            dependencies: dependencies
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.lint(graphTraverser: graphTraverser)
+
+        // Then
+        XCTAssertTrue(got.isEmpty)
+    }
 
     func test_lint_missingProjectConfigurationsFromDependencyProjects() throws {
         // Given

--- a/Tests/TuistGraphTests/Models/ProductTests.swift
+++ b/Tests/TuistGraphTests/Models/ProductTests.swift
@@ -120,4 +120,70 @@ final class ProductTests: XCTestCase {
             }
         }
     }
+    
+    func test_can_host_tests() {
+        // App
+        var subject = Product.app
+        XCTAssert(subject.canHostTests())
+        
+        // App Clip
+        subject = Product.appClip
+        XCTAssert(subject.canHostTests())
+        
+        // App Extension
+        subject = Product.appExtension
+        XCTAssertFalse(subject.canHostTests())
+        
+        // Watch App
+        subject = Product.appClip
+        XCTAssert(subject.canHostTests())
+        
+        // Watch2Extension
+        subject = Product.watch2Extension
+        XCTAssertFalse(subject.canHostTests())
+        
+        // UITests
+        subject = Product.uiTests
+        XCTAssertFalse(subject.canHostTests())
+        
+        // UnitTests
+        subject = Product.unitTests
+        XCTAssertFalse(subject.canHostTests())
+        
+        // Framework
+        subject = Product.framework
+        XCTAssertFalse(subject.canHostTests())
+        
+        // Static Framework
+        subject = Product.staticFramework
+        XCTAssertFalse(subject.canHostTests())
+        
+        // Static Library
+        subject = Product.staticLibrary
+        XCTAssertFalse(subject.canHostTests())
+        
+        // Dynamic Library
+        subject = Product.dynamicLibrary
+        XCTAssertFalse(subject.canHostTests())
+        
+        // Bundle
+        subject = Product.bundle
+        XCTAssertFalse(subject.canHostTests())
+
+        // Command Line Tool
+        subject = Product.commandLineTool
+        XCTAssertFalse(subject.canHostTests())
+        
+        // Messages Extension
+        subject = Product.messagesExtension
+        XCTAssertFalse(subject.canHostTests())
+
+        // Sticker Pack Extension
+        subject = Product.stickerPackExtension
+        XCTAssertFalse(subject.canHostTests())
+        
+        // TV Top Shelf Extension
+        subject = Product.tvTopShelfExtension
+        XCTAssertFalse(subject.canHostTests())
+    }
 }

--- a/Tests/TuistGraphTests/Models/ProductTests.swift
+++ b/Tests/TuistGraphTests/Models/ProductTests.swift
@@ -120,52 +120,52 @@ final class ProductTests: XCTestCase {
             }
         }
     }
-    
+
     func test_can_host_tests() {
         // App
         var subject = Product.app
         XCTAssert(subject.canHostTests())
-        
+
         // App Clip
         subject = Product.appClip
         XCTAssert(subject.canHostTests())
-        
+
         // App Extension
         subject = Product.appExtension
         XCTAssertFalse(subject.canHostTests())
-        
+
         // Watch App
         subject = Product.appClip
         XCTAssert(subject.canHostTests())
-        
+
         // Watch2Extension
         subject = Product.watch2Extension
         XCTAssertFalse(subject.canHostTests())
-        
+
         // UITests
         subject = Product.uiTests
         XCTAssertFalse(subject.canHostTests())
-        
+
         // UnitTests
         subject = Product.unitTests
         XCTAssertFalse(subject.canHostTests())
-        
+
         // Framework
         subject = Product.framework
         XCTAssertFalse(subject.canHostTests())
-        
+
         // Static Framework
         subject = Product.staticFramework
         XCTAssertFalse(subject.canHostTests())
-        
+
         // Static Library
         subject = Product.staticLibrary
         XCTAssertFalse(subject.canHostTests())
-        
+
         // Dynamic Library
         subject = Product.dynamicLibrary
         XCTAssertFalse(subject.canHostTests())
-        
+
         // Bundle
         subject = Product.bundle
         XCTAssertFalse(subject.canHostTests())
@@ -173,7 +173,7 @@ final class ProductTests: XCTestCase {
         // Command Line Tool
         subject = Product.commandLineTool
         XCTAssertFalse(subject.canHostTests())
-        
+
         // Messages Extension
         subject = Product.messagesExtension
         XCTAssertFalse(subject.canHostTests())
@@ -181,7 +181,7 @@ final class ProductTests: XCTestCase {
         // Sticker Pack Extension
         subject = Product.stickerPackExtension
         XCTAssertFalse(subject.canHostTests())
-        
+
         // TV Top Shelf Extension
         subject = Product.tvTopShelfExtension
         XCTAssertFalse(subject.canHostTests())

--- a/projects/tuist/fixtures/ios_app_with_watchapp2/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_watchapp2/Project.swift
@@ -49,5 +49,12 @@ let project = Project(
                 .package(product: "LibraryA"),
             ]
         ),
+        Target(
+            name: "WatchAppUITests",
+            platform: .watchOS,
+            product: .uiTests,
+            bundleId: "io.tuist.App.watchkitapp.uitests",
+            dependencies: [.target(name: "WatchApp")]
+        ),
     ]
 )


### PR DESCRIPTION
Resolves #4382 

### Short description 📝

Add support for WatchOS tests with a Target Application

### How to test the changes locally 🧐

`tuist init`
`tuist edit`

In Project.swift change platform to .watchOS

`tuist generate`

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
