### PR TITLE
Support for SwiftUI font in font template

### DIFF
--- a/Sources/TuistGenerator/Templates/FontsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/FontsTemplate.swift
@@ -13,6 +13,9 @@ extension SynthesizedResourceInterfaceTemplates {
     #elseif os(iOS) || os(tvOS) || os(watchOS)
       import UIKit.UIFont
     #endif
+    #if canImport(SwiftUI)
+      import SwiftUI
+    #endif
 
     // swiftlint:disable superfluous_disable_command
     // swiftlint:disable file_length
@@ -62,6 +65,20 @@ extension SynthesizedResourceInterfaceTemplates {
         }
         return font
       }
+
+      #if canImport(SwiftUI)
+      @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+      {{accessModifier}} func swiftUIFont(size: CGFloat) -> SwiftUI.Font {
+        guard let font = Font(font: self, size: size) else {
+          fatalError("Unable to initialize font '\\(name)' (\\(family))")
+        }
+        #if os(macOS)
+        return SwiftUI.Font.custom(font.fontName, size: font.size)
+        #elseif os(iOS) || os(tvOS) || os(watchOS)
+        return SwiftUI.Font(font)
+        #endif
+      }
+      #endif
 
       {{accessModifier}} func register() {
         // swiftlint:disable:next conditional_returns_on_newline


### PR DESCRIPTION
### Short description 📝

For convenience, I added the SwiftUI font to the font template.

### How to test the changes locally 🧐

tested SwiftUI Font works properly on both macOS and iOS target.

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
