### PR TITLE
Delete old tuistenv when updating

### DIFF
--- a/Sources/TuistEnvKit/Installer/EnvInstaller.swift
+++ b/Sources/TuistEnvKit/Installer/EnvInstaller.swift
@@ -86,12 +86,20 @@ final class EnvInstaller: EnvInstalling {
         logger.notice("Installing…")
         try System.shared.run(["/usr/bin/unzip", "-q", downloadPath.pathString, "tuistenv", "-d", temporaryDirectory.pathString])
 
-        // Copy
-        let cpArgs = ["cp", temporaryDirectory.appending(component: "tuistenv").pathString, installationPath]
+        // Remove old version
+        let rmArgs = ["rm", installationPath]
         do {
-            try System.shared.run(cpArgs)
+            try System.shared.run(rmArgs)
         } catch {
-            try System.shared.run(["sudo"] + cpArgs)
+            try System.shared.run(["sudo"] + rmArgs)
+        }
+
+        // Move
+        let mvArgs = ["mv", temporaryDirectory.appending(component: "tuistenv").pathString, installationPath]
+        do {
+            try System.shared.run(mvArgs)
+        } catch {
+            try System.shared.run(["sudo"] + mvArgs)
         }
 
         logger.notice("TuistEnv Version \(version) installed")

--- a/Tests/TuistEnvKitTests/Installer/EnvInstallerTests.swift
+++ b/Tests/TuistEnvKitTests/Installer/EnvInstallerTests.swift
@@ -61,7 +61,11 @@ final class EnvInstallerTests: TuistUnitTestCase {
             temporaryDirectory.path.pathString,
         ])
         system.succeedCommand([
-            "cp",
+            "rm",
+            "/path/to/tuist",
+        ])
+        system.succeedCommand([
+            "mv",
             temporaryDirectory.path.appending(component: "tuistenv").pathString,
             "/path/to/tuist",
         ])
@@ -110,7 +114,12 @@ final class EnvInstallerTests: TuistUnitTestCase {
         ])
         system.succeedCommand([
             "sudo",
-            "cp",
+            "rm",
+            "/path/to/tuist",
+        ])
+        system.succeedCommand([
+            "sudo",
+            "mv",
             temporaryDirectory.path.appending(component: "tuistenv").pathString,
             "/path/to/tuist",
         ])


### PR DESCRIPTION
May resolve #4552.

### Short description 📝

This PR changes `tuistenv update` to use `rm`/`mv` instead of `cp`. This matches the behavior of the install script. I suspect this may fix #4552.

### How to test the changes locally 🧐

1. Build `tuist`.
2. Replace the installed tuistenv with the built version.
3. Delete the latest installed version of `tuist`.
4. Run `tuist update`.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
