### PR TITLE
Make `tuistenv` ignore empty `.tuist-bin` folder

### DIFF
--- a/Sources/TuistEnvKit/Versions/VersionResolver.swift
+++ b/Sources/TuistEnvKit/Versions/VersionResolver.swift
@@ -52,7 +52,7 @@ class VersionResolver: VersionResolving {
     private func resolveTraversing(from path: AbsolutePath) throws -> ResolvedVersion {
         let versionPath = path.appending(component: Constants.versionFileName)
         let binPath = path.appending(component: Constants.binFolderName)
-        if fileManager.fileExists(atPath: binPath.pathString) {
+        if fileManager.fileExists(atPath: binPath.appending(component: Constants.binName).pathString) {
             return .bin(binPath)
         } else if fileManager.fileExists(atPath: versionPath.pathString) {
             return try resolveVersionFile(path: versionPath)

--- a/Tests/TuistEnvKitTests/Versions/VersionResolverTests.swift
+++ b/Tests/TuistEnvKitTests/Versions/VersionResolverTests.swift
@@ -37,6 +37,7 @@ final class VersionResolverTests: XCTestCase {
         let tmp_dir = try TemporaryDirectory(removeTreeOnDeinit: true)
         let versionPath = tmp_dir.path.appending(component: Constants.versionFileName)
         let binPath = tmp_dir.path.appending(component: Constants.binFolderName)
+        let tuistPath = binPath.appending(component: Constants.binName)
 
         // /tmp/dir/.tuist-version
         try "3.2.1".write(
@@ -49,6 +50,11 @@ final class VersionResolverTests: XCTestCase {
             at: URL(fileURLWithPath: binPath.pathString),
             withIntermediateDirectories: true,
             attributes: nil
+        )
+        // /tmp/dir/.tuist-bin/tuist
+        FileManager.default.createFile(
+            atPath: tuistPath.pathString,
+            contents: nil
         )
 
         let got = try subject.resolve(path: tmp_dir.path)
@@ -88,6 +94,27 @@ final class VersionResolverTests: XCTestCase {
     func test_resolve_when_bin() throws {
         let tmp_dir = try TemporaryDirectory(removeTreeOnDeinit: true)
         let binPath = tmp_dir.path.appending(component: Constants.binFolderName)
+        let tuistPath = binPath.appending(component: Constants.binName)
+
+        // /tmp/dir/.tuist-bin
+        try FileManager.default.createDirectory(
+            at: URL(fileURLWithPath: binPath.pathString),
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        // /tmp/dir/.tuist-bin/tuist
+        FileManager.default.createFile(
+            atPath: tuistPath.pathString,
+            contents: nil
+        )
+
+        let got = try subject.resolve(path: tmp_dir.path)
+        XCTAssertEqual(got, .bin(binPath))
+    }
+
+    func test_resolve_when_empty_bin() throws {
+        let tmp_dir = try TemporaryDirectory(removeTreeOnDeinit: true)
+        let binPath = tmp_dir.path.appending(component: Constants.binFolderName)
 
         // /tmp/dir/.tuist-bin
         try FileManager.default.createDirectory(
@@ -97,7 +124,7 @@ final class VersionResolverTests: XCTestCase {
         )
 
         let got = try subject.resolve(path: tmp_dir.path)
-        XCTAssertEqual(got, .bin(binPath))
+        XCTAssertEqual(got, .undefined)
     }
 
     func test_resolve_when_version_in_parent_directory() throws {
@@ -124,6 +151,7 @@ final class VersionResolverTests: XCTestCase {
     func test_resolve_when_bin_in_parent_directory() throws {
         let tmp_dir = try TemporaryDirectory(removeTreeOnDeinit: true)
         let binPath = tmp_dir.path.appending(component: Constants.binFolderName)
+        let tuistPath = binPath.appending(component: Constants.binName)
         let childPath = tmp_dir.path.appending(component: "child")
 
         // /tmp/dir/.tuist-bin
@@ -131,6 +159,11 @@ final class VersionResolverTests: XCTestCase {
             at: URL(fileURLWithPath: binPath.pathString),
             withIntermediateDirectories: true,
             attributes: nil
+        )
+        // /tmp/dir/.tuist-bin/tuist
+        FileManager.default.createFile(
+            atPath: tuistPath.pathString,
+            contents: nil
         )
         try FileManager.default.createDirectory(
             at: URL(fileURLWithPath: childPath.pathString),


### PR DESCRIPTION
Resolves #4753

### Short description 📝

When a `.tuist-bin` folder is present, tuistenv will use the `tuist` binary in that folder. However, if that file is missing `tuistenv` will fail silently.

This PR changes the behavior of VersionResolver to instead look for a file named `tuist` inside a folder named `.tuist-bin`. If that file is missing, `.tuist-bin` will be ignored.

### How to test the changes locally 🧐

Create an empty `.tuist-bin` folder then run `tuistenv`. A new unit test has also been added.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] The title of the PR will be used as changelog entry, please make sure it is clear and suitable
- [ ] In case the PR introduces changes that affect users, the documentation has been updated
- [x] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`
