### PR TITLE
Fix concurrency warning in bundle extension

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -104,7 +104,7 @@ public class ResourcesProjectMapper: ProjectMapping {
             extension Foundation.Bundle {
                 /// Since \(targetName) is a \(target
                 .product), the bundle containing the resources is copied into the final product.
-                static var module: Bundle = {
+                static let module: Bundle = {
                     let bundleName = "\(bundleName)"
 
                     let candidates = [
@@ -127,9 +127,9 @@ public class ResourcesProjectMapper: ProjectMapping {
 
             @objc
             public class \(target.productName.camelized.uppercasingFirst)Resources: NSObject {
-               @objc public class var bundle: Bundle {
-                     return .module
-               }
+                @objc public class var bundle: Bundle {
+                    return .module
+                }
             }
             // swiftlint:enable all
             // swiftformat:enable all
@@ -149,18 +149,16 @@ public class ResourcesProjectMapper: ProjectMapping {
             extension Foundation.Bundle {
                 /// Since \(targetName) is a \(target
                 .product), the bundle for classes within this module can be used directly.
-                static var module: Bundle = {
-                    return Bundle(for: BundleFinder.self)
-                }()
+                static let module = Bundle(for: BundleFinder.self)
             }
 
             // MARK: - Objective-C Bundle Accessor
 
             @objc
             public class \(target.productName.camelized.uppercasingFirst)Resources: NSObject {
-               @objc public class var bundle: Bundle {
-                     return .module
-               }
+                @objc public class var bundle: Bundle {
+                    return .module
+                }
             }
             // swiftlint:enable all
             // swiftformat:enable all


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4874

### Short description 📝

When `SWIFT_STRICT_CONCURRENCY` setting is set to `complete`, xcode performs stricter checks regarding concurrency safety. Tuist was creating file `Bundle+Target.swift` with content:
```
extension Foundation.Bundle {
    static var bundle: Bundle = {
        return Bundle(for: BundleFinder.self)
    }()
}
```
In code generated above `bundle` is a variable, so xcode warns that mutable shared variable are not concurrency-safe. However, bundle should never be changed, so this PR changes code above to:
```
extension Foundation.Bundle {
    static let bundle = Bundle(for: BundleFinder.self)
}
```

### How to test the changes locally 🧐

I used two locally modified fixtures to test it:
- To test simple bundle, modify `ios_app_with_static_frameworks_with_resources` with project setting: `.settings(base: ["SWIFT_STRICT_CONCURRENCY": "complete"])`
- To test code when target doesn't support resources, add a resource and set setting above in fixture `command_line_tool_basic`

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] The title of the PR will be used as changelog entry, please make sure it is clear and suitable
- [ ] In case the PR introduces changes that affect users, the documentation has been updated
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`
