### PR TITLE
Ensure unit test host application logic is consistent

### DIFF
--- a/projects/tuist/fixtures/ios_app_with_appclip/AppClip1/Sources/AppClipModel.swift
+++ b/projects/tuist/fixtures/ios_app_with_appclip/AppClip1/Sources/AppClipModel.swift
@@ -1,0 +1,11 @@
+import StaticFramework
+
+final class AppClipModel {
+    func makeStaticFrameworkType() -> StaticFrameworkType {
+        StaticFrameworkType(name: "AppClip")
+    }
+
+    func staticFrameworkTypeIdentifier() -> String {
+        StaticFrameworkType.typeIdentifier
+    }
+}

--- a/projects/tuist/fixtures/ios_app_with_appclip/AppClip1Tests/Tests/AppClipTests.swift
+++ b/projects/tuist/fixtures/ios_app_with_appclip/AppClip1Tests/Tests/AppClipTests.swift
@@ -1,8 +1,33 @@
+import StaticFramework
 import XCTest
-@testable import AppClip
+@testable import AppClip1
 
 final class AppClipTests: XCTestCase {
     func testExample() {
         XCTAssertTrue(2 == 2)
+    }
+
+    func testStaticFrameworkCode() {
+        // Given
+        let subject = AppClipModel()
+
+        // When
+        let result = subject.makeStaticFrameworkType()
+
+        // Then
+        XCTAssertEqual(result.name, "AppClip")
+    }
+
+    func testStaticFrameworkTypeIdentifier() {
+        // Given
+        let subject = AppClipModel()
+
+        // When
+        let result = subject.staticFrameworkTypeIdentifier()
+
+        // Then
+        // In the event of duplicate symbols, the type identifiers
+        // will mismatch when referenced from two different sources
+        XCTAssertEqual(result, StaticFrameworkType.typeIdentifier)
     }
 }

--- a/projects/tuist/fixtures/ios_app_with_appclip/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_appclip/Project.swift
@@ -25,6 +25,15 @@ let project = Project(
             dependencies: []
         ),
         Target(
+            name: "StaticFramework",
+            platform: .iOS,
+            product: .staticFramework,
+            bundleId: "io.tuist.StaticFramework",
+            infoPlist: .default,
+            sources: ["StaticFramework/Sources/**"],
+            dependencies: []
+        ),
+        Target(
             name: "AppClip1",
             platform: .iOS,
             product: .appClip,
@@ -34,6 +43,7 @@ let project = Project(
             entitlements: "AppClip1/Entitlements/AppClip.entitlements",
             dependencies: [
                 .target(name: "Framework"),
+                .target(name: "StaticFramework"),
             ]
         ),
         Target(
@@ -45,6 +55,7 @@ let project = Project(
             sources: ["AppClip1Tests/Tests/**"],
             dependencies: [
                 .target(name: "AppClip1"),
+                .target(name: "StaticFramework"),
             ]
         ),
         Target(

--- a/projects/tuist/fixtures/ios_app_with_appclip/StaticFramework/Sources/StaticFramework.swift
+++ b/projects/tuist/fixtures/ios_app_with_appclip/StaticFramework/Sources/StaticFramework.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public struct StaticFrameworkType {
+    public let name: String
+    public init(name: String) {
+        self.name = name
+    }
+
+    public static var typeIdentifier: String {
+        "\(ObjectIdentifier(StaticFrameworkType.self))"
+    }
+}


### PR DESCRIPTION
Follow up to: https://github.com/tuist/tuist/pull/4766

### Short description 📝

- https://github.com/tuist/tuist/pull/4766 ensured that app clips and their unit tests do not flag duplicate static symbol warnings as they can both safely depened on the same ones
- https://github.com/tuist/tuist/pull/664 introduced the removal of redundant static products from being linked in cases where a unit test and its host application share common static products
- This change ensure we follow the same logic now for all tests and their hosts rather than only application targets (e.g. it will now work for watch and appliclips too)
- To clarfify the intended use of the `hostApplication` method, it was renamed to `unitTestHost`
  - _Internally within `GraphTraverser` it was only used for this purpose_



### How to test the changes locally 🧐

- Generate the app clip fixture

```swift
swift build
swift run tuist generate --path projects/tuist/fixtures/ios_app_with_appclip
```

- Verify the static framework isn't linked in the app clip unit tests target
- Verify app clip unit tests continue to pass

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] The title of the PR will be used as changelog entry, please make sure it is clear and suitable
- [ ] In case the PR introduces changes that affect users, the documentation has been updated
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`
