### PR TITLE
fix: Variadic Parameters were applied to the files in the Source folder.

### DIFF
--- a/Sources/ProjectDescription/ArchiveAction.swift
+++ b/Sources/ProjectDescription/ArchiveAction.swift
@@ -28,6 +28,22 @@ public struct ArchiveAction: Equatable, Codable {
         self.preActions = preActions
         self.postActions = postActions
     }
+  
+  convenience init(
+    configuration: ConfigurationName,
+    revealArchiveInOrganizer: Bool = true,
+    customArchiveName: String? = nil,
+    preActions: ExecutionAction... = [],
+    postActions: ExecutionAction... = []
+  ) {
+    self.init(
+      configuration: configuration,
+      revealArchiveInOrganizer: revealArchiveInOrganizer,
+      customArchiveName: customArchiveName,
+      preActions: preActions,
+      postActions: postActions
+    )
+  }
 
     /// Initialize a `ArchiveAction`
     /// - Parameters:

--- a/Sources/ProjectDescription/Arguments.swift
+++ b/Sources/ProjectDescription/Arguments.swift
@@ -12,4 +12,14 @@ public struct Arguments: Equatable, Codable {
         self.environment = environment
         self.launchArguments = launchArguments
     }
+  
+  public convenience init(
+    environment: [String: String] = [:],
+    launchArguments: LaunchArgument = []
+  ) {
+    self.init(
+      environment: environment,
+      launchArguments: launchArguments
+    )
+  }
 }

--- a/Sources/ProjectDescription/BuildAction.swift
+++ b/Sources/ProjectDescription/BuildAction.swift
@@ -24,6 +24,20 @@ public struct BuildAction: Equatable, Codable {
         self.postActions = postActions
         self.runPostActionsOnFailure = runPostActionsOnFailure
     }
+  
+  public convenience init(
+    targets: TargetReference...,
+    preActions: ExecutionAction... = [],
+    postActions: ExecutionAction... = [],
+    runPostActionsOnFailure: Bool = false
+  ) {
+    self.init(
+      targets: targets,
+      preActions: preActions,
+      postActions: postActions,
+      runPostActionsOnFailure: runPostActionsOnFailure
+    )
+  }
 
     /// Returns a build action.
     /// - Parameters:
@@ -45,4 +59,18 @@ public struct BuildAction: Equatable, Codable {
             runPostActionsOnFailure: runPostActionsOnFailure
         )
     }
+  
+  public static func buildAction(
+    targets: TargetReference...,
+    preActions: ExecutionAction... = [],
+    postActions: ExecutionAction... = [],
+    runPostActionsOnFailure: Bool = false
+  ) -> BuildAction {
+    buildAction(
+      targets: targets,
+      preActions: preActions,
+      postActions: postActions,
+      runPostActionsOnFailure: runPostActionsOnFailure
+    )
+  }
 }

--- a/Sources/ProjectDescription/Cache.swift
+++ b/Sources/ProjectDescription/Cache.swift
@@ -49,4 +49,8 @@ public struct Cache: Codable, Equatable {
     public static func cache(profiles: [Profile] = [], path: Path? = nil) -> Cache {
         Cache(profiles: profiles, path: path)
     }
+  
+  public static func cache(profiles: Profile... = [], path: Path? = nil) -> Cache {
+    cache(profiles: profiles, path: path)
+  }
 }

--- a/Sources/ProjectDescription/Cloud.swift
+++ b/Sources/ProjectDescription/Cloud.swift
@@ -38,4 +38,8 @@ public struct Cloud: Codable, Equatable {
     public static func cloud(projectId: String, url: String, options: [Option] = []) -> Cloud {
         Cloud(url: url, projectId: projectId, options: options)
     }
+  
+  public static func cloud(projectId: String, url: String, options: Option... = []) -> Cloud {
+    cloud(projectId: projectId, url: url, options: options)
+  }
 }

--- a/Sources/ProjectDescription/Config.swift
+++ b/Sources/ProjectDescription/Config.swift
@@ -72,4 +72,22 @@ public struct Config: Codable, Equatable {
         self.swiftVersion = swiftVersion
         dumpIfNeeded(self)
     }
+  
+  public convenience init(
+    compatibleXcodeVersions: CompatibleXcodeVersions = .all,
+    cloud: Cloud? = nil,
+    cache: Cache? = nil,
+    swiftVersion: Version? = nil,
+    plugins: PluginLocation... = [],
+    generationOptions: GenerationOptions = .options()
+  ) {
+    self.init(
+      compatibleXcodeVersions: compatibleXcodeVersions,
+      cloud: cloud,
+      cache: cache,
+      swiftVersion: swiftVersion,
+      plugins: plugins,
+      generationOptions: generationOptions
+    )
+  }
 }

--- a/Sources/ProjectDescription/CopyFilesAction.swift
+++ b/Sources/ProjectDescription/CopyFilesAction.swift
@@ -44,6 +44,20 @@ public struct CopyFilesAction: Codable, Equatable {
         self.subpath = subpath
         self.files = files
     }
+  
+  convenience init(
+      name: String,
+      destination: Destination,
+      subpath: String? = nil,
+      files: FileElement...
+  ) {
+    self.init(
+      name: name,
+      destination: destination,
+      subpath: subpath,
+      files: files
+    )
+  }
 
     // MARK: - Static initializers
 
@@ -65,6 +79,24 @@ public struct CopyFilesAction: Codable, Equatable {
             files: files
         )
     }
+  
+  /// A copy files action for the products directory.
+  /// - Parameters:
+  ///   - name: Name of the build phase when the project gets generated.
+  ///   - subpath: Path to a folder inside the destination.
+  ///   - files: Relative paths to the files to be copied.
+  /// - Returns: Copy files action.
+  public static func productsDirectory(
+    name: String,
+    subpath: String? = nil,
+    files: FileElement...
+  ) -> CopyFilesAction {
+    productsDirectory(
+      name: name,
+      subpath: subpath,
+      files: files
+    )
+  }
 
     /// A copy files action for the wrapper directory.
     /// - Parameters:
