### PR TITLE
Skip cloud setup for non-cloud feature suites

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -166,12 +166,14 @@ jobs:
             ${{ runner.os }}-
       - name: Install cloud dependencies
         working-directory: projects/cloud
+        if: ${{ matrix.feature == 'cloud' }}
         run: |
           gem install bundler
           bundle config path vendor/bundle
           bundle install --jobs=4 --retry=3
           npm install
       - name: Start PostgreSQL for cloud
+        if: ${{ matrix.feature == 'cloud' }}
         run: |
           brew services start postgresql
           echo "Check PostgreSQL service is running"
@@ -190,6 +192,7 @@ jobs:
           done
       - name: Seed database
         working-directory: projects/cloud
+        if: ${{ matrix.feature == 'cloud' }}
         run: |
           bin/rails db:create
           bin/rails db:migrate

--- a/projects/cloud/app/services/project_create_service.rb
+++ b/projects/cloud/app/services/project_create_service.rb
@@ -61,7 +61,6 @@ class ProjectCreateService < ApplicationService
       default_project: project,
     )
     project.update(remote_cache_storage: s3_bucket)
-    puts s3_bucket_name
     s3_client.create_bucket(bucket: s3_bucket_name)
     project
   end

--- a/projects/cloud/app/services/project_create_service.rb
+++ b/projects/cloud/app/services/project_create_service.rb
@@ -61,6 +61,7 @@ class ProjectCreateService < ApplicationService
       default_project: project,
     )
     project.update(remote_cache_storage: s3_bucket)
+    puts s3_bucket_name
     s3_client.create_bucket(bucket: s3_bucket_name)
     project
   end

--- a/projects/cloud/db/seeds.rb
+++ b/projects/cloud/db/seeds.rb
@@ -27,7 +27,7 @@ organization_ids = []
 end
 
 10.times do |index|
-  email = Faker::Internet.email
+  email = Faker::Internet.email.tr("_", "-")
   password = Faker::Internet.password(min_length: 6, max_length: 8)
   user = User.create!(
     email: email,


### PR DESCRIPTION
### Short description 📝

Setting up the cloud server should only be necessary for the `cloud.feature` test suite. Running for others is useless and leads to longer CI times.