### PR TITLE
Add support to enable frame gpu capture

### DIFF
--- a/Sources/ProjectDescription/RunActionOptions.swift
+++ b/Sources/ProjectDescription/RunActionOptions.swift
@@ -147,10 +147,10 @@ extension RunActionOptions {
 
 extension RunActionOptions {
     public enum GPUFrameCaptureMode: String, Codable, Equatable {
-        case autoEnabled = "0"
-        case metal = "1"
-        case openGL = "2"
-        case disabled = "3"
+        case autoEnabled
+        case metal
+        case openGL
+        case disabled
 
         public static var `default`: GPUFrameCaptureMode {
             .autoEnabled

--- a/Sources/ProjectDescription/RunActionOptions.swift
+++ b/Sources/ProjectDescription/RunActionOptions.swift
@@ -28,7 +28,9 @@ public struct RunActionOptions: Equatable, Codable {
     ///     - simulatedLocation: The simulated GPS location to use when running the app.
     ///     Please note that the `.custom(gpxPath:)` case must refer to a valid GPX file in your project's resources.
     ///
-    ///     - enableGPUFrameCaptureMode: The capture mode to use. e.g: .disabled
+    ///     - enableGPUFrameCaptureMode: The Metal Frame Capture mode to use. e.g: .disabled
+    ///     If your target links to the Metal framework, Xcode enables GPU Frame Capture.
+    ///     You can disable it to test your app in best perfomance.
     init(
         language: SchemeLanguage? = nil,
         storeKitConfigurationPath: Path? = nil,
@@ -54,7 +56,9 @@ public struct RunActionOptions: Equatable, Codable {
     ///     - simulatedLocation: The simulated GPS location to use when running the app.
     ///     Please note that the `.custom(gpxPath:)` case must refer to a valid GPX file in your project's resources.
     ///
-    ///     - enableGPUFrameCaptureMode: The capture mode to use. e.g: .disabled
+    ///     - enableGPUFrameCaptureMode: The Metal Frame Capture mode to use. e.g: .disabled
+    ///     If your target links to the Metal framework, Xcode enables GPU Frame Capture.
+    ///     You can disable it to test your app in best perfomance.
 
     public static func options(
         language: SchemeLanguage? = nil,

--- a/Sources/ProjectDescription/RunActionOptions.swift
+++ b/Sources/ProjectDescription/RunActionOptions.swift
@@ -12,6 +12,9 @@ public struct RunActionOptions: Equatable, Codable {
     /// A simulated GPS location to use when running the app.
     public let simulatedLocation: SimulatedLocation?
 
+    /// Configure your project to work with the Metal frame debugger.
+    public let enableGPUFrameCaptureMode: GPUFrameCaptureMode
+
     /// Creates an `RunActionOptions` instance
     ///
     /// - Parameters:
@@ -24,14 +27,18 @@ public struct RunActionOptions: Equatable, Codable {
     ///
     ///     - simulatedLocation: The simulated GPS location to use when running the app.
     ///     Please note that the `.custom(gpxPath:)` case must refer to a valid GPX file in your project's resources.
+    ///
+    ///     - enableGPUFrameCaptureMode: The capture mode to use. e.g: .disabled
     init(
         language: SchemeLanguage? = nil,
         storeKitConfigurationPath: Path? = nil,
-        simulatedLocation: SimulatedLocation? = nil
+        simulatedLocation: SimulatedLocation? = nil,
+        enableGPUFrameCaptureMode: GPUFrameCaptureMode = GPUFrameCaptureMode.default
     ) {
         self.language = language
         self.storeKitConfigurationPath = storeKitConfigurationPath
         self.simulatedLocation = simulatedLocation
+        self.enableGPUFrameCaptureMode = enableGPUFrameCaptureMode
     }
 
     /// Creates an `RunActionOptions` instance
@@ -46,15 +53,20 @@ public struct RunActionOptions: Equatable, Codable {
     ///
     ///     - simulatedLocation: The simulated GPS location to use when running the app.
     ///     Please note that the `.custom(gpxPath:)` case must refer to a valid GPX file in your project's resources.
+    ///
+    ///     - enableGPUFrameCaptureMode: The capture mode to use. e.g: .disabled
+
     public static func options(
         language: SchemeLanguage? = nil,
         storeKitConfigurationPath: Path? = nil,
-        simulatedLocation: SimulatedLocation? = nil
+        simulatedLocation: SimulatedLocation? = nil,
+        enableGPUFrameCaptureMode: GPUFrameCaptureMode = GPUFrameCaptureMode.default
     ) -> Self {
         self.init(
             language: language,
             storeKitConfigurationPath: storeKitConfigurationPath,
-            simulatedLocation: simulatedLocation
+            simulatedLocation: simulatedLocation,
+            enableGPUFrameCaptureMode: enableGPUFrameCaptureMode
         )
     }
 }
@@ -125,6 +137,19 @@ extension RunActionOptions {
 
         public static var rioDeJaneiro: SimulatedLocation {
             .init(identifier: "Rio De Janeiro, Brazil")
+        }
+    }
+}
+
+extension RunActionOptions {
+    public enum GPUFrameCaptureMode: String, Codable, Equatable {
+        case autoEnabled = "0"
+        case metal = "1"
+        case openGL = "2"
+        case disabled = "3"
+
+        public static var `default`: GPUFrameCaptureMode {
+            .autoEnabled
         }
     }
 }

--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -496,6 +496,22 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
             )
         }
 
+        let enableGPUFrameCaptureMode: XCScheme.LaunchAction.GPUFrameCaptureMode
+        if let captureMode = scheme.runAction?.options.enableGPUFrameCaptureMode {
+            switch captureMode {
+            case .autoEnabled:
+                enableGPUFrameCaptureMode = .autoEnabled
+            case .metal:
+                enableGPUFrameCaptureMode = .metal
+            case .openGL:
+                enableGPUFrameCaptureMode = .openGL
+            case .disabled:
+                enableGPUFrameCaptureMode = .disabled
+            }
+        } else {
+            enableGPUFrameCaptureMode = .autoEnabled
+        }
+
         let preActions = try scheme.runAction?.preActions.map {
             try schemeExecutionAction(
                 action: $0,
@@ -525,6 +541,7 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
             askForAppToLaunch: launchActionConstants.askForAppToLaunch,
             pathRunnable: pathRunnable,
             locationScenarioReference: locationScenarioReference,
+            enableGPUFrameCaptureMode: enableGPUFrameCaptureMode,
             disableMainThreadChecker: disableMainThreadChecker,
             commandlineArguments: commandlineArguments,
             environmentVariables: environments,

--- a/Sources/TuistGraph/Models/RunActionOptions.swift
+++ b/Sources/TuistGraph/Models/RunActionOptions.swift
@@ -93,10 +93,10 @@ extension RunActionOptions.SimulatedLocation: Equatable, Codable {
 
 extension RunActionOptions {
     public enum GPUFrameCaptureMode: String, Codable, Equatable {
-        case autoEnabled = "0"
-        case metal = "1"
-        case openGL = "2"
-        case disabled = "3"
+        case autoEnabled
+        case metal
+        case openGL
+        case disabled
 
         public static var `default`: GPUFrameCaptureMode {
             .autoEnabled

--- a/Sources/TuistGraph/Models/RunActionOptions.swift
+++ b/Sources/TuistGraph/Models/RunActionOptions.swift
@@ -13,6 +13,9 @@ public struct RunActionOptions: Equatable, Codable {
     /// A simulated location used when running the provided run action.
     public let simulatedLocation: SimulatedLocation?
 
+    /// Configure your project to work with the Metal frame debugger.
+    public let enableGPUFrameCaptureMode: GPUFrameCaptureMode
+
     /// Creates an `RunActionOptions` instance
     ///
     /// - Parameters:
@@ -24,14 +27,19 @@ public struct RunActionOptions: Equatable, Codable {
     ///     configuration defined for the scheme
     ///
     ///     - simulatedLocation: The simulated GPS location to use when running the app.
+    ///
+    ///     - enableGPUFrameCaptureMode: The capture mode to use. e.g: .disabled
+
     public init(
         language: String? = nil,
         storeKitConfigurationPath: AbsolutePath? = nil,
-        simulatedLocation: SimulatedLocation? = nil
+        simulatedLocation: SimulatedLocation? = nil,
+        enableGPUFrameCaptureMode: GPUFrameCaptureMode = .autoEnabled
     ) {
         self.language = language
         self.storeKitConfigurationPath = storeKitConfigurationPath
         self.simulatedLocation = simulatedLocation
+        self.enableGPUFrameCaptureMode = enableGPUFrameCaptureMode
     }
 }
 
@@ -78,5 +86,18 @@ extension RunActionOptions.SimulatedLocation: Equatable, Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(identifier)
+    }
+}
+
+extension RunActionOptions {
+    public enum GPUFrameCaptureMode: String, Codable, Equatable {
+        case autoEnabled = "0"
+        case metal = "1"
+        case openGL = "2"
+        case disabled = "3"
+
+        public static var `default`: GPUFrameCaptureMode {
+            .autoEnabled
+        }
     }
 }

--- a/Sources/TuistGraph/Models/RunActionOptions.swift
+++ b/Sources/TuistGraph/Models/RunActionOptions.swift
@@ -28,7 +28,9 @@ public struct RunActionOptions: Equatable, Codable {
     ///
     ///     - simulatedLocation: The simulated GPS location to use when running the app.
     ///
-    ///     - enableGPUFrameCaptureMode: The capture mode to use. e.g: .disabled
+    ///     - enableGPUFrameCaptureMode: The Metal Frame Capture mode to use. e.g: .disabled
+    ///     If your target links to the Metal framework, Xcode enables GPU Frame Capture.
+    ///     You can disable it to test your app in best perfomance.
 
     public init(
         language: String? = nil,

--- a/Sources/TuistLoader/Models+ManifestMappers/RunActionOptions+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/RunActionOptions+ManifestMapper.swift
@@ -15,8 +15,11 @@ extension TuistGraph.RunActionOptions {
         var language: String?
         var storeKitConfigurationPath: AbsolutePath?
         var simulatedLocation: SimulatedLocation?
+        var enableGPUFrameCaptureMode: GPUFrameCaptureMode
 
         language = manifest.language?.identifier
+        enableGPUFrameCaptureMode = GPUFrameCaptureMode(rawValue: manifest.enableGPUFrameCaptureMode.rawValue) ??
+            GPUFrameCaptureMode.default
 
         if let path = manifest.storeKitConfigurationPath {
             storeKitConfigurationPath = try generatorPaths.resolveSchemeActionProjectPath(path)
@@ -36,7 +39,8 @@ extension TuistGraph.RunActionOptions {
         return TuistGraph.RunActionOptions(
             language: language,
             storeKitConfigurationPath: storeKitConfigurationPath,
-            simulatedLocation: simulatedLocation
+            simulatedLocation: simulatedLocation,
+            enableGPUFrameCaptureMode: enableGPUFrameCaptureMode
         )
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/RunActionOptions+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/RunActionOptions+ManifestMapper.swift
@@ -18,8 +18,17 @@ extension TuistGraph.RunActionOptions {
         var enableGPUFrameCaptureMode: GPUFrameCaptureMode
 
         language = manifest.language?.identifier
-        enableGPUFrameCaptureMode = GPUFrameCaptureMode(rawValue: manifest.enableGPUFrameCaptureMode.rawValue) ??
-            GPUFrameCaptureMode.default
+
+        switch manifest.enableGPUFrameCaptureMode {
+        case .autoEnabled:
+            enableGPUFrameCaptureMode = .autoEnabled
+        case .metal:
+            enableGPUFrameCaptureMode = .metal
+        case .openGL:
+            enableGPUFrameCaptureMode = .openGL
+        case .disabled:
+            enableGPUFrameCaptureMode = .disabled
+        }
 
         if let path = manifest.storeKitConfigurationPath {
             storeKitConfigurationPath = try generatorPaths.resolveSchemeActionProjectPath(path)

--- a/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -865,7 +865,8 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
             options: .init(
                 language: "pl",
                 storeKitConfigurationPath: "/somepath/Workspace/Projects/Project/nested/configuration/configuration.storekit",
-                simulatedLocation: .reference("New York, NY, USA")
+                simulatedLocation: .reference("New York, NY, USA"),
+                enableGPUFrameCaptureMode: .metal
             )
         )
 

--- a/projects/tuist/fixtures/ios_app_with_custom_scheme/App/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_custom_scheme/App/Project.swift
@@ -12,7 +12,7 @@ let debugScheme = Scheme(
     testAction: TestAction.targets(["AppTests"]),
     runAction: .runAction(
         executable: "App",
-        options: .options(simulatedLocation: .johannesburg)
+        options: .options(simulatedLocation: .johannesburg, enableGPUFrameCaptureMode: .metal)
     )
 )
 
@@ -24,7 +24,7 @@ let releaseScheme = Scheme(
     testAction: TestAction.targets(["AppTests"]),
     runAction: .runAction(
         executable: "App",
-        options: .options(simulatedLocation: .custom(gpxFile: "Resources/Grand Canyon.gpx"))
+        options: .options(simulatedLocation: .custom(gpxFile: "Resources/Grand Canyon.gpx"), enableGPUFrameCaptureMode: .disabled)
     )
 )
 


### PR DESCRIPTION
### Short description 📝

Add support to edit GPU frame capture mode on the Scheme. This will allow for instance to fix bugs when working with `MKMapView` ([stackoverflow link](https://stackoverflow.com/a/33331769))

### How to test the changes locally 🧐

- Unit tests are working properly

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