@@ -103,7 +135,25 @@ public struct CopyFilesAction: Codable, Equatable {
             files: files
         )
     }
-
+  
+  /// A copy files action for the executables directory.
+  /// - Parameters:
+  ///   - name: Name of the build phase when the project gets generated.
+  ///   - subpath: Path to a folder inside the destination.
+  ///   - files: Relative paths to the files to be copied.
+  /// - Returns: Copy files action.
+  public static func executables(
+    name: String,
+    subpath: String? = nil,
+    files: [FileElement]
+  ) -> CopyFilesAction {
+    executables(
+      name: name,
+      subpath: subpath,
+      files: files
+    )
+  }
+  
     /// A copy files action for the resources directory.
     /// - Parameters:
     ///   - name: Name of the build phase when the project gets generated.
@@ -122,6 +172,24 @@ public struct CopyFilesAction: Codable, Equatable {
             files: files
         )
     }
+  
+  /// A copy files action for the resources directory.
+  /// - Parameters:
+  ///   - name: Name of the build phase when the project gets generated.
+  ///   - subpath: Path to a folder inside the destination.
+  ///   - files: Relative paths to the files to be copied.
+  /// - Returns: Copy files action.
+  public static func resources(
+    name: String,
+    subpath: String? = nil,
+    files: FileElement...
+  ) -> CopyFilesAction {
+    resources(
+      name: name,
+      subpath: subpath,
+      files: files
+    )
+  }
 
     /// A copy files action for the java resources directory.
     /// - Parameters:
@@ -141,6 +209,24 @@ public struct CopyFilesAction: Codable, Equatable {
             files: files
         )
     }
+  
+  /// A copy files action for the java resources directory.
+  /// - Parameters:
+  ///   - name: Name of the build phase when the project gets generated.
+  ///   - subpath: Path to a folder inside the destination.
+  ///   - files: Relative paths to the files to be copied.
+  /// - Returns: Copy files action.
+  public static func javaResources(
+    name: String,
+    subpath: String? = nil,
+    files: FileElement...
+  ) -> CopyFilesAction {
+    javaResources(
+      name: name,
+      subpath: subpath,
+      files: files
+    )
+  }
 
     /// A copy files action for the frameworks directory.
     /// - Parameters:
@@ -160,6 +246,24 @@ public struct CopyFilesAction: Codable, Equatable {
             files: files
         )
     }
+  
+  /// A copy files action for the frameworks directory.
+  /// - Parameters:
+  ///   - name: Name of the build phase when the project gets generated.
+  ///   - subpath: Path to a folder inside the destination.
+  ///   - files: Relative paths to the files to be copied.
+  /// - Returns: Copy files action.
+  public static func frameworks(
+    name: String,
+    subpath: String? = nil,
+    files: [FileElement]
+  ) -> CopyFilesAction {
+    frameworks(
+      name: name,
+      subpath: subpath,
+      files: files
+    )
+  }
 
     /// A copy files action for the shared frameworks directory.
     /// - Parameters:
@@ -179,6 +283,24 @@ public struct CopyFilesAction: Codable, Equatable {
             files: files
         )
     }
+  
+  /// A copy files action for the shared frameworks directory.
+  /// - Parameters:
+  ///   - name: Name of the build phase when the project gets generated.
+  ///   - subpath: Path to a folder inside the destination.
+  ///   - files: Relative paths to the files to be copied.
+  /// - Returns: Copy files action.
+  public static func sharedFrameworks(
+    name: String,
+    subpath: String? = nil,
+    files: FileElement...
+  ) -> CopyFilesAction {
+    sharedSupport(
+      name: name,
+      subpath: subpath,
+      files: files
+    )
+  }
 
     /// A copy files action for the shared support directory.
     /// - Parameters:
@@ -198,6 +320,24 @@ public struct CopyFilesAction: Codable, Equatable {
             files: files
         )
     }
+  
+  /// A copy files action for the shared support directory.
+  /// - Parameters:
+  ///   - name: Name of the build phase when the project gets generated.
+  ///   - subpath: Path to a folder inside the destination.
+  ///   - files: Relative paths to the files to be copied.
+  /// - Returns: Copy files action.
+  public static func sharedSupport(
+    name: String,
+    subpath: String? = nil,
+    files: FileElement...
+  ) -> CopyFilesAction {
+    sharedSupport(
+      name: name,
+      subpath: subpath,
+      files: files
+    )
+  }
 
     /// A copy files action for the plugins directory.
     /// - Parameters:
@@ -217,4 +357,22 @@ public struct CopyFilesAction: Codable, Equatable {
             files: files
         )
     }
+  
+  /// A copy files action for the plugins directory.
+  /// - Parameters:
+  ///   - name: Name of the build phase when the project gets generated.
+  ///   - subpath: Path to a folder inside the destination.
+  ///   - files: Relative paths to the files to be copied.
+  /// - Returns: Copy files action.
+  public static func plugins(
+    name: String,
+    subpath: String? = nil,
+    files: FileElement...
+  ) -> CopyFilesAction {
+    plugins(
+      name: name,
+      subpath: subpath,
+      files: files
+    )
+  }
 }

--- a/Sources/ProjectDescription/Dependencies/CarthageDependencies.swift
+++ b/Sources/ProjectDescription/Dependencies/CarthageDependencies.swift
@@ -10,6 +10,10 @@ public struct CarthageDependencies: Codable, Equatable {
     public init(_ dependencies: [Dependency]) {
         self.dependencies = dependencies
     }
+  
+  public convenience init(_ dependencies: Dependency...) {
+    self.init(dependencies)
+  }
 }
 
 // MARK: - ExpressibleByArrayLiteral

