### PR TITLE
Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ Resolves https://github.com/tuist/tuist/issues/YYY
 
 ### Contributor checklist ✅
 
-- [ ] The code has been linted using run `./fourier lint tuist`
+- [ ] The code has been linted using run `./fourier lint tuist --fix`
 - [ ] The change is tested via unit testing or acceptance testing, or both
 - [ ] The title of the PR is formulated in a way that is usable as a changelog entry
 - [ ] In case the PR introduces changes that affect users, the documentation has been updated

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,9 +8,14 @@ Resolves https://github.com/tuist/tuist/issues/YYY
 
 > Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).
 
-### Checklist ✅
+### Contributor checklist ✅
+
+- [ ] The code has been linted using run `./fourier lint tuist`
+- [ ] The change is tested via unit testing or acceptance testing, or both
+- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
+- [ ] In case the PR introduces changes that affect users, the documentation has been updated
+
+### Reviewer checklist ✅
 
 - [ ] The code architecture and patterns are consistent with the rest of the codebase
-- [ ] The title of the PR will be used as changelog entry, please make sure it is clear and suitable
-- [ ] In case the PR introduces changes that affect users, the documentation has been updated
-- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`
+- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry


### PR DESCRIPTION
### Short description 📝

Make clearer which steps are for the contributor and which ones are for the reviewers, and add formatting as contributor step

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
