### PR TITLE
Update generated target resource name.

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -32,7 +32,7 @@ public class ResourcesProjectMapper: ProjectMapping {
         var additionalTargets: [Target] = []
         var sideEffects: [SideEffectDescriptor] = []
 
-        let bundleName = "\(target.name)Resources"
+        let bundleName = "\(project.name)_\(target.name)"
         var modifiedTarget = target
 
         if !target.supportsResources {

--- a/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -48,7 +48,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
             .appending(component: Constants.DerivedDirectory.sources)
             .appending(component: "TuistBundle+\(target.name).swift")
         let expectedContents = ResourcesProjectMapper
-            .fileContent(targetName: target.name, bundleName: "\(target.name)Resources", target: target)
+            .fileContent(targetName: target.name, bundleName: "\(project.name)_\(target.name)", target: target)
         XCTAssertEqual(file.path, expectedPath)
         XCTAssertEqual(file.contents, expectedContents.data(using: .utf8))
 
@@ -62,10 +62,10 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(gotTarget.sources.first?.path, expectedPath)
         XCTAssertNotNil(gotTarget.sources.first?.contentHash)
         XCTAssertEqual(gotTarget.dependencies.count, 1)
-        XCTAssertEqual(gotTarget.dependencies.first, TargetDependency.target(name: "\(target.name)Resources"))
+        XCTAssertEqual(gotTarget.dependencies.first, TargetDependency.target(name: "\(project.name)_\(target.name)"))
 
         let resourcesTarget = try XCTUnwrap(gotProject.targets.last)
-        XCTAssertEqual(resourcesTarget.name, "\(target.name)Resources")
+        XCTAssertEqual(resourcesTarget.name, "\(project.name)_\(target.name)")
         XCTAssertEqual(resourcesTarget.product, .bundle)
         XCTAssertEqual(resourcesTarget.platform, target.platform)
         XCTAssertEqual(resourcesTarget.bundleId, "\(target.bundleId).resources")
@@ -116,7 +116,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
             .appending(component: Constants.DerivedDirectory.sources)
             .appending(component: "TuistBundle+\(target.name).swift")
         let expectedContents = ResourcesProjectMapper
-            .fileContent(targetName: target.name, bundleName: "\(target.name)Resources", target: target)
+            .fileContent(targetName: target.name, bundleName: "\(project.name)_\(target.name)", target: target)
         XCTAssertEqual(file.path, expectedPath)
         XCTAssertEqual(file.contents, expectedContents.data(using: .utf8))
 
@@ -130,10 +130,10 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(gotTarget.sources.first?.path, expectedPath)
         XCTAssertNotNil(gotTarget.sources.first?.contentHash)
         XCTAssertEqual(gotTarget.dependencies.count, 1)
-        XCTAssertEqual(gotTarget.dependencies.first, TargetDependency.target(name: "\(target.name)Resources"))
+        XCTAssertEqual(gotTarget.dependencies.first, TargetDependency.target(name: "\(project.name)_\(target.name)"))
 
         let resourcesTarget = try XCTUnwrap(gotProject.targets.last)
-        XCTAssertEqual(resourcesTarget.name, "\(target.name)Resources")
+        XCTAssertEqual(resourcesTarget.name, "\(project.name)_\(target.name)")
         XCTAssertEqual(resourcesTarget.product, .bundle)
         XCTAssertEqual(resourcesTarget.platform, target.platform)
         XCTAssertEqual(resourcesTarget.bundleId, "\(target.bundleId).resources")
@@ -163,7 +163,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
             .appending(component: Constants.DerivedDirectory.sources)
             .appending(component: "TuistBundle+\(target.name).swift")
         let expectedContents = ResourcesProjectMapper
-            .fileContent(targetName: target.name, bundleName: "\(target.name)Resources", target: target)
+            .fileContent(targetName: target.name, bundleName: "", target: target)
         XCTAssertEqual(file.path, expectedPath)
         XCTAssertEqual(file.contents, expectedContents.data(using: .utf8))
 
@@ -201,7 +201,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
             .appending(component: Constants.DerivedDirectory.sources)
             .appending(component: "TuistBundle+\(target.name).swift")
         let expectedContents = ResourcesProjectMapper
-            .fileContent(targetName: target.name, bundleName: "\(target.name)Resources", target: target)
+            .fileContent(targetName: target.name, bundleName: "", target: target)
         XCTAssertEqual(file.path, expectedPath)
         XCTAssertEqual(file.contents, expectedContents.data(using: .utf8))
 
@@ -269,7 +269,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
             .appending(component: Constants.DerivedDirectory.sources)
             .appending(component: "TuistBundle+\(target.name).swift")
         let expectedContents = ResourcesProjectMapper
-            .fileContent(targetName: target.name, bundleName: "test_tuistResources", target: target)
+            .fileContent(targetName: target.name, bundleName: "\(project.name)_test_tuist", target: target)
         XCTAssertEqual(file.path, expectedPath)
         XCTAssertEqual(file.contents, expectedContents.data(using: .utf8))
     }

--- a/projects/tuist/features/cache-frameworks.feature
+++ b/projects/tuist/features/cache-frameworks.feature
@@ -45,9 +45,9 @@ Feature: Focuses projects with pre-compiled cached xcframeworks
     Then App links the framework B from the cache
     Then App links the framework C from the cache
     Then App links the framework D from the cache
-    Then App copies the bundle AResources from the cache
-    Then App copies the bundle BResources from the cache
-    Then App copies the bundle CResources from the cache
+    Then App copies the bundle A_A from the cache
+    Then App copies the bundle B_B from the cache
+    Then App copies the bundle C_C from the cache
     Then I should be able to build for iOS the scheme App
 
   Scenario: The project is an application with static frameworks that each has resources and a target is modified after being cached (ios_app_with_static_frameworks_with_resources)
@@ -61,7 +61,7 @@ Feature: Focuses projects with pre-compiled cached xcframeworks
     Then App links the framework B from the cache
     Then App links the framework C from the cache
     Then App links the framework D from the cache
-    Then App copies the bundle AResources from the build directory
-    Then App copies the bundle BResources from the cache
-    Then App copies the bundle CResources from the cache
+    Then App copies the bundle A_A from the build directory
+    Then App copies the bundle B_B from the cache
+    Then App copies the bundle C_C from the cache
     Then I should be able to build for iOS the scheme App


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4540
Request for comments document (if applies):

### Short description 📝

> Update generated target resource name.

### How to test the changes locally 🧐

> Unit tests should be enough.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