--- a/Sources/ProjectDescription/Dependencies/SwiftPackageManagerDependencies.swift
+++ b/Sources/ProjectDescription/Dependencies/SwiftPackageManagerDependencies.swift
@@ -49,6 +49,22 @@ public struct SwiftPackageManagerDependencies: Codable, Equatable {
         self.targetSettings = targetSettings
         self.projectOptions = projectOptions
     }
+  
+  public convenience init(
+    _ packages: Package...,
+      productTypes: [String: Product] = [:],
+      baseSettings: Settings = .settings(),
+      targetSettings: [String: SettingsDictionary] = [:],
+    projectOptions: [String: ProjectDescription.Project.Options] = [:]
+  ) {
+    self.init(
+      packages,
+      productTypes: productTypes,
+      baseSettings: baseSettings,
+      targetSettings: targetSettings,
+      projectOptions: projectOptions
+    )
+  }
 }
 
 // MARK: - ExpressibleByArrayLiteral

--- a/Sources/ProjectDescription/FileList.swift
+++ b/Sources/ProjectDescription/FileList.swift
@@ -14,6 +14,14 @@ public struct FileList: Codable, Equatable {
     public static func list(_ globs: [FileListGlob]) -> FileList {
         FileList(globs: globs)
     }
+  
+  /// Creates a file list from a collection of glob patterns.
+  ///
+  ///   - glob: Relative glob pattern.
+  ///   - excluding: Relative glob patterns for excluded files.
+  public static func list(_ globs: FileListGlob...) -> FileList {
+      list(globs)
+  }
 }
 
 extension FileList: ExpressibleByStringInterpolation {

--- a/Sources/ProjectDescription/FileListGlob.swift
+++ b/Sources/ProjectDescription/FileListGlob.swift
@@ -18,6 +18,17 @@ public struct FileListGlob: Codable, Equatable {
     ) -> FileListGlob {
         FileListGlob(glob: glob, excluding: excluding)
     }
+  
+  /// Returns a generic file list glob.
+  /// - Parameters:
+  ///   - glob: The path with a glob pattern.
+  ///   - excluding: The excluding paths.
+  public static func glob(
+    _ glob: Path,
+    excluding: Path... = []
+  ) -> FileListGlob {
+    glob(glob, excluding: excluding)
+  }
 
     /// Returns a file list glob with an optional excluding path.
     public static func glob(

--- a/Sources/ProjectDescription/ProfileAction.swift
+++ b/Sources/ProjectDescription/ProfileAction.swift
@@ -32,6 +32,22 @@ public struct ProfileAction: Equatable, Codable {
         self.executable = executable
         self.arguments = arguments
     }
+  
+  convenience init(
+    configuration: ConfigurationName = .release,
+    preActions: [ExecutionAction] = [],
+    postActions: [ExecutionAction] = [],
+    executable: TargetReference? = nil,
+    arguments: Arguments? = nil
+  ) {
+    self.init(
+      configuration: configuration,
+      preActions: preActions,
+      postActions: postActions,
+      executable: executable,
+      arguments: arguments
+    )
+  }
 
     /// Returns a profile action.
     /// - Parameters:
@@ -56,4 +72,20 @@ public struct ProfileAction: Equatable, Codable {
             arguments: arguments
         )
     }
+  
+  public static func profileAction(
+    configuration: ConfigurationName = .release,
+    preActions: ExecutionAction... = [],
+    postActions: ExecutionAction... = [],
+    executable: TargetReference? = nil,
+    arguments: Arguments? = nil
+  ) -> ProfileAction {
+    profileAction(
+      configuration: configuration,
+      preActions: preActions,
+      postActions: postActions,
+      executable: executable,
+      arguments: arguments
+    )
+  }
 }

--- a/Sources/ProjectDescription/Project.swift
+++ b/Sources/ProjectDescription/Project.swift
@@ -106,4 +106,30 @@ public struct Project: Codable, Equatable {
         self.resourceSynthesizers = resourceSynthesizers
         dumpIfNeeded(self)
     }
+  
+  public convenience init(
+    name: String,
+    organizationName: String? = nil,
+    options: Options = .options(),
+    packages: Package = [],
+    settings: Settings? = nil,
+    targets: Target = [],
+    schemes: Scheme = [],
+    fileHeaderTemplate: FileHeaderTemplate? = nil,
+    additionalFiles: FileElement = [],
+    resourceSynthesizers: ResourceSynthesizer = .default
+  ) {
+    self.init(
+      name: name,
+      organizationName: organizationName,
+      options: options,
+      packages: packages,
+      settings: settings,
+      targets: targets,
+      schemes: schemes,
+      fileHeaderTemplate: fileHeaderTemplate,
+      additionalFiles: additionalFiles,
+      resourceSynthesizers: resourceSynthesizers
+    )
+  }
 }

--- a/Sources/ProjectDescription/ProjectOptions.swift
+++ b/Sources/ProjectDescription/ProjectOptions.swift
@@ -48,6 +48,28 @@ extension Project {
                 xcodeProjectName: xcodeProjectName
             )
         }
+      
+      public static func options(
+        automaticSchemesOptions: AutomaticSchemesOptions = .enabled(),
+        defaultKnownRegions: [String]? = nil,
+        developmentRegion: String? = nil,
+        disableBundleAccessors: Bool = false,
+        disableShowEnvironmentVarsInScriptPhases: Bool = false,
+        disableSynthesizedResourceAccessors: Bool = false,
+        textSettings: TextSettings = .textSettings(),
+        xcodeProjectName: String? = nil
+      ) -> Self {
+        options(
+          automaticSchemesOptions: automaticSchemesOptions,
+          defaultKnownRegions: defaultKnownRegions,
+          developmentRegion: developmentRegion,
+          disableBundleAccessors: disableBundleAccessors,
+          disableShowEnvironmentVarsInScriptPhases: disableShowEnvironmentVarsInScriptPhases,
+          disableSynthesizedResourceAccessors: disableSynthesizedResourceAccessors,
+          textSettings: textSettings,
+          xcodeProjectName: xcodeProjectName
+        )
+      }
     }
 }
 

