### PR TITLE
Fix for `tuist clean dependencies` cleaning also the `Tuist/Dependencies/Lockfiles` folder

### DIFF
--- a/Sources/TuistCore/Cache/CacheDirectoriesProvider.swift
+++ b/Sources/TuistCore/Cache/CacheDirectoriesProvider.swift
@@ -25,7 +25,7 @@ public final class CacheDirectoriesProvider: CacheDirectoriesProviding {
     }
 
     public func cacheDirectory(for category: CacheCategory) -> AbsolutePath {
-        Self.forcedCacheDirectory ?? cacheDirectory.appending(component: category.directoryName)
+        (Self.forcedCacheDirectory ?? cacheDirectory).appending(component: category.directoryName)
     }
 }
 

--- a/Sources/TuistKit/Services/CleanService.swift
+++ b/Sources/TuistKit/Services/CleanService.swift
@@ -61,15 +61,15 @@ final class CleanService {
     private func cleanDependencies(at path: AbsolutePath) throws {
         let dependenciesPath = path.appending(components: [Constants.tuistDirectoryName, Constants.DependenciesDirectory.name])
         if FileHandler.shared.exists(dependenciesPath) {
-          let carthagePath = dependenciesPath.appending(component: Constants.DependenciesDirectory.carthageDirectoryName)
-          if FileHandler.shared.exists(carthagePath) {
-            try FileHandler.shared.delete(carthagePath)
-          }
+            let carthagePath = dependenciesPath.appending(component: Constants.DependenciesDirectory.carthageDirectoryName)
+            if FileHandler.shared.exists(carthagePath) {
+                try FileHandler.shared.delete(carthagePath)
+            }
 
-          let spmPath = dependenciesPath.appending(component: Constants.DependenciesDirectory.swiftPackageManagerDirectoryName)
-          if FileHandler.shared.exists(spmPath) {
-            try FileHandler.shared.delete(spmPath)
-          }
+            let spmPath = dependenciesPath.appending(component: Constants.DependenciesDirectory.swiftPackageManagerDirectoryName)
+            if FileHandler.shared.exists(spmPath) {
+                try FileHandler.shared.delete(spmPath)
+            }
         }
         logger.info("Successfully cleaned dependencies at path \(dependenciesPath.pathString)", metadata: .success)
     }

--- a/Sources/TuistKit/Services/CleanService.swift
+++ b/Sources/TuistKit/Services/CleanService.swift
@@ -61,7 +61,15 @@ final class CleanService {
     private func cleanDependencies(at path: AbsolutePath) throws {
         let dependenciesPath = path.appending(components: [Constants.tuistDirectoryName, Constants.DependenciesDirectory.name])
         if FileHandler.shared.exists(dependenciesPath) {
-            try FileHandler.shared.delete(dependenciesPath)
+          let carthagePath = dependenciesPath.appending(component: Constants.DependenciesDirectory.carthageDirectoryName)
+          if FileHandler.shared.exists(carthagePath) {
+            try FileHandler.shared.delete(carthagePath)
+          }
+
+          let spmPath = dependenciesPath.appending(component: Constants.DependenciesDirectory.swiftPackageManagerDirectoryName)
+          if FileHandler.shared.exists(spmPath) {
+            try FileHandler.shared.delete(spmPath)
+          }
         }
         logger.info("Successfully cleaned dependencies at path \(dependenciesPath.pathString)", metadata: .success)
     }

--- a/Tests/TuistKitTests/Services/CleanServiceTests.swift
+++ b/Tests/TuistKitTests/Services/CleanServiceTests.swift
@@ -106,7 +106,7 @@ final class CleanServiceTests: TuistUnitTestCase {
         )
         XCTAssertFalse(
             FileManager.default.fileExists(atPath: spmDependenciesPath.pathString),
-            "Cache folder at path \(spmDependenciesPath) should not have been deleted by the test."
+            "Cache folder at path \(spmDependenciesPath) should have been deleted by the test."
         )
     }
 }

--- a/Tests/TuistKitTests/Services/CleanServiceTests.swift
+++ b/Tests/TuistKitTests/Services/CleanServiceTests.swift
@@ -82,4 +82,29 @@ final class CleanServiceTests: TuistUnitTestCase {
             "Cache folder at path \(dependenciesPath) should have been deleted by the test."
         )
     }
+
+    func test_run_with_dependencies_category() throws {
+        // Given
+        let cachePaths = try createFolders([
+          "Tuist/Dependencies",
+          "Tuist/Dependencies/Lockfiles",
+          "Tuist/Dependencies/Carthage",
+          "Tuist/Dependencies/SwiftPackageManager"
+        ])
+        for path in cachePaths {
+            let correctlyCreated = FileManager.default.fileExists(atPath: path.pathString)
+            XCTAssertTrue(correctlyCreated, "Test setup is not properly done. Folder \(path.pathString) should exist")
+        }
+
+        // When
+        try subject.run(categories: [.dependencies], path: try temporaryPath().pathString)
+
+        // Then
+        let lockfilesExists = FileManager.default.fileExists(atPath: cachePaths[1].pathString)
+        XCTAssertTrue(lockfilesExists, "Lockflies folder at path \(cachePaths[1]) should not have been deleted by the test.")
+        let carthageExists = FileManager.default.fileExists(atPath: cachePaths[2].pathString)
+        XCTAssertFalse(carthageExists, "Carthage folder at path \(cachePaths[2]) should have been deleted by the test.")
+        let spmExists = FileManager.default.fileExists(atPath: cachePaths[2].pathString)
+        XCTAssertFalse(spmExists, "SwiftPackageManager folder at path \(cachePaths[2]) should have been deleted by the test.")
+    }
 }

