### PR TITLE
Update Preprocessor statement inside Font Template

### DIFF
--- a/Sources/TuistGenerator/Templates/FontsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/FontsTemplate.swift
@@ -8,7 +8,7 @@ extension SynthesizedResourceInterfaceTemplates {
     {% if families %}
     {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
     {% set fontType %}{{param.name}}FontConvertible{% endset %}
-    #if os(OSX)
+    #if os(macOS)
       import AppKit.NSFont
     #elseif os(iOS) || os(tvOS) || os(watchOS)
       import UIKit.UIFont
@@ -50,7 +50,7 @@ extension SynthesizedResourceInterfaceTemplates {
       {{accessModifier}} let family: String
       {{accessModifier}} let path: String
 
-      #if os(OSX)
+      #if os(macOS)
       {{accessModifier}} typealias Font = NSFont
       #elseif os(iOS) || os(tvOS) || os(watchOS)
       {{accessModifier}} typealias Font = UIFont
@@ -85,7 +85,7 @@ extension SynthesizedResourceInterfaceTemplates {
         if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
           font.register()
         }
-        #elseif os(OSX)
+        #elseif os(macOS)
         if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
           font.register()
         }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY

### Short description 📝
Preprocessor statement update inside Font Template
Content changes ``OSX -> macOS``

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
