### PR TITLE
Fix generation of resource accessor for AR reference images

### DIFF
--- a/Sources/TuistGenerator/Templates/AssetsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/AssetsTemplate.swift
@@ -129,7 +129,7 @@ extension SynthesizedResourceInterfaceTemplates {
     @available(iOS 11.3, *)
     {{accessModifier}} extension ARReferenceImage {
       static func referenceImages(in asset: {{arResourceGroupType}}) -> Set<ARReferenceImage> {
-        let bundle = .bundle
+        let bundle = {{bundleToken}}.bundle
         return referenceImages(inGroupNamed: asset.name, bundle: bundle) ?? Set()
       }
     }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY

### Short description 📝

`tuist generate` is preventing the project to compile properly when using an AR resource image from the assets: it does generate a missing context error.

<img width="1008" alt="Screenshot 2022-12-14 at 18 29 45" src="https://user-images.githubusercontent.com/5658984/207666511-223f4f9e-9d7c-436c-8aa7-ac5c48a9aafd.png">


### How to test the changes locally 🧐

1) Add a `AR resource Group` into one of your multi-targets project assets:
 <img width="444" alt="Screenshot 2022-12-14 at 18 33 59" src="https://user-images.githubusercontent.com/5658984/207666803-79522423-4d42-435d-bc07-4cfa6a10ff10.png">

2) `tuist generate`

3) Project should not compile anymore on the `tuist/main` branch whereas it should compile on the `tulleb/fix-bundle-issue` branch.

### Checklist ✅

- [X] The code architecture and patterns are consistent with the rest of the codebase
- [X] The title of the PR will be used as changelog entry, please make sure it is clear and suitable
- [X] In case the PR introduces changes that affect users, the documentation has been updated
- [X] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`
