### PR TITLE
When tuist chooses a simulator device while building, make sure it's available

### DIFF
--- a/Sources/TuistCore/Simulator/SimulatorController.swift
+++ b/Sources/TuistCore/Simulator/SimulatorController.swift
@@ -139,6 +139,7 @@ public final class SimulatorController: SimulatorControlling {
         let availableDevices = devicesAndRuntimes
             .sorted(by: { $0.runtime.version >= $1.runtime.version })
             .filter { simulatorDeviceAndRuntime in
+                guard simulatorDeviceAndRuntime.device.isAvailable else { return false }
                 let nameComponents = simulatorDeviceAndRuntime.runtime.name.components(separatedBy: " ")
                 guard nameComponents.first == platform.caseValue else { return false }
                 let deviceVersion = nameComponents.last?.version()


### PR DESCRIPTION
### Short description 📝

The `build` acceptance test is failing in CI. The reason is that in the current CI environment the chosen tvOS simulator device is not available and the logic which filters for device availability does not actually check `isAvailable`. This PR adds that check.

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] The title of the PR will be used as changelog entry, please make sure it is clear and suitable
- [ ] In case the PR introduces changes that affect users, the documentation has been updated
- [x] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`
