### PR TITLE
Extend ProjectAutomation.Target: resources and dependencies

### DIFF
--- a/Sources/ProjectAutomation/Target.swift
+++ b/Sources/ProjectAutomation/Target.swift
@@ -11,13 +11,18 @@ public struct Target: Codable, Equatable {
     /// List of file paths that are the target's sources.
     public let sources: [String]
 
+    /// List of file paths that are the target's resources.
+    public let resources: [String]
+
     public init(
         name: String,
         product: String,
-        sources: [String]
+        sources: [String],
+        resources: [String]
     ) {
         self.name = name
         self.product = product
         self.sources = sources
+        self.resources = resources
     }
 }

--- a/Sources/ProjectAutomation/Target.swift
+++ b/Sources/ProjectAutomation/Target.swift
@@ -14,15 +14,20 @@ public struct Target: Codable, Equatable {
     /// List of file paths that are the target's resources.
     public let resources: [String]
 
+    /// The target’s dependencies.
+    public let dependencies: [TargetDependency]
+
     public init(
         name: String,
         product: String,
         sources: [String],
-        resources: [String]
+        resources: [String],
+        dependencies: [TargetDependency]
     ) {
         self.name = name
         self.product = product
         self.sources = sources
         self.resources = resources
+        self.dependencies = dependencies
     }
 }

--- a/Sources/ProjectAutomation/TargetDependency.swift
+++ b/Sources/ProjectAutomation/TargetDependency.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public enum SDKStatus: String, Codable {
+    case required
+    case optional
+}
+
+public enum TargetDependency: Equatable, Hashable, Codable {
+    case target(name: String)
+    case project(target: String, path: String)
+    case framework(path: String)
+    case xcframework(path: String)
+    case library(path: String, publicHeaders: String, swiftModuleMap: String?)
+    case package(product: String)
+    case sdk(name: String, status: SDKStatus)
+    case xctest
+}

--- a/Sources/TuistKit/Services/GraphService.swift
+++ b/Sources/TuistKit/Services/GraphService.swift
@@ -207,12 +207,46 @@ extension ProjectAutomation.Package {
 
 extension ProjectAutomation.Target {
     fileprivate static func from(_ target: TuistGraph.Target) -> ProjectAutomation.Target {
-        ProjectAutomation.Target(
+        let dependencies = target.dependencies.map { Self.from($0) }
+        return ProjectAutomation.Target(
             name: target.name,
             product: target.product.rawValue,
             sources: target.sources.map(\.path.pathString),
-            resources: target.resources.map(\.path.pathString)
+            resources: target.resources.map(\.path.pathString),
+            dependencies: dependencies
         )
+    }
+
+    private static func from(_ dependency: TuistGraph.TargetDependency) -> ProjectAutomation.TargetDependency {
+        switch dependency {
+        case let .target(name):
+            return .target(name: name)
+        case let .project(target, path):
+            return .project(target: target, path: path.pathString)
+        case let .framework(path):
+            return .framework(path: path.pathString)
+        case let .xcframework(path):
+            return .xcframework(path: path.pathString)
+        case let .library(path, publicHeaders, swiftModuleMap):
+            return .library(
+                path: path.pathString,
+                publicHeaders: publicHeaders.pathString,
+                swiftModuleMap: swiftModuleMap?.pathString
+            )
+        case let .package(product):
+            return .package(product: product)
+        case let .sdk(name, status):
+            let projectAutomationStatus: ProjectAutomation.SDKStatus
+            switch status {
+            case .optional:
+                projectAutomationStatus = .optional
+            case .required:
+                projectAutomationStatus = .required
+            }
+            return .sdk(name: name, status: projectAutomationStatus)
+        case .xctest:
+            return .xctest
+        }
     }
 }
 

--- a/Sources/TuistKit/Services/GraphService.swift
+++ b/Sources/TuistKit/Services/GraphService.swift
@@ -210,7 +210,8 @@ extension ProjectAutomation.Target {
         ProjectAutomation.Target(
             name: target.name,
             product: target.product.rawValue,
-            sources: target.sources.map(\.path.pathString)
+            sources: target.sources.map(\.path.pathString),
+            resources: target.resources.map(\.path.pathString)
         )
     }
 }

--- a/projects/docs/docs/guides/task.md
+++ b/projects/docs/docs/guides/task.md
@@ -88,6 +88,7 @@ You might wonder what the return value of `Tuist.graph()` is - the method return
 | `name`| Name of the target | `String` |
 | `product` | Product type the target produces | `String` |
 | `sources` | List of file paths that are the target's sources. | `[String]` |
+| `resources` | List of file paths that are the target's resources. | `[String]` |
 
 #### Package
 

--- a/projects/docs/docs/guides/task.md
+++ b/projects/docs/docs/guides/task.md
@@ -89,6 +89,7 @@ You might wonder what the return value of `Tuist.graph()` is - the method return
 | `product` | Product type the target produces | `String` |
 | `sources` | List of file paths that are the target's sources. | `[String]` |
 | `resources` | List of file paths that are the target's resources. | `[String]` |
+| `dependencies` | The target’s dependencies. | `[TargetDependency]` |
 
 #### Package
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY
Request for comments document (if applies):

### Short description 📝

Current interface of `ProjectAutomation.Target` is minimalistic and skips some information about target. Extending the API of `ProjectAutomation` is required to make a task which generate Cocoapods podspecs.

### How to test the changes locally 🧐

Actually I have no idea, I tried to make a tuist binary with `fourier bundle` but result didn't contain new `ProjectAutomation.Target` property.  

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