--- a/Sources/ProjectDescription/ResourceFileElements.swift
+++ b/Sources/ProjectDescription/ResourceFileElements.swift
@@ -8,6 +8,10 @@ public struct ResourceFileElements: Codable, Equatable {
     public init(resources: [ResourceFileElement]) {
         self.resources = resources
     }
+  
+  public convenience init(resources: ResourceFileElement) {
+    self.init(resources: resources)
+  }
 }
 
 extension ResourceFileElements: ExpressibleByStringInterpolation {

--- a/Sources/ProjectDescription/RunAction.swift
+++ b/Sources/ProjectDescription/RunAction.swift
@@ -47,6 +47,28 @@ public struct RunAction: Equatable, Codable {
         self.options = options
         self.diagnosticsOptions = diagnosticsOptions
     }
+  
+  public convenience init(
+    configuration: ConfigurationName,
+    attachDebugger: Bool = true,
+    preActions: ExecutionAction... = [],
+    postActions: ExecutionAction... = [],
+    executable: TargetReference? = nil,
+    arguments: Arguments? = nil,
+    options: RunActionOptions = .options(),
+    diagnosticsOptions: SchemeDiagnosticsOption... = [.mainThreadChecker, .performanceAntipatternChecker]
+  ) {
+    self.init(
+      configuration: configuration,
+      attachDebugger: attachDebugger,
+      preActions: preActions,
+      postActions: postActions,
+      executable: executable,
+      arguments: arguments,
+      options: options,
+      diagnosticsOptions: diagnosticsOptions
+    )
+  }
 
     /// Returns a run action.
     /// - Parameters:
@@ -80,4 +102,37 @@ public struct RunAction: Equatable, Codable {
             diagnosticsOptions: diagnosticsOptions
         )
     }
+  
+  /// Returns a run action.
+  /// - Parameters:
+  ///   - configuration: Indicates the build configuration the product should run with.
+  ///   - attachDebugger: Whether a debugger should be attached to the run process or not.
+  ///   - preActions: A list of actions that are executed before starting the run process.
+  ///   - postActions: A list of actions that are executed after the run process.
+  ///   - executable: The name of the executable or target to run.
+  ///   - arguments: Command line arguments passed on launch and environment variables.
+  ///   - options: List of options to set to the action.
+  ///   - diagnosticsOptions: List of diagnostics options to set to the action.
+  /// - Returns: Run action.
+  public static func runAction(
+    configuration: ConfigurationName = .debug,
+    attachDebugger: Bool = true,
+    preActions: ExecutionAction... = [],
+    postActions: ExecutionAction... = [],
+    executable: TargetReference? = nil,
+    arguments: Arguments? = nil,
+    options: RunActionOptions = .options(),
+    diagnosticsOptions: SchemeDiagnosticsOption... = [.mainThreadChecker]
+  ) -> RunAction {
+    runAction(
+      configuration: configuration,
+      attachDebugger: attachDebugger,
+      preActions: preActions,
+      postActions: postActions,
+      executable: executable,
+      arguments: arguments,
+      options: options,
+      diagnosticsOptions: diagnosticsOptions
+    )
+  }
 }

--- a/Sources/ProjectDescription/Settings.swift
+++ b/Sources/ProjectDescription/Settings.swift
@@ -186,4 +186,29 @@ public struct Settings: Equatable, Codable {
             defaultSettings: defaultSettings
         )
     }
+  
+  /// Creates settings with any number of configurations.
+  ///
+  /// - Parameters:
+  ///   - base: A dictionary with build settings that are inherited from all the configurations.
+  ///   - configurations: A list of configurations.
+  ///   - defaultSettings: An enum specifying the set of default settings.
+  ///
+  /// - Note: Configurations shouldn't be empty, please use the alternate static method
+  ///         `.settings(base:debug:release:defaultSettings:)` to leverage the default configurations
+  ///          if you don't have any custom configurations.
+  ///
+  /// - seealso: Configuration
+  /// - seealso: DefaultSettings
+  public static func settings(
+    base: SettingsDictionary = [:],
+    configurations: Configuration...,
+    defaultSettings: DefaultSettings = .recommended
+  ) -> Settings {
+    settings(
+      base: base,
+      configurations: configurations,
+      defaultSettings: defaultSettings
+    )
+  }
 }

