### PR TITLE
Fix `tuist fetch` for dependencies when using Xcode 14

### DIFF
--- a/Sources/TuistSupportTesting/SwiftPackageManager/PackageInfo+TestData.swift
+++ b/Sources/TuistSupportTesting/SwiftPackageManager/PackageInfo+TestData.swift
@@ -291,6 +291,285 @@ extension PackageInfo {
         """
     }
 
+    public static var testJSONXcode14: String {
+        """
+        {
+          "cLanguageStandard" : "c99",
+          "cxxLanguageStandard" : null,
+          "dependencies" : [
+            {
+              "name" : "a-dependency",
+              "productFilter" : null,
+              "requirement" : {
+                "range" : [
+                  {
+                    "lowerBound" : "0.4.0",
+                    "upperBound" : "1.0.0"
+                  }
+                ]
+              },
+              "url" : "https://github.com/tuist/a-dependency"
+            },
+            {
+              "name" : "another-dependency",
+              "productFilter" : null,
+              "requirement" : {
+                "range" : [
+                  {
+                    "lowerBound" : "0.1.3",
+                    "upperBound" : "1.0.0"
+                  }
+                ]
+              },
+              "url" : "https://github.com/tuist/another-dependency"
+            }
+          ],
+          "name" : "tuist",
+          "packageKind" : "root",
+          "pkgConfig" : null,
+          "platforms" : [
+            {
+              "options" : [
+
+              ],
+              "platformName" : "ios",
+              "version" : "13.0"
+            },
+            {
+              "options" : [
+
+              ],
+              "platformName" : "macos",
+              "version" : "10.15"
+            },
+            {
+              "options" : [
+
+              ],
+              "platformName" : "watchos",
+              "version" : "6.0"
+            }
+          ],
+          "products" : [
+            {
+              "name" : "Tuist",
+              "targets" : [
+                "Tuist"
+              ],
+              "type" : {
+                "library" : [
+                  "static"
+                ]
+              }
+            }
+          ],
+          "providers" : null,
+          "swiftLanguageVersions" : null,
+          "targets" : [
+            {
+              "dependencies" : [
+                {
+                  "target" : [
+                    "TuistKit",
+                    null
+                  ]
+                },
+                {
+                  "product" : [
+                    "ALibrary",
+                    "a-dependency",
+                    {
+                      "platformNames" : [
+                        "ios"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "exclude" : [
+                "excluded/sources"
+              ],
+              "name" : "Tuist",
+              "path" : "customPath",
+              "publicHeadersPath" : "custom/Public/Headers/Path",
+              "sources": [
+                "customSources"
+              ],
+              "resources" : [
+                {
+                  "rule": {
+                    "copy": {
+                    }
+                  },
+                  "path": "resources"
+                }
+              ],
+              "settings" : [
+                {
+                  "tool": "c",
+                  "kind": {
+                    "headerSearchPath": {
+                      "_0": "cSearchPath"
+                    }
+                  }
+                },
+                {
+                  "tool": "cxx",
+                  "kind": {
+                    "headerSearchPath": {
+                      "_0": "cxxSearchPath"
+                    }
+                  }
+                },
+                {
+                  "tool": "c",
+                  "kind": {
+                    "unsafeFlags": {
+                      "_0": ["CUSTOM_C_FLAG"]
+                    }
+                  }
+                },
+                {
+                  "tool": "cxx",
+                  "kind": {
+                    "unsafeFlags": {
+                      "_0": ["CUSTOM_CXX_FLAG"]
+                    }
+                  }
+                },
+                {
+                  "tool": "swift",
+                  "kind": {
+                    "unsafeFlags": {
+                      "_0": ["CUSTOM_SWIFT_FLAG1", "CUSTOM_SWIFT_FLAG2"]
+                    }
+                  }
+                },
+                {
+                  "tool": "c",
+                  "kind": {
+                    "define": {
+                      "_0": "C_DEFINE=C_VALUE"
+                    }
+                  }
+                },
+                {
+                  "tool": "cxx",
+                  "kind": {
+                    "define": {
+                      "_0": "CXX_DEFINE=CXX_VALUE"
+                    }
+                  }
+                },
+                {
+                  "tool": "swift",
+                  "kind": {
+                    "define": {
+                      "_0": "SWIFT_DEFINE"
+                    }
+                  }
+                },
+                {
+                  "condition" : {
+                    "platformNames" : [
+                      "watchos"
+                    ]
+                  },
+                  "kind": {
+                    "linkedFramework": {
+                      "_0": "WatchKit"
+                    }
+                  },
+                  "tool" : "linker",
+                },
+                {
+                  "condition" : {
+                    "platformNames" : [
+                      "tvos"
+                    ]
+                  },
+                  "tool": "swift",
+                  "kind": {
+                    "define": {
+                      "_0": "SWIFT_TVOS_DEFINE"
+                    }
+                  }
+                }
+              ],
+              "type" : "regular"
+            },
+            {
+              "dependencies" : [
+                {
+                  "product" : [
+                    "AnotherLibrary",
+                    "another-dependency",
+                    null
+                  ]
+                }
+              ],
+              "exclude" : [
+
+              ],
+              "name" : "TuistKit",
+              "resources" : [
+
+              ],
+              "settings" : [
+
+              ],
+              "type" : "regular"
+            },
+            {
+              "dependencies" : [],
+              "exclude" : [
+
+              ],
+              "name" : "TestUtilities",
+              "resources" : [
+
+              ],
+              "settings" : [
+
+              ],
+              "type" : "regular"
+            },
+            {
+              "dependencies" : [
+                {
+                  "byName" : [
+                    "TuistKit",
+                    null
+                  ]
+                },
+                {
+                  "byName" : [
+                    "TestUtilities",
+                    null
+                  ]
+                }
+              ],
+              "exclude" : [
+
+              ],
+              "name" : "TuistKitTests",
+              "resources" : [
+
+              ],
+              "settings" : [
+
+              ],
+              "type" : "test"
+            }
+          ],
+          "toolsVersion" : {
+            "_version" : "5.1.0"
+          }
+        }
+
+        """
+    }
+
     public static var test: PackageInfo {
         .init(
             products: [

--- a/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerControllerTests.swift
+++ b/Tests/TuistSupportTests/SwiftPackageManager/SwiftPackageManagerControllerTests.swift
@@ -90,6 +90,27 @@ final class SwiftPackageManagerControllerTests: TuistUnitTestCase {
         XCTAssertEqual(packageInfo, PackageInfo.test)
     }
 
+    func test_loadPackageInfo_Xcode14() throws {
+        // Given
+        let path = try temporaryPath()
+        system.succeedCommand(
+            [
+                "swift",
+                "package",
+                "--package-path",
+                path.pathString,
+                "dump-package",
+            ],
+            output: PackageInfo.testJSONXcode14
+        )
+
+        // When
+        let packageInfo = try subject.loadPackageInfo(at: path)
+
+        // Then
+        XCTAssertEqual(packageInfo, PackageInfo.test)
+    }
+
     func test_loadPackageInfo_alamofire() throws {
         // Given
         let path = try temporaryPath()


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4538

### How to test the changes locally 🧐

Added unit tests
`./fourier generate tuist` should now work on Xcode 14
`./fourier test tuist acceptance projects/tuist/features/dependencies.feature` should now work on Xcode 14

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
