### PR TITLE
Support for custom remote plugins location

### DIFF
--- a/Sources/ProjectDescription/PluginLocation.swift
+++ b/Sources/ProjectDescription/PluginLocation.swift
@@ -15,24 +15,24 @@ public struct PluginLocation: Codable, Equatable {
         PluginLocation(type: .local(path: path))
     }
 
-    /// A `URL` to a `git` repository pointing at a `tag`.
+    /// A `URL` to a `git` repository pointing at a `tag`, and optionally a subfolder.
     ///
     /// Example:
     /// ```
     /// .git(url: "https://git/plugin.git", tag: "1.0.0")
     /// ```
-    public static func git(url: String, tag: String) -> Self {
-        PluginLocation(type: .gitWithTag(url: url, tag: tag))
+    public static func git(url: String, tag: String, subfolder: String? = nil) -> Self {
+        PluginLocation(type: .gitWithTag(url: url, tag: tag, subfolder: subfolder))
     }
 
-    /// A `URL` to a `git` repository pointing at a commit `sha`.
+    /// A `URL` to a `git` repository pointing at a commit `sha`, and optionally a subfolder.
     ///
     /// Example:
     /// ```
     /// .git(url: "https://git/plugin.git", sha: "d06b4b3d")
     /// ```
-    public static func git(url: String, sha: String) -> Self {
-        PluginLocation(type: .gitWithSha(url: url, sha: sha))
+    public static func git(url: String, sha: String, subfolder: String? = nil) -> Self {
+        PluginLocation(type: .gitWithSha(url: url, sha: sha, subfolder: subfolder))
     }
 }
 
@@ -41,7 +41,7 @@ public struct PluginLocation: Codable, Equatable {
 extension PluginLocation {
     public enum LocationType: Codable, Equatable {
         case local(path: Path)
-        case gitWithTag(url: String, tag: String)
-        case gitWithSha(url: String, sha: String)
+        case gitWithTag(url: String, tag: String, subfolder: String?)
+        case gitWithSha(url: String, sha: String, subfolder: String?)
     }
 }

--- a/Sources/ProjectDescription/PluginLocation.swift
+++ b/Sources/ProjectDescription/PluginLocation.swift
@@ -15,24 +15,26 @@ public struct PluginLocation: Codable, Equatable {
         PluginLocation(type: .local(path: path))
     }
 
-    /// A `URL` to a `git` repository pointing at a `tag`, and optionally a subfolder.
+    /// A `URL` to a `git` repository pointing at a `tag`.
+    /// You can also specify a custom directory in case the plugin is not located at the root of the repository.
     ///
     /// Example:
     /// ```
-    /// .git(url: "https://git/plugin.git", tag: "1.0.0")
+    /// .git(url: "https://git/plugin.git", tag: "1.0.0", directory: "PluginDirectory")
     /// ```
-    public static func git(url: String, tag: String, subfolder: String? = nil) -> Self {
-        PluginLocation(type: .gitWithTag(url: url, tag: tag, subfolder: subfolder))
+    public static func git(url: String, tag: String, directory: String? = nil) -> Self {
+        PluginLocation(type: .gitWithTag(url: url, tag: tag, directory: directory))
     }
 
-    /// A `URL` to a `git` repository pointing at a commit `sha`, and optionally a subfolder.
+    /// A `URL` to a `git` repository pointing at a commit `sha`.
+    /// You can also specify a custom directory in case the plugin is not located at the root of the repository.
     ///
     /// Example:
     /// ```
     /// .git(url: "https://git/plugin.git", sha: "d06b4b3d")
     /// ```
-    public static func git(url: String, sha: String, subfolder: String? = nil) -> Self {
-        PluginLocation(type: .gitWithSha(url: url, sha: sha, subfolder: subfolder))
+    public static func git(url: String, sha: String, directory: String? = nil) -> Self {
+        PluginLocation(type: .gitWithSha(url: url, sha: sha, directory: directory))
     }
 }
 
@@ -41,7 +43,7 @@ public struct PluginLocation: Codable, Equatable {
 extension PluginLocation {
     public enum LocationType: Codable, Equatable {
         case local(path: Path)
-        case gitWithTag(url: String, tag: String, subfolder: String?)
-        case gitWithSha(url: String, sha: String, subfolder: String?)
+        case gitWithTag(url: String, tag: String, directory: String?)
+        case gitWithSha(url: String, sha: String, directory: String?)
     }
 }

--- a/Sources/TuistGraph/Models/PluginLocation.swift
+++ b/Sources/TuistGraph/Models/PluginLocation.swift
@@ -15,14 +15,14 @@ public enum PluginLocation: Hashable, Equatable {
     /// ```
     case local(path: String)
 
-    /// A `URL` to a `git` repository pointing at a `GitReference` (either sha or tag), and optionally a subfolder
+    /// A `URL` to a `git` repository pointing at a `GitReference` (either sha or tag), and optionally a directory
     ///
     /// Examples:
     /// ```
     /// .git(url: "https://git/helpers.git", gitReference: .tag("1.0.0"))
     /// .git(url: "https://git/helpers.git", gitReference: .sha("1.0.0"))
     /// ```
-    case git(url: String, gitReference: GitReference, subfolder: String?)
+    case git(url: String, gitReference: GitReference, directory: String?)
 }
 
 // MARK: - description
@@ -32,10 +32,10 @@ extension PluginLocation: CustomStringConvertible {
         switch self {
         case let .local(path):
             return "local path: \(path)"
-        case let .git(url, .tag(tag), subfolder):
-            return "git url: \(url), tag: \(tag), subfolder: \(subfolder ?? "nil")"
-        case let .git(url, .sha(sha), subfolder):
-            return "git url: \(url), sha: \(sha), subfolder: \(subfolder ?? "nil")"
+        case let .git(url, .tag(tag), directory):
+            return "git url: \(url), tag: \(tag), directory: \(directory ?? "nil")"
+        case let .git(url, .sha(sha), directory):
+            return "git url: \(url), sha: \(sha), directory: \(directory ?? "nil")"
         }
     }
 }

--- a/Sources/TuistGraph/Models/PluginLocation.swift
+++ b/Sources/TuistGraph/Models/PluginLocation.swift
@@ -15,14 +15,14 @@ public enum PluginLocation: Hashable, Equatable {
     /// ```
     case local(path: String)
 
-    /// A `URL` to a `git` repository pointing at a `GitReference` - either sha or tag.
+    /// A `URL` to a `git` repository pointing at a `GitReference` (either sha or tag), and optionally a subfolder
     ///
     /// Examples:
     /// ```
     /// .git(url: "https://git/helpers.git", gitReference: .tag("1.0.0"))
     /// .git(url: "https://git/helpers.git", gitReference: .sha("1.0.0"))
     /// ```
-    case git(url: String, gitReference: GitReference)
+    case git(url: String, gitReference: GitReference, subfolder: String?)
 }
 
 // MARK: - description
@@ -32,10 +32,10 @@ extension PluginLocation: CustomStringConvertible {
         switch self {
         case let .local(path):
             return "local path: \(path)"
-        case let .git(url, .tag(tag)):
-            return "git url: \(url), tag: \(tag)"
-        case let .git(url, .sha(sha)):
-            return "git url: \(url), sha: \(sha)"
+        case let .git(url, .tag(tag), subfolder):
+            return "git url: \(url), tag: \(tag), subfolder: \(subfolder ?? "nil")"
+        case let .git(url, .sha(sha), subfolder):
+            return "git url: \(url), sha: \(sha), subfolder: \(subfolder ?? "nil")"
         }
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/PluginLocation+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/PluginLocation+ManifestMapper.swift
@@ -11,10 +11,10 @@ extension TuistGraph.PluginLocation {
         switch manifest.type {
         case let .local(path):
             return .local(path: try generatorPaths.resolve(path: path).pathString)
-        case let .gitWithTag(url, tag):
-            return .git(url: url, gitReference: .tag(tag))
-        case let .gitWithSha(url, sha):
-            return .git(url: url, gitReference: .sha(sha))
+        case let .gitWithTag(url, tag, subfolder):
+            return .git(url: url, gitReference: .tag(tag), subfolder: subfolder)
+        case let .gitWithSha(url, sha, subfolder):
+            return .git(url: url, gitReference: .sha(sha), subfolder: subfolder)
         }
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/PluginLocation+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/PluginLocation+ManifestMapper.swift
@@ -11,10 +11,10 @@ extension TuistGraph.PluginLocation {
         switch manifest.type {
         case let .local(path):
             return .local(path: try generatorPaths.resolve(path: path).pathString)
-        case let .gitWithTag(url, tag, subfolder):
-            return .git(url: url, gitReference: .tag(tag), subfolder: subfolder)
-        case let .gitWithSha(url, sha, subfolder):
-            return .git(url: url, gitReference: .sha(sha), subfolder: subfolder)
+        case let .gitWithTag(url, tag, directory):
+            return .git(url: url, gitReference: .tag(tag), directory: directory)
+        case let .gitWithSha(url, sha, directory):
+            return .git(url: url, gitReference: .sha(sha), directory: directory)
         }
     }
 }

--- a/Sources/TuistPlugin/PluginService.swift
+++ b/Sources/TuistPlugin/PluginService.swift
@@ -119,29 +119,29 @@ public final class PluginService: PluginServicing {
             switch pluginLocation {
             case .local:
                 return nil
-            case let .git(url: url, gitReference: .sha(sha), subfolder):
+            case let .git(url: url, gitReference: .sha(sha), directory):
                 let pluginCacheDirectory = try self.pluginCacheDirectory(
                     url: url,
                     gitId: sha,
                     config: config
                 )
                 var repositoryPath = pluginCacheDirectory.appending(component: PluginServiceConstants.repository)
-                if let subfolder = subfolder {
-                    repositoryPath = repositoryPath.appending(RelativePath(subfolder))
+                if let directory = directory {
+                    repositoryPath = repositoryPath.appending(RelativePath(directory))
                 }
                 return RemotePluginPaths(
                     repositoryPath: repositoryPath,
                     releasePath: nil
                 )
-            case let .git(url: url, gitReference: .tag(tag), subfolder):
+            case let .git(url: url, gitReference: .tag(tag), directory):
                 let pluginCacheDirectory = try self.pluginCacheDirectory(
                     url: url,
                     gitId: tag,
                     config: config
                 )
                 var repositoryPath = pluginCacheDirectory.appending(component: PluginServiceConstants.repository)
-                if let subfolder = subfolder {
-                    repositoryPath = repositoryPath.appending(RelativePath(subfolder))
+                if let directory = directory {
+                    repositoryPath = repositoryPath.appending(RelativePath(directory))
                 }
                 let releasePath = pluginCacheDirectory.appending(component: PluginServiceConstants.release)
                 return RemotePluginPaths(

--- a/Sources/TuistPlugin/PluginService.swift
+++ b/Sources/TuistPlugin/PluginService.swift
@@ -102,7 +102,7 @@ public final class PluginService: PluginServicing {
     public func fetchRemotePlugins(using config: Config) async throws {
         for pluginLocation in config.plugins {
             switch pluginLocation {
-            case let .git(url, gitReference):
+            case let .git(url, gitReference, _):
                 try await fetchRemotePlugin(
                     url: url,
                     gitReference: gitReference,
@@ -119,25 +119,33 @@ public final class PluginService: PluginServicing {
             switch pluginLocation {
             case .local:
                 return nil
-            case let .git(url: url, gitReference: .sha(sha)):
+            case let .git(url: url, gitReference: .sha(sha), subfolder):
                 let pluginCacheDirectory = try self.pluginCacheDirectory(
                     url: url,
                     gitId: sha,
                     config: config
                 )
+                var repositoryPath = pluginCacheDirectory.appending(component: PluginServiceConstants.repository)
+                if let subfolder = subfolder {
+                    repositoryPath = repositoryPath.appending(RelativePath(subfolder))
+                }
                 return RemotePluginPaths(
-                    repositoryPath: pluginCacheDirectory.appending(component: PluginServiceConstants.repository),
+                    repositoryPath: repositoryPath,
                     releasePath: nil
                 )
-            case let .git(url: url, gitReference: .tag(tag)):
+            case let .git(url: url, gitReference: .tag(tag), subfolder):
                 let pluginCacheDirectory = try self.pluginCacheDirectory(
                     url: url,
                     gitId: tag,
                     config: config
                 )
+                var repositoryPath = pluginCacheDirectory.appending(component: PluginServiceConstants.repository)
+                if let subfolder = subfolder {
+                    repositoryPath = repositoryPath.appending(RelativePath(subfolder))
+                }
                 let releasePath = pluginCacheDirectory.appending(component: PluginServiceConstants.release)
                 return RemotePluginPaths(
-                    repositoryPath: pluginCacheDirectory.appending(component: PluginServiceConstants.repository),
+                    repositoryPath: repositoryPath,
                     releasePath: FileHandler.shared.exists(releasePath) ? releasePath : nil
                 )
             }

--- a/Tests/ProjectDescriptionTests/ConfigTests.swift
+++ b/Tests/ProjectDescriptionTests/ConfigTests.swift
@@ -17,7 +17,7 @@ final class ConfigTests: XCTestCase {
 
     func test_config_toJSON_with_gitPlugin() {
         let config = Config(
-            plugins: [.git(url: "https://git.com/repo.git", tag: "1.0.0", subfolder: "subfolder")],
+            plugins: [.git(url: "https://git.com/repo.git", tag: "1.0.0", directory: "PluginDirectory")],
             generationOptions: .options()
         )
 

--- a/Tests/ProjectDescriptionTests/ConfigTests.swift
+++ b/Tests/ProjectDescriptionTests/ConfigTests.swift
@@ -17,7 +17,7 @@ final class ConfigTests: XCTestCase {
 
     func test_config_toJSON_with_gitPlugin() {
         let config = Config(
-            plugins: [.git(url: "https://git.com/repo.git", tag: "1.0.0")],
+            plugins: [.git(url: "https://git.com/repo.git", tag: "1.0.0", subfolder: "subfolder")],
             generationOptions: .options()
         )
 

--- a/Tests/ProjectDescriptionTests/PluginLocationTests.swift
+++ b/Tests/ProjectDescriptionTests/PluginLocationTests.swift
@@ -16,4 +16,9 @@ final class PluginLocationTests: XCTestCase {
         let subject = PluginLocation.git(url: "https://git.com/repo.git", sha: "64d8d24f")
         XCTAssertCodable(subject)
     }
+
+    func test_codable_gitWithSubfolder() throws {
+        let subject = PluginLocation.git(url: "https://git.com/repo.git", tag: "1.0.0", subfolder: "subfolder")
+        XCTAssertCodable(subject)
+    }
 }

--- a/Tests/ProjectDescriptionTests/PluginLocationTests.swift
+++ b/Tests/ProjectDescriptionTests/PluginLocationTests.swift
@@ -17,8 +17,8 @@ final class PluginLocationTests: XCTestCase {
         XCTAssertCodable(subject)
     }
 
-    func test_codable_gitWithSubfolder() throws {
-        let subject = PluginLocation.git(url: "https://git.com/repo.git", tag: "1.0.0", subfolder: "subfolder")
+    func test_codable_gitWithDirectory() throws {
+        let subject = PluginLocation.git(url: "https://git.com/repo.git", tag: "1.0.0", directory: "directory")
         XCTAssertCodable(subject)
     }
 }

--- a/Tests/TuistKitTests/Services/FetchServiceTests.swift
+++ b/Tests/TuistKitTests/Services/FetchServiceTests.swift
@@ -111,7 +111,7 @@ final class FetchServiceTests: TuistUnitTestCase {
         // Given
         let config = Config.test(
             plugins: [
-                .git(url: "url", gitReference: .tag("tag")),
+                .git(url: "url", gitReference: .tag("tag"), subfolder: nil),
             ]
         )
         configLoader.loadConfigStub = { _ in

--- a/Tests/TuistKitTests/Services/FetchServiceTests.swift
+++ b/Tests/TuistKitTests/Services/FetchServiceTests.swift
@@ -111,7 +111,7 @@ final class FetchServiceTests: TuistUnitTestCase {
         // Given
         let config = Config.test(
             plugins: [
-                .git(url: "url", gitReference: .tag("tag"), subfolder: nil),
+                .git(url: "url", gitReference: .tag("tag"), directory: nil),
             ]
         )
         configLoader.loadConfigStub = { _ in

--- a/Tests/TuistPluginTests/PluginServiceTests.swift
+++ b/Tests/TuistPluginTests/PluginServiceTests.swift
@@ -74,9 +74,9 @@ final class PluginServiceTests: TuistUnitTestCase {
         let pluginCFingerprint = "\(pluginCGitURL)-\(pluginCGitTag)".md5
         let config = mockConfig(
             plugins: [
-                .git(url: pluginAGitURL, gitReference: .sha(pluginAGitSha), subfolder: nil),
-                .git(url: pluginBGitURL, gitReference: .tag(pluginBGitTag), subfolder: nil),
-                .git(url: pluginCGitURL, gitReference: .tag(pluginCGitTag), subfolder: "Sub/Subfolder"),
+                .git(url: pluginAGitURL, gitReference: .sha(pluginAGitSha), directory: nil),
+                .git(url: pluginBGitURL, gitReference: .tag(pluginBGitTag), directory: nil),
+                .git(url: pluginCGitURL, gitReference: .tag(pluginCGitTag), directory: "Sub/Subfolder"),
             ]
         )
         let pluginADirectory = cacheDirectoriesProvider.cacheDirectory(for: .plugins)
@@ -120,7 +120,7 @@ final class PluginServiceTests: TuistUnitTestCase {
         let pluginFingerprint = "\(pluginGitURL)-\(pluginGitSha)".md5
         let config = mockConfig(
             plugins: [
-                .git(url: pluginGitURL, gitReference: .sha(pluginGitSha), subfolder: nil),
+                .git(url: pluginGitURL, gitReference: .sha(pluginGitSha), directory: nil),
             ]
         )
         var invokedCloneURL: String?
@@ -161,7 +161,7 @@ final class PluginServiceTests: TuistUnitTestCase {
         let pluginFingerprint = "\(pluginGitURL)-\(pluginGitTag)".md5
         let config = mockConfig(
             plugins: [
-                .git(url: pluginGitURL, gitReference: .tag(pluginGitTag), subfolder: nil),
+                .git(url: pluginGitURL, gitReference: .tag(pluginGitTag), directory: nil),
             ]
         )
         var invokedCloneURL: String?
@@ -202,7 +202,7 @@ final class PluginServiceTests: TuistUnitTestCase {
         let pluginFingerprint = "\(pluginGitURL)-\(pluginGitTag)".md5
         let config = mockConfig(
             plugins: [
-                .git(url: pluginGitURL, gitReference: .tag(pluginGitTag), subfolder: nil),
+                .git(url: pluginGitURL, gitReference: .tag(pluginGitTag), directory: nil),
             ]
         )
 
@@ -270,7 +270,7 @@ final class PluginServiceTests: TuistUnitTestCase {
         try fileHandler.createFolder(cachedPluginPath.appending(component: Constants.helpersDirectoryName))
 
         let config = mockConfig(plugins: [
-            TuistGraph.PluginLocation.git(url: pluginGitUrl, gitReference: .tag(pluginGitReference), subfolder: nil),
+            TuistGraph.PluginLocation.git(url: pluginGitUrl, gitReference: .tag(pluginGitReference), directory: nil),
         ])
 
         // When
@@ -333,7 +333,7 @@ final class PluginServiceTests: TuistUnitTestCase {
 
         let config =
             mockConfig(plugins: [
-                TuistGraph.PluginLocation.git(url: pluginGitUrl, gitReference: .tag(pluginGitReference), subfolder: nil),
+                TuistGraph.PluginLocation.git(url: pluginGitUrl, gitReference: .tag(pluginGitReference), directory: nil),
             ])
 
         // When
@@ -405,7 +405,7 @@ final class PluginServiceTests: TuistUnitTestCase {
         let config =
             mockConfig(plugins: [
                 TuistGraph.PluginLocation
-                    .git(url: pluginGitUrl, gitReference: .tag(pluginGitReference), subfolder: nil),
+                    .git(url: pluginGitUrl, gitReference: .tag(pluginGitReference), directory: nil),
             ])
 
         // Then
@@ -421,7 +421,7 @@ final class PluginServiceTests: TuistUnitTestCase {
         let config =
             mockConfig(plugins: [
                 TuistGraph.PluginLocation
-                    .git(url: pluginGitUrl, gitReference: .tag(pluginGitReference), subfolder: nil),
+                    .git(url: pluginGitUrl, gitReference: .tag(pluginGitReference), directory: nil),
             ])
 
         // When / Then

--- a/Tests/TuistPluginTests/PluginServiceTests.swift
+++ b/Tests/TuistPluginTests/PluginServiceTests.swift
@@ -74,9 +74,9 @@ final class PluginServiceTests: TuistUnitTestCase {
         let pluginCFingerprint = "\(pluginCGitURL)-\(pluginCGitTag)".md5
         let config = mockConfig(
             plugins: [
-                .git(url: pluginAGitURL, gitReference: .sha(pluginAGitSha)),
-                .git(url: pluginBGitURL, gitReference: .tag(pluginBGitTag)),
-                .git(url: pluginCGitURL, gitReference: .tag(pluginCGitTag)),
+                .git(url: pluginAGitURL, gitReference: .sha(pluginAGitSha), subfolder: nil),
+                .git(url: pluginBGitURL, gitReference: .tag(pluginBGitTag), subfolder: nil),
+                .git(url: pluginCGitURL, gitReference: .tag(pluginCGitTag), subfolder: "Sub/Subfolder"),
             ]
         )
         let pluginADirectory = cacheDirectoriesProvider.cacheDirectory(for: .plugins)
@@ -105,7 +105,8 @@ final class PluginServiceTests: TuistUnitTestCase {
                     releasePath: pluginBDirectory.appending(component: PluginServiceConstants.release)
                 ),
                 RemotePluginPaths(
-                    repositoryPath: pluginCDirectory.appending(component: PluginServiceConstants.repository),
+                    repositoryPath: pluginCDirectory.appending(component: PluginServiceConstants.repository)
+                        .appending(component: "Sub").appending(component: "Subfolder"),
                     releasePath: nil
                 ),
             ])
@@ -119,7 +120,7 @@ final class PluginServiceTests: TuistUnitTestCase {
         let pluginFingerprint = "\(pluginGitURL)-\(pluginGitSha)".md5
         let config = mockConfig(
             plugins: [
-                .git(url: pluginGitURL, gitReference: .sha(pluginGitSha)),
+                .git(url: pluginGitURL, gitReference: .sha(pluginGitSha), subfolder: nil),
             ]
         )
         var invokedCloneURL: String?
@@ -160,7 +161,7 @@ final class PluginServiceTests: TuistUnitTestCase {
         let pluginFingerprint = "\(pluginGitURL)-\(pluginGitTag)".md5
         let config = mockConfig(
             plugins: [
-                .git(url: pluginGitURL, gitReference: .tag(pluginGitTag)),
+                .git(url: pluginGitURL, gitReference: .tag(pluginGitTag), subfolder: nil),
             ]
         )
         var invokedCloneURL: String?
@@ -201,7 +202,7 @@ final class PluginServiceTests: TuistUnitTestCase {
         let pluginFingerprint = "\(pluginGitURL)-\(pluginGitTag)".md5
         let config = mockConfig(
             plugins: [
-                .git(url: pluginGitURL, gitReference: .tag(pluginGitTag)),
+                .git(url: pluginGitURL, gitReference: .tag(pluginGitTag), subfolder: nil),
             ]
         )
 
@@ -268,8 +269,9 @@ final class PluginServiceTests: TuistUnitTestCase {
 
         try fileHandler.createFolder(cachedPluginPath.appending(component: Constants.helpersDirectoryName))
 
-        let config =
-            mockConfig(plugins: [TuistGraph.PluginLocation.git(url: pluginGitUrl, gitReference: .tag(pluginGitReference))])
+        let config = mockConfig(plugins: [
+            TuistGraph.PluginLocation.git(url: pluginGitUrl, gitReference: .tag(pluginGitReference), subfolder: nil),
+        ])
 
         // When
         let plugins = try subject.loadPlugins(using: config)
@@ -330,7 +332,9 @@ final class PluginServiceTests: TuistUnitTestCase {
         }
 
         let config =
-            mockConfig(plugins: [TuistGraph.PluginLocation.git(url: pluginGitUrl, gitReference: .tag(pluginGitReference))])
+            mockConfig(plugins: [
+                TuistGraph.PluginLocation.git(url: pluginGitUrl, gitReference: .tag(pluginGitReference), subfolder: nil),
+            ])
 
         // When
         let plugins = try subject.loadPlugins(using: config)
@@ -399,7 +403,10 @@ final class PluginServiceTests: TuistUnitTestCase {
         }
 
         let config =
-            mockConfig(plugins: [TuistGraph.PluginLocation.git(url: pluginGitUrl, gitReference: .tag(pluginGitReference))])
+            mockConfig(plugins: [
+                TuistGraph.PluginLocation
+                    .git(url: pluginGitUrl, gitReference: .tag(pluginGitReference), subfolder: nil),
+            ])
 
         // Then
         let plugins = try subject.loadPlugins(using: config)
@@ -412,7 +419,10 @@ final class PluginServiceTests: TuistUnitTestCase {
         let pluginGitUrl = "https://url/to/repo.git"
         let pluginGitReference = "1.0.0"
         let config =
-            mockConfig(plugins: [TuistGraph.PluginLocation.git(url: pluginGitUrl, gitReference: .tag(pluginGitReference))])
+            mockConfig(plugins: [
+                TuistGraph.PluginLocation
+                    .git(url: pluginGitUrl, gitReference: .tag(pluginGitReference), subfolder: nil),
+            ])
 
         // When / Then
         XCTAssertThrowsSpecific(

--- a/projects/docs/docs/plugins/using-plugins.md
+++ b/projects/docs/docs/plugins/using-plugins.md
@@ -49,6 +49,8 @@ Remote plugins are stored on a remote server and can be downloaded by Tuist and 
 A common place to store plugins is in a git repository which is uploaded to a remote server. You can specify where to download the plugin as well as what version of the plugin to take.
 This allows you to version your plugins and share them with others.
 
+Optionally, you can also specify a directory where the plugin is located, in case it's not at the root of the repository.
+
 You can choose to collect a plugin at a specific git tag:
 
 ```swift


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3150

### Short description 📝

Allow remote plugins to be anywhere within the repo

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
