### PR TITLE
Clarify documentation about codeCoverageTargets that it takes a list of targets

### DIFF
--- a/Sources/ProjectDescription/TestActionOptions.swift
+++ b/Sources/ProjectDescription/TestActionOptions.swift
@@ -31,7 +31,7 @@ public struct TestActionOptions: Equatable, Codable {
     ///   - language: Language used for running the tests.
     ///   - region: Region used for running the tests.
     ///   - coverage: Whether test coverage should be collected.
-    ///   - codeCoverageTargets: List of targets whose code coverage information should be collected.
+    ///   - codeCoverageTargets: List of test targets whose code coverage information should be collected.
     /// - Returns: A set of options.
     public static func options(
         language: SchemeLanguage? = nil,

--- a/Sources/ProjectDescription/TestActionOptions.swift
+++ b/Sources/ProjectDescription/TestActionOptions.swift
@@ -31,7 +31,7 @@ public struct TestActionOptions: Equatable, Codable {
     ///   - language: Language used for running the tests.
     ///   - region: Region used for running the tests.
     ///   - coverage: Whether test coverage should be collected.
-    ///   - codeCoverageTargets: List of tests whose code coverage information should be collected.
+    ///   - codeCoverageTargets: List of targets whose code coverage information should be collected.
     /// - Returns: A set of options.
     public static func options(
         language: SchemeLanguage? = nil,


### PR DESCRIPTION
IMHO the description was a little bit weird because a `test` it self is not really a dedicated entity known by xcode.