### PR TITLE
Fix resource bundle signing error when archiving with Xcode 14 beta

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -44,6 +44,12 @@ public class ResourcesProjectMapper: ProjectMapping {
                 bundleId: "\(target.bundleId).resources",
                 deploymentTarget: target.deploymentTarget,
                 infoPlist: .extendingDefault(with: [:]),
+                settings: Settings(
+                    base: [
+                        "CODE_SIGNING_ALLOWED": "NO",
+                    ],
+                    configurations: [:]
+                ),
                 resources: target.resources,
                 copyFiles: target.copyFiles,
                 coreDataModels: target.coreDataModels,

--- a/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -75,6 +75,9 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(resourcesTarget.deploymentTarget, target.deploymentTarget)
         XCTAssertEqual(resourcesTarget.filesGroup, target.filesGroup)
         XCTAssertEqual(resourcesTarget.resources, resources)
+        XCTAssertEqual(resourcesTarget.settings?.base, [
+            "CODE_SIGNING_ALLOWED": "NO",
+        ])
     }
 
     func testMap_whenDisableBundleAccessorsIsTrue_doesNotGenerateAccessors() throws {

--- a/projects/tuist/fixtures/ios_app_with_static_frameworks_with_resources/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_static_frameworks_with_resources/Project.swift
@@ -14,7 +14,12 @@ let project = Project(
                 .project(target: "A", path: "Modules/A"),
                 .project(target: "C", path: "Modules/C"),
                 .framework(path: "Prebuilt/prebuilt/PrebuiltStaticFramework.framework"),
-            ]
+            ],
+            settings: .settings(
+                base: [
+                    "BITCODE_ENABLED": "NO",
+                ]
+            )
         ),
         Target(
             name: "AppTests",


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/4568

### Short description 📝

- Archiving resources bundles when using Xcode 14 beta results in a code signing error as Xcode attempts to codesign it (whereas it didn't before)

```
error: Signing for "A_A" requires a development team. Select a development team in the Signing & Capabilities editor. (in target 'A_A' from project 'A')
```

- The `CODE_SIGNING_ALLOWED` default value appears to have changed to `YES` for bundle targets in Xcode 14 (it used to be `NO` in Xcode 13), which appears to be causing this issue
- To mitigate this, we can explicitly set the `CODE_SIGNING_ALLOWED` to `NO` for generated resource targets
  - This should be backwards compatible with Xcode 13

### Notes 📝:

- An additional change is required to XcodeProj to ensure any bundle target for iOS has this as a default recommended setting to account for manually created resource bundle targets https://github.com/tuist/XcodeProj/pull/697 - this can be added independently from this PR.

### How to test the changes locally 🧐

- Run `swift build` to build this version of Tuist
- Generate a fixture that contains a resource bundle that is automatically generated by Tuist

```sh
swift run tuist generate --path ./projects/tuist/fixtures/ios_app_with_static_frameworks_with_resources
```

- Select the resource bundle scheme (e.g. `A_A`) and attempt to archive it on Xcode 13 and Xcode 14
- Verify it successfully archives without issues

References 📚:

- https://developer.apple.com/forums/thread/708659

`A_A` is a generated resource bundle target.

```sh
$ xcrun xcodebuild -showBuildSettings -workspace App.xcworkspace -scheme A_A | grep CODE_SIGN
    AD_HOC_CODE_SIGNING_ALLOWED = NO
    CODE_SIGNING_ALLOWED = NO
    CODE_SIGNING_REQUIRED = YES
    CODE_SIGN_CONTEXT_CLASS = XCiPhoneOSCodeSignContext
    CODE_SIGN_IDENTITY = iPhone Developer
    CODE_SIGN_INJECT_BASE_ENTITLEMENTS = YES
    EXPANDED_CODE_SIGN_IDENTITY =
    EXPANDED_CODE_SIGN_IDENTITY_NAME =
    __CODE_SIGNING_ALLOWED_appletvos = NO
    __CODE_SIGNING_ALLOWED_iphoneos = NO
    __CODE_SIGNING_ALLOWED_watchos = NO
```

```sh
$ DEVELOPER_DIR=/Applications/Xcode14-beta2.app/Contents/Developer/ xcrun xcodebuild -showBuildSettings -workspace App.xcworkspace -scheme A_A | grep CODE_SIGN
    AD_HOC_CODE_SIGNING_ALLOWED = NO
    CODE_SIGNING_ALLOWED = YES
    CODE_SIGNING_REQUIRED = YES
    CODE_SIGN_CONTEXT_CLASS = XCiPhoneOSCodeSignContext
    CODE_SIGN_IDENTITY = iPhone Developer
    CODE_SIGN_INJECT_BASE_ENTITLEMENTS = YES
    EXPANDED_CODE_SIGN_IDENTITY =
    EXPANDED_CODE_SIGN_IDENTITY_NAME =
```

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- ~In case the PR introduces changes that affect users, the documentation has been updated.~
- ~In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.~
