### PR TITLE
Fix work with resource bundles in tvOS targets

### DIFF
--- a/Sources/TuistGenerator/Generator/InfoPlistContentProvider.swift
+++ b/Sources/TuistGenerator/Generator/InfoPlistContentProvider.swift
@@ -131,7 +131,7 @@ final class InfoPlistContentProvider: InfoPlistContentProviding {
     func bundleExecutable(_ target: Target) -> [String: Any] {
         let shouldIncludeBundleExecutableKey: (Target) -> Bool = {
             switch ($0.platform, $0.product) {
-            case (.iOS, .bundle):
+            case (.iOS, .bundle), (.tvOS, .bundle):
                 return false
             default:
                 return true

--- a/Sources/TuistGraph/Models/Target.swift
+++ b/Sources/TuistGraph/Models/Target.swift
@@ -144,8 +144,8 @@ public struct Target: Equatable, Hashable, Comparable, Codable {
     /// Returns true if the target supports having sources.
     public var supportsSources: Bool {
         switch (platform, product) {
-        case (.iOS, .bundle), (.iOS, .stickerPackExtension), 
-            (.watchOS, .watch2App), (.tvOS, .bundle):
+        case (.iOS, .bundle), (.iOS, .stickerPackExtension),
+             (.watchOS, .watch2App), (.tvOS, .bundle):
             return false
         default:
             return true

--- a/Sources/TuistGraph/Models/Target.swift
+++ b/Sources/TuistGraph/Models/Target.swift
@@ -144,7 +144,8 @@ public struct Target: Equatable, Hashable, Comparable, Codable {
     /// Returns true if the target supports having sources.
     public var supportsSources: Bool {
         switch (platform, product) {
-        case (.iOS, .bundle), (.iOS, .stickerPackExtension), (.watchOS, .watch2App):
+        case (.iOS, .bundle), (.iOS, .stickerPackExtension), 
+            (.watchOS, .watch2App), (.tvOS, .bundle):
             return false
         default:
             return true


### PR DESCRIPTION
### Short description 📝
After adding Tuist to TV project our team encountered a few problems:
1. Redundant warning `"The target XXX doesn't contain source files."` appeared during `tuist generate`
Here is [example app](https://github.com/xoxo-anastasi-xoxo/sample-tuist-bug-project/tree/master) with this problem, as well as [the same project but with ios target](https://github.com/xoxo-anastasi-xoxo/sample-tuist-bug-project/tree/ios-example) without the warning.
2. Uploading to TestFlight started to fail with an error `"ERROR ITMS-90535 : "Unexpected CFBundleExecutable Key."`

### How to test the changes locally 🧐
1 - clone the [repo](https://github.com/xoxo-anastasi-xoxo/sample-tuist-bug-project/tree/master) and try to generate workspace
2 - in the exact same repo look at generated infoplist 

### Contributor checklist ✅

- [ ] The code has been linted using run `./fourier lint tuist --fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
