### PR TITLE
feature(dependencies): use optional when target version is lower than linked framework's introduced at

### DIFF
--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -2147,6 +2147,51 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             )
         )
     }
+    
+    func testMap_whenSettingsContainsLinkedFramework_mapsToSDKDependency_optional() throws {
+        let basePath = try temporaryPath()
+        let sourcesPath = basePath.appending(RelativePath("Package/Sources/Target1"))
+        try fileHandler.createFolder(sourcesPath)
+
+        let project = try subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageInfos: [
+                "Package": .init(
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(
+                            name: "Target1",
+                            settings: [
+                                .init(tool: .linker, name: .linkedFramework, condition: nil, value: ["AdServices"]),
+                            ]
+                        ),
+                    ],
+                    platforms: [
+                        .init(platformName: "iOS", version: "11.0", options: [])
+                    ],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+        XCTAssertEqual(
+            project,
+            .testWithDefaultConfigs(
+                name: "Package",
+                targets: [
+                    .test(
+                        "Target1",
+                        basePath: basePath,
+                        dependencies: [.sdk(name: "AdServices", type: .framework, status: .optional)]
+                    ),
+                ]
+            )
+        )
+    }
 
     func testMap_whenSettingsContainsLinkedLibrary_mapsToSDKDependency() throws {
         let basePath = try temporaryPath()


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5078

### Short description 📝

This PR add support to `TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper` can choice `.optional` when project target version is lower than linkedFramework's target version.

### How to test the changes locally 🧐

I add unit test function. You can change platform and linkedFramework's name of test function.

### Contributor checklist ✅

- [ ] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
