### PR TITLE
Adds a fetch-dependencies option on a couple of commands

### DIFF
--- a/Sources/TuistKit/Commands/Cache/CacheWarmCommand.swift
+++ b/Sources/TuistKit/Commands/Cache/CacheWarmCommand.swift
@@ -32,6 +32,12 @@ struct CacheWarmCommand: AsyncParsableCommand, HasTrackableParameters {
     )
     var dependenciesOnly: Bool = false
 
+    @Flag(
+        name: .shortAndLong,
+        help: "Perform a fetch operation before generating the project"
+    )
+    var fetchDependencies: Bool = false
+
     func validate() throws {
         if !options.xcframeworks, options.destination != [.device, .simulator] {
             throw ValidationError.invalidXCFrameworkOptions
@@ -39,6 +45,12 @@ struct CacheWarmCommand: AsyncParsableCommand, HasTrackableParameters {
     }
 
     func run() async throws {
+        if fetchDependencies {
+            try await FetchService().run(
+                path: options.path,
+                update: false
+            )
+        }
         try await CacheWarmService().run(
             path: options.path,
             profile: options.profile,

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -36,6 +36,12 @@ struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
     var noOpen: Bool = false
 
     @Flag(
+        name: .shortAndLong,
+        help: "Perform a fetch operation before generating the project"
+    )
+    var fetchDependencies: Bool = false
+
+    @Flag(
         name: [.customShort("x"), .long],
         help: "When passed it uses xcframeworks (simulator and device) from the cache instead of frameworks (only simulator)."
     )
@@ -67,6 +73,12 @@ struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
     }
 
     func run() async throws {
+        if fetchDependencies {
+            try await FetchService().run(
+                path: path,
+                update: false
+            )
+        }
         try await GenerateService().run(
             path: path,
             sources: Set(sources),

--- a/Sources/TuistKit/Commands/RunCommand.swift
+++ b/Sources/TuistKit/Commands/RunCommand.swift
@@ -57,7 +57,19 @@ struct RunCommand: AsyncParsableCommand {
     )
     var arguments: [String] = []
 
+    @Flag(
+        name: .shortAndLong,
+        help: "Perform a fetch operation before generating the project"
+    )
+    var fetchDependencies: Bool = false
+
     func run() async throws {
+        if fetchDependencies {
+            try await FetchService().run(
+                path: path,
+                update: false
+            )
+        }
         try await RunService().run(
             path: path,
             schemeName: scheme,

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -65,6 +65,12 @@ struct TestCommand: AsyncParsableCommand {
     )
     var retryCount: Int = 0
 
+    @Flag(
+        name: .shortAndLong,
+        help: "Perform a fetch operation before generating the project"
+    )
+    var fetchDependencies: Bool = false
+
     func run() async throws {
         let absolutePath: AbsolutePath
 
@@ -72,6 +78,13 @@ struct TestCommand: AsyncParsableCommand {
             absolutePath = try AbsolutePath(validating: path, relativeTo: FileHandler.shared.currentPath)
         } else {
             absolutePath = FileHandler.shared.currentPath
+        }
+
+        if fetchDependencies {
+            try await FetchService().run(
+                path: path,
+                update: false
+            )
         }
 
         try await TestService().run(

--- a/projects/cloud/app/services/command_cache_hit_rate_service.rb
+++ b/projects/cloud/app/services/command_cache_hit_rate_service.rb
@@ -12,7 +12,7 @@ class CommandCacheHitRateService < ApplicationService
     if command_event.cacheable_targets == nil &&
         command_event.local_cache_target_hits == nil &&
         command_event.remote_cache_target_hits == nil
-      return nil
+      return
     end
     all_cache_hits =
     command_event.local_cache_target_hits.split(";").length + command_event.remote_cache_target_hits.split(";").length


### PR DESCRIPTION
The following PR tries to improve on the following [ticket](https://github.com/tuist/tuist/issues/3109)

### Short description 📝

When reading the ticket above it was mentioned that we should fetch the dependencies directly in case the user does have the dependencies locally. However, looking at it from a different point of view, it would give developers the ability to directly fetch dependencies if they want to, instead of forcing all commands to fetch them directly.

### How to test the changes locally 🧐

Using the tuist command try the following:

- [ ] Generate the new tuist project
- [ ] Make sure to set the working directory to the current one
- [ ] Select any of the projects that has dependencies and run `tuist generate -f` or `tuist generate --fetch-dependencies`

### Contributor checklist ✅

- [ ] The code has been linted using run `./fourier lint tuist --fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
