### PR TITLE
Fix `tuist fetch` failing when package identifier is different from package name

### DIFF
--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -88,14 +88,14 @@ public protocol PackageInfoMapping {
     /// Preprocesses SwiftPackageManager dependencies.
     /// - Parameters:
     ///   - packageInfos: All available `PackageInfo`s
-    ///   - productToPackage: Mapping from a product to its package
+    ///   - idToPackage: Mapping from an identifier to its package
     ///   - packageToFolder: Mapping from a package name to its local folder
     ///   - packageToTargetsToArtifactPaths: Mapping from a package name its targets' names to artifacts' paths
     ///   - platforms: The configured platforms
     /// - Returns: Mapped project
     func preprocess(
         packageInfos: [String: PackageInfo],
-        productToPackage: [String: String],
+        idToPackage: [String: String],
         packageToFolder: [String: AbsolutePath],
         packageToTargetsToArtifactPaths: [String: [String: AbsolutePath]],
         platforms: Set<TuistGraph.Platform>
@@ -159,14 +159,14 @@ public final class PackageInfoMapper: PackageInfoMapping {
     /// Resolves all SwiftPackageManager dependencies.
     /// - Parameters:
     ///   - packageInfos: All available `PackageInfo`s
-    ///   - productToPackage: Mapping from a product to its package
+    ///   - idToPackage: Mapping from an identifier to its package
     ///   - packageToFolder: Mapping from a package name to its local folder
     ///   - packageToTargetsToArtifactPaths: Mapping from a package name its targets' names to artifacts' paths
     ///   - platforms: The configured platforms
     /// - Returns: Mapped project
     public func preprocess( // swiftlint:disable:this function_body_length
         packageInfos: [String: PackageInfo],
-        productToPackage: [String: String],
+        idToPackage: [String: String],
         packageToFolder: [String: AbsolutePath],
         packageToTargetsToArtifactPaths: [String: [String: AbsolutePath]],
         platforms: Set<TuistGraph.Platform>
@@ -223,7 +223,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
                             dependencies: target.dependencies,
                             packageInfo: packageInfo,
                             packageInfos: packageInfos,
-                            productToPackage: productToPackage,
+                            idToPackage: idToPackage,
                             targetDependencyToFramework: targetDependencyToFramework
                         )
                     }
@@ -1161,7 +1161,7 @@ extension PackageInfoMapper {
             dependencies: [PackageInfo.Target.Dependency],
             packageInfo: PackageInfo,
             packageInfos: [String: PackageInfo],
-            productToPackage _: [String: String],
+            idToPackage: [String: String],
             targetDependencyToFramework: [String: Path]
         ) throws -> [ResolvedDependency] {
             try dependencies.flatMap { dependency -> [Self] in
@@ -1170,7 +1170,7 @@ extension PackageInfoMapper {
                     return Self.fromTarget(name: name, targetDependencyToFramework: targetDependencyToFramework)
                 case let .product(name, package, _):
                     return try Self.fromProduct(
-                        package: package,
+                        package: idToPackage[package.lowercased()] ?? package,
                         product: name,
                         packageInfos: packageInfos,
                         targetDependencyToFramework: targetDependencyToFramework


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4411

### Short description 📝

> Describe here the purpose of your PR.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
