### PR TITLE
Fix sending analytics from the CI

### DIFF
--- a/projects/cloud/app/controllers/analytics_controller.rb
+++ b/projects/cloud/app/controllers/analytics_controller.rb
@@ -5,6 +5,7 @@ class AnalyticsController < APIController
     CommandEventCreateService.call(
       project_slug: params[:project_id],
       user: current_user,
+      project: @project,
       name: params[:name],
       subcommand: params[:subcommand],
       command_arguments: params[:command_arguments],

--- a/projects/cloud/app/services/command_event_create_service.rb
+++ b/projects/cloud/app/services/command_event_create_service.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
 class CommandEventCreateService < ApplicationService
-  attr_reader :account_name, :project_name, :user, :name, :subcommand, :command_arguments, :duration, :client_id,
+  attr_reader :account_name, :project_name, :user, :project, :name,
+    :subcommand, :command_arguments, :duration, :client_id,
     :tuist_version, :swift_version, :macos_version, :cacheable_targets, :local_cache_target_hits,
     :remote_cache_target_hits
 
   def initialize(
     project_slug:,
     user:,
+    project:,
     name:,
     subcommand:,
     command_arguments:,
@@ -21,9 +23,12 @@ class CommandEventCreateService < ApplicationService
     remote_cache_target_hits:
   )
     super()
-    split_project_slug = project_slug.split("/")
-    @account_name = split_project_slug.first
-    @project_name = split_project_slug.last
+    if project.nil?
+      split_project_slug = project_slug.split("/")
+      @account_name = split_project_slug.first
+      @project_name = split_project_slug.last
+    end
+    @project = project
     @user = user
     @name = name
     @subcommand = subcommand
@@ -39,7 +44,9 @@ class CommandEventCreateService < ApplicationService
   end
 
   def call
-    project = ProjectFetchService.new.fetch_by_name(name: project_name, account_name: account_name, user: user)
+    if project.nil?
+      @project = ProjectFetchService.new.fetch_by_name(name: project_name, account_name: account_name, user: user)
+    end
 
     CommandEvent.create!(
       name: name,

--- a/projects/cloud/test/services/command_event_create_service_test.rb
+++ b/projects/cloud/test/services/command_event_create_service_test.rb
@@ -11,8 +11,9 @@ class CommandEventCreateServiceTest < ActiveSupport::TestCase
 
     # When
     got = CommandEventCreateService.call(
-      project_slug: "#{account.name}/#{project.name}",
-      user: user,
+      project_slug: nil,
+      user: nil,
+      project: project,
       name: "fetch",
       subcommand: "",
       command_arguments: ["fetch", "--path", "./"],
@@ -44,6 +45,7 @@ class CommandEventCreateServiceTest < ActiveSupport::TestCase
     got = CommandEventCreateService.call(
       project_slug: "#{account.name}/#{project.name}",
       user: user,
+      project: nil,
       name: "cache",
       subcommand: "warm",
       command_arguments: ["cache", "warm"],


### PR DESCRIPTION
### Short description 📝

Analytics from the CI were not being sent since the assumption was that `user` would be provided.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
