### PR TITLE
Fix signing when certificate name contains quotes

### DIFF
--- a/Sources/TuistSigning/Certificate/CertificateParser.swift
+++ b/Sources/TuistSigning/Certificate/CertificateParser.swift
@@ -56,24 +56,24 @@ final class CertificateParser: CertificateParsing {
         let isRevoked = subject.contains("REVOKED")
 
         let nameRegex = try NSRegularExpression(
-            pattern: SubjectAttribute.commonName.rawValue + " *= *([^/,]+)",
+            pattern: SubjectAttribute.commonName.rawValue + " *= *(?:\"(.*)\"|([^/,]+))",
             options: []
         )
-        guard let nameResult = nameRegex.firstMatch(in: subject, options: [], range: NSRange(location: 0, length: subject.count))
+        guard let nameResult = nameRegex.firstMatch(in: subject, range: NSRange(location: 0, length: subject.count)),
+              nameResult.range(at: 1).length > 0 || nameResult.range(at: 2).length > 0
         else { throw CertificateParserError.nameParsingFailed(publicKey, subject) }
-        let name = NSString(string: subject).substring(with: nameResult.range(at: 1)).spm_chomp()
+        let nameResultRange = nameResult.range(at: nameResult.range(at: 1).length > 0 ? 1 : 2)
+        let name = NSString(string: subject).substring(with: nameResultRange).spm_chomp()
 
         let developmentTeamRegex = try NSRegularExpression(
-            pattern: SubjectAttribute.organizationalUnit.rawValue + " *= *([^/,]+)",
+            pattern: SubjectAttribute.organizationalUnit.rawValue + " *= *(?:\"(.*)\"|([^/,]+))",
             options: []
         )
-        guard let developmentTeamResult = developmentTeamRegex.firstMatch(
-            in: subject,
-            options: [],
-            range: NSRange(location: 0, length: subject.count)
-        )
+        guard let developmentTeamResult = developmentTeamRegex.firstMatch(in: subject, range: NSRange(location: 0, length: subject.count)),
+              nameResult.range(at: 1).length > 0 || nameResult.range(at: 2).length > 0
         else { throw CertificateParserError.developmentTeamParsingFailed(publicKey, subject) }
-        let developmentTeam = NSString(string: subject).substring(with: developmentTeamResult.range(at: 1)).spm_chomp()
+        let developmentTeamResultRange = developmentTeamResult.range(at: developmentTeamResult.range(at: 1).length > 0 ? 1 : 2)
+        let developmentTeam = NSString(string: subject).substring(with: developmentTeamResultRange).spm_chomp()
 
         return Certificate(
             publicKey: publicKey,

--- a/Sources/TuistSigning/Certificate/CertificateParser.swift
+++ b/Sources/TuistSigning/Certificate/CertificateParser.swift
@@ -69,8 +69,10 @@ final class CertificateParser: CertificateParsing {
             pattern: SubjectAttribute.organizationalUnit.rawValue + " *= *(?:\"(.*)\"|([^/,]+))",
             options: []
         )
-        guard let developmentTeamResult = developmentTeamRegex.firstMatch(in: subject, range: NSRange(location: 0, length: subject.count)),
-              nameResult.range(at: 1).length > 0 || nameResult.range(at: 2).length > 0
+        guard let developmentTeamResult = developmentTeamRegex.firstMatch(
+            in: subject,
+            range: NSRange(location: 0, length: subject.count)
+        ), nameResult.range(at: 1).length > 0 || nameResult.range(at: 2).length > 0
         else { throw CertificateParserError.developmentTeamParsingFailed(publicKey, subject) }
         let developmentTeamResultRange = developmentTeamResult.range(at: developmentTeamResult.range(at: 1).length > 0 ? 1 : 2)
         let developmentTeam = NSString(string: subject).substring(with: developmentTeamResultRange).spm_chomp()

--- a/Sources/TuistSigning/Certificate/CertificateParser.swift
+++ b/Sources/TuistSigning/Certificate/CertificateParser.swift
@@ -56,7 +56,7 @@ final class CertificateParser: CertificateParsing {
         let isRevoked = subject.contains("REVOKED")
 
         let nameRegex = try NSRegularExpression(
-            pattern: SubjectAttribute.commonName.rawValue + " *= *(?:\"(.*)\"|([^/,]+))",
+            pattern: SubjectAttribute.commonName.rawValue + " *= *(?:\"([^/,]+)\"|([^/,]+))",
             options: []
         )
         guard let nameResult = nameRegex.firstMatch(in: subject, range: NSRange(location: 0, length: subject.count)),
@@ -66,7 +66,7 @@ final class CertificateParser: CertificateParsing {
         let name = NSString(string: subject).substring(with: nameResultRange).spm_chomp()
 
         let developmentTeamRegex = try NSRegularExpression(
-            pattern: SubjectAttribute.organizationalUnit.rawValue + " *= *(?:\"(.*)\"|([^/,]+))",
+            pattern: SubjectAttribute.organizationalUnit.rawValue + " *= *(?:\"([^/,]+)\"|([^/,]+))",
             options: []
         )
         guard let developmentTeamResult = developmentTeamRegex.firstMatch(

--- a/Tests/TuistSigningTests/CertificateParserTests.swift
+++ b/Tests/TuistSigningTests/CertificateParserTests.swift
@@ -96,7 +96,7 @@ final class CertificateParserTests: TuistUnitTestCase {
         let publicKey = try temporaryPath().appending(component: "Target.Debug.p12")
         let privateKey = try temporaryPath()
         let subjectOutput =
-            "subject=UID = VD55TKL3V6, CN = \"Apple Development: Name (54GSF6G47V)\", OU = QH95ER52SG, O = Name, C = US"
+            "subject=UID = VD55TKL3V6, CN = \"Apple Development: Name (54GSF6G47V)\", OU = QH95ER52SG, O = \"Name\", C = US"
         system.succeedCommand(
             ["openssl", "x509", "-inform", "der", "-in", publicKey.pathString, "-noout", "-subject"],
             output: subjectOutput

--- a/Tests/TuistSigningTests/CertificateParserTests.swift
+++ b/Tests/TuistSigningTests/CertificateParserTests.swift
@@ -96,7 +96,7 @@ final class CertificateParserTests: TuistUnitTestCase {
         let publicKey = try temporaryPath().appending(component: "Target.Debug.p12")
         let privateKey = try temporaryPath()
         let subjectOutput =
-            "subject=UID = VD55TKL3V6, CN = Apple Development: Name (54GSF6G47V), OU = QH95ER52SG, O = Name, C = US"
+            "subject=UID = VD55TKL3V6, CN = \"Apple Development: Name (54GSF6G47V)\", OU = QH95ER52SG, O = Name, C = US"
         system.succeedCommand(
             ["openssl", "x509", "-inform", "der", "-in", publicKey.pathString, "-noout", "-subject"],
             output: subjectOutput


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4889

### Short description 📝

Add support for certificates that include quotes in the common name

### How to test the changes locally 🧐

- Added unit tests
- Use a mock or certificate with a CN with quotes something like: `subject=UID = VD55TKL3V6, CN = "Apple Development: Name (54GSF6G47V)", OU = QH95ER52SG, O = "Name", C = US`
- Configure tuist signing with that cert
- The `CODE_SIGN_IDENTITY` should be generated without the starting quote

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] The title of the PR will be used as changelog entry, please make sure it is clear and suitable
- [ ] In case the PR introduces changes that affect users, the documentation has been updated
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`
