### PR TITLE
Add support for `.when(platforms:)` condition in SwiftPackageManager dependencies

### DIFF
--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -244,7 +244,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
                             try ResolvedDependency.fromTarget(
                                 name: target,
                                 targetDependencyToFramework: targetDependencyToFramework,
-                                packageConditionDescription: nil
+                                condition: nil
                             )
                             .map {
                                 switch $0 {
@@ -1193,7 +1193,7 @@ extension PackageInfoMapper {
         case target(name: String, condition: Condition?)
         case xcframework(path: Path, condition: Condition?)
         case externalTarget(package: String, target: String, condition: Condition?)
-        
+
         fileprivate var condition: Condition? {
             switch self {
             case let .target(_, condition):
@@ -1218,7 +1218,7 @@ extension PackageInfoMapper {
                     return Self.fromTarget(
                         name: name,
                         targetDependencyToFramework: targetDependencyToFramework,
-                        packageConditionDescription: condition
+                        condition: condition
                     )
                 case let .product(name, package, condition):
                     return try Self.fromProduct(
@@ -1226,14 +1226,14 @@ extension PackageInfoMapper {
                         product: name,
                         packageInfos: packageInfos,
                         targetDependencyToFramework: targetDependencyToFramework,
-                        packageConditionDescription: condition
+                        condition: condition
                     )
                 case let .byName(name, condition):
                     if packageInfo.targets.contains(where: { $0.name == name }) {
                         return Self.fromTarget(
                             name: name,
                             targetDependencyToFramework: targetDependencyToFramework,
-                            packageConditionDescription: condition
+                            condition: condition
                         )
                     } else {
                         guard let packageNameAndInfo = packageInfos
@@ -1247,7 +1247,7 @@ extension PackageInfoMapper {
                             product: name,
                             packageInfos: packageInfos,
                             targetDependencyToFramework: targetDependencyToFramework,
-                            packageConditionDescription: condition
+                            condition: condition
                         )
                     }
                 }
@@ -1257,10 +1257,10 @@ extension PackageInfoMapper {
         fileprivate static func fromTarget(
             name: String,
             targetDependencyToFramework: [String: Path],
-            packageConditionDescription: PackageInfo.PackageConditionDescription?
+            condition packageConditionDescription: PackageInfo.PackageConditionDescription?
         ) -> [Self] {
             let condition = packageConditionDescription.flatMap(Condition.from)
-            
+
             if let framework = targetDependencyToFramework[name] {
                 return [.xcframework(path: framework, condition: condition)]
             } else {
@@ -1273,7 +1273,7 @@ extension PackageInfoMapper {
             product: String,
             packageInfos: [String: PackageInfo],
             targetDependencyToFramework: [String: Path],
-            packageConditionDescription: PackageInfo.PackageConditionDescription?
+            condition packageConditionDescription: PackageInfo.PackageConditionDescription?
         ) throws -> [Self] {
             guard let packageProduct = packageInfos[package]?.products.first(where: { $0.name == product }) else {
                 throw PackageInfoMapperError.unknownProductDependency(product, package)
@@ -1302,12 +1302,12 @@ extension PackageInfoMapper.ResolvedDependency {
         public init(platforms: [ProjectDescription.Platform]) {
             self.platforms = platforms
         }
-        
+
         fileprivate static func from(
             _ packageConditionDescription: PackageInfo.PackageConditionDescription
         ) -> Self? {
             let platforms = packageConditionDescription.platformNames.compactMap(ProjectDescription.Platform.init(rawValue:))
-            
+
             return platforms.isEmpty ? nil : Self(platforms: platforms)
         }
     }

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -243,13 +243,14 @@ public final class PackageInfoMapper: PackageInfoMapping {
                         result[product.name] = try product.targets.flatMap { target in
                             try ResolvedDependency.fromTarget(
                                 name: target,
-                                targetDependencyToFramework: targetDependencyToFramework
+                                targetDependencyToFramework: targetDependencyToFramework,
+                                packageConditionDescription: nil
                             )
                             .map {
                                 switch $0 {
-                                case let .xcframework(path):
+                                case let .xcframework(path, _):
                                     return .xcframework(path: path)
-                                case let .target(name):
+                                case let .target(name, _):
                                     // When multiple platforms are supported, add the platform name as a suffix to the target
                                     let targetName = platforms.count == 1 ? name : "\(name)_\(platform.rawValue)"
                                     return .project(target: targetName, path: Path(packageToFolder[packageInfo.key]!.pathString))
@@ -702,13 +703,16 @@ extension ProjectDescription.TargetDependency {
         packageToProject: [String: AbsolutePath],
         addPlatformSuffix: Bool
     ) throws -> [Self] {
-        let targetDependencies = resolvedDependencies.map { dependency -> Self in
+        let targetDependencies = resolvedDependencies.compactMap { dependency -> Self? in
+            if let condition = dependency.condition, !condition.platforms.contains(platform) {
+                return nil
+            }
             switch dependency {
-            case let .target(name):
+            case let .target(name, _):
                 return .target(name: addPlatformSuffix ? "\(name)_\(platform.rawValue)" : name)
-            case let .xcframework(path):
+            case let .xcframework(path, _):
                 return .xcframework(path: path)
-            case let .externalTarget(project, target):
+            case let .externalTarget(project, target, _):
                 return .project(
                     target: addPlatformSuffix ? "\(target)_\(platform.rawValue)" : target,
                     path: Path(packageToProject[project]!.pathString)
@@ -920,14 +924,14 @@ extension ProjectDescription.Settings {
                 let resolvedDependencies = targetToResolvedDependencies[packageTarget.target.name] ?? []
                 return resolvedDependencies.flatMap { resolvedDependency -> [PackageTarget] in
                     switch resolvedDependency {
-                    case let .target(name):
+                    case let .target(name, _):
                         guard let packageInfo = packageInfos[packageTarget.package],
                               let target = packageInfo.targets.first(where: { $0.name == name })
                         else {
                             return []
                         }
                         return [PackageTarget(package: packageTarget.package, target: target)]
-                    case let .externalTarget(package, target):
+                    case let .externalTarget(package, target, _):
                         guard let packageInfo = packageInfos[package] else { return [] }
                         return packageInfo.targets
                             .filter { $0.name == target }
@@ -1186,9 +1190,20 @@ extension PackageInfo.Target {
 
 extension PackageInfoMapper {
     public enum ResolvedDependency: Equatable {
-        case target(name: String)
-        case xcframework(path: Path)
-        case externalTarget(package: String, target: String)
+        case target(name: String, condition: Condition?)
+        case xcframework(path: Path, condition: Condition?)
+        case externalTarget(package: String, target: String, condition: Condition?)
+        
+        fileprivate var condition: Condition? {
+            switch self {
+            case let .target(_, condition):
+                return condition
+            case let .xcframework(_, condition):
+                return condition
+            case let .externalTarget(_, _, condition):
+                return condition
+            }
+        }
 
         fileprivate static func from(
             dependencies: [PackageInfo.Target.Dependency],
@@ -1199,18 +1214,27 @@ extension PackageInfoMapper {
         ) throws -> [ResolvedDependency] {
             try dependencies.flatMap { dependency -> [Self] in
                 switch dependency {
-                case let .target(name, _):
-                    return Self.fromTarget(name: name, targetDependencyToFramework: targetDependencyToFramework)
-                case let .product(name, package, _):
+                case let .target(name, condition):
+                    return Self.fromTarget(
+                        name: name,
+                        targetDependencyToFramework: targetDependencyToFramework,
+                        packageConditionDescription: condition
+                    )
+                case let .product(name, package, condition):
                     return try Self.fromProduct(
                         package: idToPackage[package.lowercased()] ?? package,
                         product: name,
                         packageInfos: packageInfos,
-                        targetDependencyToFramework: targetDependencyToFramework
+                        targetDependencyToFramework: targetDependencyToFramework,
+                        packageConditionDescription: condition
                     )
-                case let .byName(name, _):
+                case let .byName(name, condition):
                     if packageInfo.targets.contains(where: { $0.name == name }) {
-                        return Self.fromTarget(name: name, targetDependencyToFramework: targetDependencyToFramework)
+                        return Self.fromTarget(
+                            name: name,
+                            targetDependencyToFramework: targetDependencyToFramework,
+                            packageConditionDescription: condition
+                        )
                     } else {
                         guard let packageNameAndInfo = packageInfos
                             .first(where: { $0.value.products.contains { $0.name == name } })
@@ -1222,18 +1246,25 @@ extension PackageInfoMapper {
                             package: packageNameAndInfo.key,
                             product: name,
                             packageInfos: packageInfos,
-                            targetDependencyToFramework: targetDependencyToFramework
+                            targetDependencyToFramework: targetDependencyToFramework,
+                            packageConditionDescription: condition
                         )
                     }
                 }
             }
         }
 
-        fileprivate static func fromTarget(name: String, targetDependencyToFramework: [String: Path]) -> [Self] {
+        fileprivate static func fromTarget(
+            name: String,
+            targetDependencyToFramework: [String: Path],
+            packageConditionDescription: PackageInfo.PackageConditionDescription?
+        ) -> [Self] {
+            let condition = packageConditionDescription.flatMap(Condition.from)
+            
             if let framework = targetDependencyToFramework[name] {
-                return [.xcframework(path: framework)]
+                return [.xcframework(path: framework, condition: condition)]
             } else {
-                return [.target(name: PackageInfoMapper.sanitize(targetName: name))]
+                return [.target(name: PackageInfoMapper.sanitize(targetName: name), condition: condition)]
             }
         }
 
@@ -1241,19 +1272,43 @@ extension PackageInfoMapper {
             package: String,
             product: String,
             packageInfos: [String: PackageInfo],
-            targetDependencyToFramework: [String: Path]
+            targetDependencyToFramework: [String: Path],
+            packageConditionDescription: PackageInfo.PackageConditionDescription?
         ) throws -> [Self] {
             guard let packageProduct = packageInfos[package]?.products.first(where: { $0.name == product }) else {
                 throw PackageInfoMapperError.unknownProductDependency(product, package)
             }
+            let condition = packageConditionDescription.flatMap(Condition.from)
 
             return packageProduct.targets.map { name in
                 if let framework = targetDependencyToFramework[name] {
-                    return .xcframework(path: framework)
+                    return .xcframework(path: framework, condition: condition)
                 } else {
-                    return .externalTarget(package: package, target: PackageInfoMapper.sanitize(targetName: name))
+                    return .externalTarget(
+                        package: package,
+                        target: PackageInfoMapper.sanitize(targetName: name),
+                        condition: condition
+                    )
                 }
             }
+        }
+    }
+}
+
+extension PackageInfoMapper.ResolvedDependency {
+    public struct Condition: Equatable {
+        public let platforms: [ProjectDescription.Platform]
+
+        public init(platforms: [ProjectDescription.Platform]) {
+            self.platforms = platforms
+        }
+        
+        fileprivate static func from(
+            _ packageConditionDescription: PackageInfo.PackageConditionDescription
+        ) -> Self? {
+            let platforms = packageConditionDescription.platformNames.compactMap(ProjectDescription.Platform.init(rawValue:))
+            
+            return platforms.isEmpty ? nil : Self(platforms: platforms)
         }
     }
 }

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -231,7 +231,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             ]
         )
     }
-    
+
     func testPreprocess_whenTargetDependenciesOnTargetHaveConditions() throws {
         let basePath = try temporaryPath()
         try fileHandler.createFolder(basePath.appending(RelativePath("Package/Sources/Target_1")))
@@ -248,21 +248,21 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             name: "Target_1",
                             dependencies: [
                                 .byName(name: "Dependency_1", condition: .init(platformNames: ["ios"], config: nil)),
-                                .target(name: "Dependency_2", condition: .init(platformNames: ["tvos"], config: nil))
+                                .target(name: "Dependency_2", condition: .init(platformNames: ["tvos"], config: nil)),
                             ]
                         ),
                         .test(name: "Dependency_1"),
-                        .test(name: "Dependency_2")
+                        .test(name: "Dependency_2"),
                     ],
                     platforms: [],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
-                )
+                ),
             ],
             idToPackage: [:],
             packageToFolder: [
-                "Package": basePath.appending(component: "Package")
+                "Package": basePath.appending(component: "Package"),
             ],
             packageToTargetsToArtifactPaths: [:],
             platforms: [.iOS, .tvOS]
@@ -276,11 +276,11 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     .target(name: "Dependency_2", condition: .init(platforms: [.tvOS])),
                 ],
                 "Dependency_1": [],
-                "Dependency_2": []
+                "Dependency_2": [],
             ]
         )
     }
-    
+
     func testPreprocess_whenTargetDependenciesOnProductHaveConditions() throws {
         let basePath = try temporaryPath()
         try fileHandler.createFolder(basePath.appending(RelativePath("Package_1/Sources/Target_1")))
@@ -296,8 +296,16 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         .test(
                             name: "Target_1",
                             dependencies: [
-                                .product(name: "Product_2", package: "Package_2", condition: .init(platformNames: ["ios"], config: nil)),
-                                .product(name: "Product_3", package: "Package_2", condition: .init(platformNames: ["tvos"], config: nil)),
+                                .product(
+                                    name: "Product_2",
+                                    package: "Package_2",
+                                    condition: .init(platformNames: ["ios"], config: nil)
+                                ),
+                                .product(
+                                    name: "Product_3",
+                                    package: "Package_2",
+                                    condition: .init(platformNames: ["tvos"], config: nil)
+                                ),
                             ]
                         ),
                     ],
@@ -2830,7 +2838,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             )
         )
     }
-    
+
     func testMap_whenTargetDependenciesOnTargetHaveConditions() throws {
         let basePath = try temporaryPath()
         try fileHandler.createFolder(basePath.appending(RelativePath("Package/Sources/Target1")))
@@ -2850,11 +2858,11 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             name: "Target1",
                             dependencies: [
                                 .target(name: "Dependency1", condition: .init(platformNames: ["ios"], config: nil)),
-                                .target(name: "Dependency2", condition: .init(platformNames: ["tvos"], config: nil))
+                                .target(name: "Dependency2", condition: .init(platformNames: ["tvos"], config: nil)),
                             ]
                         ),
                         .test(name: "Dependency1"),
-                        .test(name: "Dependency2")
+                        .test(name: "Dependency2"),
                     ],
                     platforms: [],
                     cLanguageStandard: nil,
@@ -2879,7 +2887,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         basePath.appending(RelativePath("Package/Sources/Target1/**")).pathString,
                     ])),
                     dependencies: [
-                        .target(name: "Dependency2_tvos")
+                        .target(name: "Dependency2_tvos"),
                     ]
                 ),
                 .test(
@@ -2892,7 +2900,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         basePath.appending(RelativePath("Package/Sources/Target1/**")).pathString,
                     ])),
                     dependencies: [
-                        .target(name: "Dependency1_ios")
+                        .target(name: "Dependency1_ios"),
                     ]
                 ),
                 .test(
@@ -2946,7 +2954,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         let expectedTargets = expected.targets.sorted(by: \.name)
         XCTAssertEqual(projectTargets, expectedTargets)
     }
-    
+
     func testMap_whenTargetDependenciesOnProductHaveConditions() throws {
         let basePath = try temporaryPath()
         try fileHandler.createFolder(basePath.appending(RelativePath("Package/Sources/Target1")))
@@ -2962,10 +2970,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     name: "Target1",
                     dependencies: [
                         .product(
-                            name:  "Product2",
+                            name: "Product2",
                             package: "Package2",
                             condition: .init(platformNames: ["ios"], config: nil)
-                        )
+                        ),
                     ]
                 ),
             ],
@@ -2993,7 +3001,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             packageInfos: ["Package": package1, "Package2": package2],
             platforms: [.iOS, .tvOS]
         )
-        
+
         let expected: ProjectDescription.Project = .testWithDefaultConfigs(
             name: "Package",
             targets: [
@@ -3025,9 +3033,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 ),
             ]
         )
-        
+
         XCTAssertEqual(project?.name, expected.name)
-        
+
         let projectTargets = project!.targets.sorted(by: \.name)
         let expectedTargets = expected.targets.sorted(by: \.name)
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4713

### Short description 📝

Filter target resolved dependencies from Package.swift by platform.

### How to test the changes locally 🧐

1) Add to any `Package.swift` conditional dependency:
```
        .target(
            name: "Toast",
            dependencies: [
                "Fonts",
                "Toolbox",
                .target(name: "AssetsMobile", condition: .when(platforms: [.iOS])),
                .target(name: "AssetsTV", condition: .when(platforms: [.tvOS]))
            ],
            path: "Toast/Toast",
        ),
```
2) Link this `Package.swift` to `Tuist/Dependencies.swift`
3) `tuist fetch`
4) `tuist graph`


### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] The title of the PR will be used as changelog entry, please make sure it is clear and suitable
- [ ] In case the PR introduces changes that affect users, the documentation has been updated
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`
