### PR TITLE
Fix dispatcher error printed when command execution is short (for example, `tuist version`)

### DIFF
--- a/Sources/TuistAnalytics/TuistAnalytics.swift
+++ b/Sources/TuistAnalytics/TuistAnalytics.swift
@@ -7,6 +7,8 @@ import TuistLoader
 public enum TuistAnalytics {
     public static func bootstrap(config: Config) throws {
         AsyncQueue.sharedInstance.register(dispatcher: TuistAnalyticsDispatcher(cloud: config.cloud))
-        AsyncQueue.sharedInstance.start() // Re-try to send all events that got persisted and haven't been sent yet
+        Task.detached(priority: .background) {
+            AsyncQueue.sharedInstance.start() // Re-try to send all events that got persisted and haven't been sent yet
+        }
     }
 }

--- a/Sources/tuist/TuistApp.swift
+++ b/Sources/tuist/TuistApp.swift
@@ -23,9 +23,7 @@ enum TuistApp {
 
         try TuistSupport.Environment.shared.bootstrap()
 
-        Task.detached(priority: .background) {
-            try TuistAnalytics.bootstrap(config: ConfigLoader().loadConfig(path: path))
-        }
+        try TuistAnalytics.bootstrap(config: ConfigLoader().loadConfig(path: path))
 
         await TuistCommand.main()
     }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4071

### Short description 📝

Start the dispatcher synchronously to avoid errors

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