--- a/Tests/TuistKitTests/Services/CleanServiceTests.swift
+++ b/Tests/TuistKitTests/Services/CleanServiceTests.swift
@@ -61,11 +61,28 @@ final class CleanServiceTests: TuistUnitTestCase {
         }
         cacheDirectoriesProvider.cacheDirectoryStub = cachePath
         let projectPath = try temporaryPath()
-        let dependenciesPath = projectPath.appending(
-            components: Constants.tuistDirectoryName,
+        let dependenciesPath = projectPath.appending(components:
+            Constants.tuistDirectoryName,
             Constants.DependenciesDirectory.name
         )
+        let lockfilesPath = projectPath.appending(components:
+            Constants.tuistDirectoryName,
+            Constants.DependenciesDirectory.lockfilesDirectoryName
+        )
+        let carthageDependenciesPath = projectPath.appending(
+            components: Constants.tuistDirectoryName,
+            Constants.DependenciesDirectory.name,
+            Constants.DependenciesDirectory.carthageDirectoryName
+        )
+        let spmDependenciesPath = projectPath.appending(
+            components: Constants.tuistDirectoryName,
+            Constants.DependenciesDirectory.name,
+            Constants.DependenciesDirectory.carthageDirectoryName
+        )
         try fileHandler.createFolder(dependenciesPath)
+        try fileHandler.createFolder(lockfilesPath)
+        try fileHandler.createFolder(carthageDependenciesPath)
+        try fileHandler.createFolder(spmDependenciesPath)
 
         // When
         try subject.run(categories: CleanCategory.allCases, path: nil)
@@ -77,34 +94,17 @@ final class CleanServiceTests: TuistUnitTestCase {
         XCTAssertFalse(manifestsExists, "Cache folder at path \(cachePaths[2].pathString) should have been deleted by the test.")
         let testsExists = FileManager.default.fileExists(atPath: cachePaths[3].pathString)
         XCTAssertFalse(testsExists, "Cache folder at path \(cachePaths[3].pathString) should not have been deleted by the test.")
-        XCTAssertFalse(
-            FileManager.default.fileExists(atPath: dependenciesPath.pathString),
-            "Cache folder at path \(dependenciesPath) should have been deleted by the test."
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: lockfilesPath.pathString),
+            "Cache folder at path \(lockfilesPath) should not have been deleted by the test."
         )
-    }
-
-    func test_run_with_dependencies_category() throws {
-        // Given
-        let cachePaths = try createFolders([
-          "Tuist/Dependencies",
-          "Tuist/Dependencies/Lockfiles",
-          "Tuist/Dependencies/Carthage",
-          "Tuist/Dependencies/SwiftPackageManager"
-        ])
-        for path in cachePaths {
-            let correctlyCreated = FileManager.default.fileExists(atPath: path.pathString)
-            XCTAssertTrue(correctlyCreated, "Test setup is not properly done. Folder \(path.pathString) should exist")
-        }
-
-        // When
-        try subject.run(categories: [.dependencies], path: try temporaryPath().pathString)
-
-        // Then
-        let lockfilesExists = FileManager.default.fileExists(atPath: cachePaths[1].pathString)
-        XCTAssertTrue(lockfilesExists, "Lockflies folder at path \(cachePaths[1]) should not have been deleted by the test.")
-        let carthageExists = FileManager.default.fileExists(atPath: cachePaths[2].pathString)
-        XCTAssertFalse(carthageExists, "Carthage folder at path \(cachePaths[2]) should have been deleted by the test.")
-        let spmExists = FileManager.default.fileExists(atPath: cachePaths[2].pathString)
-        XCTAssertFalse(spmExists, "SwiftPackageManager folder at path \(cachePaths[2]) should have been deleted by the test.")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: carthageDependenciesPath.pathString),
+            "Cache folder at path \(carthageDependenciesPath) should not have been deleted by the test."
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: spmDependenciesPath.pathString),
+            "Cache folder at path \(spmDependenciesPath) should not have been deleted by the test."
+        )
     }
 }

--- a/Tests/TuistKitTests/Services/CleanServiceTests.swift
+++ b/Tests/TuistKitTests/Services/CleanServiceTests.swift
@@ -102,7 +102,7 @@ final class CleanServiceTests: TuistUnitTestCase {
         )
         XCTAssertFalse(
             FileManager.default.fileExists(atPath: carthageDependenciesPath.pathString),
-            "Cache folder at path \(carthageDependenciesPath) should not have been deleted by the test."
+            "Cache folder at path \(carthageDependenciesPath) should have been deleted by the test."
         )
         XCTAssertFalse(
             FileManager.default.fileExists(atPath: spmDependenciesPath.pathString),

--- a/Tests/TuistKitTests/Services/CleanServiceTests.swift
+++ b/Tests/TuistKitTests/Services/CleanServiceTests.swift
@@ -61,11 +61,13 @@ final class CleanServiceTests: TuistUnitTestCase {
         }
         cacheDirectoriesProvider.cacheDirectoryStub = cachePath
         let projectPath = try temporaryPath()
-        let dependenciesPath = projectPath.appending(components:
+        let dependenciesPath = projectPath.appending(
+            components:
             Constants.tuistDirectoryName,
             Constants.DependenciesDirectory.name
         )
-        let lockfilesPath = projectPath.appending(components:
+        let lockfilesPath = projectPath.appending(
+            components:
             Constants.tuistDirectoryName,
             Constants.DependenciesDirectory.lockfilesDirectoryName
         )


### PR DESCRIPTION
### Short description 📝

- `tuist clean dependenceis` should NOT clean lockfiles
- Fixed computation of subdirectories when forced cache directory is configured

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
