### PR TITLE
Disable tests when pushing on main

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,9 +3,6 @@ name: Checks
 
 # This workflow only runs when there are changes to the Swift code.
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - Tuist/Dependencies/Lockfiles/Package.resolved
@@ -27,7 +24,7 @@ env:
 jobs:
   lint_lockfiles:
     name: Lint lockfiles
-    runs-on: macOS-12
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -1,13 +1,11 @@
 name: Cloud
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - projects/cloud/**
       - projects/fourier/**
+      - .github/workflows/cloud.yml
 
 env:
   RAILS_ENV: test
@@ -70,7 +68,7 @@ jobs:
           bundle exec rails test
   lint:
     name: Lint
-    runs-on: macOS-12
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,6 @@
 name: Docs
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - projects/docs/**

--- a/.github/workflows/fixturegen.yml
+++ b/.github/workflows/fixturegen.yml
@@ -1,9 +1,6 @@
 name: Fixturegen
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - projects/fixturegen/**
@@ -12,6 +9,7 @@ on:
       - Sources/**
       - .github/workflows/fixture-generator.yml
       - projects/fourier/**
+      - .github/workflows/fixturegen.yml
 
 concurrency:
   group: fixture-generator-${{ github.head_ref }}
@@ -23,7 +21,7 @@ env:
 jobs:
   test:
     name: Test the fixture generator with Xcode
-    runs-on: macOS-12
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
@@ -47,7 +45,7 @@ jobs:
         run: ./fourier tuist generate --path Fixture
   lint:
     name: Lint
-    runs-on: macOS-12
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/fourier.yml
+++ b/.github/workflows/fourier.yml
@@ -1,9 +1,6 @@
 name: Fourier
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - projects/fourier/**
@@ -42,7 +39,7 @@ jobs:
           ./fourier test fourier
   lint:
     name: Lint
-    runs-on: macOS-12
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/meta-tuist.yml
+++ b/.github/workflows/meta-tuist.yml
@@ -1,9 +1,6 @@
 name: Meta Tuist
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - Tuist/**
@@ -15,9 +12,9 @@ on:
       - Tests/**
       - projects/tuist/features/**
       - projects/tuist/fixtures/**
-      - .github/workflows/meta-tuist.yml
       - .package.resolved
       - projects/fourier/**
+      - .github/workflows/meta-tuist.yml
 
 concurrency:
   group: meta-tuist-${{ github.head_ref }}
@@ -31,7 +28,7 @@ env:
 jobs:
   build:
     name: Build with Xcode
-    runs-on: macOS-12
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
@@ -54,7 +51,7 @@ jobs:
           ./fourier build tuist all
   generate:
     name: Generate with Xcode
-    runs-on: macOS-12
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
@@ -77,7 +74,7 @@ jobs:
           ./fourier generate tuist --targets tuist
   test:
     name: Test with Xcode
-    runs-on: macOS-12
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
@@ -101,7 +98,7 @@ jobs:
   
   lint-lockfiles:
     name: Lint lockfiles
-    runs-on: macOS-12
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,9 +1,6 @@
 name: Release dry-run
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - Tuist/Dependencies/Lockfiles/Package.resolved
@@ -22,7 +19,7 @@ env:
 jobs:
   bundle-all:
     name: Bundle tuist and tuistenv with Xcode
-    runs-on: macOS-12
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v1
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -1,9 +1,6 @@
 name: Tuist
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - Tuist/**
@@ -16,9 +13,9 @@ on:
       - Tests/**
       - projects/tuist/features/**
       - projects/tuist/fixtures/**
-      - .github/workflows/tuist.yml
       - .package.resolved
       - projects/fourier/**
+      - .github/workflows/tuist.yml
 
 concurrency:
   group: tuist-${{ github.head_ref }}
@@ -34,7 +31,7 @@ env:
 jobs:
   unit_tests:
     name: Unit tests with Xcode
-    runs-on: macOS-12
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
@@ -65,7 +62,7 @@ jobs:
           ./fourier test tuist unit
   release_build:
     name: Release build with Xcode
-    runs-on: macOS-12
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v2
@@ -87,7 +84,7 @@ jobs:
 
   acceptance_tests:
     name: ${{ matrix.feature }} acceptance tests with Xcode
-    runs-on: macOS-12
+    runs-on: macos-12
     strategy:
       matrix:
         feature:
@@ -203,7 +200,7 @@ jobs:
   
   lint:
     name: Lint
-    runs-on: macOS-12
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
@@ -228,7 +225,7 @@ jobs:
   
   lint-lockfiles:
     name: Lint lockfiles
-    runs-on: macOS-12
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/tuistbench.yml
+++ b/.github/workflows/tuistbench.yml
@@ -1,9 +1,6 @@
 name: Tuistbench
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - projects/fourier/**
@@ -21,7 +18,7 @@ env:
 jobs:
   test:
     name: Build benchmarking tooling with Xcode
-    runs-on: macOS-12
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode
@@ -41,10 +38,9 @@ jobs:
           bundle install --jobs 4 --retry 3
       - name: Build
         run: ./fourier build benchmark
-
   lint:
     name: Lint
-    runs-on: macOS-12
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,9 +1,6 @@
 name: Website
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - projects/website/**


### PR DESCRIPTION
You can't merge if tests don't pass on the PR, so running tests on main just steals CI resources from the other PRs.
Also, even if they would fail nobody would probably notice :D