### PR TITLE
Fix default resources warnings for local packages

### DIFF
--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -661,8 +661,8 @@ extension ResourceFileElements {
     ]
 
     private static func defaultResourcePaths(from path: AbsolutePath) -> [AbsolutePath] {
-        ResourceFileElements.defaultSpmResourceFileExtensions.map { fileExtension -> AbsolutePath in
-            path.appending(components: ["**", "*.\(fileExtension)"])
+        ResourceFileElements.defaultSpmResourceFileExtensions.flatMap {
+            FileHandler.shared.glob(path, glob: "**/*.\($0)")
         }
     }
 }

--- a/Sources/TuistDependenciesTesting/DependenciesGraph/DependenciesGraph+TestData.swift
+++ b/Sources/TuistDependenciesTesting/DependenciesGraph/DependenciesGraph+TestData.swift
@@ -121,9 +121,6 @@ extension TuistCore.DependenciesGraph {
                             sources: [
                                 "\(packageFolder.pathString)/Sources/TuistKit/**",
                             ],
-                            resources: ResourceFileElements(
-                                resources: defaultResources(folder: "\(packageFolder.pathString)/Sources/TuistKit")
-                            ),
                             dependencies: [
                                 .project(
                                     target: "AnotherLibrary",
@@ -175,9 +172,6 @@ extension TuistCore.DependenciesGraph {
                             sources: [
                                 "\(packageFolder.pathString)/Sources/ALibrary/**",
                             ],
-                            resources: ResourceFileElements(
-                                resources: defaultResources(folder: "\(packageFolder.pathString)/Sources/ALibrary")
-                            ),
                             dependencies: [
                                 .target(name: "ALibraryUtils"),
                             ],
@@ -193,9 +187,6 @@ extension TuistCore.DependenciesGraph {
                             sources: [
                                 "\(packageFolder.pathString)/Sources/ALibraryUtils/**",
                             ],
-                            resources: ResourceFileElements(
-                                resources: defaultResources(folder: "\(packageFolder.pathString)/Sources/ALibraryUtils")
-                            ),
                             settings: Self.spmSettings()
                         ),
                     ],
@@ -239,9 +230,6 @@ extension TuistCore.DependenciesGraph {
                             sources: [
                                 "\(packageFolder.pathString)/Sources/AnotherLibrary/**",
                             ],
-                            resources: ResourceFileElements(
-                                resources: defaultResources(folder: "\(packageFolder.pathString)/Sources/AnotherLibrary")
-                            ),
                             settings: Self.spmSettings()
                         ),
                     ],
@@ -280,9 +268,6 @@ extension TuistCore.DependenciesGraph {
                             sources: [
                                 "\(packageFolder.pathString)/Source/**",
                             ],
-                            resources: ResourceFileElements(
-                                resources: defaultResources(folder: "\(packageFolder.pathString)/Source")
-                            ),
                             dependencies: [
                                 .sdk(name: "CFNetwork", type: .framework, status: .required),
                             ],
@@ -339,9 +324,6 @@ extension TuistCore.DependenciesGraph {
                             sources: [
                                 "\(packageFolder.pathString)/GoogleAppMeasurementWrapper/**",
                             ],
-                            resources: ResourceFileElements(
-                                resources: defaultResources(folder: "\(packageFolder.pathString)/GoogleAppMeasurementWrapper")
-                            ),
                             dependencies: [
                                 .xcframework(path: "\(artifactsFolder.pathString)/GoogleAppMeasurement.xcframework"),
                                 .project(
@@ -378,11 +360,6 @@ extension TuistCore.DependenciesGraph {
                             sources: [
                                 "\(packageFolder.pathString)/GoogleAppMeasurementWithoutAdIdSupportWrapper/**",
                             ],
-                            resources: ResourceFileElements(
-                                resources: defaultResources(
-                                    folder: "\(packageFolder.pathString)/GoogleAppMeasurementWithoutAdIdSupportWrapper"
-                                )
-                            ),
                             dependencies: [
                                 .xcframework(
                                     path: "\(artifactsFolder.pathString)/GoogleAppMeasurementWithoutAdIdSupport.xcframework"
@@ -454,9 +431,6 @@ extension TuistCore.DependenciesGraph {
                             sources: [
                                 "\(packageFolder.pathString)/Sources/GULAppDelegateSwizzler/**",
                             ],
-                            resources: ResourceFileElements(
-                                resources: defaultResources(folder: "\(packageFolder.pathString)/Sources/GULAppDelegateSwizzler")
-                            ),
                             settings: Self.spmSettings()
                         ),
                         .init(
@@ -469,9 +443,6 @@ extension TuistCore.DependenciesGraph {
                             sources: [
                                 "\(packageFolder.pathString)/Sources/GULMethodSwizzler/**",
                             ],
-                            resources: ResourceFileElements(
-                                resources: defaultResources(folder: "\(packageFolder.pathString)/Sources/GULMethodSwizzler")
-                            ),
                             settings: Self.spmSettings()
                         ),
                         .init(
@@ -484,9 +455,6 @@ extension TuistCore.DependenciesGraph {
                             sources: [
                                 "\(packageFolder.pathString)/Sources/GULNSData/**",
                             ],
-                            resources: ResourceFileElements(
-                                resources: defaultResources(folder: "\(packageFolder.pathString)/Sources/GULNSData")
-                            ),
                             settings: Self.spmSettings()
                         ),
                         .init(
@@ -499,9 +467,6 @@ extension TuistCore.DependenciesGraph {
                             sources: [
                                 "\(packageFolder.pathString)/Sources/GULNetwork/**",
                             ],
-                            resources: ResourceFileElements(
-                                resources: defaultResources(folder: "\(packageFolder.pathString)/Sources/GULNetwork")
-                            ),
                             settings: Self.spmSettings()
                         ),
                     ],
@@ -543,9 +508,6 @@ extension TuistCore.DependenciesGraph {
                             sources: [
                                 "\(packageFolder.pathString)/Sources/nanopb/**",
                             ],
-                            resources: ResourceFileElements(
-                                resources: defaultResources(folder: "\(packageFolder.pathString)/Sources/nanopb")
-                            ),
                             settings: Self.spmSettings()
                         ),
                     ],
@@ -553,17 +515,6 @@ extension TuistCore.DependenciesGraph {
                 ),
             ]
         )
-    }
-
-    private static func defaultResources(folder: String, excluding: [String] = []) -> [ResourceFileElement] {
-        let fileExtensions = ["xib", "storyboard", "xcdatamodeld", "xcmappingmodel", "xcassets", "lproj"]
-
-        return fileExtensions.map { fileExtension in
-            .glob(
-                pattern: "\(folder)/**/*.\(fileExtension)",
-                excluding: excluding.map(Path.init(stringLiteral:))
-            )
-        }
     }
 }
 

--- a/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
@@ -30,8 +30,7 @@ extension TuistGraph.ResourceFileElement {
                 .filter(includeFiles)
                 .filter { !excluded.contains($0) }
 
-            // FIXME: Do not hardcode this
-            if files.isEmpty, !path.pathString.contains("Tuist/Dependencies/SwiftPackageManager/.build/checkouts") {
+            if files.isEmpty {
                 if FileHandler.shared.isFolder(path) {
                     logger.warning("'\(path.pathString)' is a directory, try using: '\(path.pathString)/**' to list its files")
                 } else {

--- a/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
+++ b/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
@@ -89,6 +89,14 @@ public final class MockFileHandler: FileHandler {
     override public func inTemporaryDirectory<Result>(_ closure: (AbsolutePath) throws -> Result) throws -> Result {
         try closure(temporaryDirectory())
     }
+
+    public var stubGlob: ((AbsolutePath, String) -> [AbsolutePath])?
+    override public func glob(_ path: AbsolutePath, glob: String) -> [AbsolutePath] {
+        guard let stubGlob = stubGlob else {
+            return super.glob(path, glob: glob)
+        }
+        return stubGlob(path, glob)
+    }
 }
 
 open class TuistTestCase: XCTestCase {


### PR DESCRIPTION
Previous path based workaround doesn't work for local packages as they are not located in the standard path