### PR TITLE
chore: Removed `BundleExecutableKey` from Info.plist for watchOS bundles

### DIFF
--- a/Sources/TuistGenerator/Generator/InfoPlistContentProvider.swift
+++ b/Sources/TuistGenerator/Generator/InfoPlistContentProvider.swift
@@ -131,7 +131,7 @@ final class InfoPlistContentProvider: InfoPlistContentProviding {
     func bundleExecutable(_ target: Target) -> [String: Any] {
         let shouldIncludeBundleExecutableKey: (Target) -> Bool = {
             switch ($0.platform, $0.product) {
-            case (.iOS, .bundle), (.tvOS, .bundle):
+            case (.iOS, .bundle), (.tvOS, .bundle), (.watchOS, .bundle):
                 return false
             default:
                 return true

--- a/Tests/TuistGeneratorTests/Generator/InfoPlistContentProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/InfoPlistContentProviderTests.swift
@@ -215,6 +215,30 @@ final class InfoPlistContentProviderTests: XCTestCase {
         ])
     }
 
+    func test_content_whenwatchOSResourceBundle() {
+        // Given
+        let target = Target.test(platform: .watchOS, product: .bundle)
+
+        // When
+        let got = subject.content(
+            project: .empty(),
+            target: target,
+            extendedWith: ["ExtraAttribute": "Value"]
+        )
+
+        // Then
+        assertEqual(got, [
+            "CFBundlePackageType": "BNDL",
+            "ExtraAttribute": "Value",
+            "CFBundleDevelopmentRegion": "$(DEVELOPMENT_LANGUAGE)",
+            "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
+            "CFBundleShortVersionString": "1.0",
+            "CFBundleVersion": "1",
+            "CFBundleInfoDictionaryVersion": "6.0",
+            "CFBundleName": "$(PRODUCT_NAME)",
+        ])
+    }
+
     func test_contentPackageType() {
         func content(for target: Target) -> [String: Any]? {
             subject.content(


### PR DESCRIPTION
Based off of PR: #1361

### Short description 📝

Currently generating the plist file for a watchOS resource bundle target includes the key CFBundleExecutable, having it included causes a validation error when uploading application to the app store

`Error 1: ITMS-90535 - Unexpected CFBundleExecutable Key`

### Solution 📦

Omit that key incase the target is a watchOS bundle.

### Implementation 👩‍💻👨‍💻

Update info plist provider

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
