### PR TITLE
Synthesize SWIFTPM_MODULE_BUNDLE for targets with Objc sources

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -78,7 +78,7 @@ public class ResourcesProjectMapper: ProjectMapping {
             let headerFile = SourceFile(path: headerFilePath, contentHash: headerHash)
             let headerSideEffect = SideEffectDescriptor.file(.init(path: headerFilePath, contents: headerData, state: .present))
 
-            // This is not the right way of making the header being imported globally for this project
+            // FIXME: Is there any better way than GCC_PREFIX_HEADER? And what if the target would have set this already, then we're breakings something here.
             var settings = modifiedTarget.settings?.base ?? SettingsDictionary()
             settings["GCC_PREFIX_HEADER"] = .string(headerFile.path.url.relativePath)
             modifiedTarget.settings = modifiedTarget.settings?.with(base: settings)

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -125,24 +125,6 @@ public class ResourcesProjectMapper: ProjectMapping {
         return (filePath, content.data(using: .utf8))
     }
 
-    static func objcHeaderFileContent(targetName: String, bundleName: String, target: Target) -> String {
-        return """
-        #import <Foundation/Foundation.h>
-
-        #if __cplusplus
-        extern "C" {
-        #endif
-
-        NSBundle* \(targetName)_SWIFTPM_MODULE_BUNDLE(void);
-
-        #define SWIFTPM_MODULE_BUNDLE \(targetName)_SWIFTPM_MODULE_BUNDLE()
-
-        #if __cplusplus
-        }
-        #endif
-        """
-    }
-
     func synthesizedObjcImplementationFile(bundleName: String, target: Target, project: Project) -> (AbsolutePath, Data?) {
         let filePath = project.path
             .appending(component: Constants.DerivedDirectory.name)
@@ -155,17 +137,6 @@ public class ResourcesProjectMapper: ProjectMapping {
             target: target
         )
         return (filePath, content.data(using: .utf8))
-    }
-
-    static func objcImplementationFileContent(targetName: String, bundleName: String, target: Target) -> String {
-        return """
-        #import <Foundation/Foundation.h>
-        #import <\(targetName)/\(targetName)-Swift.h>
-
-        NSBundle* \(targetName)_SWIFTPM_MODULE_BUNDLE(void) {
-            return \(targetName)Resources.bundle;
-        }
-        """
     }
 
     // swiftlint:disable:next function_body_length
@@ -245,5 +216,34 @@ public class ResourcesProjectMapper: ProjectMapping {
 
             """
         }
+    }
+
+    static func objcHeaderFileContent(targetName: String, bundleName: String, target: Target) -> String {
+        return """
+        #import <Foundation/Foundation.h>
+
+        #if __cplusplus
+        extern "C" {
+        #endif
+
+        NSBundle* \(targetName)_SWIFTPM_MODULE_BUNDLE(void);
+
+        #define SWIFTPM_MODULE_BUNDLE \(targetName)_SWIFTPM_MODULE_BUNDLE()
+
+        #if __cplusplus
+        }
+        #endif
+        """
+    }
+
+    static func objcImplementationFileContent(targetName: String, bundleName: String, target: Target) -> String {
+        return """
+        #import <Foundation/Foundation.h>
+        #import <\(targetName)/\(targetName)-Swift.h>
+
+        NSBundle* \(targetName)_SWIFTPM_MODULE_BUNDLE(void) {
+            return \(targetName)Resources.bundle;
+        }
+        """
     }
 }

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -62,7 +62,7 @@ public class ResourcesProjectMapper: ProjectMapping {
         }
 
         if target.supportsSources {
-            let (filePath, data) = synthesizedFile(bundleName: bundleName, target: target, project: project)
+            let (filePath, data) = synthesizedSwiftFile(bundleName: bundleName, target: target, project: project)
 
             let hash = try data.map(contentHasher.hash)
             let sourceFile = SourceFile(path: filePath, contentHash: hash)
@@ -97,7 +97,7 @@ public class ResourcesProjectMapper: ProjectMapping {
         return ([modifiedTarget] + additionalTargets, sideEffects)
     }
 
-    func synthesizedFile(bundleName: String, target: Target, project: Project) -> (AbsolutePath, Data?) {
+    func synthesizedSwiftFile(bundleName: String, target: Target, project: Project) -> (AbsolutePath, Data?) {
         let filePath = synthesizedFilePath(target: target, project: project, fileExtension: "swift")
 
         let content: String = ResourcesProjectMapper.fileContent(

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -80,7 +80,7 @@ public class ResourcesProjectMapper: ProjectMapping {
             let sideEffect = SideEffectDescriptor.file(.init(path: filePath, contents: data, state: .present))
             // This is not the right way of making the header being imported globally for this project
             var settings = modifiedTarget.settings?.base ?? SettingsDictionary()
-            settings["OTHER_CFLAGS"] = .array(["$(inherited)", "-include", sourceFile.path.url.relativePath])
+            settings["GCC_PREFIX_HEADER"] = .string(sourceFile.path.url.relativePath)
             modifiedTarget.settings = modifiedTarget.settings?.with(base: settings)
             // This is probably not needed at all for the header, just leaving it here for now so we can see it in the project tree. Needs to be removed later
             modifiedTarget.sources.append(sourceFile)

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -98,10 +98,7 @@ public class ResourcesProjectMapper: ProjectMapping {
     }
 
     func synthesizedFile(bundleName: String, target: Target, project: Project) -> (AbsolutePath, Data?) {
-        let filePath = project.path
-            .appending(component: Constants.DerivedDirectory.name)
-            .appending(component: Constants.DerivedDirectory.sources)
-            .appending(component: "TuistBundle+\(target.name.camelized.uppercasingFirst).swift")
+        let filePath = synthesizedFilePath(target: target, project: project, fileExtension: "swift")
 
         let content: String = ResourcesProjectMapper.fileContent(
             targetName: target.name,
@@ -112,10 +109,7 @@ public class ResourcesProjectMapper: ProjectMapping {
     }
 
     func synthesizedObjcHeaderFile(bundleName: String, target: Target, project: Project) -> (AbsolutePath, Data?) {
-        let filePath = project.path
-            .appending(component: Constants.DerivedDirectory.name)
-            .appending(component: Constants.DerivedDirectory.sources)
-            .appending(component: "TuistBundle+\(target.name.camelized.uppercasingFirst).h")
+        let filePath = synthesizedFilePath(target: target, project: project, fileExtension: "h")
 
         let content: String = ResourcesProjectMapper.objcHeaderFileContent(
             targetName: target.name,
@@ -126,10 +120,7 @@ public class ResourcesProjectMapper: ProjectMapping {
     }
 
     func synthesizedObjcImplementationFile(bundleName: String, target: Target, project: Project) -> (AbsolutePath, Data?) {
-        let filePath = project.path
-            .appending(component: Constants.DerivedDirectory.name)
-            .appending(component: Constants.DerivedDirectory.sources)
-            .appending(component: "TuistBundle+\(target.name.camelized.uppercasingFirst).m")
+        let filePath = synthesizedFilePath(target: target, project: project, fileExtension: "m")
 
         let content: String = ResourcesProjectMapper.objcImplementationFileContent(
             targetName: target.name,
@@ -137,6 +128,13 @@ public class ResourcesProjectMapper: ProjectMapping {
             target: target
         )
         return (filePath, content.data(using: .utf8))
+    }
+
+    func synthesizedFilePath(target: Target, project: Project, fileExtension: String) -> AbsolutePath {
+        project.path
+            .appending(component: Constants.DerivedDirectory.name)
+            .appending(component: Constants.DerivedDirectory.sources)
+            .appending(component: "TuistBundle+\(target.name.camelized.uppercasingFirst).\(fileExtension)")
     }
 
     // swiftlint:disable:next function_body_length

--- a/Sources/TuistGraph/Models/Target.swift
+++ b/Sources/TuistGraph/Models/Target.swift
@@ -125,6 +125,17 @@ public struct Target: Equatable, Hashable, Comparable, Codable {
         ].contains(product)
     }
 
+    /// Returns true if there's any .m or .mm files in the target
+    public var containsObjcFiles: Bool {
+        let objcExtensions = Set(["m", "mm"])
+        return sources.contains { sourceFile in
+            guard let ext = sourceFile.path.extension else {
+                return false
+            }
+            return objcExtensions.contains(ext)
+        }
+    }
+
     /// Returns true if the target supports having a headers build phase..
     public var shouldIncludeHeadersBuildPhase: Bool {
         switch product {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3785

### Short description 📝

Synthesizes two more files into `Derived/Sources`, next to the already existing `TuistBundle+TargetName.swift`:

* `TuistBundle+TargetName.h`
* `TuistBundle+TargetName.m`

Only if the target contains Objective-C header files. The implementation is trying to mimic what [SPM](https://github.com/apple/swift-package-manager/blob/ce959edd3ad914ca256a7f9ea87cf752b8ce4ada/Sources/Build/BuildPlan.swift#L440-L493) does.

### How to test the changes locally 🧐

You can try to use the attached example app from #3785.

### Checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] The title of the PR will be used as changelog entry, please make sure it is clear and suitable
- [ ] In case the PR introduces changes that affect users, the documentation has been updated
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`
