### PR TITLE
Fix SwiftPackageManagerDependencies init parameter documentation

### DIFF
--- a/Sources/ProjectDescription/Dependencies/SwiftPackageManagerDependencies.swift
+++ b/Sources/ProjectDescription/Dependencies/SwiftPackageManagerDependencies.swift
@@ -34,7 +34,7 @@ public struct SwiftPackageManagerDependencies: Codable, Equatable {
     /// - Parameter productTypes: The custom `Product` types to be used for SPM targets.
     /// - Parameter baseSettings: Additional settings to be added to targets generated from SwiftPackageManager.
     /// - Parameter targetSettings: Additional settings to be added to targets generated from SwiftPackageManager.
-    /// - Parameter generationOptions: Custom project configurations to be used for projects generated from SwiftPackageManager.
+    /// - Parameter projectOptions: Custom project configurations to be used for projects generated from SwiftPackageManager.
 
     public init(
         _ packages: [Package],

--- a/Sources/TuistGraph/Models/Dependencies/SwiftPackageManagerDependencies.swift
+++ b/Sources/TuistGraph/Models/Dependencies/SwiftPackageManagerDependencies.swift
@@ -39,7 +39,7 @@ public struct SwiftPackageManagerDependencies: Equatable {
     ///    - productTypes: The custom `Product` types to be used for SPM targets.
     ///    - baseSettings: The base settings to be used for targets generated from SwiftPackageManager
     ///    - targetSettings: The custom `SettingsDictionary` to be applied to denoted targets
-    ///    - generationOptions: The custom project options for each project generated from a swift package
+    ///    - projectOptions: The custom project options for each project generated from a swift package
 
     public init(
         _ packages: [Package],


### PR DESCRIPTION
### Short description 📝

> The init comment in `struct SwiftPackageManagerDependencies` states generationOptions as a parameter, but the actual name is projectOptions. So I changed the generation Options in the comment to project Options.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
