### PR TITLE
Fix: lproj directories not being detected as resources

### DIFF
--- a/Sources/TuistGraph/Models/Target.swift
+++ b/Sources/TuistGraph/Models/Target.swift
@@ -11,7 +11,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable {
         "playground",
     ]
     public static let validFolderExtensions: [String] = [
-        "framework", "bundle", "app", "xcassets", "appiconset", "scnassets",
+        "framework", "bundle", "app", "xcassets", "appiconset", "scnassets", "lproj",
     ]
 
     // MARK: - Attributes

--- a/Tests/TuistGraphTests/Models/TargetTests.swift
+++ b/Tests/TuistGraphTests/Models/TargetTests.swift
@@ -265,6 +265,7 @@ final class TargetTests: TuistUnitTestCase {
             "resources/d.xcassets",
             "resources/d.scnassets",
             "resources/g.bundle",
+            "resources/h.lproj",
         ])
 
         let files = try createFiles([
@@ -287,6 +288,7 @@ final class TargetTests: TuistUnitTestCase {
             "resources/d.xcassets",
             "resources/d.scnassets",
             "resources/g.bundle",
+            "resources/h.lproj",
             "resources/a.png",
             "resources/b.jpg",
             "resources/b.jpeg",


### PR DESCRIPTION
Resolves #4505
Request for comments document (if applies): -

### Short description 📝

Adds the `lproj` extension to the [`validFolderExtensions`](https://github.com/tuist/tuist/blob/6001d23278f345233f9395862b5aedaa12bd33d3/Sources/TuistGraph/Models/Target.swift#L13) so that the [`isResource(path:)`](https://github.com/tuist/tuist/blob/8dd9ae027f4c56ed6820762605d41d916e31e3d8/Sources/TuistCore/Graph/ModelExtensions/Target%2BCore.swift#L35) will return `true` instead of `false` when it's input is a `lproj` directory.

Question for the maintainers: Is the addition in the tests enough, or should I also add some `lproj` to any fixtures to assert that a `...Resources` target is being generated?

### How to test the changes locally 🧐

1. Use the sample project attached to #4505
2. Run `tuist fetch && tuist generate`
3. Open the `AppCenter` project in `Tuist > Dependencies > SwiftPackageManager > .build > checkouts`
4. See that Tuist generated the `AppCenterDistributeResources` target

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
