### PR TITLE
[wip] Add support for aria2 command line tool to download cached artifacts

### DIFF
--- a/Sources/TuistCache/Cache/CacheRemoteStorage.swift
+++ b/Sources/TuistCache/Cache/CacheRemoteStorage.swift
@@ -36,12 +36,13 @@ public final class CacheRemoteStorage: CacheStoring {
     public convenience init(
         cloudConfig: Cloud,
         cloudClient: CloudClienting,
+        fileClient: FileClienting,
         cacheDirectoriesProvider: CacheDirectoriesProviding
     ) {
         self.init(
             cloudClient: cloudClient,
             fileArchiverFactory: FileArchivingFactory(),
-            fileClient: FileClient(),
+            fileClient: fileClient,
             cloudCacheResourceFactory: CloudCacheResourceFactory(cloudConfig: cloudConfig),
             cacheDirectoriesProvider: cacheDirectoriesProvider
         )

--- a/Sources/TuistCache/Cache/CacheStorageProviding.swift
+++ b/Sources/TuistCache/Cache/CacheStorageProviding.swift
@@ -4,7 +4,7 @@ import TuistGraph
 
 /// It defines the interface to get the storages that should be used given a config.
 public protocol CacheStorageProviding: AnyObject {
-    init(config: Config)
+    init(config: Config, cacheDownloaderType: CacheDownloaderType)
 
     /// Given a configuration, it returns the storages that should be used.
     func storages() throws -> [CacheStoring]

--- a/Sources/TuistCacheTesting/Cache/Mocks/MockCacheStorageProvider.swift
+++ b/Sources/TuistCacheTesting/Cache/Mocks/MockCacheStorageProvider.swift
@@ -5,7 +5,7 @@ import TuistGraph
 public final class MockCacheStorageProvider: CacheStorageProviding {
     var storagesStub: [CacheStoring]
 
-    public init(config _: Config, cacheDownloaderType: CacheDownloaderType) {
+    public init(config _: Config, cacheDownloaderType _: CacheDownloaderType) {
         storagesStub = []
     }
 

--- a/Sources/TuistCacheTesting/Cache/Mocks/MockCacheStorageProvider.swift
+++ b/Sources/TuistCacheTesting/Cache/Mocks/MockCacheStorageProvider.swift
@@ -1,10 +1,11 @@
 import TuistCache
+import TuistCore
 import TuistGraph
 
 public final class MockCacheStorageProvider: CacheStorageProviding {
     var storagesStub: [CacheStoring]
 
-    public init(config _: Config) {
+    public init(config _: Config, cacheDownloaderType: CacheDownloaderType) {
         storagesStub = []
     }
 

--- a/Sources/TuistCore/Cache/CacheDownloaderType.swift
+++ b/Sources/TuistCore/Cache/CacheDownloaderType.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// An enum that represents the type of downloader that the generate feature can work with.
+public enum CacheDownloaderType {
+    /// aria2 command-line download utility.
+    /// https://github.com/aria2/aria2
+    case aria2c
+    
+    /// Apple's default object to oordinates a group of related, network data transfer tasks.
+    /// https://developer.apple.com/documentation/foundation/urlsession
+    case urlsession
+}

--- a/Sources/TuistCore/Cache/CacheDownloaderType.swift
+++ b/Sources/TuistCore/Cache/CacheDownloaderType.swift
@@ -5,7 +5,7 @@ public enum CacheDownloaderType {
     /// aria2 command-line download utility.
     /// https://github.com/aria2/aria2
     case aria2c
-    
+
     /// Apple's default object to oordinates a group of related, network data transfer tasks.
     /// https://developer.apple.com/documentation/foundation/urlsession
     case urlsession

--- a/Sources/TuistKit/Cache/CacheStorageProvider.swift
+++ b/Sources/TuistKit/Cache/CacheStorageProvider.swift
@@ -90,7 +90,7 @@ final class CacheStorageProvider: CacheStorageProviding {
     }
 }
 
-private extension CacheDownloaderType {
+extension CacheDownloaderType {
     public var client: FileClienting {
         switch self {
         case .aria2c:

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -51,7 +51,7 @@ struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
         help: "Ignore cached targets, and use their sources instead."
     )
     var ignoreCache: Bool = false
-    
+
     @Flag(
         name: [.customShort("a"), .long],
         help: "When passed it uses aria2 to download cached artifacts."

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -51,6 +51,12 @@ struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
         help: "Ignore cached targets, and use their sources instead."
     )
     var ignoreCache: Bool = false
+    
+    @Flag(
+        name: [.customShort("a"), .long],
+        help: "When passed it uses aria2 to download cached artifacts."
+    )
+    var aria2: Bool = false
 
     func run() async throws {
         try await GenerateService().run(
@@ -59,13 +65,15 @@ struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
             noOpen: noOpen,
             xcframeworks: xcframeworks,
             profile: profile,
-            ignoreCache: ignoreCache
+            ignoreCache: ignoreCache,
+            aria2: aria2
         )
         GenerateCommand.analyticsDelegate?.addParameters(
             [
                 "no_open": AnyCodable(noOpen),
                 "xcframeworks": AnyCodable(xcframeworks),
                 "no_cache": AnyCodable(ignoreCache),
+                "aria2": AnyCodable(aria2),
                 "n_targets": AnyCodable(sources.count),
                 "cacheable_targets": AnyCodable(CacheAnalytics.cacheableTargets),
                 "local_cache_target_hits": AnyCodable(CacheAnalytics.localCacheTargetsHits),

--- a/Sources/TuistKit/Generator/GeneratorFactory.swift
+++ b/Sources/TuistKit/Generator/GeneratorFactory.swift
@@ -16,13 +16,15 @@ protocol GeneratorFactorying {
     /// - Parameter xcframeworks: Whether targets should be cached as xcframeworks.
     /// - Parameter cacheProfile: The caching profile.
     /// - Parameter ignoreCache: True to not include binaries from the cache.
+    /// - Parameter aria2: True to download cached artifacts using aria2.
     /// - Returns: The generator for focused projects.
     func focus(
         config: Config,
         sources: Set<String>,
         xcframeworks: Bool,
         cacheProfile: TuistGraph.Cache.Profile,
-        ignoreCache: Bool
+        ignoreCache: Bool,
+        aria2: Bool
     ) -> Generating
 
     /// Returns the generator to generate a project to run tests on.
@@ -70,7 +72,8 @@ class GeneratorFactory: GeneratorFactorying {
         sources: Set<String>,
         xcframeworks: Bool,
         cacheProfile: TuistGraph.Cache.Profile,
-        ignoreCache: Bool
+        ignoreCache: Bool,
+        aria2: Bool
     ) -> Generating {
         let contentHasher = ContentHasher()
         let projectMapperFactory = ProjectMapperFactory(contentHasher: contentHasher)
@@ -83,7 +86,8 @@ class GeneratorFactory: GeneratorFactorying {
             cache: !ignoreCache,
             cacheSources: sources,
             cacheProfile: cacheProfile,
-            cacheOutputType: xcframeworks ? .xcframework : .framework
+            cacheOutputType: xcframeworks ? .xcframework : .framework,
+            cacheDownloaderType: aria2 ? .aria2c : .urlsession
         )
         let workspaceMappers = workspaceMapperFactory.default()
         let manifestLoader = ManifestLoaderFactory().createManifestLoader()
@@ -144,7 +148,8 @@ class GeneratorFactory: GeneratorFactorying {
                 cache: true,
                 cacheSources: focusedTargets,
                 cacheProfile: cacheProfile,
-                cacheOutputType: xcframeworks ? .xcframework : .framework
+                cacheOutputType: xcframeworks ? .xcframework : .framework,
+                cacheDownloaderType: .urlsession
             ) + graphMapperFactory.cache(includedTargets: includedTargets)
         } else {
             graphMappers = graphMapperFactory.cache(includedTargets: includedTargets)

--- a/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
+++ b/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
@@ -22,7 +22,8 @@ protocol GraphMapperFactorying {
         cache: Bool,
         cacheSources: Set<String>,
         cacheProfile: TuistGraph.Cache.Profile,
-        cacheOutputType: CacheOutputType
+        cacheOutputType: CacheOutputType,
+        cacheDownloaderType: CacheDownloaderType
     ) -> [GraphMapping]
 
     /// Returns the graph mapper whose output project is a cacheable graph.
@@ -57,7 +58,8 @@ final class GraphMapperFactory: GraphMapperFactorying {
         cache: Bool,
         cacheSources: Set<String>,
         cacheProfile: TuistGraph.Cache.Profile,
-        cacheOutputType: CacheOutputType
+        cacheOutputType: CacheOutputType,
+        cacheDownloaderType: CacheDownloaderType
     ) -> [GraphMapping] {
         var mappers: [GraphMapping] = []
         mappers.append(FocusTargetsGraphMappers(includedTargets: cacheSources))
@@ -65,7 +67,7 @@ final class GraphMapperFactory: GraphMapperFactorying {
         if cache {
             let focusTargetsGraphMapper = TargetsToCacheBinariesGraphMapper(
                 config: config,
-                cacheStorageProvider: CacheStorageProvider(config: config),
+                cacheStorageProvider: CacheStorageProvider(config: config, cacheDownloaderType: cacheDownloaderType),
                 sources: cacheSources,
                 cacheProfile: cacheProfile,
                 cacheOutputType: cacheOutputType

--- a/Sources/TuistKit/Services/GenerateService.swift
+++ b/Sources/TuistKit/Services/GenerateService.swift
@@ -41,7 +41,8 @@ final class GenerateService {
         noOpen: Bool,
         xcframeworks: Bool,
         profile: String?,
-        ignoreCache: Bool
+        ignoreCache: Bool,
+        aria2: Bool
     ) async throws {
         let timer = clock.startTimer()
         let path = self.path(path)
@@ -52,7 +53,8 @@ final class GenerateService {
             sources: sources,
             xcframeworks: xcframeworks,
             cacheProfile: cacheProfile,
-            ignoreCache: ignoreCache
+            ignoreCache: ignoreCache,
+            aria2: aria2
         )
         let workspacePath = try await generator.generate(path: path)
         if !noOpen {

--- a/Sources/TuistSupport/HTTP/Aria2Client.swift
+++ b/Sources/TuistSupport/HTTP/Aria2Client.swift
@@ -1,0 +1,86 @@
+import Combine
+import Foundation
+import TSCBasic
+
+public class Aria2Client: FileClienting {
+    
+    // MARK: - Attributes
+
+    /// Fallback `FileClienting` implementation to provide functionalities aria2 does not support.
+    private let fileClient: FileClienting
+
+    // MARK: - Init
+
+    public init(fileClient: FileClienting = FileClient()) {
+        self.fileClient = fileClient
+    }
+
+    // MARK: - Public
+
+    public func download(url: URL) async throws -> AbsolutePath {
+        let request = URLRequest(url: url)
+        let localUrl = try await downloadWithAria2(for: request)
+        return AbsolutePath(localUrl.path)
+    }
+
+    public func upload(file: AbsolutePath, hash: String, to url: URL) async throws -> Bool {
+        try await fileClient.upload(file: file, hash: hash, to: url)
+    }
+
+    // MARK: - Private
+    
+    private func aria2Path() throws -> String {
+        try System.shared.which("aria2c")
+    }
+    
+    private func downloadWithAria2(for request: URLRequest) async throws -> URL {
+        guard let url = request.url else {
+            throw FileClientError.invalidResponse(request, nil)
+        }
+        
+        // Random filename to avoid name collisions
+        let filename = url.lastPathComponent.appending("-\(UUID().uuidString)")
+        let storePath = AbsolutePath(FileManager.default.temporaryDirectory.appendingPathComponent(filename).path)
+        
+        var command = [try aria2Path()]
+        
+        // Maximum number of connections to one server for each download.
+        command.append("--max-connection-per-server=16")
+        
+        // Download the file using 16 connections.
+        command.append("--split=16")
+        
+        // Interval in seconds to output download progress summary.
+        command.append("--summary-interval=0")
+        
+        // Stop application when process is not running
+        command.append("--stop-with-process=\(ProcessInfo.processInfo.processIdentifier)")
+        
+        // Directory to store the downloaded file.
+        command.append("--dir=\(storePath.parentDirectory.pathString)")
+        
+        // File name of the downloaded file
+        command.append("--out=\(storePath.basename)")
+        
+        // URI to download
+        command.append(url.absoluteString)
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            cancellable = System.shared.publisher(command)
+            .mapToString()
+            .collectAndMergeOutput()
+            .sink { result in
+                switch result {
+                case .finished:
+                    break
+                case let .failure(error):
+                    continuation.resume(throwing: error)
+                }
+                cancellable?.cancel()
+            } receiveValue: { value in
+                continuation.resume(with: .success(storePath.url))
+            }
+        }
+    }
+}

--- a/Sources/TuistSupport/HTTP/Aria2Client.swift
+++ b/Sources/TuistSupport/HTTP/Aria2Client.swift
@@ -3,7 +3,6 @@ import Foundation
 import TSCBasic
 
 public class Aria2Client: FileClienting {
-    
     // MARK: - Attributes
 
     /// Fallback `FileClienting` implementation to provide functionalities aria2 does not support.
@@ -28,59 +27,59 @@ public class Aria2Client: FileClienting {
     }
 
     // MARK: - Private
-    
+
     private func aria2Path() throws -> String {
         try System.shared.which("aria2c")
     }
-    
+
     private func downloadWithAria2(for request: URLRequest) async throws -> URL {
         guard let url = request.url else {
             throw FileClientError.invalidResponse(request, nil)
         }
-        
+
         // Random filename to avoid name collisions
         let filename = url.lastPathComponent.appending("-\(UUID().uuidString)")
         let storePath = AbsolutePath(FileManager.default.temporaryDirectory.appendingPathComponent(filename).path)
-        
+
         var command = [try aria2Path()]
-        
+
         // Maximum number of connections to one server for each download.
         command.append("--max-connection-per-server=16")
-        
+
         // Download the file using 16 connections.
         command.append("--split=16")
-        
+
         // Interval in seconds to output download progress summary.
         command.append("--summary-interval=0")
-        
+
         // Stop application when process is not running
         command.append("--stop-with-process=\(ProcessInfo.processInfo.processIdentifier)")
-        
+
         // Directory to store the downloaded file.
         command.append("--dir=\(storePath.parentDirectory.pathString)")
-        
+
         // File name of the downloaded file
         command.append("--out=\(storePath.basename)")
-        
+
         // URI to download
         command.append(url.absoluteString)
-        
+
         return try await withCheckedThrowingContinuation { continuation in
             var cancellable: AnyCancellable?
             cancellable = System.shared.publisher(command)
-            .mapToString()
-            .collectAndMergeOutput()
-            .sink { result in
-                switch result {
-                case .finished:
-                    break
-                case let .failure(error):
-                    continuation.resume(throwing: error)
+                .mapToString()
+                .collectAndMergeOutput()
+                .sink { result in
+                    switch result {
+                    case .finished:
+                        break
+                    case let .failure(error):
+                        continuation.resume(throwing: error)
+                    }
+                    cancellable?.cancel()
+                } receiveValue: { _ in
+                    continuation.resume(with: .success(storePath.url))
                 }
-                cancellable?.cancel()
-            } receiveValue: { value in
-                continuation.resume(with: .success(storePath.url))
-            }
         }
     }
 }

--- a/Tests/TuistCacheTests/Mappers/Graph/TargetsToCacheBinariesGraphMapperTests.swift
+++ b/Tests/TuistCacheTests/Mappers/Graph/TargetsToCacheBinariesGraphMapperTests.swift
@@ -20,7 +20,7 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
     override func setUp() {
         super.setUp()
         config = .test()
-        cacheStorageProvider = MockCacheStorageProvider(config: config)
+        cacheStorageProvider = MockCacheStorageProvider(config: config, cacheDownloaderType: .urlsession)
         cacheFactory = MockCacheFactory()
         cacheGraphContentHasher = MockCacheGraphContentHasher()
         cacheGraphMutator = MockCacheGraphMutator()

--- a/Tests/TuistKitTests/Cache/CacheStorageProviderTests.swift
+++ b/Tests/TuistKitTests/Cache/CacheStorageProviderTests.swift
@@ -1,6 +1,7 @@
 import TuistCache
 import TuistCloud
 import TuistCloudTesting
+import TuistCore
 import TuistCoreTesting
 import TuistGraphTesting
 import TuistSupportTesting
@@ -9,6 +10,7 @@ import XCTest
 
 final class CacheStorageProviderTests: TuistUnitTestCase {
     private var subject: CacheStorageProvider!
+    private var cacheDownloaderType: CacheDownloaderType = .urlsession
     private var cacheDirectoryProviderFactory: MockCacheDirectoriesProviderFactory!
     private var cloudAuthenticationController: MockCloudAuthenticationController!
 
@@ -18,6 +20,7 @@ final class CacheStorageProviderTests: TuistUnitTestCase {
         cloudAuthenticationController = MockCloudAuthenticationController()
         subject = CacheStorageProvider(
             config: .test(),
+            cacheDownloaderType: cacheDownloaderType,
             cacheDirectoryProviderFactory: cacheDirectoryProviderFactory,
             cloudAuthenticationController: cloudAuthenticationController
         )
@@ -35,6 +38,7 @@ final class CacheStorageProviderTests: TuistUnitTestCase {
         // Given
         subject = CacheStorageProvider(
             config: .test(cloud: .test(options: [])),
+            cacheDownloaderType: cacheDownloaderType,
             cacheDirectoryProviderFactory: cacheDirectoryProviderFactory,
             cloudAuthenticationController: cloudAuthenticationController
         )
@@ -54,6 +58,7 @@ final class CacheStorageProviderTests: TuistUnitTestCase {
         // Given
         subject = CacheStorageProvider(
             config: .test(cloud: .test(options: [])),
+            cacheDownloaderType: cacheDownloaderType,
             cacheDirectoryProviderFactory: cacheDirectoryProviderFactory,
             cloudAuthenticationController: cloudAuthenticationController
         )
@@ -72,6 +77,7 @@ final class CacheStorageProviderTests: TuistUnitTestCase {
         // Given
         subject = CacheStorageProvider(
             config: .test(cloud: .test(options: [.optional])),
+            cacheDownloaderType: cacheDownloaderType,
             cacheDirectoryProviderFactory: cacheDirectoryProviderFactory,
             cloudAuthenticationController: cloudAuthenticationController
         )
@@ -94,6 +100,7 @@ final class CacheStorageProviderTests: TuistUnitTestCase {
         // Given
         subject = CacheStorageProvider(
             config: .test(cloud: nil),
+            cacheDownloaderType: cacheDownloaderType,
             cacheDirectoryProviderFactory: cacheDirectoryProviderFactory,
             cloudAuthenticationController: cloudAuthenticationController
         )

--- a/Tests/TuistKitTests/Generator/Mocks/MockGeneratorFactory.swift
+++ b/Tests/TuistKitTests/Generator/Mocks/MockGeneratorFactory.swift
@@ -12,10 +12,11 @@ final class MockGeneratorFactory: GeneratorFactorying {
         sources: Set<String>,
         xcframeworks: Bool,
         cacheProfile: TuistGraph.Cache.Profile,
-        ignoreCache: Bool
+        ignoreCache: Bool,
+        aria2: Bool
     )?
     var invokedFocusParametersList =
-        [(config: Config, sources: Set<String>, xcframeworks: Bool, cacheProfile: TuistGraph.Cache.Profile, ignoreCache: Bool)]()
+    [(config: Config, sources: Set<String>, xcframeworks: Bool, cacheProfile: TuistGraph.Cache.Profile, ignoreCache: Bool, aria2: Bool)]()
     var stubbedFocusResult: Generating!
 
     func focus(
@@ -23,12 +24,13 @@ final class MockGeneratorFactory: GeneratorFactorying {
         sources: Set<String>,
         xcframeworks: Bool,
         cacheProfile: TuistGraph.Cache.Profile,
-        ignoreCache: Bool
+        ignoreCache: Bool,
+        aria2: Bool
     ) -> Generating {
         invokedFocus = true
         invokedFocusCount += 1
-        invokedFocusParameters = (config, sources, xcframeworks, cacheProfile, ignoreCache)
-        invokedFocusParametersList.append((config, sources, xcframeworks, cacheProfile, ignoreCache))
+        invokedFocusParameters = (config, sources, xcframeworks, cacheProfile, ignoreCache, aria2)
+        invokedFocusParametersList.append((config, sources, xcframeworks, cacheProfile, ignoreCache, aria2))
         return stubbedFocusResult
     }
 

--- a/Tests/TuistKitTests/Generator/Mocks/MockGeneratorFactory.swift
+++ b/Tests/TuistKitTests/Generator/Mocks/MockGeneratorFactory.swift
@@ -16,7 +16,14 @@ final class MockGeneratorFactory: GeneratorFactorying {
         aria2: Bool
     )?
     var invokedFocusParametersList =
-    [(config: Config, sources: Set<String>, xcframeworks: Bool, cacheProfile: TuistGraph.Cache.Profile, ignoreCache: Bool, aria2: Bool)]()
+        [(
+            config: Config,
+            sources: Set<String>,
+            xcframeworks: Bool,
+            cacheProfile: TuistGraph.Cache.Profile,
+            ignoreCache: Bool,
+            aria2: Bool
+        )]()
     var stubbedFocusResult: Generating!
 
     func focus(

--- a/Tests/TuistKitTests/Mappers/Factories/GraphMapperFactoryTests.swift
+++ b/Tests/TuistKitTests/Mappers/Factories/GraphMapperFactoryTests.swift
@@ -62,6 +62,7 @@ final class GraphMapperFactoryTests: TuistUnitTestCase {
         let cacheSources = Set(["MyTarget"])
         let cacheProfile = Cache.Profile.test()
         let cacheOutputType = CacheOutputType.framework
+        let cacheDownloaderType = CacheDownloaderType.urlsession
 
         // When
         let got = subject.focus(
@@ -69,7 +70,8 @@ final class GraphMapperFactoryTests: TuistUnitTestCase {
             cache: true,
             cacheSources: cacheSources,
             cacheProfile: cacheProfile,
-            cacheOutputType: cacheOutputType
+            cacheOutputType: cacheOutputType,
+            cacheDownloaderType: cacheDownloaderType
         )
 
         // Then
@@ -83,6 +85,7 @@ final class GraphMapperFactoryTests: TuistUnitTestCase {
         let cacheSources = Set(["MyTarget"])
         let cacheProfile = Cache.Profile.test()
         let cacheOutputType = CacheOutputType.framework
+        let cacheDownloaderType = CacheDownloaderType.urlsession
 
         // When
         let got = subject.focus(
@@ -90,7 +93,8 @@ final class GraphMapperFactoryTests: TuistUnitTestCase {
             cache: true,
             cacheSources: cacheSources,
             cacheProfile: cacheProfile,
-            cacheOutputType: cacheOutputType
+            cacheOutputType: cacheOutputType,
+            cacheDownloaderType: cacheDownloaderType
         )
 
         // Then
@@ -104,6 +108,7 @@ final class GraphMapperFactoryTests: TuistUnitTestCase {
         let cacheSources = Set(["MyTarget"])
         let cacheProfile = Cache.Profile.test()
         let cacheOutputType = CacheOutputType.framework
+        let cacheDownloaderType = CacheDownloaderType.urlsession
 
         // When
         let got = subject.focus(
@@ -111,7 +116,8 @@ final class GraphMapperFactoryTests: TuistUnitTestCase {
             cache: true,
             cacheSources: cacheSources,
             cacheProfile: cacheProfile,
-            cacheOutputType: cacheOutputType
+            cacheOutputType: cacheOutputType,
+            cacheDownloaderType: cacheDownloaderType
         )
 
         // Then

--- a/Tests/TuistKitTests/Services/GenerateServiceTests.swift
+++ b/Tests/TuistKitTests/Services/GenerateServiceTests.swift
@@ -51,7 +51,15 @@ final class GenerateServiceTests: TuistUnitTestCase {
 
         do {
             try await subject
-                .run(path: nil, sources: ["Target"], noOpen: true, xcframeworks: false, profile: nil, ignoreCache: false, aria2: false)
+                .run(
+                    path: nil,
+                    sources: ["Target"],
+                    noOpen: true,
+                    xcframeworks: false,
+                    profile: nil,
+                    ignoreCache: false,
+                    aria2: false
+                )
             XCTFail("Must throw")
         } catch {
             XCTAssertEqual(error as NSError?, expectedError)

--- a/Tests/TuistKitTests/Services/GenerateServiceTests.swift
+++ b/Tests/TuistKitTests/Services/GenerateServiceTests.swift
@@ -51,7 +51,7 @@ final class GenerateServiceTests: TuistUnitTestCase {
 
         do {
             try await subject
-                .run(path: nil, sources: ["Target"], noOpen: true, xcframeworks: false, profile: nil, ignoreCache: false)
+                .run(path: nil, sources: ["Target"], noOpen: true, xcframeworks: false, profile: nil, ignoreCache: false, aria2: false)
             XCTFail("Must throw")
         } catch {
             XCTAssertEqual(error as NSError?, expectedError)
@@ -71,7 +71,8 @@ final class GenerateServiceTests: TuistUnitTestCase {
             noOpen: false,
             xcframeworks: false,
             profile: nil,
-            ignoreCache: false
+            ignoreCache: false,
+            aria2: false
         )
 
         XCTAssertEqual(opener.openArgs.last?.0, workspacePath.pathString)
@@ -96,7 +97,8 @@ final class GenerateServiceTests: TuistUnitTestCase {
             noOpen: false,
             xcframeworks: false,
             profile: nil,
-            ignoreCache: false
+            ignoreCache: false,
+            aria2: false
         )
 
         // Then


### PR DESCRIPTION
Related issue: https://github.com/tuist/tuist/issues/4556
Related comment: https://github.com/tuist/tuist/issues/4556#issuecomment-1213154001

### Short description 📝

Adds support for aria2 to download cached artifacts improving speed and reliability compared to apple's URLSession.

This a work in progress PR as I'd like to gather feedback about what's the best way to approach this and even if this addition make sense for tuist. 

Of course this can be fully tested (following below section steps) and from my tests, aria2 is bit faster and reliable that URLSession. I'm preparing a full range of tests to back up my assertions comparing gains versus URLSession so stay tuned for that.

### How to test the changes locally 🧐

- Install aria2 through brew:
> brew install aria2

- Prepare a project with remote cache configured.
- Run `tuist generate` adding `--aria2` or `-a`.

### Contributor checklist ✅

- [X] The code has been linted using run `./fourier lint tuist --fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [X] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
