### PR TITLE
Add support for Xcode 14 compatible watch application targets

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -213,8 +213,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "b7667f3e266af621e5cc9c77e74cacd8e8c00cb4",
-          "version": "0.2.5"
+          "revision": "0b77e67c484e532444ceeab60119b8536f8cd648",
+          "version": "0.3.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         .package(url: "https://github.com/stencilproject/Stencil.git", from: "0.14.0"),
         .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", from: "4.2.2"),
         .package(url: "https://github.com/httpswift/swifter.git", revision: "1e4f51c92d7ca486242d8bf0722b99de2c3531aa"),
-        .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.2.5")),
+        .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.3.0")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.1.1"),
         .package(url: "https://github.com/fortmarek/ZIPFoundation.git", revision: "9dbe729b90202c19d0fe1010f1430fa75a576cd3"),
         .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.0"),

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -502,7 +502,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
         pbxproj: PBXProj
     ) throws {
         let targetDependencies = graphTraverser.directLocalTargetDependencies(path: path, name: target.name).sorted()
-        let watchApps = targetDependencies.filter { $0.target.product == .watch2App }
+        let watchApps = targetDependencies.filter { $0.target.isEmbeddableWatchApplication() }
         guard !watchApps.isEmpty else { return }
         var pbxBuildFiles = [PBXBuildFile]()
 

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -499,6 +499,12 @@ public class GraphLinter: GraphLinting {
 //            LintableTarget(platform: .watchOS, product: .framework),
 //            LintableTarget(platform: .watchOS, product: .watchExtension),
 //        ],
+        LintableTarget(platform: .watchOS, product: .app): [
+            LintableTarget(platform: .watchOS, product: .staticLibrary),
+            LintableTarget(platform: .watchOS, product: .dynamicLibrary),
+            LintableTarget(platform: .watchOS, product: .framework),
+            LintableTarget(platform: .watchOS, product: .staticFramework),
+        ],
         LintableTarget(platform: .watchOS, product: .watch2App): [
             LintableTarget(platform: .watchOS, product: .watch2Extension),
         ],

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -314,6 +314,7 @@ public class GraphLinter: GraphLinting {
             LintableTarget(platform: .iOS, product: .messagesExtension),
             LintableTarget(platform: .iOS, product: .stickerPackExtension),
             LintableTarget(platform: .watchOS, product: .watch2App),
+            LintableTarget(platform: .watchOS, product: .app),
             LintableTarget(platform: .iOS, product: .appClip),
 //            LintableTarget(platform: .watchOS, product: .watchApp),
         ],

--- a/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
+++ b/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
@@ -127,6 +127,7 @@ public final class DefaultSettingsProvider: DefaultSettingsProviding {
             product: product,
             swift: true
         ).toSettings()
+        let additionalTargetDefaults = additionalTargetSettings(for: target)
         let targetDefaultVariant = try BuildSettingsProvider.targetDefault(
             variant: variant,
             platform: platform,
@@ -140,6 +141,7 @@ public final class DefaultSettingsProvider: DefaultSettingsProviding {
         )
         var settings: SettingsDictionary = [:]
         settingsHelper.extend(buildSettings: &settings, with: targetDefaultAll)
+        settingsHelper.extend(buildSettings: &settings, with: additionalTargetDefaults)
         settingsHelper.extend(buildSettings: &settings, with: targetDefaultVariant)
         settingsHelper.extend(buildSettings: &settings, with: projectOverridableTargetDefaultSettings(for: project))
         return settings.filter(filter)
@@ -179,6 +181,20 @@ public final class DefaultSettingsProvider: DefaultSettingsProviding {
             settings["SWIFT_VERSION"] = "5.0"
         }
         return settings
+    }
+
+    private func additionalTargetSettings(for target: Target) -> SettingsDictionary {
+        switch (target.platform, target.product) {
+        case (.watchOS, .app):
+            return [
+                "LD_RUNPATH_SEARCH_PATHS": [
+                    "$(inherited)",
+                    "@executable_path/Frameworks",
+                ],
+            ]
+        default:
+            return [:]
+        }
     }
 }
 

--- a/Sources/TuistGraph/Models/Target.swift
+++ b/Sources/TuistGraph/Models/Target.swift
@@ -178,6 +178,19 @@ public struct Target: Equatable, Hashable, Comparable, Codable {
         return false
     }
 
+    /// Determines if the target is an embeddable watch application
+    /// i.e. a product that can be bundled with a host iOS application
+    public func isEmbeddableWatchApplication() -> Bool {
+        switch (platform, product) {
+        case (.watchOS, .watch2App):
+            return true
+        case (.watchOS, .app):
+            return true
+        default:
+            return false
+        }
+    }
+
     /// For iOS targets that support macOS (Catalyst), this value is used
     /// in the generated build files of the target dependency products to
     /// indicate the build system that the dependency should be compiled

--- a/Sources/TuistGraph/Models/Target.swift
+++ b/Sources/TuistGraph/Models/Target.swift
@@ -182,9 +182,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable {
     /// i.e. a product that can be bundled with a host iOS application
     public func isEmbeddableWatchApplication() -> Bool {
         switch (platform, product) {
-        case (.watchOS, .watch2App):
-            return true
-        case (.watchOS, .app):
+        case (.watchOS, .watch2App), (.watchOS, .app):
             return true
         default:
             return false

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -917,6 +917,51 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
         )
     }
 
+    func test_generateWatchBuildPhase_watchApplication() throws {
+        // Given
+        let app = Target.test(name: "App", product: .app)
+        let watchApp = Target.test(name: "WatchApp", platform: .watchOS, product: .app)
+        let project = Project.test()
+        let pbxproj = PBXProj()
+        let nativeTarget = PBXNativeTarget(name: "Test")
+        let fileElements = createProductFileElements(for: [app, watchApp])
+
+        let targets: [AbsolutePath: [String: Target]] = [
+            project.path: [app.name: app, watchApp.name: watchApp],
+        ]
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: watchApp.name, path: project.path): Set(),
+            .target(name: app.name, path: project.path): Set([.target(name: watchApp.name, path: project.path)]),
+        ]
+        let graph = Graph.test(
+            path: project.path,
+            projects: [project.path: project],
+            targets: targets,
+            dependencies: dependencies
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        try subject.generateEmbedWatchBuildPhase(
+            path: project.path,
+            target: app,
+            graphTraverser: graphTraverser,
+            pbxTarget: nativeTarget,
+            fileElements: fileElements,
+            pbxproj: pbxproj
+        )
+
+        // Then
+        let pbxBuildPhase = try XCTUnwrap(nativeTarget.buildPhases.first as? PBXCopyFilesBuildPhase)
+        XCTAssertEqual(pbxBuildPhase.files?.compactMap { $0.file?.nameOrPath }, [
+            "WatchApp",
+        ])
+        XCTAssertEqual(
+            pbxBuildPhase.files?.compactMap { $0.settings as? [String: [String]] },
+            [["ATTRIBUTES": ["RemoveHeadersOnCopy"]]]
+        )
+    }
+
     func test_generateTarget_actions() throws {
         // Given
         system.swiftVersionStub = { "5.2" }

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -875,8 +875,8 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
 
     func test_generateWatchBuildPhase() throws {
         // Given
-        let app = Target.test(name: "App", product: .app)
-        let watchApp = Target.test(name: "WatchApp", product: .watch2App)
+        let app = Target.test(name: "App", platform: .iOS, product: .app)
+        let watchApp = Target.test(name: "WatchApp", platform: .watchOS, product: .watch2App)
         let project = Project.test()
         let pbxproj = PBXProj()
         let nativeTarget = PBXNativeTarget(name: "Test")
@@ -919,7 +919,7 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
 
     func test_generateWatchBuildPhase_watchApplication() throws {
         // Given
-        let app = Target.test(name: "App", product: .app)
+        let app = Target.test(name: "App", platform: .iOS, product: .app)
         let watchApp = Target.test(name: "WatchApp", platform: .watchOS, product: .app)
         let project = Project.test()
         let pbxproj = PBXProj()

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -676,6 +676,52 @@ final class GraphLinterTests: TuistUnitTestCase {
         XCTAssertTrue(got.isEmpty)
     }
 
+    func test_lint_iOSApp_withCompanionWatchApplication() throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let app = Target.empty(
+            name: "App",
+            platform: .iOS,
+            product: .app,
+            dependencies: [
+                .target(name: "WatchApp"),
+            ]
+        )
+        let watchApplication = Target.empty(
+            name: "WatchApp",
+            platform: .watchOS,
+            product: .app
+        )
+        let project = Project.test(path: path, targets: [app, watchApplication])
+
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: app.name, path: path): [
+                .target(name: watchApplication.name, path: path),
+            ],
+            .target(name: watchApplication.name, path: path): [],
+        ]
+
+        let graph = Graph.test(
+            path: path,
+            workspace: Workspace.test(projects: [path]),
+            projects: [path: project],
+            targets: [
+                path: [
+                    app.name: app,
+                    watchApplication.name: watchApplication,
+                ],
+            ],
+            dependencies: dependencies
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.lint(graphTraverser: graphTraverser)
+
+        // Then
+        XCTAssertTrue(got.isEmpty)
+    }
+
     func test_lint_missingProjectConfigurationsFromDependencyProjects() throws {
         // Given
         let path: AbsolutePath = "/project"

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -5,7 +5,7 @@ let dependencies = Dependencies(
         [
             .package(url: "https://github.com/tuist/XcodeProj.git", .upToNextMajor(from: "8.8.0")),
             .package(url: "https://github.com/CombineCommunity/CombineExt.git", .upToNextMajor(from: "1.3.0")),
-            .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.2.5")),
+            .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.3.0")),
             .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.2")),
             .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", .upToNextMajor(from: "4.2.2")),
             .package(url: "https://github.com/httpswift/swifter.git", .revision("1e4f51c92d7ca486242d8bf0722b99de2c3531aa")),

--- a/Tuist/Dependencies/Lockfiles/Package.resolved
+++ b/Tuist/Dependencies/Lockfiles/Package.resolved
@@ -213,8 +213,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "b7667f3e266af621e5cc9c77e74cacd8e8c00cb4",
-          "version": "0.2.5"
+          "revision": "0b77e67c484e532444ceeab60119b8536f8cd648",
+          "version": "0.3.0"
         }
       },
       {

--- a/projects/tuist/fixtures/ios_app_with_watch_application/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/projects/tuist/fixtures/ios_app_with_watch_application/App/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/App/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/projects/tuist/fixtures/ios_app_with_watch_application/App/Resources/Assets.xcassets/Contents.json
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/App/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/projects/tuist/fixtures/ios_app_with_watch_application/App/Sources/ClocksApp.swift
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/App/Sources/ClocksApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct ClocksApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/projects/tuist/fixtures/ios_app_with_watch_application/App/Sources/ContentView.swift
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/App/Sources/ContentView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundColor(.accentColor)
+            Text("Hello, world!")
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/projects/tuist/fixtures/ios_app_with_watch_application/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/Project.swift
@@ -1,0 +1,50 @@
+import ProjectDescription
+
+let project = Project(
+    name: "AppWithWatchApp",
+    targets: [
+        Target(
+            name: "App",
+            platform: .iOS,
+            product: .app,
+            bundleId: "io.tuist.App",
+            infoPlist: .default,
+            sources: [
+                "App/Sources/**",
+            ],
+            resources: [
+                "App/Resources/**",
+            ],
+            dependencies: [
+                // ...
+            ]
+        ),
+        // In Xcode 14, watch application can now leverage the `.app` product type
+        // rather than the previous `.watch2App` type
+        Target(
+            name: "WatchApp",
+            platform: .watchOS,
+            product: .app,
+            bundleId: "io.tuist.App.watchkitapp",
+            infoPlist: nil,
+            sources: "WatchApp/Sources/**",
+            resources: "WatchApp/Resources/**",
+            dependencies: [
+                // ...
+            ],
+            settings: .settings(
+                base: [
+                    "GENERATE_INFOPLIST_FILE": true,
+                    "CURRENT_PROJECT_VERSION": "1.0",
+                    "MARKETING_VERSION": "1.0",
+                    "INFOPLIST_KEY_UISupportedInterfaceOrientations": [
+                        "UIInterfaceOrientationPortrait",
+                        "UIInterfaceOrientationPortraitUpsideDown",
+                    ],
+                    "INFOPLIST_KEY_WKCompanionAppBundleIdentifier": "io.tuist.App",
+                    "INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp": false,
+                ]
+            )
+        ),
+    ]
+)

--- a/projects/tuist/fixtures/ios_app_with_watch_application/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/Project.swift
@@ -16,7 +16,7 @@ let project = Project(
                 "App/Resources/**",
             ],
             dependencies: [
-                // ...
+                .target(name: "WatchApp"),
             ]
         ),
         // In Xcode 14, watch application can now leverage the `.app` product type

--- a/projects/tuist/fixtures/ios_app_with_watch_application/WatchApp/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/WatchApp/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/projects/tuist/fixtures/ios_app_with_watch_application/WatchApp/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/WatchApp/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "watchos",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/projects/tuist/fixtures/ios_app_with_watch_application/WatchApp/Resources/Assets.xcassets/Contents.json
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/WatchApp/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/projects/tuist/fixtures/ios_app_with_watch_application/WatchApp/Sources/ContentView.swift
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/WatchApp/Sources/ContentView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundColor(.accentColor)
+            Text("Hello, world!")
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/projects/tuist/fixtures/ios_app_with_watch_application/WatchApp/Sources/WatchApp.swift
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/WatchApp/Sources/WatchApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct WatchApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/4572

### Short description 📝

- In Xcode 14, watch applications can now leverage the regular application product identifier (`.app`)
- This now alleviates the need to have a watch extension target all together, the application target can host both code and resources and behaves like regular target (e.g. can link other products)
- The linter in Tuist has been updated to accomodate for this use case and allow watchOS `.app` targets to be created as well as be linked to iOS applications

### How to test the changes locally 🧐

- Generate the newly added fixture `ios_app_with_watch_application`

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
