### PR TITLE
Fix for Resource targets not being excluded by caching when focusing on their source target

### DIFF
--- a/Sources/TuistCache/ContentHashing/CacheGraphContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/CacheGraphContentHasher.swift
@@ -70,7 +70,7 @@ public final class CacheGraphContentHasher: CacheGraphContentHashing {
         excludedTargets: Set<String>
     ) -> Bool {
         let frameworkNameFromResourceTargetName = target.target.name.dropPrefix("\(target.project.name)_")
-        
+
         let product = target.target.product
         let name = target.target.name
 

--- a/Sources/TuistCache/ContentHashing/CacheGraphContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/CacheGraphContentHasher.swift
@@ -69,11 +69,14 @@ public final class CacheGraphContentHasher: CacheGraphContentHashing {
         graphTraverser: GraphTraversing,
         excludedTargets: Set<String>
     ) -> Bool {
+        let frameworkNameFromResourceTargetName = target.target.name.dropPrefix("\(target.project.name)_")
+        
         let product = target.target.product
         let name = target.target.name
 
         return CacheGraphContentHasher.cachableProducts.contains(product) &&
             !excludedTargets.contains(name) &&
+            !excludedTargets.contains(frameworkNameFromResourceTargetName) &&
             !graphTraverser.dependsOnXCTest(path: target.path, name: name)
     }
 }

--- a/Tests/TuistCacheTests/Cache/CacheGraphContentHasherTests.swift
+++ b/Tests/TuistCacheTests/Cache/CacheGraphContentHasherTests.swift
@@ -82,10 +82,10 @@ final class CacheGraphContentHasherTests: TuistUnitTestCase {
         )
         XCTAssertTrue(contentHashesCalled)
     }
-    
+
     func test_contentHashes_when_excluded_targets_resources_hashes_are_not_computed() throws {
         let project = Project.test()
-        
+
         var contentHashesCalled = false
         let excludedTarget = GraphTarget(
             path: "/Project/Path",


### PR DESCRIPTION
### Short description 📝

When running `tuist generate` with a list of targets to focus on, we noticed that Tuist always tried to download the binary artifacts for the synthesized resource targets (the ones named `ProjecName_TargetName`).

After a bit of investigation we found out that the culprit was the CacheGraphContentHasher not excluding them correctly. I made the change and added a test.

### How to test the changes locally 🧐

- Have a project that contains targets with resources
- Run `tuist generate TargetName`
- Observe from the log that you're not downloading the binary artifacts for `ProjectName_TargetName` (AKA the resources target)

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