--- a/Sources/ProjectDescription/SettingsTransformers.swift
+++ b/Sources/ProjectDescription/SettingsTransformers.swift
@@ -148,6 +148,11 @@ extension SettingsDictionary {
     public func otherCFlags(_ flags: [String]) -> SettingsDictionary {
         merging(["OTHER_CFLAGS": .array(flags)])
     }
+  
+  /// Sets `"OTHER_CFLAGS"` to `flags`
+  public func otherCFlags(_ flags: String...) -> SettingsDictionary {
+    otherCFlags(flags)
+  }
 
     // MARK: - Linking
 
@@ -155,6 +160,11 @@ extension SettingsDictionary {
     public func otherLinkerFlags(_ flags: [String]) -> SettingsDictionary {
         merging(["OTHER_LDFLAGS": .array(flags)])
     }
+  
+  /// Sets `"OTHER_LDFLAGS"` to `flags`
+  public func otherLinkerFlags(_ flags: String...) -> SettingsDictionary {
+    otherLinkerFlags(flags)
+  }
 
     // MARK: - Bitcode
 

--- a/Sources/ProjectDescription/SourceFilesList.swift
+++ b/Sources/ProjectDescription/SourceFilesList.swift
@@ -29,6 +29,27 @@ public struct SourceFileGlob: Codable, Equatable {
     ) -> Self {
         .init(glob: glob, excluding: excluding, compilerFlags: compilerFlags, codeGen: codeGen)
     }
+  
+  /// Returns a source glob pattern configuration.
+  ///
+  /// - Parameters:
+  ///   - glob: Glob pattern to the source files.
+  ///   - excluding: Glob patterns for source files that will be excluded.
+  ///   - compilerFlags: The compiler flags to be set to the source files in the sources build phase.
+  ///   - codeGen: The source file attribute to be set in the build phase.
+  public static func glob(
+      _ glob: Path,
+      excluding: Path... = [],
+      compilerFlags: String? = nil,
+      codeGen: FileCodeGen? = nil
+  ) -> Self {
+    glob(
+      glob,
+      excluding: excluding,
+      compilerFlags: compilerFlags,
+      codeGen: codeGen
+    )
+  }
 
     public static func glob(
         _ glob: Path,
@@ -58,6 +79,13 @@ public struct SourceFilesList: Codable, Equatable {
     public init(globs: [SourceFileGlob]) {
         self.globs = globs
     }
+  
+  /// Creates the source files list with the glob patterns.
+  ///
+  /// - Parameter globs: Glob patterns.
+  public convenience init(globs: SourceFileGlob...) {
+    self.init(globs: globs)
+  }
 
     /// Creates the source files list with the glob patterns as strings.
     ///
@@ -65,12 +93,25 @@ public struct SourceFilesList: Codable, Equatable {
     public init(globs: [String]) {
         self.globs = globs.map(SourceFileGlob.init)
     }
+  
+  /// Creates the source files list with the glob patterns as strings.
+  ///
+  /// - Parameter globs: Glob patterns.
+  public convenience init(globs: String...) {
+    self.init(globs: globs)
+  }
 
     /// Returns a sources list from a list of paths.
     /// - Parameter paths: Source paths.
     public static func paths(_ paths: [Path]) -> SourceFilesList {
         SourceFilesList(globs: paths.map { .glob($0) })
     }
+  
+  /// Returns a sources list from a list of paths.
+  /// - Parameter paths: Source paths.
+  public static func paths(_ paths: Path...) -> SourceFilesList {
+      paths(paths)
+  }
 }
 
 /// Support file as single string

--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -102,4 +102,48 @@ public struct Target: Codable, Equatable {
         self.deploymentTarget = deploymentTarget
         self.additionalFiles = additionalFiles
     }
+  
+  public convenience init(
+    name: String,
+    platform: Platform,
+    product: Product,
+    productName: String? = nil,
+    bundleId: String,
+    deploymentTarget: DeploymentTarget? = nil,
+    infoPlist: InfoPlist? = .default,
+    sources: SourceFilesList? = nil,
+    resources: ResourceFileElements? = nil,
+    copyFiles: CopyFilesAction...? = nil,
+    headers: Headers? = nil,
+    entitlements: Path? = nil,
+    scripts: TargetScript... = [],
+    dependencies: TargetDependency... = [],
+    settings: Settings? = nil,
+    coreDataModels: CoreDataModel... = [],
+    environment: [String: String] = [:],
+    launchArguments: LaunchArgument... = [],
+    additionalFiles: FileElement... = []
+  ) {
+    self.init(
+      name: name,
+      platform: platform,
+      product: product,
+      productName: productName,
+      bundleId: bundleId,
+      deploymentTarget: deploymentTarget,
+      infoPlist: infoPlist,
+      sources: sources,
+      resources: resources,
+      copyFiles: copyFiles,
+      headers: headers,
+      entitlements: entitlements,
+      scripts: scripts,
+      dependencies: dependencies,
+      settings: settings,
+      coreDataModels: coreDataModels,
+      environment: environment,
+      launchArguments: launchArguments,
+      additionalFiles: additionalFiles
+    )
+  }
 }

--- a/Sources/ProjectDescription/TargetScript.swift
+++ b/Sources/ProjectDescription/TargetScript.swift
@@ -96,6 +96,48 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
         self.shellPath = shellPath
         self.dependencyFile = dependencyFile
     }
+  
+  /// Creates the target script with its attributes.
+  ///
+  /// - Parameters:
+  ///   - name: Name of the build phase when the project gets generated.
+  ///   - script: The script to be executed.
+  ///   - order: Target script order
+  ///   - inputPaths: List of input file paths.
+  ///   - inputFileListPaths: List of input filelist paths.
+  ///   - outputPaths: List of output file paths.
+  ///   - outputFileListPaths: List of output filelist paths.
+  ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+  ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
+  ///   - shellPath: The path to the shell which shall execute this script. Default is `/bin/sh`.
+  ///   - dependencyFile The path to the dependency file. Default is `nil`.
+  convenience init(
+    name: String,
+    script: Script = .embedded(""),
+    order: Order,
+    inputPaths: Path... = [],
+    inputFileListPaths: [Path] = [],
+    outputPaths: Path... = [],
+    outputFileListPaths: Path... = [],
+    basedOnDependencyAnalysis: Bool? = nil,
+    runForInstallBuildsOnly: Bool = false,
+    shellPath: String = "/bin/sh",
+    dependencyFile: Path? = nil
+  ) {
+    self.init(
+      name: name,
+      script: script,
+      order: order,
+      inputPaths: inputPaths,
+      inputFileListPaths: inputFileListPaths,
+      outputPaths: outputPaths,
+      outputFileListPaths: outputFileListPaths,
+      basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+      runForInstallBuildsOnly: runForInstallBuildsOnly,
+      shellPath: shellPath,
+      dependencyFile: dependencyFile
+    )
+  }
 
     // MARK: - Path init
 
@@ -141,6 +183,51 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
             dependencyFile: dependencyFile
         )
     }
