### PR TITLE
Fix warnings in dependencies project generated with Xcode 14

### DIFF
--- a/Sources/ProjectDescription/DeploymentTarget.swift
+++ b/Sources/ProjectDescription/DeploymentTarget.swift
@@ -19,4 +19,12 @@ public enum DeploymentTarget: Codable, Hashable {
         case watchOS
         case tvOS
     }
+
+    /// The target platform version
+    public var targetVersion: String {
+        switch self {
+        case let .iOS(targetVersion, _), let .macOS(targetVersion), let .watchOS(targetVersion), let .tvOS(targetVersion):
+            return targetVersion
+        }
+    }
 }

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -267,7 +267,8 @@ public final class PackageInfoMapper: PackageInfoMapping {
                 }
         }
 
-        let minDeploymentTargets = Platform.oldestVersions.reduce(
+        let version = try Version(versionString: try System.shared.swiftVersion(), usesLenientParsing: true)
+        let minDeploymentTargets = Platform.oldestVersions(isLegacy: version < TSCUtility.Version(5, 7, 0)).reduce(
             into: [ProjectDescription.Platform: ProjectDescription.DeploymentTarget]()
         ) { acc, next in
             switch next.key {

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -554,23 +554,33 @@ extension ProjectDescription.DeploymentTarget {
         packageName _: String
     ) throws -> Self {
         if let packagePlatform = package.first(where: { $0.tuistPlatformName == platform.rawValue }) {
+            // Deployment targets below the minimum one raises warnings
+            let targetVersion = try Self.max(packagePlatform.version, minDeploymentTargets[platform]?.targetVersion)
+
             switch platform {
             case .iOS:
                 let hasMacCatalyst = package.contains(where: { $0.platformName == "maccatalyst" })
                 return .iOS(
-                    targetVersion: packagePlatform.version,
+                    targetVersion: targetVersion,
                     devices: hasMacCatalyst ? [.iphone, .ipad, .mac] : [.iphone, .ipad]
                 )
             case .macOS:
-                return .macOS(targetVersion: packagePlatform.version)
+                return .macOS(targetVersion: targetVersion)
             case .watchOS:
-                return .watchOS(targetVersion: packagePlatform.version)
+                return .watchOS(targetVersion: targetVersion)
             case .tvOS:
-                return .tvOS(targetVersion: packagePlatform.version)
+                return .tvOS(targetVersion: targetVersion)
             }
         } else {
             return minDeploymentTargets[platform]!
         }
+    }
+
+    fileprivate static func max(_ lVersionString: String, _ rVersionString: String?) throws -> String {
+        guard let rVersionString = rVersionString else { return lVersionString }
+        let lVersion = try Version(versionString: lVersionString, usesLenientParsing: true)
+        let rVersion = try Version(versionString: rVersionString, usesLenientParsing: true)
+        return lVersion > rVersion ? lVersionString : rVersionString
     }
 }
 

--- a/Sources/TuistGraph/Models/Platform.swift
+++ b/Sources/TuistGraph/Models/Platform.swift
@@ -16,13 +16,25 @@ public enum Platform: String, CaseIterable, Codable {
     }
 
     /// A dictionary that contains the oldes supported version of each platform
-    /// https://github.com/apple/swift-package-manager/blob/5d3db35d1f388f4b0bb7e82f4cfa050103bb3e07/Sources/PackageModel/Platform.swift#L32-L42
-    public static var oldestVersions: [Platform: String] = [
-        .iOS: "9.0",
-        .tvOS: "9.0",
-        .macOS: "10.10",
-        .watchOS: "2.0",
-    ]
+    public static func oldestVersions(isLegacy: Bool) -> [Platform: String] {
+        guard !isLegacy else {
+            /// https://github.com/apple/swift-package-manager/blob/5d3db35d1f388f4b0bb7e82f4cfa050103bb3e07/Sources/PackageModel/Platform.swift#L32-L42
+            return [
+                .iOS: "9.0",
+                .tvOS: "9.0",
+                .macOS: "10.10",
+                .watchOS: "2.0",
+            ]
+        }
+        
+        /// https://github.com/apple/swift-package-manager/blob/86b245fd68157a0592b1d9ef15284e3b22c3fb44/Sources/PackageModel/Platform.swift#L34-L44
+        return [
+            .iOS: "11.0",
+            .tvOS: "11.0",
+            .macOS: "10.13",
+            .watchOS: "4.0",
+        ]
+    }
 }
 
 extension Platform {

--- a/Sources/TuistGraph/Models/Platform.swift
+++ b/Sources/TuistGraph/Models/Platform.swift
@@ -26,7 +26,7 @@ public enum Platform: String, CaseIterable, Codable {
                 .watchOS: "2.0",
             ]
         }
-        
+
         /// https://github.com/apple/swift-package-manager/blob/86b245fd68157a0592b1d9ef15284e3b22c3fb44/Sources/PackageModel/Platform.swift#L34-L44
         return [
             .iOS: "11.0",

--- a/Sources/TuistSupportTesting/SwiftPackageManager/PackageInfo+TestData.swift
+++ b/Sources/TuistSupportTesting/SwiftPackageManager/PackageInfo+TestData.swift
@@ -674,7 +674,7 @@ extension PackageInfo {
                 ),
             ],
             platforms: [
-                .init(platformName: "ios", version: "10.0", options: []),
+                .init(platformName: "ios", version: "11.0", options: []),
                 .init(platformName: "macos", version: "10.15", options: []),
                 .init(platformName: "watchos", version: "8.5", options: []),
             ],

--- a/Sources/TuistSupportTesting/SwiftPackageManager/PlatformTestInfo.swift
+++ b/Sources/TuistSupportTesting/SwiftPackageManager/PlatformTestInfo.swift
@@ -5,6 +5,6 @@ import TuistGraph
 public var PLATFORM_TEST_VERSION: [Platform: String] = [ // swiftlint:disable:this identifier_name
     .iOS: "11.0",
     .macOS: "10.15",
-    .watchOS: "9.0",
+    .watchOS: "8.5",
     .tvOS: "11.0",
 ]

--- a/Sources/TuistSupportTesting/SwiftPackageManager/PlatformTestInfo.swift
+++ b/Sources/TuistSupportTesting/SwiftPackageManager/PlatformTestInfo.swift
@@ -3,8 +3,8 @@ import TuistGraph
 
 /// Global configuration of which platform versions used during mock generation
 public var PLATFORM_TEST_VERSION: [Platform: String] = [ // swiftlint:disable:this identifier_name
-    .iOS: "10.0",
+    .iOS: "11.0",
     .macOS: "10.15",
-    .watchOS: "8.5",
-    .tvOS: "9.0",
+    .watchOS: "9.0",
+    .tvOS: "11.0",
 ]

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -16,47 +16,6 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
     override func setUp() {
         super.setUp()
 
-        system.stubs["/usr/bin/xcrun --sdk iphoneos --show-sdk-platform-path"] = (
-            stderror: nil,
-            stdout: "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform\n",
-            exitstatus: 0
-        )
-        system.stubs[
-            "/usr/bin/xcrun vtool -show-build /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest"
-        ] = (
-            stderror: nil,
-            stdout: """
-            /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture armv7):
-            Load command 8
-                  cmd LC_VERSION_MIN_IPHONEOS
-              cmdsize 16
-              version 9.0
-                  sdk 15.0
-            /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture armv7s):
-            Load command 8
-                  cmd LC_VERSION_MIN_IPHONEOS
-              cmdsize 16
-              version 9.0
-                  sdk 15.0
-            /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture arm64):
-            Load command 8
-                  cmd LC_VERSION_MIN_IPHONEOS
-              cmdsize 16
-              version 9.0
-                  sdk 15.0
-            /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture arm64e):
-            Load command 9
-                  cmd LC_BUILD_VERSION
-              cmdsize 32
-             platform IOS
-                minos 14.0
-                  sdk 15.0
-               ntools 1
-                 tool LD
-              version 711.0
-            """,
-            exitstatus: 0
-        )
         system.swiftVersionStub = { "5.7.0" }
         subject = PackageInfoMapper()
     }
@@ -1515,38 +1474,6 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
     }
 
     func testMap_whenIOSNotAvailable_takesOthers() throws {
-        system.stubs = [:]
-        system.stubs["/usr/bin/xcrun --sdk appletvos --show-sdk-platform-path"] = (
-            stderror: nil,
-            stdout: "/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform\n",
-            exitstatus: 0
-        )
-        system
-            .stubs[
-                "/usr/bin/xcrun vtool -show-build /Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest"
-            ] =
-            (
-                stderror: nil,
-                stdout: """
-                /Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture arm64):
-                Load command 8
-                      cmd LC_VERSION_MIN_TVOS
-                  cmdsize 16
-                  version 9.0
-                      sdk 15.0
-                /Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture arm64e):
-                Load command 9
-                      cmd LC_BUILD_VERSION
-                   cmdsize 32
-                  platform TVOS
-                     minos 14.0
-                       sdk 15.0
-                    ntools 1
-                      tool LD
-                   version 711.0
-                """,
-                exitstatus: 0
-            )
         let basePath = try temporaryPath()
         let sourcesPath = basePath.appending(RelativePath("Package/Sources/Target1"))
         try fileHandler.createFolder(sourcesPath)

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -21,44 +21,43 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             stdout: "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform\n",
             exitstatus: 0
         )
