### PR TITLE
Fix `tuist build` failing to build workspaces with watchOS targets

### DIFF
--- a/Sources/TuistAutomation/Utilities/BuildGraphInspector.swift
+++ b/Sources/TuistAutomation/Utilities/BuildGraphInspector.swift
@@ -61,12 +61,7 @@ public final class BuildGraphInspector: BuildGraphInspecting {
         configuration: String?,
         skipSigning: Bool
     ) -> [XcodeBuildArgument] {
-        var arguments: [XcodeBuildArgument]
-        if target.platform == .macOS {
-            arguments = [.sdk(target.platform.xcodeDeviceSDK)]
-        } else {
-            arguments = [.sdk(target.platform.xcodeSimulatorSDK!)]
-        }
+        var arguments = [XcodeBuildArgument]()
 
         // Configuration
         if let configuration = configuration {

--- a/Tests/TuistAutomationTests/Utilities/BuildGraphInspectorTests.swift
+++ b/Tests/TuistAutomationTests/Utilities/BuildGraphInspectorTests.swift
@@ -22,61 +22,6 @@ final class BuildGraphInspectorTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_buildArguments_when_macOS() throws {
-        // Given
-        let target = Target.test(platform: .macOS)
-
-        // When
-        let got = subject.buildArguments(project: .test(), target: target, configuration: nil, skipSigning: false)
-
-        // Then
-        XCTAssertEqual(got, [
-            .sdk(Platform.macOS.xcodeDeviceSDK),
-        ])
-    }
-
-    func test_buildArguments_when_iOS() throws {
-        // Given
-        let target = Target.test(platform: .iOS)
-        let iosSimulatorSDK = try XCTUnwrap(Platform.iOS.xcodeSimulatorSDK)
-
-        // When
-        let got = subject.buildArguments(project: .test(), target: target, configuration: nil, skipSigning: false)
-
-        // Then
-        XCTAssertEqual(got, [
-            .sdk(iosSimulatorSDK),
-        ])
-    }
-
-    func test_buildArguments_when_watchOS() throws {
-        // Given
-        let target = Target.test(platform: .watchOS)
-        let watchosSimulatorSDK = try XCTUnwrap(Platform.watchOS.xcodeSimulatorSDK)
-
-        // When
-        let got = subject.buildArguments(project: .test(), target: target, configuration: nil, skipSigning: false)
-
-        // Then
-        XCTAssertEqual(got, [
-            .sdk(watchosSimulatorSDK),
-        ])
-    }
-
-    func test_buildArguments_when_tvOS() throws {
-        // Given
-        let target = Target.test(platform: .tvOS)
-        let tvosSimulatorSDK = try XCTUnwrap(Platform.tvOS.xcodeSimulatorSDK)
-
-        // When
-        let got = subject.buildArguments(project: .test(), target: target, configuration: nil, skipSigning: false)
-
-        // Then
-        XCTAssertEqual(got, [
-            .sdk(tvosSimulatorSDK),
-        ])
-    }
-
     func test_buildArguments_when_skipSigning() throws {
         // Given
         let target = Target.test(platform: .iOS)
@@ -87,7 +32,6 @@ final class BuildGraphInspectorTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(got, [
-            .sdk(iosSimulatorSDK),
             .xcarg("CODE_SIGN_IDENTITY", ""),
             .xcarg("CODE_SIGNING_REQUIRED", "NO"),
             .xcarg("CODE_SIGN_ENTITLEMENTS", ""),


### PR DESCRIPTION
### Short description 📝

Fixes an issue where adding the sdk parameter failed to build workspaces with watchOS target

### How to test the changes locally 🧐

Run `tuist test` on a workspace with a mix of iOS and watchOS targets

### Checklist ✅

- [ x] The code architecture and patterns are consistent with the rest of the codebase.
- [ x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ x] In case the PR introduces changes that affect users, the documentation has been updated.
- [ x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