+  
+  // MARK: - Path init
+
+  /// Returns a target script that gets executed before the sources and resources build phase.
+  ///
+  /// - Parameters:
+  ///   - path: Path to the script to execute.
+  ///   - arguments: Arguments that to be passed.
+  ///   - name: Name of the build phase when the project gets generated.
+  ///   - inputPaths: List of input file paths.
+  ///   - inputFileListPaths: List of input filelist paths.
+  ///   - outputPaths: List of output file paths.
+  ///   - outputFileListPaths: List of output filelist paths.
+  ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+  ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
+  ///   - shellPath: The path to the shell which shall execute this script. Default is `/bin/sh`.
+  ///   - dependencyFile The path to the dependency file. Default is `nil`.
+  /// - Returns: Target script.
+  public static func pre(
+    path: Path,
+    arguments: String...,
+    name: String,
+    inputPaths: Path... = [],
+    inputFileListPaths: Path... = [],
+    outputPaths: Path... = [],
+    outputFileListPaths: Path... = [],
+    basedOnDependencyAnalysis: Bool? = nil,
+    runForInstallBuildsOnly: Bool = false,
+    shellPath: String = "/bin/sh",
+    dependencyFile: Path? = nil
+  ) -> TargetScript {
+    pre(
+      path: path,
+      arguments: arguments,
+      name: name,
+      inputPaths: inputPaths,
+      inputFileListPaths: inputFileListPaths,
+      outputPaths: outputPaths,
+      outputFileListPaths: outputFileListPaths,
+      basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+      runForInstallBuildsOnly: runForInstallBuildsOnly,
+      shellPath: shellPath,
+      dependencyFile: dependencyFile
+    )
+  }
 
     /// Returns a target script that gets executed before the sources and resources build phase.
     ///
@@ -227,6 +314,50 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
             dependencyFile: dependencyFile
         )
     }
+  
+  /// Returns a target script that gets executed after the sources and resources build phase.
+  ///
+  /// - Parameters:
+  ///   - path: Path to the script to execute.
+  ///   - arguments: Arguments that to be passed.
+  ///   - name: Name of the build phase when the project gets generated.
+  ///   - inputPaths: List of input file paths.
+  ///   - inputFileListPaths: List of input filelist paths.
+  ///   - outputPaths: List of output file paths.
+  ///   - outputFileListPaths: List of output filelist paths.
+  ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+  ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
+  ///   - shellPath: The path to the shell which shall execute this script. Default is `/bin/sh`.
+  ///   - dependencyFile The path to the dependency file. Default is `nil`.
+  /// - Returns: Target script.
+  public static func post(
+    path: Path,
+    arguments: String...,
+    name: String,
+    inputPaths: Path... = [],
+    inputFileListPaths: Path... = [],
+    outputPaths: Path... = [],
+    outputFileListPaths: Path... = [],
+    basedOnDependencyAnalysis: Bool? = nil,
+    runForInstallBuildsOnly: Bool = false,
+    shellPath: String = "/bin/sh",
+    dependencyFile: Path? = nil
+  ) -> TargetScript {
+    post(
+      path: path,
+      arguments: arguments,
+      name: name,
+      inputPaths: inputPaths,
+      inputFileListPaths: inputFileListPaths,
+      outputPaths: outputPaths,
+      outputFileListPaths: outputFileListPaths,
+      basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+      runForInstallBuildsOnly: runForInstallBuildsOnly,
+      shellPath: shellPath,
+      dependencyFile: dependencyFile
+    )
+  }
+
 
     /// Returns a target script that gets executed after the sources and resources build phase.
     ///
@@ -316,6 +447,49 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
         )
     }
 
+  /// Returns a target script that gets executed before the sources and resources build phase.
+  ///
+  /// - Parameters:
+  ///   - tool: Name of the tool to execute. Tuist will look up the tool on the environment's PATH.
+  ///   - arguments: Arguments that to be passed.
+  ///   - name: Name of the build phase when the project gets generated.
+  ///   - inputPaths: List of input file paths.
+  ///   - inputFileListPaths: List of input filelist paths.
+  ///   - outputPaths: List of output file paths.
+  ///   - outputFileListPaths: List of output filelist paths.
+  ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+  ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
+  ///   - shellPath: The path to the shell which shall execute this script. Default is `/bin/sh`.
+  ///   - dependencyFile The path to the dependency file. Default is `nil`.
+  /// - Returns: Target script.
+  public static func pre(
+    tool: String,
+    arguments: String...,
+    name: String,
+    inputPaths: Path... = [],
+    inputFileListPaths: Path... = [],
+    outputPaths: Path... = [],
+    outputFileListPaths: Path... = [],
+    basedOnDependencyAnalysis: Bool? = nil,
+    runForInstallBuildsOnly: Bool = false,
+    shellPath: String = "/bin/sh",
+    dependencyFile: Path? = nil
+  ) -> TargetScript {
+    pre(
+      tool: tool,
+      arguments: arguments,
+      name: name,
+      inputPaths: inputPaths,
+      inputFileListPaths: inputFileListPaths,
+      outputPaths: outputPaths,
+      outputFileListPaths: outputFileListPaths,
+      basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+      runForInstallBuildsOnly: runForInstallBuildsOnly,
+      shellPath: shellPath,
+      dependencyFile: dependencyFile
+    )
+  }
+  
     /// Returns a target script that gets executed before the sources and resources build phase.
     ///
     /// - Parameters:
@@ -401,6 +575,49 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
             dependencyFile: dependencyFile
         )
     }
