### PR TITLE
Add support for `--no-open` flag in `tuist graph`

### DIFF
--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -36,6 +36,12 @@ struct GraphCommand: AsyncParsableCommand, HasTrackableParameters {
     )
     var format: GraphFormat = .png
 
+    @Flag(
+        name: .shortAndLong,
+        help: "Don't open the file after generating it."
+    )
+    var noOpen: Bool = false
+
     @Option(
         name: [.customShort("a"), .customLong("algorithm")],
         help: "Available formats: dot, neato, twopi, circo, fdp, sfddp, patchwork"
@@ -72,6 +78,7 @@ struct GraphCommand: AsyncParsableCommand, HasTrackableParameters {
             layoutAlgorithm: layoutAlgorithm,
             skipTestTargets: skipTestTargets,
             skipExternalDependencies: skipExternalDependencies,
+            noOpen: noOpen,
             targetsToFilter: targets,
             path: path.map { AbsolutePath($0) } ?? FileHandler.shared.currentPath,
             outputPath: outputPath.map { AbsolutePath($0, relativeTo: FileHandler.shared.currentPath) } ?? FileHandler.shared

--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -78,7 +78,7 @@ struct GraphCommand: AsyncParsableCommand, HasTrackableParameters {
             layoutAlgorithm: layoutAlgorithm,
             skipTestTargets: skipTestTargets,
             skipExternalDependencies: skipExternalDependencies,
-            noOpen: noOpen,
+            open: !noOpen,
             targetsToFilter: targets,
             path: path.map { AbsolutePath($0) } ?? FileHandler.shared.currentPath,
             outputPath: outputPath.map { AbsolutePath($0, relativeTo: FileHandler.shared.currentPath) } ?? FileHandler.shared

--- a/Sources/TuistKit/Services/GraphService.swift
+++ b/Sources/TuistKit/Services/GraphService.swift
@@ -106,7 +106,7 @@ final class GraphService {
         from graphVizGraph: GraphViz.Graph,
         at filePath: AbsolutePath,
         layoutAlgorithm: LayoutAlgorithm,
-        noOpen: Bool = false
+        noOpen: Bool
     ) throws {
         if !isGraphVizInstalled() {
             try installGraphViz()

--- a/Sources/TuistKit/Services/GraphService.swift
+++ b/Sources/TuistKit/Services/GraphService.swift
@@ -85,7 +85,7 @@ final class GraphService {
         at filePath: AbsolutePath,
         withFormat format: GraphFormat,
         layoutAlgorithm: LayoutAlgorithm,
-        noOpen: Bool = false
+        noOpen: Bool
     ) throws {
         switch format {
         case .dot:

--- a/Sources/TuistKit/Services/GraphService.swift
+++ b/Sources/TuistKit/Services/GraphService.swift
@@ -42,7 +42,7 @@ final class GraphService {
         layoutAlgorithm: GraphViz.LayoutAlgorithm,
         skipTestTargets: Bool,
         skipExternalDependencies: Bool,
-        noOpen: Bool,
+        open: Bool,
         targetsToFilter: [String],
         path: AbsolutePath,
         outputPath: AbsolutePath
@@ -68,7 +68,7 @@ final class GraphService {
                 targetsAndDependencies: filteredTargetsAndDependencies
             )
 
-            try export(graph: graphVizGraph, at: filePath, withFormat: format, layoutAlgorithm: layoutAlgorithm, noOpen: noOpen)
+            try export(graph: graphVizGraph, at: filePath, withFormat: format, layoutAlgorithm: layoutAlgorithm, open: open)
         case .json:
             let outputGraph = ProjectAutomation.Graph.from(
                 graph: graph,
@@ -85,13 +85,13 @@ final class GraphService {
         at filePath: AbsolutePath,
         withFormat format: GraphFormat,
         layoutAlgorithm: LayoutAlgorithm,
-        noOpen: Bool
+        open: Bool = true
     ) throws {
         switch format {
         case .dot:
             try exportDOTRepresentation(from: graph, at: filePath)
         case .png:
-            try exportPNGRepresentation(from: graph, at: filePath, layoutAlgorithm: layoutAlgorithm, noOpen: noOpen)
+            try exportPNGRepresentation(from: graph, at: filePath, layoutAlgorithm: layoutAlgorithm, open: open)
         case .json:
             throw GraphServiceError.jsonNotValidForVisualExport
         }
@@ -106,7 +106,7 @@ final class GraphService {
         from graphVizGraph: GraphViz.Graph,
         at filePath: AbsolutePath,
         layoutAlgorithm: LayoutAlgorithm,
-        noOpen: Bool
+        open: Bool = true
     ) throws {
         if !isGraphVizInstalled() {
             try installGraphViz()
@@ -114,7 +114,7 @@ final class GraphService {
         let data = try graphVizGraph.render(using: layoutAlgorithm, to: .png)
         FileManager.default.createFile(atPath: filePath.pathString, contents: data, attributes: nil)
 
-        if !noOpen {
+        if open {
             try System.shared.async(["open", filePath.pathString])
         }
     }

--- a/Tests/TuistKitTests/Services/GraphServiceTests.swift
+++ b/Tests/TuistKitTests/Services/GraphServiceTests.swift
@@ -53,6 +53,7 @@ final class GraphServiceTests: TuistUnitTestCase {
             layoutAlgorithm: .dot,
             skipTestTargets: false,
             skipExternalDependencies: false,
+            open: false,
             targetsToFilter: [],
             path: temporaryPath,
             outputPath: temporaryPath
@@ -82,6 +83,7 @@ final class GraphServiceTests: TuistUnitTestCase {
             layoutAlgorithm: .dot,
             skipTestTargets: false,
             skipExternalDependencies: false,
+            open: false,
             targetsToFilter: [],
             path: temporaryPath,
             outputPath: temporaryPath


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4636
Request for comments document (if applies):

### Short description 📝

## Current behaviour

Running

```
$ tuist graph --format=png
```

Generates a PNG and **opens** the image file.

Add a command flag telling `tuist graph` not to open the generated file.

This is useful in cases where you have CI that generates the image (pre-commit) and you don't want the image to show up.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
