### PR TITLE
Add insights for tuist cache warm

### DIFF
--- a/projects/cloud/app/frontend/components/pages/dashboard/DashboardPage.tsx
+++ b/projects/cloud/app/frontend/components/pages/dashboard/DashboardPage.tsx
@@ -104,10 +104,10 @@ const DashboardPage = observer(() => {
               <Select
                 label=""
                 options={[
-                  // TODO: Load this dynamically once command name and subcommand issue is resolved
-                  { label: 'generate', value: 'generate' },
-                  { label: 'fetch', value: 'fetch' },
                   { label: 'build', value: 'build' },
+                  { label: 'cache warm', value: 'cache warm' },
+                  { label: 'fetch', value: 'fetch' },
+                  { label: 'generate', value: 'generate' },
                   { label: 'test', value: 'test' },
                 ]}
                 onChange={(newValue) => {

--- a/projects/cloud/app/services/command_average_service.rb
+++ b/projects/cloud/app/services/command_average_service.rb
@@ -22,8 +22,14 @@ class CommandAverageService < ApplicationService
   def call
     project = ProjectFetchService.new.fetch_by_id(project_id: project_id, user: user)
 
+    split_command_name = command_name.split(" ")
+    name = split_command_name.first
+    if split_command_name.length > 1
+      subcommand = command_name.split(" ").drop(1)
+    end
+
     project.command_events
-      .where("created_at > ? AND name = ?", 30.days.ago, command_name)
+      .where(created_at: 30.days.ago.., name: name, subcommand: subcommand)
       .group_by_day(:created_at, range: 30.days.ago..Time.now)
       .average(:duration)
       .map { |key, value| CommandAverage.new(date: key, duration_average: value.nil? ? 0 : value) }

--- a/projects/cloud/test/services/command_average_service_test.rb
+++ b/projects/cloud/test/services/command_average_service_test.rb
@@ -15,10 +15,10 @@ class CommandAverageServiceTest < ActiveSupport::TestCase
     Time.stubs(:now).returns(Time.new(2022, 03, 31))
   end
 
-  def create_command_event(name:, duration:, created_at:)
+  def create_command_event(name:, subcommand: nil, duration:, created_at:)
     CommandEvent.create!(
       name: name,
-      subcommand: "",
+      subcommand: subcommand,
       command_arguments: [name],
       duration: duration,
       client_id: "client id",
@@ -41,12 +41,37 @@ class CommandAverageServiceTest < ActiveSupport::TestCase
     got = CommandAverageService.call(project_id: @project.id, command_name: "generate", user: @user)
 
     # Then
-
     assert_equal (1..31).map { |day| Date.new(2022, 03, day) }, got.map(&:date)
     assert_equal (1..31).map { |day|
       if day == 05
         5
       elsif day == 30
+        15
+      else
+        0
+      end
+    }, got.map(&:duration_average)
+  end
+
+  test "returns average for the last thirty days for a subcommand" do
+    # Given
+    create_command_event(name: "cache", subcommand: "warm", duration: 20, created_at: Time.new(2022, 03, 30))
+    create_command_event(name: "cache", subcommand: "warm", duration: 10, created_at: Time.new(2022, 03, 30))
+    create_command_event(name: "cache", subcommand: "print-hashes", duration: 5, created_at: Time.new(2022, 03, 30))
+    create_command_event(name: "fetch", duration: 10, created_at: Time.new(2022, 03, 30))
+    create_command_event(name: "cache", subcommand: "print-hashes", duration: 5, created_at: Time.new(2022, 03, 05))
+
+    # When
+    got = CommandAverageService.call(
+      project_id: @project.id,
+      command_name: "cache warm",
+      user: @user
+    )
+
+    # Then
+    assert_equal (1..31).map { |day| Date.new(2022, 03, day) }, got.map(&:date)
+    assert_equal (1..31).map { |day|
+      if day == 30
         15
       else
         0


### PR DESCRIPTION
### Short description 📝

Before, it was not possible to query command averages if it was a subcommand. I changed the `CommandAverageService` to allow that and included `cache warm` command in the insights.

I have contemplated loading the list dynamically but I decided not to. I feel it would create too much noise as the duration is not really relevant for most commands. I am keeping the list concise, so only commands where it's interesting to see the time it takes to execute them are visible.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
