### PR TITLE
Sort project targets alphabetically

### DIFF
--- a/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
@@ -189,7 +189,7 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
         graphTraverser: GraphTraversing
     ) throws -> [String: PBXNativeTarget] {
         var nativeTargets: [String: PBXNativeTarget] = [:]
-        try project.targets.forEach { target in
+        try project.targets.sorted(by: { $0.name < $1.name }).forEach { target in
             let nativeTarget = try targetGenerator.generateTarget(
                 target: target,
                 project: project,


### PR DESCRIPTION
Resolves -

### Short description 📝

As mentioned in #3324, the list of targets in the _New File_ prompt and in the _Target Membership_ inspector are not in alphabetical order in Tuist-generated projects. This makes it almost impossible to find the correct target in Xcode when adding a new file to a project with many targets.

As a fix, I sorted the targets in `ProjectDescriptorGenerator`.`generateTargets`. I can confirm that the targets are now sorted perfectly in our project but I'm not sure if this is the right place to do it, or if there are any downsides to this approach. Happy to hear your feedback!

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] The title of the PR will be used as changelog entry, please make sure it is clear and suitable
- [ ] In case the PR introduces changes that affect users, the documentation has been updated
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`
