### PR TITLE
Fixed Docs Typos

### DIFF
--- a/projects/docs/docs/building-at-scale/best-practices.md
+++ b/projects/docs/docs/building-at-scale/best-practices.md
@@ -4,7 +4,7 @@ slug: '/building-at-scale/best-practices'
 description: Xcode being weakly opinionated in regards to the project structure might result in complex and hard to manage project. To prevent that, this document describes best practices that users of Tuist can follow to have projects that are optimal and easy to reason about.
 ---
 
-Although Tuist defaults to some conventions on the projects that are initialized with Tuist, its API doesn't enforce them purposely to ease the adoption of the tool. Very often, Xcode projects end up being complex because Xcode is weakly opinionated about the project structure. As long as the build system is able to process build settings and phases and output valid, it's all good.
+Although Tuist defaults to some conventions on the projects that are initialized with Tuist, its API doesn't enforce them purposedly to ease the adoption of the tool. Very often, Xcode projects end up being complex because Xcode is weakly opinionated about the project structure. As long as the build system is able to process build settings and phases and output valid, it's all good.
 
 **Complex and non-conventional projects** are undesirable because they are hard to reason about and might lead to compilation errors. The result of that is that only a few people in the team can make well-informed decisions to scale up the project. In other words, your team ends up with a high [bus factor](https://en.wikipedia.org/wiki/Bus_factor).
 

--- a/projects/docs/docs/building-at-scale/best-practices.md
+++ b/projects/docs/docs/building-at-scale/best-practices.md
@@ -4,7 +4,7 @@ slug: '/building-at-scale/best-practices'
 description: Xcode being weakly opinionated in regards to the project structure might result in complex and hard to manage project. To prevent that, this document describes best practices that users of Tuist can follow to have projects that are optimal and easy to reason about.
 ---
 
-Although Tuist defaults to some conventions on the projects that are initialized with Tuist, its API doesn't enforce them purposedly to ease the adoption of the tool. Very often, Xcode projects end up being complex because Xcode is weakly opinionated about the project structure. As long as the build system is able to process build settings and phases and output valid, it's all good.
+Although Tuist defaults to some conventions on the projects that are initialized with Tuist, its API doesn't enforce them purposely to ease the adoption of the tool. Very often, Xcode projects end up being complex because Xcode is weakly opinionated about the project structure. As long as the build system is able to process build settings and phases and output valid, it's all good.
 
 **Complex and non-conventional projects** are undesirable because they are hard to reason about and might lead to compilation errors. The result of that is that only a few people in the team can make well-informed decisions to scale up the project. In other words, your team ends up with a high [bus factor](https://en.wikipedia.org/wiki/Bus_factor).
 
@@ -17,7 +17,7 @@ This document contains a list of recommendations for conventions that we'd follo
 
 - **Explicit definition:** Dependencies can be defined implicitly through build settings. Xcode is smart enough to detect them and determine the order in which targets should be built. Although implicitness might work fine in small projects, as they get larger, it might turn into a source of issues and slowness. Default to explicit definition of dependencies using the [dependencies API](guides/dependencies.md) that Tuist provides. Tuist has handy built-in features such as [tuist graph](commands/graph.md) or detection of circular dependencies that rely on dependencies being explicitly defined.
 - **XCTest dependency:** If a target that is not a test target depends on `XCTest`, declare the dependency explicitly with `.xctest`.
-- **Avoid re-exported modules:** If a target A, re-exports a dependency B using the syntax `@_exported`, to a target C, B should be a dependency of C. Dependencies defined through [re-exports](https://github.com/apple/swift/blob/main/docs/Modules.rst#modules-can-re-export-other-modules) create implicit dependencies that complicate [caching](building-at-scale/caching.md). If that setup is not possible becase it leads to duplicated symbols, you might consider wrapping the transitive static dependency into a dynamic target.
+- **Avoid re-exported modules:** If a target A, re-exports a dependency B using the syntax `@_exported`, to a target C, B should be a dependency of C. Dependencies defined through [re-exports](https://github.com/apple/swift/blob/main/docs/Modules.rst#modules-can-re-export-other-modules) create implicit dependencies that complicate [caching](building-at-scale/caching.md). If that setup is not possible because it leads to duplicated symbols, you might consider wrapping the transitive static dependency into a dynamic target.
 
 ### File structure
 

--- a/projects/docs/docs/building-at-scale/microfeatures.md
+++ b/projects/docs/docs/building-at-scale/microfeatures.md
@@ -240,7 +240,7 @@ In pre-Tuist era, there were many factor that influenced that decision:
 
 - Whether the target includes resources or not.
 - Whether the target depends on static targets that might lead to duplicated symbols issues upstream.
-- The number of dynamic targets that need to be linked at startup time and therfore might increase the time to launch the app.
+- The number of dynamic targets that need to be linked at startup time and therefore might increase the time to launch the app.
 
 Thanks to Tuist,
 the decision process has been notably simplified.

--- a/projects/docs/docs/cloud/self-hosting.md
+++ b/projects/docs/docs/cloud/self-hosting.md
@@ -35,7 +35,7 @@ fly launch
 fly deploy
 
 # Set a RAILS_MASTER_KEY secret (contents of your master.key file)
-fly secrects set RAILS_MASTER_KEY=$(cat config/master.key)
+fly secrets set RAILS_MASTER_KEY=$(cat config/master.key)
 ```
 
 And that's it! That being said, you might need to upgrade the memory on the provided CPU by:

--- a/projects/docs/docs/commands/cache.md
+++ b/projects/docs/docs/commands/cache.md
@@ -4,13 +4,13 @@ slug: '/commands/cache'
 description: "Learn how to use Tuist's cache command to generate binary artifacts for your targets."
 ---
 
-Target caching is one of Tuist's distictive features.
+Target caching is one of Tuist's distinctive features.
 Caching creates binary artifacts of your targets, which can later be used in your project if your generation is focused on other targets.
 For more details on the caching workflow, please refer to the [caching]](building-at-scale/caching.md) documentation.
 
 ### Warm
 
-To generate the cache for all the target of your project, youn can simply run:
+To generate the cache for all the target of your project, you can simply run:
 
 ```bash
 tuist cache warm

--- a/projects/docs/docs/commands/edit.md
+++ b/projects/docs/docs/commands/edit.md
@@ -1,7 +1,7 @@
 ---
 title: tuist edit
 slug: '/commands/edit'
-description: 'Learn how to edit your manifest files using Xcode and get documentation, syntax highliting and auto-completion, and validation by Xcode.'
+description: 'Learn how to edit your manifest files using Xcode and get documentation, syntax highlighting and auto-completion, and validation by Xcode.'
 ---
 
 One of the advantages of defining your projects in [Swift](https://swift.org/) is that we can leverage Xcode and the Swift compiler to safely edit the projects with syntax auto-completion and documentation.

--- a/projects/docs/docs/commands/generate.md
+++ b/projects/docs/docs/commands/generate.md
@@ -12,7 +12,7 @@ and Xcode projects and workspaces as a implementation detail to edit your projec
 
 ### Command
 
-To generate the project in the current directory, youn can simply run:
+To generate the project in the current directory, you can simply run:
 
 ```bash
 tuist generate

--- a/projects/docs/docs/commands/graph.md
+++ b/projects/docs/docs/commands/graph.md
@@ -11,7 +11,7 @@ saying goes, "one image is worth a thousand words":
 ![Sample graph exported with the graph command](assets/GraphExample.png)
 
 The command will output the dependency graph as an image, in the `png` format.
-You can change the output format using the `--format` paramenter.
+You can change the output format using the `--format` parameter.
 
 :::caution
 You can also change the format to `json` to export the graph as a JSON file. The JSON schema is subject

--- a/projects/docs/docs/commands/plugin.md
+++ b/projects/docs/docs/commands/plugin.md
@@ -33,7 +33,7 @@ we provide a set of commands under `tuist plugin`. These plugin commands are aim
 | `--path`  | `-p`  | Path to the directory that contains the definition of the plugin | Current directory | No |
 | `--build-tests` | n/a | Build both source and test targets | No | No |
 | `--show-bin-path` | n/a | Print the binary output path | No | No |
-| `--targets` | n/a | Build the specificed targets |  | No |
+| `--targets` | n/a | Build the specified targets |  | No |
 | `--products` | n/a | Build the specified products | | No |
 
 ### Test

--- a/projects/docs/docs/commands/signing.md
+++ b/projects/docs/docs/commands/signing.md
@@ -6,7 +6,7 @@ description: 'Tuist offers a deterministic, pain-free solution to signing. Read 
 
 Signing is one of the most complicated things that developers have to deal with
 when working with Xcode. While Xcode does offer an option of automatic signing,
-most teams choose not to use it since it creates an unmanagable mess in their team accounts.
+most teams choose not to use it since it creates an unmanageable mess in their team accounts.
 But manually working with signing artifacts is tedious, error-prone and tools
 automating this process are often non-deterministic and you still have to manually change
 settings of your Xcode projects.
@@ -38,7 +38,7 @@ that means, yes, also build settings!
 `tuist generate` automatically encrypts all signing artifacts.
 If you want to decrypt your signing files,
 feel free to run `tuist signing decrypt`.
-To reencrypt them run `tuist signing encrypt` (note that encryption is done automatically in `tuist generate`)
+To re-encrypt them run `tuist signing encrypt` (note that encryption is done automatically in `tuist generate`)
 
 ### Vendor
 

--- a/projects/docs/docs/contributors/analytics-events.md
+++ b/projects/docs/docs/contributors/analytics-events.md
@@ -21,5 +21,5 @@ Schema:
 | `tuistVersion`        | `String`           | The version of Tuist when the command run                    | `1.27.0`                           | true     |
 | `swiftVersion`        | `String`           | The version of Swift when the command run                    | `5.0`                              | true     |
 | `macOSVersion`        | `String`           | The version of macOS when the command run                    | `10.15.7`                          | true     |
-| `machineHardwareName` | `String`           | A string identifing the architecture of the operating system | `arm64`                            | true     |
+| `machineHardwareName` | `String`           | A string identifying the architecture of the operating system | `arm64`                            | true     |
 | `isCI` | `Bool`           | Indicates whether Tuist is running in Continuous Integration (CI) environment | true                            | true     |

--- a/projects/docs/docs/contributors/architecture.md
+++ b/projects/docs/docs/contributors/architecture.md
@@ -46,7 +46,7 @@ logger.critical("") // Use `critical` for unrecoverable, system errors.
 logger.error("") // Use `error` for user errors, particularly problems with their machine, manifest or configuration.
 logger.warning("") // Use `warning` to highlight potential issues.
 logger.notice("") // Use `notice` to log to console, this is the normal level of logging.
-logger.info("") // Use `info` to provide small meta messages, this will be printed but won't be promenant.
+logger.info("") // Use `info` to provide small meta messages, this will be printed but won't be prominent.
 logger.debug("") // Use `debug` to print in verbose mode.
 logger.pretty("") // Use `pretty` to print a string with formatted interpolations, useful for highlighting certain elements in the string.
 ```

--- a/projects/docs/docs/guides/continuous-integration.md
+++ b/projects/docs/docs/guides/continuous-integration.md
@@ -55,7 +55,7 @@ If your CI provider is not supported yet, you can still use Tuist by adding the 
 
 Here are a number of best practice you can follow:
 
-- Define your local version in the `.tuist-version` file (for exmaple, running `tuist local 3.0.0`)
+- Define your local version in the `.tuist-version` file (for example, running `tuist local 3.0.0`)
   - This makes sure the same version of Tuist is used across all machines, both locally and in CI
 - Install tuist unzipping the `tuist.zip` downloaded directly from the GitHub releases, using the version defined in the `.tuist-version` file (for example, [link for 3.0.0](https://github.com/tuist/tuist/releases/download/3.0.0/tuist.zip))
   - Make sure to cache the unzipped folder across CI runs to avoid having to download it over and over again

--- a/projects/docs/docs/manifests/project.md
+++ b/projects/docs/docs/manifests/project.md
@@ -1,6 +1,6 @@
 ---
 title: Project.swift
-description: 'This page documents the models that users can use to define their project: how to initialize them, attributes and their meaning, protocol conformance.'
+description: 'This page documents the models that users can use to define their project: how to initialize them, attributes and their meaning, protocol conformances.'
 slug: '/manifests/project'
 ---
 

--- a/projects/docs/docs/manifests/project.md
+++ b/projects/docs/docs/manifests/project.md
@@ -1,6 +1,6 @@
 ---
 title: Project.swift
-description: 'This page documents the models that users can use to define their project: how to initialize them, attributes and their meaning, protocol comformances.'
+description: 'This page documents the models that users can use to define their project: how to initialize them, attributes and their meaning, protocol conformance.'
 slug: '/manifests/project'
 ---
 

--- a/projects/docs/docs/plugins/creating-plugins.md
+++ b/projects/docs/docs/plugins/creating-plugins.md
@@ -174,7 +174,7 @@ Notice how you label extensions, methods, classes and structs as `public` if you
 
 #### Use the plugin
 
-We can follow the [using plugins](plugins/using-plugins.md) to learn more about how to use plugins. For this exmaple we may want to include the plugin and use it like so:
+We can follow the [using plugins](plugins/using-plugins.md) to learn more about how to use plugins. For this example we may want to include the plugin and use it like so:
 
 ```swift
 // Project.swift

--- a/projects/docs/docs/plugins/using-plugins.md
+++ b/projects/docs/docs/plugins/using-plugins.md
@@ -91,7 +91,7 @@ You can read more about tasks [here](guides/task.md).
 
 #### Project description helpers
 
-You can import a project description helper plugin with the name defined in the [`Plugin.swift`](plugins/creating-plugins.md) manifest, which can then be used in a project manfiest:
+You can import a project description helper plugin with the name defined in the [`Plugin.swift`](plugins/creating-plugins.md) manifest, which can then be used in a project manifest:
 
 ```swift
 import ProjectDescription


### PR DESCRIPTION
### Short description 📝

This PR fixes small typos that I noticed in the docs. 

### How to test the changes locally 🧐
Run existing tests suite

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
