### PR TITLE
Add `TargetDependency.target()` helper accepting a target instance

### DIFF
--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -87,6 +87,14 @@ public enum TargetDependency: Codable, Hashable {
         .sdk(name: name, type: type, status: .required)
     }
 
+    /// Dependency on another target within the same project. This is just syntactic sugar for `.target(name: target.name)`.
+    ///
+    /// - Parameters:
+    ///   - target: Instance of the target to depend on
+    public static func target(_ target: Target) -> TargetDependency {
+        .target(name: target.name)
+    }
+
     public var typeName: String {
         switch self {
         case .target:

--- a/Tests/ProjectDescriptionTests/TargetDependencyTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetDependencyTests.swift
@@ -52,4 +52,10 @@ final class TargetDependencyTests: XCTestCase {
         // Then
         XCTAssertCodable(subject)
     }
+
+    func test_instanceTarget() {
+        let target = Target(name: "Target", platform: .iOS, product: .framework, bundleId: "bundleId")
+        let subject = TargetDependency.target(target)
+        XCTAssertEqual(subject, TargetDependency.target(name: "Target"))
+    }
 }


### PR DESCRIPTION
### Short description 📝

I often find myself to use `.target(name: anotherTarget.name)`, so I think it's worth to provide some syntactic sugar for it so it can be expressed as `.target(anotherTarget)`

### Checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] The title of the PR will be used as changelog entry, please make sure it is clear and suitable
- [x] In case the PR introduces changes that affect users, the documentation has been updated
- [x] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`
