### PR TITLE
Improve cache errors logging

### DIFF
--- a/Sources/TuistCache/Cache/CacheRemoteStorage.swift
+++ b/Sources/TuistCache/Cache/CacheRemoteStorage.swift
@@ -74,7 +74,7 @@ public final class CacheRemoteStorage: CacheStoring {
             }
             return exists
         } catch {
-            if case let HTTPRequestDispatcherError.serverSideError(_, response) = error, response.statusCode == 404 {
+            if case let HTTPRequestDispatcherError.serverSideError(_, _, response) = error, response.statusCode == 404 {
                 return false
             } else {
                 throw error
@@ -86,7 +86,7 @@ public final class CacheRemoteStorage: CacheStoring {
         let resource = try cloudCacheResourceFactory.fetchResource(name: name, hash: hash)
         let url = try await cloudClient.request(resource).object.data.url
 
-        logger.info("Downloading cache artifact with hash \(hash).")
+        logger.info("Downloading cache artifact for target \(name) with hash \(hash).")
         let filePath = try await fileClient.download(url: url)
         return try unzip(downloadedArchive: filePath, hash: hash)
     }

--- a/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -20,6 +20,7 @@ protocol ManifestGraphLoading {
     /// Loads a Workspace or Project Graph at a given path based on manifest availability
     /// - Note: This will search for a Workspace manifest first, then fallback to searching for a Project manifest
     func load(path: AbsolutePath) async throws -> (Graph, [SideEffectDescriptor], [LintingIssue])
+    // swiftlint:disable:previous large_tuple
 }
 
 final class ManifestGraphLoader: ManifestGraphLoading {
@@ -83,6 +84,7 @@ final class ManifestGraphLoader: ManifestGraphLoading {
         self.graphMapper = graphMapper
     }
 
+    // swiftlint:disable:next large_tuple
     func load(path: AbsolutePath) async throws -> (Graph, [SideEffectDescriptor], [LintingIssue]) {
         let manifests = manifestLoader.manifests(at: path)
         guard manifests.contains(.workspace) || manifests.contains(.project) else {


### PR DESCRIPTION
We are experiencing some errors when a lot of cached targets need to be downloaded, and reported error didn't help much. Hence, we are trying to improve it

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
