### PR TITLE
Point back to tuist/ExampleTuistPlugin in acceptance tests

### DIFF
--- a/projects/tuist/fixtures/app_with_plugins/Tuist/Config.swift
+++ b/projects/tuist/fixtures/app_with_plugins/Tuist/Config.swift
@@ -3,7 +3,6 @@ import ProjectDescription
 let config = Config(
     plugins: [
         .local(path: .relativeToManifest("../../LocalPlugin")),
-        // TODO: Change back to tuist organization
-        .git(url: "https://github.com/fortmarek/ExampleTuistPlugin", tag: "0.4.0"),
+        .git(url: "https://github.com/tuist/ExampleTuistPlugin", tag: "3.0.0"),
     ]
 )


### PR DESCRIPTION
### Short description 📝

Point back to tuist/ExampleTuistPlugin in acceptance tests.

I've made some updates to the repo to make this possible.