### PR TITLE
Fix link phase for tvOS top shelf extension

### DIFF
--- a/Sources/TuistGraph/Models/Target.swift
+++ b/Sources/TuistGraph/Models/Target.swift
@@ -127,6 +127,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable {
             .watch2Extension,
             .messagesExtension,
             .appClip,
+            .tvTopShelfExtension,
         ].contains(product)
     }
 


### PR DESCRIPTION
### Short description 📝

On tvOS application if TopShelf extension contains dependencies to static frameworks, currently build phase "Link Binary With Libraries" will not contains those dependencies and when building app we will get errors on linking stage like "Undefined symbol: _XXXXX".

Looks like somebody just forget to enable support for static frameworks linking for TopShelf extension.

Here is the fix&

### How to test the changes locally 🧐

1. Create new tvOS application with TopShelf extension.
2. Setup Tuist for application.
3. Create new shared "static framework" target with SPM dependency (to "FirebaseRemoteConfig" for example).
4. Add dependency in TopShelf target and main target to created static framework.
5. Run "tuist generate"
6. Build.

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
