### PR TITLE
Do not run cloud feature suite for forks

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -19,6 +19,7 @@ on:
       - .github/workflows/tuist.yml
       - .package.resolved
       - projects/fourier/**
+      - .github/workflows/tuist.yml
 
 concurrency:
   group: tuist-${{ github.head_ref }}
@@ -198,6 +199,7 @@ jobs:
           bin/rails db:migrate
           bin/rails db:seed
       - name: Run tests
+        if: ${{ matrix.feature != 'cloud' }} || ${{ secrets.CLOUD_RAILS_MASTER_KEY != '' }}
         run: ./fourier test tuist acceptance projects/tuist/features/${{ matrix.feature }}.feature
   
   lint:


### PR DESCRIPTION
### Short description 📝

`cloud` acceptance test is currently not passing for forks since they don't have access to the tuist cloud secret. We should figure out a better way to do this but for now, we can skip that acceptance test for forks.
