### PR TITLE
Consider system architecture when computing macOS target hashes

### DIFF
--- a/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/TargetContentHasher.swift
@@ -130,6 +130,12 @@ public final class TargetContentHasher: TargetContentHashing {
             stringsToHash.append(settingsHash)
         }
         stringsToHash += additionalStrings
+        switch graphTarget.target.deploymentTarget {
+        case .macOS, .none:
+            stringsToHash.append(DeveloperEnvironment.shared.architecture.rawValue)
+        case .iOS, .watchOS, .tvOS:
+            break
+        }
 
         return try contentHasher.hash(stringsToHash)
     }


### PR DESCRIPTION
I got some framework from tuist cache which were not containing the arm64 binary and compilation was failing.
This should solve the issue by generating separate binaries for different archictectures