### PR TITLE
Avoid generated file name conflicts by prepending Tuist to them

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -72,7 +72,7 @@ public class ResourcesProjectMapper: ProjectMapping {
         let filePath = project.path
             .appending(component: Constants.DerivedDirectory.name)
             .appending(component: Constants.DerivedDirectory.sources)
-            .appending(component: "Bundle+\(target.name).swift")
+            .appending(component: "TuistBundle+\(target.name).swift")
 
         let content: String = ResourcesProjectMapper.fileContent(
             targetName: target.name,

--- a/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
@@ -130,7 +130,7 @@ public final class SynthesizedResourceInterfaceProjectMapper: ProjectMapping { /
             let name = target.name.camelized.uppercasingFirst
             renderedInterfaces = [
                 (
-                    templateName + "+" + name,
+                    "Tuist\(templateName)+\(name)",
                     try synthesizedResourceInterfacesGenerator.render(
                         parser: resourceSynthesizer.parser,
                         templateString: templateString,

--- a/Tests/TuistEnvKitTests/Commands/CommandRunnerTests.swift
+++ b/Tests/TuistEnvKitTests/Commands/CommandRunnerTests.swift
@@ -134,7 +134,7 @@ final class CommandRunnerTests: TuistUnitTestCase {
 
         versionResolver.resolveStub = { _ in ResolvedVersion.undefined }
 
-        versionsController.semverVersionsStub = [Version(string: "3.2.1")!]
+        versionsController.semverVersionsStub = [Version("3.2.1")]
         versionsController.pathStub = {
             $0 == "3.2.1" ? temporaryPath : AbsolutePath("/invalid")
         }
@@ -153,7 +153,7 @@ final class CommandRunnerTests: TuistUnitTestCase {
 
         versionsController.semverVersionsStub = []
         updater.updateStub = {
-            self.versionsController.semverVersionsStub = [Version(string: "3.2.1")!]
+            self.versionsController.semverVersionsStub = [Version("3.2.1")]
         }
 
         versionsController.pathStub = {
@@ -190,7 +190,7 @@ final class CommandRunnerTests: TuistUnitTestCase {
 
         versionResolver.resolveStub = { _ in ResolvedVersion.undefined }
 
-        versionsController.semverVersionsStub = [Version(string: "3.2.1")!]
+        versionsController.semverVersionsStub = [Version("3.2.1")]
         versionsController.pathStub = {
             $0 == "3.2.1" ? temporaryPath : AbsolutePath("/invalid")
         }

--- a/Tests/TuistEnvKitTests/Services/LocalServiceTests.swift
+++ b/Tests/TuistEnvKitTests/Services/LocalServiceTests.swift
@@ -54,7 +54,7 @@ final class LocalServiceTests: TuistUnitTestCase {
 
     func test_run_prints_when_no_argument_is_passed() throws {
         // Given
-        versionController.semverVersionsStub = [Version(string: "1.2.3")!, Version(string: "3.2.1")!]
+        versionController.semverVersionsStub = [Version("1.2.3"), Version("3.2.1")]
 
         // When
         try subject.run(version: nil)

--- a/Tests/TuistEnvKitTests/Versions/VersionsControllerTests.swift
+++ b/Tests/TuistEnvKitTests/Versions/VersionsControllerTests.swift
@@ -51,7 +51,7 @@ final class VersionsControllerTests: TuistUnitTestCase {
         let versions = subject.versions()
 
         XCTAssertTrue(versions.contains(.reference("ref")))
-        XCTAssertTrue(versions.contains(.semver(Version(string: "3.2.1")!)))
+        XCTAssertTrue(versions.contains(.semver(Version("3.2.1"))))
     }
 
     func test_semverVersions_ordered() throws {

--- a/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -46,7 +46,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         let expectedPath = project.path
             .appending(component: Constants.DerivedDirectory.name)
             .appending(component: Constants.DerivedDirectory.sources)
-            .appending(component: "Bundle+\(target.name).swift")
+            .appending(component: "TuistBundle+\(target.name).swift")
         let expectedContents = ResourcesProjectMapper
             .fileContent(targetName: target.name, bundleName: "\(target.name)Resources", target: target)
         XCTAssertEqual(file.path, expectedPath)
@@ -114,7 +114,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         let expectedPath = project.path
             .appending(component: Constants.DerivedDirectory.name)
             .appending(component: Constants.DerivedDirectory.sources)
-            .appending(component: "Bundle+\(target.name).swift")
+            .appending(component: "TuistBundle+\(target.name).swift")
         let expectedContents = ResourcesProjectMapper
             .fileContent(targetName: target.name, bundleName: "\(target.name)Resources", target: target)
         XCTAssertEqual(file.path, expectedPath)
@@ -161,7 +161,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         let expectedPath = project.path
             .appending(component: Constants.DerivedDirectory.name)
             .appending(component: Constants.DerivedDirectory.sources)
-            .appending(component: "Bundle+\(target.name).swift")
+            .appending(component: "TuistBundle+\(target.name).swift")
         let expectedContents = ResourcesProjectMapper
             .fileContent(targetName: target.name, bundleName: "\(target.name)Resources", target: target)
         XCTAssertEqual(file.path, expectedPath)
@@ -199,7 +199,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         let expectedPath = project.path
             .appending(component: Constants.DerivedDirectory.name)
             .appending(component: Constants.DerivedDirectory.sources)
-            .appending(component: "Bundle+\(target.name).swift")
+            .appending(component: "TuistBundle+\(target.name).swift")
         let expectedContents = ResourcesProjectMapper
             .fileContent(targetName: target.name, bundleName: "\(target.name)Resources", target: target)
         XCTAssertEqual(file.path, expectedPath)
@@ -267,7 +267,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         let expectedPath = project.path
             .appending(component: Constants.DerivedDirectory.name)
             .appending(component: Constants.DerivedDirectory.sources)
-            .appending(component: "Bundle+\(target.name).swift")
+            .appending(component: "TuistBundle+\(target.name).swift")
         let expectedContents = ResourcesProjectMapper
             .fileContent(targetName: target.name, bundleName: "test_tuistResources", target: target)
         XCTAssertEqual(file.path, expectedPath)

--- a/Tests/TuistGeneratorTests/ProjectMappers/SynthesizedResourceInterfaceProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/SynthesizedResourceInterfaceProjectMapperTests.swift
@@ -144,32 +144,32 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
             [
                 .file(
                     FileDescriptor(
-                        path: derivedSourcesPath.appending(component: "Assets+TargetA.swift"),
+                        path: derivedSourcesPath.appending(component: "TuistAssets+TargetA.swift"),
                         contents: "TargetA/a.xcassets".data(using: .utf8)
                     )
                 ),
                 .file(
                     FileDescriptor(
-                        path: derivedSourcesPath.appending(component: "Strings+TargetA.swift"),
+                        path: derivedSourcesPath.appending(component: "TuistStrings+TargetA.swift"),
                         contents: "en.lproj/aStrings.strings, en.lproj/aStrings.stringsdict"
                             .data(using: .utf8)
                     )
                 ),
                 .file(
                     FileDescriptor(
-                        path: derivedSourcesPath.appending(component: "Plists+TargetA.swift"),
+                        path: derivedSourcesPath.appending(component: "TuistPlists+TargetA.swift"),
                         contents: "TargetA/Environment.plist".data(using: .utf8)
                     )
                 ),
                 .file(
                     FileDescriptor(
-                        path: derivedSourcesPath.appending(component: "Fonts+TargetA.swift"),
+                        path: derivedSourcesPath.appending(component: "TuistFonts+TargetA.swift"),
                         contents: "TargetA/otfFont.otf, TargetA/ttcFont.ttc, TargetA/ttfFont.ttf".data(using: .utf8)
                     )
                 ),
                 .file(
                     FileDescriptor(
-                        path: derivedSourcesPath.appending(component: "Lottie+TargetA.swift"),
+                        path: derivedSourcesPath.appending(component: "TuistLottie+TargetA.swift"),
                         contents: "TargetA/LottieAnimation.lottie".data(using: .utf8)
                     )
                 ),
@@ -185,13 +185,13 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
                         sources: [
                             SourceFile(
                                 path: derivedSourcesPath
-                                    .appending(component: "Assets+TargetA.swift"),
+                                    .appending(component: "TuistAssets+TargetA.swift"),
                                 compilerFlags: nil,
                                 contentHash: try contentHasher.hash("TargetA/a.xcassets".data(using: .utf8)!)
                             ),
                             SourceFile(
                                 path: derivedSourcesPath
-                                    .appending(component: "Strings+TargetA.swift"),
+                                    .appending(component: "TuistStrings+TargetA.swift"),
                                 compilerFlags: nil,
                                 contentHash: try contentHasher.hash(
                                     "en.lproj/aStrings.strings, en.lproj/aStrings.stringsdict".data(using: .utf8)!
@@ -199,20 +199,20 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
                             ),
                             SourceFile(
                                 path: derivedSourcesPath
-                                    .appending(component: "Plists+TargetA.swift"),
+                                    .appending(component: "TuistPlists+TargetA.swift"),
                                 compilerFlags: nil,
                                 contentHash: try contentHasher.hash("TargetA/Environment.plist".data(using: .utf8)!)
                             ),
                             SourceFile(
                                 path: derivedSourcesPath
-                                    .appending(component: "Fonts+TargetA.swift"),
+                                    .appending(component: "TuistFonts+TargetA.swift"),
                                 compilerFlags: nil,
                                 contentHash: try contentHasher
                                     .hash("TargetA/otfFont.otf, TargetA/ttcFont.ttc, TargetA/ttfFont.ttf".data(using: .utf8)!)
                             ),
                             SourceFile(
                                 path: derivedSourcesPath
-                                    .appending(component: "Lottie+TargetA.swift"),
+                                    .appending(component: "TuistLottie+TargetA.swift"),
                                 compilerFlags: nil,
                                 contentHash: try contentHasher.hash("TargetA/LottieAnimation.lottie".data(using: .utf8)!)
                             ),

--- a/Tests/TuistGraphTests/Models/LintingIssueTests.swift
+++ b/Tests/TuistGraphTests/Models/LintingIssueTests.swift
@@ -44,7 +44,7 @@ final class LintingIssueTests: TuistUnitTestCase {
     func test_printWarningsIfNeeded() throws {
         let first = LintingIssue(reason: "warning", severity: .warning)
 
-        XCTAssertNoThrow(try [first].printWarningsIfNeeded())
+        XCTAssertNoThrow([first].printWarningsIfNeeded())
 
         XCTAssertPrinterOutputContains(
             """

--- a/Tests/TuistSigningTests/SigningInteractorTests.swift
+++ b/Tests/TuistSigningTests/SigningInteractorTests.swift
@@ -77,7 +77,7 @@ final class SigningInteractorTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.install(graphTraverser: graphTraverser)
+        _ = try subject.install(graphTraverser: graphTraverser)
 
         // Then
         XCTAssertEqual(masterKey, receivedMasterKey)
@@ -110,7 +110,7 @@ final class SigningInteractorTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.install(graphTraverser: graphTraverser)
+        _ = try subject.install(graphTraverser: graphTraverser)
 
         // Then
         XCTAssertEqual(masterKey, receivedMasterKey)
@@ -142,7 +142,7 @@ final class SigningInteractorTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.install(graphTraverser: graphTraverser)
+        _ = try subject.install(graphTraverser: graphTraverser)
 
         // Then
         XCTAssertEqual(masterKey, receivedMasterKey)
@@ -171,7 +171,7 @@ final class SigningInteractorTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.install(graphTraverser: graphTraverser)
+        _ = try subject.install(graphTraverser: graphTraverser)
 
         // Then
         XCTAssertEqual(signingPath, entryPath)
@@ -200,7 +200,7 @@ final class SigningInteractorTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.install(graphTraverser: graphTraverser)
+        _ = try subject.install(graphTraverser: graphTraverser)
 
         // Then
         XCTAssertEqual(signingPath, entryPath)
@@ -259,7 +259,7 @@ final class SigningInteractorTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.install(graphTraverser: graphTraverser)
+        _ = try subject.install(graphTraverser: graphTraverser)
 
         // Then
         XCTAssertEqual([expectedCertificate], installedCertificates)

--- a/projects/tuist/features/generate-2.feature
+++ b/projects/tuist/features/generate-2.feature
@@ -35,9 +35,9 @@ Feature: Generate a new project using Tuist (suite 2)
     Then the product 'StaticFramework2Resources.bundle' with destination 'Debug-iphonesimulator' contains resource 'StaticFramework2Resources-tuist.png'
     Then the product 'StaticFramework3Resources.bundle' with destination 'Debug-iphonesimulator' contains resource 'StaticFramework3Resources-tuist.png'
     Then the product 'StaticFramework4Resources.bundle' with destination 'Debug-iphonesimulator' contains resource 'StaticFramework4Resources-tuist.png'
-    Then a file App/Derived/Sources/Bundle+App.swift exists
-    Then a file App/Derived/Sources/Strings+App.swift exists
-    Then a file App/Derived/Sources/Assets+App.swift exists
-    Then a file App/Derived/Sources/Fonts+App.swift exists
-    Then a file App/Derived/Sources/Plists+App.swift exists
-    Then a file StaticFramework3/Derived/Sources/Assets+StaticFramework3.swift exists
+    Then a file App/Derived/Sources/TuistBundle+App.swift exists
+    Then a file App/Derived/Sources/TuistStrings+App.swift exists
+    Then a file App/Derived/Sources/TuistAssets+App.swift exists
+    Then a file App/Derived/Sources/TuistFonts+App.swift exists
+    Then a file App/Derived/Sources/TuistPlists+App.swift exists
+    Then a file StaticFramework3/Derived/Sources/TuistAssets+StaticFramework3.swift exists

--- a/projects/tuist/features/generate-8.feature
+++ b/projects/tuist/features/generate-8.feature
@@ -33,9 +33,9 @@ Scenario: The ios app with framework has disabled resources (ios_app_with_framew
     And I have a working directory
     Then I copy the fixture ios_app_with_framework_and_disabled_resources into the working directory
     Then tuist generates the project
-    Then a file App/Derived/Sources/Bundle+App.swift does not exist
-    Then a file Framework1/Derived/Sources/Bundle+Framework1.swift does not exist
-    Then a file StaticFramework/Derived/Sources/Bundle+StaticFramework.swift does not exist
+    Then a file App/Derived/Sources/TuistBundle+App.swift does not exist
+    Then a file Framework1/Derived/Sources/TuistBundle+Framework1.swift does not exist
+    Then a file StaticFramework/Derived/Sources/TuistBundle+StaticFramework.swift does not exist
 
 Scenario: The project is a macOS app with extensions (macos_app_with_extensions)
     Given that tuist is available


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4467

### Short description 📝

Prepend `Tuist` to generated file names to avoid name conflicts
