### PR TITLE
Avoid pruning schemes with test plans

### DIFF
--- a/Sources/TuistCache/Mappers/Graph/TreeShakePrunedTargetsGraphMapper.swift
+++ b/Sources/TuistCache/Mappers/Graph/TreeShakePrunedTargetsGraphMapper.swift
@@ -82,19 +82,19 @@ public final class TreeShakePrunedTargetsGraphMapper: GraphMapping {
         schemes.compactMap { scheme -> Scheme? in
             var scheme = scheme
 
-            var buildAction = scheme.buildAction
-            buildAction?.targets = scheme.buildAction?.targets.filter(sourceTargets.contains) ?? []
+            if let buildAction = scheme.buildAction {
+                scheme.buildAction?.targets = buildAction.targets.filter(sourceTargets.contains)
+            }
 
-            var testAction = scheme.testAction
-            testAction?.targets = scheme.testAction?.targets.filter { sourceTargets.contains($0.target) } ?? []
-            testAction?.codeCoverageTargets = scheme.testAction?.codeCoverageTargets.filter(sourceTargets.contains) ?? []
+            if let testAction = scheme.testAction {
+                scheme.testAction?.targets = testAction.targets.filter { sourceTargets.contains($0.target) }
+                scheme.testAction?.codeCoverageTargets = testAction.codeCoverageTargets.filter(sourceTargets.contains)
+            }
 
-            scheme.buildAction = buildAction
-            scheme.testAction = testAction
-
-            guard buildAction?.targets.isEmpty == false ||
-                testAction?.targets.isEmpty == false
-            else {
+            let hasBuildTargets = !(scheme.buildAction?.targets ?? []).isEmpty
+            let hasTestTargets = !(scheme.testAction?.targets ?? []).isEmpty
+            let hasTestPlans = !(scheme.testAction?.testPlans ?? []).isEmpty
+            guard hasBuildTargets || hasTestTargets || hasTestPlans else {
                 return nil
             }
 

--- a/Tests/TuistCacheTests/Mappers/Graph/TreeShakePrunedTargetsGraphMapperTests.swift
+++ b/Tests/TuistCacheTests/Mappers/Graph/TreeShakePrunedTargetsGraphMapperTests.swift
@@ -129,7 +129,7 @@ final class TreeShakePrunedTargetsGraphMapperTests: TuistUnitTestCase {
                 .test(
                     buildAction: .test(targets: []),
                     testAction: .test(targets: [], testPlans: [.init(path: "/Test.xctestplan", isDefault: true)])
-                )
+                ),
             ]
         )
     }

--- a/Tests/TuistCacheTests/Mappers/Graph/TreeShakePrunedTargetsGraphMapperTests.swift
+++ b/Tests/TuistCacheTests/Mappers/Graph/TreeShakePrunedTargetsGraphMapperTests.swift
@@ -75,16 +75,17 @@ final class TreeShakePrunedTargetsGraphMapperTests: TuistUnitTestCase {
     func test_map_removes_project_schemes_with_whose_all_targets_have_been_removed() throws {
         // Given
         let path = AbsolutePath("/project")
-        let target = Target.test(name: "first", prune: true)
+        let prunedTarget = Target.test(name: "first", prune: true)
+        let keptTarget = Target.test(name: "second", prune: false)
         let schemes: [Scheme] = [
-            .test(buildAction: .test(targets: [.init(projectPath: path, name: target.name)])),
+            .test(buildAction: .test(targets: [.init(projectPath: path, name: prunedTarget.name)])),
         ]
-        let project = Project.test(path: path, targets: [target], schemes: schemes)
+        let project = Project.test(path: path, targets: [prunedTarget, keptTarget], schemes: schemes)
 
         let graph = Graph.test(
             path: project.path,
             projects: [project.path: project],
-            targets: [project.path: [target.name: target]],
+            targets: [project.path: [prunedTarget.name: prunedTarget, keptTarget.name: keptTarget]],
             dependencies: [:]
         )
 
@@ -93,11 +94,44 @@ final class TreeShakePrunedTargetsGraphMapperTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEmpty(gotSideEffects)
-        XCTAssertEqual(gotGraph.projects.count, 0)
-        let valueProjectSchemes = gotGraph.projects.values.first?.schemes ?? []
-        XCTAssertEmpty(valueProjectSchemes)
-        let valueTargets = gotGraph.targets.flatMap(\.value)
-        XCTAssertEqual(valueTargets.count, 0)
+        XCTAssertNotEmpty(gotGraph.projects)
+        XCTAssertEmpty(gotGraph.projects.values.flatMap(\.schemes))
+    }
+
+    func test_map_keeps_project_schemes_with_whose_all_targets_have_been_removed_but_have_test_plans() throws {
+        let path = AbsolutePath("/project")
+        let prunedTarget = Target.test(name: "first", prune: true)
+        let keptTarget = Target.test(name: "second", prune: false)
+        let schemes: [Scheme] = [
+            .test(
+                buildAction: .test(targets: [.init(projectPath: path, name: prunedTarget.name)]),
+                testAction: .test(testPlans: [.init(path: "/Test.xctestplan", isDefault: true)])
+            ),
+        ]
+        let project = Project.test(path: path, targets: [prunedTarget, keptTarget], schemes: schemes)
+
+        let graph = Graph.test(
+            path: project.path,
+            projects: [project.path: project],
+            targets: [project.path: [prunedTarget.name: prunedTarget, keptTarget.name: keptTarget]],
+            dependencies: [:]
+        )
+
+        // When
+        let (gotGraph, gotSideEffects) = try subject.map(graph: graph)
+
+        // Then
+        XCTAssertEmpty(gotSideEffects)
+        XCTAssertNotEmpty(gotGraph.projects)
+        XCTAssertEqual(
+            gotGraph.projects.values.flatMap(\.schemes),
+            [
+                .test(
+                    buildAction: .test(targets: []),
+                    testAction: .test(targets: [], testPlans: [.init(path: "/Test.xctestplan", isDefault: true)])
+                )
+            ]
+        )
     }
 
     func test_map_removes_the_workspace_projects_that_no_longer_exist() throws {


### PR DESCRIPTION
If a scheme has test plans tuist can't know whether they should be pruned or not, hence they should be kept in the project