### PR TITLE
Fix typo in swiftObjcBridingHeaderPath

### DIFF
--- a/Sources/ProjectDescription/SettingsTransformers.swift
+++ b/Sources/ProjectDescription/SettingsTransformers.swift
@@ -136,7 +136,7 @@ extension SettingsDictionary {
     // MARK: - Swift Compiler - General
 
     /// Sets `"SWIFT_OBJC_BRIDGING_HEADER"` to `path`
-    public func swiftObjcBridingHeaderPath(_ path: String) -> SettingsDictionary {
+    public func swiftObjcBridgingHeaderPath(_ path: String) -> SettingsDictionary {
         var settings = self
         settings["SWIFT_OBJC_BRIDGING_HEADER"] = SettingValue(path)
         return settings
@@ -168,5 +168,12 @@ extension SettingsDictionary {
     /// Sets `"DEBUG_INFORMATION_FORMAT"`to `"dwarf"` or `"dwarf-with-dsym"`
     public func debugInformationFormat(_ format: DebugInformationFormat) -> SettingsDictionary {
         merging(["DEBUG_INFORMATION_FORMAT": SettingValue(format)])
+    }
+}
+
+extension SettingsDictionary {
+    @available(*, deprecated, renamed: "swiftObjcBridgingHeaderPath")
+    public func swiftObjcBridingHeaderPath(_ path: String) -> SettingsDictionary {
+        swiftObjcBridgingHeaderPath(path)
     }
 }

--- a/Tests/ProjectDescriptionTests/SettingsTests.swift
+++ b/Tests/ProjectDescriptionTests/SettingsTests.swift
@@ -99,7 +99,7 @@ final class SettingsTests: XCTestCase {
             .bitcodeEnabled(true)
             .debugInformationFormat(.dwarf)
             .swiftActiveCompilationConditions("FIRST", "SECOND", "THIRD")
-            .swiftObjcBridingHeaderPath("/my/briding/header/path.h")
+            .swiftObjcBridgingHeaderPath("/my/bridging/header/path.h")
             .otherCFlags(["$(inherited)", "-my-c-flag"])
             .otherLinkerFlags(["$(inherited)", "-my-linker-flag"])
 
@@ -119,7 +119,7 @@ final class SettingsTests: XCTestCase {
             "ENABLE_BITCODE": "YES",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "FIRST SECOND THIRD",
-            "SWIFT_OBJC_BRIDGING_HEADER": "/my/briding/header/path.h",
+            "SWIFT_OBJC_BRIDGING_HEADER": "/my/bridging/header/path.h",
             "OTHER_CFLAGS": ["$(inherited)", "-my-c-flag"],
             "OTHER_LDFLAGS": ["$(inherited)", "-my-linker-flag"],
         ])
@@ -198,14 +198,14 @@ final class SettingsTests: XCTestCase {
         ])
     }
 
-    func test_settingsDictionary_swiftObjcBridingHeaderPath() {
+    func test_settingsDictionary_swiftObjcBridgingHeaderPath() {
         /// Given/When
         let settings = SettingsDictionary()
-            .swiftObjcBridingHeaderPath("/my/briding/header/path.h")
+            .swiftObjcBridgingHeaderPath("/my/bridging/header/path.h")
 
         /// Then
         XCTAssertEqual(settings, [
-            "SWIFT_OBJC_BRIDGING_HEADER": "/my/briding/header/path.h",
+            "SWIFT_OBJC_BRIDGING_HEADER": "/my/bridging/header/path.h",
         ])
     }
 


### PR DESCRIPTION
### Short description 📝

Just fixed typo in swiftObjcBridingHeaderPath and added backward-compatible method not to break any client code.

### How to test the changes locally 🧐

Run existing tests suite

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
