### PR TITLE
Fix crash during `tuist cache warm` when cloud is configured and a lot of targets are present in the project

### DIFF
--- a/Sources/TuistCloud/Client/CloudClient.swift
+++ b/Sources/TuistCloud/Client/CloudClient.swift
@@ -9,20 +9,19 @@ public class CloudClient: CloudClienting {
 
     // Use session without redirect to prevent redirects to be wrongly interpreted as successful responses.
     // For example, the `CacheRemoteStorage.exists` method would return true if the request is not authenticated and redirect is allowed.
-    private var noRedirectDelegate: NoRedirectDelegate? // swiftlint:disable:this weak_delegate
-    lazy var requestDispatcher: HTTPRequestDispatching = {
-        noRedirectDelegate = NoRedirectDelegate()
-        return HTTPRequestDispatcher(session: URLSession(
-            configuration: .default,
-            delegate: noRedirectDelegate,
-            delegateQueue: nil
-        ))
-    }()
+    private let noRedirectDelegate: NoRedirectDelegate // swiftlint:disable:this weak_delegate
+    private let requestDispatcher: HTTPRequestDispatching
 
     // MARK: - Init
 
     public init(cloudHTTPRequestAuthenticator: CloudHTTPRequestAuthenticating = CloudHTTPRequestAuthenticator()) {
         self.cloudHTTPRequestAuthenticator = cloudHTTPRequestAuthenticator
+        noRedirectDelegate = NoRedirectDelegate()
+        requestDispatcher = HTTPRequestDispatcher(session: URLSession(
+            configuration: .default,
+            delegate: noRedirectDelegate,
+            delegateQueue: nil
+        ))
     }
 
     // MARK: - Public


### PR DESCRIPTION
### Short description 📝

When a project has a lot of targets, it sometimes crashes during `tuist cache warm` while trying to contact the could backend.
The crash was inside the `HTTPRequestDispatcher` instantiation in the lazy block

### How to test the changes locally 🧐

1. have a project with a lot of targets 
2. run `tuist clean builds projectDescriptionHelpers manifests`
3. run `tuist cache warm` -> it crashes almost half of the times, running it again it works fine

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
