### PR TITLE
Skip resources warning for SPM dependencies

### DIFF
--- a/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
@@ -31,7 +31,7 @@ extension TuistGraph.ResourceFileElement {
                 .filter { !excluded.contains($0) }
 
             // FIXME: Do not hardcode this
-            if files.isEmpty && !path.pathString.contains("Tuist/Dependencies/SwiftPackageManager/.build/checkouts") {
+            if files.isEmpty, !path.pathString.contains("Tuist/Dependencies/SwiftPackageManager/.build/checkouts") {
                 if FileHandler.shared.isFolder(path) {
                     logger.warning("'\(path.pathString)' is a directory, try using: '\(path.pathString)/**' to list its files")
                 } else {

--- a/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
@@ -30,7 +30,8 @@ extension TuistGraph.ResourceFileElement {
                 .filter(includeFiles)
                 .filter { !excluded.contains($0) }
 
-            if files.isEmpty {
+            // FIXME: Do not hardcode this
+            if files.isEmpty && !path.pathString.contains("Tuist/Dependencies/SwiftPackageManager/.build/checkouts") {
                 if FileHandler.shared.isFolder(path) {
                     logger.warning("'\(path.pathString)' is a directory, try using: '\(path.pathString)/**' to list its files")
                 } else {


### PR DESCRIPTION
### Short description 📝

This is only a temporary fix for https://github.com/tuist/tuist/issues/4446.

In the long run, we want to remove the linting to a linter - the blocker currently is that we need access to `ProjectDescription` to assess whether any resources have been missed.

Let's merge this now to make a release and ensure users won't see false positives during `tuist fetch`.

### How to test the changes locally 🧐

- checkout this PR
- run `swift run tuist fetch`
- you should not see any resources-related warning.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
