### PR TITLE
Set BuildIndependentTargetsInParallel setting to true by default

### DIFF
--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -822,7 +822,7 @@ extension ProjectDescription.Settings {
     ) throws -> Self? {
         var headerSearchPaths: [String] = []
         var defines = ["SWIFT_PACKAGE": "1"]
-        var swiftDefines = ["SWIFT_PACKAGE"]
+        var swiftDefines = "SWIFT_PACKAGE"
         var cFlags: [String] = []
         var cxxFlags: [String] = []
         var swiftFlags: [String] = []
@@ -879,7 +879,7 @@ extension ProjectDescription.Settings {
                 case (.cxx, .unsafeFlags):
                     cxxFlags.append(contentsOf: setting.value)
                 case (.swift, .define):
-                    swiftDefines.append(setting.value[0])
+                    swiftDefines.append(" \(setting.value[0])")
                 case (.swift, .unsafeFlags):
                     swiftFlags.append(contentsOf: setting.value)
                 case (.linker, .unsafeFlags):
@@ -927,7 +927,7 @@ extension ProjectDescription.Settings {
         }
 
         if !swiftDefines.isEmpty {
-            settingsDictionary["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = .array(["$(inherited)"] + swiftDefines)
+            settingsDictionary["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = "$(inherited) \(swiftDefines)"
         }
 
         if !cFlags.isEmpty {

--- a/Sources/TuistDependenciesTesting/DependenciesGraph/DependenciesGraph+TestData.swift
+++ b/Sources/TuistDependenciesTesting/DependenciesGraph/DependenciesGraph+TestData.swift
@@ -110,7 +110,7 @@ extension TuistCore.DependenciesGraph {
                         "OTHER_CPLUSPLUSFLAGS": ["CUSTOM_CXX_FLAG"],
                         "OTHER_SWIFT_FLAGS": ["CUSTOM_SWIFT_FLAG1", "CUSTOM_SWIFT_FLAG2"],
                         "GCC_PREPROCESSOR_DEFINITIONS": ["CXX_DEFINE=CXX_VALUE", "C_DEFINE=C_VALUE"],
-                        "SWIFT_ACTIVE_COMPILATION_CONDITIONS": ["SWIFT_DEFINE"],
+                        "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "SWIFT_DEFINE",
                     ])
                 ),
                 .init(
@@ -782,11 +782,11 @@ extension DependenciesGraph {
             settingsDictionary["GCC_PREPROCESSOR_DEFINITIONS"] = .array(["$(inherited)", "SWIFT_PACKAGE=1"])
         }
 
-        if case let .array(swiftDefinitions) = settingsDictionary["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] {
+        if case let .string(swiftDefinitions) = settingsDictionary["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] {
             settingsDictionary["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] =
-                .array(["$(inherited)"] + ["SWIFT_PACKAGE"] + swiftDefinitions)
+                .string("$(inherited) SWIFT_PACKAGE \(swiftDefinitions)")
         } else {
-            settingsDictionary["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = .array(["$(inherited)"] + ["SWIFT_PACKAGE"])
+            settingsDictionary["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = .string("$(inherited) SWIFT_PACKAGE")
         }
 
         if case let .array(cFlags) = settingsDictionary["OTHER_CFLAGS"] {

--- a/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
@@ -34,6 +34,13 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
                 archiveVersion: Xcode.LastKnown.archiveVersion
             )
         }
+
+        static var xcode13: ProjectConstants {
+            ProjectConstants(
+                objectVersion: 55,
+                archiveVersion: Xcode.LastKnown.archiveVersion
+            )
+        }
     }
 
     // MARK: - Attributes
@@ -78,7 +85,7 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
         let selfRefFile = XCWorkspaceDataElement.file(selfRef)
         let workspaceData = XCWorkspaceData(children: [selfRefFile])
         let workspace = XCWorkspace(data: workspaceData)
-        let projectConstants = try determineProjectConstants(graphTraverser: graphTraverser)
+        let projectConstants = try determineProjectConstants()
         let pbxproj = PBXProj(
             objectVersion: projectConstants.objectVersion,
             archiveVersion: projectConstants.archiveVersion,
@@ -288,6 +295,9 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
             attributes["KnownAssetTags"] = uniqueTags
         }
 
+        // BuildIndependentTargetsInParallel
+        attributes["BuildIndependentTargetsInParallel"] = "YES"
+
         /// Organization name
         if let organizationName = project.organizationName {
             attributes["ORGANIZATIONNAME"] = organizationName
@@ -301,11 +311,8 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
         return attributes
     }
 
-    private func determineProjectConstants(graphTraverser: GraphTraversing) throws -> ProjectConstants {
-        if graphTraverser.hasPackages {
-            return .xcode11
-        } else {
-            return .xcode10
-        }
+    private func determineProjectConstants() throws -> ProjectConstants {
+        // TODO: Determine if this can be inferred by the set Xcode version
+        .xcode13
     }
 }

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -1763,7 +1763,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             .testWithDefaultConfigs(
                 name: "Package",
                 targets: [
-                    .test("Target1", basePath: basePath, customSettings: ["SWIFT_ACTIVE_COMPILATION_CONDITIONS": ["key"]]),
+                    .test("Target1", basePath: basePath, customSettings: ["SWIFT_ACTIVE_COMPILATION_CONDITIONS": "key"]),
                 ]
             )
         )

--- a/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
@@ -127,7 +127,7 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
 
         // Then
         let pbxproj = got.xcodeProj.pbxproj
-        XCTAssertEqual(pbxproj.objectVersion, 52)
+        XCTAssertEqual(pbxproj.objectVersion, 55)
         XCTAssertEqual(pbxproj.archiveVersion, Xcode.LastKnown.archiveVersion)
     }
 
@@ -151,7 +151,7 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
 
         // Then
         let pbxproj = got.xcodeProj.pbxproj
-        XCTAssertEqual(pbxproj.objectVersion, 50)
+        XCTAssertEqual(pbxproj.objectVersion, 55)
         XCTAssertEqual(pbxproj.archiveVersion, Xcode.LastKnown.archiveVersion)
     }
 
@@ -175,7 +175,7 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
 
         // Then
         let pbxproj = got.xcodeProj.pbxproj
-        XCTAssertEqual(pbxproj.objectVersion, 50)
+        XCTAssertEqual(pbxproj.objectVersion, 55)
         XCTAssertEqual(pbxproj.archiveVersion, Xcode.LastKnown.archiveVersion)
     }
 
@@ -267,6 +267,7 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
         let pbxProject = try XCTUnwrap(try got.xcodeProj.pbxproj.rootProject())
         let attributes = try XCTUnwrap(pbxProject.attributes as? [String: String])
         XCTAssertEqual(attributes, [
+            "BuildIndependentTargetsInParallel": "YES",
             "ORGANIZATIONNAME": "tuist",
         ])
     }
@@ -292,6 +293,7 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
         let pbxProject = try XCTUnwrap(try got.xcodeProj.pbxproj.rootProject())
         let attributes = try XCTUnwrap(pbxProject.attributes as? [String: AnyHashable])
         XCTAssertEqual(attributes, [
+            "BuildIndependentTargetsInParallel": "YES",
             "KnownAssetTags": ["fileTag", "folderTag", "commonTag"].sorted(),
         ])
     }
@@ -397,6 +399,7 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
         let pbxProject = try XCTUnwrap(try got.xcodeProj.pbxproj.rootProject())
         let attributes = try XCTUnwrap(pbxProject.attributes as? [String: String])
         XCTAssertEqual(attributes, [
+            "BuildIndependentTargetsInParallel": "YES",
             "LastUpgradeCheck": "1251",
         ])
     }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5219

### Short description 📝

Adds BuildIndependentTargetsInParallel and converts SWIFT_ACTIVE_COMPILATION_SETTINGS to a string list instead of an array, as changed in the Xcode 13 structure (although it seems as if both can be parsed)

### How to test the changes locally 🧐

Generate any project

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
