### PR TITLE
Fix: swap comments inside generated resources finder file

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -96,7 +96,7 @@ public class ResourcesProjectMapper: ProjectMapping {
             private class BundleFinder {}
 
             extension Foundation.Bundle {
-                /// Since \(targetName) is a \(target.product), the bundle for classes within this module can be used directly.
+                /// Since \(targetName) is a \(target.product), the bundle containing the resources is copied into the final product.
                 static var module: Bundle = {
                     let bundleName = "\(bundleName)"
 
@@ -141,7 +141,7 @@ public class ResourcesProjectMapper: ProjectMapping {
 
             extension Foundation.Bundle {
                 /// Since \(targetName) is a \(target
-                .product), the bundle containing the resources is copied into the final product.
+                .product), the bundle for classes within this module can be used directly.
                 static var module: Bundle = {
                     return Bundle(for: BundleFinder.self)
                 }()

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -96,7 +96,8 @@ public class ResourcesProjectMapper: ProjectMapping {
             private class BundleFinder {}
 
             extension Foundation.Bundle {
-                /// Since \(targetName) is a \(target.product), the bundle containing the resources is copied into the final product.
+                /// Since \(targetName) is a \(target
+                .product), the bundle containing the resources is copied into the final product.
                 static var module: Bundle = {
                     let bundleName = "\(bundleName)"
 


### PR DESCRIPTION
### Short description 📝

It seems the generated resource file comments are incorrect in terms of the nature of the product (static/dynamic) and needs to be swapped.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
