### PR TITLE
Fetch remote plugins when loading them

### DIFF
--- a/Sources/TuistKit/Commands/DumpCommand.swift
+++ b/Sources/TuistKit/Commands/DumpCommand.swift
@@ -4,7 +4,7 @@ import TSCBasic
 import TuistLoader
 import TuistSupport
 
-struct DumpCommand: ParsableCommand {
+struct DumpCommand: AsyncParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "dump",

--- a/Sources/TuistKit/Commands/DumpCommand.swift
+++ b/Sources/TuistKit/Commands/DumpCommand.swift
@@ -24,8 +24,8 @@ struct DumpCommand: ParsableCommand {
     @Argument(help: "The manifest to be dumped")
     var manifest: DumpableManifest = .project
 
-    func run() throws {
-        try DumpService().run(path: path, manifest: manifest)
+    func run() async throws {
+        try await DumpService().run(path: path, manifest: manifest)
     }
 }
 

--- a/Sources/TuistKit/Commands/EditCommand.swift
+++ b/Sources/TuistKit/Commands/EditCommand.swift
@@ -31,8 +31,8 @@ struct EditCommand: ParsableCommand {
     )
     var onlyCurrentDirectory: Bool = false
 
-    func run() throws {
-        try EditService().run(
+    func run() async throws {
+        try await EditService().run(
             path: path,
             permanent: permanent,
             onlyCurrentDirectory: onlyCurrentDirectory

--- a/Sources/TuistKit/Commands/EditCommand.swift
+++ b/Sources/TuistKit/Commands/EditCommand.swift
@@ -4,7 +4,7 @@ import TSCBasic
 import TuistGenerator
 import TuistSupport
 
-struct EditCommand: ParsableCommand {
+struct EditCommand: AsyncParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "edit",

--- a/Sources/TuistKit/Commands/ListCommand.swift
+++ b/Sources/TuistKit/Commands/ListCommand.swift
@@ -23,9 +23,9 @@ struct ListCommand: ParsableCommand {
     )
     var path: String?
 
-    func run() throws {
+    func run() async throws {
         let format: ListService.OutputFormat = json ? .json : .table
-        try ListService().run(
+        try await ListService().run(
             path: path,
             outputFormat: format
         )

--- a/Sources/TuistKit/Commands/ListCommand.swift
+++ b/Sources/TuistKit/Commands/ListCommand.swift
@@ -1,7 +1,7 @@
 import ArgumentParser
 import Foundation
 
-struct ListCommand: ParsableCommand {
+struct ListCommand: AsyncParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "list",

--- a/Sources/TuistKit/Commands/ScaffoldCommand.swift
+++ b/Sources/TuistKit/Commands/ScaffoldCommand.swift
@@ -25,7 +25,7 @@ enum ScaffoldCommandError: FatalError, Equatable {
     }
 }
 
-struct ScaffoldCommand: ParsableCommand {
+struct ScaffoldCommand: AsyncParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "scaffold",

--- a/Sources/TuistKit/Commands/ScaffoldCommand.swift
+++ b/Sources/TuistKit/Commands/ScaffoldCommand.swift
@@ -76,13 +76,13 @@ struct ScaffoldCommand: ParsableCommand {
         }
     }
 
-    func run() throws {
+    func run() async throws {
         // Currently, @Argument and subcommand clashes, so we need to handle that ourselves
         if template == ListCommand.configuration.commandName {
             let format: ListService.OutputFormat = json ? .json : .table
-            try ListService().run(path: path, outputFormat: format)
+            try await ListService().run(path: path, outputFormat: format)
         } else {
-            try ScaffoldService().run(
+            try await ScaffoldService().run(
                 path: path,
                 templateName: template,
                 requiredTemplateOptions: requiredTemplateOptions,
@@ -99,7 +99,7 @@ extension ScaffoldCommand {
     static var optionalTemplateOptions: [(name: String, option: Option<String?>)] = []
 
     /// We do not know template's option in advance -> we need to dynamically add them
-    static func preprocess(_ arguments: [String]? = nil) throws {
+    static func preprocess(_ arguments: [String]? = nil) async throws {
         guard let arguments = arguments,
               arguments.count >= 2
         else { throw ScaffoldCommandError.templateNotProvided }
@@ -117,7 +117,7 @@ extension ScaffoldCommand {
 
         guard let command = try parseAsRoot([arguments[1]] + filteredArguments) as? ScaffoldCommand else { return }
 
-        let (required, optional) = try ScaffoldService().loadTemplateOptions(
+        let (required, optional) = try await ScaffoldService().loadTemplateOptions(
             templateName: command.template,
             path: command.path
         )

--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -3,7 +3,7 @@ import Foundation
 import TuistAnalytics
 import TuistSupport
 
-public struct TuistCommand: ParsableCommand {
+public struct TuistCommand: AsyncParsableCommand {
     public init() {}
 
     public static var configuration: CommandConfiguration {

--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -45,7 +45,7 @@ public struct TuistCommand: ParsableCommand {
         var parsedError: Error?
         do {
             if processedArguments.first == ScaffoldCommand.configuration.commandName {
-                try ScaffoldCommand.preprocess(processedArguments)
+                try await ScaffoldCommand.preprocess(processedArguments)
             }
             if processedArguments.first == InitCommand.configuration.commandName {
                 try InitCommand.preprocess(processedArguments)

--- a/Sources/TuistKit/Services/DumpService.swift
+++ b/Sources/TuistKit/Services/DumpService.swift
@@ -12,7 +12,7 @@ final class DumpService {
         self.manifestLoader = manifestLoader
     }
 
-    func run(path: String?, manifest: DumpableManifest) throws {
+    func run(path: String?, manifest: DumpableManifest) async throws {
         let projectPath: AbsolutePath
         if let path = path {
             projectPath = AbsolutePath(path, relativeTo: AbsolutePath.current)
@@ -25,7 +25,7 @@ final class DumpService {
             workspaceMapper: SequentialWorkspaceMapper(mappers: []),
             graphMapper: SequentialGraphMapper([])
         )
-        try manifestGraphLoader.loadPlugins(at: projectPath)
+        try await manifestGraphLoader.loadPlugins(at: projectPath)
 
         let encoded: Encodable
         switch manifest {

--- a/Sources/TuistKit/Services/FetchService.swift
+++ b/Sources/TuistKit/Services/FetchService.swift
@@ -55,8 +55,7 @@ final class FetchService {
         logger.info("Resolving and fetching plugins.", metadata: .section)
 
         let config = try configLoader.loadConfig(path: path)
-        try await pluginService.fetchRemotePlugins(using: config)
-        let plugins = try pluginService.loadPlugins(using: config)
+        let plugins = try await pluginService.loadPlugins(using: config)
 
         logger.info("Plugins resolved and fetched successfully.", metadata: .success)
 

--- a/Sources/TuistKit/Services/ListService.swift
+++ b/Sources/TuistKit/Services/ListService.swift
@@ -31,10 +31,10 @@ class ListService {
         self.templateLoader = templateLoader
     }
 
-    func run(path: String?, outputFormat format: OutputFormat) throws {
+    func run(path: String?, outputFormat format: OutputFormat) async throws {
         let path = self.path(path)
 
-        let plugins = try loadPlugins(at: path)
+        let plugins = try await loadPlugins(at: path)
         let templateDirectories = try locateTemplateDirectories(at: path, plugins: plugins)
         let templates: [PrintableTemplate] = try templateDirectories.map { path in
             let template = try templateLoader.loadTemplate(at: path)
@@ -73,9 +73,9 @@ class ListService {
         }
     }
 
-    private func loadPlugins(at path: AbsolutePath) throws -> Plugins {
+    private func loadPlugins(at path: AbsolutePath) async throws -> Plugins {
         let config = try configLoader.loadConfig(path: path)
-        return try pluginService.loadPlugins(using: config)
+        return try await pluginService.loadPlugins(using: config)
     }
 
     /// Locates all template directories, local, system, and plugin.

--- a/Sources/TuistKit/Services/ScaffoldService.swift
+++ b/Sources/TuistKit/Services/ScaffoldService.swift
@@ -57,12 +57,9 @@ final class ScaffoldService {
     func loadTemplateOptions(
         templateName: String,
         path: String?
-    ) throws -> (
-        required: [String],
-        optional: [String]
-    ) {
+    ) async throws -> (required: [String], optional: [String]) {
         let path = self.path(path)
-        let plugins = try loadPlugins(at: path)
+        let plugins = try await loadPlugins(at: path)
         let templateDirectories = try locateTemplateDirectories(at: path, plugins: plugins)
         let templateDirectory = try templateDirectory(
             templateDirectories: templateDirectories,
@@ -86,9 +83,9 @@ final class ScaffoldService {
         templateName: String,
         requiredTemplateOptions: [String: String],
         optionalTemplateOptions: [String: String?]
-    ) throws {
+    ) async throws {
         let path = self.path(path)
-        let plugins = try loadPlugins(at: path)
+        let plugins = try await loadPlugins(at: path)
         let templateDirectories = try locateTemplateDirectories(at: path, plugins: plugins)
 
         let templateDirectory = try templateDirectory(
@@ -123,9 +120,9 @@ final class ScaffoldService {
         }
     }
 
-    private func loadPlugins(at path: AbsolutePath) throws -> Plugins {
+    private func loadPlugins(at path: AbsolutePath) async throws -> Plugins {
         let config = try configLoader.loadConfig(path: path)
-        return try pluginService.loadPlugins(using: config)
+        return try await pluginService.loadPlugins(using: config)
     }
 
     /// Parses all `attributes` from `template`

--- a/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -92,7 +92,7 @@ final class ManifestGraphLoader: ManifestGraphLoading {
         }
 
         // Load Plugins
-        let plugins = try loadPlugins(at: path)
+        let plugins = try await loadPlugins(at: path)
 
         // Load DependenciesGraph
         let dependenciesGraph = try dependenciesGraphController.load(at: path)
@@ -159,9 +159,9 @@ final class ManifestGraphLoader: ManifestGraphLoading {
     }
 
     @discardableResult
-    func loadPlugins(at path: AbsolutePath) throws -> Plugins {
+    func loadPlugins(at path: AbsolutePath) async throws -> Plugins {
         let config = try configLoader.loadConfig(path: path)
-        let plugins = try pluginsService.loadPlugins(using: config)
+        let plugins = try await pluginsService.loadPlugins(using: config)
         try manifestLoader.register(plugins: plugins)
         return plugins
     }

--- a/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
@@ -103,7 +103,7 @@ extension XCTestCase {
         do {
             _ = try await closure()
         } catch let closureError as Error {
-            XCTAssertEqual(error, closureError, file: file, line: line)
+            XCTAssertEqual(closureError, error, file: file, line: line)
             return
         } catch let closureError {
             XCTFail("\(error) is not equal to: \(closureError)", file: file, line: line)

--- a/Tests/TuistKitIntegrationTests/Commands/DumpServiceIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Commands/DumpServiceIntegrationTests.swift
@@ -20,7 +20,7 @@ final class DumpServiceTests: TuistTestCase {
         super.tearDown()
     }
 
-    func test_prints_the_manifest_when_project_manifest() throws {
+    func test_prints_the_manifest_when_project_manifest() async throws {
         let tmpDir = try temporaryPath()
         let config = """
         import ProjectDescription
@@ -38,7 +38,7 @@ final class DumpServiceTests: TuistTestCase {
             atomically: true,
             encoding: .utf8
         )
-        try subject.run(path: tmpDir.pathString, manifest: .project)
+        try await subject.run(path: tmpDir.pathString, manifest: .project)
         let expectedStart = """
         {
           "additionalFiles": [
@@ -89,7 +89,7 @@ final class DumpServiceTests: TuistTestCase {
         XCTAssertPrinterOutputContains(expectedEnd)
     }
 
-    func test_prints_the_manifest_when_workspace_manifest() throws {
+    func test_prints_the_manifest_when_workspace_manifest() async throws {
         let tmpDir = try temporaryPath()
         let config = """
         import ProjectDescription
@@ -107,7 +107,7 @@ final class DumpServiceTests: TuistTestCase {
             atomically: true,
             encoding: .utf8
         )
-        try subject.run(path: tmpDir.pathString, manifest: .workspace)
+        try await subject.run(path: tmpDir.pathString, manifest: .workspace)
         let expected = """
         {
           "additionalFiles": [
@@ -141,7 +141,7 @@ final class DumpServiceTests: TuistTestCase {
         XCTAssertPrinterOutputContains(expected)
     }
 
-    func test_prints_the_manifest_when_config_manifest() throws {
+    func test_prints_the_manifest_when_config_manifest() async throws {
         let tmpDir = try temporaryPath()
         let config = """
         import ProjectDescription
@@ -161,7 +161,7 @@ final class DumpServiceTests: TuistTestCase {
             atomically: true,
             encoding: .utf8
         )
-        try subject.run(path: tmpDir.pathString, manifest: .config)
+        try await subject.run(path: tmpDir.pathString, manifest: .config)
         let expected = """
         {
           "compatibleXcodeVersions": {
@@ -183,7 +183,7 @@ final class DumpServiceTests: TuistTestCase {
         XCTAssertPrinterOutputContains(expected)
     }
 
-    func test_prints_the_manifest_when_template_manifest() throws {
+    func test_prints_the_manifest_when_template_manifest() async throws {
         let tmpDir = try temporaryPath()
         let config = """
         import ProjectDescription
@@ -199,7 +199,7 @@ final class DumpServiceTests: TuistTestCase {
             atomically: true,
             encoding: .utf8
         )
-        try subject.run(path: tmpDir.pathString, manifest: .template)
+        try await subject.run(path: tmpDir.pathString, manifest: .template)
         let expected = """
         {
           "attributes": [
@@ -216,7 +216,7 @@ final class DumpServiceTests: TuistTestCase {
         XCTAssertPrinterOutputContains(expected)
     }
 
-    func test_prints_the_manifest_when_plugin_manifest() throws {
+    func test_prints_the_manifest_when_plugin_manifest() async throws {
         let tmpDir = try temporaryPath()
         let config = """
         import ProjectDescription
@@ -230,7 +230,7 @@ final class DumpServiceTests: TuistTestCase {
             atomically: true,
             encoding: .utf8
         )
-        try subject.run(path: tmpDir.pathString, manifest: .plugin)
+        try await subject.run(path: tmpDir.pathString, manifest: .plugin)
         let expected = """
         {
           "name": "tuist"
@@ -241,7 +241,7 @@ final class DumpServiceTests: TuistTestCase {
         XCTAssertPrinterOutputContains(expected)
     }
 
-    func test_prints_the_manifest_when_dependencies_manifest() throws {
+    func test_prints_the_manifest_when_dependencies_manifest() async throws {
         let tmpDir = try temporaryPath()
         let config = """
         import ProjectDescription
@@ -258,7 +258,7 @@ final class DumpServiceTests: TuistTestCase {
             atomically: true,
             encoding: .utf8
         )
-        try subject.run(path: tmpDir.pathString, manifest: .dependencies)
+        try await subject.run(path: tmpDir.pathString, manifest: .dependencies)
         let expected = """
         {
           "platforms": [
@@ -271,31 +271,31 @@ final class DumpServiceTests: TuistTestCase {
         XCTAssertPrinterOutputContains(expected)
     }
 
-    func test_run_throws_when_project_and_file_doesnt_exist() throws {
-        try assertLoadingRaisesWhenManifestNotFound(manifest: .project)
+    func test_run_throws_when_project_and_file_doesnt_exist() async throws {
+        try await assertLoadingRaisesWhenManifestNotFound(manifest: .project)
     }
 
-    func test_run_throws_when_workspace_and_file_doesnt_exist() throws {
-        try assertLoadingRaisesWhenManifestNotFound(manifest: .workspace)
+    func test_run_throws_when_workspace_and_file_doesnt_exist() async throws {
+        try await assertLoadingRaisesWhenManifestNotFound(manifest: .workspace)
     }
 
-    func test_run_throws_when_config_and_file_doesnt_exist() throws {
-        try assertLoadingRaisesWhenManifestNotFound(manifest: .config)
+    func test_run_throws_when_config_and_file_doesnt_exist() async throws {
+        try await assertLoadingRaisesWhenManifestNotFound(manifest: .config)
     }
 
-    func test_run_throws_when_template_and_file_doesnt_exist() throws {
-        try assertLoadingRaisesWhenManifestNotFound(manifest: .template)
+    func test_run_throws_when_template_and_file_doesnt_exist() async throws {
+        try await assertLoadingRaisesWhenManifestNotFound(manifest: .template)
     }
 
-    func test_run_throws_when_dependencies_and_file_doesnt_exist() throws {
-        try assertLoadingRaisesWhenManifestNotFound(manifest: .dependencies)
+    func test_run_throws_when_dependencies_and_file_doesnt_exist() async throws {
+        try await assertLoadingRaisesWhenManifestNotFound(manifest: .dependencies)
     }
 
-    func test_run_throws_when_plugin_and_file_doesnt_exist() throws {
-        try assertLoadingRaisesWhenManifestNotFound(manifest: .plugin)
+    func test_run_throws_when_plugin_and_file_doesnt_exist() async throws {
+        try await assertLoadingRaisesWhenManifestNotFound(manifest: .plugin)
     }
 
-    func test_run_throws_when_the_manifest_loading_fails() throws {
+    func test_run_throws_when_the_manifest_loading_fails() async throws {
         for manifest in DumpableManifest.allCases {
             let tmpDir = try temporaryPath()
             try "invalid config".write(
@@ -303,23 +303,26 @@ final class DumpServiceTests: TuistTestCase {
                 atomically: true,
                 encoding: .utf8
             )
-            XCTAssertThrowsError(try subject.run(path: tmpDir.pathString, manifest: manifest))
+            await XCTAssertThrowsSpecific(
+                try await subject.run(path: tmpDir.pathString, manifest: manifest),
+                TestError("ciao")
+            )
         }
     }
 
     // MARK: - Helpers
 
-    private func assertLoadingRaisesWhenManifestNotFound(manifest: DumpableManifest) throws {
-        try fileHandler.inTemporaryDirectory { tmpDir in
+    private func assertLoadingRaisesWhenManifestNotFound(manifest: DumpableManifest) async throws {
+        try await fileHandler.inTemporaryDirectory { tmpDir in
             var expectedDirectory = tmpDir
             if manifest == .config || manifest == .dependencies {
                 expectedDirectory = expectedDirectory.appending(component: Constants.tuistDirectoryName)
-                if !fileHandler.exists(expectedDirectory) {
-                    try fileHandler.createFolder(expectedDirectory)
+                if !self.fileHandler.exists(expectedDirectory) {
+                    try self.fileHandler.createFolder(expectedDirectory)
                 }
             }
-            XCTAssertThrowsSpecific(
-                try subject.run(path: tmpDir.pathString, manifest: manifest),
+            await self.XCTAssertThrowsSpecific(
+                try await self.subject.run(path: tmpDir.pathString, manifest: manifest),
                 ManifestLoaderError.manifestNotFound(manifest.manifest, expectedDirectory)
             )
         }

--- a/Tests/TuistKitIntegrationTests/Commands/DumpServiceIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Commands/DumpServiceIntegrationTests.swift
@@ -303,10 +303,12 @@ final class DumpServiceTests: TuistTestCase {
                 atomically: true,
                 encoding: .utf8
             )
-            await XCTAssertThrowsSpecific(
-                try await subject.run(path: tmpDir.pathString, manifest: manifest),
-                TestError("ciao")
-            )
+            do {
+                try await subject.run(path: tmpDir.pathString, manifest: manifest)
+                XCTFail("Expected error not thrown")
+            } catch {
+                // can't use XCTAssertError because it doesn't support async
+            }
         }
     }
 

--- a/Tests/TuistKitTests/Services/FetchServiceTests.swift
+++ b/Tests/TuistKitTests/Services/FetchServiceTests.swift
@@ -118,8 +118,9 @@ final class FetchServiceTests: TuistUnitTestCase {
             config
         }
         var invokedConfig: Config?
-        pluginService.fetchRemotePluginsStub = { config in
+        pluginService.loadPluginsStub = { config in
             invokedConfig = config
+            return .test()
         }
 
         // When
@@ -129,9 +130,7 @@ final class FetchServiceTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertEqual(
-            config, invokedConfig
-        )
+        XCTAssertEqual(invokedConfig, config)
     }
 
     func test_run_when_fetching_dependencies() async throws {

--- a/Tests/TuistKitTests/Services/ListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/ListServiceTests.swift
@@ -36,7 +36,7 @@ final class ListServiceTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_lists_available_templates_table_format() throws {
+    func test_lists_available_templates_table_format() async throws {
         // Given
         let expectedTemplates = ["template", "customTemplate"]
         let expectedOutput = """
@@ -55,13 +55,13 @@ final class ListServiceTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.run(path: nil, outputFormat: .table)
+        try await subject.run(path: nil, outputFormat: .table)
 
         // Then
         XCTAssertPrinterContains(expectedOutput, at: .info, ==)
     }
 
-    func test_lists_available_templates_json_format() throws {
+    func test_lists_available_templates_json_format() async throws {
         // Given
         let expectedTemplates = ["template", "customTemplate"]
         let expectedOutput = """
@@ -86,13 +86,13 @@ final class ListServiceTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.run(path: nil, outputFormat: .json)
+        try await subject.run(path: nil, outputFormat: .json)
 
         // Then
         XCTAssertPrinterContains(expectedOutput, at: .info, ==)
     }
 
-    func test_lists_available_templates_with_plugins() throws {
+    func test_lists_available_templates_with_plugins() async throws {
         // Given
         let expectedTemplates = ["template", "customTemplate", "pluginTemplate"]
         let expectedOutput = """
@@ -117,7 +117,7 @@ final class ListServiceTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.run(path: nil, outputFormat: .table)
+        try await subject.run(path: nil, outputFormat: .table)
 
         // Then
         XCTAssertPrinterContains(expectedOutput, at: .info, ==)

--- a/Tests/TuistKitTests/Services/ScaffoldServiceTests.swift
+++ b/Tests/TuistKitTests/Services/ScaffoldServiceTests.swift
@@ -46,7 +46,7 @@ final class ScaffoldServiceTests: TuistUnitTestCase {
         super.tearDown()
     }
 
-    func test_load_template_options() throws {
+    func test_load_template_options() async throws {
         // Given
         templateLoader.loadTemplateStub = { _ in
             Template(
@@ -66,7 +66,7 @@ final class ScaffoldServiceTests: TuistUnitTestCase {
         let expectedOptions = (required: ["required"], optional: ["optional"])
 
         // When
-        let options = try subject.loadTemplateOptions(
+        let options = try await subject.loadTemplateOptions(
             templateName: "template",
             path: nil
         )
@@ -76,7 +76,7 @@ final class ScaffoldServiceTests: TuistUnitTestCase {
         XCTAssertEqual(options.optional, expectedOptions.optional)
     }
 
-    func test_load_template_plugin_options() throws {
+    func test_load_template_plugin_options() async throws {
         // Given
         templateLoader.loadTemplateStub = { _ in
             Template(
@@ -101,7 +101,7 @@ final class ScaffoldServiceTests: TuistUnitTestCase {
         }
 
         // When
-        let options = try subject.loadTemplateOptions(
+        let options = try await subject.loadTemplateOptions(
             templateName: "PluginTemplate",
             path: nil
         )
@@ -111,15 +111,15 @@ final class ScaffoldServiceTests: TuistUnitTestCase {
         XCTAssertEqual(options.optional, expectedOptions.optional)
     }
 
-    func test_fails_when_template_not_found() throws {
+    func test_fails_when_template_not_found() async throws {
         let templateName = "template"
-        XCTAssertThrowsSpecific(
-            try subject.testRun(templateName: templateName),
+        await XCTAssertThrowsSpecific(
+            try await subject.testRun(templateName: templateName),
             ScaffoldServiceError.templateNotFound(templateName, searchPaths: [])
         )
     }
 
-    func test_fails_when_required_attribute_not_provided() throws {
+    func test_fails_when_required_attribute_not_provided() async throws {
         // Given
         templateLoader.loadTemplateStub = { _ in
             Template.test(attributes: [.required("required")])
@@ -130,13 +130,13 @@ final class ScaffoldServiceTests: TuistUnitTestCase {
         }
 
         // Then
-        XCTAssertThrowsSpecific(
-            try subject.testRun(),
+        await XCTAssertThrowsSpecific(
+            try await subject.testRun(),
             ScaffoldServiceError.attributeNotProvided("required")
         )
     }
 
-    func test_optional_attribute_is_taken_from_template() throws {
+    func test_optional_attribute_is_taken_from_template() async throws {
         // Given
         templateLoader.loadTemplateStub = { _ in
             Template.test(attributes: [.optional("optional", default: "optionalValue")])
@@ -152,7 +152,7 @@ final class ScaffoldServiceTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.testRun()
+        try await subject.testRun()
 
         // Then
         XCTAssertEqual(
@@ -161,7 +161,7 @@ final class ScaffoldServiceTests: TuistUnitTestCase {
         )
     }
 
-    func test_attributes_are_passed_to_generator() throws {
+    func test_attributes_are_passed_to_generator() async throws {
         // Given
         templateLoader.loadTemplateStub = { _ in
             Template.test(attributes: [
@@ -180,7 +180,7 @@ final class ScaffoldServiceTests: TuistUnitTestCase {
         }
 
         // When
-        try subject.testRun(
+        try await subject.testRun(
             requiredTemplateOptions: ["required": "requiredValue"],
             optionalTemplateOptions: ["optional": "optionalValue"]
         )
@@ -202,8 +202,8 @@ extension ScaffoldService {
         templateName: String = "template",
         requiredTemplateOptions: [String: String] = [:],
         optionalTemplateOptions: [String: String] = [:]
-    ) throws {
-        try run(
+    ) async throws {
+        try await run(
             path: path,
             templateName: templateName,
             requiredTemplateOptions: requiredTemplateOptions,

--- a/Tests/TuistPluginTests/PluginServiceTests.swift
+++ b/Tests/TuistPluginTests/PluginServiceTests.swift
@@ -407,21 +407,6 @@ final class PluginServiceTests: TuistUnitTestCase {
         XCTAssertEqual(plugins, expectedPlugins)
     }
 
-    func test_cacheConfiguration_WHEN_loadPlugin() throws {
-        // Given
-        let pluginGitUrl = "https://url/to/repo.git"
-        let pluginGitReference = "1.0.0"
-        let config =
-            mockConfig(plugins: [TuistGraph.PluginLocation.git(url: pluginGitUrl, gitReference: .tag(pluginGitReference))])
-
-        // When / Then
-        XCTAssertThrowsSpecific(
-            { try await self.subject.loadPlugins(using: config) },
-            PluginServiceError.missingRemotePlugins(["Plugin"])
-        )
-        XCTAssertEqual(cacheDirectoryProviderFactory.cacheDirectoriesConfig, config)
-    }
-
     private func mockConfig(plugins: [TuistGraph.PluginLocation]) -> TuistGraph.Config {
         Config(
             compatibleXcodeVersions: .all,

--- a/Tests/TuistPluginTests/PluginServiceTests.swift
+++ b/Tests/TuistPluginTests/PluginServiceTests.swift
@@ -220,7 +220,7 @@ final class PluginServiceTests: TuistUnitTestCase {
         _ = try await subject.fetchRemotePlugins(using: config)
     }
 
-    func test_loadPlugins_WHEN_localHelpers() throws {
+    func test_loadPlugins_WHEN_localHelpers() async throws {
         // Given
         let pluginPath = try temporaryPath().appending(component: "Plugin")
         let pluginName = "TestPlugin"
@@ -240,7 +240,7 @@ final class PluginServiceTests: TuistUnitTestCase {
         )
 
         // When
-        let plugins = try subject.loadPlugins(using: config)
+        let plugins = try await subject.loadPlugins(using: config)
 
         // Then
         let expectedHelpersPath = pluginPath.appending(component: Constants.helpersDirectoryName)
@@ -249,7 +249,7 @@ final class PluginServiceTests: TuistUnitTestCase {
         XCTAssertEqual(plugins, expectedPlugins)
     }
 
-    func test_loadPlugins_WHEN_gitHelpers() throws {
+    func test_loadPlugins_WHEN_gitHelpers() async throws {
         // Given
         let pluginGitUrl = "https://url/to/repo.git"
         let pluginGitReference = "1.0.0"
@@ -272,7 +272,7 @@ final class PluginServiceTests: TuistUnitTestCase {
             mockConfig(plugins: [TuistGraph.PluginLocation.git(url: pluginGitUrl, gitReference: .tag(pluginGitReference))])
 
         // When
-        let plugins = try subject.loadPlugins(using: config)
+        let plugins = try await subject.loadPlugins(using: config)
 
         // Then
         let expectedHelpersPath = cachedPluginPath.appending(component: Constants.helpersDirectoryName)
@@ -281,7 +281,7 @@ final class PluginServiceTests: TuistUnitTestCase {
         XCTAssertEqual(plugins, expectedPlugins)
     }
 
-    func test_loadPlugins_when_localResourceSynthesizer() throws {
+    func test_loadPlugins_when_localResourceSynthesizer() async throws {
         // Given
         let pluginPath = try temporaryPath()
         let pluginName = "TestPlugin"
@@ -300,7 +300,7 @@ final class PluginServiceTests: TuistUnitTestCase {
         let config = mockConfig(plugins: [TuistGraph.PluginLocation.local(path: pluginPath.pathString)])
 
         // When
-        let plugins = try subject.loadPlugins(using: config)
+        let plugins = try await subject.loadPlugins(using: config)
         let expectedPlugins = Plugins.test(
             resourceSynthesizers: [
                 PluginResourceSynthesizer(name: pluginName, path: resourceTemplatesPath),
@@ -309,7 +309,7 @@ final class PluginServiceTests: TuistUnitTestCase {
         XCTAssertEqual(plugins, expectedPlugins)
     }
 
-    func test_loadPlugins_when_remoteResourceSynthesizer() throws {
+    func test_loadPlugins_when_remoteResourceSynthesizer() async throws {
         // Given
         let pluginGitUrl = "https://url/to/repo.git"
         let pluginGitReference = "1.0.0"
@@ -333,7 +333,7 @@ final class PluginServiceTests: TuistUnitTestCase {
             mockConfig(plugins: [TuistGraph.PluginLocation.git(url: pluginGitUrl, gitReference: .tag(pluginGitReference))])
 
         // When
-        let plugins = try subject.loadPlugins(using: config)
+        let plugins = try await subject.loadPlugins(using: config)
         let expectedPlugins = Plugins.test(
             resourceSynthesizers: [
                 PluginResourceSynthesizer(name: pluginName, path: resourceTemplatesPath),
@@ -342,7 +342,7 @@ final class PluginServiceTests: TuistUnitTestCase {
         XCTAssertEqual(plugins, expectedPlugins)
     }
 
-    func test_loadPlugins_WHEN_localTemplate() throws {
+    func test_loadPlugins_WHEN_localTemplate() async throws {
         // Given
         let pluginPath = try temporaryPath()
         let pluginName = "TestPlugin"
@@ -367,12 +367,12 @@ final class PluginServiceTests: TuistUnitTestCase {
         let config = mockConfig(plugins: [TuistGraph.PluginLocation.local(path: pluginPath.pathString)])
 
         // Then
-        let plugins = try subject.loadPlugins(using: config)
+        let plugins = try await subject.loadPlugins(using: config)
         let expectedPlugins = Plugins.test(templatePaths: [templatePath])
         XCTAssertEqual(plugins, expectedPlugins)
     }
 
-    func test_loadPlugins_WHEN_gitTemplate() throws {
+    func test_loadPlugins_WHEN_gitTemplate() async throws {
         // Given
         let pluginGitUrl = "https://url/to/repo.git"
         let pluginGitReference = "1.0.0"
@@ -402,7 +402,7 @@ final class PluginServiceTests: TuistUnitTestCase {
             mockConfig(plugins: [TuistGraph.PluginLocation.git(url: pluginGitUrl, gitReference: .tag(pluginGitReference))])
 
         // Then
-        let plugins = try subject.loadPlugins(using: config)
+        let plugins = try await subject.loadPlugins(using: config)
         let expectedPlugins = Plugins.test(templatePaths: [templatePath])
         XCTAssertEqual(plugins, expectedPlugins)
     }
@@ -416,7 +416,7 @@ final class PluginServiceTests: TuistUnitTestCase {
 
         // When / Then
         XCTAssertThrowsSpecific(
-            try subject.loadPlugins(using: config),
+            { try await self.subject.loadPlugins(using: config) },
             PluginServiceError.missingRemotePlugins(["Plugin"])
         )
         XCTAssertEqual(cacheDirectoryProviderFactory.cacheDirectoriesConfig, config)


### PR DESCRIPTION
### Short description 📝

This problem was an unintended change introduced in 3.0.
Without this change, after a `tuist clean`, running `tuist generate` would fail if `tuist fetch` is not run before.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
