### PR TITLE
Exclude Swift Package build directory from manifest search

### DIFF
--- a/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
@@ -122,6 +122,7 @@ final class ProjectEditor: ProjectEditing {
 
         let pathsToExclude = [
             "**/\(Constants.tuistDirectoryName)/\(Constants.DependenciesDirectory.name)/**",
+            "**/\(Constants.DependenciesDirectory.packageBuildDirectoryName)/**",
         ] + tuistIgnoreEntries
 
         let projectDescriptionPath = try resourceLocator.projectDescription()

--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -45,6 +45,7 @@ public enum Constants {
         public static let cartfileResolvedName = "Cartfile.resolved"
         public static let packageSwiftName = "Package.swift"
         public static let packageResolvedName = "Package.resolved"
+        public static let packageBuildDirectoryName = ".build"
         public static let carthageDirectoryName = "Carthage"
         public static let swiftPackageManagerDirectoryName = "SwiftPackageManager"
     }

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorTests.swift
@@ -112,6 +112,7 @@ final class ProjectEditorTests: TuistUnitTestCase {
                 excluding,
                 [
                     "**/Tuist/Dependencies/**",
+                    "**/.build/**",
                     "\(directory.pathString)/a folder/**",
                     "\(directory.pathString)/B.swift",
                 ]


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5138

### Short description 📝

Fix issue where `tuist edit` would throw a fatal error if plugin had a dependency on a package that has a `Project.swift` in it's source, like `ProjectAutomation`.

`Swift/NativeDictionary.swift:770: Fatal error: Duplicate values for key: 'LocalPlugin'`

### How to test the changes locally 🧐

1. Clone this test repo (or create a new repo with a plugin and add `ProjectAutomation` as a dependency in `Package.swift`)
2. Build the plugin
3. Run `tuist edit`

Notice you get the error from above without the changes in this PR.


### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
