### PR TITLE
Feature: Add four new SettingsTransformers

### DIFF
--- a/Sources/ProjectDescription/SettingsTransformers.swift
+++ b/Sources/ProjectDescription/SettingsTransformers.swift
@@ -97,17 +97,26 @@ extension SettingsDictionary {
         return merging(versionSettings)
     }
 
-    // MARK: - Swift Settings
+    // MARK: - Swift Compiler - Language
 
     /// Sets `"SWIFT_VERSION"` to `version`
     public func swiftVersion(_ version: String) -> SettingsDictionary {
         merging(["SWIFT_VERSION": SettingValue(version)])
     }
+    
+    // MARK: - Swift Compiler - Custom Flags
 
     /// Sets `"OTHER_SWIFT_FLAGS"` to `flags`
     public func otherSwiftFlags(_ flags: String...) -> SettingsDictionary {
         merging(["OTHER_SWIFT_FLAGS": SettingValue(flags.joined(separator: " "))])
     }
+    
+    /// Sets `"SWIFT_ACTIVE_COMPILATION_CONDITIONS"` to `conditions`
+    public func swiftActiveCompilationConditions(_ conditions: String...) -> SettingsDictionary {
+        merging(["SWIFT_ACTIVE_COMPILATION_CONDITIONS": SettingValue(conditions.joined(separator: " "))])
+    }
+    
+    // MARK: - Swift Compiler - Code Generation
 
     /// Sets `"SWIFT_COMPILATION_MODE"` to the available `SwiftCompilationMode` (`"singlefile"` or `"wholemodule"`)
     public func swiftCompilationMode(_ mode: SwiftCompilationMode) -> SettingsDictionary {
@@ -122,6 +131,27 @@ extension SettingsDictionary {
     /// Sets `"SWIFT_OPTIMIZE_OBJECT_LIFETIME"` to `"YES"` or `"NO"`
     public func swiftOptimizeObjectLifetimes(_ enabled: Bool) -> SettingsDictionary {
         merging(["SWIFT_OPTIMIZE_OBJECT_LIFETIME": SettingValue(enabled)])
+    }
+    
+    // MARK: - Swift Compiler - General
+
+    /// Sets `"SWIFT_OBJC_BRIDGING_HEADER"` to `path`
+    public func swiftObjcBridingHeaderPath(_ path: String) -> SettingsDictionary {
+        merging(["SWIFT_OBJC_BRIDGING_HEADER": SettingValue(path)])
+    }
+    
+    // MARK: - Apple Clang - Custom Compiler Flags
+    
+    /// Sets `"OTHER_CFLAGS"` to `flags`
+    public func otherCFlags(_ flags: String...) -> SettingsDictionary {
+        merging(["OTHER_CFLAGS": SettingValue(flags.joined(separator: " "))])
+    }
+    
+    // MARK: - Linking
+
+    /// Sets `"OTHER_LDFLAGS"` to `flags`
+    public func otherLinkerFlags(_ flags: String...) -> SettingsDictionary {
+        merging(["OTHER_LDFLAGS": SettingValue(flags.joined(separator: " "))])
     }
 
     // MARK: - Bitcode

--- a/Sources/ProjectDescription/SettingsTransformers.swift
+++ b/Sources/ProjectDescription/SettingsTransformers.swift
@@ -137,7 +137,9 @@ extension SettingsDictionary {
 
     /// Sets `"SWIFT_OBJC_BRIDGING_HEADER"` to `path`
     public func swiftObjcBridingHeaderPath(_ path: String) -> SettingsDictionary {
-        merging(["SWIFT_OBJC_BRIDGING_HEADER": SettingValue(path)])
+        var settings = self
+        settings["SWIFT_OBJC_BRIDGING_HEADER"] = SettingValue(path)
+        return settings
     }
     
     // MARK: - Apple Clang - Custom Compiler Flags

--- a/Sources/ProjectDescription/SettingsTransformers.swift
+++ b/Sources/ProjectDescription/SettingsTransformers.swift
@@ -143,15 +143,15 @@ extension SettingsDictionary {
     // MARK: - Apple Clang - Custom Compiler Flags
     
     /// Sets `"OTHER_CFLAGS"` to `flags`
-    public func otherCFlags(_ flags: String...) -> SettingsDictionary {
-        merging(["OTHER_CFLAGS": SettingValue(flags.joined(separator: " "))])
+    public func otherCFlags(_ flags: [String]) -> SettingsDictionary {
+        merging(["OTHER_CFLAGS": .array(flags)])
     }
     
     // MARK: - Linking
 
     /// Sets `"OTHER_LDFLAGS"` to `flags`
-    public func otherLinkerFlags(_ flags: String...) -> SettingsDictionary {
-        merging(["OTHER_LDFLAGS": SettingValue(flags.joined(separator: " "))])
+    public func otherLinkerFlags(_ flags: [String]) -> SettingsDictionary {
+        merging(["OTHER_LDFLAGS": .array(flags)])
     }
 
     // MARK: - Bitcode

--- a/Sources/ProjectDescription/SettingsTransformers.swift
+++ b/Sources/ProjectDescription/SettingsTransformers.swift
@@ -103,19 +103,19 @@ extension SettingsDictionary {
     public func swiftVersion(_ version: String) -> SettingsDictionary {
         merging(["SWIFT_VERSION": SettingValue(version)])
     }
-    
+
     // MARK: - Swift Compiler - Custom Flags
 
     /// Sets `"OTHER_SWIFT_FLAGS"` to `flags`
     public func otherSwiftFlags(_ flags: String...) -> SettingsDictionary {
         merging(["OTHER_SWIFT_FLAGS": SettingValue(flags.joined(separator: " "))])
     }
-    
+
     /// Sets `"SWIFT_ACTIVE_COMPILATION_CONDITIONS"` to `conditions`
     public func swiftActiveCompilationConditions(_ conditions: String...) -> SettingsDictionary {
         merging(["SWIFT_ACTIVE_COMPILATION_CONDITIONS": SettingValue(conditions.joined(separator: " "))])
     }
-    
+
     // MARK: - Swift Compiler - Code Generation
 
     /// Sets `"SWIFT_COMPILATION_MODE"` to the available `SwiftCompilationMode` (`"singlefile"` or `"wholemodule"`)
@@ -132,7 +132,7 @@ extension SettingsDictionary {
     public func swiftOptimizeObjectLifetimes(_ enabled: Bool) -> SettingsDictionary {
         merging(["SWIFT_OPTIMIZE_OBJECT_LIFETIME": SettingValue(enabled)])
     }
-    
+
     // MARK: - Swift Compiler - General
 
     /// Sets `"SWIFT_OBJC_BRIDGING_HEADER"` to `path`
@@ -141,14 +141,14 @@ extension SettingsDictionary {
         settings["SWIFT_OBJC_BRIDGING_HEADER"] = SettingValue(path)
         return settings
     }
-    
+
     // MARK: - Apple Clang - Custom Compiler Flags
-    
+
     /// Sets `"OTHER_CFLAGS"` to `flags`
     public func otherCFlags(_ flags: [String]) -> SettingsDictionary {
         merging(["OTHER_CFLAGS": .array(flags)])
     }
-    
+
     // MARK: - Linking
 
     /// Sets `"OTHER_LDFLAGS"` to `flags`

--- a/Tests/ProjectDescriptionTests/SettingsTests.swift
+++ b/Tests/ProjectDescriptionTests/SettingsTests.swift
@@ -137,7 +137,7 @@ final class SettingsTests: XCTestCase {
             "PROVISIONING_PROFILE_SPECIFIER": "ABC",
         ])
     }
-    
+
     func test_settingsDictionary_swiftActiveCompilationConditions() {
         /// Given/When
         let settings = SettingsDictionary()
@@ -197,7 +197,7 @@ final class SettingsTests: XCTestCase {
             "SWIFT_OPTIMIZATION_LEVEL": "-Osize",
         ])
     }
-    
+
     func test_settingsDictionary_swiftObjcBridingHeaderPath() {
         /// Given/When
         let settings = SettingsDictionary()
@@ -208,7 +208,7 @@ final class SettingsTests: XCTestCase {
             "SWIFT_OBJC_BRIDGING_HEADER": "/my/briding/header/path.h"
         ])
     }
-    
+
     func test_settingsDictionary_otherCFlags() {
         /// Given/When
         let settings = SettingsDictionary()
@@ -219,7 +219,7 @@ final class SettingsTests: XCTestCase {
             "OTHER_CFLAGS": ["$(inherited)", "-my-c-flag"]
         ])
     }
-    
+
     func test_settingsDictionary_otherLinkerFlags() {
         /// Given/When
         let settings = SettingsDictionary()

--- a/Tests/ProjectDescriptionTests/SettingsTests.swift
+++ b/Tests/ProjectDescriptionTests/SettingsTests.swift
@@ -121,7 +121,7 @@ final class SettingsTests: XCTestCase {
             "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "FIRST SECOND THIRD",
             "SWIFT_OBJC_BRIDGING_HEADER": "/my/briding/header/path.h",
             "OTHER_CFLAGS": ["$(inherited)", "-my-c-flag"],
-            "OTHER_LDFLAGS": ["$(inherited)", "-my-linker-flag"]
+            "OTHER_LDFLAGS": ["$(inherited)", "-my-linker-flag"],
         ])
     }
 
@@ -145,7 +145,7 @@ final class SettingsTests: XCTestCase {
 
         /// Then
         XCTAssertEqual(settings, [
-            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "FIRST SECOND THIRD"
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "FIRST SECOND THIRD",
         ])
     }
 
@@ -205,7 +205,7 @@ final class SettingsTests: XCTestCase {
 
         /// Then
         XCTAssertEqual(settings, [
-            "SWIFT_OBJC_BRIDGING_HEADER": "/my/briding/header/path.h"
+            "SWIFT_OBJC_BRIDGING_HEADER": "/my/briding/header/path.h",
         ])
     }
 
@@ -216,7 +216,7 @@ final class SettingsTests: XCTestCase {
 
         /// Then
         XCTAssertEqual(settings, [
-            "OTHER_CFLAGS": ["$(inherited)", "-my-c-flag"]
+            "OTHER_CFLAGS": ["$(inherited)", "-my-c-flag"],
         ])
     }
 
@@ -227,7 +227,7 @@ final class SettingsTests: XCTestCase {
 
         /// Then
         XCTAssertEqual(settings, [
-            "OTHER_LDFLAGS": ["$(inherited)", "-my-linker-flag"]
+            "OTHER_LDFLAGS": ["$(inherited)", "-my-linker-flag"],
         ])
     }
 

--- a/Tests/ProjectDescriptionTests/SettingsTests.swift
+++ b/Tests/ProjectDescriptionTests/SettingsTests.swift
@@ -100,8 +100,8 @@ final class SettingsTests: XCTestCase {
             .debugInformationFormat(.dwarf)
             .swiftActiveCompilationConditions("FIRST", "SECOND", "THIRD")
             .swiftObjcBridingHeaderPath("/my/briding/header/path.h")
-            .otherCFlags("$(inherited) -my-c-flag")
-            .otherLinkerFlags("$(inherited) -my-linker-flag")
+            .otherCFlags(["$(inherited)", "-my-c-flag"])
+            .otherLinkerFlags(["$(inherited)", "-my-linker-flag"])
 
         /// Then
         XCTAssertEqual(settings, [
@@ -120,8 +120,8 @@ final class SettingsTests: XCTestCase {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "FIRST SECOND THIRD",
             "SWIFT_OBJC_BRIDGING_HEADER": "/my/briding/header/path.h",
-            "OTHER_CFLAGS": "$(inherited) -my-c-flag",
-            "OTHER_LDFLAGS": "$(inherited) -my-linker-flag"
+            "OTHER_CFLAGS": ["$(inherited)", "-my-c-flag"],
+            "OTHER_LDFLAGS": ["$(inherited)", "-my-linker-flag"]
         ])
     }
 
@@ -212,22 +212,22 @@ final class SettingsTests: XCTestCase {
     func test_settingsDictionary_otherCFlags() {
         /// Given/When
         let settings = SettingsDictionary()
-            .otherCFlags("$(inherited) -my-c-flag")
+            .otherCFlags(["$(inherited)", "-my-c-flag"])
 
         /// Then
         XCTAssertEqual(settings, [
-            "OTHER_CFLAGS": "$(inherited) -my-c-flag"
+            "OTHER_CFLAGS": ["$(inherited)", "-my-c-flag"]
         ])
     }
     
     func test_settingsDictionary_otherLinkerFlags() {
         /// Given/When
         let settings = SettingsDictionary()
-            .otherLinkerFlags("$(inherited) -my-linker-flag")
+            .otherLinkerFlags(["$(inherited)", "-my-linker-flag"])
 
         /// Then
         XCTAssertEqual(settings, [
-            "OTHER_LDFLAGS": "$(inherited) -my-linker-flag"
+            "OTHER_LDFLAGS": ["$(inherited)", "-my-linker-flag"]
         ])
     }
 

--- a/Tests/ProjectDescriptionTests/SettingsTests.swift
+++ b/Tests/ProjectDescriptionTests/SettingsTests.swift
@@ -98,6 +98,10 @@ final class SettingsTests: XCTestCase {
             .otherSwiftFlags("first", "second", "third")
             .bitcodeEnabled(true)
             .debugInformationFormat(.dwarf)
+            .swiftActiveCompilationConditions("FIRST", "SECOND", "THIRD")
+            .swiftObjcBridingHeaderPath("/my/briding/header/path.h")
+            .otherCFlags("$(inherited) -my-c-flag")
+            .otherLinkerFlags("$(inherited) -my-linker-flag")
 
         /// Then
         XCTAssertEqual(settings, [
@@ -114,6 +118,10 @@ final class SettingsTests: XCTestCase {
             "OTHER_SWIFT_FLAGS": "first second third",
             "ENABLE_BITCODE": "YES",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "FIRST SECOND THIRD",
+            "SWIFT_OBJC_BRIDGING_HEADER": "/my/briding/header/path.h",
+            "OTHER_CFLAGS": "$(inherited) -my-c-flag",
+            "OTHER_LDFLAGS": "$(inherited) -my-linker-flag"
         ])
     }
 
@@ -127,6 +135,17 @@ final class SettingsTests: XCTestCase {
             "CODE_SIGN_STYLE": "Manual",
             "CODE_SIGN_IDENTITY": "Apple Distribution",
             "PROVISIONING_PROFILE_SPECIFIER": "ABC",
+        ])
+    }
+    
+    func test_settingsDictionary_swiftActiveCompilationConditions() {
+        /// Given/When
+        let settings = SettingsDictionary()
+            .swiftActiveCompilationConditions("FIRST", "SECOND", "THIRD")
+
+        /// Then
+        XCTAssertEqual(settings, [
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "FIRST SECOND THIRD"
         ])
     }
 
@@ -176,6 +195,39 @@ final class SettingsTests: XCTestCase {
         /// Then
         XCTAssertEqual(settings3, [
             "SWIFT_OPTIMIZATION_LEVEL": "-Osize",
+        ])
+    }
+    
+    func test_settingsDictionary_swiftObjcBridingHeaderPath() {
+        /// Given/When
+        let settings = SettingsDictionary()
+            .swiftObjcBridingHeaderPath("/my/briding/header/path.h")
+
+        /// Then
+        XCTAssertEqual(settings, [
+            "SWIFT_OBJC_BRIDGING_HEADER": "/my/briding/header/path.h"
+        ])
+    }
+    
+    func test_settingsDictionary_otherCFlags() {
+        /// Given/When
+        let settings = SettingsDictionary()
+            .otherCFlags("$(inherited) -my-c-flag")
+
+        /// Then
+        XCTAssertEqual(settings, [
+            "OTHER_CFLAGS": "$(inherited) -my-c-flag"
+        ])
+    }
+    
+    func test_settingsDictionary_otherLinkerFlags() {
+        /// Given/When
+        let settings = SettingsDictionary()
+            .otherLinkerFlags("$(inherited) -my-linker-flag")
+
+        /// Then
+        XCTAssertEqual(settings, [
+            "OTHER_LDFLAGS": "$(inherited) -my-linker-flag"
         ])
     }
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY
Request for comments document (if applies):

### Short description 📝

- Organize SettingsTransformers MARKS

1. Add swiftActiveCompilationConditions as setting transformer
2. Add swiftObjcBridingHeaderPath as a setting transformer
3. Add otherCFlags as setting transformer
4. Add otherLinkerFlags as a setting transformer

### How to test the changes locally 🧐

Just run the unit tests

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
