### PR TITLE
Render cloud errors

### DIFF
--- a/projects/cloud/app/controllers/api_controller.rb
+++ b/projects/cloud/app/controllers/api_controller.rb
@@ -18,4 +18,9 @@ class APIController < ApplicationController
       end
     end
   end
+
+  rescue_from(CloudError) do |error, obj, args, ctx, field|
+    render(json: { errors: [{ message: error.message, code: :bad_request }], status: :bad_request },
+      status: :bad_request)
+  end
 end

--- a/projects/cloud/app/controllers/cache_controller.rb
+++ b/projects/cloud/app/controllers/cache_controller.rb
@@ -2,11 +2,20 @@
 
 class CacheController < APIController
   def cache
+    # TODO: This should be removed eventually as it's only used to support older tuist versions.
     if request.head? && !cache_artifact_upload_service.object_exists?
       render(json: { message: "S3 object was not found", code: :not_found }, status: :not_found)
     else
       # TODO: Handle expires_at instead of hardcoded value
       render(json: { status: "success", data: { url: cache_artifact_upload_service.fetch, expires_at: 1000 } })
+    end
+  end
+
+  def exists
+    if cache_artifact_upload_service.object_exists?
+      render(json: { status: "success", data: {} })
+    else
+      render(json: { message: "S3 object was not found", code: :not_found }, status: :not_found)
     end
   end
 

--- a/projects/cloud/app/services/project_fetch_service.rb
+++ b/projects/cloud/app/services/project_fetch_service.rb
@@ -42,7 +42,7 @@ class ProjectFetchService < ApplicationService
   end
 
   def fetch_by_name(name:, account_name:, user:)
-    account = Account.find_by(name: account_name)
+    account = AccountFetchService.call(name: account_name)
     begin
       project = Project.find_by!(account_id: account.id, name: name)
     rescue ActiveRecord::RecordNotFound

--- a/projects/cloud/config/routes.rb
+++ b/projects/cloud/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
   get "/auth", to: "auth#authenticate"
 
   get "/api/cache", to: "cache#cache"
+  get "/api/cache/exists", to: "cache#exists"
   post "/api/cache", to: "cache#upload_cache_artifact"
   post "/api/cache/verify_upload", to: "cache#verify_upload"
 

--- a/projects/cloud/test/services/project_fetch_service_test.rb
+++ b/projects/cloud/test/services/project_fetch_service_test.rb
@@ -67,4 +67,14 @@ class ProjectFetchServiceTest < ActiveSupport::TestCase
     # Then
     assert_equal project, got
   end
+
+  test "fails with account not found when account does not exist" do
+    # Given
+    user = User.create!(email: "test@cloud.tuist.io", password: Devise.friendly_token.first(16))
+
+    # When / Then
+    assert_raises(AccountFetchService::Error::AccountNotFound) do
+      ProjectFetchService.new.fetch_by_name(name: "tuist", account_name: "tuist", user: user)
+    end
+  end
 end


### PR DESCRIPTION
### Short description 📝

We were using `HEAD` request and `CloudEmptyResponseError` as the error type for checking whether a resource exists in a remote storage. However, if we received an error different than 404, we were not able to parse it. That made it very hard for end-users to realise what could be the error.

I change the logic to properly surface the errors.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
