### PR TITLE
Fix for stencils directory not added to the `tuist edit` project

### DIFF
--- a/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
@@ -63,6 +63,9 @@ final class ProjectEditor: ProjectEditing {
     /// Utility to locate the resource synthesizers directory
     let resourceSynthesizersDirectoryLocator: ResourceSynthesizerPathLocating
 
+    /// Utility to locate the stencil directory
+    let stencilDirectoryLocator: StencilPathLocating
+
     private let cacheDirectoryProviderFactory: CacheDirectoriesProviderFactoring
     private let projectDescriptionHelpersBuilderFactory: ProjectDescriptionHelpersBuilderFactoring
 
@@ -79,6 +82,7 @@ final class ProjectEditor: ProjectEditing {
         templatesDirectoryLocator: TemplatesDirectoryLocating = TemplatesDirectoryLocator(),
         resourceSynthesizersDirectoryLocator: ResourceSynthesizerPathLocating = ResourceSynthesizerPathLocator(),
         cacheDirectoryProviderFactory: CacheDirectoriesProviderFactoring = CacheDirectoriesProviderFactory(),
+        stencilDirectoryLocator: StencilPathLocating = StencilPathLocator(),
         projectDescriptionHelpersBuilderFactory: ProjectDescriptionHelpersBuilderFactoring =
             ProjectDescriptionHelpersBuilderFactory()
     ) {
@@ -91,6 +95,7 @@ final class ProjectEditor: ProjectEditing {
         self.templatesDirectoryLocator = templatesDirectoryLocator
         self.resourceSynthesizersDirectoryLocator = resourceSynthesizersDirectoryLocator
         self.cacheDirectoryProviderFactory = cacheDirectoryProviderFactory
+        self.stencilDirectoryLocator = stencilDirectoryLocator
         self.projectDescriptionHelpersBuilderFactory = projectDescriptionHelpersBuilderFactory
     }
 
@@ -144,6 +149,10 @@ final class ProjectEditor: ProjectEditing {
             FileHandler.shared.glob($0, glob: "**/*.stencil")
         } ?? []
 
+        let stencils = stencilDirectoryLocator.locate(at: editingPath).map {
+            FileHandler.shared.glob($0, glob: "**/*.stencil")
+        } ?? []
+
         let editablePluginManifests = locateEditablePluginManifests(
             at: editingPath,
             excluding: pathsToExclude,
@@ -159,7 +168,7 @@ final class ProjectEditor: ProjectEditing {
 
         /// We error if the user tries to edit a project in a directory where there are no editable files.
         if projectManifests.isEmpty, editablePluginManifests.isEmpty, helpers.isEmpty, templates.isEmpty,
-           resourceSynthesizers.isEmpty
+           resourceSynthesizers.isEmpty, stencils.isEmpty
         {
             throw ProjectEditorError.noEditableFiles(editingPath)
         }
@@ -181,6 +190,7 @@ final class ProjectEditor: ProjectEditing {
             helpers: helpers,
             templates: templates,
             resourceSynthesizers: resourceSynthesizers,
+            stencils: stencils,
             projectDescriptionSearchPath: projectDescriptionPath.parentDirectory
         )
 

--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -19,6 +19,7 @@ protocol ProjectEditorMapping: AnyObject {
         helpers: [AbsolutePath],
         templates: [AbsolutePath],
         resourceSynthesizers: [AbsolutePath],
+        stencils: [AbsolutePath],
         projectDescriptionSearchPath: AbsolutePath
     ) throws -> Graph
 }
@@ -39,6 +40,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
         helpers: [AbsolutePath],
         templates: [AbsolutePath],
         resourceSynthesizers: [AbsolutePath],
+        stencils: [AbsolutePath],
         projectDescriptionSearchPath: AbsolutePath
     ) throws -> Graph {
         let swiftVersion = try System.shared.swiftVersion()
@@ -62,6 +64,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
             helpers: helpers,
             templates: templates,
             resourceSynthesizers: resourceSynthesizers,
+            stencils: stencils,
             configPath: configPath,
             dependenciesPath: dependenciesPath,
             editablePluginTargets: editablePluginManifests.map(\.name),
@@ -135,6 +138,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
         helpers: [AbsolutePath],
         templates: [AbsolutePath],
         resourceSynthesizers: [AbsolutePath],
+        stencils: [AbsolutePath],
         configPath: AbsolutePath?,
         dependenciesPath: AbsolutePath?,
         editablePluginTargets: [String],
@@ -209,6 +213,17 @@ final class ProjectEditorMapper: ProjectEditorMapping {
             )
         }()
 
+        let stencilsTarget: Target? = {
+            guard !stencils.isEmpty else { return nil }
+            return editorHelperTarget(
+                name: Constants.stencilsDirectoryName,
+                filesGroup: manifestsFilesGroup,
+                targetSettings: baseTargetSettings,
+                sourcePaths: stencils,
+                dependencies: helpersTarget.flatMap { [TargetDependency.target(name: $0.name)] } ?? []
+            )
+        }()
+
         let helperTargetDependencies = helpersTarget.map { [TargetDependency.target(name: $0.name)] } ?? []
         let helperAndPluginDependencies = helperTargetDependencies + editablePluginTargetDependencies
 
@@ -237,6 +252,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
             helpersTarget,
             templatesTarget,
             resourceSynthesizersTarget,
+            stencilsTarget,
             configTarget,
             dependenciesTarget,
         ]

--- a/Sources/TuistLoader/Models/PluginStencil.swift
+++ b/Sources/TuistLoader/Models/PluginStencil.swift
@@ -1,0 +1,18 @@
+import Foundation
+import TSCBasic
+
+/// Stencil plugin model
+public struct PluginStencil: Equatable {
+    /// Name of the plugin
+    public let name: String
+    /// Path to `Stencil` directory where all resource templates are located
+    public let path: AbsolutePath
+
+    public init(
+        name: String,
+        path: AbsolutePath
+    ) {
+        self.name = name
+        self.path = path
+    }
+}

--- a/Sources/TuistLoader/Utils/StencilPathLocator.swift
+++ b/Sources/TuistLoader/Utils/StencilPathLocator.swift
@@ -1,0 +1,96 @@
+import Foundation
+import TSCBasic
+import TuistCore
+import TuistGraph
+import TuistSupport
+
+public protocol StencilPathLocating {
+    func locate(at: AbsolutePath) -> AbsolutePath?
+
+    func templatePath(
+        for pluginName: String,
+        resourceName: String,
+        stencilPlugins: [PluginStencil]
+    ) throws -> AbsolutePath
+
+    func templatePath(
+        for resourceName: String,
+        path: AbsolutePath
+    ) -> AbsolutePath?
+}
+
+enum StencilPathLocatorError: FatalError, Equatable {
+    case pluginNotFound(String, [String])
+    case resourceTemplateNotFound(name: String, plugin: String)
+
+    var type: ErrorType {
+        switch self {
+        case .pluginNotFound,
+             .resourceTemplateNotFound:
+            return .abort
+        }
+    }
+
+    var description: String {
+        switch self {
+        case let .pluginNotFound(name, availablePlugins):
+            return "Plugin \(name) was not found. Available plugins: \(availablePlugins.joined(separator: ", "))"
+        case let .resourceTemplateNotFound(name: name, plugin: pluginName):
+            return "No template \(name) found in a plugin \(pluginName)"
+        }
+    }
+}
+
+public final class StencilPathLocator: StencilPathLocating {
+    private let rootDirectoryLocator: RootDirectoryLocating
+
+    public init(
+        rootDirectoryLocator: RootDirectoryLocating = RootDirectoryLocator()
+    ) {
+        self.rootDirectoryLocator = rootDirectoryLocator
+    }
+
+    public func templatePath(
+        for pluginName: String,
+        resourceName: String,
+        stencilPlugins: [PluginStencil]
+    ) throws -> AbsolutePath {
+        guard let plugin = stencilPlugins.first(where: { $0.name == pluginName })
+        else { throw StencilPathLocatorError.pluginNotFound(pluginName, stencilPlugins.map(\.name)) }
+
+        let resourceTemplatePath = plugin.path
+            .appending(components: "\(resourceName).stencil")
+        guard FileHandler.shared.exists(resourceTemplatePath)
+        else {
+            throw StencilPathLocatorError
+                .resourceTemplateNotFound(name: "\(resourceName).stencil", plugin: plugin.name)
+        }
+
+        return resourceTemplatePath
+    }
+
+    public func templatePath(
+        for resourceName: String,
+        path: AbsolutePath
+    ) -> AbsolutePath? {
+        guard let rootDirectory = rootDirectoryLocator.locate(from: path) else { return nil }
+        let templatePath = rootDirectory
+            .appending(
+                components: Constants.tuistDirectoryName,
+                Constants.stencilsDirectoryName,
+                "\(resourceName).stencil"
+            )
+        return FileHandler.shared.exists(templatePath) ? templatePath : nil
+    }
+
+    // MARK: - Helpers
+
+    public func locate(at: AbsolutePath) -> AbsolutePath? {
+        guard let rootDirectory = rootDirectoryLocator.locate(from: at) else { return nil }
+        let helpersDirectory = rootDirectory
+            .appending(component: Constants.tuistDirectoryName)
+            .appending(component: Constants.stencilsDirectoryName)
+        if !FileHandler.shared.exists(helpersDirectory) { return nil }
+        return helpersDirectory
+    }
+}

--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -21,6 +21,7 @@ public enum Constants {
     public static let encryptedExtension = "encrypted"
     public static let templatesDirectoryName: String = "Templates"
     public static let resourceSynthesizersDirectoryName: String = "ResourceSynthesizers"
+    public static let stencilsDirectoryName: String = "Stencils"
     public static let vendorDirectoryName: String = "vendor"
     public static let twitterHandle: String = "tuistio"
     public static let joinSlackURL: String = "https://slack.tuist.io/"

--- a/Tests/TuistKitTests/ProjectEditor/Mocks/MockProjectEditorMapper.swift
+++ b/Tests/TuistKitTests/ProjectEditor/Mocks/MockProjectEditorMapper.swift
@@ -23,6 +23,7 @@ final class MockProjectEditorMapper: ProjectEditorMapping {
         helpers: [AbsolutePath],
         templates: [AbsolutePath],
         resourceSynthesizers: [AbsolutePath],
+        stencils: [AbsolutePath],
         projectDescriptionPath: AbsolutePath
     )] = []
 
@@ -39,6 +40,7 @@ final class MockProjectEditorMapper: ProjectEditorMapping {
         helpers: [AbsolutePath],
         templates: [AbsolutePath],
         resourceSynthesizers: [AbsolutePath],
+        stencils: [AbsolutePath],
         projectDescriptionSearchPath: AbsolutePath
     ) throws -> Graph {
         mapArgs.append((
@@ -54,6 +56,7 @@ final class MockProjectEditorMapper: ProjectEditorMapping {
             helpers: helpers,
             templates: templates,
             resourceSynthesizers: resourceSynthesizers,
+            stencils: stencils,
             projectDescriptionPath: projectDescriptionSearchPath
         ))
 

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
@@ -34,6 +34,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         let helperPaths = [sourceRootPath].map { $0.appending(component: "Project+Template.swift") }
         let templates = [sourceRootPath].map { $0.appending(component: "template") }
         let resourceSynthesizers = [sourceRootPath].map { $0.appending(component: "resourceSynthesizer") }
+        let stencils = [sourceRootPath].map { $0.appending(component: "Stencil") }
         let projectDescriptionPath = sourceRootPath.appending(component: "ProjectDescription.framework")
         let tuistPath = AbsolutePath("/usr/bin/foo/bar/tuist")
         let projectName = "Manifests"
@@ -57,6 +58,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             helpers: helperPaths,
             templates: templates,
             resourceSynthesizers: resourceSynthesizers,
+            stencils: stencils,
             projectDescriptionSearchPath: projectDescriptionPath
         )
 
@@ -69,7 +71,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         // Then
         XCTAssertEqual(graph.name, "TestManifests")
 
-        XCTAssertEqual(targets.count, 8)
+        XCTAssertEqual(targets.count, 9)
 
         // Generated Manifests target
         let manifestsTarget = try XCTUnwrap(project.targets.first(where: { $0.name == sourceRootPath.basename + projectName }))
@@ -142,6 +144,23 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             .target(name: "ProjectDescriptionHelpers"),
         ]))
 
