### PR TITLE
Add GraphLinter support for watchOS app appExtension targets

### DIFF
--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -564,6 +564,6 @@ public class GraphLinter: GraphLinting {
             LintableTarget(platform: .watchOS, product: .dynamicLibrary),
             LintableTarget(platform: .watchOS, product: .staticFramework),
             LintableTarget(platform: .watchOS, product: .framework),
-        ]
+        ],
     ]
 }

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -558,5 +558,12 @@ public class GraphLinter: GraphLinting {
             LintableTarget(platform: .watchOS, product: .framework),
             LintableTarget(platform: .watchOS, product: .staticFramework),
         ],
+
+        LintableTarget(platform: .watchOS, product: .appExtension): [
+            LintableTarget(platform: .watchOS, product: .staticLibrary),
+            LintableTarget(platform: .watchOS, product: .dynamicLibrary),
+            LintableTarget(platform: .watchOS, product: .staticFramework),
+            LintableTarget(platform: .watchOS, product: .framework),
+        ]
     ]
 }

--- a/projects/tuist/fixtures/ios_app_with_watch_application/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/Project.swift
@@ -17,7 +17,22 @@ let project = Project(
             ],
             dependencies: [
                 .target(name: "WatchApp"),
+                .target(name: "Framework_a_ios")
             ]
+        ),
+        Target(
+            name: "Framework_a_ios",
+            platform: .iOS,
+            product: .framework,
+            productName: "FrameworkA",
+            bundleId: "io.tuist.framework.a"
+        ),
+        Target(
+            name: "Framework_a_watchos",
+            platform: .watchOS,
+            product: .framework,
+            productName: "FrameworkA",
+            bundleId: "io.tuist.framework.a"
         ),
         // In Xcode 14, watch application can now leverage the `.app` product type
         // rather than the previous `.watch2App` type
@@ -31,6 +46,7 @@ let project = Project(
             resources: "WatchApp/Resources/**",
             dependencies: [
                 .target(name: "WatchWidgetExtension"),
+                .target(name: "Framework_a_watchos")
             ],
             settings: .settings(
                 base: [
@@ -60,6 +76,7 @@ let project = Project(
             sources: "WatchWidgetExtension/Sources/**",
             resources: "WatchWidgetExtension/Resources/**",
             dependencies: [
+                .target(name: "Framework_a_watchos")
             ]
         ),
         Target(

--- a/projects/tuist/fixtures/ios_app_with_watch_application/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_watch_application/Project.swift
@@ -17,7 +17,7 @@ let project = Project(
             ],
             dependencies: [
                 .target(name: "WatchApp"),
-                .target(name: "Framework_a_ios")
+                .target(name: "Framework_a_ios"),
             ]
         ),
         Target(
@@ -46,7 +46,7 @@ let project = Project(
             resources: "WatchApp/Resources/**",
             dependencies: [
                 .target(name: "WatchWidgetExtension"),
-                .target(name: "Framework_a_watchos")
+                .target(name: "Framework_a_watchos"),
             ],
             settings: .settings(
                 base: [
@@ -76,7 +76,7 @@ let project = Project(
             sources: "WatchWidgetExtension/Sources/**",
             resources: "WatchWidgetExtension/Resources/**",
             dependencies: [
-                .target(name: "Framework_a_watchos")
+                .target(name: "Framework_a_watchos"),
             ]
         ),
         Target(


### PR DESCRIPTION
### Short description 📝

This PR adds support for `.appExtensions` being added to `.watchOS` `.app` targets. This is a valid combination starting with Xcode 14 for single target `.watchOS` applications. 

I additionally updated the corresponding fixture `ios_app_with_watch_application` to cover the new case. 

### How to test the changes locally 🧐

- Run `tuist generate` on fixture `ios_app_with_watch_application`

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
