### PR TITLE
Fix showing cloud errors

### DIFF
--- a/Sources/TuistCache/Cache/Resources/CloudCacheResourceFactory.swift
+++ b/Sources/TuistCache/Cache/Resources/CloudCacheResourceFactory.swift
@@ -3,7 +3,7 @@ import TuistCore
 import TuistGraph
 import TuistSupport
 
-typealias CloudExistsResource = HTTPResource<CloudResponse<CloudEmptyResponse>, CloudEmptyResponseError>
+typealias CloudExistsResource = HTTPResource<CloudResponse<CloudEmptyResponse>, CloudResponseError>
 typealias CloudCacheResource = HTTPResource<CloudResponse<CloudCacheResponse>, CloudResponseError>
 typealias CloudVerifyUploadResource = HTTPResource<CloudResponse<CloudVerifyUploadResponse>, CloudResponseError>
 
@@ -23,14 +23,14 @@ class CloudCacheResourceFactory: CloudCacheResourceFactorying {
     }
 
     func existsResource(name: String, hash: String) throws -> CloudExistsResource {
-        let url = try apiCacheURL(name: name, hash: hash, cacheURL: cloudConfig.url, projectId: cloudConfig.projectId)
-        var request = URLRequest(url: url)
-        request.httpMethod = "HEAD"
-        return HTTPResource(
-            request: { request },
-            parse: { _, _ in CloudResponse(status: "HEAD", data: CloudEmptyResponse()) },
-            parseError: { _, _ in CloudEmptyResponseError() }
+        let url = try apiCacheURL(
+            name: name,
+            hash: hash,
+            cacheURL: cloudConfig.url,
+            path: "/api/cache/exists",
+            projectId: cloudConfig.projectId
         )
+        return .jsonResource(for: url, httpMethod: "GET")
     }
 
     func fetchResource(name: String, hash: String) throws -> CloudCacheResource {
@@ -38,6 +38,7 @@ class CloudCacheResourceFactory: CloudCacheResourceFactorying {
             name: name,
             hash: hash,
             cacheURL: cloudConfig.url,
+            path: "/api/cache",
             projectId: cloudConfig.projectId
         )
         return HTTPResource.jsonResource(for: url, httpMethod: "GET")
@@ -48,6 +49,7 @@ class CloudCacheResourceFactory: CloudCacheResourceFactorying {
             name: name,
             hash: hash,
             cacheURL: cloudConfig.url,
+            path: "/api/cache",
             projectId: cloudConfig.projectId,
             contentMD5: contentMD5
         )
@@ -71,6 +73,7 @@ class CloudCacheResourceFactory: CloudCacheResourceFactorying {
         name: String,
         hash: String,
         cacheURL: URL,
+        path: String,
         projectId: String,
         contentMD5: String? = nil
     ) throws -> URL {
@@ -84,7 +87,7 @@ class CloudCacheResourceFactory: CloudCacheResourceFactorying {
             queryItems.append(URLQueryItem(name: "content_md5", value: contentMD5))
         }
 
-        urlComponents.path = "/api/cache"
+        urlComponents.path = path
         urlComponents.queryItems = queryItems
         return urlComponents.url!
     }

--- a/Sources/TuistCacheTesting/Cache/Mocks/MockCloudCacheResponseFactory.swift
+++ b/Sources/TuistCacheTesting/Cache/Mocks/MockCloudCacheResponseFactory.swift
@@ -18,13 +18,13 @@ public class MockCloudCacheResourceFactory: CloudCacheResourceFactorying {
     public var stubbedExistsResourceResult: CloudExistsResource = HTTPResource(
         request: { URLRequest.test() },
         parse: { _, _ in CloudResponse(status: "HEAD", data: CloudEmptyResponse()) },
-        parseError: { _, _ in CloudEmptyResponseError() }
+        parseError: { _, _ in CloudResponseError.test() }
     )
 
     public func existsResource(
         name: String,
         hash: String
-    ) throws -> HTTPResource<CloudResponse<CloudEmptyResponse>, CloudEmptyResponseError> {
+    ) throws -> HTTPResource<CloudResponse<CloudEmptyResponse>, CloudResponseError> {
         invokedExistsResource = true
         invokedExistsResourceCount += 1
         invokedExistsResourceParameters = (name, hash, ())


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY
Request for comments document (if applies):

### Short description 📝

Changes in the tuist CLI to show errors coming from checking cache artifacts' existence. This needs to be a separate PR since the new version of the tuist cloud needs to be deployed first. This is a limitation of the current acceptance test setup which we might want to look into in the future.

**NOTE:** If you have a custom cloud server, you will need to update it to support the new endpoing `GET {url}/cache/exists` which used to be `HEAD {url}/cache`

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
