### PR TITLE
Ignore UUID when matching default s3 buckets

### DIFF
--- a/projects/cloud/app/services/s3_buckets_fetch_service.rb
+++ b/projects/cloud/app/services/s3_buckets_fetch_service.rb
@@ -29,7 +29,7 @@ class S3BucketsFetchService < ApplicationService
     raise Error::Unauthorized.new(account_name) unless AccountPolicy.new(user, account).show?
 
     account.s3_buckets.reject { |s3_bucket|
-      s3_bucket.is_default && s3_bucket.name != "#{account_name}-#{project_name}"
+      s3_bucket.is_default && !s3_bucket.name.end_with?("#{account_name}-#{project_name}")
     }
   end
 end

--- a/projects/cloud/test/services/s3_buckets_fetch_service_test.rb
+++ b/projects/cloud/test/services/s3_buckets_fetch_service_test.rb
@@ -22,7 +22,7 @@ class S3BucketsFetchServiceTest < ActiveSupport::TestCase
     s3_bucket_default_one = account.s3_buckets.create!(
       access_key_id: "2",
       is_default: true,
-      name: "#{account.name}-project_one",
+      name: "random-id-#{account.name}-project_one",
       secret_access_key: "secret",
       region: "region",
     )


### PR DESCRIPTION
### Short description 📝

We were rejecting default s3 buckets since we introduce a UUID but did not reflect that in the fetch logic.