### PR TITLE
Add attachDebugger parameter to TestAction.testPlans(...)

### DIFF
--- a/Sources/ProjectDescription/TestAction.swift
+++ b/Sources/ProjectDescription/TestAction.swift
@@ -99,12 +99,14 @@ public struct TestAction: Equatable, Codable {
     /// - Parameters:
     ///   - testPlans: List of test plans to run.
     ///   - configuration: Configuration to be used.
+    ///   - attachDebugger: A boolean controlling whether a debugger is attached to the process running the tests.
     ///   - preActions: Actions to execute before running the tests.
     ///   - postActions: Actions to execute after running the tests.
     /// - Returns: A test action.
     public static func testPlans(
         _ testPlans: [Path],
         configuration: ConfigurationName = .debug,
+        attachDebugger: Bool = true,
         preActions: [ExecutionAction] = [],
         postActions: [ExecutionAction] = []
     ) -> Self {
@@ -113,7 +115,7 @@ public struct TestAction: Equatable, Codable {
             targets: [],
             arguments: nil,
             configuration: configuration,
-            attachDebugger: true,
+            attachDebugger: attachDebugger,
             expandVariableFromTarget: nil,
             preActions: preActions,
             postActions: postActions,


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4424
Request for comments document (if applies):

### Short description 📝

> Add attachDebugger parameter to TestAction.testPlans(...)

This will allow to disable the debugger during Unit and UI tests

```
Scheme(
                name: "\(name)UITests",
                shared: true,
                buildAction:  .buildAction(
                    targets: ["\(name)", "\(name)UITests"]
                ),
                testAction: .testPlans(
                    [.relativeToRoot("TestPlan/\(name)UITests.xctestplan")],
                    configuration: .debug,
                    attachDebugger: false,
                    preActions: [],
                    postActions: []
                )
)
```

> The parameter `attachDebugger` will be defaulted to `true` to allow backward compatibility.

```
Scheme(
                name: "\(name)UITests",
                shared: true,
                buildAction:  .buildAction(
                    targets: ["\(name)", "\(name)UITests"]
                ),
                testAction: .testPlans(
                    [.relativeToRoot("TestPlan/\(name)UITests.xctestplan")],
                    configuration: .debug,
                    preActions: [],
                    postActions: []
                )
)
```

The previous code will behave as before.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

A demo project has been provide [here](https://github.com/Andrea-Scuderi/DemoTuist)

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