+        // Generated Stencils target
+        let stencilsTarget = try XCTUnwrap(project.targets.last(where: { $0.name == "Stencils" }))
+        XCTAssertTrue(targets.contains(stencilsTarget))
+
+        XCTAssertEqual(stencilsTarget.name, "Stencils")
+        XCTAssertEqual(stencilsTarget.platform, .macOS)
+        XCTAssertEqual(stencilsTarget.product, .staticFramework)
+        XCTAssertEqual(
+            stencilsTarget.settings,
+            expectedSettings(includePaths: [projectDescriptionPath, projectDescriptionPath.parentDirectory])
+        )
+        XCTAssertEqual(stencilsTarget.sources.map(\.path), stencils)
+        XCTAssertEqual(stencilsTarget.filesGroup, projectsGroup)
+        XCTAssertEqual(Set(stencilsTarget.dependencies), Set([
+            .target(name: "ProjectDescriptionHelpers"),
+        ]))
+
         // Generated Config target
         let configTarget = try XCTUnwrap(project.targets.last(where: { $0.name == "Config" }))
         XCTAssertTrue(targets.contains(configTarget))
@@ -207,6 +226,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         let helperPaths: [AbsolutePath] = []
         let templates: [AbsolutePath] = []
         let resourceSynthesizers: [AbsolutePath] = []