-        system
-            .stubs[
-                "/usr/bin/xcrun vtool -show-build /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest"
-            ] =
-            (
-                stderror: nil,
-                stdout: """
-                /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture armv7):
-                Load command 8
-                      cmd LC_VERSION_MIN_IPHONEOS
-                  cmdsize 16
-                  version 9.0
-                      sdk 15.0
-                /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture armv7s):
-                Load command 8
-                      cmd LC_VERSION_MIN_IPHONEOS
-                  cmdsize 16
-                  version 9.0
-                      sdk 15.0
-                /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture arm64):
-                Load command 8
-                      cmd LC_VERSION_MIN_IPHONEOS
-                  cmdsize 16
-                  version 9.0
-                      sdk 15.0
-                /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture arm64e):
-                Load command 9
-                      cmd LC_BUILD_VERSION
-                  cmdsize 32
-                 platform IOS
-                    minos 14.0
-                      sdk 15.0
-                   ntools 1
-                     tool LD
-                  version 711.0
-                """,
-                exitstatus: 0
-            )
+        system.stubs[
+            "/usr/bin/xcrun vtool -show-build /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest"
+        ] = (
+            stderror: nil,
+            stdout: """
+            /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture armv7):
+            Load command 8
+                  cmd LC_VERSION_MIN_IPHONEOS
+              cmdsize 16
+              version 9.0
+                  sdk 15.0
+            /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture armv7s):
+            Load command 8
+                  cmd LC_VERSION_MIN_IPHONEOS
+              cmdsize 16
+              version 9.0
+                  sdk 15.0
+            /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture arm64):
+            Load command 8
+                  cmd LC_VERSION_MIN_IPHONEOS
+              cmdsize 16
+              version 9.0
+                  sdk 15.0
+            /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture arm64e):
+            Load command 9
+                  cmd LC_BUILD_VERSION
+              cmdsize 32
+             platform IOS
+                minos 14.0
+                  sdk 15.0
+               ntools 1
+                 tool LD
+              version 711.0
+            """,
+            exitstatus: 0
+        )
+        system.swiftVersionStub = { "5.7.0" }
         subject = PackageInfoMapper()
     }
 

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -385,6 +385,43 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         )
     }
 
