### PR TITLE
Fix appearance of multiple default buckets

### DIFF
--- a/projects/cloud/app/frontend/components/pages/remote-cache/RemoteCachePageStore.ts
+++ b/projects/cloud/app/frontend/components/pages/remote-cache/RemoteCachePageStore.ts
@@ -156,6 +156,7 @@ class RemoteCachePageStore {
       query: S3BucketsDocument,
       variables: {
         accountName: this.projectStore.project.account.name,
+        projectName: this.projectStore.project.name,
       },
     });
     runInAction(() => {

--- a/projects/cloud/app/frontend/graphql/S3BucketsQuery.graphql
+++ b/projects/cloud/app/frontend/graphql/S3BucketsQuery.graphql
@@ -1,5 +1,5 @@
-query S3Buckets($accountName: String!) {
-  s3Buckets(accountName: $accountName) {
+query S3Buckets($accountName: String!, $projectName: String!) {
+  s3Buckets(accountName: $accountName, projectName: $projectName) {
     ...S3BucketInfo
   }
 }

--- a/projects/cloud/app/frontend/graphql/types.ts
+++ b/projects/cloud/app/frontend/graphql/types.ts
@@ -346,6 +346,7 @@ export type QueryProjectArgs = {
 
 export type QueryS3BucketsArgs = {
   accountName: Scalars['String'];
+  projectName: Scalars['String'];
 };
 
 export type RemoteCacheStorage = S3Bucket;
@@ -567,6 +568,7 @@ export type S3BucketInfoFragment = { __typename?: 'S3Bucket', id: string, name: 
 
 export type S3BucketsQueryVariables = Exact<{
   accountName: Scalars['String'];
+  projectName: Scalars['String'];
 }>;
 
 
@@ -1406,8 +1408,8 @@ export type ResendInviteMutationHookResult = ReturnType<typeof useResendInviteMu
 export type ResendInviteMutationResult = Apollo.MutationResult<ResendInviteMutation>;
 export type ResendInviteMutationOptions = Apollo.BaseMutationOptions<ResendInviteMutation, ResendInviteMutationVariables>;
 export const S3BucketsDocument = gql`
-    query S3Buckets($accountName: String!) {
-  s3Buckets(accountName: $accountName) {
+    query S3Buckets($accountName: String!, $projectName: String!) {
+  s3Buckets(accountName: $accountName, projectName: $projectName) {
     ...S3BucketInfo
   }
 }
@@ -1426,6 +1428,7 @@ export const S3BucketsDocument = gql`
  * const { data, loading, error } = useS3BucketsQuery({
  *   variables: {
  *      accountName: // value for 'accountName'
+ *      projectName: // value for 'projectName'
  *   },
  * });
  */

--- a/projects/cloud/app/graphql/types/query_type.rb
+++ b/projects/cloud/app/graphql/types/query_type.rb
@@ -61,9 +61,10 @@ module Types
     field :s3_buckets, [S3BucketType], null: false,
       description: "Returns S3 buckets for an account of a given name" do
       argument :account_name, String, required: true
+      argument :project_name, String, required: true
     end
-    def s3_buckets(account_name:)
-      S3BucketsFetchService.call(account_name: account_name, user: context[:current_user])
+    def s3_buckets(account_name:, project_name:)
+      S3BucketsFetchService.call(account_name: account_name, project_name: project_name, user: context[:current_user])
     end
 
     field :command_events, CommandEventType.connection_type, null: false,

--- a/projects/cloud/app/services/s3_buckets_fetch_service.rb
+++ b/projects/cloud/app/services/s3_buckets_fetch_service.rb
@@ -15,11 +15,12 @@ class S3BucketsFetchService < ApplicationService
     end
   end
 
-  attr_reader :account_name, :user
+  attr_reader :account_name, :project_name, :user
 
-  def initialize(account_name:, user:)
+  def initialize(account_name:, project_name:, user:)
     super()
     @account_name = account_name
+    @project_name = project_name
     @user = user
   end
 
@@ -27,6 +28,8 @@ class S3BucketsFetchService < ApplicationService
     account = AccountFetchService.call(name: account_name)
     raise Error::Unauthorized.new(account_name) unless AccountPolicy.new(user, account).show?
 
-    account.s3_buckets
+    account.s3_buckets.reject { |s3_bucket|
+      s3_bucket.is_default && s3_bucket.name != "#{account_name}-#{project_name}"
+    }
   end
 end

--- a/projects/cloud/schema.graphql
+++ b/projects/cloud/schema.graphql
@@ -427,7 +427,7 @@ type Query {
   """
   Returns S3 buckets for an account of a given name
   """
-  s3Buckets(accountName: String!): [S3Bucket!]!
+  s3Buckets(accountName: String!, projectName: String!): [S3Bucket!]!
 }
 
 union RemoteCacheStorage = S3Bucket

--- a/projects/cloud/schema.json
+++ b/projects/cloud/schema.json
@@ -2422,6 +2422,22 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "projectName",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {

--- a/projects/cloud/test/services/s3_buckets_fetch_service_test.rb
+++ b/projects/cloud/test/services/s3_buckets_fetch_service_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class S3BucketsFetchServiceTest < ActiveSupport::TestCase
-  test "fetches S3 buckets with a given account name" do
+  test "fetches S3 buckets with a given account name and project name" do
     # Given
     user = User.create!(email: "test@cloud.tuist.io", password: Devise.friendly_token.first(16))
     account = user.account
@@ -19,12 +19,26 @@ class S3BucketsFetchServiceTest < ActiveSupport::TestCase
       secret_access_key: "secret",
       region: "region",
     )
+    s3_bucket_default_one = account.s3_buckets.create!(
+      access_key_id: "2",
+      is_default: true,
+      name: "#{account.name}-project_one",
+      secret_access_key: "secret",
+      region: "region",
+    )
+    account.s3_buckets.create!(
+      access_key_id: "2",
+      is_default: true,
+      name: "#{account.name}-project_two",
+      secret_access_key: "secret",
+      region: "region",
+    )
 
     # When
-    got = S3BucketsFetchService.call(account_name: account.name, user: user)
+    got = S3BucketsFetchService.call(account_name: account.name, project_name: "project_one", user: user)
 
     # Then
-    assert_equal [s3_bucket_one, s3_bucket_two], got
+    assert_equal [s3_bucket_one, s3_bucket_two, s3_bucket_default_one], got
   end
 
   test "fails to fetch S3 buckets if user does not have rights to access them" do
@@ -35,7 +49,7 @@ class S3BucketsFetchServiceTest < ActiveSupport::TestCase
 
     # When / Then
     assert_raises(S3BucketsFetchService::Error::Unauthorized) do
-      S3BucketsFetchService.call(account_name: account.name, user: user)
+      S3BucketsFetchService.call(account_name: account.name, project_name: "project", user: user)
     end
   end
 end


### PR DESCRIPTION
### Short description 📝

Default buckets are created per-project but buckets as a whole are fetched per account. Instead, we should only fetch one default bucket that is tied to the present project. In other words, this select should include only one `Default bucket`:
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/9371695/207681846-0631cc1d-b3ff-43df-a96c-6b751e5c0960.png">