### PR TITLE
Fix resource mapping when target name contains hyphens

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -56,7 +56,11 @@ public class ResourcesProjectMapper: ProjectMapping {
         }
 
         if target.supportsSources {
-            let (filePath, data) = synthesizedFile(bundleName: bundleName, target: target, project: project)
+            let (filePath, data) = synthesizedFile(
+                bundleName: bundleName.replacingOccurrences(of: "-", with: "_"),
+                target: target,
+                project: project
+            )
 
             let hash = try data.map(contentHasher.hash)
             let sourceFile = SourceFile(path: filePath, contentHash: hash)

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -56,11 +56,7 @@ public class ResourcesProjectMapper: ProjectMapping {
         }
 
         if target.supportsSources {
-            let (filePath, data) = synthesizedFile(
-                bundleName: bundleName.replacingOccurrences(of: "-", with: "_"),
-                target: target,
-                project: project
-            )
+            let (filePath, data) = synthesizedFile(bundleName: bundleName, target: target, project: project)
 
             let hash = try data.map(contentHasher.hash)
             let sourceFile = SourceFile(path: filePath, contentHash: hash)
@@ -80,7 +76,7 @@ public class ResourcesProjectMapper: ProjectMapping {
 
         let content: String = ResourcesProjectMapper.fileContent(
             targetName: target.name,
-            bundleName: bundleName,
+            bundleName: bundleName.replacingOccurrences(of: "-", with: "_"),
             target: target
         )
         return (filePath, content.data(using: .utf8))


### PR DESCRIPTION
### Short description 📝

> When target's name has an hyphen, its resource bundle's name has an underscore(replacing hyphen).
In that case, bundle cannot be found using BundleFinder.

### How to test the changes locally 🧐

> A unit test has been added for that case.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