+        let stencils: [AbsolutePath] = []
         let projectDescriptionPath = sourceRootPath.appending(component: "ProjectDescription.framework")
         let tuistPath = AbsolutePath("/usr/bin/foo/bar/tuist")
         let projectName = "Manifests"
@@ -226,6 +246,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             helpers: helperPaths,
             templates: templates,
             resourceSynthesizers: resourceSynthesizers,
+            stencils: stencils,
             projectDescriptionSearchPath: projectDescriptionPath
         )
 
@@ -289,6 +310,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         let helperPaths: [AbsolutePath] = []
         let templates: [AbsolutePath] = []
         let resourceSynthesizers: [AbsolutePath] = []
+        let stencils: [AbsolutePath] = []
         let projectDescriptionPath = sourceRootPath.appending(component: "ProjectDescription.framework")
         let tuistPath = AbsolutePath("/usr/bin/foo/bar/tuist")
         let projectName = "Manifests"
@@ -307,6 +329,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             helpers: helperPaths,
             templates: templates,
             resourceSynthesizers: resourceSynthesizers,
+            stencils: stencils,
             projectDescriptionSearchPath: projectDescriptionPath
         )
 
@@ -395,6 +418,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         let helperPaths: [AbsolutePath] = []
         let templates: [AbsolutePath] = []
         let resourceSynthesizers: [AbsolutePath] = []
