### PR TITLE
Fixed rendering of generated `Info.plist` in Xcode

### DIFF
--- a/Sources/TuistGenerator/Mappers/GenerateInfoPlistProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/GenerateInfoPlistProjectMapper.swift
@@ -71,7 +71,7 @@ public final class GenerateInfoPlistProjectMapper: ProjectMapping {
         let infoPlistPath = project.path
             .appending(component: derivedDirectoryName)
             .appending(component: infoPlistsDirectoryName)
-            .appending(component: "\(target.name).plist")
+            .appending(component: "\(target.name)-Info.plist")
         let sideEffect = SideEffectDescriptor.file(FileDescriptor(path: infoPlistPath, contents: data))
 
         let newTarget = target.with(infoPlist: InfoPlist.generatedFile(path: infoPlistPath, data: data))

--- a/Tests/TuistGeneratorTests/ProjectMappers/GenerateInfoPlistProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/GenerateInfoPlistProjectMapperTests.swift
@@ -43,23 +43,23 @@ public final class GenerateInfoPlistProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(mappedProject.targets.count, 2)
 
         try XCTAssertSideEffectsCreateDerivedInfoPlist(
-            named: "A.plist",
+            named: "A-Info.plist",
             content: ["A": "A_VALUE"],
             projectPath: project.path,
             sideEffects: sideEffects
         )
         try XCTAssertSideEffectsCreateDerivedInfoPlist(
-            named: "B.plist",
+            named: "B-Info.plist",
             content: ["B": "B_VALUE"],
             projectPath: project.path,
             sideEffects: sideEffects
         )
         XCTAssertTargetExistsWithDerivedInfoPlist(
-            named: "A.plist",
+            named: "A-Info.plist",
             project: mappedProject
         )
         XCTAssertTargetExistsWithDerivedInfoPlist(
-            named: "B.plist",
+            named: "B-Info.plist",
             project: mappedProject
         )
     }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4492
Request for comments document (if applies):

### Short description 📝

Xcode properly recognizes `Info.plist` files when they include `-Info` suffix in their names.
This PR changes file name format from `TargetName.plist` to `TargetName-Info.plist`.

### How to test the changes locally 🧐

See reproduction steps and expected result in the linked issue.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
