### PR TITLE
Add string prefix for new cloud buckets

### DIFF
--- a/projects/cloud/app/services/project_create_service.rb
+++ b/projects/cloud/app/services/project_create_service.rb
@@ -47,7 +47,7 @@ class ProjectCreateService < ApplicationService
   end
 
   def create_s3_bucket(project, organization)
-    # A string prefix is added as the bucket name must be unique across the whole AWS and not just across the tuist AWS account itself.
+    # A prefix is added as the bucket name must be unique across the whole AWS and not just across the tuist one.
     s3_bucket_name = "95bb0f482d8e70cc5-#{project.account.name}-#{name}"
     s3_client.create_bucket(bucket: s3_bucket_name)
     s3_bucket = S3BucketCreateService.call(

--- a/projects/cloud/app/services/project_create_service.rb
+++ b/projects/cloud/app/services/project_create_service.rb
@@ -47,7 +47,8 @@ class ProjectCreateService < ApplicationService
   end
 
   def create_s3_bucket(project, organization)
-    s3_bucket_name = "#{project.account.name}-#{name}"
+    # A string prefix is added as the bucket name must be unique across the whole AWS and not just across the tuist AWS account itself.
+    s3_bucket_name = "95bb0f482d8e70cc5-#{project.account.name}-#{name}"
     s3_client.create_bucket(bucket: s3_bucket_name)
     s3_bucket = S3BucketCreateService.call(
       name: s3_bucket_name,

--- a/projects/cloud/test/services/project_create_service_test.rb
+++ b/projects/cloud/test/services/project_create_service_test.rb
@@ -20,7 +20,7 @@ class ProjectCreateServiceTest < ActiveSupport::TestCase
     # Then
     assert_equal project_name, got.name
     assert_equal account, got.account
-    assert_equal "#{account.name}-#{project_name}", got.remote_cache_storage.name
+    assert_equal "95bb0f482d8e70cc5-#{account.name}-#{project_name}", got.remote_cache_storage.name
     assert_equal true, got.remote_cache_storage.is_default
   end
 


### PR DESCRIPTION
### Short description 📝

A bucket name must be unique across whole AWS. For the default bucket, we can decrease the likelihood by prepending a random string.
