### PR TITLE
Add support for `systemLibrary` SwiftPackageManager targets

### DIFF
--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -289,7 +289,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
                     /// System library targets assume the module map is located at the source directory root
                     /// https://github.com/apple/swift-package-manager/blob/main/Sources/PackageLoading/ModuleMapGenerator.swift
                     let packagePath = try target.basePath(packageFolder: packageToFolder[packageInfo.key]!)
-                    let moduleMapPath = packagePath.appending(component: moduleMapFilename)
+                    let moduleMapPath = packagePath.appending(component: ModuleMap.filename)
 
                     guard FileHandler.shared.exists(moduleMapPath), !FileHandler.shared.isFolder(moduleMapPath) else {
                         throw PackageInfoMapperError.modulemapMissing(

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -43,10 +43,12 @@ enum PackageInfoMapperError: FatalError, Equatable {
     /// Thrown when a binary target defined in a package doesn't have a corresponding artifact
     case missingBinaryArtifact(package: String, target: String)
 
+    case modulemapMissing(moduleMapPath: String, package: String, target: String)
+
     /// Error type.
     var type: ErrorType {
         switch self {
-        case .noSupportedPlatforms, .unknownByNameDependency, .unknownPlatform, .unknownProductDependency, .unknownProductTarget:
+        case .noSupportedPlatforms, .unknownByNameDependency, .unknownPlatform, .unknownProductDependency, .unknownProductTarget, .modulemapMissing:
             return .abort
         case .minDeploymentTargetParsingFailed, .defaultPathNotFound, .unsupportedSetting, .missingBinaryArtifact:
             return .bug
@@ -77,6 +79,8 @@ enum PackageInfoMapperError: FatalError, Equatable {
             return "The \(tool) and \(setting) pair is not a supported setting."
         case let .missingBinaryArtifact(package, target):
             return "The artifact for binary target \(target) of package \(package) cannot be found."
+        case let .modulemapMissing(moduleMapPath, package, target):
+            return "Target \(target) of package \(package) is a system library. Module map is missing at \(moduleMapPath)."
         }
     }
 }
@@ -279,11 +283,28 @@ public final class PackageInfoMapper: PackageInfoMapping {
         let targetToModuleMap: [String: ModuleMap]
         targetToModuleMap = try packageInfos.reduce(into: [:]) { result, packageInfo in
             try packageInfo.value.targets.forEach { target in
-                guard target.type == .regular else { return }
-                result[target.name] = try moduleMapGenerator.generate(
-                    moduleName: target.name,
-                    publicHeadersPath: target.publicHeadersPath(packageFolder: packageToFolder[packageInfo.key]!)
-                )
+                switch target.type {
+                case .system:
+                    /// System library targets assume the module map is located at the source directory root
+                    /// https://github.com/apple/swift-package-manager/blob/main/Sources/PackageLoading/ModuleMapGenerator.swift
+                    let packagePath = try target.basePath(packageFolder: packageToFolder[packageInfo.key]!)
+                    let moduleMapPath = packagePath.appending(component: moduleMapFilename)
+
+                    guard FileHandler.shared.exists(moduleMapPath), !FileHandler.shared.isFolder(moduleMapPath) else {
+                        throw PackageInfoMapperError.modulemapMissing(moduleMapPath: moduleMapPath.pathString,
+                                                                      package: packageInfo.key,
+                                                                      target: target.name)
+                    }
+
+                    result[target.name] = ModuleMap.custom(moduleMapPath)
+                case .regular:
+                    result[target.name] = try moduleMapGenerator.generate(
+                        moduleName: target.name,
+                        publicHeadersPath: target.publicHeadersPath(packageFolder: packageToFolder[packageInfo.key]!)
+                    )
+                default:
+                    return
+                }
             }
         }
 
@@ -425,7 +446,7 @@ extension ProjectDescription.Target {
         targetToModuleMap: [String: ModuleMap],
         addPlatformSuffix: Bool
     ) throws -> Self? {
-        guard target.type == .regular else {
+        guard target.type == .regular || target.type == .system else {
             logger.debug("Target \(target.name) of type \(target.type) ignored")
             return nil
         }
@@ -736,7 +757,7 @@ extension ProjectDescription.Settings {
         let mainRelativePath = mainPath.relative(to: packageFolder)
 
         let moduleMap = targetToModuleMap[target.name]!
-        if moduleMap != .none {
+        if moduleMap != .none && target.type != .system {
             let publicHeadersPath = try target.publicHeadersPath(packageFolder: packageFolder)
             let publicHeadersRelativePath = publicHeadersPath.relative(to: packageFolder)
             headerSearchPaths.append("$(SRCROOT)/\(publicHeadersRelativePath.pathString)")

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -876,19 +876,19 @@ extension ProjectDescription.Settings {
             settingsDictionary["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = .array(["$(inherited)"] + swiftDefines)
         }
 
-        if !cFlags.isEmpty {
+        if !cFlags.isEmpty, target.type.supportsCSettings {
             settingsDictionary["OTHER_CFLAGS"] = .array(["$(inherited)"] + cFlags)
         }
 
-        if !cxxFlags.isEmpty {
+        if !cxxFlags.isEmpty, target.type.supportsCxxSettings {
             settingsDictionary["OTHER_CPLUSPLUSFLAGS"] = .array(["$(inherited)"] + cxxFlags)
         }
 
-        if !swiftFlags.isEmpty {
+        if !swiftFlags.isEmpty, target.type.supportsSwiftSettings {
             settingsDictionary["OTHER_SWIFT_FLAGS"] = .array(["$(inherited)"] + swiftFlags)
         }
 
-        if !linkerFlags.isEmpty {
+        if !linkerFlags.isEmpty, target.type.supportsLinkerSettings {
             settingsDictionary["OTHER_LDFLAGS"] = .array(["$(inherited)"] + linkerFlags)
         }
 

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -808,38 +808,40 @@ extension ProjectDescription.Settings {
             }
             .sorted()
 
-        try settings.forEach { setting in
-            if let condition = setting.condition {
-                guard condition.platformNames.contains(platform.rawValue) else {
-                    return
+        if target.type.supportsCustomSettings {
+            try settings.forEach { setting in
+                if let condition = setting.condition {
+                    guard condition.platformNames.contains(platform.rawValue) else {
+                        return
+                    }
                 }
-            }
 
-            switch (setting.tool, setting.name) {
-            case (.c, .headerSearchPath), (.cxx, .headerSearchPath):
-                headerSearchPaths.append("$(SRCROOT)/\(mainRelativePath.pathString)/\(setting.value[0])")
-            case (.c, .define), (.cxx, .define):
-                let (name, value) = setting.extractDefine
-                defines[name] = value
-            case (.c, .unsafeFlags):
-                cFlags.append(contentsOf: setting.value)
-            case (.cxx, .unsafeFlags):
-                cxxFlags.append(contentsOf: setting.value)
-            case (.swift, .define):
-                swiftDefines.append(setting.value[0])
-            case (.swift, .unsafeFlags):
-                swiftFlags.append(contentsOf: setting.value)
-            case (.linker, .unsafeFlags):
-                linkerFlags.append(contentsOf: setting.value)
+                switch (setting.tool, setting.name) {
+                case (.c, .headerSearchPath), (.cxx, .headerSearchPath):
+                    headerSearchPaths.append("$(SRCROOT)/\(mainRelativePath.pathString)/\(setting.value[0])")
+                case (.c, .define), (.cxx, .define):
+                    let (name, value) = setting.extractDefine
+                    defines[name] = value
+                case (.c, .unsafeFlags):
+                    cFlags.append(contentsOf: setting.value)
+                case (.cxx, .unsafeFlags):
+                    cxxFlags.append(contentsOf: setting.value)
+                case (.swift, .define):
+                    swiftDefines.append(setting.value[0])
+                case (.swift, .unsafeFlags):
+                    swiftFlags.append(contentsOf: setting.value)
+                case (.linker, .unsafeFlags):
+                    linkerFlags.append(contentsOf: setting.value)
 
-            case (.linker, .linkedFramework), (.linker, .linkedLibrary):
-                // Handled as dependency
-                return
+                case (.linker, .linkedFramework), (.linker, .linkedLibrary):
+                    // Handled as dependency
+                    return
 
-            case (.c, .linkedFramework), (.c, .linkedLibrary), (.cxx, .linkedFramework), (.cxx, .linkedLibrary),
-                 (.swift, .headerSearchPath), (.swift, .linkedFramework), (.swift, .linkedLibrary),
-                 (.linker, .headerSearchPath), (.linker, .define):
-                throw PackageInfoMapperError.unsupportedSetting(setting.tool, setting.name)
+                case (.c, .linkedFramework), (.c, .linkedLibrary), (.cxx, .linkedFramework), (.cxx, .linkedLibrary),
+                     (.swift, .headerSearchPath), (.swift, .linkedFramework), (.swift, .linkedLibrary),
+                     (.linker, .headerSearchPath), (.linker, .define):
+                    throw PackageInfoMapperError.unsupportedSetting(setting.tool, setting.name)
+                }
             }
         }
 
@@ -876,19 +878,19 @@ extension ProjectDescription.Settings {
             settingsDictionary["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = .array(["$(inherited)"] + swiftDefines)
         }
 
-        if !cFlags.isEmpty, target.type.supportsCSettings {
+        if !cFlags.isEmpty {
             settingsDictionary["OTHER_CFLAGS"] = .array(["$(inherited)"] + cFlags)
         }
 
-        if !cxxFlags.isEmpty, target.type.supportsCxxSettings {
+        if !cxxFlags.isEmpty {
             settingsDictionary["OTHER_CPLUSPLUSFLAGS"] = .array(["$(inherited)"] + cxxFlags)
         }
 
-        if !swiftFlags.isEmpty, target.type.supportsSwiftSettings {
+        if !swiftFlags.isEmpty {
             settingsDictionary["OTHER_SWIFT_FLAGS"] = .array(["$(inherited)"] + swiftFlags)
         }
 
-        if !linkerFlags.isEmpty, target.type.supportsLinkerSettings {
+        if !linkerFlags.isEmpty {
             settingsDictionary["OTHER_LDFLAGS"] = .array(["$(inherited)"] + linkerFlags)
         }
 

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -48,7 +48,8 @@ enum PackageInfoMapperError: FatalError, Equatable {
     /// Error type.
     var type: ErrorType {
         switch self {
-        case .noSupportedPlatforms, .unknownByNameDependency, .unknownPlatform, .unknownProductDependency, .unknownProductTarget, .modulemapMissing:
+        case .noSupportedPlatforms, .unknownByNameDependency, .unknownPlatform, .unknownProductDependency, .unknownProductTarget,
+             .modulemapMissing:
             return .abort
         case .minDeploymentTargetParsingFailed, .defaultPathNotFound, .unsupportedSetting, .missingBinaryArtifact:
             return .bug
@@ -291,9 +292,11 @@ public final class PackageInfoMapper: PackageInfoMapping {
                     let moduleMapPath = packagePath.appending(component: moduleMapFilename)
 
                     guard FileHandler.shared.exists(moduleMapPath), !FileHandler.shared.isFolder(moduleMapPath) else {
-                        throw PackageInfoMapperError.modulemapMissing(moduleMapPath: moduleMapPath.pathString,
-                                                                      package: packageInfo.key,
-                                                                      target: target.name)
+                        throw PackageInfoMapperError.modulemapMissing(
+                            moduleMapPath: moduleMapPath.pathString,
+                            package: packageInfo.key,
+                            target: target.name
+                        )
                     }
 
                     result[target.name] = ModuleMap.custom(moduleMapPath)
@@ -757,7 +760,7 @@ extension ProjectDescription.Settings {
         let mainRelativePath = mainPath.relative(to: packageFolder)
 
         let moduleMap = targetToModuleMap[target.name]!
-        if moduleMap != .none && target.type != .system {
+        if moduleMap != .none, target.type != .system {
             let publicHeadersPath = try target.publicHeadersPath(packageFolder: packageFolder)
             let publicHeadersRelativePath = publicHeadersPath.relative(to: packageFolder)
             headerSearchPaths.append("$(SRCROOT)/\(publicHeadersRelativePath.pathString)")

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerModuleMapGenerator.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerModuleMapGenerator.swift
@@ -1,9 +1,6 @@
 import TSCBasic
 import TuistSupport
 
-/// Name of the module map file recognized by the Clang and Swift compilers.
-public let moduleMapFilename = "module.modulemap"
-
 /// The type of modulemap file
 public enum ModuleMap: Equatable {
     /// No headers and hence no modulemap file
@@ -25,6 +22,9 @@ public enum ModuleMap: Equatable {
             return nil
         }
     }
+
+    /// Name of the module map file recognized by the Clang and Swift compilers.
+    public static let filename = "module.modulemap"
 }
 
 /// Protocol that allows to generate a modulemap for an SPM target.
@@ -77,7 +77,7 @@ public final class SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerMod
     static func customModuleMapPath(publicHeadersPath: AbsolutePath) throws -> AbsolutePath? {
         guard FileHandler.shared.exists(publicHeadersPath) else { return nil }
 
-        let moduleMapPath = RelativePath(moduleMapFilename)
+        let moduleMapPath = RelativePath(ModuleMap.filename)
         let publicHeadersFolderContent = try FileHandler.shared.contentsOfDirectory(publicHeadersPath)
 
         if publicHeadersFolderContent.contains(publicHeadersPath.appending(moduleMapPath)) {

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerModuleMapGenerator.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerModuleMapGenerator.swift
@@ -1,6 +1,9 @@
 import TSCBasic
 import TuistSupport
 
+/// Name of the module map file recognized by the Clang and Swift compilers.
+public let moduleMapFilename = "module.modulemap"
+
 /// The type of modulemap file
 public enum ModuleMap: Equatable {
     /// No headers and hence no modulemap file
@@ -74,7 +77,7 @@ public final class SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerMod
     static func customModuleMapPath(publicHeadersPath: AbsolutePath) throws -> AbsolutePath? {
         guard FileHandler.shared.exists(publicHeadersPath) else { return nil }
 
-        let moduleMapPath = RelativePath("module.modulemap")
+        let moduleMapPath = RelativePath(moduleMapFilename)
         let publicHeadersFolderContent = try FileHandler.shared.contentsOfDirectory(publicHeadersPath)
 
         if publicHeadersFolderContent.contains(publicHeadersPath.appending(moduleMapPath)) {

--- a/Sources/TuistSupport/SwiftPackageManager/PackageInfo.swift
+++ b/Sources/TuistSupport/SwiftPackageManager/PackageInfo.swift
@@ -591,4 +591,8 @@ extension PackageInfo.Target.TargetType {
             return false
         }
     }
+
+    public var supportsCustomSettings: Bool {
+        supportsCSettings || supportsCxxSettings || supportsSwiftSettings || supportsLinkerSettings
+    }
 }

--- a/Sources/TuistSupport/SwiftPackageManager/PackageInfo.swift
+++ b/Sources/TuistSupport/SwiftPackageManager/PackageInfo.swift
@@ -547,4 +547,48 @@ extension PackageInfo.Target.TargetType {
             return false
         }
     }
+
+    /// Defines if target supports C settings
+    /// Based on preconditions in https://github.com/apple/swift-package-manager/blob/main/Sources/PackageDescription/Target.swift
+    public var supportsCSettings: Bool {
+        switch self {
+        case .regular, .executable, .test:
+            return true
+        case .system, .binary, .plugin:
+            return false
+        }
+    }
+
+    /// Defines if target supports CXX settings
+    /// Based on preconditions in https://github.com/apple/swift-package-manager/blob/main/Sources/PackageDescription/Target.swift
+    public var supportsCxxSettings: Bool {
+        switch self {
+        case .regular, .executable, .test:
+            return true
+        case .system, .binary, .plugin:
+            return false
+        }
+    }
+
+    /// Defines if target supports Swift settings
+    /// Based on preconditions in https://github.com/apple/swift-package-manager/blob/main/Sources/PackageDescription/Target.swift
+    public var supportsSwiftSettings: Bool {
+        switch self {
+        case .regular, .executable, .test:
+            return true
+        case .system, .binary, .plugin:
+            return false
+        }
+    }
+
+    /// Defines if target supports linker settings
+    /// Based on preconditions in https://github.com/apple/swift-package-manager/blob/main/Sources/PackageDescription/Target.swift
+    public var supportsLinkerSettings: Bool {
+        switch self {
+        case .regular, .executable, .test:
+            return true
+        case .system, .binary, .plugin:
+            return false
+        }
+    }
 }

--- a/Sources/TuistSupport/SwiftPackageManager/PackageInfo.swift
+++ b/Sources/TuistSupport/SwiftPackageManager/PackageInfo.swift
@@ -548,51 +548,14 @@ extension PackageInfo.Target.TargetType {
         }
     }
 
-    /// Defines if target supports C settings
+    /// Defines if target supports C, CXX, Swift or linker settings
     /// Based on preconditions in https://github.com/apple/swift-package-manager/blob/main/Sources/PackageDescription/Target.swift
-    public var supportsCSettings: Bool {
-        switch self {
-        case .regular, .executable, .test:
-            return true
-        case .system, .binary, .plugin:
-            return false
-        }
-    }
-
-    /// Defines if target supports CXX settings
-    /// Based on preconditions in https://github.com/apple/swift-package-manager/blob/main/Sources/PackageDescription/Target.swift
-    public var supportsCxxSettings: Bool {
-        switch self {
-        case .regular, .executable, .test:
-            return true
-        case .system, .binary, .plugin:
-            return false
-        }
-    }
-
-    /// Defines if target supports Swift settings
-    /// Based on preconditions in https://github.com/apple/swift-package-manager/blob/main/Sources/PackageDescription/Target.swift
-    public var supportsSwiftSettings: Bool {
-        switch self {
-        case .regular, .executable, .test:
-            return true
-        case .system, .binary, .plugin:
-            return false
-        }
-    }
-
-    /// Defines if target supports linker settings
-    /// Based on preconditions in https://github.com/apple/swift-package-manager/blob/main/Sources/PackageDescription/Target.swift
-    public var supportsLinkerSettings: Bool {
-        switch self {
-        case .regular, .executable, .test:
-            return true
-        case .system, .binary, .plugin:
-            return false
-        }
-    }
-
     public var supportsCustomSettings: Bool {
-        supportsCSettings || supportsCxxSettings || supportsSwiftSettings || supportsLinkerSettings
+        switch self {
+        case .regular, .executable, .test:
+            return true
+        case .system, .binary, .plugin:
+            return false
+        }
     }
 }

--- a/Sources/TuistSupport/SwiftPackageManager/PackageInfo.swift
+++ b/Sources/TuistSupport/SwiftPackageManager/PackageInfo.swift
@@ -492,3 +492,59 @@ extension PackageInfo.Product.ProductType: Decodable {
         }
     }
 }
+
+extension PackageInfo.Target.TargetType {
+    /// Defines if the target would be processed when processing the package
+    public var isSupported: Bool {
+        switch self {
+        case .regular, .system:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Defines if target may have a public headers path
+    /// Based on preconditions in https://github.com/apple/swift-package-manager/blob/main/Sources/PackageDescription/Target.swift
+    public var supportsPublicHeaderPath: Bool {
+        switch self {
+        case .regular, .executable, .test:
+            return true
+        case .system, .binary, .plugin:
+            return false
+        }
+    }
+
+    /// Defines if target may have source files
+    /// Based on preconditions in https://github.com/apple/swift-package-manager/blob/main/Sources/PackageDescription/Target.swift
+    public var supportsSources: Bool {
+        switch self {
+        case .regular, .executable, .test, .plugin:
+            return true
+        case .system, .binary:
+            return false
+        }
+    }
+
+    /// Defines if target may have resource files
+    /// Based on preconditions in https://github.com/apple/swift-package-manager/blob/main/Sources/PackageDescription/Target.swift
+    public var supportsResources: Bool {
+        switch self {
+        case .regular, .executable, .test:
+            return true
+        case .system, .binary, .plugin:
+            return false
+        }
+    }
+
+    /// Defines if target may have other dependencies
+    /// Based on preconditions in https://github.com/apple/swift-package-manager/blob/main/Sources/PackageDescription/Target.swift
+    public var supportsDependencies: Bool {
+        switch self {
+        case .regular, .executable, .test, .plugin:
+            return true
+        case .system, .binary:
+            return false
+        }
+    }
+}

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -916,6 +916,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     .test(
                         "Target1",
                         basePath: basePath,
+                        customSources: SourceFilesList(),
                         moduleMap: "$(SRCROOT)/Sources/Target1/module.modulemap"
                     ),
                 ]
@@ -2870,7 +2871,18 @@ extension ProjectDescription.Target {
         customSettings: ProjectDescription.SettingsDictionary = [:],
         moduleMap: String? = nil
     ) -> Self {
-        .init(
+        var sources: SourceFilesList?
+
+        switch customSources {
+        case let .some(list) where !list.globs.isEmpty:
+            sources = list
+        case .none:
+            sources = .init(globs: [basePath.appending(RelativePath("Package/Sources/\(name)/**")).pathString])
+        default:
+            break
+        }
+
+        return ProjectDescription.Target(
             name: name,
             platform: platform,
             product: product,
@@ -2878,8 +2890,7 @@ extension ProjectDescription.Target {
             bundleId: customBundleID ?? name,
             deploymentTarget: deploymentTarget,
             infoPlist: .default,
-            sources: customSources ??
-                .init(globs: [basePath.appending(RelativePath("Package/Sources/\(name)/**")).pathString]),
+            sources: sources,
             resources: resources.isEmpty ? nil : ResourceFileElements(resources: resources),
             headers: headers,
             dependencies: dependencies,

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -929,9 +929,11 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         let moduleMapPath = targetPath.appending(component: "module.modulemap")
         try fileHandler.createFolder(targetPath)
 
-        let error = PackageInfoMapperError.modulemapMissing(moduleMapPath: moduleMapPath.pathString,
-                                                            package: "Package",
-                                                            target: "Target1")
+        let error = PackageInfoMapperError.modulemapMissing(
+            moduleMapPath: moduleMapPath.pathString,
+            package: "Package",
+            target: "Target1"
+        )
 
         XCTAssertThrowsSpecific(try subject.map(
             package: "Package",

--- a/projects/tuist/fixtures/app_with_spm_dependencies/App/Project.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/App/Project.swift
@@ -39,6 +39,7 @@ let project = Project(
                 .external(name: "IterableSDK"),
                 .external(name: "Stripe"),
                 .external(name: "TYStatusBarView"),
+                .external(name: "GRDB"),
             ],
             settings: .targetSettings
         ),

--- a/projects/tuist/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
@@ -7,6 +7,7 @@ import FirebaseCore
 import FirebaseCrashlytics
 import FirebaseDatabase
 import FirebaseFirestore
+import GRDB
 import IterableSDK
 import Stripe
 import TYStatusBarView
@@ -39,5 +40,8 @@ public enum AppKit {
 
         // Use IterableSDK to make sure it links fine
         _ = IterableSDK.IterableAPI.sdkVersion
+
+        // Use GRDB to make sure it links fine
+        try? DatabasePool(path: NSTemporaryDirectory().appending("db.sqlite")).erase()
     }
 }

--- a/projects/tuist/fixtures/app_with_spm_dependencies/Tuist/Dependencies.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/Tuist/Dependencies.swift
@@ -11,6 +11,7 @@ let packages: [Package] = [
     .package(url: "https://github.com/Trendyol/ios-components", .revision("c9260bfe203a16a278eca5542c98455eece98aa4")),
     .package(url: "https://github.com/stripe/stripe-ios", .upToNextMajor(from: "22.4.0")),
     .local(path: "LocalSwiftPackage"),
+    .package(url: "https://github.com/groue/GRDB.swift.git", .upToNextMajor(from: "5.26.0")),
 ]
 
 let dependencies = Dependencies(


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3477

### Short description 📝
This pull request attempts to resolve the issue with system library targets not being correctly linked.

`PackageInfoMapper` implementation was updated to process `.system` targets and search for corresponding module map file similar to SPM implementation.

### How to test the changes locally 🧐
- download a sample project which includes a basic setup for targets depending on GRDB (https://drive.google.com/file/d/1FiK0NMeOlI63-6cX16A1ZwR5HkYrxcp3/view?usp=sharing)
- run `tuist fetch` and `tuist generate`
- observe the project is generated with no errors and can be successfully run. Current tuist version would display a `GRDB is not a valid configured external dependency` error.

### Checklist ✅

- [X] The code architecture and patterns are consistent with the rest of the codebase.
- [X] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [X] In case the PR introduces changes that affect users, the documentation has been updated.
- [X] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
