### PR TITLE
Whitelist combinations of "unitTests+macOS+staticFramework" + "uiTests+macOS+staticFramework"

### DIFF
--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -422,14 +422,14 @@ public class GraphLinter: GraphLinting {
             LintableTarget(platform: .macOS, product: .staticLibrary),
             LintableTarget(platform: .macOS, product: .dynamicLibrary),
             LintableTarget(platform: .macOS, product: .framework),
-            LintableTarget(platform: .iOS, product: .staticFramework),
+            LintableTarget(platform: .macOS, product: .staticFramework),
         ],
         LintableTarget(platform: .macOS, product: .uiTests): [
             LintableTarget(platform: .macOS, product: .app),
             LintableTarget(platform: .macOS, product: .staticLibrary),
             LintableTarget(platform: .macOS, product: .dynamicLibrary),
             LintableTarget(platform: .macOS, product: .framework),
-            LintableTarget(platform: .iOS, product: .staticFramework),
+            LintableTarget(platform: .macOS, product: .staticFramework),
         ],
         LintableTarget(platform: .macOS, product: .appExtension): [
             LintableTarget(platform: .macOS, product: .staticLibrary),


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4732

### Short description 📝

Updated LintableTargets to support combinations of  "unitTests+macOS+staticFramework" + "uiTests+macOS+staticFramework"

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] The title of the PR will be used as changelog entry, please make sure it is clear and suitable
- [ ] In case the PR introduces changes that affect users, the documentation has been updated
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`
