### PR TITLE
Fix for computing hash of target scripts with output files

### DIFF
--- a/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
@@ -84,7 +84,10 @@ public final class TargetContentHasher: TargetContentHashing {
         let resourcesHash = try resourcesContentHasher.hash(resources: graphTarget.target.resources)
         let copyFilesHash = try copyFilesContentHasher.hash(copyFiles: graphTarget.target.copyFiles)
         let coreDataModelHash = try coreDataModelsContentHasher.hash(coreDataModels: graphTarget.target.coreDataModels)
-        let targetScriptsHash = try targetScriptsContentHasher.hash(targetScripts: graphTarget.target.scripts)
+        let targetScriptsHash = try targetScriptsContentHasher.hash(
+            targetScripts: graphTarget.target.scripts,
+            sourceRootPath: graphTarget.project.sourceRootPath
+        )
         let dependenciesHash = try dependenciesContentHasher.hash(
             graphTarget: graphTarget,
             hashedTargets: &hashedTargets,

--- a/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
@@ -8,11 +8,6 @@ public protocol TargetContentHashing {
     func contentHash(
         for target: GraphTarget,
         hashedTargets: inout [GraphHashedTarget: String],
-        hashedPaths: inout [AbsolutePath: String]
-    ) throws -> String
-    func contentHash(
-        for target: GraphTarget,
-        hashedTargets: inout [GraphHashedTarget: String],
         hashedPaths: inout [AbsolutePath: String],
         additionalStrings: [String]
     ) throws -> String
@@ -80,18 +75,10 @@ public final class TargetContentHasher: TargetContentHashing {
     // MARK: - TargetContentHashing
 
     public func contentHash(
-        for target: GraphTarget,
-        hashedTargets: inout [GraphHashedTarget: String],
-        hashedPaths: inout [AbsolutePath: String]
-    ) throws -> String {
-        try contentHash(for: target, hashedTargets: &hashedTargets, hashedPaths: &hashedPaths, additionalStrings: [])
-    }
-
-    public func contentHash(
         for graphTarget: GraphTarget,
         hashedTargets: inout [GraphHashedTarget: String],
         hashedPaths: inout [AbsolutePath: String],
-        additionalStrings: [String]
+        additionalStrings: [String] = []
     ) throws -> String {
         let sourcesHash = try sourceFilesContentHasher.hash(sources: graphTarget.target.sources)
         let resourcesHash = try resourcesContentHasher.hash(resources: graphTarget.target.resources)

--- a/Sources/TuistCache/ContentHashing/TargetScriptsContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/TargetScriptsContentHasher.swift
@@ -4,7 +4,7 @@ import TuistCore
 import TuistGraph
 
 public protocol TargetScriptsContentHashing {
-    func hash(targetScripts: [TargetScript]) throws -> String
+    func hash(targetScripts: [TargetScript], sourceRootPath: AbsolutePath) throws -> String
 }
 
 /// `TargetScriptsContentHasher`
@@ -22,14 +22,14 @@ public final class TargetScriptsContentHasher: TargetScriptsContentHashing {
 
     /// Returns the hash that uniquely identifies an array of target scripts
     /// The hash takes into consideration the content of the script to execute, the content of input/output files, the name of the tool to execute, the order, the arguments and its name
-    public func hash(targetScripts: [TargetScript]) throws -> String {
+    public func hash(targetScripts: [TargetScript], sourceRootPath: AbsolutePath) throws -> String {
         var stringsToHash: [String] = []
         for script in targetScripts {
             var pathsToHash: [AbsolutePath] = []
             script.path.map { pathsToHash.append($0) }
             (script.inputPaths + script.inputFileListPaths).forEach { path in
                 if path.pathString.contains("$") {
-                    stringsToHash.append(path.pathString)
+                    stringsToHash.append(path.relative(to: sourceRootPath).pathString)
                     logger.notice(
                         "The path of the file \'\(path.url.lastPathComponent)\' is hashed, not the content. Because it has a build variable."
                     )
@@ -38,7 +38,9 @@ public final class TargetScriptsContentHasher: TargetScriptsContentHashing {
                 }
             }
             stringsToHash.append(contentsOf: try pathsToHash.map { try contentHasher.hash(path: $0) })
-            stringsToHash.append(contentsOf: (script.outputPaths + script.outputFileListPaths).map(\.pathString))
+            stringsToHash.append(
+                contentsOf: (script.outputPaths + script.outputFileListPaths).map { $0.relative(to: sourceRootPath).pathString }
+            )
             stringsToHash.append(contentsOf: [
                 script.name,
                 script.tool ?? "",

--- a/Tests/TuistCacheTests/ContentHashing/TargetScriptsContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/TargetScriptsContentHasherTests.swift
@@ -68,14 +68,14 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
         )
 
         // When
-        _ = try subject.hash(targetScripts: [targetScript])
+        _ = try subject.hash(targetScripts: [targetScript], sourceRootPath: "/")
 
         // Then
         let expected = [
-            "/$(SRCROOT)/inputPaths1",
+            "$(SRCROOT)/inputPaths1",
             inputFileListPaths1,
-            "/$(DERIVED_FILE_DIR)/outputPaths1",
-            "/outputFileListPaths1",
+            "$(DERIVED_FILE_DIR)/outputPaths1",
+            "outputFileListPaths1",
             "1",
             "tool1",
             "pre",
@@ -98,14 +98,14 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
         let targetScript = makeTargetScript()
 
         // When
-        _ = try subject.hash(targetScripts: [targetScript])
+        _ = try subject.hash(targetScripts: [targetScript], sourceRootPath: "/")
 
         // Then
         let expected = [
             inputPaths1Hash,
             inputFileListPaths1,
-            "/outputPaths1",
-            "/outputFileListPaths1",
+            "outputPaths1",
+            "outputFileListPaths1",
             "1",
             "tool1",
             "pre",
@@ -124,14 +124,14 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
         let targetScript = makeTargetScript()
 
         // When
-        _ = try subject.hash(targetScripts: [targetScript])
+        _ = try subject.hash(targetScripts: [targetScript], sourceRootPath: "/")
 
         // Then
         let expected = [
             inputPaths1Hash,
             inputFileListPaths1,
-            "/outputPaths1",
-            "/outputFileListPaths1",
+            "outputPaths1",
+            "outputFileListPaths1",
             "1",
             "tool1",
             "pre",
@@ -158,14 +158,14 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
         )
 
         // When
-        _ = try subject.hash(targetScripts: [targetScript])
+        _ = try subject.hash(targetScripts: [targetScript], sourceRootPath: "/")
 
         // Then
         let expected = [
             inputPaths2Hash,
             inputFileListPaths2,
-            "/outputPaths2",
-            "/outputFileListPaths2",
+            "outputPaths2",
+            "outputFileListPaths2",
             "2",
             "tool2",
             "post",

--- a/Tests/TuistCacheTests/ContentHashing/TargetScriptsContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/TargetScriptsContentHasherTests.swift
@@ -58,17 +58,11 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
 
     func test_hash_targetAction_withBuildVariables_callsMockHasherWithOnlyPathWithoutBuildVariable() throws {
         // Given
-        let inputPaths1Hash = "inputPaths1-hash"
         let inputFileListPaths1 = "inputFileListPaths1-hash"
-        let outputPaths1 = "outputPaths1-hash"
-        let outputFileListPaths1 = "outputFileListPaths1-hash"
-        mockContentHasher.stubHashForPath[AbsolutePath("/$(SRCROOT)/inputPaths1")] = inputPaths1Hash
-        mockContentHasher.stubHashForPath[AbsolutePath("/$(SRCROOT)/inputFileListPaths1")] = inputFileListPaths1
-        mockContentHasher.stubHashForPath[AbsolutePath("/$(DERIVED_FILE_DIR)/outputPaths1")] = outputPaths1
-        mockContentHasher.stubHashForPath[AbsolutePath("/outputFileListPaths1")] = outputFileListPaths1
+        mockContentHasher.stubHashForPath[AbsolutePath("/inputFileListPaths1")] = inputFileListPaths1
         let targetScript = makeTargetScript(
             inputPaths: [AbsolutePath("/$(SRCROOT)/inputPaths1")],
-            inputFileListPaths: [AbsolutePath("/$(SRCROOT)/inputFileListPaths1")],
+            inputFileListPaths: [AbsolutePath("/inputFileListPaths1")],
             outputPaths: [AbsolutePath("/$(DERIVED_FILE_DIR)/outputPaths1")],
             outputFileListPaths: [AbsolutePath("/outputFileListPaths1")]
         )
@@ -79,9 +73,9 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
         // Then
         let expected = [
             "/$(SRCROOT)/inputPaths1",
-            "/$(SRCROOT)/inputFileListPaths1",
+            inputFileListPaths1,
             "/$(DERIVED_FILE_DIR)/outputPaths1",
-            outputFileListPaths1,
+            "/outputFileListPaths1",
             "1",
             "tool1",
             "pre",
@@ -91,12 +85,6 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
 
         XCTAssertPrinterOutputContains(
             "The path of the file 'inputPaths1' is hashed, not the content. Because it has a build variable."
-        )
-        XCTAssertPrinterOutputContains(
-            "The path of the file 'inputFileListPaths1' is hashed, not the content. Because it has a build variable."
-        )
-        XCTAssertPrinterOutputContains(
-            "The path of the file 'outputPaths1' is hashed, not the content. Because it has a build variable."
         )
         XCTAssertEqual(mockContentHasher.hashStringsSpy, expected)
     }

--- a/Tests/TuistCacheTests/ContentHashing/TargetScriptsContentHasherTests.swift
+++ b/Tests/TuistCacheTests/ContentHashing/TargetScriptsContentHasherTests.swift
@@ -93,12 +93,8 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
         // Given
         let inputPaths1Hash = "inputPaths1-hash"
         let inputFileListPaths1 = "inputFileListPaths1-hash"
-        let outputPaths1 = "outputPaths1-hash"
-        let outputFileListPaths1 = "outputFileListPaths1-hash"
         mockContentHasher.stubHashForPath[AbsolutePath("/inputPaths1")] = inputPaths1Hash
         mockContentHasher.stubHashForPath[AbsolutePath("/inputFileListPaths1")] = inputFileListPaths1
-        mockContentHasher.stubHashForPath[AbsolutePath("/outputPaths1")] = outputPaths1
-        mockContentHasher.stubHashForPath[AbsolutePath("/outputFileListPaths1")] = outputFileListPaths1
         let targetScript = makeTargetScript()
 
         // When
@@ -108,8 +104,8 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
         let expected = [
             inputPaths1Hash,
             inputFileListPaths1,
-            outputPaths1,
-            outputFileListPaths1,
+            "/outputPaths1",
+            "/outputFileListPaths1",
             "1",
             "tool1",
             "pre",
@@ -123,12 +119,8 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
         // Given
         let inputPaths1Hash = "inputPaths1-hash"
         let inputFileListPaths1 = "inputFileListPaths1-hash"
-        let outputPaths1 = "outputPaths1-hash"
-        let outputFileListPaths1 = "outputFileListPaths1-hash"
         mockContentHasher.stubHashForPath[AbsolutePath("/inputPaths1")] = inputPaths1Hash
         mockContentHasher.stubHashForPath[AbsolutePath("/inputFileListPaths1")] = inputFileListPaths1
-        mockContentHasher.stubHashForPath[AbsolutePath("/outputPaths1")] = outputPaths1
-        mockContentHasher.stubHashForPath[AbsolutePath("/outputFileListPaths1")] = outputFileListPaths1
         let targetScript = makeTargetScript()
 
         // When
@@ -138,8 +130,8 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
         let expected = [
             inputPaths1Hash,
             inputFileListPaths1,
-            outputPaths1,
-            outputFileListPaths1,
+            "/outputPaths1",
+            "/outputFileListPaths1",
             "1",
             "tool1",
             "pre",
@@ -153,12 +145,8 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
         // Given
         let inputPaths2Hash = "inputPaths2-hash"
         let inputFileListPaths2 = "inputFileListPaths2-hash"
-        let outputPaths2 = "outputPaths2-hash"
-        let outputFileListPaths2 = "outputFileListPaths2-hash"
         mockContentHasher.stubHashForPath[AbsolutePath("/inputPaths2")] = inputPaths2Hash
         mockContentHasher.stubHashForPath[AbsolutePath("/inputFileListPaths2")] = inputFileListPaths2
-        mockContentHasher.stubHashForPath[AbsolutePath("/outputPaths2")] = outputPaths2
-        mockContentHasher.stubHashForPath[AbsolutePath("/outputFileListPaths2")] = outputFileListPaths2
         let targetScript = makeTargetScript(
             name: "2",
             order: .post,
@@ -176,8 +164,8 @@ final class TargetScriptsContentHasherTests: TuistUnitTestCase {
         let expected = [
             inputPaths2Hash,
             inputFileListPaths2,
-            outputPaths2,
-            outputFileListPaths2,
+            "/outputPaths2",
+            "/outputFileListPaths2",
             "2",
             "tool2",
             "post",


### PR DESCRIPTION
### Short description 📝

The content of the output files shouldn't be taken into account when calculating the hash of a target, as the file has not been generated yet.
Also, the hash should be a relative path, or the hash will be different on each machine

### How to test the changes locally 🧐

1. Add a script with an output file 
2. run tuist generate
3. see tuist complaining like `The path of the file 'output.mock' is hashed, not the content. Because it has a build variable.`, which is actually correct

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase.
- [x] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [x] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [x] In case the PR introduces changes that affect users, the documentation has been updated.
- [x] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