+        let stencils: [AbsolutePath] = []
         let projectDescriptionPath = sourceRootPath.appending(component: "ProjectDescription.framework")
         let tuistPath = AbsolutePath("/usr/bin/foo/bar/tuist")
         let projectName = "Plugins"
@@ -414,6 +438,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             helpers: helperPaths,
             templates: templates,
             resourceSynthesizers: resourceSynthesizers,
+            stencils: stencils,
             projectDescriptionSearchPath: projectDescriptionPath
         )
 
@@ -474,6 +499,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         let helperPaths: [AbsolutePath] = []
         let templates: [AbsolutePath] = []
         let resourceSynthesizers: [AbsolutePath] = []
+        let stencils: [AbsolutePath] = []
         let projectDescriptionPath = sourceRootPath.appending(component: "ProjectDescription.framework")
         let tuistPath = AbsolutePath("/usr/bin/foo/bar/tuist")
         let projectName = "Plugins"
@@ -493,6 +519,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             helpers: helperPaths,
             templates: templates,
             resourceSynthesizers: resourceSynthesizers,
+            stencils: stencils,
             projectDescriptionSearchPath: projectDescriptionPath
         )
 
@@ -576,6 +603,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         let helperPaths: [AbsolutePath] = []
         let templates: [AbsolutePath] = []
         let resourceSynthesizers: [AbsolutePath] = []
