### PR TITLE
Support for custom shell path in `ExecuteAction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Next
 
 ### Added
-- Added custom shellPath to ExecuteAction to enable /bin/zsh as shell. [#NNNN](https://github.com/tuist/tuist/pull/NNNN) by [@JCSooHwanCho](https://github.com/JCSooHwanCho)
+- Added custom shellPath to ExecuteAction to enable /bin/zsh as shell. [#5154](https://github.com/tuist/tuist/pull/5154) by [@JCSooHwanCho](https://github.com/JCSooHwanCho)
 
 ## 3.18.0 - 2023-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Next
+
+### Added
+- Added custom shellPath to ExecuteAction to enable /bin/zsh as shell. [#NNNN](https://github.com/tuist/tuist/pull/NNNN) by [@JCSooHwanCho](https://github.com/JCSooHwanCho)
+
 ## 3.18.0 - 2023-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Next
 
 ### Added
-- Added custom shellPath to ExecuteAction to enable /bin/zsh as shell. [#5154](https://github.com/tuist/tuist/pull/5154) by [@JCSooHwanCho](https://github.com/JCSooHwanCho)
+- Added custom shellPath to ExecuteAction [#5154](https://github.com/tuist/tuist/pull/5154) by [@JCSooHwanCho](https://github.com/JCSooHwanCho)
 
 ## 3.18.0 - 2023-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## Next
-
-### Added
-- Added custom shellPath to ExecuteAction [#5154](https://github.com/tuist/tuist/pull/5154) by [@JCSooHwanCho](https://github.com/JCSooHwanCho)
-
 ## 3.18.0 - 2023-04-14
 
 ### Added

--- a/Package.resolved
+++ b/Package.resolved
@@ -265,8 +265,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "revision" : "fae27b48bc14ff3fd9b02902e48c4665ce5a0793",
-        "version" : "8.9.0"
+        "revision" : "5fdac93cb4a7fd4bad5ac2da34e5bc878263043f",
+        "version" : "8.10.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -265,8 +265,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "revision" : "b6de1bfe021b861c94e7c83821b595083f74b997",
-        "version" : "8.8.0"
+        "revision" : "fae27b48bc14ff3fd9b02902e48c4665ce5a0793",
+        "version" : "8.9.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -62,7 +62,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", exact: "0.2.0"),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", exact: "2.9.0"),
         .package(url: "https://github.com/SwiftGen/SwiftGen", exact: "6.5.1"),
-        .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.8.0"),
+        .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.9.0"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -62,7 +62,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", exact: "0.2.0"),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", exact: "2.9.0"),
         .package(url: "https://github.com/SwiftGen/SwiftGen", exact: "6.5.1"),
-        .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.9.0"),
+        .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.10.0"),
     ],
     targets: [
         .target(

--- a/Sources/ProjectDescription/ExecuteAction.swift
+++ b/Sources/ProjectDescription/ExecuteAction.swift
@@ -6,8 +6,7 @@ public struct ExecutionAction: Equatable, Codable {
     public let scriptText: String
     public let target: TargetReference?
 
-    /// The path to the shell which shall execute this script.
-    /// if it is nil, "/bin/sh" will be used
+    /// The path to the shell which shall execute this script. if it is nil, Xcode will use default value.
     public let shellPath: String?
 
     public init(title: String = "Run Script", scriptText: String, target: TargetReference? = nil, shellPath: String? = nil) {

--- a/Sources/ProjectDescription/ExecuteAction.swift
+++ b/Sources/ProjectDescription/ExecuteAction.swift
@@ -6,9 +6,14 @@ public struct ExecutionAction: Equatable, Codable {
     public let scriptText: String
     public let target: TargetReference?
 
-    public init(title: String = "Run Script", scriptText: String, target: TargetReference? = nil) {
+    /// The path to the shell which shall execute this script.
+    /// if it is nil, "/bin/sh" will be used
+    public let shellPath: String?
+
+    public init(title: String = "Run Script", scriptText: String, target: TargetReference? = nil, shellPath: String? = nil) {
         self.title = title
         self.scriptText = scriptText
         self.target = target
+        self.shellPath = shellPath
     }
 }

--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -731,6 +731,7 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
             return XCScheme.ExecutionAction(
                 scriptText: action.scriptText,
                 title: action.title,
+                shellToInvoke: action.shellPath,
                 environmentBuildable: nil
             )
         }
@@ -745,6 +746,7 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
         return XCScheme.ExecutionAction(
             scriptText: action.scriptText,
             title: action.title,
+            shellToInvoke: action.shellPath,
             environmentBuildable: buildableReference
         )
     }

--- a/Sources/TuistGraph/Models/ExecutionAction.swift
+++ b/Sources/TuistGraph/Models/ExecutionAction.swift
@@ -11,6 +11,9 @@ public struct ExecutionAction: Equatable, Codable {
     public let scriptText: String
     /// Name of the build or test target that will provide the action's build settings.
     public let target: TargetReference?
+    /// The path to the shell which shall execute this script.
+    // if it is nil, "/bin/sh" will be used
+    public let shellPath: String?
 
     public let showEnvVarsInLog: Bool
 
@@ -20,11 +23,13 @@ public struct ExecutionAction: Equatable, Codable {
         title: String,
         scriptText: String,
         target: TargetReference?,
+        shellPath: String?,
         showEnvVarsInLog: Bool = true
     ) {
         self.title = title
         self.scriptText = scriptText
         self.target = target
+        self.shellPath = shellPath
         self.showEnvVarsInLog = showEnvVarsInLog
     }
 }

--- a/Sources/TuistGraph/Models/ExecutionAction.swift
+++ b/Sources/TuistGraph/Models/ExecutionAction.swift
@@ -11,8 +11,7 @@ public struct ExecutionAction: Equatable, Codable {
     public let scriptText: String
     /// Name of the build or test target that will provide the action's build settings.
     public let target: TargetReference?
-    /// The path to the shell which shall execute this script.
-    // if it is nil, "/bin/sh" will be used
+    /// The path to the shell which shall execute this script. if it is nil, Xcode will use default value.
     public let shellPath: String?
 
     public let showEnvVarsInLog: Bool

--- a/Sources/TuistLoader/Models+ManifestMappers/ExecutionAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/ExecutionAction+ManifestMapper.swift
@@ -17,6 +17,11 @@ extension TuistGraph.ExecutionAction {
                 name: $0.targetName
             )
         }
-        return ExecutionAction(title: manifest.title, scriptText: manifest.scriptText, target: targetReference, shellPath: manifest.shellPath)
+        return ExecutionAction(
+            title: manifest.title,
+            scriptText: manifest.scriptText,
+            target: targetReference,
+            shellPath: manifest.shellPath
+        )
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/ExecutionAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/ExecutionAction+ManifestMapper.swift
@@ -17,6 +17,6 @@ extension TuistGraph.ExecutionAction {
                 name: $0.targetName
             )
         }
-        return ExecutionAction(title: manifest.title, scriptText: manifest.scriptText, target: targetReference)
+        return ExecutionAction(title: manifest.title, scriptText: manifest.scriptText, target: targetReference, shellPath: manifest.shellPath)
     }
 }

--- a/Tests/ProjectDescriptionTests/SchemeTests.swift
+++ b/Tests/ProjectDescriptionTests/SchemeTests.swift
@@ -99,7 +99,8 @@ final class SchemeTests: XCTestCase {
                 target: TargetReference(
                     projectPath: nil,
                     target: "target"
-                )
+                ),
+                shellPath: "/bin/sh"
             ),
         ]
     }

--- a/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -211,12 +211,14 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let preAction = ExecutionAction(
             title: "Pre Action",
             scriptText: "echo Pre Actions",
-            target: TargetReference(projectPath: projectPath, name: "App")
+            target: TargetReference(projectPath: projectPath, name: "App"),
+            shellPath: "/bin/sh"
         )
         let postAction = ExecutionAction(
             title: "Post Action",
             scriptText: "echo Post Actions",
-            target: TargetReference(projectPath: projectPath, name: "App")
+            target: TargetReference(projectPath: projectPath, name: "App"),
+            shellPath: "/bin/sh"
         )
         let buildAction = BuildAction.test(
             targets: [TargetReference(projectPath: projectPath, name: "App")],
@@ -252,6 +254,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         // Pre Action
         XCTAssertEqual(got?.preActions.first?.title, "Pre Action")
         XCTAssertEqual(got?.preActions.first?.scriptText, "echo Pre Actions")
+        XCTAssertEqual(got?.preActions.first?.shellToInvoke, "/bin/sh")
 
         let preBuildableReference = got?.preActions.first?.environmentBuildable
 
@@ -263,6 +266,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         // Post Action
         XCTAssertEqual(got?.postActions.first?.title, "Post Action")
         XCTAssertEqual(got?.postActions.first?.scriptText, "echo Post Actions")
+        XCTAssertEqual(got?.postActions.first?.shellToInvoke, "/bin/sh")
 
         let postBuildableReference = got?.postActions.first?.environmentBuildable
 
@@ -319,7 +323,8 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let preAction = ExecutionAction(
             title: "Pre Action",
             scriptText: "echo Pre Actions",
-            target: TargetReference(projectPath: projectPath, name: "App")
+            target: TargetReference(projectPath: projectPath, name: "App"),
+            shellPath: nil
         )
         let buildAction = BuildAction.test(
             targets: [TargetReference(projectPath: projectPath, name: "App")],
@@ -773,12 +778,14 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let preAction = ExecutionAction(
             title: "Pre Action",
             scriptText: "echo Pre Actions",
-            target: TargetReference(projectPath: projectPath, name: "AppTests")
+            target: TargetReference(projectPath: projectPath, name: "AppTests"),
+            shellPath: "/bin/sh"
         )
         let postAction = ExecutionAction(
             title: "Post Action",
             scriptText: "echo Post Actions",
-            target: TargetReference(projectPath: projectPath, name: "AppTests")
+            target: TargetReference(projectPath: projectPath, name: "AppTests"),
+            shellPath: "/bin/sh"
         )
         let testAction = TestAction.test(
             targets: [TestableTarget(target: TargetReference(projectPath: projectPath, name: "AppTests"))],
@@ -824,6 +831,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         XCTAssertEqual(result.preActions.first?.title, "Pre Action")
         XCTAssertEqual(result.preActions.first?.scriptText, "echo Pre Actions")
+        XCTAssertEqual(result.preActions.first?.shellToInvoke, "/bin/sh")
 
         let preBuildableReference = try XCTUnwrap(result.preActions.first?.environmentBuildable)
 
@@ -835,6 +843,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         // Post Action
         XCTAssertEqual(result.postActions.first?.title, "Post Action")
         XCTAssertEqual(result.postActions.first?.scriptText, "echo Post Actions")
+        XCTAssertEqual(result.postActions.first?.shellToInvoke, "/bin/sh")
 
         let postBuildableReference = try XCTUnwrap(result.postActions.first?.environmentBuildable)
 
@@ -1090,12 +1099,14 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let preAction = ExecutionAction(
             title: "Pre Action",
             scriptText: "echo Pre Actions",
-            target: TargetReference(projectPath: projectPath, name: "App")
+            target: TargetReference(projectPath: projectPath, name: "App"),
+            shellPath: "/bin/sh"
         )
         let postAction = ExecutionAction(
             title: "Post Action",
             scriptText: "echo Post Actions",
-            target: TargetReference(projectPath: projectPath, name: "App")
+            target: TargetReference(projectPath: projectPath, name: "App"),
+            shellPath: "/bin/sh"
         )
 
         let launchAction = RunAction.test(
@@ -1136,8 +1147,10 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         // Then
         XCTAssertEqual(got?.preActions.first?.title, "Pre Action")
         XCTAssertEqual(got?.preActions.first?.scriptText, "echo Pre Actions")
+        XCTAssertEqual(got?.preActions.first?.shellToInvoke, "/bin/sh")
         XCTAssertEqual(got?.postActions.first?.title, "Post Action")
         XCTAssertEqual(got?.postActions.first?.scriptText, "echo Post Actions")
+        XCTAssertEqual(got?.postActions.first?.shellToInvoke, "/bin/sh")
     }
 
     func test_schemeLaunchAction_with_disabled_attachDebugger() throws {
@@ -1562,12 +1575,14 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let preAction = ExecutionAction(
             title: "Pre Action",
             scriptText: "echo Pre Actions",
-            target: TargetReference(projectPath: projectPath, name: "App")
+            target: TargetReference(projectPath: projectPath, name: "App"),
+            shellPath: "/bin/sh"
         )
         let postAction = ExecutionAction(
             title: "Post Action",
             scriptText: "echo Post Actions",
-            target: TargetReference(projectPath: projectPath, name: "App")
+            target: TargetReference(projectPath: projectPath, name: "App"),
+            shellPath: "/bin/sh"
         )
         let scheme = makeProfileActionScheme(
             preActions: [preAction],
@@ -1599,8 +1614,10 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         // Then
         XCTAssertEqual(got?.preActions.first?.title, "Pre Action")
         XCTAssertEqual(got?.preActions.first?.scriptText, "echo Pre Actions")
+        XCTAssertEqual(got?.preActions.first?.shellToInvoke, "/bin/sh")
         XCTAssertEqual(got?.postActions.first?.title, "Post Action")
         XCTAssertEqual(got?.postActions.first?.scriptText, "echo Post Actions")
+        XCTAssertEqual(got?.postActions.first?.shellToInvoke, "/bin/sh")
     }
 
     // MARK: - Analyze Action Tests

--- a/Tests/TuistGeneratorTests/Linter/SchemeLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/SchemeLinterTests.swift
@@ -144,7 +144,8 @@ class SchemeLinterTests: TuistTestCase {
                     target: .init(
                         projectPath: try! AbsolutePath(validating: "/Project/../Project2"),
                         name: "Target2"
-                    )
+                    ),
+                    shellPath: nil
                 )])
             ),
         ])

--- a/Tests/TuistGraphTests/Models/ArchiveActionTests.swift
+++ b/Tests/TuistGraphTests/Models/ArchiveActionTests.swift
@@ -16,6 +16,7 @@ final class ArchiveActionTests: TuistUnitTestCase {
                     title: "preActionTitle",
                     scriptText: "text",
                     target: nil,
+                    shellPath: nil,
                     showEnvVarsInLog: false
                 ),
             ],
@@ -24,6 +25,7 @@ final class ArchiveActionTests: TuistUnitTestCase {
                     title: "postActionTitle",
                     scriptText: "text",
                     target: nil,
+                    shellPath: nil,
                     showEnvVarsInLog: true
                 ),
             ]

--- a/Tests/TuistGraphTests/Models/BuildActionTests.swift
+++ b/Tests/TuistGraphTests/Models/BuildActionTests.swift
@@ -19,6 +19,7 @@ final class BuildActionTests: TuistUnitTestCase {
                     title: "preActionTitle",
                     scriptText: "text",
                     target: nil,
+                    shellPath: nil,
                     showEnvVarsInLog: true
                 ),
             ],
@@ -27,6 +28,7 @@ final class BuildActionTests: TuistUnitTestCase {
                     title: "postActionTitle",
                     scriptText: "text",
                     target: nil,
+                    shellPath: nil,
                     showEnvVarsInLog: false
                 ),
             ]

--- a/Tests/TuistGraphTests/Models/ExecutionActionTests.swift
+++ b/Tests/TuistGraphTests/Models/ExecutionActionTests.swift
@@ -14,6 +14,7 @@ final class ExecutionActionTests: TuistUnitTestCase {
                 projectPath: "/path/to/project",
                 name: "name"
             ),
+            shellPath: nil,
             showEnvVarsInLog: false
         )
 

--- a/Tests/TuistIntegrationTests/Generator/TestModelGenerator.swift
+++ b/Tests/TuistIntegrationTests/Generator/TestModelGenerator.swift
@@ -363,7 +363,7 @@ final class TestModelGenerator {
 
     private func createExecutionActions() -> [ExecutionAction] {
         (0 ..< 10).map {
-            ExecutionAction(title: "ExecutionAction\($0)", scriptText: "ScripText\($0)", target: nil, showEnvVarsInLog: false)
+            ExecutionAction(title: "ExecutionAction\($0)", scriptText: "ScripText\($0)", target: nil, shellPath: nil, showEnvVarsInLog: false)
         }
     }
 

--- a/Tests/TuistIntegrationTests/Generator/TestModelGenerator.swift
+++ b/Tests/TuistIntegrationTests/Generator/TestModelGenerator.swift
@@ -363,7 +363,13 @@ final class TestModelGenerator {
 
     private func createExecutionActions() -> [ExecutionAction] {
         (0 ..< 10).map {
-            ExecutionAction(title: "ExecutionAction\($0)", scriptText: "ScripText\($0)", target: nil, shellPath: nil, showEnvVarsInLog: false)
+            ExecutionAction(
+                title: "ExecutionAction\($0)",
+                scriptText: "ScripText\($0)",
+                target: nil,
+                shellPath: nil,
+                showEnvVarsInLog: false
+            )
         }
     }
 

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -18,7 +18,7 @@ let dependencies = Dependencies(
         .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", .exact("0.2.0")),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .exact("2.9.0")),
         .package(url: "https://github.com/SwiftGen/SwiftGen", .exact("6.5.1")),
-        .package(url: "https://github.com/tuist/XcodeProj.git", .exact("8.8.0")),
+        .package(url: "https://github.com/tuist/XcodeProj.git", .exact("8.9.0")),
     ],
     platforms: [.macOS]
 )

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -18,7 +18,7 @@ let dependencies = Dependencies(
         .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", .exact("0.2.0")),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .exact("2.9.0")),
         .package(url: "https://github.com/SwiftGen/SwiftGen", .exact("6.5.1")),
-        .package(url: "https://github.com/tuist/XcodeProj.git", .exact("8.9.0")),
+        .package(url: "https://github.com/tuist/XcodeProj.git", .exact("8.10.0")),
     ],
     platforms: [.macOS]
 )

--- a/Tuist/Dependencies/Lockfiles/Package.resolved
+++ b/Tuist/Dependencies/Lockfiles/Package.resolved
@@ -247,8 +247,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "revision" : "b6de1bfe021b861c94e7c83821b595083f74b997",
-        "version" : "8.8.0"
+        "revision" : "fae27b48bc14ff3fd9b02902e48c4665ce5a0793",
+        "version" : "8.9.0"
       }
     },
     {

--- a/Tuist/Dependencies/Lockfiles/Package.resolved
+++ b/Tuist/Dependencies/Lockfiles/Package.resolved
@@ -247,8 +247,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "revision" : "fae27b48bc14ff3fd9b02902e48c4665ce5a0793",
-        "version" : "8.9.0"
+        "revision" : "5fdac93cb4a7fd4bad5ac2da34e5bc878263043f",
+        "version" : "8.10.0"
       }
     },
     {

--- a/projects/tuist/fixtures/ios_app_with_custom_scheme/Workspace.swift
+++ b/projects/tuist/fixtures/ios_app_with_custom_scheme/Workspace.swift
@@ -10,14 +10,16 @@ let customAppScheme = Scheme(
         ],
         preActions: [
             ExecutionAction(
-                scriptText: "echo pre-action",
-                target: .project(path: "App", target: "App")
+                scriptText: "echo \"pre-action in $SHELL\"",
+                target: .project(path: "App", target: "App"),
+                shellPath: "/bin/zsh"
             ),
         ],
         postActions: [
             ExecutionAction(
-                scriptText: "echo post-action",
-                target: .project(path: "Frameworks/Framework1", target: "Framework1")
+                scriptText: "echo \"post-action in $SHELL\"",
+                target: .project(path: "Frameworks/Framework1", target: "Framework1"),
+                shellPath: "/bin/zsh"
             ),
         ]
     ),


### PR DESCRIPTION
### Short description 📝

#3384 introduced custom shellPath to TargetAction. Although ExecutionAction also has this feature, It was missing. So this time, I wanna add this feature.

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