+  
+  /// Returns a target script that gets executed after the sources and resources build phase.
+  ///
+  /// - Parameters:
+  ///   - tool: Name of the tool to execute. Tuist will look up the tool on the environment's PATH.
+  ///   - arguments: Arguments that to be passed.
+  ///   - name: Name of the build phase when the project gets generated.
+  ///   - inputPaths: List of input file paths.
+  ///   - inputFileListPaths: List of input filelist paths.
+  ///   - outputPaths: List of output file paths.
+  ///   - outputFileListPaths: List of output filelist paths.
+  ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+  ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
+  ///   - shellPath: The path to the shell which shall execute this script. Default is `/bin/sh`.
+  ///   - dependencyFile The path to the dependency file. Default is `nil`.
+  /// - Returns: Target script.
+  public static func post(
+    tool: String,
+    arguments: String...,
+    name: String,
+    inputPaths: [Path] = [],
+    inputFileListPaths: [Path] = [],
+    outputPaths: [Path] = [],
+    outputFileListPaths: [Path] = [],
+    basedOnDependencyAnalysis: Bool? = nil,
+    runForInstallBuildsOnly: Bool = false,
+    shellPath: String = "/bin/sh",
+    dependencyFile: Path? = nil
+  ) -> TargetScript {
+    post(
+      tool: tool,
+      arguments: arguments,
+      name: name,
+      inputPaths: inputPaths,
+      inputFileListPaths: inputFileListPaths,
+      outputPaths: outputPaths,
+      outputFileListPaths: outputFileListPaths,
+      basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+      runForInstallBuildsOnly: runForInstallBuildsOnly,
+      shellPath: shellPath,
+      dependencyFile: dependencyFile
+    )
+  }
 
     /// Returns a target script that gets executed after the sources and resources build phase.
     ///
@@ -488,6 +705,47 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
             dependencyFile: dependencyFile
         )
     }
+  
+  /// Returns a target script that gets executed before the sources and resources build phase.
+  ///
+  /// - Parameters:
+  ///   - script: The text of the script to run. This should be kept small.
+  ///   - arguments: Arguments that to be passed.
+  ///   - name: Name of the build phase when the project gets generated.
+  ///   - inputPaths: List of input file paths.
+  ///   - inputFileListPaths: List of input filelist paths.
+  ///   - outputPaths: List of output file paths.
+  ///   - outputFileListPaths: List of output filelist paths.
+  ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+  ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
+  ///   - shellPath: The path to the shell which shall execute this script. Default is `/bin/sh`.
+  ///   - dependencyFile The path to the dependency file. Default is `nil`.
+  /// - Returns: Target script.
+  public static func pre(
+    script: String,
+    name: String,
+    inputPaths: Path... = [],
+    inputFileListPaths: Path... = [],
+    outputPaths: Path... = [],
+    outputFileListPaths: Path... = [],
+    basedOnDependencyAnalysis: Bool? = nil,
+    runForInstallBuildsOnly: Bool = false,
+    shellPath: String = "/bin/sh",
+    dependencyFile: Path? = nil
+  ) -> TargetScript {
+    pre(
+      script: script,
+      name: name,
+      inputPaths: inputPaths,
+      inputFileListPaths: inputFileListPaths,
+      outputPaths: outputPaths,
+      outputFileListPaths: outputFileListPaths,
+      basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+      runForInstallBuildsOnly: runForInstallBuildsOnly,
+      shellPath: shellPath,
+      dependencyFile: dependencyFile
+    )
+  }
 
     /// Returns a target script that gets executed after the sources and resources build phase.
     ///
@@ -529,4 +787,44 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
             dependencyFile: dependencyFile
         )
     }
+  
+  /// Returns a target script that gets executed after the sources and resources build phase.
+  ///
+  /// - Parameters:
+  ///   - script: The script to be executed.
+  ///   - name: Name of the build phase when the project gets generated.
+  ///   - inputPaths: List of input file paths.
+  ///   - inputFileListPaths: List of input filelist paths.
+  ///   - outputPaths: List of output file paths.
+  ///   - outputFileListPaths: List of output filelist paths.
+  ///   - basedOnDependencyAnalysis: Whether to skip running this script in incremental builds
+  ///   - runForInstallBuildsOnly: Whether this script only runs on install builds (default is false)
+  ///   - shellPath: The path to the shell which shall execute this script. Default is `/bin/sh`.
+  ///   - dependencyFile The path to the dependency file. Default is `nil`.
+  /// - Returns: Target script.
+  public static func post(
+    script: String,
+    name: String,
+    inputPaths: Path... = [],
+    inputFileListPaths: Path... = [],
+    outputPaths: Path... = [],
+    outputFileListPaths: Path... = [],
+    basedOnDependencyAnalysis: Bool? = nil,
+    runForInstallBuildsOnly: Bool = false,
+    shellPath: String = "/bin/sh",
+    dependencyFile: Path? = nil
+  ) -> TargetScript {
+    post(
+      script: script,
+      name: name,
+      inputPaths: inputPaths,
+      inputFileListPaths: inputFileListPaths,
+      outputPaths: outputPaths,
+      outputFileListPaths: outputFileListPaths,
+      basedOnDependencyAnalysis: basedOnDependencyAnalysis,
+      runForInstallBuildsOnly: runForInstallBuildsOnly,
+      shellPath: shellPath,
+      dependencyFile: dependencyFile
+    )
+  }
 }

--- a/Sources/ProjectDescription/Template/Template.swift
+++ b/Sources/ProjectDescription/Template/Template.swift
@@ -19,6 +19,18 @@ public struct Template: Codable, Equatable {
         self.items = items
         dumpIfNeeded(self)
     }
+  
+  public convenience init(
+    description: String,
+    attributes: Attribute... = [],
+    items: Item... = []
+  ) {
+    self.init(
+      description: description,
+      attributes: attributes,
+      items: items
+    )
+  }
 
     /// Enum containing information about how to generate item
     public enum Contents: Codable, Equatable {

--- a/Sources/ProjectDescription/TestAction.swift
+++ b/Sources/ProjectDescription/TestAction.swift
@@ -94,6 +94,42 @@ public struct TestAction: Equatable, Codable {
             diagnosticsOptions: diagnosticsOptions
         )
     }
