### PR TITLE
Stop transitive import of static libraries that are inside xcframeworks

### DIFF
--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -301,6 +301,8 @@ public class GraphTraverser: GraphTraversing {
         // Static libraries and frameworks / Static libraries' dynamic libraries
         if target.target.canLinkStaticProducts() {
             let transitiveStaticTargetReferences = transitiveStaticDependencies(from: .target(name: name, path: path))
+                .lazy
+                .filter(\.isNotStaticLibrary)
 
             // Exclude any static products linked in a host application
             // however, for search paths it's fine to keep them included
@@ -321,16 +323,17 @@ public class GraphTraverser: GraphTraversing {
                     .filter(isDependencyDynamicTarget)
             }
 
-            let staticDependenciesPrecompiledLibrariesAndFrameworks = transitiveStaticTargetReferences.flatMap { dependency in
+            let staticDependenciesPrecompiledFrameworks = transitiveStaticTargetReferences.flatMap { dependency in
                 self.graph.dependencies[dependency, default: []]
                     .lazy
                     .filter(\.isPrecompiled)
+                    .filter(\.isNotStaticLibrary)
             }
 
             let allDependencies = (
                 transitiveStaticTargetReferences
                     + staticDependenciesDynamicLibrariesAndFrameworks
-                    + staticDependenciesPrecompiledLibrariesAndFrameworks
+                    + staticDependenciesPrecompiledFrameworks
             )
 
             references.formUnion(

--- a/Sources/TuistGraph/Graph/GraphDependency.swift
+++ b/Sources/TuistGraph/Graph/GraphDependency.swift
@@ -97,6 +97,19 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         }
     }
 
+    public var isNotStaticLibrary: Bool {
+        switch self {
+        case let .xcframework(path: _, infoPlist: _, primaryBinaryPath: binaryPath, linking: _):
+            return binaryPath.extension != "a"
+        case .framework: return true
+        case .library: return false
+        case .bundle: return true
+        case .packageProduct: return true
+        case .target: return true
+        case .sdk: return true
+        }
+    }
+
     // MARK: - Internal
 
     public var targetDependency: (name: String, path: AbsolutePath)? {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4859

Also https://tuistapp.slack.com/archives/C018QG7U7SN/p1649434788599699 (thank you @ffittschen for your example project in Slack. I've attached a slightly altered one in this PR).

### Short description 📝

Example: 
* Static framework `SF` depends on an XCFramework which contains a static _library_, called `XSL`.
* If an App target depends on `SF` Tuist will transitively import `XSL` into the App target.
* Since `XSL` is a static _library_, its symbols become part of what it's linked into, resulting in duplicate symbol errors for being inside the App and `SF` (assuming the App target uses `-ObjC` in `OTHER_LD_FLAGS`, which is common).

This change stops the transitive import of static libraries if they're inside an XCFramework. We already prevent this for static libraries _not_ inside an XCFramework.

### How to test the changes locally 🧐

* Download my sample app. [ios_app_static_in_xcframework.zip](https://github.com/tuist/tuist/files/10925596/ios_app_static_in_xcframework.zip)
* Verify that the App target won't build on Tuist `main` (because of duplicate symbol errors).
* Now generate the project through this PR. All should be good!

### Contributor checklist ✅

- [ ] The code has been linted using run `./fourier lint tuist --fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Contributors have checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
