### PR TITLE
Use newer `Version` initializer to suppress build warnings

### DIFF
--- a/Sources/TuistEnvKit/Commands/CommandRunner.swift
+++ b/Sources/TuistEnvKit/Commands/CommandRunner.swift
@@ -102,7 +102,7 @@ class CommandRunner: CommandRunning {
     }
 
     func runVersion(_ version: String) throws {
-        guard Version(string: version) != nil else {
+        guard Version(version) != nil else {
             logger.error("\(version) is not a valid version")
             exiter(1)
             return

--- a/Sources/TuistEnvKit/Versions/VersionsController.swift
+++ b/Sources/TuistEnvKit/Versions/VersionsController.swift
@@ -57,7 +57,7 @@ class VersionsController: VersionsControlling {
     func versions() -> [InstalledVersion] {
         Environment.shared.versionsDirectory.glob("*").map { path in
             let versionStringValue = path.components.last!
-            if let version = Version(string: versionStringValue) {
+            if let version = Version(versionStringValue) {
                 return InstalledVersion.semver(version)
             } else {
                 return InstalledVersion.reference(versionStringValue)


### PR DESCRIPTION
### Short description 📝

I just noticed some build warnings in the log that could be easily resolved, so I resolved them. A cleaner log is a useful log!

### How to test the changes locally 🧐

1. Run `./fourier generate tuist
2. Note that there are no build warnings mentioning the outdated Version api
    ```
    Sources/TuistEnvKit/Versions/VersionsController.swift:60:30: note: use 'init(_:)' instead
                if let version = Version(string: versionStringValue) {
                                 ^       ~~~~~~~~
    ```

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
