### PR TITLE
Fix generation of DocC documentation when a target name starts with and underscore

### DIFF
--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -538,7 +538,7 @@ extension ProjectDescription.Target {
                 .sanitize(targetName: target.name)
                 .replacingOccurrences(of: "-", with: "_"),
             bundleId: target.name
-                .replacingOccurrences(of: "_", with: "-"),
+                .replacingOccurrences(of: "_", with: "."),
             deploymentTarget: deploymentTarget,
             infoPlist: .default,
             sources: sources,

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -517,7 +517,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             .testWithDefaultConfigs(
                 name: "Package",
                 targets: [
-                    .test("Target_1", basePath: basePath, customBundleID: "Target-1"),
+                    .test("Target_1", basePath: basePath, customBundleID: "Target.1"),
                 ]
             )
         )


### PR DESCRIPTION
https://github.com/tuist/tuist/issues/5087

### Short description 📝

Looks like Xcode is not able to handle a bundle identifier starting with `-` (see screenshot below, probably they would need to wrap the bundleID in double quotes), so we replace `_` with `.` instead
<img width="1345" alt="Screenshot 2023-03-07 at 21 09 08" src="https://user-images.githubusercontent.com/2794031/223540906-57049e3f-4b4e-4cc5-9a39-3ff4a6bc44bd.png">
