### PR TITLE
Validate names when creating project or organization

### DIFF
--- a/projects/cloud/app/frontend/components/pages/new-project/NewProjectPage.tsx
+++ b/projects/cloud/app/frontend/components/pages/new-project/NewProjectPage.tsx
@@ -49,6 +49,12 @@ export const NewProjectPage = observer(() => {
               <TextField
                 type="text"
                 label="Organization name"
+                error={
+                  newProjectPageStore.isOrganizationNameValid
+                    ? false
+                    : 'The name is invalid'
+                }
+                helpText="The allowed characters are a-z and the dash symbol '-' (for example organization-name)"
                 value={newProjectPageStore.organizationName}
                 onChange={(value) =>
                   newProjectPageStore.organizationNameChanged(value)
@@ -56,10 +62,15 @@ export const NewProjectPage = observer(() => {
                 autoComplete="off"
               />
             )}
-            {/* TODO: Only allow kebab-case names */}
             <TextField
               type="text"
               label="Project name"
+              error={
+                newProjectPageStore.isNewProjectNameValid
+                  ? false
+                  : 'The name is invalid'
+              }
+              helpText="The allowed characters are a-z and the dash symbol '-' (for example project-name)"
               value={newProjectPageStore.newProjectName}
               onChange={(value) => {
                 newProjectPageStore.projectNameChanged(value);

--- a/projects/cloud/app/frontend/components/pages/new-project/NewProjectPageStore.ts
+++ b/projects/cloud/app/frontend/components/pages/new-project/NewProjectPageStore.ts
@@ -31,11 +31,21 @@ export class NewProjectPageStore {
   get isCreateProjectButtonDisabled() {
     return (
       this.newProjectName.length === 0 ||
+      !this.isNewProjectNameValid ||
       (this.selectedProjectOwner == null &&
         !this.isCreatingOrganization) ||
       (this.isCreatingOrganization &&
-        this.organizationName.length === 0)
+        (this.organizationName.length === 0 ||
+          !this.isOrganizationNameValid))
     );
+  }
+
+  get isNewProjectNameValid() {
+    return this.isNameValid(this.newProjectName);
+  }
+
+  get isOrganizationNameValid() {
+    return this.isNameValid(this.organizationName);
   }
 
   get options(): SelectOption[] {
@@ -83,9 +93,6 @@ export class NewProjectPageStore {
   }
 
   projectNameChanged(newProjectName: string) {
-    console.log(this);
-    console.log(newProjectName);
-    console.log(this.newProjectName);
     this.newProjectName = newProjectName;
   }
 
@@ -112,5 +119,10 @@ export class NewProjectPageStore {
     if (data) {
       onCompleted(data?.createProject.slug);
     }
+  }
+
+  private isNameValid(name: string) {
+    const regex = new RegExp('[^a-z\\-]');
+    return !regex.test(name);
   }
 }

--- a/projects/cloud/app/frontend/components/pages/new-project/__tests__/NewProjectPageStore.test.ts
+++ b/projects/cloud/app/frontend/components/pages/new-project/__tests__/NewProjectPageStore.test.ts
@@ -1,0 +1,166 @@
+import { MyAccountsQuery } from '@/graphql/types';
+import { NewProjectPageStore } from '../NewProjectPageStore';
+
+jest.mock('@apollo/client');
+
+describe('NewProjectPageStore', () => {
+  const client = {
+    query: jest.fn(),
+    mutate: jest.fn(),
+  } as any;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('initially new project name is valid', () => {
+    // Given
+    const newProjectPageStore = new NewProjectPageStore(client);
+
+    // Then
+    expect(newProjectPageStore.isNewProjectNameValid).toBe(true);
+  });
+
+  it('new project name is valid when name contains only lowercase ASCII characters', () => {
+    // Given
+    const newProjectPageStore = new NewProjectPageStore(client);
+
+    // When
+    newProjectPageStore.projectNameChanged('projectname');
+
+    // Then
+    expect(newProjectPageStore.isNewProjectNameValid).toBe(true);
+  });
+
+  it('new project name is valid when name contains only lowercase ASCII characters and -', () => {
+    // Given
+    const newProjectPageStore = new NewProjectPageStore(client);
+
+    // When
+    newProjectPageStore.projectNameChanged('project-name');
+
+    // Then
+    expect(newProjectPageStore.isNewProjectNameValid).toBe(true);
+  });
+
+  it('new project name is not valid when it contains a space', () => {
+    // Given
+    const newProjectPageStore = new NewProjectPageStore(client);
+
+    // When
+    newProjectPageStore.projectNameChanged('project name');
+
+    // Then
+    expect(newProjectPageStore.isNewProjectNameValid).toBe(false);
+  });
+
+  it('new project name is not valid when it contains an uppercase character', () => {
+    // Given
+    const newProjectPageStore = new NewProjectPageStore(client);
+
+    // When
+    newProjectPageStore.projectNameChanged('ProjectName');
+
+    // Then
+    expect(newProjectPageStore.isNewProjectNameValid).toBe(false);
+  });
+
+  it('initially organization name is valid', () => {
+    // Given
+    const newProjectPageStore = new NewProjectPageStore(client);
+
+    // Then
+    expect(newProjectPageStore.isOrganizationNameValid).toBe(true);
+  });
+
+  it('organization name is valid when name contains only lowercase ASCII characters', () => {
+    // Given
+    const newProjectPageStore = new NewProjectPageStore(client);
+
+    // When
+    newProjectPageStore.organizationNameChanged('organizationname');
+
+    // Then
+    expect(newProjectPageStore.isOrganizationNameValid).toBe(true);
+  });
+
+  it('organization name is valid when name contains only lowercase ASCII characters and -', () => {
+    // Given
+    const newProjectPageStore = new NewProjectPageStore(client);
+
+    // When
+    newProjectPageStore.organizationNameChanged('organization-name');
+
+    // Then
+    expect(newProjectPageStore.isOrganizationNameValid).toBe(true);
+  });
+
+  it('organization name is not valid when it contains a space', () => {
+    // Given
+    const newProjectPageStore = new NewProjectPageStore(client);
+
+    // When
+    newProjectPageStore.organizationNameChanged('organization name');
+
+    // Then
+    expect(newProjectPageStore.isOrganizationNameValid).toBe(false);
+  });
+
+  it('organization name is not valid when it contains an uppercase character', () => {
+    // Given
+    const newProjectPageStore = new NewProjectPageStore(client);
+
+    // When
+    newProjectPageStore.organizationNameChanged('OrganizationName');
+
+    // Then
+    expect(newProjectPageStore.isOrganizationNameValid).toBe(false);
+  });
+
+  it('create project button is disabled when newProjectName is empty', () => {
+    // Given
+    const newProjectPageStore = new NewProjectPageStore(client);
+
+    // Then
+    expect(newProjectPageStore.isCreateProjectButtonDisabled).toBe(
+      true,
+    );
+  });
+
+  it('create project button is disabled when newProjectName is invalid', () => {
+    // Given
+    const newProjectPageStore = new NewProjectPageStore(client);
+
+    // When
+    newProjectPageStore.projectNameChanged('project name');
+
+    // Then
+    expect(newProjectPageStore.isCreateProjectButtonDisabled).toBe(
+      true,
+    );
+  });
+
+  it('create project button is enabled when project name and organization are valid', async () => {
+    // Given
+    const newProjectPageStore = new NewProjectPageStore(client);
+    client.query.mockResolvedValueOnce({
+      data: {
+        accounts: [
+          {
+            id: 'id-my-account',
+            name: 'my-account',
+          },
+        ],
+      } as MyAccountsQuery,
+    });
+    await newProjectPageStore.load();
+
+    // When
+    newProjectPageStore.projectNameChanged('project-name');
+
+    // Then
+    expect(newProjectPageStore.isCreateProjectButtonDisabled).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
### Short description 📝

Backend currently relies on the project and organization to be in kebab-case – for example, because the whole project name is directly translated to be an URL. This follows a similar logic as Github does when creating a repository.

![image](https://user-images.githubusercontent.com/9371695/197058555-96a942d6-fef0-4ea5-b4aa-ce0c6a2843dc.png)
