### PR TITLE
Fix for `tuist fetch` not failing when run outside of a Tuist project

### DIFF
--- a/Sources/TuistKit/Services/FetchService.swift
+++ b/Sources/TuistKit/Services/FetchService.swift
@@ -66,10 +66,7 @@ final class FetchService {
     }
 
     private func fetchDependencies(path: AbsolutePath, update: Bool, with plugins: TuistGraph.Plugins) throws {
-        let manifests = manifestLoader.manifests(at: path)
-        guard manifests.contains(.workspace) || manifests.contains(.project) else {
-            throw ManifestLoaderError.manifestNotFound(path)
-        }
+        try manifestLoader.validateHasProjectOrWorkspaceManifest(at: path)
 
         if update {
             logger.info("Updating dependencies.", metadata: .section)

--- a/Sources/TuistKit/Services/FetchService.swift
+++ b/Sources/TuistKit/Services/FetchService.swift
@@ -69,7 +69,6 @@ final class FetchService {
         try manifestLoader.validateHasProjectOrWorkspaceManifest(at: path)
 
         guard FileHandler.shared.exists(
-havebeenfitz marked this conversation as resolved.
             path.appending(components: Constants.tuistDirectoryName, Manifest.dependencies.fileName(path))
         ) else {
             return

--- a/Sources/TuistKit/Services/FetchService.swift
+++ b/Sources/TuistKit/Services/FetchService.swift
@@ -10,6 +10,7 @@ import TuistSupport
 final class FetchService {
     private let pluginService: PluginServicing
     private let configLoader: ConfigLoading
+    private let manifestLoader: ManifestLoading
     private let dependenciesController: DependenciesControlling
     private let dependenciesModelLoader: DependenciesModelLoading
     private let converter: ManifestModelConverting
@@ -17,12 +18,14 @@ final class FetchService {
     init(
         pluginService: PluginServicing = PluginService(),
         configLoader: ConfigLoading = ConfigLoader(manifestLoader: CachedManifestLoader()),
+        manifestLoader: ManifestLoading = ManifestLoader(),
         dependenciesController: DependenciesControlling = DependenciesController(),
         dependenciesModelLoader: DependenciesModelLoading = DependenciesModelLoader(),
         converter: ManifestModelConverting = ManifestModelConverter()
     ) {
         self.pluginService = pluginService
         self.configLoader = configLoader
+        self.manifestLoader = manifestLoader
         self.dependenciesController = dependenciesController
         self.dependenciesModelLoader = dependenciesModelLoader
         self.converter = converter
@@ -63,6 +66,11 @@ final class FetchService {
     }
 
     private func fetchDependencies(path: AbsolutePath, update: Bool, with plugins: TuistGraph.Plugins) throws {
+        let manifests = manifestLoader.manifests(at: path)
+        guard manifests.contains(.workspace) || manifests.contains(.project) else {
+            throw ManifestLoaderError.manifestNotFound(path)
+        }
+
         if update {
             logger.info("Updating dependencies.", metadata: .section)
         } else {

--- a/Sources/TuistKit/Services/FetchService.swift
+++ b/Sources/TuistKit/Services/FetchService.swift
@@ -68,6 +68,13 @@ final class FetchService {
     private func fetchDependencies(path: AbsolutePath, update: Bool, with plugins: TuistGraph.Plugins) throws {
         try manifestLoader.validateHasProjectOrWorkspaceManifest(at: path)
 
+        guard FileHandler.shared.exists(
+havebeenfitz marked this conversation as resolved.
+            path.appending(components: Constants.tuistDirectoryName, Manifest.dependencies.fileName(path))
+        ) else {
+            return
+        }
+
         if update {
             logger.info("Updating dependencies.", metadata: .section)
         } else {

--- a/Sources/TuistKit/Services/FetchService.swift
+++ b/Sources/TuistKit/Services/FetchService.swift
@@ -63,12 +63,6 @@ final class FetchService {
     }
 
     private func fetchDependencies(path: AbsolutePath, update: Bool, with plugins: TuistGraph.Plugins) throws {
-        guard FileHandler.shared.exists(
-            path.appending(components: Constants.tuistDirectoryName, Manifest.dependencies.fileName(path))
-        ) else {
-            return
-        }
-
         if update {
             logger.info("Updating dependencies.", metadata: .section)
         } else {

--- a/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -86,10 +86,8 @@ final class ManifestGraphLoader: ManifestGraphLoading {
 
     // swiftlint:disable:next large_tuple
     func load(path: AbsolutePath) async throws -> (Graph, [SideEffectDescriptor], [LintingIssue]) {
+        try manifestLoader.validateHasProjectOrWorkspaceManifest(at: path)
         let manifests = manifestLoader.manifests(at: path)
-        guard manifests.contains(.workspace) || manifests.contains(.project) else {
-            throw ManifestLoaderError.manifestNotFound(path)
-        }
 
         // Load Plugins
         let plugins = try await loadPlugins(at: path)

--- a/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -87,7 +87,6 @@ final class ManifestGraphLoader: ManifestGraphLoading {
     // swiftlint:disable:next large_tuple
     func load(path: AbsolutePath) async throws -> (Graph, [SideEffectDescriptor], [LintingIssue]) {
         try manifestLoader.validateHasProjectOrWorkspaceManifest(at: path)
-        let manifests = manifestLoader.manifests(at: path)
 
         // Load Plugins
         let plugins = try await loadPlugins(at: path)

--- a/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -93,10 +93,6 @@ public class CachedManifestLoader: ManifestLoading {
     public func loadDependencies(at path: AbsolutePath) throws -> Dependencies {
         try manifestLoader.loadDependencies(at: path)
     }
-    
-    public func validateHasProjectOrWorkspaceManifest(at path: AbsolutePath) throws {
-        try manifestLoader.validateHasProjectOrWorkspaceManifest(at: path)
-    }
 
     public func manifests(at path: AbsolutePath) -> Set<Manifest> {
         manifestLoader.manifests(at: path)

--- a/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -93,6 +93,10 @@ public class CachedManifestLoader: ManifestLoading {
     public func loadDependencies(at path: AbsolutePath) throws -> Dependencies {
         try manifestLoader.loadDependencies(at: path)
     }
+    
+    public func validateHasProjectOrWorkspaceManifest(at path: AbsolutePath) throws {
+        try manifestLoader.validateHasProjectOrWorkspaceManifest(at: path)
+    }
 
     public func manifests(at path: AbsolutePath) -> Set<Manifest> {
         manifestLoader.manifests(at: path)

--- a/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -102,6 +102,10 @@ public class CachedManifestLoader: ManifestLoading {
         manifestLoader.manifests(at: path)
     }
 
+    public func validateHasProjectOrWorkspaceManifest(at path: AbsolutePath) throws {
+        try manifestLoader.validateHasProjectOrWorkspaceManifest(at: path)
+    }
+
     public func register(plugins: Plugins) throws {
         pluginsHashCache = try calculatePluginsHash(for: plugins)
         try manifestLoader.register(plugins: plugins)

--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -84,8 +84,11 @@ public protocol ManifestLoading {
     func validateHasProjectOrWorkspaceManifest(at path: AbsolutePath) throws
 
     /// List all the manifests in the given directory.
-    /// - Parameter path: Path to the directory whose manifest files will be returend.
+    /// - Parameter path: Path to the directory whose manifest files will be returned.
     func manifests(at path: AbsolutePath) -> Set<Manifest>
+
+    /// Verifies that there is a project or workspace manifest at the given path, or throws an error otherwise.
+    func validateHasProjectOrWorkspaceManifest(at: AbsolutePath) throws
 
     /// Registers plugins that will be used within the manifest loading process.
     /// - Parameter plugins: The plugins to register.
@@ -144,6 +147,13 @@ public class ManifestLoader: ManifestLoading {
 
     public func manifests(at path: AbsolutePath) -> Set<Manifest> {
         Set(manifestFilesLocator.locateManifests(at: path).map(\.0))
+    }
+
+    public func validateHasProjectOrWorkspaceManifest(at path: AbsolutePath) throws {
+        let manifests = manifests(at: path)
+        guard manifests.contains(.workspace) || manifests.contains(.project) else {
+            throw ManifestLoaderError.manifestNotFound(path)
+        }
     }
 
     public func loadConfig(at path: AbsolutePath) throws -> ProjectDescription.Config {

--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -78,17 +78,13 @@ public protocol ManifestLoading {
     /// Loads the Plugin.swift in the given directory.
     /// - Parameter path: Path to the directory that contains Plugin.swift
     func loadPlugin(at path: AbsolutePath) throws -> ProjectDescription.Plugin
-    
-    /// Validated any manifest exists in the given path
-    /// - Parameter at: Path to the working directory
-    func validateHasProjectOrWorkspaceManifest(at path: AbsolutePath) throws
 
     /// List all the manifests in the given directory.
     /// - Parameter path: Path to the directory whose manifest files will be returned.
     func manifests(at path: AbsolutePath) -> Set<Manifest>
 
     /// Verifies that there is a project or workspace manifest at the given path, or throws an error otherwise.
-    func validateHasProjectOrWorkspaceManifest(at: AbsolutePath) throws
+    func validateHasProjectOrWorkspaceManifest(at path: AbsolutePath) throws
 
     /// Registers plugins that will be used within the manifest loading process.
     /// - Parameter plugins: The plugins to register.
@@ -136,13 +132,6 @@ public class ManifestLoader: ManifestLoading {
         self.projectDescriptionHelpersBuilderFactory = projectDescriptionHelpersBuilderFactory
         self.manifestFilesLocator = manifestFilesLocator
         decoder = JSONDecoder()
-    }
-    
-    public func validateHasProjectOrWorkspaceManifest(at path: AbsolutePath) throws {
-        let manifests = manifests(at: path)
-        guard manifests.contains(.workspace) || manifests.contains(.project) else {
-            throw ManifestLoaderError.manifestNotFound(path)
-        }
     }
 
     public func manifests(at path: AbsolutePath) -> Set<Manifest> {

--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -78,6 +78,10 @@ public protocol ManifestLoading {
     /// Loads the Plugin.swift in the given directory.
     /// - Parameter path: Path to the directory that contains Plugin.swift
     func loadPlugin(at path: AbsolutePath) throws -> ProjectDescription.Plugin
+    
+    /// Validated any manifest exists in the given path
+    /// - Parameter at: Path to the working directory
+    func validateHasProjectOrWorkspaceManifest(at path: AbsolutePath) throws
 
     /// List all the manifests in the given directory.
     /// - Parameter path: Path to the directory whose manifest files will be returend.
@@ -129,6 +133,13 @@ public class ManifestLoader: ManifestLoading {
         self.projectDescriptionHelpersBuilderFactory = projectDescriptionHelpersBuilderFactory
         self.manifestFilesLocator = manifestFilesLocator
         decoder = JSONDecoder()
+    }
+    
+    public func validateHasProjectOrWorkspaceManifest(at path: AbsolutePath) throws {
+        let manifests = manifests(at: path)
+        guard manifests.contains(.workspace) || manifests.contains(.project) else {
+            throw ManifestLoaderError.manifestNotFound(path)
+        }
     }
 
     public func manifests(at path: AbsolutePath) -> Set<Manifest> {

--- a/Sources/TuistLoaderTesting/Loaders/Mocks/MockManifestLoader.swift
+++ b/Sources/TuistLoaderTesting/Loaders/Mocks/MockManifestLoader.swift
@@ -40,6 +40,13 @@ public final class MockManifestLoader: ManifestLoading {
     public func loadWorkspace(at path: AbsolutePath) throws -> Workspace {
         try loadWorkspaceStub?(path) ?? Workspace.test()
     }
+    
+    public func validateHasProjectOrWorkspaceManifest(at path: AbsolutePath) throws {
+        let manifests = manifests(at: path)
+        guard manifests.contains(.workspace) || manifests.contains(.project) else {
+            throw ManifestLoaderError.manifestNotFound(path)
+        }
+    }
 
     public func manifests(at path: AbsolutePath) -> Set<Manifest> {
         manifestsAtCount += 1

--- a/Sources/TuistLoaderTesting/Loaders/Mocks/MockManifestLoader.swift
+++ b/Sources/TuistLoaderTesting/Loaders/Mocks/MockManifestLoader.swift
@@ -53,6 +53,13 @@ public final class MockManifestLoader: ManifestLoading {
         return manifestsAtStub?(path) ?? Set()
     }
 
+    public func validateHasProjectOrWorkspaceManifest(at path: AbsolutePath) throws {
+        let manifests = manifests(at: path)
+        guard manifests.contains(.workspace) || manifests.contains(.project) else {
+            throw ManifestLoaderError.manifestNotFound(path)
+        }
+    }
+
     func manifestPath(at path: AbsolutePath, manifest: Manifest) throws -> AbsolutePath {
         manifestPathCount += 1
         return try manifestPathStub?(path, manifest) ?? TemporaryDirectory(removeTreeOnDeinit: true).path

--- a/Sources/TuistLoaderTesting/Loaders/Mocks/MockManifestLoader.swift
+++ b/Sources/TuistLoaderTesting/Loaders/Mocks/MockManifestLoader.swift
@@ -40,13 +40,6 @@ public final class MockManifestLoader: ManifestLoading {
     public func loadWorkspace(at path: AbsolutePath) throws -> Workspace {
         try loadWorkspaceStub?(path) ?? Workspace.test()
     }
-    
-    public func validateHasProjectOrWorkspaceManifest(at path: AbsolutePath) throws {
-        let manifests = manifests(at: path)
-        guard manifests.contains(.workspace) || manifests.contains(.project) else {
-            throw ManifestLoaderError.manifestNotFound(path)
-        }
-    }
 
     public func manifests(at path: AbsolutePath) -> Set<Manifest> {
         manifestsAtCount += 1

--- a/Tests/TuistKitTests/Services/FetchServiceTests.swift
+++ b/Tests/TuistKitTests/Services/FetchServiceTests.swift
@@ -18,6 +18,7 @@ import XCTest
 final class FetchServiceTests: TuistUnitTestCase {
     private var pluginService: MockPluginService!
     private var configLoader: MockConfigLoader!
+    private var manifestLoader: MockManifestLoader!
     private var dependenciesController: MockDependenciesController!
     private var dependenciesModelLoader: MockDependenciesModelLoader!
 
@@ -28,12 +29,15 @@ final class FetchServiceTests: TuistUnitTestCase {
 
         pluginService = MockPluginService()
         configLoader = MockConfigLoader()
+        manifestLoader = MockManifestLoader()
+        manifestLoader.manifestsAtStub = { _ in [.project] }
         dependenciesController = MockDependenciesController()
         dependenciesModelLoader = MockDependenciesModelLoader()
 
         subject = FetchService(
             pluginService: pluginService,
             configLoader: configLoader,
+            manifestLoader: manifestLoader,
             dependenciesController: dependenciesController,
             dependenciesModelLoader: dependenciesModelLoader
         )

--- a/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
@@ -41,7 +41,7 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
         }
 
         subject = createSubject()
-        
+
         manifestLoader.loadWorkspaceStub = { [unowned self] path in
             guard let manifest = self.workspaceManifests[path] else {
                 throw ManifestLoaderError.manifestNotFound(.workspace, path)
@@ -259,7 +259,7 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
             ManifestLoaderError.manifestNotFound(.project, path)
         )
     }
-    
+
     func test_validate_projectExists() throws {
         // Given
         let path = try temporaryPath().appending(component: "App")
@@ -270,18 +270,18 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
         // Then
         try subject.validateHasProjectOrWorkspaceManifest(at: path)
     }
-    
+
     func test_validate_workspaceExists() throws {
         // Given
         let path = try temporaryPath().appending(component: "App")
-        
+
         // When
         manifestLoader.manifestsAtStub = { _ in [.workspace] }
-        
+
         // Then
         try subject.validateHasProjectOrWorkspaceManifest(at: path)
     }
-    
+
     func test_validate_projectDoesNotExist() throws {
         // Given
         let path = try temporaryPath().appending(component: "App")
@@ -292,11 +292,11 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
             ManifestLoaderError.manifestNotFound(path)
         )
     }
-    
+
     func test_validate_workspaceDoesNotExist() throws {
         // Given
         let path = try temporaryPath().appending(component: "App")
-        
+
         // When / Then
         XCTAssertThrowsSpecific(
             try subject.validateHasProjectOrWorkspaceManifest(at: path),
@@ -317,7 +317,7 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
             tuistVersion: tuistVersion
         )
     }
-    
+
     private func stubWorkspace(
         _ workspace: Workspace,
         at path: AbsolutePath

--- a/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
@@ -282,18 +282,7 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
         try subject.validateHasProjectOrWorkspaceManifest(at: path)
     }
 
-    func test_validate_projectDoesNotExist() throws {
-        // Given
-        let path = try temporaryPath().appending(component: "App")
-
-        // When / Then
-        XCTAssertThrowsSpecific(
-            try subject.validateHasProjectOrWorkspaceManifest(at: path),
-            ManifestLoaderError.manifestNotFound(path)
-        )
-    }
-
-    func test_validate_workspaceDoesNotExist() throws {
+    func test_validate_manifestDoesNotExist() throws {
         // Given
         let path = try temporaryPath().appending(component: "App")
 

--- a/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
@@ -263,17 +263,12 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
     func test_validate_projectExists() throws {
         // Given
         let path = try temporaryPath().appending(component: "App")
-        
+
         // When
-        let project = Project.test(name: "App")
-        try stubProject(project, at: path)
-        _ = try subject.loadProject(at: path)
-        
+        manifestLoader.manifestsAtStub = { _ in [.project] }
+
         // Then
-        XCTAssertThrowsSpecific(
-            try subject.validateHasProjectOrWorkspaceManifest(at: path),
-            ManifestLoaderError.manifestNotFound(path)
-        )
+        try subject.validateHasProjectOrWorkspaceManifest(at: path)
     }
     
     func test_validate_workspaceExists() throws {
@@ -281,15 +276,10 @@ final class CachedManifestLoaderTests: TuistUnitTestCase {
         let path = try temporaryPath().appending(component: "App")
         
         // When
-        let workspace = Workspace.test(name: "App")
-        try stubWorkspace(workspace, at: path)
-        _ = try subject.loadWorkspace(at: path)
+        manifestLoader.manifestsAtStub = { _ in [.workspace] }
         
         // Then
-        XCTAssertThrowsSpecific(
-            try subject.validateHasProjectOrWorkspaceManifest(at: path),
-            ManifestLoaderError.manifestNotFound(path)
-        )
+        try subject.validateHasProjectOrWorkspaceManifest(at: path)
     }
     
     func test_validate_projectDoesNotExist() throws {

--- a/projects/tuist/features/edit.feature
+++ b/projects/tuist/features/edit.feature
@@ -11,7 +11,6 @@ Feature: Edit an existing project using Tuist
     Given that tuist is available
     And I have a working directory
     Then I copy the fixture plugin into the working directory
-    Then tuist does fetch
     Then tuist edits the project
     Then I should be able to build for macOS the scheme Plugins
 

--- a/projects/tuist/features/edit.feature
+++ b/projects/tuist/features/edit.feature
@@ -11,6 +11,7 @@ Feature: Edit an existing project using Tuist
     Given that tuist is available
     And I have a working directory
     Then I copy the fixture plugin into the working directory
+    Then tuist does fetch
     Then tuist edits the project
     Then I should be able to build for macOS the scheme Plugins
 


### PR DESCRIPTION
Resolves #5047 

### Short description 📝

`tuist fetch` won't succeed in any directory now. Internal checks from `ManifestLoader` will fail the attempt.

```
Resolving and fetching plugins.
Plugins resolved and fetched successfully.
Manifest not found at path /Users/user/Library/Developer/Xcode/DerivedData/Tuist-cswbwinvydwhonfpadailaybahcs/Build/Products/Debug
Consider creating an issue using the following link: https://github.com/tuist/tuist/issues/new/choose
Program ended with exit code: 1
```

### How to test the changes locally 🧐

Pass an argument "fetch" on launch

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
