### PR TITLE
Allow to add carthage options on Dependencies.swift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ Tuist/Dependencies/graph.json
 # Release artifacts
 vendor/
 .bundle
+gems/
+

--- a/Sources/ProjectDescription/Dependencies/CarthageDependencies.swift
+++ b/Sources/ProjectDescription/Dependencies/CarthageDependencies.swift
@@ -4,11 +4,15 @@ import Foundation
 public struct CarthageDependencies: Codable, Equatable {
     /// List of dependencies that will be installed using Carthage.
     public let dependencies: [Dependency]
+    /// Set up Carthage's options.
+    public let options: Options
 
     /// Creates `CarthageDependencies` instance.
     /// - Parameter dependencies: List of dependencies that can be installed using Carthage.
-    public init(_ dependencies: [Dependency]) {
+    /// - Parameter options: Set up Carthage's options.
+    public init(_ dependencies: [Dependency], _ options: Options = .init()) {
         self.dependencies = dependencies
+        self.options = options
     }
 }
 
@@ -17,6 +21,7 @@ public struct CarthageDependencies: Codable, Equatable {
 extension CarthageDependencies: ExpressibleByArrayLiteral {
     public init(arrayLiteral elements: Dependency...) {
         dependencies = elements
+        options = .init()
     }
 }
 
@@ -40,5 +45,31 @@ extension CarthageDependencies {
         case atLeast(Version)
         case branch(String)
         case revision(String)
+    }
+}
+
+// MARK: - CarthageDependencies.Options
+
+extension CarthageDependencies {
+    /// A set of available options when running Carthage on Tuist.
+    public struct Options: Codable, Equatable {
+        /// Don't use downloaded binaries when possible
+        public let noUseBinaries: Bool
+
+        /// Use authentication credentials from `~/.netrc` file when downloading binary only frameworks.
+        public let useNetRC: Bool
+
+        /// Use cached builds when possible
+        public let cacheBuilds: Bool
+
+        /// Use the new resolver codeline when calculating dependencies.
+        public let newResolver: Bool
+
+        public init(noUseBinaries: Bool = true, useNetRC: Bool = true, cacheBuilds: Bool = true, newResolver: Bool = true) {
+            self.noUseBinaries = noUseBinaries
+            self.useNetRC = useNetRC
+            self.cacheBuilds = cacheBuilds
+            self.newResolver = newResolver
+        }
     }
 }

--- a/Sources/TuistDependencies/Carthage/CarthageInteractor.swift
+++ b/Sources/TuistDependencies/Carthage/CarthageInteractor.swift
@@ -102,12 +102,14 @@ public final class CarthageInteractor: CarthageInteracting {
             try carthageController.update(
                 at: pathsProvider.dependenciesDirectory,
                 platforms: platforms,
+                options: dependencies.options,
                 printOutput: true
             )
         } else {
             try carthageController.bootstrap(
                 at: pathsProvider.dependenciesDirectory,
                 platforms: platforms,
+                options: dependencies.options,
                 printOutput: true
             )
         }

--- a/Sources/TuistDependencies/Carthage/Utils/CarthageController+CarthageArguments.swift
+++ b/Sources/TuistDependencies/Carthage/Utils/CarthageController+CarthageArguments.swift
@@ -1,0 +1,42 @@
+import Foundation
+import TuistGraph
+
+extension CarthageController {
+    enum CarthageArguments: String, CaseIterable {
+        /// Don't use downloaded binaries when possible
+        case noUseBinaries = "--no-use-binaries"
+
+        /// Use authentication credentials from ~/.netrc file when downloading binary only frameworks.
+        case useNetRC = "--use-netrc"
+
+        /// Use cached builds when possible
+        case cacheBuilds = "--cache-builds"
+
+        /// Use the new resolver codeline when calculating dependencies.
+        case newResolver = "--new-resolver"
+    }
+}
+
+extension CarthageController.CarthageArguments {
+    static func map(fromFlagOptions flags: CarthageDependencies.Options) -> [String] {
+        var arguments: [CarthageController.CarthageArguments] = []
+
+        if flags.noUseBinaries {
+            arguments.append(.noUseBinaries)
+        }
+
+        if flags.useNetRC {
+            arguments.append(.useNetRC)
+        }
+
+        if flags.cacheBuilds {
+            arguments.append(.cacheBuilds)
+        }
+
+        if flags.newResolver {
+            arguments.append(.newResolver)
+        }
+
+        return arguments.map(\.rawValue)
+    }
+}

--- a/Sources/TuistDependencies/Carthage/Utils/CarthageController.swift
+++ b/Sources/TuistDependencies/Carthage/Utils/CarthageController.swift
@@ -66,7 +66,7 @@ public protocol CarthageControlling {
     func bootstrap(
         at path: AbsolutePath,
         platforms: Set<TuistGraph.Platform>,
-        options: Set<CarthageDependencies.Options>,
+        options: CarthageDependencies.Options,
         printOutput: Bool
     ) throws
 
@@ -79,7 +79,7 @@ public protocol CarthageControlling {
     func update(
         at path: AbsolutePath,
         platforms: Set<TuistGraph.Platform>,
-        options: Set<CarthageDependencies.Options>,
+        options: CarthageDependencies.Options,
         printOutput: Bool
     ) throws
 }
@@ -124,7 +124,7 @@ public final class CarthageController: CarthageControlling {
     public func bootstrap(
         at path: AbsolutePath,
         platforms: Set<TuistGraph.Platform>,
-        options: Set<CarthageDependencies.Options>,
+        options: CarthageDependencies.Options,
         printOutput: Bool
     ) throws {
         guard try isXCFrameworksProductionSupported() else {
@@ -141,7 +141,7 @@ public final class CarthageController: CarthageControlling {
     public func update(
         at path: AbsolutePath,
         platforms: Set<TuistGraph.Platform>,
-        options: Set<CarthageDependencies.Options>,
+        options: CarthageDependencies.Options,
         printOutput: Bool
     ) throws {
         guard try isXCFrameworksProductionSupported() else {
@@ -161,7 +161,7 @@ public final class CarthageController: CarthageControlling {
         path: AbsolutePath,
         platforms: Set<TuistGraph.Platform>,
         subcommand: String,
-        options: Set<CarthageDependencies.Options>
+        options: CarthageDependencies.Options
     ) -> [String] {
         var commandComponents: [String] = [
             "carthage",
@@ -180,7 +180,7 @@ public final class CarthageController: CarthageControlling {
             ]
         }
 
-        commandComponents += ["--use-xcframeworks"] + options.map(\.rawValue)
+        commandComponents += ["--use-xcframeworks"] + CarthageArguments.map(fromFlagOptions: options)
 
         return commandComponents
     }

--- a/Sources/TuistDependenciesTesting/Carthage/Utils/MockCarthageController.swift
+++ b/Sources/TuistDependenciesTesting/Carthage/Utils/MockCarthageController.swift
@@ -32,26 +32,28 @@ public final class MockCarthageController: CarthageControlling {
     }
 
     var invokedBootstrap = false
-    var bootstrapStub: ((AbsolutePath, Set<TuistGraph.Platform>, Bool) throws -> Void)?
+    var bootstrapStub: ((AbsolutePath, Set<TuistGraph.Platform>, Set<CarthageDependencies.Options>, Bool) throws -> Void)?
 
     public func bootstrap(
         at path: AbsolutePath,
         platforms: Set<TuistGraph.Platform>,
+        options: Set<TuistGraph.CarthageDependencies.Options>,
         printOutput: Bool
     ) throws {
         invokedBootstrap = true
-        try bootstrapStub?(path, platforms, printOutput)
+        try bootstrapStub?(path, platforms, options, printOutput)
     }
 
     var invokedUpdate = false
-    var updateStub: ((AbsolutePath, Set<TuistGraph.Platform>, Bool) throws -> Void)?
+    var updateStub: ((AbsolutePath, Set<TuistGraph.Platform>, Set<CarthageDependencies.Options>, Bool) throws -> Void)?
 
     public func update(
         at path: AbsolutePath,
         platforms: Set<TuistGraph.Platform>,
+        options: Set<CarthageDependencies.Options>,
         printOutput: Bool
     ) throws {
         invokedUpdate = true
-        try updateStub?(path, platforms, printOutput)
+        try updateStub?(path, platforms, options, printOutput)
     }
 }

--- a/Sources/TuistDependenciesTesting/Carthage/Utils/MockCarthageController.swift
+++ b/Sources/TuistDependenciesTesting/Carthage/Utils/MockCarthageController.swift
@@ -32,12 +32,12 @@ public final class MockCarthageController: CarthageControlling {
     }
 
     var invokedBootstrap = false
-    var bootstrapStub: ((AbsolutePath, Set<TuistGraph.Platform>, Set<CarthageDependencies.Options>, Bool) throws -> Void)?
+    var bootstrapStub: ((AbsolutePath, Set<TuistGraph.Platform>, CarthageDependencies.Options, Bool) throws -> Void)?
 
     public func bootstrap(
         at path: AbsolutePath,
         platforms: Set<TuistGraph.Platform>,
-        options: Set<TuistGraph.CarthageDependencies.Options>,
+        options: CarthageDependencies.Options,
         printOutput: Bool
     ) throws {
         invokedBootstrap = true
@@ -45,12 +45,12 @@ public final class MockCarthageController: CarthageControlling {
     }
 
     var invokedUpdate = false
-    var updateStub: ((AbsolutePath, Set<TuistGraph.Platform>, Set<CarthageDependencies.Options>, Bool) throws -> Void)?
+    var updateStub: ((AbsolutePath, Set<TuistGraph.Platform>, CarthageDependencies.Options, Bool) throws -> Void)?
 
     public func update(
         at path: AbsolutePath,
         platforms: Set<TuistGraph.Platform>,
-        options: Set<CarthageDependencies.Options>,
+        options: CarthageDependencies.Options,
         printOutput: Bool
     ) throws {
         invokedUpdate = true

--- a/Sources/TuistGraph/Models/Dependencies/CarthageDependencies.swift
+++ b/Sources/TuistGraph/Models/Dependencies/CarthageDependencies.swift
@@ -5,13 +5,19 @@ public struct CarthageDependencies: Equatable {
     /// List of dependencies that can be installed using Carthage.
     public let dependencies: [Dependency]
 
+    /// List of options that can be used on Carthage command.
+    public let options: Set<Options>
+
     /// Initializes a new `CarthageDependencies` instance.
     /// - Parameters:
     ///   - dependencies: List of dependencies that can be installed using Carthage.
+    ///   - options: Set of options that can be used on Carthage.
     public init(
-        _ dependencies: [Dependency]
+        _ dependencies: [Dependency],
+        _ options: Set<Options> = [.noUseBinaries, .useNetRC, .cacheBuilds, .newResolver]
     ) {
         self.dependencies = dependencies
+        self.options = options
     }
 
     /// Returns `Cartfile` representation.
@@ -72,5 +78,23 @@ extension CarthageDependencies {
                 return #""\#(revision)""#
             }
         }
+    }
+}
+
+// MARK: - CarthageDependencies.Options
+
+extension CarthageDependencies {
+    public enum Options: String {
+        /// Don't use downloaded binaries when possible
+        case noUseBinaries = "--no-use-binaries"
+
+        /// Use authentication credentials from ~/.netrc file when downloading binary only frameworks.
+        case useNetRC = "--use-netrc"
+
+        /// Use cached builds when possible
+        case cacheBuilds = "--cache-builds"
+
+        /// Use the new resolver codeline when calculating dependencies.
+        case newResolver = "--new-resolver"
     }
 }

--- a/Sources/TuistGraph/Models/Dependencies/CarthageDependencies.swift
+++ b/Sources/TuistGraph/Models/Dependencies/CarthageDependencies.swift
@@ -6,15 +6,15 @@ public struct CarthageDependencies: Equatable {
     public let dependencies: [Dependency]
 
     /// List of options that can be used on Carthage command.
-    public let options: Set<Options>
+    public let options: Options
 
     /// Initializes a new `CarthageDependencies` instance.
     /// - Parameters:
     ///   - dependencies: List of dependencies that can be installed using Carthage.
-    ///   - options: Set of options that can be used on Carthage.
+    ///   - options: Set up Carthage's options.
     public init(
         _ dependencies: [Dependency],
-        _ options: Set<Options> = [.noUseBinaries, .useNetRC, .cacheBuilds, .newResolver]
+        _ options: Options = .init()
     ) {
         self.dependencies = dependencies
         self.options = options
@@ -84,17 +84,25 @@ extension CarthageDependencies {
 // MARK: - CarthageDependencies.Options
 
 extension CarthageDependencies {
-    public enum Options: String {
+    /// A set of available options when running Carthage on Tuist.
+    public struct Options: Equatable {
         /// Don't use downloaded binaries when possible
-        case noUseBinaries = "--no-use-binaries"
+        public let noUseBinaries: Bool
 
-        /// Use authentication credentials from ~/.netrc file when downloading binary only frameworks.
-        case useNetRC = "--use-netrc"
+        /// Use authentication credentials from `~/.netrc` file when downloading binary only frameworks.
+        public let useNetRC: Bool
 
         /// Use cached builds when possible
-        case cacheBuilds = "--cache-builds"
+        public let cacheBuilds: Bool
 
         /// Use the new resolver codeline when calculating dependencies.
-        case newResolver = "--new-resolver"
+        public let newResolver: Bool
+
+        public init(noUseBinaries: Bool = true, useNetRC: Bool = true, cacheBuilds: Bool = true, newResolver: Bool = true) {
+            self.noUseBinaries = noUseBinaries
+            self.useNetRC = useNetRC
+            self.cacheBuilds = cacheBuilds
+            self.newResolver = newResolver
+        }
     }
 }

--- a/Tests/TuistDependenciesTests/Carthage/CarthageInteractorTests.swift
+++ b/Tests/TuistDependenciesTests/Carthage/CarthageInteractorTests.swift
@@ -47,7 +47,12 @@ final class CarthageInteractorTests: TuistUnitTestCase {
             .appending(component: "Build")
 
         let platforms: Set<Platform> = [.iOS, .watchOS, .macOS, .tvOS]
-        let customOptions: Set<CarthageDependencies.Options> = [.noUseBinaries, .cacheBuilds, .useNetRC, .newResolver]
+        let customOptions = CarthageDependencies.Options(
+            noUseBinaries: true,
+            useNetRC: true,
+            cacheBuilds: true,
+            newResolver: true
+        )
         let stubbedDependencies = CarthageDependencies(
             [
                 .github(path: "Moya", requirement: .exact("1.1.1")),
@@ -157,7 +162,12 @@ final class CarthageInteractorTests: TuistUnitTestCase {
             .appending(component: "Build")
 
         let platforms: Set<Platform> = [.iOS, .watchOS, .macOS, .tvOS]
-        let customOptions: Set<CarthageDependencies.Options> = [.noUseBinaries, .cacheBuilds, .useNetRC, .newResolver]
+        let customOptions = CarthageDependencies.Options(
+            noUseBinaries: true,
+            useNetRC: true,
+            cacheBuilds: true,
+            newResolver: true
+        )
         let stubbedDependencies = CarthageDependencies(
             [
                 .github(path: "Moya", requirement: .exact("1.1.1")),

--- a/Tests/TuistDependenciesTests/Carthage/CarthageInteractorTests.swift
+++ b/Tests/TuistDependenciesTests/Carthage/CarthageInteractorTests.swift
@@ -47,16 +47,18 @@ final class CarthageInteractorTests: TuistUnitTestCase {
             .appending(component: "Build")
 
         let platforms: Set<Platform> = [.iOS, .watchOS, .macOS, .tvOS]
+        let customOptions: Set<CarthageDependencies.Options> = [.noUseBinaries, .cacheBuilds, .useNetRC, .newResolver]
         let stubbedDependencies = CarthageDependencies(
             [
                 .github(path: "Moya", requirement: .exact("1.1.1")),
             ]
         )
 
-        carthageController.bootstrapStub = { arg0, arg1, arg2 in
+        carthageController.bootstrapStub = { arg0, arg1, arg2, arg3 in
             XCTAssertEqual(arg0, dependenciesDirectory)
             XCTAssertEqual(arg1, platforms)
-            XCTAssertTrue(arg2)
+            XCTAssertEqual(arg2, customOptions)
+            XCTAssertTrue(arg3)
 
             try self.simulateCarthageOutput(at: arg0)
         }
@@ -155,16 +157,18 @@ final class CarthageInteractorTests: TuistUnitTestCase {
             .appending(component: "Build")
 
         let platforms: Set<Platform> = [.iOS, .watchOS, .macOS, .tvOS]
+        let customOptions: Set<CarthageDependencies.Options> = [.noUseBinaries, .cacheBuilds, .useNetRC, .newResolver]
         let stubbedDependencies = CarthageDependencies(
             [
                 .github(path: "Moya", requirement: .exact("1.1.1")),
             ]
         )
 
-        carthageController.updateStub = { arg0, arg1, arg2 in
+        carthageController.updateStub = { arg0, arg1, arg2, arg3 in
             XCTAssertEqual(arg0, dependenciesDirectory)
             XCTAssertEqual(arg1, platforms)
-            XCTAssertTrue(arg2)
+            XCTAssertEqual(arg2, customOptions)
+            XCTAssertTrue(arg3)
 
             try self.simulateCarthageOutput(at: arg0)
         }

--- a/Tests/TuistDependenciesTests/Carthage/Utils/CarthageControllerTests.swift
+++ b/Tests/TuistDependenciesTests/Carthage/Utils/CarthageControllerTests.swift
@@ -59,9 +59,8 @@ final class CarthageControllerTests: TuistUnitTestCase {
         // Given
         system.stubs["/usr/bin/env carthage version"] = (stderror: nil, stdout: "0.37.0", exitstatus: 0)
 
-        let options: Set<CarthageDependencies.Options> = [
-            .noUseBinaries, .useNetRC, .cacheBuilds, .newResolver,
-        ]
+        let options: CarthageDependencies.Options = .init()
+
         let path = try temporaryPath()
         system.succeedCommand([
             "carthage",
@@ -69,7 +68,11 @@ final class CarthageControllerTests: TuistUnitTestCase {
             "--project-directory",
             path.pathString,
             "--use-xcframeworks",
-        ] + options.map(\.rawValue))
+            "--no-use-binaries",
+            "--use-netrc",
+            "--cache-builds",
+            "--new-resolver",
+        ])
 
         // When / Then
         XCTAssertNoThrow(try subject.bootstrap(at: path, platforms: [], options: options, printOutput: false))
@@ -79,9 +82,7 @@ final class CarthageControllerTests: TuistUnitTestCase {
         // Given
         system.stubs["/usr/bin/env carthage version"] = (stderror: nil, stdout: "0.37.0", exitstatus: 0)
 
-        let options: Set<CarthageDependencies.Options> = [
-            .noUseBinaries, .useNetRC, .cacheBuilds, .newResolver,
-        ]
+        let options: CarthageDependencies.Options = .init()
 
         let path = try temporaryPath()
         system.succeedCommand([
@@ -92,7 +93,11 @@ final class CarthageControllerTests: TuistUnitTestCase {
             "--platform",
             "iOS",
             "--use-xcframeworks",
-        ] + options.map(\.rawValue))
+            "--no-use-binaries",
+            "--use-netrc",
+            "--cache-builds",
+            "--new-resolver",
+        ])
 
         // When / Then
         XCTAssertNoThrow(try subject.bootstrap(at: path, platforms: [.iOS], options: options, printOutput: false))
@@ -102,7 +107,12 @@ final class CarthageControllerTests: TuistUnitTestCase {
         // Given
         system.stubs["/usr/bin/env carthage version"] = (stderror: nil, stdout: "0.37.0", exitstatus: 0)
 
-        let options: Set<CarthageDependencies.Options> = []
+        let options: CarthageDependencies.Options = .init(
+            noUseBinaries: false,
+            useNetRC: false,
+            cacheBuilds: false,
+            newResolver: false
+        )
 
         let path = try temporaryPath()
         system.succeedCommand([
@@ -124,9 +134,8 @@ final class CarthageControllerTests: TuistUnitTestCase {
         let carthageVersion = Version("0.36.0")
         system.stubs["/usr/bin/env carthage version"] = (stderror: nil, stdout: carthageVersion.description, exitstatus: 0)
 
-        let options: Set<CarthageDependencies.Options> = [
-            .noUseBinaries, .useNetRC, .cacheBuilds, .newResolver,
-        ]
+        let options: CarthageDependencies.Options = .init()
+
         let path = try temporaryPath()
         system.succeedCommand([
             "carthage",
@@ -136,7 +145,11 @@ final class CarthageControllerTests: TuistUnitTestCase {
             "--platform",
             "iOS",
             "--use-xcframeworks",
-        ] + options.map(\.rawValue))
+            "--no-use-binaries",
+            "--use-netrc",
+            "--cache-builds",
+            "--new-resolver",
+        ])
 
         // When / Then
         XCTAssertThrowsSpecific(
@@ -148,9 +161,7 @@ final class CarthageControllerTests: TuistUnitTestCase {
     func test_update() throws {
         // Given
         system.stubs["/usr/bin/env carthage version"] = (stderror: nil, stdout: "0.37.0", exitstatus: 0)
-        let options: Set<CarthageDependencies.Options> = [
-            .noUseBinaries, .useNetRC, .cacheBuilds, .newResolver,
-        ]
+        let options: CarthageDependencies.Options = .init()
         let path = try temporaryPath()
         system.succeedCommand([
             "carthage",
@@ -158,7 +169,11 @@ final class CarthageControllerTests: TuistUnitTestCase {
             "--project-directory",
             path.pathString,
             "--use-xcframeworks",
-        ] + options.map(\.rawValue))
+            "--no-use-binaries",
+            "--use-netrc",
+            "--cache-builds",
+            "--new-resolver",
+        ])
 
         // When / Then
         XCTAssertNoThrow(try subject.update(at: path, platforms: [], options: options, printOutput: false))
@@ -167,9 +182,7 @@ final class CarthageControllerTests: TuistUnitTestCase {
     func test_update_with_platforms() throws {
         // Given
         system.stubs["/usr/bin/env carthage version"] = (stderror: nil, stdout: "0.37.0", exitstatus: 0)
-        let options: Set<CarthageDependencies.Options> = [
-            .noUseBinaries, .useNetRC, .cacheBuilds, .newResolver,
-        ]
+        let options: CarthageDependencies.Options = .init()
         let path = try temporaryPath()
         system.succeedCommand([
             "carthage",
@@ -179,7 +192,11 @@ final class CarthageControllerTests: TuistUnitTestCase {
             "--platform",
             "iOS",
             "--use-xcframeworks",
-        ] + options.map(\.rawValue))
+            "--no-use-binaries",
+            "--use-netrc",
+            "--cache-builds",
+            "--new-resolver",
+        ])
 
         // When / Then
         XCTAssertNoThrow(try subject.update(at: path, platforms: [.iOS], options: options, printOutput: false))
@@ -188,7 +205,12 @@ final class CarthageControllerTests: TuistUnitTestCase {
     func test_update_without_options() throws {
         // Given
         system.stubs["/usr/bin/env carthage version"] = (stderror: nil, stdout: "0.37.0", exitstatus: 0)
-        let options: Set<CarthageDependencies.Options> = []
+        let options: CarthageDependencies.Options = .init(
+            noUseBinaries: false,
+            useNetRC: false,
+            cacheBuilds: false,
+            newResolver: false
+        )
         let path = try temporaryPath()
         system.succeedCommand([
             "carthage",
@@ -208,9 +230,7 @@ final class CarthageControllerTests: TuistUnitTestCase {
         // Given
         let carthageVersion = Version("0.36.0")
         system.stubs["/usr/bin/env carthage version"] = (stderror: nil, stdout: carthageVersion.description, exitstatus: 0)
-        let options: Set<CarthageDependencies.Options> = [
-            .noUseBinaries, .useNetRC, .cacheBuilds, .newResolver,
-        ]
+        let options: CarthageDependencies.Options = .init()
         let path = try temporaryPath()
         system.succeedCommand([
             "carthage",
@@ -220,7 +240,11 @@ final class CarthageControllerTests: TuistUnitTestCase {
             "--platform",
             "iOS",
             "--use-xcframeworks",
-        ] + options.map(\.rawValue))
+            "--no-use-binaries",
+            "--use-netrc",
+            "--cache-builds",
+            "--new-resolver",
+        ])
 
         // When / Then
         XCTAssertThrowsSpecific(

--- a/Tests/TuistDependenciesTests/Carthage/Utils/CarthageControllerTests.swift
+++ b/Tests/TuistDependenciesTests/Carthage/Utils/CarthageControllerTests.swift
@@ -59,6 +59,9 @@ final class CarthageControllerTests: TuistUnitTestCase {
         // Given
         system.stubs["/usr/bin/env carthage version"] = (stderror: nil, stdout: "0.37.0", exitstatus: 0)
 
+        let options: Set<CarthageDependencies.Options> = [
+            .noUseBinaries, .useNetRC, .cacheBuilds, .newResolver,
+        ]
         let path = try temporaryPath()
         system.succeedCommand([
             "carthage",
@@ -66,19 +69,19 @@ final class CarthageControllerTests: TuistUnitTestCase {
             "--project-directory",
             path.pathString,
             "--use-xcframeworks",
-            "--no-use-binaries",
-            "--use-netrc",
-            "--cache-builds",
-            "--new-resolver",
-        ])
+        ] + options.map(\.rawValue))
 
         // When / Then
-        XCTAssertNoThrow(try subject.bootstrap(at: path, platforms: [], printOutput: false))
+        XCTAssertNoThrow(try subject.bootstrap(at: path, platforms: [], options: options, printOutput: false))
     }
 
     func test_bootstrap_with_platforms() throws {
         // Given
         system.stubs["/usr/bin/env carthage version"] = (stderror: nil, stdout: "0.37.0", exitstatus: 0)
+
+        let options: Set<CarthageDependencies.Options> = [
+            .noUseBinaries, .useNetRC, .cacheBuilds, .newResolver,
+        ]
 
         let path = try temporaryPath()
         system.succeedCommand([
@@ -89,14 +92,31 @@ final class CarthageControllerTests: TuistUnitTestCase {
             "--platform",
             "iOS",
             "--use-xcframeworks",
-            "--no-use-binaries",
-            "--use-netrc",
-            "--cache-builds",
-            "--new-resolver",
+        ] + options.map(\.rawValue))
+
+        // When / Then
+        XCTAssertNoThrow(try subject.bootstrap(at: path, platforms: [.iOS], options: options, printOutput: false))
+    }
+
+    func test_bootstrap_without_options() throws {
+        // Given
+        system.stubs["/usr/bin/env carthage version"] = (stderror: nil, stdout: "0.37.0", exitstatus: 0)
+
+        let options: Set<CarthageDependencies.Options> = []
+
+        let path = try temporaryPath()
+        system.succeedCommand([
+            "carthage",
+            "bootstrap",
+            "--project-directory",
+            path.pathString,
+            "--platform",
+            "iOS",
+            "--use-xcframeworks",
         ])
 
         // When / Then
-        XCTAssertNoThrow(try subject.bootstrap(at: path, platforms: [.iOS], printOutput: false))
+        XCTAssertNoThrow(try subject.bootstrap(at: path, platforms: [.iOS], options: options, printOutput: false))
     }
 
     func test_bootstrap_with_platforms_throws_when_xcframeworkdProductionUnsupported() throws {
@@ -104,6 +124,9 @@ final class CarthageControllerTests: TuistUnitTestCase {
         let carthageVersion = Version("0.36.0")
         system.stubs["/usr/bin/env carthage version"] = (stderror: nil, stdout: carthageVersion.description, exitstatus: 0)
 
+        let options: Set<CarthageDependencies.Options> = [
+            .noUseBinaries, .useNetRC, .cacheBuilds, .newResolver,
+        ]
         let path = try temporaryPath()
         system.succeedCommand([
             "carthage",
@@ -113,15 +136,11 @@ final class CarthageControllerTests: TuistUnitTestCase {
             "--platform",
             "iOS",
             "--use-xcframeworks",
-            "--no-use-binaries",
-            "--use-netrc",
-            "--cache-builds",
-            "--new-resolver",
-        ])
+        ] + options.map(\.rawValue))
 
         // When / Then
         XCTAssertThrowsSpecific(
-            try subject.bootstrap(at: path, platforms: [.iOS], printOutput: false),
+            try subject.bootstrap(at: path, platforms: [.iOS], options: options, printOutput: false),
             CarthageControllerError.xcframeworksProductionNotSupported(installedVersion: carthageVersion)
         )
     }
@@ -129,7 +148,9 @@ final class CarthageControllerTests: TuistUnitTestCase {
     func test_update() throws {
         // Given
         system.stubs["/usr/bin/env carthage version"] = (stderror: nil, stdout: "0.37.0", exitstatus: 0)
-
+        let options: Set<CarthageDependencies.Options> = [
+            .noUseBinaries, .useNetRC, .cacheBuilds, .newResolver,
+        ]
         let path = try temporaryPath()
         system.succeedCommand([
             "carthage",
@@ -137,20 +158,18 @@ final class CarthageControllerTests: TuistUnitTestCase {
             "--project-directory",
             path.pathString,
             "--use-xcframeworks",
-            "--no-use-binaries",
-            "--use-netrc",
-            "--cache-builds",
-            "--new-resolver",
-        ])
+        ] + options.map(\.rawValue))
 
         // When / Then
-        XCTAssertNoThrow(try subject.update(at: path, platforms: [], printOutput: false))
+        XCTAssertNoThrow(try subject.update(at: path, platforms: [], options: options, printOutput: false))
     }
 
     func test_update_with_platforms() throws {
         // Given
         system.stubs["/usr/bin/env carthage version"] = (stderror: nil, stdout: "0.37.0", exitstatus: 0)
-
+        let options: Set<CarthageDependencies.Options> = [
+            .noUseBinaries, .useNetRC, .cacheBuilds, .newResolver,
+        ]
         let path = try temporaryPath()
         system.succeedCommand([
             "carthage",
@@ -160,21 +179,38 @@ final class CarthageControllerTests: TuistUnitTestCase {
             "--platform",
             "iOS",
             "--use-xcframeworks",
-            "--no-use-binaries",
-            "--use-netrc",
-            "--cache-builds",
-            "--new-resolver",
+        ] + options.map(\.rawValue))
+
+        // When / Then
+        XCTAssertNoThrow(try subject.update(at: path, platforms: [.iOS], options: options, printOutput: false))
+    }
+
+    func test_update_without_options() throws {
+        // Given
+        system.stubs["/usr/bin/env carthage version"] = (stderror: nil, stdout: "0.37.0", exitstatus: 0)
+        let options: Set<CarthageDependencies.Options> = []
+        let path = try temporaryPath()
+        system.succeedCommand([
+            "carthage",
+            "update",
+            "--project-directory",
+            path.pathString,
+            "--platform",
+            "iOS",
+            "--use-xcframeworks",
         ])
 
         // When / Then
-        XCTAssertNoThrow(try subject.update(at: path, platforms: [.iOS], printOutput: false))
+        XCTAssertNoThrow(try subject.update(at: path, platforms: [.iOS], options: options, printOutput: false))
     }
 
     func test_update_with_platforms_throws_when_xcframeworkdProductionUnsupported() throws {
         // Given
         let carthageVersion = Version("0.36.0")
         system.stubs["/usr/bin/env carthage version"] = (stderror: nil, stdout: carthageVersion.description, exitstatus: 0)
-
+        let options: Set<CarthageDependencies.Options> = [
+            .noUseBinaries, .useNetRC, .cacheBuilds, .newResolver,
+        ]
         let path = try temporaryPath()
         system.succeedCommand([
             "carthage",
@@ -184,15 +220,11 @@ final class CarthageControllerTests: TuistUnitTestCase {
             "--platform",
             "iOS",
             "--use-xcframeworks",
-            "--no-use-binaries",
-            "--use-netrc",
-            "--cache-builds",
-            "--new-resolver",
-        ])
+        ] + options.map(\.rawValue))
 
         // When / Then
         XCTAssertThrowsSpecific(
-            try subject.bootstrap(at: path, platforms: [.iOS], printOutput: false),
+            try subject.bootstrap(at: path, platforms: [.iOS], options: options, printOutput: false),
             CarthageControllerError.xcframeworksProductionNotSupported(installedVersion: carthageVersion)
         )
     }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3586

### Short description 📝

Allow to add Carthage options on Dependencies.swift

The available options are:

- Don't use downloaded binaries when possible: `--no-use-binaries`.
- Use authentication credentials from ~/.netrc file when downloading binary only frameworks: `--use-netrc`.
- Use cached builds when possible: `--cache-builds`.
- Use the new resolver codeline when calculating dependencies: `--new-resolver`.
- Resolves #3586

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
