### PR TITLE
Generate Package.swift with correct format when custom swift version is specified

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -29,21 +29,12 @@
         }
       },
       {
-        "package": "combine-schedulers",
-        "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
-        "state": {
-          "branch": null,
-          "revision": "f1250faa1c1436ca83950ce676a4fe97a309a457",
-          "version": "0.4.1"
-        }
-      },
-      {
         "package": "CombineExt",
         "repositoryURL": "https://github.com/CombineCommunity/CombineExt.git",
         "state": {
           "branch": null,
-          "revision": "5b8a0c0f178527f9204200505c5fefa6847e528f",
-          "version": "1.3.0"
+          "revision": "38a4d4cb01f8c7750671c786d33dfbea00cbd131",
+          "version": "1.6.1"
         }
       },
       {
@@ -60,8 +51,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
         "state": {
           "branch": null,
-          "revision": "8d4f6384e0a8cc41f2005247241dd553963a492a",
-          "version": "1.4.1"
+          "revision": "039f56c5d7960f277087a0be51f5eb04ed0ec073",
+          "version": "1.5.1"
         }
       },
       {
@@ -96,8 +87,17 @@
         "repositoryURL": "https://github.com/shibapm/Komondor.git",
         "state": {
           "branch": null,
-          "revision": "855c74f395a4dc9e02828f58d931be6920bcbf6f",
-          "version": "1.0.6"
+          "revision": "dedffeaf42a1b52bf072a9dc47afb35000a8b265",
+          "version": "1.1.4"
+        }
+      },
+      {
+        "package": "Logger",
+        "repositoryURL": "https://github.com/shibapm/Logger",
+        "state": {
+          "branch": null,
+          "revision": "53c3ecca5abe8cf46697e33901ee774236d94cce",
+          "version": "0.2.3"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/shibapm/PackageConfig.git",
         "state": {
           "branch": null,
-          "revision": "bf90dc69fa0792894b08a0b74cf34029694ae486",
-          "version": "0.13.0"
+          "revision": "58523193c26fb821ed1720dcd8a21009055c7cdb",
+          "version": "1.1.3"
         }
       },
       {
@@ -128,12 +128,30 @@
         }
       },
       {
+        "package": "Rocket",
+        "repositoryURL": "https://github.com/f-meloni/Rocket",
+        "state": {
+          "branch": null,
+          "revision": "9880a5beb7fcb9e61ddd5764edc1700b8c418deb",
+          "version": "1.2.1"
+        }
+      },
+      {
         "package": "ShellOut",
         "repositoryURL": "https://github.com/JohnSundell/ShellOut.git",
         "state": {
           "branch": null,
           "revision": "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
           "version": "2.3.0"
+        }
+      },
+      {
+        "package": "SourceKitten",
+        "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
+        "state": {
+          "branch": null,
+          "revision": "817dfa6f2e09b0476f3a6c9dbc035991f02f0241",
+          "version": "0.32.0"
         }
       },
       {
@@ -150,8 +168,8 @@
         "repositoryURL": "https://github.com/stencilproject/Stencil.git",
         "state": {
           "branch": null,
-          "revision": "973e190edf5d09274e4a6bc2e636c86899ed84c3",
-          "version": "0.14.1"
+          "revision": "ccd9402682f4c07dac9561befd207c8156e80e20",
+          "version": "0.14.2"
         }
       },
       {
@@ -168,8 +186,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "e1465042f195f374b94f915ba8ca49de24300a0d",
-          "version": "1.0.2"
+          "revision": "f3c9084a71ef4376f2fabbdf1d3d90a49f1fabdb",
+          "version": "1.1.2"
         }
       },
       {
@@ -209,6 +227,15 @@
         }
       },
       {
+        "package": "SwiftFormat",
+        "repositoryURL": "https://github.com/nicklockwood/SwiftFormat.git",
+        "state": {
+          "branch": null,
+          "revision": "f8e35f6716c369c8412664052a0a7337da2ca0e3",
+          "version": "0.49.9"
+        }
+      },
+      {
         "package": "SwiftGen",
         "repositoryURL": "https://github.com/SwiftGen/SwiftGen",
         "state": {
@@ -218,21 +245,48 @@
         }
       },
       {
+        "package": "SwiftLint",
+        "repositoryURL": "https://github.com/Realm/SwiftLint.git",
+        "state": {
+          "branch": null,
+          "revision": "e8ef21fef61f12536964c4e3cf6d5a6e3ad81e49",
+          "version": "0.46.5"
+        }
+      },
+      {
+        "package": "SwiftShell",
+        "repositoryURL": "https://github.com/kareman/SwiftShell",
+        "state": {
+          "branch": null,
+          "revision": "a6014fe94c3dbff0ad500e8da4f251a5d336530b",
+          "version": "5.1.0-beta.1"
+        }
+      },
+      {
+        "package": "SwiftyTextTable",
+        "repositoryURL": "https://github.com/scottrhoyt/SwiftyTextTable.git",
+        "state": {
+          "branch": null,
+          "revision": "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+          "version": "0.9.0"
+        }
+      },
+      {
+        "package": "SWXMLHash",
+        "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
+        "state": {
+          "branch": null,
+          "revision": "6469881a3f30417c5bb02404ea4b69207f297592",
+          "version": "6.0.0"
+        }
+      },
+      {
         "package": "XcodeProj",
         "repositoryURL": "https://github.com/tuist/XcodeProj.git",
         "state": {
           "branch": null,
           "revision": "c75c3acc25460195cfd203a04dde165395bf00e0",
           "version": "8.7.1"
-        }
-      },
-      {
-        "package": "xctest-dynamic-overlay",
-        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
-        "state": {
-          "branch": null,
-          "revision": "603974e3909ad4b48ba04aad7e0ceee4f077a518",
-          "version": "0.1.0"
         }
       },
       {

--- a/Sources/TuistDependencies/Carthage/Utils/CarthageController.swift
+++ b/Sources/TuistDependencies/Carthage/Utils/CarthageController.swift
@@ -61,14 +61,14 @@ public protocol CarthageControlling {
     /// - Parameters:
     ///   - path: Directory where project's dependencies will be installed.
     ///   - platforms: The platforms to build for.
-    ///   - printOutput: When true it prints the Carthage's ouput.
+    ///   - printOutput: When true it prints the Carthage's output.
     func bootstrap(at path: AbsolutePath, platforms: Set<TuistGraph.Platform>, printOutput: Bool) throws
 
     /// Updates and rebuilds the project's dependencies
     /// - Parameters:
     ///   - path: Directory where project's dependencies will be installed.
     ///   - platforms: The platforms to build for.
-    ///   - printOutput: When true it prints the Carthage's ouput.
+    ///   - printOutput: When true it prints the Carthage's output.
     func update(at path: AbsolutePath, platforms: Set<TuistGraph.Platform>, printOutput: Bool) throws
 }
 

--- a/Sources/TuistDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
@@ -136,7 +136,8 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
         dependencies: TuistGraph.SwiftPackageManagerDependencies,
         swiftToolsVersion: TSCUtility.Version?
     ) throws {
-        let version = try TSCUtility.Version(versionString: try System.shared.swiftVersion(), usesLenientParsing: true)
+        let version = try swiftToolsVersion ??
+            TSCUtility.Version(versionString: try System.shared.swiftVersion(), usesLenientParsing: true)
         let isLegacy = version < TSCUtility.Version(5, 6, 0)
 
         // copy `Package.resolved` directory from lockfiles folder
@@ -155,7 +156,7 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
         // set `swift-tools-version` in `Package.swift`
         try swiftPackageManagerController.setToolsVersion(
             at: pathsProvider.destinationSwiftPackageManagerDirectory,
-            to: swiftToolsVersion?.description
+            to: version
         )
 
         let generatedManifestContent = try fileHandler.readTextFile(packageManifestPath)

--- a/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerController.swift
+++ b/Sources/TuistSupport/SwiftPackageManager/SwiftPackageManagerController.swift
@@ -1,24 +1,25 @@
 import Foundation
 import TSCBasic
+import TSCUtility
 
 /// Protocol that defines an interface to interact with the Swift Package Manager.
 public protocol SwiftPackageManagerControlling {
     /// Resolves package dependencies.
     /// - Parameters:
     ///   - path: Directory where the `Package.swift` is defined.
-    ///   - printOutput: When true it prints the Swift Package Manager's ouput.
+    ///   - printOutput: When true it prints the Swift Package Manager's output.
     func resolve(at path: AbsolutePath, printOutput: Bool) throws
 
     /// Updates package dependencies.
     /// - Parameters:
     ///   - path: Directory where the `Package.swift` is defined.
-    ///   - printOutput: When true it prints the Swift Package Manager's ouput.
+    ///   - printOutput: When true it prints the Swift Package Manager's output.
     func update(at path: AbsolutePath, printOutput: Bool) throws
 
     /// Sets tools version of package to the given value.
     /// - Parameter path: Directory where the `Package.swift` is defined.
     /// - Parameter version: Version of tools. When `nil` then the environment’s version will be set.
-    func setToolsVersion(at path: AbsolutePath, to version: String?) throws
+    func setToolsVersion(at path: AbsolutePath, to version: Version) throws
 
     /// Loads the information from the package.
     /// - Parameter path: Directory where the `Package.swift` is defined.
@@ -57,13 +58,8 @@ public final class SwiftPackageManagerController: SwiftPackageManagerControlling
             try System.shared.run(command)
     }
 
-    public func setToolsVersion(at path: AbsolutePath, to version: String?) throws {
-        let extraArguments: [String]
-        if let version = version {
-            extraArguments = ["tools-version", "--set", version]
-        } else {
-            extraArguments = ["tools-version", "--set-current"]
-        }
+    public func setToolsVersion(at path: AbsolutePath, to version: Version) throws {
+        let extraArguments = ["tools-version", "--set", "\(version.major).\(version.minor)"]
 
         let command = buildSwiftPackageCommand(packagePath: path, extraArguments: extraArguments)
 

--- a/Sources/TuistSupportTesting/SwiftPackageManager/MockSwiftPackageManagerController.swift
+++ b/Sources/TuistSupportTesting/SwiftPackageManager/MockSwiftPackageManagerController.swift
@@ -1,4 +1,5 @@
 import TSCBasic
+import TSCUtility
 @testable import TuistSupport
 
 public final class MockSwiftPackageManagerController: SwiftPackageManagerControlling {
@@ -19,8 +20,8 @@ public final class MockSwiftPackageManagerController: SwiftPackageManagerControl
     }
 
     public var invokedSetToolsVersion = false
-    public var setToolsVersionStub: ((AbsolutePath, String?) throws -> Void)?
-    public func setToolsVersion(at path: AbsolutePath, to version: String?) throws {
+    public var setToolsVersionStub: ((AbsolutePath, Version) throws -> Void)?
+    public func setToolsVersion(at path: AbsolutePath, to version: Version) throws {
         invokedSetToolsVersion = true
         try setToolsVersionStub?(path, version)
     }

--- a/Sources/TuistSupportTesting/Utils/MockGitHandler.swift
+++ b/Sources/TuistSupportTesting/Utils/MockGitHandler.swift
@@ -23,6 +23,6 @@ public final class MockGitHandler: GitHandling {
 
     public var remoteTaggedVersionsStub: [String]?
     public func remoteTaggedVersions(url _: String) -> [Version] {
-        remoteTaggedVersionsStub?.compactMap { Version(string: $0) } ?? []
+        remoteTaggedVersionsStub?.compactMap { Version($0) } ?? []
     }
 }

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
@@ -61,7 +61,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         }
         swiftPackageManagerController.setToolsVersionStub = { path, version in
             XCTAssertEqual(path, swiftPackageManagerDirectory)
-            XCTAssertNil(version) // swift-tools-version is not specified
+            XCTAssertEqual(version, TSCUtility.Version(5, 6, 0))
         }
 
         swiftPackageManagerGraphGenerator
@@ -153,10 +153,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         }
         swiftPackageManagerController.setToolsVersionStub = { path, version in
             XCTAssertEqual(path, swiftPackageManagerDirectory)
-            XCTAssertEqual(
-                version,
-                swiftToolsVersion.description
-            ) // version should be equal to the version that has been specified
+            XCTAssertEqual(version, swiftToolsVersion)
         }
 
         swiftPackageManagerGraphGenerator
@@ -246,7 +243,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         }
         swiftPackageManagerController.setToolsVersionStub = { path, version in
             XCTAssertEqual(path, swiftPackageManagerDirectory)
-            XCTAssertNil(version) // swift-tools-version is not specified
+            XCTAssertEqual(version, Version("5.6.0"))
         }
 
         swiftPackageManagerGraphGenerator

--- a/Tests/TuistKitIntegrationTests/Automation/CacheFrameworkBuilderIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Automation/CacheFrameworkBuilderIntegrationTests.swift
@@ -74,7 +74,12 @@ final class CacheFrameworkBuilderIntegrationTests: TuistTestCase {
         XCTAssertEqual(FileHandler.shared.glob(temporaryPath, glob: "*.dSYM").count, 1)
         let frameworkPath = try XCTUnwrap(FileHandler.shared.glob(temporaryPath, glob: "*.framework").first)
         XCTAssertEqual(try binaryLinking(path: frameworkPath), .dynamic)
-        XCTAssertTrue(try architectures(path: frameworkPath).contains(.x8664))
+        switch DeveloperEnvironment.shared.architecture {
+        case .arm64:
+            XCTAssertTrue(try architectures(path: frameworkPath).contains(.arm64))
+        case .x8664:
+            XCTAssertTrue(try architectures(path: frameworkPath).contains(.x8664))
+        }
         XCTAssertEqual(try architectures(path: frameworkPath).count, 1)
     }
 

--- a/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerControllerTests.swift
+++ b/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerControllerTests.swift
@@ -1,4 +1,5 @@
 import TSCBasic
+import TSCUtility
 import TuistCore
 import TuistGraph
 import TuistSupport
@@ -53,7 +54,7 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
     func test_setToolsVersion_specificVersion() throws {
         // Given
         let path = try temporaryPath()
-        let version = "5.4"
+        let version = Version("5.4.0")
         system.succeedCommand([
             "swift",
             "package",
@@ -61,27 +62,11 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
             path.pathString,
             "tools-version",
             "--set",
-            version,
+            "5.4",
         ])
 
         // When / Then
         XCTAssertNoThrow(try subject.setToolsVersion(at: path, to: version))
-    }
-
-    func test_setToolsVersion_currentVersion() throws {
-        // Given
-        let path = try temporaryPath()
-        system.succeedCommand([
-            "swift",
-            "package",
-            "--package-path",
-            path.pathString,
-            "tools-version",
-            "--set-current",
-        ])
-
-        // When / Then
-        XCTAssertNoThrow(try subject.setToolsVersion(at: path, to: nil))
     }
 
     func test_loadPackageInfo() throws {

--- a/Tuist/Config.swift
+++ b/Tuist/Config.swift
@@ -1,5 +1,10 @@
 import ProjectDescription
 
 let config = Config(
-    cloud: .cloud(projectId: "tuist/tuist", url: "https://cloud.tuist.io", options: [.optional, .analytics])
+    cloud: .cloud(
+        projectId: "tuist/tuist",
+        url: "https://cloud.tuist.io",
+        options: [.optional, .analytics]
+    ),
+    swiftVersion: .init("5.4.0")
 )

--- a/Tuist/Dependencies/Lockfiles/Package.resolved
+++ b/Tuist/Dependencies/Lockfiles/Package.resolved
@@ -29,21 +29,12 @@
         }
       },
       {
-        "package": "combine-schedulers",
-        "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
-        "state": {
-          "branch": null,
-          "revision": "f1250faa1c1436ca83950ce676a4fe97a309a457",
-          "version": "0.4.1"
-        }
-      },
-      {
         "package": "CombineExt",
         "repositoryURL": "https://github.com/CombineCommunity/CombineExt.git",
         "state": {
           "branch": null,
-          "revision": "5b8a0c0f178527f9204200505c5fefa6847e528f",
-          "version": "1.3.0"
+          "revision": "38a4d4cb01f8c7750671c786d33dfbea00cbd131",
+          "version": "1.6.1"
         }
       },
       {
@@ -60,8 +51,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
         "state": {
           "branch": null,
-          "revision": "8d4f6384e0a8cc41f2005247241dd553963a492a",
-          "version": "1.4.1"
+          "revision": "039f56c5d7960f277087a0be51f5eb04ed0ec073",
+          "version": "1.5.1"
         }
       },
       {
@@ -96,8 +87,17 @@
         "repositoryURL": "https://github.com/shibapm/Komondor.git",
         "state": {
           "branch": null,
-          "revision": "855c74f395a4dc9e02828f58d931be6920bcbf6f",
-          "version": "1.0.6"
+          "revision": "dedffeaf42a1b52bf072a9dc47afb35000a8b265",
+          "version": "1.1.4"
+        }
+      },
+      {
+        "package": "Logger",
+        "repositoryURL": "https://github.com/shibapm/Logger",
+        "state": {
+          "branch": null,
+          "revision": "53c3ecca5abe8cf46697e33901ee774236d94cce",
+          "version": "0.2.3"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/shibapm/PackageConfig.git",
         "state": {
           "branch": null,
-          "revision": "bf90dc69fa0792894b08a0b74cf34029694ae486",
-          "version": "0.13.0"
+          "revision": "58523193c26fb821ed1720dcd8a21009055c7cdb",
+          "version": "1.1.3"
         }
       },
       {
@@ -128,12 +128,30 @@
         }
       },
       {
+        "package": "Rocket",
+        "repositoryURL": "https://github.com/f-meloni/Rocket",
+        "state": {
+          "branch": null,
+          "revision": "9880a5beb7fcb9e61ddd5764edc1700b8c418deb",
+          "version": "1.2.1"
+        }
+      },
+      {
         "package": "ShellOut",
         "repositoryURL": "https://github.com/JohnSundell/ShellOut.git",
         "state": {
           "branch": null,
           "revision": "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
           "version": "2.3.0"
+        }
+      },
+      {
+        "package": "SourceKitten",
+        "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
+        "state": {
+          "branch": null,
+          "revision": "817dfa6f2e09b0476f3a6c9dbc035991f02f0241",
+          "version": "0.32.0"
         }
       },
       {
@@ -150,8 +168,8 @@
         "repositoryURL": "https://github.com/stencilproject/Stencil.git",
         "state": {
           "branch": null,
-          "revision": "973e190edf5d09274e4a6bc2e636c86899ed84c3",
-          "version": "0.14.1"
+          "revision": "ccd9402682f4c07dac9561befd207c8156e80e20",
+          "version": "0.14.2"
         }
       },
       {
@@ -168,8 +186,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "e1465042f195f374b94f915ba8ca49de24300a0d",
-          "version": "1.0.2"
+          "revision": "f3c9084a71ef4376f2fabbdf1d3d90a49f1fabdb",
+          "version": "1.1.2"
         }
       },
       {
@@ -209,6 +227,15 @@
         }
       },
       {
+        "package": "SwiftFormat",
+        "repositoryURL": "https://github.com/nicklockwood/SwiftFormat.git",
+        "state": {
+          "branch": null,
+          "revision": "f8e35f6716c369c8412664052a0a7337da2ca0e3",
+          "version": "0.49.9"
+        }
+      },
+      {
         "package": "SwiftGen",
         "repositoryURL": "https://github.com/SwiftGen/SwiftGen",
         "state": {
@@ -218,21 +245,48 @@
         }
       },
       {
+        "package": "SwiftLint",
+        "repositoryURL": "https://github.com/Realm/SwiftLint.git",
+        "state": {
+          "branch": null,
+          "revision": "e8ef21fef61f12536964c4e3cf6d5a6e3ad81e49",
+          "version": "0.46.5"
+        }
+      },
+      {
+        "package": "SwiftShell",
+        "repositoryURL": "https://github.com/kareman/SwiftShell",
+        "state": {
+          "branch": null,
+          "revision": "a6014fe94c3dbff0ad500e8da4f251a5d336530b",
+          "version": "5.1.0-beta.1"
+        }
+      },
+      {
+        "package": "SwiftyTextTable",
+        "repositoryURL": "https://github.com/scottrhoyt/SwiftyTextTable.git",
+        "state": {
+          "branch": null,
+          "revision": "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+          "version": "0.9.0"
+        }
+      },
+      {
+        "package": "SWXMLHash",
+        "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
+        "state": {
+          "branch": null,
+          "revision": "6469881a3f30417c5bb02404ea4b69207f297592",
+          "version": "6.0.0"
+        }
+      },
+      {
         "package": "XcodeProj",
         "repositoryURL": "https://github.com/tuist/XcodeProj.git",
         "state": {
           "branch": null,
           "revision": "c75c3acc25460195cfd203a04dde165395bf00e0",
           "version": "8.7.1"
-        }
-      },
-      {
-        "package": "xctest-dynamic-overlay",
-        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
-        "state": {
-          "branch": null,
-          "revision": "603974e3909ad4b48ba04aad7e0ceee4f077a518",
-          "version": "0.1.0"
         }
       },
       {

--- a/projects/tuist/fixtures/app_with_spm_dependencies/Tuist/Dependencies.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/Tuist/Dependencies.swift
@@ -11,20 +11,22 @@ let packages: [Package] = [
     .local(path: "LocalSwiftPackage"),
 ]
 
-let projectOptions: Project.Options = .options(
-    automaticSchemesOptions: .disabled,
-    disableSynthesizedResourceAccessors: false
-)
-
 let dependencies = Dependencies(
     swiftPackageManager: .init(
         packages,
-        baseSettings: .settings(configurations: [
-            .debug(name: .debug),
-            .release(name: .release),
-            .release(name: "Internal"),
-        ]),
-        projectOptions: ["LocalSwiftPackage": projectOptions]
+        baseSettings: .settings(
+            configurations: [
+                .debug(name: .debug),
+                .release(name: .release),
+                .release(name: "Internal"),
+            ]
+        ),
+        projectOptions: [
+            "LocalSwiftPackage": .options(
+                automaticSchemesOptions: .disabled,
+                disableSynthesizedResourceAccessors: false
+            )
+        ]
     ),
     platforms: [.iOS]
 )

--- a/projects/tuist/fixtures/app_with_spm_dependencies/Tuist/Dependencies.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/Tuist/Dependencies.swift
@@ -25,7 +25,7 @@ let dependencies = Dependencies(
             "LocalSwiftPackage": .options(
                 automaticSchemesOptions: .disabled,
                 disableSynthesizedResourceAccessors: false
-            )
+            ),
         ]
     ),
     platforms: [.iOS]


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY
Request for comments document (if applies):

### Short description 📝

Before, if newer swift version (5.6.0+) is used but legacy version was configured (<5.6.0), the Package.swift was written with old toolchain version in the top `// swift-tools-version:` directive, but the content was in the new format (5.6.0+)

### How to test the changes locally 🧐

- run ./fourier generate tuist
- check that the generated `Tuist/Dependencies/SwiftPackageManager/Package.swift` has the old 5.4.0 format

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
