### PR TITLE
Fix flaky xcframeworks acceptance tests

### DIFF
--- a/projects/tuist/fixtures/ios_app_with_xcframeworks/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_xcframeworks/Project.swift
@@ -19,7 +19,7 @@ let project = Project(
                     "$(inherited)",
                     "-ObjC",
                 ],
-                "BITCODE_ENABLED": "NO",
+                "ENABLE_BITCODE": "NO",
             ])
         ),
         Target(


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/5182

### Short description 📝

- https://github.com/tuist/tuist/pull/5157 updated the acceptance tests to archive one of the fixtures
- When building with Xcode 13.4.1 (the current CI setup) the fixture fails to archive due to one of the xcframeworks not containing bitcode symbols

```
ld: bitcode bundle could not be generated because '/.../libMyStaticLibrary.a(MyStaticLibraryComponent.o)' was built without full bitcode. All object files and libraries for bitcode must be generated from Xcode Archive or Install build file '/.../libMyStaticLibrary.a' for architecture arm64
```

- As of Xcode 14 bitcode is deprecated and no longer in use which explains why this passes when building with Xcode 14 as opposed to Xcode 13
- For the purposes of this fixture, bitcode can safely be disabled
- It appears a previous attempt to fix this in https://github.com/tuist/tuist/pull/5157 used an incorrect build setting to disable bitcode
- It passed purely do the flaky nature
- `ENABLE_BITCODE` (the correct build setting) is now in use

References:

- https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes


### How to test the changes locally 🧐

- Verify bitcode setting is disabled via generating and inspect the generated project

```sh
swift build tuist
swift run tuist --path projects/tuist/fixtures/ios_app_with_xcframeworks
```

- Archive the porject multiple times and verify it passes reliably (ideally on Xcode 13.4.1 if you still have it)

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
