### PR TITLE
Alternative check to see if graphviz is installed

### DIFF
--- a/Sources/TuistKit/Services/GraphService.swift
+++ b/Sources/TuistKit/Services/GraphService.swift
@@ -98,7 +98,7 @@ final class GraphService {
         at filePath: AbsolutePath,
         layoutAlgorithm: LayoutAlgorithm
     ) throws {
-        if try !isGraphVizInstalled() {
+        if !isGraphVizInstalled() {
             try installGraphViz()
         }
         let data = try graphVizGraph.render(using: layoutAlgorithm, to: .png)
@@ -106,8 +106,8 @@ final class GraphService {
         try System.shared.async(["open", filePath.pathString])
     }
 
-    private func isGraphVizInstalled() throws -> Bool {
-        try System.shared.capture(["brew", "list", "--formula"]).contains("graphviz")
+    private func isGraphVizInstalled() -> Bool {
+        System.shared.commandExists("dot")
     }
 
     private func installGraphViz() throws {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY
Request for comments document (if applies):

### Short description 📝

Checking for graphviz installation by validating if the dot command exists.
This addresses the issue discussed here: https://github.com/tuist/tuist/discussions/4512.


### How to test the changes locally 🧐

- Uninstall graphviz - `brew uninstall graphviz`
- Run `swift run tuist graph`
- See graphviz is installed via brew
- Re-run `swift run tuist graph` to ensure it's not re-installed.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
