### PR TITLE
Support for period (`.`) character in `Target.productName`

### DIFF
--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -75,7 +75,7 @@ class TargetLinter: TargetLinting {
 
         if target.productName.unicodeScalars.allSatisfy(allowed.contains) == false {
             let reason =
-                "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9) and underscore (_) characters."
+                "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), period (.), and underscore (_) characters."
 
             return [LintingIssue(reason: reason, severity: .warning)]
         }

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -78,8 +78,9 @@ class TargetLinter: TargetLinting {
         }
         
         if target.productName.unicodeScalars.allSatisfy(allowed.contains) == false {
-            let reason =
-                "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), period (.), and underscore (_) characters."
+            let reason = target.product == .app ?
+                "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), period (.), and underscore (_) characters." :
+                "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), and underscore (_) characters."
 
             return [LintingIssue(reason: reason, severity: .warning)]
         }

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -71,8 +71,12 @@ class TargetLinter: TargetLinting {
     }
 
     private func lintProductName(target: Target) -> [LintingIssue] {
-        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.")
+        var allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
 
+        if target.product == .app {
+            allowed.formUnion(CharacterSet(charactersIn: "."))
+        }
+        
         if target.productName.unicodeScalars.allSatisfy(allowed.contains) == false {
             let reason =
                 "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), period (.), and underscore (_) characters."

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -76,7 +76,7 @@ class TargetLinter: TargetLinting {
         if target.product == .app {
             allowed.formUnion(CharacterSet(charactersIn: "."))
         }
-        
+
         if target.productName.unicodeScalars.allSatisfy(allowed.contains) == false {
             let reason = target.product == .app ?
                 "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), period (.), and underscore (_) characters." :

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -71,7 +71,7 @@ class TargetLinter: TargetLinting {
     }
 
     private func lintProductName(target: Target) -> [LintingIssue] {
-        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.")
 
         if target.productName.unicodeScalars.allSatisfy(allowed.contains) == false {
             let reason =

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -35,11 +35,11 @@ final class TargetLinterTests: TuistUnitTestCase {
             let got = self.subject.lint(target: target)
             XCTAssertNil(got.first(where: { $0.description.contains("Invalid product name") }))
         }
-        
+
         XCTAssertValidProductNameApp(Target.test(product: .app, productName: "MyApp.iOS"))
         XCTAssertValidProductNameApp(Target.test(productName: "MyFramework_iOS"))
         XCTAssertValidProductNameApp(Target.test(productName: "MyFramework"))
-        
+
         XCTAssertInvalidProductNameApp(Target.test(product: .framework, productName: "MyFramework.iOS"))
         XCTAssertInvalidProductNameApp(Target.test(productName: "MyFramework-iOS"))
         XCTAssertInvalidProductNameApp(Target.test(productName: "ⅫFramework"))

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -23,27 +23,29 @@ final class TargetLinterTests: TuistUnitTestCase {
     }
 
     func test_lint_when_target_has_invalid_product_name() {
-        let XCTAssertInvalidProductName: (String) -> Void = { productName in
-            let target = Target.test(productName: productName)
+        let XCTAssertInvalidProductNameApp: (Target) -> Void = { target in
             let got = self.subject.lint(target: target)
-            let reason =
-                "Invalid product name '\(productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), period (.), and underscore (_) characters."
+            let reason = target.product == .app ?
+                "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), period (.), and underscore (_) characters." :
+                "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), and underscore (_) characters."
             self.XCTContainsLintingIssue(got, LintingIssue(reason: reason, severity: .warning))
         }
 
-        let XCTAssertValidProductName: (String) -> Void = { bundleId in
-            let target = Target.test(bundleId: bundleId)
+        let XCTAssertValidProductNameApp: (Target) -> Void = { target in
             let got = self.subject.lint(target: target)
             XCTAssertNil(got.first(where: { $0.description.contains("Invalid product name") }))
         }
-
-        XCTAssertValidProductName("MyFramework")
-        XCTAssertValidProductName("MyFramework_iOS")
-        XCTAssertValidProductName("MyFramework.iOS")
-
-        XCTAssertInvalidProductName("MyFramework-iOS")
-        XCTAssertInvalidProductName("ⅫFramework")
-        XCTAssertInvalidProductName("ؼFramework")
+        
+        XCTAssertValidProductNameApp(Target.test(product: .app, productName: "MyApp.iOS"))
+        XCTAssertValidProductNameApp(Target.test(productName: "MyFramework_iOS"))
+        XCTAssertValidProductNameApp(Target.test(productName: "MyFramework"))
+        
+        XCTAssertInvalidProductNameApp(Target.test(product: .framework, productName: "MyFramework.iOS"))
+        XCTAssertInvalidProductNameApp(Target.test(productName: "MyFramework-iOS"))
+        XCTAssertInvalidProductNameApp(Target.test(productName: "ⅫFramework"))
+        XCTAssertInvalidProductNameApp(Target.test(productName: "ؼFramework"))
+        
+        
     }
 
     func test_lint_when_target_has_invalid_bundle_identifier() {

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -37,12 +37,13 @@ final class TargetLinterTests: TuistUnitTestCase {
             XCTAssertNil(got.first(where: { $0.description.contains("Invalid product name") }))
         }
 
+        XCTAssertValidProductName("MyFramework")
+        XCTAssertValidProductName("MyFramework_iOS")
+        XCTAssertValidProductName("MyFramework.iOS")
+
         XCTAssertInvalidProductName("MyFramework-iOS")
-        XCTAssertInvalidProductName("My.Framework")
         XCTAssertInvalidProductName("ⅫFramework")
         XCTAssertInvalidProductName("ؼFramework")
-        XCTAssertValidProductName("MyFramework_iOS")
-        XCTAssertValidProductName("MyFramework")
     }
 
     func test_lint_when_target_has_invalid_bundle_identifier() {

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -27,7 +27,7 @@ final class TargetLinterTests: TuistUnitTestCase {
             let target = Target.test(productName: productName)
             let got = self.subject.lint(target: target)
             let reason =
-                "Invalid product name '\(productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9) and underscore (_) characters."
+                "Invalid product name '\(productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), period (.), and underscore (_) characters."
             self.XCTContainsLintingIssue(got, LintingIssue(reason: reason, severity: .warning))
         }
 

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -44,8 +44,6 @@ final class TargetLinterTests: TuistUnitTestCase {
         XCTAssertInvalidProductNameApp(Target.test(productName: "MyFramework-iOS"))
         XCTAssertInvalidProductNameApp(Target.test(productName: "ⅫFramework"))
         XCTAssertInvalidProductNameApp(Target.test(productName: "ؼFramework"))
-        
-        
     }
 
     func test_lint_when_target_has_invalid_bundle_identifier() {


### PR DESCRIPTION
### Short description 📝

This adds period characters to the list of allowed characters for `productName`.

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
