### PR TITLE
Allow AppClip tests and their associated AppClip to include the same static framework

### DIFF
--- a/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -104,22 +104,22 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
         linkedBy: Set<GraphDependency>,
         graphTraverser: GraphTraversing
     ) -> [StaticDependencyWarning] {
-        // Common dependencies between test bundles and their host apps are automatically omitted
+        // Common dependencies between test bundles and their hosts are automatically omitted
         // during generation - as such those shouldn't be flagged
         //
         // reference: https://github.com/tuist/tuist/pull/664
-        let apps: Set<GraphDependency> = linkedBy.filter { dependency -> Bool in
+        let hosts: Set<GraphDependency> = linkedBy.filter { dependency -> Bool in
             guard case let GraphDependency.target(targetName, targetPath) = dependency else { return false }
             guard let target = graphTraverser.target(path: targetPath, name: targetName) else { return false }
-            return target.target.product == .app
+            return target.target.product.canHostTests()
         }
         let hostedTestBundles = linkedBy.filter { dependency -> Bool in
             guard case let GraphDependency.target(targetName, targetPath) = dependency else { return false }
             guard let target = graphTraverser.target(path: targetPath, name: targetName) else { return false }
 
             let isTestsBundle = target.target.product.testsBundle
-            let hasHostApp = dependencies(for: dependency, graphTraverser: graphTraverser).contains(where: { apps.contains($0) })
-            return isTestsBundle && hasHostApp
+            let hasHost = dependencies(for: dependency, graphTraverser: graphTraverser).contains(where: { hosts.contains($0) })
+            return isTestsBundle && hasHost
         }
 
         let links = linkedBy.subtracting(hostedTestBundles)

--- a/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
@@ -591,7 +591,7 @@ class StaticProductsGraphLinterTests: XCTestCase {
         // Then
         XCTAssertTrue(results.isEmpty)
     }
-    
+
     func test_lint_whenNoStaticProductLinkedTwice_hostedTestTargets_3() throws {
         // Given
         let path: AbsolutePath = "/project"


### PR DESCRIPTION
### Short description 📝

In our project, our AppClip targets have associated unit tests. We'd like to include the same static frameworks in both. I noticed there's an exception for this in the StaticLinter code, which I believe should be extended to AppClips as well.

### How to test the changes locally 🧐

Create an AppClip target, a unit testing target, and a static framework as a dependency on both. Before this PR, a linter warning will appear. After this PR, no more warning!

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] The title of the PR will be used as changelog entry, please make sure it is clear and suitable
- [x] In case the PR introduces changes that affect users, the documentation has been updated
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`
