### PR TITLE
Fix selectedLauncherIdentifier when attachDebug is false in LaunchAction and TestAction

### DIFF
--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -37,6 +37,10 @@ protocol SchemeDescriptorsGenerating {
     ) throws -> [SchemeDescriptor]
 }
 
+public extension XCScheme {
+    static let posixSpawnLauncher = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+}
+
 // swiftlint:disable:next type_body_length
 final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
     private enum Constants {
@@ -61,7 +65,7 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
 
             static var `extension`: LaunchAction {
                 LaunchAction(
-                    launcher: "Xcode.IDEFoundation.Launcher.PosixSpawn",
+                    launcher: XCScheme.posixSpawnLauncher,
                     askForAppToLaunch: true,
                     launchAutomaticallySubstyle: "2"
                 )
@@ -377,6 +381,7 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
             preActions: preActions,
             postActions: postActions,
             selectedDebuggerIdentifier: testAction.attachDebugger ? XCScheme.defaultDebugger : "",
+            selectedLauncherIdentifier: testAction.attachDebugger ? XCScheme.defaultLauncher : XCScheme.posixSpawnLauncher,
             shouldUseLaunchSchemeArgsEnv: shouldUseLaunchSchemeArgsEnv,
             codeCoverageEnabled: testAction.coverage,
             codeCoverageTargets: codeCoverageTargets,

--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -454,17 +454,21 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
         let disableMainThreadChecker = scheme.runAction?.diagnosticsOptions.contains(.mainThreadChecker) == false
 
         let launchActionConstants: Constants.LaunchAction
+        let launcherIdentifier: String
         let debuggerIdentifier: String
         let isSchemeForAppExtension = isSchemeForAppExtension(scheme: scheme, graphTraverser: graphTraverser)
         if isSchemeForAppExtension == true {
             launchActionConstants = .extension
             debuggerIdentifier = ""
+            launcherIdentifier = launchActionConstants.launcher
         } else {
             launchActionConstants = .default
             if let runAction = scheme.runAction {
                 debuggerIdentifier = runAction.attachDebugger ? XCScheme.defaultDebugger : ""
+                launcherIdentifier = runAction.attachDebugger ? launchActionConstants.launcher : XCScheme.posixSpawnLauncher
             } else {
                 debuggerIdentifier = XCScheme.defaultDebugger
+                launcherIdentifier = launchActionConstants.launcher
             }
         }
 
@@ -517,7 +521,7 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
             postActions: postActions,
             macroExpansion: macroExpansion,
             selectedDebuggerIdentifier: debuggerIdentifier,
-            selectedLauncherIdentifier: launchActionConstants.launcher,
+            selectedLauncherIdentifier: launcherIdentifier,
             askForAppToLaunch: launchActionConstants.askForAppToLaunch,
             pathRunnable: pathRunnable,
             locationScenarioReference: locationScenarioReference,

--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -37,7 +37,7 @@ protocol SchemeDescriptorsGenerating {
     ) throws -> [SchemeDescriptor]
 }
 
-public extension XCScheme {
+extension XCScheme {
     static let posixSpawnLauncher = "Xcode.IDEFoundation.Launcher.PosixSpawn"
 }
 

--- a/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -406,6 +406,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let result = try XCTUnwrap(got)
         XCTAssertEqual(result.buildConfiguration, "Debug")
         XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
         XCTAssertEqual(result.shouldUseLaunchSchemeArgsEnv, true)
         XCTAssertNil(result.macroExpansion)
         let testable = try XCTUnwrap(result.testables.first)
@@ -460,6 +461,8 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         // Then
         let result = try XCTUnwrap(got)
         XCTAssertEqual(result.buildConfiguration, "Debug")
+        XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
         XCTAssertEqual(result.shouldUseLaunchSchemeArgsEnv, true)
         let testable = try XCTUnwrap(result.testables.first)
         let buildableReference = testable.buildableReference
@@ -520,8 +523,10 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         // Then
         let result = try XCTUnwrap(got)
+        XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
+        
         let codeCoverageTargetsBuildableReference = try XCTUnwrap(result.codeCoverageTargets)
-
         XCTAssertEqual(result.onlyGenerateCoverageForSpecifiedTargets, true)
         XCTAssertEqual(codeCoverageTargetsBuildableReference.count, 1)
         XCTAssertEqual(codeCoverageTargetsBuildableReference.first?.buildableName, "App.app")
@@ -548,6 +553,8 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         // When
         let result = try XCTUnwrap(got)
         XCTAssertEqual(result.buildConfiguration, "Debug")
+        XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
         XCTAssertEqual(result.shouldUseLaunchSchemeArgsEnv, false)
         XCTAssertNil(result.macroExpansion)
         XCTAssertEqual(result.testables.count, 0)
@@ -575,6 +582,36 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         // When
         let result = try XCTUnwrap(got)
+        XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
+        XCTAssertEqual(result.testPlans?.count, 1)
+        XCTAssertEqual(result.testPlans?.first?.reference, "container:folder/Plan.xctestplan")
+    }
+    
+    func test_schemeTestAction_when_usingTestPlans_with_disabled_attachDebugger() throws {
+        // Given
+        let project = Project.test()
+        let planPath = AbsolutePath(project.path, "folder/Plan.xctestplan")
+        let planList = [TestPlan(path: planPath, isDefault: true)]
+        let scheme = Scheme.test(testAction: TestAction.test(attachDebugger: false, testPlans: planList))
+        let generatedProject = GeneratedProject.test()
+        let graph = Graph.test(
+            projects: [project.path: project]
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // Then
+        let got = try subject.schemeTestAction(
+            scheme: scheme,
+            graphTraverser: graphTraverser,
+            rootPath: project.path,
+            generatedProjects: [project.path: generatedProject]
+        )
+
+        // When
+        let result = try XCTUnwrap(got)
+        XCTAssertEqual(result.selectedDebuggerIdentifier, "")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.IDEFoundation.Launcher.PosixSpawn")
         XCTAssertEqual(result.testPlans?.count, 1)
         XCTAssertEqual(result.testPlans?.first?.reference, "container:folder/Plan.xctestplan")
     }
@@ -618,9 +655,13 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
             rootPath: project.path,
             generatedProjects: createGeneratedProjects(projects: [project])
         )
+        
+        let result = try XCTUnwrap(got)
+        XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
 
         // Then
-        let testableTargetReference = got!.testables[0]
+        let testableTargetReference = result.testables[0]
         XCTAssertEqual(testableTargetReference.skipped, false)
         XCTAssertEqual(testableTargetReference.parallelizable, true)
         XCTAssertEqual(testableTargetReference.randomExecutionOrdering, true)
@@ -710,6 +751,8 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         // Then
         let result = try XCTUnwrap(got)
+        XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
         XCTAssertEqual(result.buildConfiguration, "Debug")
         XCTAssertEqual(result.shouldUseLaunchSchemeArgsEnv, true)
         XCTAssertNil(result.macroExpansion)
@@ -777,6 +820,8 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let result = try XCTUnwrap(got)
         XCTAssertEqual(result.language, "es")
         XCTAssertEqual(result.region, "ES")
+        XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
 
         XCTAssertEqual(result.preActions.first?.title, "Pre Action")
         XCTAssertEqual(result.preActions.first?.scriptText, "echo Pre Actions")
@@ -854,7 +899,8 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         // Then
         let result = try XCTUnwrap(got)
-
+        XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
         XCTAssertNil(result.macroExpansion)
 
         let buildableReference = try XCTUnwrap(result.runnable?.buildableReference)
@@ -929,6 +975,8 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         // Then
         let result = try XCTUnwrap(got)
+        XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
 
         XCTAssertEqual(result.commandlineArguments, XCScheme.CommandLineArguments(arguments: [
             XCScheme.CommandLineArguments.CommandLineArgument(name: "arg4", enabled: true),
@@ -973,6 +1021,8 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         // Then
         let result = try XCTUnwrap(got)
+        XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
         XCTAssertNil(result.runnable?.buildableReference)
         XCTAssertEqual(result.buildConfiguration, "Debug")
         XCTAssertEqual(result.pathRunnable?.filePath, "/usr/bin/foo")
@@ -1017,6 +1067,8 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         // Then
         let result = try XCTUnwrap(got)
+        XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
         XCTAssertNil(result.runnable?.buildableReference)
 
         XCTAssertEqual(result.buildConfiguration, "Debug")
@@ -1075,6 +1127,10 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
             rootPath: projectPath,
             generatedProjects: createGeneratedProjects(projects: [project])
         )
+        
+        let result = try XCTUnwrap(got)
+        XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
 
         // Then
         XCTAssertEqual(got?.preActions.first?.title, "Pre Action")
@@ -1120,6 +1176,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         // Then
         let result = try XCTUnwrap(got)
         XCTAssertEqual(result.selectedDebuggerIdentifier, "")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.IDEFoundation.Launcher.PosixSpawn")
     }
 
     func test_schemeLaunchAction_without_explicit_runAction() throws {
@@ -1154,6 +1211,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         // Then
         let result = try XCTUnwrap(got)
         XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
     }
 
     func test_schemeLaunchAction_for_app_extension() throws {

--- a/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -525,7 +525,6 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let result = try XCTUnwrap(got)
         XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
         XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
-        
         let codeCoverageTargetsBuildableReference = try XCTUnwrap(result.codeCoverageTargets)
         XCTAssertEqual(result.onlyGenerateCoverageForSpecifiedTargets, true)
         XCTAssertEqual(codeCoverageTargetsBuildableReference.count, 1)
@@ -587,7 +586,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         XCTAssertEqual(result.testPlans?.count, 1)
         XCTAssertEqual(result.testPlans?.first?.reference, "container:folder/Plan.xctestplan")
     }
-    
+
     func test_schemeTestAction_when_usingTestPlans_with_disabled_attachDebugger() throws {
         // Given
         let project = Project.test()
@@ -655,7 +654,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
             rootPath: project.path,
             generatedProjects: createGeneratedProjects(projects: [project])
         )
-        
+
         let result = try XCTUnwrap(got)
         XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
         XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
@@ -1127,7 +1126,6 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
             rootPath: projectPath,
             generatedProjects: createGeneratedProjects(projects: [project])
         )
-        
         let result = try XCTUnwrap(got)
         XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
         XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")

--- a/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -667,6 +667,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         // Then
         let result = try XCTUnwrap(got)
         XCTAssertEqual(result.selectedDebuggerIdentifier, "")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.IDEFoundation.Launcher.PosixSpawn")
     }
 
     func test_schemeBuildAction() throws {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4424
Request for comments document (if applies):

### Short description 📝

> Disabling attachDebugger on TestAction and LaunchAction doesn't produce the same configuration produced by XCode. This cause issues during automated tests.

When the attachDebugger is enabled Xcode produces the following schema:

```
   <LaunchAction
      buildConfiguration = "Debug"
      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
...
```
and
```
  <TestAction
      buildConfiguration = "Debug"
      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
...
```

When the attachDebugger is disabled, Xcode generates the following:

```
   <LaunchAction
      buildConfiguration = "Debug"
      selectedDebuggerIdentifier = ""
      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
```

and 

```
   <TestAction
      buildConfiguration = "Debug"
      selectedDebuggerIdentifier = ""
      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
```

With `tuist` version `3.4.0` disabling attachDebugger generates the following:

```
   <TestAction
      buildConfiguration = "Debug"
      selectedDebuggerIdentifier = ""
      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
```

### How to test the changes locally 🧐

> Run `tuist generate` on [a demo project](https://github.com/Andrea-Scuderi/DemoTuist) generates the following output:

```
   <TestAction
      buildConfiguration = "Debug"
      selectedDebuggerIdentifier = ""
      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
```

Note: 
After switching schema, Xcode fixes the value, that's why the issue was not spotted in #4425

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