+        let stencils: [AbsolutePath] = []
         let projectDescriptionPath = sourceRootPath.appending(component: "ProjectDescription.framework")
         let tuistPath = AbsolutePath("/usr/bin/foo/bar/tuist")
         try createFiles([
@@ -606,6 +634,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             helpers: helperPaths,
             templates: templates,
             resourceSynthesizers: resourceSynthesizers,
+            stencils: stencils,
             projectDescriptionSearchPath: projectDescriptionPath
         )
 
@@ -626,6 +655,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         let helperPaths: [AbsolutePath] = [sourceRootPath].map { $0.appending(components: "Tuist", "ProjectDescriptionHelpers") }
         let templates: [AbsolutePath] = []
         let resourceSynthesizers: [AbsolutePath] = []
+        let stencils: [AbsolutePath] = []
         let projectDescriptionPath = sourceRootPath.appending(components: "Frameworks", "ProjectDescription.framework")
         let tuistPath = AbsolutePath("/usr/bin/foo/bar/tuist")
         let manifestsProjectName = "Manifests"
@@ -649,6 +679,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             helpers: helperPaths,
             templates: templates,
             resourceSynthesizers: resourceSynthesizers,
+            stencils: stencils,
             projectDescriptionSearchPath: projectDescriptionPath
         )
 

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/Stencil+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/Stencil+ManifestMapperTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import ProjectDescription
+import TSCBasic
+import TuistCore
+import TuistGraph
+import TuistLoaderTesting
+import TuistSupportTesting
+import XCTest
+
+@testable import TuistLoader
+
+final class StencilManifestMapperTests: TuistUnitTestCase {
+    private var subject: StencilPathLocator!
+
+    override func setUp() {
+        super.setUp()
+
+        subject = StencilPathLocator(rootDirectoryLocator: RootDirectoryLocator())
+    }
+
+    override func tearDown() {
+        subject = nil
+        super.tearDown()
+    }
+
+    func test_locate_when_a_stencil_and_git_directory_exists() throws {
+        // Given
+        let stencilDirectory = try temporaryPath()
+        try createFolders(["this/is/a/very/nested/directory", "this/is/Tuist/Stencils", "this/.git"])
+
+        // When
+        let got = subject.locate(at: stencilDirectory.appending(RelativePath("this/is/a/very/nested/directory")))
+
+        // Then
+        XCTAssertEqual(got, stencilDirectory.appending(RelativePath("this/is/Tuist/Stencils")))
+    }
+
+    func test_locate_when_a_stencil_directory_exists() throws {
+        // Given
+        let stencilDirectory = try temporaryPath()
+        try createFolders(["this/is/a/very/nested/directory", "this/is/Tuist/Stencils"])
+
+        // When
+        let got = subject.locate(at: stencilDirectory.appending(RelativePath("this/is/a/very/nested/directory")))
+
+        // Then
+        XCTAssertEqual(got, stencilDirectory.appending(RelativePath("this/is/Tuist/Stencils")))
+    }
+
+    func test_locate_when_a_git_directory_exists() throws {
+        // Given
+        let stencilDirectory = try temporaryPath()
+        try createFolders(["this/is/a/very/nested/directory", "this/.git", "this/Tuist/Stencils"])
+
+        // When
+        let got = subject.locate(at: stencilDirectory.appending(RelativePath("this/is/a/very/nested/directory")))
+
+        // Then
+        XCTAssertEqual(got, stencilDirectory.appending(RelativePath("this/Tuist/Stencils")))
+    }
+
+    func test_locate_when_multiple_tuist_directories_exists() throws {
+        // Given
+        let stencilDirectory = try temporaryPath()
+        try createFolders(["this/is/a/very/nested/Tuist/Stencils", "this/is/Tuist/Stencils"])
+        let paths = [
+            "this/is/a/very/directory",
+            "this/is/a/very/nested/directory",
+        ]
+
+        // When
+        let got = paths.map {
+            subject.locate(at: stencilDirectory.appending(RelativePath($0)))
+        }
+
+        // Then
+        XCTAssertEqual(got, [
+            "this/is/Tuist/Stencils",
+            "this/is/a/very/nested/Tuist/Stencils",
+        ].map { stencilDirectory.appending(RelativePath($0)) })
+    }
+}


### PR DESCRIPTION
Resolves [#4845](https://github.com/tuist/tuist/issues/4845)

### Short description 📝

- Fixed issuese #3406 split to this issues.

### How to test the changes locally 🧐

After downloading this [sample project](https://github.com/tuist/tuist/files/7115065/StencilBug.zip), run `tuist edit` command and found to the Stencils directory inside the Manifests project.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] The title of the PR will be used as changelog entry, please make sure it is clear and suitable
- [ ] In case the PR introduces changes that affect users, the documentation has been updated
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`
