### PR TITLE
Handle missing remote cache storage

### DIFF
--- a/projects/cloud/test/services/cache_service_test.rb
+++ b/projects/cloud/test/services/cache_service_test.rb
@@ -40,6 +40,22 @@ class CacheServiceTest < ActiveSupport::TestCase
     assert_equal true, got
   end
 
+  test "object exists when remote storage is not defined" do
+    # Given
+    @project.update(remote_cache_storage: nil)
+    # When / Then
+    assert_raises(CacheService::Error::MissingRemoteCacheStorage) do
+      CacheService.new(
+        project_slug: "my-project/tuist",
+        hash: "artifact-hash",
+        name: "MyFramework",
+        user: @user,
+        project: nil
+      )
+        .object_exists?
+    end
+  end
+
   test "object exists with using passed project" do
     # Given
     Aws::S3::Client.any_instance.stubs(:head_object).returns(true)


### PR DESCRIPTION
### Short description 📝

Throw a proper error when remote cache storage is not defined.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
