### PR TITLE
Allow using a period in a CLI product name

### DIFF
--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -73,20 +73,14 @@ class TargetLinter: TargetLinting {
     private func lintProductName(target: Target) -> [LintingIssue] {
         var allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
 
-        if target.product == .app || target.product == .commandLineTool {
+        let allowsDot = target.product == .app || target.product == .commandLineTool
+        if allowsDot {
             allowed.formUnion(CharacterSet(charactersIn: "."))
         }
 
         if target.productName.unicodeScalars.allSatisfy(allowed.contains) == false {
-            let reason: String
-            switch target.product {
-            case .app, .commandLineTool:
-                reason =
-                    "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), period (.), and underscore (_) characters."
-            default:
-                reason =
-                    "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), and underscore (_) characters."
-            }
+            let reason =
+                "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9)\(allowsDot ? ", period (.)" : ""), and underscore (_) characters."
 
             return [LintingIssue(reason: reason, severity: .warning)]
         }

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -73,14 +73,20 @@ class TargetLinter: TargetLinting {
     private func lintProductName(target: Target) -> [LintingIssue] {
         var allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
 
-        if target.product == .app {
+        if target.product == .app || target.product == .commandLineTool {
             allowed.formUnion(CharacterSet(charactersIn: "."))
         }
 
         if target.productName.unicodeScalars.allSatisfy(allowed.contains) == false {
-            let reason = target.product == .app ?
-                "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), period (.), and underscore (_) characters." :
-                "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), and underscore (_) characters."
+            let reason: String
+            switch target.product {
+            case .app, .commandLineTool:
+                reason =
+                    "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), period (.), and underscore (_) characters."
+            default:
+                reason =
+                    "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), and underscore (_) characters."
+            }
 
             return [LintingIssue(reason: reason, severity: .warning)]
         }

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -25,9 +25,16 @@ final class TargetLinterTests: TuistUnitTestCase {
     func test_lint_when_target_has_invalid_product_name() {
         let XCTAssertInvalidProductNameApp: (Target) -> Void = { target in
             let got = self.subject.lint(target: target)
-            let reason = target.product == .app ?
-                "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), period (.), and underscore (_) characters." :
-                "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), and underscore (_) characters."
+            let reason: String
+            switch target.product {
+            case .app, .commandLineTool:
+                reason =
+                    "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), period (.), and underscore (_) characters."
+            default:
+                reason =
+                    "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), and underscore (_) characters."
+            }
+
             self.XCTContainsLintingIssue(got, LintingIssue(reason: reason, severity: .warning))
         }
 


### PR DESCRIPTION
### Short description 📝

Here's one more fix for macOS developers 😅

A macOS app can use privileged helper tools that are run under admin.
The tools are stored in `/Library/PrivilegedHelperTools` and have a strict format: `<bundle_id>.name`. So a period is a legal symbol for such tools

Here's an example:
<img width="338" alt="image" src="https://user-images.githubusercontent.com/2575555/236445999-d873095f-a3d1-4591-8588-0228537dff4c.png">


### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

### Contributor checklist ✅

- [ ] The code has been linted using run `./fourier lint tuist --fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
