### PR TITLE
Fix: Skip linting for watch targets

### DIFF
--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -246,7 +246,10 @@ public class GraphLinter: GraphLinting {
     }
 
     private func lint(watchApp: GraphTarget, parentApp: GraphTarget) -> [LintingIssue] {
-        guard watchApp.target.bundleId.hasPrefix(parentApp.target.bundleId) else {
+        let buildSettingRegex = "\\$[\\({](.*)[\\)}]"
+        
+        guard watchApp.target.bundleId.matches(pattern: buildSettingRegex) ||
+                watchApp.target.bundleId.hasPrefix(parentApp.target.bundleId) else {
             return [
                 LintingIssue(reason: """
                 Watch app '\(watchApp.target.name)' bundleId: \(watchApp.target
@@ -257,9 +260,12 @@ public class GraphLinter: GraphLinting {
         }
         return []
     }
-
+    
     private func lint(watchExtension: GraphTarget, parentWatchApp: GraphTarget) -> [LintingIssue] {
-        guard watchExtension.target.bundleId.hasPrefix(parentWatchApp.target.bundleId) else {
+        let buildSettingRegex = "\\$[\\({](.*)[\\)}]"
+        
+        guard watchExtension.target.bundleId.matches(pattern: buildSettingRegex) ||
+                watchExtension.target.bundleId.hasPrefix(parentWatchApp.target.bundleId) else {
             return [
                 LintingIssue(reason: """
                 Watch extension '\(watchExtension.target.name)' bundleId: \(watchExtension.target

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -246,10 +246,9 @@ public class GraphLinter: GraphLinting {
     }
 
     private func lint(watchApp: GraphTarget, parentApp: GraphTarget) -> [LintingIssue] {
-        let buildSettingRegex = "\\$[\\({](.*)[\\)}]"
-        
-        guard watchApp.target.bundleId.matches(pattern: buildSettingRegex) ||
-                watchApp.target.bundleId.hasPrefix(parentApp.target.bundleId) else {
+        guard watchApp.target.bundleId.contains("$") ||
+            watchApp.target.bundleId.hasPrefix(parentApp.target.bundleId)
+        else {
             return [
                 LintingIssue(reason: """
                 Watch app '\(watchApp.target.name)' bundleId: \(watchApp.target
@@ -260,12 +259,11 @@ public class GraphLinter: GraphLinting {
         }
         return []
     }
-    
+
     private func lint(watchExtension: GraphTarget, parentWatchApp: GraphTarget) -> [LintingIssue] {
-        let buildSettingRegex = "\\$[\\({](.*)[\\)}]"
-        
-        guard watchExtension.target.bundleId.matches(pattern: buildSettingRegex) ||
-                watchExtension.target.bundleId.hasPrefix(parentWatchApp.target.bundleId) else {
+        guard watchExtension.target.bundleId.contains("$") ||
+            watchExtension.target.bundleId.hasPrefix(parentWatchApp.target.bundleId)
+        else {
             return [
                 LintingIssue(reason: """
                 Watch extension '\(watchExtension.target.name)' bundleId: \(watchExtension.target

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -1486,7 +1486,7 @@ final class GraphLinterTests: TuistUnitTestCase {
             ]
         )
     }
-    
+
     func test_lint_when_bundle_id_is_derived_from_build_settings_using_parentheses_pattern() {
         // Given
         let path: AbsolutePath = "/project"
@@ -1508,7 +1508,7 @@ final class GraphLinterTests: TuistUnitTestCase {
             bundleId: "$(WATCH_EXTENSION_PRODUCT_BUNDLE_IDENTIFIER)"
         )
         let project = Project.test(targets: [app, watchApp, watchExtension])
-        
+
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
             .target(name: app.name, path: path): Set([.target(name: watchApp.name, path: path)]),
             .target(name: watchApp.name, path: path): Set([.target(name: watchExtension.name, path: path)]),
@@ -1552,7 +1552,7 @@ final class GraphLinterTests: TuistUnitTestCase {
             bundleId: "${WATCH_EXTENSION_PRODUCT_BUNDLE_IDENTIFIER}"
         )
         let project = Project.test(targets: [app, watchApp, watchExtension])
-        
+
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
             .target(name: app.name, path: path): Set([.target(name: watchApp.name, path: path)]),
             .target(name: watchApp.name, path: path): Set([.target(name: watchExtension.name, path: path)]),

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -1486,4 +1486,92 @@ final class GraphLinterTests: TuistUnitTestCase {
             ]
         )
     }
+    
+    func test_lint_when_bundle_id_is_derived_from_build_settings_using_parentheses_pattern() {
+        // Given
+        let path: AbsolutePath = "/project"
+        let app = Target.test(
+            name: "App",
+            product: .app,
+            bundleId: "$(PRODUCT_BUNDLE_IDENTIFIER)"
+        )
+        let watchApp = Target.test(
+            name: "WatchApp",
+            platform: .watchOS,
+            product: .watch2App,
+            bundleId: "$(WATCH_APP_PRODUCT_BUNDLE_IDENTIFIER)"
+        )
+        let watchExtension = Target.test(
+            name: "WatchExtension",
+            platform: .watchOS,
+            product: .watch2Extension,
+            bundleId: "$(WATCH_EXTENSION_PRODUCT_BUNDLE_IDENTIFIER)"
+        )
+        let project = Project.test(targets: [app, watchApp, watchExtension])
+        
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: app.name, path: path): Set([.target(name: watchApp.name, path: path)]),
+            .target(name: watchApp.name, path: path): Set([.target(name: watchExtension.name, path: path)]),
+            .target(name: watchExtension.name, path: path): Set([]),
+        ]
+
+        let graph = Graph.test(
+            path: path,
+            workspace: Workspace.test(projects: [path]),
+            projects: [path: project],
+            targets: [path: [app.name: app, watchApp.name: watchApp, watchExtension.name: watchExtension]],
+            dependencies: dependencies
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.lint(graphTraverser: graphTraverser)
+
+        // Then
+        XCTAssertEmpty(got)
+    }
+
+    func test_lint_when_bundle_id_is_derived_from_build_settings_using_braces_pattern() {
+        // Given
+        let path: AbsolutePath = "/project"
+        let app = Target.test(
+            name: "App",
+            product: .app,
+            bundleId: "${PRODUCT_BUNDLE_IDENTIFIER}"
+        )
+        let watchApp = Target.test(
+            name: "WatchApp",
+            platform: .watchOS,
+            product: .watch2App,
+            bundleId: "${WATCH_APP_PRODUCT_BUNDLE_IDENTIFIER}"
+        )
+        let watchExtension = Target.test(
+            name: "WatchExtension",
+            platform: .watchOS,
+            product: .watch2Extension,
+            bundleId: "${WATCH_EXTENSION_PRODUCT_BUNDLE_IDENTIFIER}"
+        )
+        let project = Project.test(targets: [app, watchApp, watchExtension])
+        
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: app.name, path: path): Set([.target(name: watchApp.name, path: path)]),
+            .target(name: watchApp.name, path: path): Set([.target(name: watchExtension.name, path: path)]),
+            .target(name: watchExtension.name, path: path): Set([]),
+        ]
+
+        let graph = Graph.test(
+            path: path,
+            workspace: Workspace.test(projects: [path]),
+            projects: [path: project],
+            targets: [path: [app.name: app, watchApp.name: watchApp, watchExtension.name: watchExtension]],
+            dependencies: dependencies
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.lint(graphTraverser: graphTraverser)
+
+        // Then
+        XCTAssertEmpty(got)
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4394

### Short description 📝

Skips linting for watchApp and watchExtension targets when using generic bundle identifier.

### How to test the changes locally 🧐

1. Provide xcconfig file with `$(WATCH_APP_PRODUCT_BUNDLE_IDENTIFIER)` property and `$(WATCH_EXTENSION_PRODUCT_BUNDLE_IDENTIFIER)` property
2. Assign the value `$(WATCH_APP_PRODUCT_BUNDLE_IDENTIFIER)` to the argument bundleId creating the watch2App target
3. Assign the value `$(WATCH_EXTENSION_PRODUCT_BUNDLE_IDENTIFIER)` to the argument bundleId creating the watch2Extension target
4. run `tuist generate` command

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