+  
+  /// Returns a test action from a list of targets to be tested.
+  /// - Parameters:
+  ///   - targets: List of targets to be tested.
+  ///   - arguments: Arguments passed when running the tests.
+  ///   - configuration: Configuration to be used.
+  ///   - attachDebugger: A boolean controlling whether a debugger is attached to the process running the tests.
+  ///   - expandVariableFromTarget: A target that will be used to expand the variables defined inside Environment Variables definition
+  ///   - preActions: Actions to execute before running the tests.
+  ///   - postActions: Actions to execute after running the tests.
+  ///   - options: Test options.
+  ///   - diagnosticsOptions: Diagnostics options.
+  /// - Returns: An initialized test action.
+  public static func targets(
+    _ targets: TestableTarget...,
+    arguments: Arguments? = nil,
+    configuration: ConfigurationName = .debug,
+    attachDebugger: Bool = true,
+    expandVariableFromTarget: TargetReference? = nil,
+    preActions: ExecutionAction... = [],
+    postActions: ExecutionAction... = [],
+    options: TestActionOptions = .options(),
+    diagnosticsOptions: SchemeDiagnosticsOption... = [.mainThreadChecker]
+  ) -> Self {
+    targets(
+      targets,
+      arguments: arguments,
+      configuration: configuration,
+      attachDebugger: attachDebugger,
+      expandVariableFromTarget: expandVariableFromTarget,
+      preActions: preActions,
+      postActions: postActions,
+      options: options,
+      diagnosticsOptions: diagnosticsOptions
+    )
+  }
 
     /// Returns a test action from a list of test plans.
     /// - Parameters:
@@ -123,4 +159,28 @@ public struct TestAction: Equatable, Codable {
             diagnosticsOptions: []
         )
     }
+  
+  /// Returns a test action from a list of test plans.
+  /// - Parameters:
+  ///   - testPlans: List of test plans to run.
+  ///   - configuration: Configuration to be used.
+  ///   - attachDebugger: A boolean controlling whether a debugger is attached to the process running the tests.
+  ///   - preActions: Actions to execute before running the tests.
+  ///   - postActions: Actions to execute after running the tests.
+  /// - Returns: A test action.
+  public static func testPlans(
+    _ testPlans: Path...,
+    configuration: ConfigurationName = .debug,
+    attachDebugger: Bool = true,
+    preActions: ExecutionAction... = [],
+    postActions: ExecutionAction... = []
+  ) -> Self {
+    testPlans(
+      testPlans,
+      configuration: configuration,
+      attachDebugger: attachDebugger,
+      preActions: preActions,
+      postActions: postActions
+    )
+  }
 }

--- a/Sources/ProjectDescription/TestActionOptions.swift
+++ b/Sources/ProjectDescription/TestActionOptions.swift
@@ -25,6 +25,20 @@ public struct TestActionOptions: Equatable, Codable {
         self.coverage = coverage
         self.codeCoverageTargets = codeCoverageTargets
     }
+  
+  convenience init(
+    language: SchemeLanguage?,
+    region: String?,
+    coverage: Bool,
+    codeCoverageTargets: TargetReference...
+  ) {
+    self.init(
+      language: language,
+      region: region,
+      coverage: coverage,
+      codeCoverageTargets: codeCoverageTargets
+    )
+  }
 
     /// Returns a set of options for a test action.
     /// - Parameters:
@@ -46,4 +60,25 @@ public struct TestActionOptions: Equatable, Codable {
             codeCoverageTargets: codeCoverageTargets
         )
     }
+  
+  /// Returns a set of options for a test action.
+  /// - Parameters:
+  ///   - language: Language used for running the tests.
+  ///   - region: Region used for running the tests.
+  ///   - coverage: Whether test coverage should be collected.
+  ///   - codeCoverageTargets: List of tests whose code coverage information should be collected.
+  /// - Returns: A set of options.
+  public static func options(
+      language: SchemeLanguage? = nil,
+      region: String? = nil,
+      coverage: Bool = false,
+      codeCoverageTargets: TargetReference... = []
+  ) -> TestActionOptions {
+      options(
+        language: language,
+        region: region,
+        coverage: coverage,
+        codeCoverageTargets: codeCoverageTargets
+      )
+  }
 }

--- a/Sources/ProjectDescription/Version.swift
+++ b/Sources/ProjectDescription/Version.swift
@@ -31,6 +31,22 @@ public struct Version: Hashable, Codable {
         self.prereleaseIdentifiers = prereleaseIdentifiers
         self.buildMetadataIdentifiers = buildMetadataIdentifiers
     }
+  
+  public convenience init(
+    _ major: Int,
+    _ minor: Int,
+    _ patch: Int,
+    prereleaseIdentifiers: String... = [],
+    buildMetadataIdentifiers: String... = []
+  ) {
+    self.init(
+      major,
+      minor,
+      patch,
+      prereleaseIdentifiers: prereleaseIdentifiers,
+      buildMetadataIdentifiers: buildMetadataIdentifiers
+    )
+  }
 }
 
 extension Version: Comparable {

--- a/Sources/ProjectDescription/Workspace.swift
+++ b/Sources/ProjectDescription/Workspace.swift
@@ -57,4 +57,22 @@ public struct Workspace: Codable, Equatable {
         self.generationOptions = generationOptions
         dumpIfNeeded(self)
     }
+  
+  public convenience init(
+    name: String,
+    projects: Path...,
+    schemes: Scheme... = [],
+    fileHeaderTemplate: FileHeaderTemplate? = nil,
+    additionalFiles: FileElement... = [],
+    generationOptions: GenerationOptions = .options()
+  ) {
+    self.init(
+      name: name,
+      projects: projects,
+      schemes: schemes,
+      fileHeaderTemplate : fileHeaderTemplate,
+      additionalFiles: additionalFiles,
+      generationOptions: generationOptions
+    )
+  }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY

### Short description 📝

Variadic Parameters were applied to the files in the Source folder.

Variadic parameters were applied only to some files, so there was an inconvenience of having to use [] in many methods.

So, it was applied to all methods.

To comply with the DRY principle, the existing method was used.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

### Contributor checklist ✅

- [ ] The code has been linted using run `./fourier lint tuist --fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