+    func testMap_whenLegacySwift_usesLegacyIOSVersion() throws {
+        system.swiftVersionStub = { "5.6.0" }
+
+        let basePath = try temporaryPath()
+        let sourcesPath = basePath.appending(RelativePath("Package/Sources/Target1"))
+        try fileHandler.createFolder(sourcesPath)
+
+        let project = try subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageInfos: [
+                "Package": .init(
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(name: "Target1"),
+                    ],
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+
+        XCTAssertEqual(
+            project,
+            .testWithDefaultConfigs(
+                name: "Package",
+                targets: [
+                    .test("Target1", basePath: basePath, deploymentTarget: .iOS(targetVersion: "9.0", devices: [.iphone, .ipad])),
+                ]
+            )
+        )
+    }
+
     func testMap_whenMacCatalyst() throws {
         let basePath = try temporaryPath()
         let sourcesPath = basePath.appending(RelativePath("Package/Sources/Target1"))
@@ -1448,7 +1485,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     platform: .tvOS,
                     customProductName: "Target1",
                     customBundleID: "Target1",
-                    deploymentTarget: .tvOS(targetVersion: "9.0"),
+                    deploymentTarget: .tvOS(targetVersion: "11.0"),
                     customSources: .custom(.init(globs: [
                         basePath.appending(RelativePath("Package/Sources/Target1/**"))
                             .pathString,
@@ -1537,7 +1574,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             .testWithDefaultConfigs(
                 name: "Package",
                 targets: [
-                    .test("Target1", basePath: basePath, platform: .tvOS, deploymentTarget: .tvOS(targetVersion: "9.0")),
+                    .test("Target1", basePath: basePath, platform: .tvOS, deploymentTarget: .tvOS(targetVersion: "11.0")),
                 ]
             )
         )
@@ -2881,7 +2918,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     platform: .tvOS,
                     customProductName: "Target1",
                     customBundleID: "Target1",
-                    deploymentTarget: .tvOS(targetVersion: "9.0"),
+                    deploymentTarget: .tvOS(targetVersion: "11.0"),
                     customSources: .custom(.init(globs: [
                         basePath.appending(RelativePath("Package/Sources/Target1/**")).pathString,
                     ])),
@@ -2908,7 +2945,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     platform: .tvOS,
                     customProductName: "Dependency1",
                     customBundleID: "Dependency1",
-                    deploymentTarget: .tvOS(targetVersion: "9.0"),
+                    deploymentTarget: .tvOS(targetVersion: "11.0"),
                     customSources: .custom(.init(globs: [
                         basePath.appending(RelativePath("Package/Sources/Dependency1/**")).pathString,
                     ]))
@@ -2929,7 +2966,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     platform: .tvOS,
                     customProductName: "Dependency2",
                     customBundleID: "Dependency2",
-                    deploymentTarget: .tvOS(targetVersion: "9.0"),
+                    deploymentTarget: .tvOS(targetVersion: "11.0"),
                     customSources: .custom(.init(globs: [
                         basePath.appending(RelativePath("Package/Sources/Dependency2/**")).pathString,
                     ]))
@@ -3024,7 +3061,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     platform: .tvOS,
                     customProductName: "Target1",
                     customBundleID: "Target1",
-                    deploymentTarget: .tvOS(targetVersion: "9.0"),
+                    deploymentTarget: .tvOS(targetVersion: "11.0"),
                     customSources: .custom(.init(globs: [
                         basePath.appending(RelativePath("Package/Sources/Target1/**")).pathString,
                     ])),
@@ -3197,7 +3234,7 @@ extension ProjectDescription.Target {
         product: ProjectDescription.Product = .staticFramework,
         customProductName: String? = nil,
         customBundleID: String? = nil,
-        deploymentTarget: ProjectDescription.DeploymentTarget = .iOS(targetVersion: "9.0", devices: [.iphone, .ipad]),
+        deploymentTarget: ProjectDescription.DeploymentTarget = .iOS(targetVersion: "11.0", devices: [.iphone, .ipad]),
         customSources: SourceFilesListType = .default,
         resources: [ProjectDescription.ResourceFileElement] = [],
         headers: ProjectDescription.Headers? = nil,

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
@@ -18,51 +18,9 @@ class SwiftPackageManagerGraphGeneratorTests: TuistUnitTestCase {
 
     override func setUp() {
         super.setUp()
+
         swiftPackageManagerController = MockSwiftPackageManagerController()
-
-        system.stubs["/usr/bin/xcrun --sdk iphoneos --show-sdk-platform-path"] = (
-            stderror: nil,
-            stdout: "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform\n",
-            exitstatus: 0
-        )
-        system.stubs[
-            "/usr/bin/xcrun vtool -show-build /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest"
-        ] = (
-            stderror: nil,
-            stdout: """
-            /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture armv7):
-            Load command 8
-                  cmd LC_VERSION_MIN_IPHONEOS
-              cmdsize 16
-              version 9.0
-                  sdk 15.0
-            /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture armv7s):
-            Load command 8
-                  cmd LC_VERSION_MIN_IPHONEOS
-              cmdsize 16
-              version 9.0
-                  sdk 15.0
-            /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture arm64):
-            Load command 8
-                  cmd LC_VERSION_MIN_IPHONEOS
-              cmdsize 16
-              version 9.0
-                  sdk 15.0
-            /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture arm64e):
-            Load command 9
-                  cmd LC_BUILD_VERSION
-              cmdsize 32
-             platform IOS
-                minos 14.0
-                  sdk 15.0
-               ntools 1
-                 tool LD
-              version 711.0
-            """,
-            exitstatus: 0
-        )
         system.swiftVersionStub = { "5.7.0" }
-
         subject = SwiftPackageManagerGraphGenerator(swiftPackageManagerController: swiftPackageManagerController)
     }
 

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
@@ -61,7 +61,7 @@ class SwiftPackageManagerGraphGeneratorTests: TuistUnitTestCase {
             """,
             exitstatus: 0
         )
-      system.swiftVersionStub = { "5.7.0" }
+        system.swiftVersionStub = { "5.7.0" }
 
         subject = SwiftPackageManagerGraphGenerator(swiftPackageManagerController: swiftPackageManagerController)
     }

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/SwiftPackageManagerGraphGeneratorTests.swift
@@ -25,44 +25,43 @@ class SwiftPackageManagerGraphGeneratorTests: TuistUnitTestCase {
             stdout: "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform\n",
             exitstatus: 0
         )
-        system
-            .stubs[
-                "/usr/bin/xcrun vtool -show-build /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest"
-            ] =
-            (
-                stderror: nil,
-                stdout: """
-                /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture armv7):
-                Load command 8
-                      cmd LC_VERSION_MIN_IPHONEOS
-                  cmdsize 16
-                  version 9.0
-                      sdk 15.0
-                /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture armv7s):
-                Load command 8
-                      cmd LC_VERSION_MIN_IPHONEOS
-                  cmdsize 16
-                  version 9.0
-                      sdk 15.0
-                /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture arm64):
-                Load command 8
-                      cmd LC_VERSION_MIN_IPHONEOS
-                  cmdsize 16
-                  version 9.0
-                      sdk 15.0
-                /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture arm64e):
-                Load command 9
-                      cmd LC_BUILD_VERSION
-                  cmdsize 32
-                 platform IOS
-                    minos 14.0
-                      sdk 15.0
-                   ntools 1
-                     tool LD
-                  version 711.0
-                """,
-                exitstatus: 0
-            )
+        system.stubs[
+            "/usr/bin/xcrun vtool -show-build /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest"
+        ] = (
+            stderror: nil,
+            stdout: """
+            /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture armv7):
+            Load command 8
+                  cmd LC_VERSION_MIN_IPHONEOS
+              cmdsize 16
+              version 9.0
+                  sdk 15.0
+            /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture armv7s):
+            Load command 8
+                  cmd LC_VERSION_MIN_IPHONEOS
+              cmdsize 16
+              version 9.0
+                  sdk 15.0
+            /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture arm64):
+            Load command 8
+                  cmd LC_VERSION_MIN_IPHONEOS
+              cmdsize 16
+              version 9.0
+                  sdk 15.0
+            /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest (architecture arm64e):
+            Load command 9
+                  cmd LC_BUILD_VERSION
+              cmdsize 32
+             platform IOS
+                minos 14.0
+                  sdk 15.0
+               ntools 1
+                 tool LD
+              version 711.0
+            """,
+            exitstatus: 0
+        )
+      system.swiftVersionStub = { "5.7.0" }
 
         subject = SwiftPackageManagerGraphGenerator(swiftPackageManagerController: swiftPackageManagerController)
     }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4765

### Short description 📝

Fix warnings in dependencies project generated with Xcode 14

### How to test the changes locally 🧐

- Generate the `app_with_spm_dependencies`
- See there are no warnings

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] The title of the PR will be used as changelog entry, please make sure it is clear and suitable
- [x] In case the PR introduces changes that affect users, the documentation has been updated
- [x] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`
