### PR TITLE
Add support for watchOS app extension dependencies

### DIFF
--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -505,6 +505,7 @@ public class GraphLinter: GraphLinting {
             LintableTarget(platform: .watchOS, product: .dynamicLibrary),
             LintableTarget(platform: .watchOS, product: .framework),
             LintableTarget(platform: .watchOS, product: .staticFramework),
+            LintableTarget(platform: .watchOS, product: .appExtension),
         ],
         LintableTarget(platform: .watchOS, product: .watch2App): [
             LintableTarget(platform: .watchOS, product: .watch2Extension),

--- a/projects/tuist/fixtures/ios_app_with_watch_application/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/Project.swift
@@ -30,7 +30,7 @@ let project = Project(
             sources: "WatchApp/Sources/**",
             resources: "WatchApp/Resources/**",
             dependencies: [
-                // ...
+                .target(name: "WatchWidgetExtension"),
             ],
             settings: .settings(
                 base: [
@@ -45,6 +45,22 @@ let project = Project(
                     "INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp": false,
                 ]
             )
+        ),
+        Target(
+            name: "WatchWidgetExtension",
+            platform: .watchOS,
+            product: .appExtension,
+            bundleId: "io.tuist.App.watchkitapp.widgetExtension",
+            infoPlist: .extendingDefault(with: [
+                "CFBundleDisplayName": "$(PRODUCT_NAME)",
+                "NSExtension": [
+                    "NSExtensionPointIdentifier": "com.apple.widgetkit-extension",
+                ],
+            ]),
+            sources: "WatchWidgetExtension/Sources/**",
+            resources: "WatchWidgetExtension/Resources/**",
+            dependencies: [
+            ]
         ),
     ]
 )

--- a/projects/tuist/fixtures/ios_app_with_watch_application/WatchWidgetExtension/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/WatchWidgetExtension/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/projects/tuist/fixtures/ios_app_with_watch_application/WatchWidgetExtension/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/WatchWidgetExtension/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "watchos",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/projects/tuist/fixtures/ios_app_with_watch_application/WatchWidgetExtension/Resources/Assets.xcassets/Contents.json
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/WatchWidgetExtension/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/projects/tuist/fixtures/ios_app_with_watch_application/WatchWidgetExtension/Resources/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/WatchWidgetExtension/Resources/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/projects/tuist/fixtures/ios_app_with_watch_application/WatchWidgetExtension/Sources/WatchWidgets.swift
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/WatchWidgetExtension/Sources/WatchWidgets.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+import WidgetKit
+
+struct Provider: TimelineProvider {
+    func placeholder(in _: Context) -> SimpleEntry {
+        SimpleEntry(date: Date())
+    }
+
+    func getSnapshot(in _: Context, completion: @escaping (SimpleEntry) -> Void) {
+        let entry = SimpleEntry(date: Date())
+        completion(entry)
+    }
+
+    func getTimeline(in _: Context, completion: @escaping (Timeline<Entry>) -> Void) {
+        var entries: [SimpleEntry] = []
+
+        // Generate a timeline consisting of five entries an hour apart, starting from the current date.
+        let currentDate = Date()
+        for hourOffset in 0 ..< 5 {
+            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
+            let entry = SimpleEntry(date: entryDate)
+            entries.append(entry)
+        }
+
+        let timeline = Timeline(entries: entries, policy: .atEnd)
+        completion(timeline)
+    }
+}
+
+struct SimpleEntry: TimelineEntry {
+    let date: Date
+}
+
+struct WatchWidgetEntryView: View {
+    var entry: Provider.Entry
+
+    var body: some View {
+        Text(entry.date, style: .time)
+    }
+}
+
+@main
+struct WatchWidget: Widget {
+    let kind: String = "WatchWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: Provider()) { entry in
+            WatchWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("My Widget")
+        .description("This is an example widget.")
+    }
+}
+
+struct WatchWidget_Previews: PreviewProvider {
+    static var previews: some View {
+        WatchWidgetEntryView(entry: SimpleEntry(date: Date()))
+            .previewContext(WidgetPreviewContext(family: .accessoryRectangular))
+    }
+}


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/4768


### Short description 📝

- WatchOS application targets can now include WidgetKit extension targets (as of Xcode 14)
- WidgetKit extension targets are regular app extension targets
- Tuist already supports embedding app extensions, the only change needed to support it for watchOS application was to update the linter logic to allow this dependency combination
- The fixture was extended to demo a watchOS WidgetKit extension

Notes:

- WidgetKit extension targets require the following info plist keys

```xml
<dict>
	<key>NSExtension</key>
	<dict>
		<key>NSExtensionPointIdentifier</key>
		<string>com.apple.widgetkit-extension</string>
	</dict>
</dict>
```

### How to test the changes locally 🧐

- Generate the watch application fixture

```sh
swift build
swift run tuist generate --path projects/tuist/fixtures/ios_app_with_watch_application
```

- Verify the project generates successfully without any lint errors
- Inspect the generated project and verify the WidgetKit extension for the watch app is created correctly

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] The title of the PR will be used as changelog entry, please make sure it is clear and suitable
- [ ] In case the PR introduces changes that affect users, the documentation has been updated
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`
