### PR TITLE
Support for `mlmodelc` resources

### DIFF
--- a/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
+++ b/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
@@ -73,6 +73,7 @@ extension AbsolutePath {
         "docc",
         "playground",
         "bundle",
+        "mlmodelc"
     ]
 
     /// An opaque directory is a directory that should be treated like a file, therefor ignoring its content.

--- a/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
+++ b/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
@@ -73,7 +73,7 @@ extension AbsolutePath {
         "docc",
         "playground",
         "bundle",
-        "mlmodelc"
+        "mlmodelc",
     ]
 
     /// An opaque directory is a directory that should be treated like a file, therefor ignoring its content.

--- a/projects/tuist/fixtures/app_with_spm_dependencies/App/Project.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/App/Project.swift
@@ -38,6 +38,7 @@ let project = Project(
                 .external(name: "FirebaseFirestore"),
                 .external(name: "IterableSDK"),
                 .external(name: "Stripe"),
+                .external(name: "StripeCardScan"),
                 .external(name: "TYStatusBarView"),
                 .external(name: "GRDB"),
             ],


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4322#issuecomment-1095453159
Request for comments document (if applies):
If there's a test suite that I should extend with test case for this directory extension, please let me know.

### Short description 📝

Fix the way compiled ML models (`*.mlmodelc` directories) are treated. Currently Tuist tries to add their contents to copy resources build phase (unnecessarily) and fails with message:

> Trying to add a file at path /[...]/Tuist/Dependencies/SwiftPackageManager/.build/checkouts/stripe-ios/StripeCardScan/StripeCardScan/Resources/CompiledModels/SSDOcr.mlmodelc/analytics/coremldata.bin to a build phase that hasn't been added to the project.

while they should be treated as opaque, sealed packages (like `xcassets`).

### How to test the changes locally 🧐

1. Download test project from linked issue
2. Remove `.tuist_version` file
3. `tuist fetch`
4. `tuist generate`
5. `tuist test`

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase.
- [ ] The changes have been tested following the [documented guidelines](https://docs.tuist.io/contributors/testing-strategy/).
- [ ] The PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, whenever it should be included in the “Added”, “Fixed” or “Changed” section of the CHANGELOG. Note: when included in the CHANGELOG, the title of the PR will be used as entry, please make sure it is clear and suitable.
- [ ] In case the PR introduces changes that affect users, the documentation has been updated.
- [ ] In case the PR introduces changes that affect how the cache artifact is generated starting from the `TuistGraph.Target`, the `Constants.cacheVersion` has been updated.
