### PR TITLE
Allow AppClips to link Static Frameworks

### DIFF
--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -372,6 +372,7 @@ public class GraphLinter: GraphLinting {
             LintableTarget(platform: .iOS, product: .staticLibrary),
             LintableTarget(platform: .iOS, product: .dynamicLibrary),
             LintableTarget(platform: .iOS, product: .framework),
+            LintableTarget(platform: .iOS, product: .staticFramework),
         ],
         //        LintableTarget(platform: .iOS, product: .messagesApplication): [
 //            LintableTarget(platform: .iOS, product: .messagesExtension),


### PR DESCRIPTION
### Short description 📝

I'd like to link in some `.staticFramework` dependencies for my `.appClip` target. 

Right now the Linter does not allow this, but I believe this is an oversight.

I didn't see any tests associated with which links are valid. If I missed them, I'd be happy to update them!

### How to test the changes locally 🧐

Create an `.appClip` target that depends on a `.staticFramework`, it should pass the linting stage now.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
