### PR TITLE
Retry failed remote cache request once on error

### DIFF
--- a/Sources/TuistCache/Cache/RetryingCacheStorage.swift
+++ b/Sources/TuistCache/Cache/RetryingCacheStorage.swift
@@ -13,7 +13,7 @@ public final class RetryingCacheStorage: CacheStoring {
     }
 
     public func exists(name: String, hash: String) async throws -> Bool {
-        try await retryOnceOnError(label: "check existence", name: name, hash: hash) {
+        try await retryOnceOnError(label: "check existence of", name: name, hash: hash) {
             try await cacheStoring.exists(name: name, hash: hash)
         }
     }
@@ -39,7 +39,7 @@ public final class RetryingCacheStorage: CacheStoring {
         do {
             return try await closure()
         } catch {
-            logger.warning("Failed to `\(label)` target \(name) with hash \(hash), Retrying…")
+            logger.warning("Failed to \(label) target \(name) with hash \(hash), Retrying…")
             return try await closure()
         }
     }

--- a/Sources/TuistCache/Cache/RetryingCacheStorage.swift
+++ b/Sources/TuistCache/Cache/RetryingCacheStorage.swift
@@ -13,28 +13,33 @@ public final class RetryingCacheStorage: CacheStoring {
     }
 
     public func exists(name: String, hash: String) async throws -> Bool {
-        try await retryOnceOnError(label: "exists", name: name, hash: hash) {
-            return try await cacheStoring.exists(name: name, hash: hash)
+        try await retryOnceOnError(label: "check existence", name: name, hash: hash) {
+            try await cacheStoring.exists(name: name, hash: hash)
         }
     }
 
     public func fetch(name: String, hash: String) async throws -> AbsolutePath {
         try await retryOnceOnError(label: "fetch", name: name, hash: hash) {
-            return try await cacheStoring.fetch(name: name, hash: hash)
+            try await cacheStoring.fetch(name: name, hash: hash)
         }
     }
 
     public func store(name: String, hash: String, paths: [AbsolutePath]) async throws {
         try await retryOnceOnError(label: "store", name: name, hash: hash) { () -> Void in
-            return try await cacheStoring.store(name: name, hash: hash, paths: paths)
+            try await cacheStoring.store(name: name, hash: hash, paths: paths)
         }
     }
 
-    private func retryOnceOnError<T>(label: String, name: String, hash: String, _ closure: () async throws -> T) async throws -> T {
+    private func retryOnceOnError<T>(
+        label: String,
+        name: String,
+        hash: String,
+        _ closure: () async throws -> T
+    ) async throws -> T {
         do {
             return try await closure()
         } catch {
-            logger.warning("Retrying failed `\(label)` for target \(name) with hash \(hash)")
+            logger.warning("Failed to `\(label)` target \(name) with hash \(hash), Retrying…")
             return try await closure()
         }
     }

--- a/Sources/TuistCache/Cache/RetryingCacheStorage.swift
+++ b/Sources/TuistCache/Cache/RetryingCacheStorage.swift
@@ -1,0 +1,41 @@
+import TSCBasic
+
+/// A wrapper for `CacheStoring` that retries API call once on failure
+public final class RetryingCacheStorage: CacheStoring {
+    // MARK: - Attributes
+
+    private let cacheStoring: CacheStoring
+
+    // MARK: - Init
+
+    public init(cacheStoring: CacheStoring) {
+        self.cacheStoring = cacheStoring
+    }
+
+    public func exists(name: String, hash: String) async throws -> Bool {
+        try await retryOnceOnError(label: "exists", name: name, hash: hash) {
+            return try await cacheStoring.exists(name: name, hash: hash)
+        }
+    }
+
+    public func fetch(name: String, hash: String) async throws -> AbsolutePath {
+        try await retryOnceOnError(label: "fetch", name: name, hash: hash) {
+            return try await cacheStoring.fetch(name: name, hash: hash)
+        }
+    }
+
+    public func store(name: String, hash: String, paths: [AbsolutePath]) async throws {
+        try await retryOnceOnError(label: "store", name: name, hash: hash) { () -> Void in
+            return try await cacheStoring.store(name: name, hash: hash, paths: paths)
+        }
+    }
+
+    private func retryOnceOnError<T>(label: String, name: String, hash: String, _ closure: () async throws -> T) async throws -> T {
+        do {
+            return try await closure()
+        } catch {
+            logger.warning("Retrying failed `\(label)` for target \(name) with hash \(hash)")
+            return try await closure()
+        }
+    }
+}

--- a/Sources/TuistCacheTesting/Cache/Mocks/MockCacheStorage.swift
+++ b/Sources/TuistCacheTesting/Cache/Mocks/MockCacheStorage.swift
@@ -17,8 +17,8 @@ public final class MockCacheStorage: CacheStoring {
         try fetchStub?(name, hash) ?? .root
     }
 
-    var storeStub: ((String, String, [AbsolutePath]) -> Void)?
+    var storeStub: ((String, String, [AbsolutePath]) throws -> Void)?
     public func store(name: String, hash: String, paths: [AbsolutePath]) async throws {
-        storeStub?(name, hash, paths)
+        try storeStub?(name, hash, paths)
     }
 }

--- a/Sources/TuistKit/Cache/CacheStorageProvider.swift
+++ b/Sources/TuistKit/Cache/CacheStorageProvider.swift
@@ -62,9 +62,9 @@ final class CacheStorageProvider: CacheStorageProviding {
         if let cloudConfig = config.cloud {
             if try cloudAuthenticationController.authenticationToken(serverURL: cloudConfig.url)?.isEmpty == false {
                 let remoteStorage = CacheRemoteStorage(
-                  cloudConfig: cloudConfig,
-                  cloudClient: CloudClient(),
-                  cacheDirectoriesProvider: cacheDirectoriesProvider
+                    cloudConfig: cloudConfig,
+                    cloudClient: CloudClient(),
+                    cacheDirectoriesProvider: cacheDirectoriesProvider
                 )
                 let storage = RetryingCacheStorage(cacheStoring: remoteStorage)
                 storages.append(storage)

--- a/Sources/TuistKit/Cache/CacheStorageProvider.swift
+++ b/Sources/TuistKit/Cache/CacheStorageProvider.swift
@@ -61,11 +61,12 @@ final class CacheStorageProvider: CacheStorageProviding {
         var storages: [CacheStoring] = [CacheLocalStorage(cacheDirectoriesProvider: cacheDirectoriesProvider)]
         if let cloudConfig = config.cloud {
             if try cloudAuthenticationController.authenticationToken(serverURL: cloudConfig.url)?.isEmpty == false {
-                let storage = CacheRemoteStorage(
-                    cloudConfig: cloudConfig,
-                    cloudClient: CloudClient(),
-                    cacheDirectoriesProvider: cacheDirectoriesProvider
+                let remoteStorage = CacheRemoteStorage(
+                  cloudConfig: cloudConfig,
+                  cloudClient: CloudClient(),
+                  cacheDirectoriesProvider: cacheDirectoriesProvider
                 )
+                let storage = RetryingCacheStorage(cacheStoring: remoteStorage)
                 storages.append(storage)
             } else {
                 if cloudConfig.options.contains(.optional) {

--- a/Tests/TuistCacheTests/Cache/RetryingCacheStorageTests.swift
+++ b/Tests/TuistCacheTests/Cache/RetryingCacheStorageTests.swift
@@ -1,0 +1,180 @@
+import TSCBasic
+import TuistCacheTesting
+import TuistCloud
+import TuistCore
+import TuistGraph
+import TuistGraphTesting
+import TuistSupport
+import XCTest
+
+@testable import TuistCache
+@testable import TuistCacheTesting
+@testable import TuistCoreTesting
+@testable import TuistSupportTesting
+
+
+final class RetryingCacheStorageTests: TuistUnitTestCase {
+    var subject: RetryingCacheStorage!
+    var storage: MockCacheStorage!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        storage = MockCacheStorage()
+        subject = RetryingCacheStorage(cacheStoring: storage)
+    }
+
+    override func tearDown() {
+        subject = nil
+        storage = nil
+        super.tearDown()
+    }
+
+    // - exists
+
+    func test_exists_whenSucceeds_doesNotRetry() async throws {
+        var existsCalls = 0
+        // Given
+        storage.existsStub = { _, _ in
+            existsCalls += 1
+            return true
+        }
+
+        // When
+        let result = try await subject.exists(name: "targetName", hash: "acho tio")
+        XCTAssertEqual(existsCalls, 1)
+        XCTAssertTrue(result)
+    }
+
+    func test_exists_whenFails_retries() async throws {
+        var existsCalls = 0
+        // Given
+        storage.existsStub = { _, _ in
+            existsCalls += 1
+            if existsCalls == 1 {
+                throw TestError("exists failed")
+            } else {
+                return true
+            }
+        }
+
+        // When
+        let result = try await subject.exists(name: "targetName", hash: "acho tio")
+        XCTAssertEqual(existsCalls, 2)
+        XCTAssertTrue(result)
+    }
+
+    func test_exists_whenFailsTwice_throws() async throws {
+        let error = TestError("exists failed")
+        var existsCalls = 0
+        // Given
+        storage.existsStub = { _, _ in
+            existsCalls += 1
+            throw error
+        }
+
+        // When
+        await XCTAssertThrowsSpecific(
+          try await subject.exists(name: "targetName", hash: "acho tio"),
+          error
+        )
+        XCTAssertEqual(existsCalls, 2)
+    }
+
+    // - fetch
+
+    func test_fetch_whenSucceeds_doesNotRetry() async throws {
+        var fetchCalls = 0
+        // Given
+        storage.fetchStub = { _, _ in
+            fetchCalls += 1
+            return "/"
+        }
+
+        // When
+        let result = try await subject.fetch(name: "targetName", hash: "acho tio")
+        XCTAssertEqual(fetchCalls, 1)
+        XCTAssertEqual(result, "/")
+    }
+
+    func test_fetch_whenFails_retries() async throws {
+        var fetchCalls = 0
+        // Given
+        storage.fetchStub = { _, _ in
+            fetchCalls += 1
+            if fetchCalls == 1 {
+                throw TestError("fetch failed")
+            } else {
+                return "/"
+            }
+        }
+
+        // When
+        let result = try await subject.fetch(name: "targetName", hash: "acho tio")
+        XCTAssertEqual(fetchCalls, 2)
+        XCTAssertEqual(result, "/")
+    }
+
+    func test_fetch_whenFailsTwice_throws() async throws {
+        let error = TestError("fetch failed")
+        var fetchCalls = 0
+        // Given
+        storage.fetchStub = { _, _ in
+            fetchCalls += 1
+            throw error
+        }
+
+        // When
+        await XCTAssertThrowsSpecific(
+          try await subject.fetch(name: "targetName", hash: "acho tio"),
+          error
+        )
+        XCTAssertEqual(fetchCalls, 2)
+    }
+
+    // - store
+
+    func test_store_whenSucceeds_doesNotRetry() async throws {
+        var storeCalls = 0
+        // Given
+        storage.storeStub = { _, _, _ in
+            storeCalls += 1
+        }
+
+        // When
+        try await subject.store(name: "targetName", hash: "acho tio", paths: [])
+        XCTAssertEqual(storeCalls, 1)
+    }
+
+    func test_store_whenFails_retries() async throws {
+        var storeCalls = 0
+        // Given
+        storage.storeStub = { _, _, _ in
+            storeCalls += 1
+            if storeCalls == 1 {
+                throw TestError("store failed")
+            }
+        }
+
+        // When
+        try await subject.store(name: "targetName", hash: "acho tio", paths: [])
+        XCTAssertEqual(storeCalls, 2)
+    }
+
+    func test_store_whenFailsTwice_throws() async throws {
+        let error = TestError("store failed")
+        var storeCalls = 0
+        // Given
+        storage.storeStub = { _, _, _ in
+            storeCalls += 1
+            throw error
+        }
+
+        // When
+        await XCTAssertThrowsSpecific(
+          try await subject.store(name: "targetName", hash: "acho tio", paths: []),
+          error
+        )
+        XCTAssertEqual(storeCalls, 2)
+    }
+}

--- a/Tests/TuistCacheTests/Cache/RetryingCacheStorageTests.swift
+++ b/Tests/TuistCacheTests/Cache/RetryingCacheStorageTests.swift
@@ -12,7 +12,6 @@ import XCTest
 @testable import TuistCoreTesting
 @testable import TuistSupportTesting
 
-
 final class RetryingCacheStorageTests: TuistUnitTestCase {
     var subject: RetryingCacheStorage!
     var storage: MockCacheStorage!
@@ -75,8 +74,8 @@ final class RetryingCacheStorageTests: TuistUnitTestCase {
 
         // When
         await XCTAssertThrowsSpecific(
-          try await subject.exists(name: "targetName", hash: "acho tio"),
-          error
+            try await subject.exists(name: "targetName", hash: "acho tio"),
+            error
         )
         XCTAssertEqual(existsCalls, 2)
     }
@@ -126,8 +125,8 @@ final class RetryingCacheStorageTests: TuistUnitTestCase {
 
         // When
         await XCTAssertThrowsSpecific(
-          try await subject.fetch(name: "targetName", hash: "acho tio"),
-          error
+            try await subject.fetch(name: "targetName", hash: "acho tio"),
+            error
         )
         XCTAssertEqual(fetchCalls, 2)
     }
@@ -172,8 +171,8 @@ final class RetryingCacheStorageTests: TuistUnitTestCase {
 
         // When
         await XCTAssertThrowsSpecific(
-          try await subject.store(name: "targetName", hash: "acho tio", paths: []),
-          error
+            try await subject.store(name: "targetName", hash: "acho tio", paths: []),
+            error
         )
         XCTAssertEqual(storeCalls, 2)
     }

--- a/Tests/TuistKitTests/Cache/CacheStorageProviderTests.swift
+++ b/Tests/TuistKitTests/Cache/CacheStorageProviderTests.swift
@@ -46,7 +46,7 @@ final class CacheStorageProviderTests: TuistUnitTestCase {
         let got = try subject.storages()
 
         // Then
-        XCTAssertContainsElementOfType(got, CacheRemoteStorage.self)
+        XCTAssertContainsElementOfType(got, RetryingCacheStorage.self)
         XCTAssertContainsElementOfType(got, CacheLocalStorage.self)
     }
 


### PR DESCRIPTION
### Short description 📝

It avoids make the whole generation fail for spurious network errors when there are a lot of dependencies to fetch or store

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
