### PR TITLE
Make `ProjectDescription.TargetDependency` hashable

### DIFF
--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -19,7 +19,7 @@ public enum SDKType: String, Codable {
 }
 
 /// A target dependency.
-public enum TargetDependency: Codable, Equatable {
+public enum TargetDependency: Codable, Hashable {
     /// Dependency on another target within the same project
     ///
     /// - Parameters:

--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Dependency status used by `.sdk` target dependencies
-public enum SDKStatus: String, Codable {
+public enum SDKStatus: String, Codable, Hashable {
     /// Required dependency
     case required
 
@@ -10,7 +10,7 @@ public enum SDKStatus: String, Codable {
 }
 
 /// Dependency type used by `.sdk` target dependencies
-public enum SDKType: String, Codable {
+public enum SDKType: String, Codable, Hashable {
     /// Library SDK dependency
     case library
 


### PR DESCRIPTION
### Short description 📝

Having `ProjectDescription.TargetDependency` conform to hashable comes for free and is sometimes useful in plugins

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
