### PR TITLE
Make `TuistKit` command and services public and include a `TuistKit` product in the `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,25 +9,37 @@ let swiftGenKitDependency: Target.Dependency = .product(name: "SwiftGenKit", pac
 let swifterDependency: Target.Dependency = .product(name: "Swifter", package: "swifter")
 let combineExtDependency: Target.Dependency = .byName(name: "CombineExt")
 
+//"XcodeProj",
+//swiftToolsSupportDependency,
+//argumentParserDependency,
+//"TuistSupport",
+//"TuistGenerator",
+//"TuistCache",
+//"TuistAutomation",
+//"ProjectDescription",
+//"ProjectAutomation",
+//"TuistLoader",
+//"TuistScaffold",
+//"TuistSigning",
+//"TuistDependencies",
+//"TuistCloud",
+//"GraphViz",
+//"TuistMigration",
+//"TuistAsyncQueue",
+//"TuistAnalytics",
+//"TuistPlugin",
+//"TuistGraph",
+
 let package = Package(
     name: "tuist",
     platforms: [.macOS(.v12)],
     products: [
         .executable(name: "tuist", targets: ["tuist"]),
         .executable(name: "tuistenv", targets: ["tuistenv"]),
-        .library(
-            name: "ProjectDescription",
-            type: .dynamic,
-            targets: ["ProjectDescription"]
-        ),
-        .library(
-            name: "ProjectAutomation",
-            targets: ["ProjectAutomation"]
-        ),
-        .library(
-            name: "TuistGraph",
-            targets: ["TuistGraph"]
-        ),
+        .library(name: "ProjectDescription", type: .dynamic, targets: ["ProjectDescription"]),
+        .library(name: "ProjectAutomation", targets: ["ProjectAutomation"]),
+        .library(name: "TuistGraph", targets: ["TuistGraph"]),
+        
         /// TuistGenerator
         ///
         /// A high level Xcode generator library

--- a/Package.swift
+++ b/Package.swift
@@ -9,27 +9,6 @@ let swiftGenKitDependency: Target.Dependency = .product(name: "SwiftGenKit", pac
 let swifterDependency: Target.Dependency = .product(name: "Swifter", package: "swifter")
 let combineExtDependency: Target.Dependency = .byName(name: "CombineExt")
 
-//"XcodeProj",
-//swiftToolsSupportDependency,
-//argumentParserDependency,
-//"TuistSupport",
-//"TuistGenerator",
-//"TuistCache",
-//"TuistAutomation",
-//"ProjectDescription",
-//"ProjectAutomation",
-//"TuistLoader",
-//"TuistScaffold",
-//"TuistSigning",
-//"TuistDependencies",
-//"TuistCloud",
-//"GraphViz",
-//"TuistMigration",
-//"TuistAsyncQueue",
-//"TuistAnalytics",
-//"TuistPlugin",
-//"TuistGraph",
-
 let package = Package(
     name: "tuist",
     platforms: [.macOS(.v12)],
@@ -39,7 +18,28 @@ let package = Package(
         .library(name: "ProjectDescription", type: .dynamic, targets: ["ProjectDescription"]),
         .library(name: "ProjectAutomation", targets: ["ProjectAutomation"]),
         .library(name: "TuistGraph", targets: ["TuistGraph"]),
-        
+        .library(name: "TuistKit", targets: [
+            "TuistKit",
+            // Features
+            "TuistGenerator",
+            "TuistCache",
+            "TuistAutomation",
+            "TuistLoader",
+            "TuistScaffold",
+            "TuistSigning",
+            "TuistDependencies",
+            "TuistCloud",
+            "TuistMigration",
+            "TuistAsyncQueue",
+            "TuistAnalytics",
+            "TuistPlugin",
+            "TuistGraph",
+            // Core
+            "TuistCore",
+            // Support
+            "TuistSupport",
+        ]),
+
         /// TuistGenerator
         ///
         /// A high level Xcode generator library

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -6,14 +6,14 @@ import TuistSupport
 /// Command that builds a target from the project in the current directory.
 public struct BuildCommand: AsyncParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "build",
             abstract: "Builds a project"
         )
     }
-    
+
     // MARK: - Arguments and flags
 
     @Argument(
@@ -61,11 +61,11 @@ public struct BuildCommand: AsyncParsableCommand {
         completion: .directory
     )
     public var buildOutputPath: String?
-    
+
     // MARK: - Init
-    
+
     public init() {}
-    
+
     // MARK: - AsyncParsableCommand
 
     public func run() async throws {

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -4,61 +4,71 @@ import TSCBasic
 import TuistSupport
 
 /// Command that builds a target from the project in the current directory.
-struct BuildCommand: AsyncParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct BuildCommand: AsyncParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "build",
             abstract: "Builds a project"
         )
     }
+    
+    // MARK: - Arguments and flags
 
     @Argument(
         help: "The scheme to be built. By default it builds all the buildable schemes of the project in the current directory."
     )
-    var scheme: String?
+    public var scheme: String?
 
     @Flag(
         help: "Force the generation of the project before building."
     )
-    var generate: Bool = false
+    public var generate: Bool = false
 
     @Flag(
         help: "When passed, it cleans the project before building it"
     )
-    var clean: Bool = false
+    public var clean: Bool = false
 
     @Option(
         name: .shortAndLong,
         help: "The path to the directory that contains the project to be built.",
         completion: .directory
     )
-    var path: String?
+    public var path: String?
 
     @Option(
         name: .shortAndLong,
         help: "Build on a specific device."
     )
-    var device: String?
+    public var device: String?
 
     @Option(
         name: .shortAndLong,
         help: "Build with a specific version of the OS."
     )
-    var os: String?
+    public var os: String?
 
     @Option(
         name: [.long, .customShort("C")],
         help: "The configuration to be used when building the scheme."
     )
-    var configuration: String?
+    public var configuration: String?
 
     @Option(
         help: "The directory where build products will be copied to when the project is built.",
         completion: .directory
     )
-    var buildOutputPath: String?
+    public var buildOutputPath: String?
+    
+    // MARK: - Init
+    
+    public init() {}
+    
+    // MARK: - AsyncParsableCommand
 
-    func run() async throws {
+    public func run() async throws {
         let absolutePath: AbsolutePath
         if let path = path {
             absolutePath = try AbsolutePath(validating: path, relativeTo: FileHandler.shared.currentPath)

--- a/Sources/TuistKit/Commands/Cache/CachePrintHashesCommand.swift
+++ b/Sources/TuistKit/Commands/Cache/CachePrintHashesCommand.swift
@@ -11,16 +11,16 @@ public struct CachePrintHashesCommand: AsyncParsableCommand {
             abstract: "Print the hashes of the cacheable frameworks in the given project."
         )
     }
-    
+
     // MARK: - Arguments and Flags
 
     @OptionGroup()
     var options: CacheOptions
-    
+
     // MARK: - Init
-    
+
     public init() {}
-    
+
     // MARK: - AsyncParsableCommand
 
     public func run() async throws {

--- a/Sources/TuistKit/Commands/Cache/CachePrintHashesCommand.swift
+++ b/Sources/TuistKit/Commands/Cache/CachePrintHashesCommand.swift
@@ -3,19 +3,27 @@ import Foundation
 import TSCBasic
 import TuistSupport
 
-struct CachePrintHashesCommand: AsyncParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct CachePrintHashesCommand: AsyncParsableCommand {
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "print-hashes",
             _superCommandName: "cache",
             abstract: "Print the hashes of the cacheable frameworks in the given project."
         )
     }
+    
+    // MARK: - Arguments and Flags
 
     @OptionGroup()
     var options: CacheOptions
+    
+    // MARK: - Init
+    
+    public init() {}
+    
+    // MARK: - AsyncParsableCommand
 
-    func run() async throws {
+    public func run() async throws {
         try await CachePrintHashesService().run(
             path: options.path,
             xcframeworks: options.xcframeworks,

--- a/Sources/TuistKit/Commands/Cache/CacheWarmCommand.swift
+++ b/Sources/TuistKit/Commands/Cache/CacheWarmCommand.swift
@@ -6,10 +6,12 @@ import TuistCache
 import TuistSupport
 
 /// Command to cache targets as `.(xc)framework`s and speed up your and your peers' build times.
-struct CacheWarmCommand: AsyncParsableCommand, HasTrackableParameters {
+public struct CacheWarmCommand: AsyncParsableCommand, HasTrackableParameters {
     static var analyticsDelegate: TrackableParametersDelegate?
-
-    static var configuration: CommandConfiguration {
+    
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "warm",
             _superCommandName: "cache",
@@ -32,13 +34,19 @@ struct CacheWarmCommand: AsyncParsableCommand, HasTrackableParameters {
     )
     var dependenciesOnly: Bool = false
 
-    func validate() throws {
+    public func validate() throws {
         if !options.xcframeworks, options.destination != [.device, .simulator] {
             throw ValidationError.invalidXCFrameworkOptions
         }
     }
+    
+    // MARK: - Init
+    
+    public init() {}
+    
+    // MARK: - AsyncParsableCommand
 
-    func run() async throws {
+    public func run() async throws {
         try await CacheWarmService().run(
             path: options.path,
             profile: options.profile,
@@ -57,11 +65,11 @@ struct CacheWarmCommand: AsyncParsableCommand, HasTrackableParameters {
             ]
         )
     }
-
-    enum ValidationError: LocalizedError {
+    
+    public enum ValidationError: LocalizedError {
         case invalidXCFrameworkOptions
 
-        var errorDescription: String? {
+        public var errorDescription: String? {
             switch self {
             case .invalidXCFrameworkOptions:
                 return "--xcframeworks must be enabled when --destination is set"

--- a/Sources/TuistKit/Commands/Cache/CacheWarmCommand.swift
+++ b/Sources/TuistKit/Commands/Cache/CacheWarmCommand.swift
@@ -8,9 +8,9 @@ import TuistSupport
 /// Command to cache targets as `.(xc)framework`s and speed up your and your peers' build times.
 public struct CacheWarmCommand: AsyncParsableCommand, HasTrackableParameters {
     static var analyticsDelegate: TrackableParametersDelegate?
-    
+
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "warm",
@@ -39,11 +39,11 @@ public struct CacheWarmCommand: AsyncParsableCommand, HasTrackableParameters {
             throw ValidationError.invalidXCFrameworkOptions
         }
     }
-    
+
     // MARK: - Init
-    
+
     public init() {}
-    
+
     // MARK: - AsyncParsableCommand
 
     public func run() async throws {
@@ -65,7 +65,7 @@ public struct CacheWarmCommand: AsyncParsableCommand, HasTrackableParameters {
             ]
         )
     }
-    
+
     public enum ValidationError: LocalizedError {
         case invalidXCFrameworkOptions
 

--- a/Sources/TuistKit/Commands/CacheCommand.swift
+++ b/Sources/TuistKit/Commands/CacheCommand.swift
@@ -2,8 +2,11 @@ import ArgumentParser
 import Foundation
 import TSCBasic
 
-struct CacheCommand: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct CacheCommand: ParsableCommand {
+    
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "cache",
             abstract: "A set of utilities related to the caching of targets.",
@@ -13,4 +16,8 @@ struct CacheCommand: ParsableCommand {
             ]
         )
     }
+    
+    // MARK: - Init
+    
+    public init() {}
 }

--- a/Sources/TuistKit/Commands/CacheCommand.swift
+++ b/Sources/TuistKit/Commands/CacheCommand.swift
@@ -3,9 +3,8 @@ import Foundation
 import TSCBasic
 
 public struct CacheCommand: ParsableCommand {
-    
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "cache",
@@ -16,8 +15,8 @@ public struct CacheCommand: ParsableCommand {
             ]
         )
     }
-    
+
     // MARK: - Init
-    
+
     public init() {}
 }

--- a/Sources/TuistKit/Commands/CleanCommand.swift
+++ b/Sources/TuistKit/Commands/CleanCommand.swift
@@ -3,8 +3,8 @@ import Foundation
 import TuistCore
 
 /// Category that can be cleaned
-enum CleanCategory: ExpressibleByArgument {
-    static let allCases = CacheCategory.allCases.map { .global($0) } + [Self.dependencies]
+public enum CleanCategory: ExpressibleByArgument {
+    public static let allCases = CacheCategory.allCases.map { .global($0) } + [Self.dependencies]
 
     /// The global cache
     case global(CacheCategory)
@@ -12,7 +12,7 @@ enum CleanCategory: ExpressibleByArgument {
     /// The local dependencies cache
     case dependencies
 
-    var defaultValueDescription: String {
+    public var defaultValueDescription: String {
         switch self {
         case let .global(cacheCategory):
             return cacheCategory.rawValue
@@ -21,7 +21,7 @@ enum CleanCategory: ExpressibleByArgument {
         }
     }
 
-    init?(argument: String) {
+    public init?(argument: String) {
         if let cacheCategory = CacheCategory(rawValue: argument) {
             self = .global(cacheCategory)
         } else if argument == "dependencies" {
@@ -32,25 +32,35 @@ enum CleanCategory: ExpressibleByArgument {
     }
 }
 
-struct CleanCommand: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct CleanCommand: ParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "clean",
             abstract: "Clean all the artifacts stored locally"
         )
     }
 
+    // MARK: - Arguments and flags
+    
     @Argument(help: "The cache and artifact categories to be cleaned. If no category is specified, everything is cleaned.")
-    var cleanCategories: [CleanCategory] = CleanCategory.allCases
+    public var cleanCategories: [CleanCategory] = CleanCategory.allCases
 
     @Option(
         name: .shortAndLong,
         help: "The path to the directory that contains the project that should be cleaned.",
         completion: .directory
     )
-    var path: String?
+    public var path: String?
+    
+    // MARK: - Init
+    
+    public init() {}
+    
+    // MARK: - ParsableCommand
 
-    func run() throws {
+    public func run() throws {
         try CleanService().run(
             categories: cleanCategories,
             path: path

--- a/Sources/TuistKit/Commands/CleanCommand.swift
+++ b/Sources/TuistKit/Commands/CleanCommand.swift
@@ -34,7 +34,7 @@ public enum CleanCategory: ExpressibleByArgument {
 
 public struct CleanCommand: ParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "clean",
@@ -43,7 +43,7 @@ public struct CleanCommand: ParsableCommand {
     }
 
     // MARK: - Arguments and flags
-    
+
     @Argument(help: "The cache and artifact categories to be cleaned. If no category is specified, everything is cleaned.")
     public var cleanCategories: [CleanCategory] = CleanCategory.allCases
 
@@ -53,11 +53,11 @@ public struct CleanCommand: ParsableCommand {
         completion: .directory
     )
     public var path: String?
-    
+
     // MARK: - Init
-    
+
     public init() {}
-    
+
     // MARK: - ParsableCommand
 
     public func run() throws {

--- a/Sources/TuistKit/Commands/Cloud/CloudAuthCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudAuthCommand.swift
@@ -4,7 +4,7 @@ import TSCBasic
 
 public struct CloudAuthCommand: ParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "auth",
@@ -12,11 +12,11 @@ public struct CloudAuthCommand: ParsableCommand {
             abstract: "Authenticates the user on the server with the URL defined in the Config.swift file"
         )
     }
-    
+
     // MARK: - Init
-    
+
     public init() {}
-    
+
     // MARK: - ParsableCommand
 
     public func run() throws {

--- a/Sources/TuistKit/Commands/Cloud/CloudAuthCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudAuthCommand.swift
@@ -2,16 +2,24 @@ import ArgumentParser
 import Foundation
 import TSCBasic
 
-struct CloudAuthCommand: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct CloudAuthCommand: ParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "auth",
             _superCommandName: "cloud",
             abstract: "Authenticates the user on the server with the URL defined in the Config.swift file"
         )
     }
+    
+    // MARK: - Init
+    
+    public init() {}
+    
+    // MARK: - ParsableCommand
 
-    func run() throws {
+    public func run() throws {
         try CloudAuthService().authenticate()
     }
 }

--- a/Sources/TuistKit/Commands/Cloud/CloudCleanCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudCleanCommand.swift
@@ -5,7 +5,7 @@ import TuistSupport
 
 public struct CloudCleanCommand: AsyncParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "clean",
@@ -15,7 +15,7 @@ public struct CloudCleanCommand: AsyncParsableCommand {
     }
 
     // MARK: - Flags and Arguments
-    
+
     @Option(
         name: .shortAndLong,
         help: "The path to the Tuist Cloud project.",
@@ -24,11 +24,11 @@ public struct CloudCleanCommand: AsyncParsableCommand {
     var path: String?
 
     // MARK: - Init
-    
+
     public init() {}
-    
+
     // MARK: - AsyncParsableCommand
-    
+
     public func run() async throws {
         try await CloudCleanService().clean(
             path: path

--- a/Sources/TuistKit/Commands/Cloud/CloudCleanCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudCleanCommand.swift
@@ -3,8 +3,10 @@ import Foundation
 import TSCBasic
 import TuistSupport
 
-struct CloudCleanCommand: AsyncParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct CloudCleanCommand: AsyncParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "clean",
             _superCommandName: "cloud",
@@ -12,6 +14,8 @@ struct CloudCleanCommand: AsyncParsableCommand {
         )
     }
 
+    // MARK: - Flags and Arguments
+    
     @Option(
         name: .shortAndLong,
         help: "The path to the Tuist Cloud project.",
@@ -19,7 +23,13 @@ struct CloudCleanCommand: AsyncParsableCommand {
     )
     var path: String?
 
-    func run() async throws {
+    // MARK: - Init
+    
+    public init() {}
+    
+    // MARK: - AsyncParsableCommand
+    
+    public func run() async throws {
         try await CloudCleanService().clean(
             path: path
         )

--- a/Sources/TuistKit/Commands/Cloud/CloudInitCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudInitCommand.swift
@@ -3,14 +3,19 @@ import Foundation
 import TSCBasic
 import TuistSupport
 
-struct CloudInitCommand: AsyncParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct CloudInitCommand: AsyncParsableCommand {
+    
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "init",
             _superCommandName: "cloud",
             abstract: "Creates a new tuist cloud project."
         )
     }
+    
+    // MARK: - Arguments and flags
 
     @Option(
         help: "Owner of the project. Either your username or a name of the organization."
@@ -33,8 +38,14 @@ struct CloudInitCommand: AsyncParsableCommand {
         completion: .directory
     )
     var path: String?
+    
+    // MARK: - Init
+    
+    public init() {}
 
-    func run() async throws {
+    // MARK: - AsyncParsableCommand
+    
+    public func run() async throws {
         try await CloudInitService().createProject(
             name: name,
             owner: owner,

--- a/Sources/TuistKit/Commands/Cloud/CloudInitCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudInitCommand.swift
@@ -4,9 +4,8 @@ import TSCBasic
 import TuistSupport
 
 public struct CloudInitCommand: AsyncParsableCommand {
-    
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "init",
@@ -14,7 +13,7 @@ public struct CloudInitCommand: AsyncParsableCommand {
             abstract: "Creates a new tuist cloud project."
         )
     }
-    
+
     // MARK: - Arguments and flags
 
     @Option(
@@ -38,13 +37,13 @@ public struct CloudInitCommand: AsyncParsableCommand {
         completion: .directory
     )
     var path: String?
-    
+
     // MARK: - Init
-    
+
     public init() {}
 
     // MARK: - AsyncParsableCommand
-    
+
     public func run() async throws {
         try await CloudInitService().createProject(
             name: name,

--- a/Sources/TuistKit/Commands/Cloud/CloudLogoutCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudLogoutCommand.swift
@@ -3,9 +3,8 @@ import Foundation
 import TSCBasic
 
 public struct CloudLogoutCommand: ParsableCommand {
-    
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "logout",
@@ -13,13 +12,13 @@ public struct CloudLogoutCommand: ParsableCommand {
             abstract: "Removes any existing session to authenticate on the server with the URL defined in the Config.swift file"
         )
     }
-    
+
     // MARK: - Init
-    
+
     public init() {}
 
     // MARK: - Run
-    
+
     public func run() throws {
         try CloudLogoutService().logout()
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudLogoutCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudLogoutCommand.swift
@@ -2,16 +2,25 @@ import ArgumentParser
 import Foundation
 import TSCBasic
 
-struct CloudLogoutCommand: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct CloudLogoutCommand: ParsableCommand {
+    
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "logout",
             _superCommandName: "cloud",
             abstract: "Removes any existing session to authenticate on the server with the URL defined in the Config.swift file"
         )
     }
+    
+    // MARK: - Init
+    
+    public init() {}
 
-    func run() throws {
+    // MARK: - Run
+    
+    public func run() throws {
         try CloudLogoutService().logout()
     }
 }

--- a/Sources/TuistKit/Commands/Cloud/CloudSessionCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudSessionCommand.swift
@@ -2,8 +2,10 @@ import ArgumentParser
 import Foundation
 import TSCBasic
 
-struct CloudSessionCommand: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct CloudSessionCommand: ParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "session",
             _superCommandName: "cloud",
@@ -11,7 +13,13 @@ struct CloudSessionCommand: ParsableCommand {
         )
     }
 
-    func run() throws {
+    // MARK: - Init
+    
+    public init() {}
+    
+    // MARK: - ParseableCommand
+    
+    public func run() throws {
         try CloudSessionService().printSession()
     }
 }

--- a/Sources/TuistKit/Commands/Cloud/CloudSessionCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudSessionCommand.swift
@@ -4,7 +4,7 @@ import TSCBasic
 
 public struct CloudSessionCommand: ParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "session",
@@ -14,11 +14,11 @@ public struct CloudSessionCommand: ParsableCommand {
     }
 
     // MARK: - Init
-    
+
     public init() {}
-    
+
     // MARK: - ParseableCommand
-    
+
     public func run() throws {
         try CloudSessionService().printSession()
     }

--- a/Sources/TuistKit/Commands/CloudCommand.swift
+++ b/Sources/TuistKit/Commands/CloudCommand.swift
@@ -4,7 +4,7 @@ import TSCBasic
 
 public struct CloudCommand: ParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "cloud",
@@ -18,8 +18,8 @@ public struct CloudCommand: ParsableCommand {
             ]
         )
     }
-    
+
     // MARK: - Init
-    
+
     public init() {}
 }

--- a/Sources/TuistKit/Commands/CloudCommand.swift
+++ b/Sources/TuistKit/Commands/CloudCommand.swift
@@ -2,8 +2,10 @@ import ArgumentParser
 import Foundation
 import TSCBasic
 
-struct CloudCommand: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct CloudCommand: ParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "cloud",
             abstract: "A set of commands to interact with the cloud.",
@@ -16,4 +18,8 @@ struct CloudCommand: ParsableCommand {
             ]
         )
     }
+    
+    // MARK: - Init
+    
+    public init() {}
 }

--- a/Sources/TuistKit/Commands/DumpCommand.swift
+++ b/Sources/TuistKit/Commands/DumpCommand.swift
@@ -4,8 +4,8 @@ import TSCBasic
 import TuistLoader
 import TuistSupport
 
-struct DumpCommand: AsyncParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct DumpCommand: AsyncParsableCommand {
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "dump",
             abstract: "Outputs the manifest as a JSON"
@@ -19,12 +19,18 @@ struct DumpCommand: AsyncParsableCommand {
         help: "The path to the folder where the manifest is",
         completion: .directory
     )
-    var path: String?
+    public var path: String?
 
     @Argument(help: "The manifest to be dumped")
-    var manifest: DumpableManifest = .project
+    public var manifest: DumpableManifest = .project
+    
+    // MARK: - Init
+    
+    public init() {}
+    
+    // MARK: - AsyncParsableCommand
 
-    func run() async throws {
+    public func run() async throws {
         try await DumpService().run(path: path, manifest: manifest)
     }
 }

--- a/Sources/TuistKit/Commands/DumpCommand.swift
+++ b/Sources/TuistKit/Commands/DumpCommand.swift
@@ -23,11 +23,11 @@ public struct DumpCommand: AsyncParsableCommand {
 
     @Argument(help: "The manifest to be dumped")
     public var manifest: DumpableManifest = .project
-    
+
     // MARK: - Init
-    
+
     public init() {}
-    
+
     // MARK: - AsyncParsableCommand
 
     public func run() async throws {

--- a/Sources/TuistKit/Commands/EditCommand.swift
+++ b/Sources/TuistKit/Commands/EditCommand.swift
@@ -4,13 +4,17 @@ import TSCBasic
 import TuistGenerator
 import TuistSupport
 
-struct EditCommand: AsyncParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct EditCommand: AsyncParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "edit",
             abstract: "Generates a temporary project to edit the project in the current directory"
         )
     }
+    
+    // MARK: - Arguments and flags
 
     @Option(
         name: .shortAndLong,
@@ -30,8 +34,14 @@ struct EditCommand: AsyncParsableCommand {
         help: "It only includes the manifest in the current directory."
     )
     var onlyCurrentDirectory: Bool = false
+    
+    // MARK: - Init
+    
+    public init() {}
 
-    func run() async throws {
+    // MARK: - AsyncParsableCommand
+    
+    public func run() async throws {
         try await EditService().run(
             path: path,
             permanent: permanent,

--- a/Sources/TuistKit/Commands/EditCommand.swift
+++ b/Sources/TuistKit/Commands/EditCommand.swift
@@ -6,14 +6,14 @@ import TuistSupport
 
 public struct EditCommand: AsyncParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "edit",
             abstract: "Generates a temporary project to edit the project in the current directory"
         )
     }
-    
+
     // MARK: - Arguments and flags
 
     @Option(
@@ -34,13 +34,13 @@ public struct EditCommand: AsyncParsableCommand {
         help: "It only includes the manifest in the current directory."
     )
     var onlyCurrentDirectory: Bool = false
-    
+
     // MARK: - Init
-    
+
     public init() {}
 
     // MARK: - AsyncParsableCommand
-    
+
     public func run() async throws {
         try await EditService().run(
             path: path,

--- a/Sources/TuistKit/Commands/FetchCommand.swift
+++ b/Sources/TuistKit/Commands/FetchCommand.swift
@@ -10,14 +10,14 @@ enum FetchCategory: String, CaseIterable, RawRepresentable, ExpressibleByArgumen
 /// A command to fetch any remote content necessary to interact with the project.
 public struct FetchCommand: AsyncParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "fetch",
             abstract: "Fetches any remote content necessary to interact with the project."
         )
     }
-    
+
     // MARK: - Aarguments and flags
 
     @Option(
@@ -32,13 +32,13 @@ public struct FetchCommand: AsyncParsableCommand {
         help: "Instead of simple fetch, update external content when available."
     )
     var update: Bool = false
-    
+
     // MARK: - Init
-    
+
     public init() {}
 
     // MARK: - AsyncParsableCommand
-    
+
     public func run() async throws {
         try await FetchService().run(
             path: path,

--- a/Sources/TuistKit/Commands/FetchCommand.swift
+++ b/Sources/TuistKit/Commands/FetchCommand.swift
@@ -8,13 +8,17 @@ enum FetchCategory: String, CaseIterable, RawRepresentable, ExpressibleByArgumen
 }
 
 /// A command to fetch any remote content necessary to interact with the project.
-struct FetchCommand: AsyncParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct FetchCommand: AsyncParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "fetch",
             abstract: "Fetches any remote content necessary to interact with the project."
         )
     }
+    
+    // MARK: - Aarguments and flags
 
     @Option(
         name: .shortAndLong,
@@ -28,8 +32,14 @@ struct FetchCommand: AsyncParsableCommand {
         help: "Instead of simple fetch, update external content when available."
     )
     var update: Bool = false
+    
+    // MARK: - Init
+    
+    public init() {}
 
-    func run() async throws {
+    // MARK: - AsyncParsableCommand
+    
+    public func run() async throws {
         try await FetchService().run(
             path: path,
             update: update

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -6,7 +6,7 @@ import TuistCore
 
 public struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
     static var analyticsDelegate: TrackableParametersDelegate?
-    
+
     // MARK: - Configuration
 
     public static var configuration: CommandConfiguration {
@@ -16,7 +16,7 @@ public struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
             subcommands: []
         )
     }
-    
+
     // MARK: - Arguments and flags
 
     @Option(
@@ -69,12 +69,13 @@ public struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
             throw ValidationError.invalidXCFrameworkOptions
         }
     }
+
     // MARK: - Init
-    
+
     public init() {}
 
     // MARK: - AsyncParsableCommand
-    
+
     public func run() async throws {
         try await GenerateService().run(
             path: path,

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -4,16 +4,20 @@ import Foundation
 import TuistCache
 import TuistCore
 
-struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
+public struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
     static var analyticsDelegate: TrackableParametersDelegate?
+    
+    // MARK: - Configuration
 
-    static var configuration: CommandConfiguration {
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "generate",
             abstract: "Generates an Xcode workspace to start working on the project.",
             subcommands: []
         )
     }
+    
+    // MARK: - Arguments and flags
 
     @Option(
         name: .shortAndLong,
@@ -60,13 +64,18 @@ struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
     )
     var ignoreCache: Bool = false
 
-    func validate() throws {
+    public func validate() throws {
         if !xcframeworks, destination != [.device, .simulator] {
             throw ValidationError.invalidXCFrameworkOptions
         }
     }
+    // MARK: - Init
+    
+    public init() {}
 
-    func run() async throws {
+    // MARK: - AsyncParsableCommand
+    
+    public func run() async throws {
         try await GenerateService().run(
             path: path,
             sources: Set(sources),
@@ -89,10 +98,10 @@ struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
         )
     }
 
-    enum ValidationError: LocalizedError {
+    public enum ValidationError: LocalizedError {
         case invalidXCFrameworkOptions
 
-        var errorDescription: String? {
+        public var errorDescription: String? {
             switch self {
             case .invalidXCFrameworkOptions:
                 return "--xcframeworks must be enabled when --destination is set"

--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -9,16 +9,20 @@ import TuistLoader
 import TuistSupport
 
 /// Command that generates and exports a dot graph from the workspace or project in the current directory.
-struct GraphCommand: AsyncParsableCommand, HasTrackableParameters {
+public struct GraphCommand: AsyncParsableCommand, HasTrackableParameters {
     static var analyticsDelegate: TrackableParametersDelegate?
 
-    static var configuration: CommandConfiguration {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "graph",
             abstract: "Generates a graph from the workspace or project in the current directory"
         )
     }
 
+    // MARK: - Arguments and flags
+    
     @Flag(
         name: [.customShort("t"), .long],
         help: "Skip Test targets during graph rendering."
@@ -70,8 +74,14 @@ struct GraphCommand: AsyncParsableCommand, HasTrackableParameters {
         help: "The path where the graph will be generated."
     )
     var outputPath: String?
+    
+    // MARK: - Init
+    
+    public init() {}
 
-    func run() async throws {
+    // MARK: - AsyncParsableCommand
+    
+    public func run() async throws {
         GraphCommand.analyticsDelegate?.addParameters(
             [
                 "format": AnyCodable(format.rawValue),
@@ -96,7 +106,7 @@ struct GraphCommand: AsyncParsableCommand, HasTrackableParameters {
     }
 }
 
-enum GraphFormat: String, ExpressibleByArgument {
+public enum GraphFormat: String, ExpressibleByArgument {
     case dot, json, png, svg
 }
 

--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -13,7 +13,7 @@ public struct GraphCommand: AsyncParsableCommand, HasTrackableParameters {
     static var analyticsDelegate: TrackableParametersDelegate?
 
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "graph",
@@ -22,7 +22,7 @@ public struct GraphCommand: AsyncParsableCommand, HasTrackableParameters {
     }
 
     // MARK: - Arguments and flags
-    
+
     @Flag(
         name: [.customShort("t"), .long],
         help: "Skip Test targets during graph rendering."
@@ -74,13 +74,13 @@ public struct GraphCommand: AsyncParsableCommand, HasTrackableParameters {
         help: "The path where the graph will be generated."
     )
     var outputPath: String?
-    
+
     // MARK: - Init
-    
+
     public init() {}
 
     // MARK: - AsyncParsableCommand
-    
+
     public func run() async throws {
         GraphCommand.analyticsDelegate?.addParameters(
             [

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -12,8 +12,11 @@ import TuistSupport
 private typealias Platform = TuistGraph.Platform
 private typealias Product = TuistGraph.Product
 
-struct InitCommand: ParsableCommand, HasTrackableParameters {
-    static var configuration: CommandConfiguration {
+public struct InitCommand: ParsableCommand, HasTrackableParameters {
+    
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "init",
             abstract: "Bootstraps a project"
@@ -22,6 +25,8 @@ struct InitCommand: ParsableCommand, HasTrackableParameters {
 
     static var analyticsDelegate: TrackableParametersDelegate?
 
+    // MARK: - Arguments and flags
+    
     @Option(
         help: "The platform (ios, tvos or macos) the product will be for (Default: ios)",
         completion: .list(["ios", "tvos", "macos"])
@@ -50,10 +55,12 @@ struct InitCommand: ParsableCommand, HasTrackableParameters {
     var requiredTemplateOptions: [String: String] = [:]
     var optionalTemplateOptions: [String: String?] = [:]
 
-    init() {}
+    // MARK: - Init
+    
+    public init() {}
 
     // Custom decoding to decode dynamic options
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         platform = try container.decodeIfPresent(Option<String>.self, forKey: .platform)?.wrappedValue
         name = try container.decodeIfPresent(Option<String>.self, forKey: .name)?.wrappedValue
@@ -73,7 +80,7 @@ struct InitCommand: ParsableCommand, HasTrackableParameters {
         }
     }
 
-    func run() throws {
+    public func run() throws {
         InitCommand.analyticsDelegate?.addParameters(
             [
                 "platform": AnyCodable(platform ?? "unknown"),
@@ -192,7 +199,7 @@ extension InitCommand {
 /// ArgumentParser library gets the list of options from a mirror
 /// Since we do not declare template's options in advance, we need to rewrite the mirror implementation and add them ourselves
 extension InitCommand: CustomReflectable {
-    var customMirror: Mirror {
+    public var customMirror: Mirror {
         let requiredTemplateChildren = InitCommand.requiredTemplateOptions
             .map { Mirror.Child(label: $0.name, value: $0.option) }
         let optionalTemplateChildren = InitCommand.optionalTemplateOptions

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -13,9 +13,8 @@ private typealias Platform = TuistGraph.Platform
 private typealias Product = TuistGraph.Product
 
 public struct InitCommand: ParsableCommand, HasTrackableParameters {
-    
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "init",
@@ -26,7 +25,7 @@ public struct InitCommand: ParsableCommand, HasTrackableParameters {
     static var analyticsDelegate: TrackableParametersDelegate?
 
     // MARK: - Arguments and flags
-    
+
     @Option(
         help: "The platform (ios, tvos or macos) the product will be for (Default: ios)",
         completion: .list(["ios", "tvos", "macos"])
@@ -56,7 +55,7 @@ public struct InitCommand: ParsableCommand, HasTrackableParameters {
     var optionalTemplateOptions: [String: String?] = [:]
 
     // MARK: - Init
-    
+
     public init() {}
 
     // Custom decoding to decode dynamic options

--- a/Sources/TuistKit/Commands/ListCommand.swift
+++ b/Sources/TuistKit/Commands/ListCommand.swift
@@ -1,8 +1,10 @@
 import ArgumentParser
 import Foundation
 
-struct ListCommand: AsyncParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct ListCommand: AsyncParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "list",
             _superCommandName: "scaffold",
@@ -10,6 +12,8 @@ struct ListCommand: AsyncParsableCommand {
             subcommands: []
         )
     }
+    
+    // MARK: - Arguments and Flags
 
     @Flag(
         help: "The output in JSON format"
@@ -22,8 +26,14 @@ struct ListCommand: AsyncParsableCommand {
         completion: .directory
     )
     var path: String?
+    
+    // MARK: - Init
+    
+    public init() {}
+    
+    // MARK: - AsyncParsableCommand
 
-    func run() async throws {
+    public func run() async throws {
         let format: ListService.OutputFormat = json ? .json : .table
         try await ListService().run(
             path: path,

--- a/Sources/TuistKit/Commands/ListCommand.swift
+++ b/Sources/TuistKit/Commands/ListCommand.swift
@@ -3,7 +3,7 @@ import Foundation
 
 public struct ListCommand: AsyncParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "list",
@@ -12,7 +12,7 @@ public struct ListCommand: AsyncParsableCommand {
             subcommands: []
         )
     }
-    
+
     // MARK: - Arguments and Flags
 
     @Flag(
@@ -26,11 +26,11 @@ public struct ListCommand: AsyncParsableCommand {
         completion: .directory
     )
     var path: String?
-    
+
     // MARK: - Init
-    
+
     public init() {}
-    
+
     // MARK: - AsyncParsableCommand
 
     public func run() async throws {

--- a/Sources/TuistKit/Commands/Migration/MigrationCheckEmptyBuildSettingsCommand.swift
+++ b/Sources/TuistKit/Commands/Migration/MigrationCheckEmptyBuildSettingsCommand.swift
@@ -3,14 +3,18 @@ import Foundation
 import TSCBasic
 import TuistSupport
 
-struct MigrationCheckEmptyBuildSettingsCommand: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct MigrationCheckEmptyBuildSettingsCommand: ParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "check-empty-settings",
             _superCommandName: "migration",
             abstract: "It checks if the build settings of a project or target are empty. Otherwise it exits unsuccessfully."
         )
     }
+    
+    // MARK: - Arguments and Flags
 
     @Option(
         name: [.customShort("p"), .long],
@@ -24,8 +28,14 @@ struct MigrationCheckEmptyBuildSettingsCommand: ParsableCommand {
         help: "The name of the target whose build settings will be checked. When not passed, it checks the build settings of the project."
     )
     var target: String?
-
-    func run() throws {
+    
+    // MARK: - Init
+    
+    public init() {}
+    
+    // MARK: - ParsableCommand
+    
+    public func run() throws {
         try MigrationCheckEmptyBuildSettingsService().run(
             xcodeprojPath: try AbsolutePath(validating: xcodeprojPath, relativeTo: FileHandler.shared.currentPath),
             target: target

--- a/Sources/TuistKit/Commands/Migration/MigrationCheckEmptyBuildSettingsCommand.swift
+++ b/Sources/TuistKit/Commands/Migration/MigrationCheckEmptyBuildSettingsCommand.swift
@@ -5,7 +5,7 @@ import TuistSupport
 
 public struct MigrationCheckEmptyBuildSettingsCommand: ParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "check-empty-settings",
@@ -13,7 +13,7 @@ public struct MigrationCheckEmptyBuildSettingsCommand: ParsableCommand {
             abstract: "It checks if the build settings of a project or target are empty. Otherwise it exits unsuccessfully."
         )
     }
-    
+
     // MARK: - Arguments and Flags
 
     @Option(
@@ -28,13 +28,13 @@ public struct MigrationCheckEmptyBuildSettingsCommand: ParsableCommand {
         help: "The name of the target whose build settings will be checked. When not passed, it checks the build settings of the project."
     )
     var target: String?
-    
+
     // MARK: - Init
-    
+
     public init() {}
-    
+
     // MARK: - ParsableCommand
-    
+
     public func run() throws {
         try MigrationCheckEmptyBuildSettingsService().run(
             xcodeprojPath: try AbsolutePath(validating: xcodeprojPath, relativeTo: FileHandler.shared.currentPath),

--- a/Sources/TuistKit/Commands/Migration/MigrationSettingsToXCConfigCommand.swift
+++ b/Sources/TuistKit/Commands/Migration/MigrationSettingsToXCConfigCommand.swift
@@ -5,7 +5,7 @@ import TuistSupport
 
 public struct MigrationSettingsToXCConfigCommand: ParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "settings-to-xcconfig",
@@ -13,7 +13,7 @@ public struct MigrationSettingsToXCConfigCommand: ParsableCommand {
             abstract: "It extracts the build settings from a project or a target into an xcconfig file."
         )
     }
-    
+
     // MARK: - Arguments & Flags
 
     @Option(
@@ -36,13 +36,13 @@ public struct MigrationSettingsToXCConfigCommand: ParsableCommand {
         completion: .default
     )
     var target: String?
-    
+
     // MARK: - Init
-    
+
     public init() {}
 
     // MARK: - ParsableCommand
-    
+
     public func run() throws {
         try MigrationSettingsToXCConfigService().run(
             xcodeprojPath: xcodeprojPath,

--- a/Sources/TuistKit/Commands/Migration/MigrationSettingsToXCConfigCommand.swift
+++ b/Sources/TuistKit/Commands/Migration/MigrationSettingsToXCConfigCommand.swift
@@ -3,14 +3,18 @@ import Foundation
 import TSCBasic
 import TuistSupport
 
-struct MigrationSettingsToXCConfigCommand: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct MigrationSettingsToXCConfigCommand: ParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "settings-to-xcconfig",
             _superCommandName: "migration",
             abstract: "It extracts the build settings from a project or a target into an xcconfig file."
         )
     }
+    
+    // MARK: - Arguments & Flags
 
     @Option(
         name: [.customShort("p"), .long],
@@ -32,8 +36,14 @@ struct MigrationSettingsToXCConfigCommand: ParsableCommand {
         completion: .default
     )
     var target: String?
+    
+    // MARK: - Init
+    
+    public init() {}
 
-    func run() throws {
+    // MARK: - ParsableCommand
+    
+    public func run() throws {
         try MigrationSettingsToXCConfigService().run(
             xcodeprojPath: xcodeprojPath,
             xcconfigPath: xcconfigPath,

--- a/Sources/TuistKit/Commands/Migration/MigrationTargetsByDependenciesCommand.swift
+++ b/Sources/TuistKit/Commands/Migration/MigrationTargetsByDependenciesCommand.swift
@@ -3,8 +3,10 @@ import Foundation
 import TSCBasic
 import TuistSupport
 
-struct MigrationTargetsByDependenciesCommand: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct MigrationTargetsByDependenciesCommand: ParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "list-targets",
             _superCommandName: "migration",
@@ -12,14 +14,22 @@ struct MigrationTargetsByDependenciesCommand: ParsableCommand {
         )
     }
 
+    // MARK: - Arguments & Flags
+    
     @Option(
         name: [.customShort("p"), .long],
         help: "The path to the Xcode project",
         completion: .directory
     )
     var xcodeprojPath: String
+    
+    // MARK: - Init
+    
+    public init() {}
 
-    func run() throws {
+    // MARK: - ParsableCommand
+    
+    public func run() throws {
         try MigrationTargetsByDependenciesService()
             .run(xcodeprojPath: try AbsolutePath(validating: xcodeprojPath, relativeTo: FileHandler.shared.currentPath))
     }

--- a/Sources/TuistKit/Commands/Migration/MigrationTargetsByDependenciesCommand.swift
+++ b/Sources/TuistKit/Commands/Migration/MigrationTargetsByDependenciesCommand.swift
@@ -5,7 +5,7 @@ import TuistSupport
 
 public struct MigrationTargetsByDependenciesCommand: ParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "list-targets",
@@ -15,20 +15,20 @@ public struct MigrationTargetsByDependenciesCommand: ParsableCommand {
     }
 
     // MARK: - Arguments & Flags
-    
+
     @Option(
         name: [.customShort("p"), .long],
         help: "The path to the Xcode project",
         completion: .directory
     )
     var xcodeprojPath: String
-    
+
     // MARK: - Init
-    
+
     public init() {}
 
     // MARK: - ParsableCommand
-    
+
     public func run() throws {
         try MigrationTargetsByDependenciesService()
             .run(xcodeprojPath: try AbsolutePath(validating: xcodeprojPath, relativeTo: FileHandler.shared.currentPath))

--- a/Sources/TuistKit/Commands/MigrationCommand.swift
+++ b/Sources/TuistKit/Commands/MigrationCommand.swift
@@ -4,7 +4,7 @@ import TSCBasic
 
 public struct MigrationCommand: ParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "migration",
@@ -16,8 +16,8 @@ public struct MigrationCommand: ParsableCommand {
             ]
         )
     }
-    
+
     // MARK: - Init
-    
+
     public init() {}
 }

--- a/Sources/TuistKit/Commands/MigrationCommand.swift
+++ b/Sources/TuistKit/Commands/MigrationCommand.swift
@@ -2,8 +2,10 @@ import ArgumentParser
 import Foundation
 import TSCBasic
 
-struct MigrationCommand: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct MigrationCommand: ParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "migration",
             abstract: "A set of utilities to assist in the migration of Xcode projects to Tuist.",
@@ -14,4 +16,8 @@ struct MigrationCommand: ParsableCommand {
             ]
         )
     }
+    
+    // MARK: - Init
+    
+    public init() {}
 }

--- a/Sources/TuistKit/Commands/Plugin/PluginArchiveCommand.swift
+++ b/Sources/TuistKit/Commands/Plugin/PluginArchiveCommand.swift
@@ -2,22 +2,31 @@ import ArgumentParser
 import Foundation
 import TSCBasic
 
-struct PluginArchiveCommannd: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct PluginArchiveCommannd: ParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "archive",
             abstract: "Archives a plugin into a NameOfPlugin.tuist-plugin.zip."
         )
     }
 
+    // MARK: - Arguments and Flags
+    
     @Option(
         name: .shortAndLong,
         help: "The path to the directory that contains the definition of the plugin.",
         completion: .directory
     )
     var path: String?
+    
+    // MARK: - Init
+    
+    public init() {}
 
-    func run() throws {
+    // MARK: - ParsableCommand
+    public func run() throws {
         try PluginArchiveService().run(
             path: path
         )

--- a/Sources/TuistKit/Commands/Plugin/PluginArchiveCommand.swift
+++ b/Sources/TuistKit/Commands/Plugin/PluginArchiveCommand.swift
@@ -4,7 +4,7 @@ import TSCBasic
 
 public struct PluginArchiveCommannd: ParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "archive",
@@ -13,19 +13,20 @@ public struct PluginArchiveCommannd: ParsableCommand {
     }
 
     // MARK: - Arguments and Flags
-    
+
     @Option(
         name: .shortAndLong,
         help: "The path to the directory that contains the definition of the plugin.",
         completion: .directory
     )
     var path: String?
-    
+
     // MARK: - Init
-    
+
     public init() {}
 
     // MARK: - ParsableCommand
+
     public func run() throws {
         try PluginArchiveService().run(
             path: path

--- a/Sources/TuistKit/Commands/Plugin/PluginBuildCommand.swift
+++ b/Sources/TuistKit/Commands/Plugin/PluginBuildCommand.swift
@@ -4,7 +4,7 @@ import TSCBasic
 
 public struct PluginBuildCommand: ParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "build",
@@ -13,7 +13,7 @@ public struct PluginBuildCommand: ParsableCommand {
     }
 
     // MARK: - Arguments and Flags
-    
+
     @OptionGroup()
     var pluginOptions: PluginCommand.PluginOptions
 
@@ -36,13 +36,13 @@ public struct PluginBuildCommand: ParsableCommand {
         help: "Build the specified products."
     )
     var products: [String] = []
-    
+
     // MARK: - Init
-    
+
     public init() {}
 
     // MARK: - ParsableCommand
-    
+
     public func run() throws {
         try PluginBuildService().run(
             path: pluginOptions.path,

--- a/Sources/TuistKit/Commands/Plugin/PluginBuildCommand.swift
+++ b/Sources/TuistKit/Commands/Plugin/PluginBuildCommand.swift
@@ -2,14 +2,18 @@ import ArgumentParser
 import Foundation
 import TSCBasic
 
-struct PluginBuildCommand: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct PluginBuildCommand: ParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "build",
             abstract: "Builds a plugin."
         )
     }
 
+    // MARK: - Arguments and Flags
+    
     @OptionGroup()
     var pluginOptions: PluginCommand.PluginOptions
 
@@ -32,8 +36,14 @@ struct PluginBuildCommand: ParsableCommand {
         help: "Build the specified products."
     )
     var products: [String] = []
+    
+    // MARK: - Init
+    
+    public init() {}
 
-    func run() throws {
+    // MARK: - ParsableCommand
+    
+    public func run() throws {
         try PluginBuildService().run(
             path: pluginOptions.path,
             configuration: pluginOptions.configuration,

--- a/Sources/TuistKit/Commands/Plugin/PluginCommand.swift
+++ b/Sources/TuistKit/Commands/Plugin/PluginCommand.swift
@@ -4,7 +4,7 @@ import TSCBasic
 
 public struct PluginCommand: ParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "plugin",
@@ -21,7 +21,7 @@ public struct PluginCommand: ParsableCommand {
     public enum PackageConfiguration: String, ExpressibleByArgument, RawRepresentable {
         case debug, release
     }
-    
+
     // MARK: - Arguments and flags
 
     public struct PluginOptions: ParsableArguments {
@@ -37,11 +37,11 @@ public struct PluginCommand: ParsableCommand {
             completion: .directory
         )
         var path: String?
-        
+
         public init() {}
     }
-    
+
     // MARK: - Init
-    
+
     public init() {}
 }

--- a/Sources/TuistKit/Commands/Plugin/PluginCommand.swift
+++ b/Sources/TuistKit/Commands/Plugin/PluginCommand.swift
@@ -2,8 +2,10 @@ import ArgumentParser
 import Foundation
 import TSCBasic
 
-struct PluginCommand: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct PluginCommand: ParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "plugin",
             abstract: "A set of commands for plugin's management.",
@@ -16,11 +18,13 @@ struct PluginCommand: ParsableCommand {
         )
     }
 
-    enum PackageConfiguration: String, ExpressibleByArgument, RawRepresentable {
+    public enum PackageConfiguration: String, ExpressibleByArgument, RawRepresentable {
         case debug, release
     }
+    
+    // MARK: - Arguments and flags
 
-    struct PluginOptions: ParsableArguments {
+    public struct PluginOptions: ParsableArguments {
         @Option(
             name: .shortAndLong,
             help: "Choose configuration (default: debug)."
@@ -33,5 +37,11 @@ struct PluginCommand: ParsableCommand {
             completion: .directory
         )
         var path: String?
+        
+        public init() {}
     }
+    
+    // MARK: - Init
+    
+    public init() {}
 }

--- a/Sources/TuistKit/Commands/Plugin/PluginRunCommand.swift
+++ b/Sources/TuistKit/Commands/Plugin/PluginRunCommand.swift
@@ -4,14 +4,14 @@ import TSCBasic
 
 public struct PluginRunCommand: ParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "run",
             abstract: "Runs a plugin."
         )
     }
-    
+
     // MARK: - Arguments and Flags
 
     @OptionGroup()
@@ -38,10 +38,11 @@ public struct PluginRunCommand: ParsableCommand {
     var arguments: [String] = []
 
     // MARK: - Init
-    
+
     public init() {}
-    
+
     // MARK: - ParsableCommand
+
     public func run() throws {
         try PluginRunService().run(
             path: pluginOptions.path,

--- a/Sources/TuistKit/Commands/Plugin/PluginRunCommand.swift
+++ b/Sources/TuistKit/Commands/Plugin/PluginRunCommand.swift
@@ -2,13 +2,17 @@ import ArgumentParser
 import Foundation
 import TSCBasic
 
-struct PluginRunCommand: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct PluginRunCommand: ParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "run",
             abstract: "Runs a plugin."
         )
     }
+    
+    // MARK: - Arguments and Flags
 
     @OptionGroup()
     var pluginOptions: PluginCommand.PluginOptions
@@ -33,7 +37,12 @@ struct PluginRunCommand: ParsableCommand {
     )
     var arguments: [String] = []
 
-    func run() throws {
+    // MARK: - Init
+    
+    public init() {}
+    
+    // MARK: - ParsableCommand
+    public func run() throws {
         try PluginRunService().run(
             path: pluginOptions.path,
             configuration: pluginOptions.configuration,

--- a/Sources/TuistKit/Commands/Plugin/PluginTestCommand.swift
+++ b/Sources/TuistKit/Commands/Plugin/PluginTestCommand.swift
@@ -4,14 +4,14 @@ import TSCBasic
 
 public struct PluginTestCommand: ParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "test",
             abstract: "Tests a plugin."
         )
     }
-    
+
     // MARK: - Arguments and Flags
 
     @OptionGroup()
@@ -26,11 +26,11 @@ public struct PluginTestCommand: ParsableCommand {
         help: "Test the specified products."
     )
     var testProducts: [String] = []
-    
+
     // MARK: - Init
-    
+
     public init() {}
-    
+
     // MARK: - ParsableCommand
 
     public func run() throws {

--- a/Sources/TuistKit/Commands/Plugin/PluginTestCommand.swift
+++ b/Sources/TuistKit/Commands/Plugin/PluginTestCommand.swift
@@ -2,13 +2,17 @@ import ArgumentParser
 import Foundation
 import TSCBasic
 
-struct PluginTestCommand: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct PluginTestCommand: ParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "test",
             abstract: "Tests a plugin."
         )
     }
+    
+    // MARK: - Arguments and Flags
 
     @OptionGroup()
     var pluginOptions: PluginCommand.PluginOptions
@@ -22,8 +26,14 @@ struct PluginTestCommand: ParsableCommand {
         help: "Test the specified products."
     )
     var testProducts: [String] = []
+    
+    // MARK: - Init
+    
+    public init() {}
+    
+    // MARK: - ParsableCommand
 
-    func run() throws {
+    public func run() throws {
         try PluginTestService().run(
             path: pluginOptions.path,
             configuration: pluginOptions.configuration,

--- a/Sources/TuistKit/Commands/RunCommand.swift
+++ b/Sources/TuistKit/Commands/RunCommand.swift
@@ -5,7 +5,7 @@ import TuistSupport
 
 public struct RunCommand: AsyncParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "run",
@@ -23,7 +23,7 @@ public struct RunCommand: AsyncParsableCommand {
     }
 
     // MARK: - Arguments and Flags
-    
+
     @Flag(help: "Force the generation of the project before running.")
     var generate: Bool = false
 
@@ -62,10 +62,11 @@ public struct RunCommand: AsyncParsableCommand {
     var arguments: [String] = []
 
     // MARK: - Init
-    
+
     public init() {}
-    
+
     // MARK: - AsyncParsableCommand
+
     public func run() async throws {
         try await RunService().run(
             path: path,

--- a/Sources/TuistKit/Commands/RunCommand.swift
+++ b/Sources/TuistKit/Commands/RunCommand.swift
@@ -3,8 +3,10 @@ import Foundation
 import TSCBasic
 import TuistSupport
 
-struct RunCommand: AsyncParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct RunCommand: AsyncParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "run",
             abstract: "Runs a scheme or target in the project",
@@ -20,6 +22,8 @@ struct RunCommand: AsyncParsableCommand {
         )
     }
 
+    // MARK: - Arguments and Flags
+    
     @Flag(help: "Force the generation of the project before running.")
     var generate: Bool = false
 
@@ -57,7 +61,12 @@ struct RunCommand: AsyncParsableCommand {
     )
     var arguments: [String] = []
 
-    func run() async throws {
+    // MARK: - Init
+    
+    public init() {}
+    
+    // MARK: - AsyncParsableCommand
+    public func run() async throws {
         try await RunService().run(
             path: path,
             schemeName: scheme,

--- a/Sources/TuistKit/Commands/ScaffoldCommand.swift
+++ b/Sources/TuistKit/Commands/ScaffoldCommand.swift
@@ -27,7 +27,7 @@ public enum ScaffoldCommandError: FatalError, Equatable {
 
 public struct ScaffoldCommand: AsyncParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "scaffold",
@@ -35,7 +35,7 @@ public struct ScaffoldCommand: AsyncParsableCommand {
             subcommands: [ListCommand.self]
         )
     }
-    
+
     // MARK: - Arguments and Flags
 
     @Flag(
@@ -59,7 +59,7 @@ public struct ScaffoldCommand: AsyncParsableCommand {
     var optionalTemplateOptions: [String: String?] = [:]
 
     // MARK: - Init
-    
+
     public init() {}
 
     // Custom decoding to decode dynamic options
@@ -83,7 +83,7 @@ public struct ScaffoldCommand: AsyncParsableCommand {
     }
 
     // MARK: - AsyncParsableCommand
-    
+
     public func run() async throws {
         // Currently, @Argument and subcommand clashes, so we need to handle that ourselves
         if template == ListCommand.configuration.commandName {

--- a/Sources/TuistKit/Commands/ScaffoldCommand.swift
+++ b/Sources/TuistKit/Commands/ScaffoldCommand.swift
@@ -7,8 +7,8 @@ import TuistLoader
 import TuistPlugin
 import TuistSupport
 
-enum ScaffoldCommandError: FatalError, Equatable {
-    var type: ErrorType {
+public enum ScaffoldCommandError: FatalError, Equatable {
+    public var type: ErrorType {
         switch self {
         case .templateNotProvided:
             return .abort
@@ -17,7 +17,7 @@ enum ScaffoldCommandError: FatalError, Equatable {
 
     case templateNotProvided
 
-    var description: String {
+    public var description: String {
         switch self {
         case .templateNotProvided:
             return "You must provide template name"
@@ -25,14 +25,18 @@ enum ScaffoldCommandError: FatalError, Equatable {
     }
 }
 
-struct ScaffoldCommand: AsyncParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct ScaffoldCommand: AsyncParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "scaffold",
             abstract: "Generates new project based on a template",
             subcommands: [ListCommand.self]
         )
     }
+    
+    // MARK: - Arguments and Flags
 
     @Flag(
         help: "The output in JSON format"
@@ -54,10 +58,12 @@ struct ScaffoldCommand: AsyncParsableCommand {
     var requiredTemplateOptions: [String: String] = [:]
     var optionalTemplateOptions: [String: String?] = [:]
 
-    init() {}
+    // MARK: - Init
+    
+    public init() {}
 
     // Custom decoding to decode dynamic options
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         template = try container.decode(Argument<String>.self, forKey: .template).wrappedValue
         json = try container.decodeIfPresent(Option<Bool>.self, forKey: .json)?.wrappedValue ?? false
@@ -76,7 +82,9 @@ struct ScaffoldCommand: AsyncParsableCommand {
         }
     }
 
-    func run() async throws {
+    // MARK: - AsyncParsableCommand
+    
+    public func run() async throws {
         // Currently, @Argument and subcommand clashes, so we need to handle that ourselves
         if template == ListCommand.configuration.commandName {
             let format: ListService.OutputFormat = json ? .json : .table
@@ -184,7 +192,7 @@ extension ScaffoldCommand {
 /// ArgumentParser library gets the list of options from a mirror
 /// Since we do not declare template's options in advance, we need to rewrite the mirror implementation and add them ourselves
 extension ScaffoldCommand: CustomReflectable {
-    var customMirror: Mirror {
+    public var customMirror: Mirror {
         let requiredTemplateChildren = ScaffoldCommand.requiredTemplateOptions
             .map { Mirror.Child(label: $0.name, value: $0.option) }
         let optionalTemplateChildren = ScaffoldCommand.optionalTemplateOptions

--- a/Sources/TuistKit/Commands/Signing/DecryptCommand.swift
+++ b/Sources/TuistKit/Commands/Signing/DecryptCommand.swift
@@ -5,14 +5,18 @@ import TuistCore
 import TuistSigning
 import TuistSupport
 
-struct DecryptCommand: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct DecryptCommand: ParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "decrypt",
             _superCommandName: "signing",
             abstract: "Decrypts all files in Tuist/Signing directory"
         )
     }
+    
+    // MARK: - Arguments and Flags
 
     @Option(
         name: .shortAndLong,
@@ -20,8 +24,14 @@ struct DecryptCommand: ParsableCommand {
         completion: .directory
     )
     var path: String?
+    
+    // MARK: - Init
+    
+    public init() {}
 
-    func run() throws {
+    // MARK: - ParsableCommand
+    
+    public func run() throws {
         try DecryptService().run(path: path)
     }
 }

--- a/Sources/TuistKit/Commands/Signing/DecryptCommand.swift
+++ b/Sources/TuistKit/Commands/Signing/DecryptCommand.swift
@@ -7,7 +7,7 @@ import TuistSupport
 
 public struct DecryptCommand: ParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "decrypt",
@@ -15,7 +15,7 @@ public struct DecryptCommand: ParsableCommand {
             abstract: "Decrypts all files in Tuist/Signing directory"
         )
     }
-    
+
     // MARK: - Arguments and Flags
 
     @Option(
@@ -24,13 +24,13 @@ public struct DecryptCommand: ParsableCommand {
         completion: .directory
     )
     var path: String?
-    
+
     // MARK: - Init
-    
+
     public init() {}
 
     // MARK: - ParsableCommand
-    
+
     public func run() throws {
         try DecryptService().run(path: path)
     }

--- a/Sources/TuistKit/Commands/Signing/EncryptCommand.swift
+++ b/Sources/TuistKit/Commands/Signing/EncryptCommand.swift
@@ -4,7 +4,7 @@ import TSCBasic
 
 public struct EncryptCommand: ParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "encrypt",
@@ -12,7 +12,7 @@ public struct EncryptCommand: ParsableCommand {
             abstract: "Encrypts all files in Tuist/Signing directory"
         )
     }
-    
+
     // MARK: - Arguments and Flags
 
     @Option(
@@ -21,13 +21,13 @@ public struct EncryptCommand: ParsableCommand {
         completion: .directory
     )
     var path: String?
-    
+
     // MARK: - Init
-    
+
     public init() {}
 
     // MARK: - ParsableCommand
-    
+
     public func run() throws {
         try EncryptService().run(path: path)
     }

--- a/Sources/TuistKit/Commands/Signing/EncryptCommand.swift
+++ b/Sources/TuistKit/Commands/Signing/EncryptCommand.swift
@@ -2,14 +2,18 @@ import ArgumentParser
 import Foundation
 import TSCBasic
 
-struct EncryptCommand: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct EncryptCommand: ParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "encrypt",
             _superCommandName: "signing",
             abstract: "Encrypts all files in Tuist/Signing directory"
         )
     }
+    
+    // MARK: - Arguments and Flags
 
     @Option(
         name: .shortAndLong,
@@ -17,8 +21,14 @@ struct EncryptCommand: ParsableCommand {
         completion: .directory
     )
     var path: String?
+    
+    // MARK: - Init
+    
+    public init() {}
 
-    func run() throws {
+    // MARK: - ParsableCommand
+    
+    public func run() throws {
         try EncryptService().run(path: path)
     }
 }

--- a/Sources/TuistKit/Commands/SigningCommand.swift
+++ b/Sources/TuistKit/Commands/SigningCommand.swift
@@ -4,7 +4,7 @@ import TSCBasic
 
 public struct SigningCommand: ParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "signing",
@@ -15,8 +15,8 @@ public struct SigningCommand: ParsableCommand {
             ]
         )
     }
-    
+
     // MARK: - Init
-    
+
     public init() {}
 }

--- a/Sources/TuistKit/Commands/SigningCommand.swift
+++ b/Sources/TuistKit/Commands/SigningCommand.swift
@@ -2,8 +2,10 @@ import ArgumentParser
 import Foundation
 import TSCBasic
 
-struct SigningCommand: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct SigningCommand: ParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "signing",
             abstract: "A set of commands for signing-related operations",
@@ -13,4 +15,8 @@ struct SigningCommand: ParsableCommand {
             ]
         )
     }
+    
+    // MARK: - Init
+    
+    public init() {}
 }

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -4,13 +4,17 @@ import TSCBasic
 import TuistSupport
 
 /// Command that tests a target from the project in the current directory.
-struct TestCommand: AsyncParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct TestCommand: AsyncParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "test",
             abstract: "Tests a project"
         )
     }
+    
+    // MARK: - Arguments and Flags
 
     @Argument(
         help: "The scheme to be tested. By default it tests all the testable targets of the project in the current directory."
@@ -64,8 +68,14 @@ struct TestCommand: AsyncParsableCommand {
         help: "Tests will retry <number> of times until success. Example: if 1 is specified, the test will be retried at most once, hence it will run up to 2 times."
     )
     var retryCount: Int = 0
+    
+    // MARK: - Init
+    
+    public init() {}
 
-    func run() async throws {
+    // MARK: - AsyncParsableCommand
+    
+    public func run() async throws {
         let absolutePath: AbsolutePath
 
         if let path = path {

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -6,14 +6,14 @@ import TuistSupport
 /// Command that tests a target from the project in the current directory.
 public struct TestCommand: AsyncParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "test",
             abstract: "Tests a project"
         )
     }
-    
+
     // MARK: - Arguments and Flags
 
     @Argument(
@@ -68,13 +68,13 @@ public struct TestCommand: AsyncParsableCommand {
         help: "Tests will retry <number> of times until success. Example: if 1 is specified, the test will be retried at most once, hence it will run up to 2 times."
     )
     var retryCount: Int = 0
-    
+
     // MARK: - Init
-    
+
     public init() {}
 
     // MARK: - AsyncParsableCommand
-    
+
     public func run() async throws {
         let absolutePath: AbsolutePath
 

--- a/Sources/TuistKit/Commands/VersionCommand.swift
+++ b/Sources/TuistKit/Commands/VersionCommand.swift
@@ -2,15 +2,23 @@ import ArgumentParser
 import Foundation
 import TSCBasic
 
-struct VersionCommand: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct VersionCommand: ParsableCommand {
+    // MARK: - Configuration
+    
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "version",
             abstract: "Outputs the current version of tuist"
         )
     }
+    
+    // MARK: - Init
+    
+    public init() {}
+    
+    // MARK: - ParseableCommand
 
-    func run() throws {
+    public func run() throws {
         try VersionService().run()
     }
 }

--- a/Sources/TuistKit/Commands/VersionCommand.swift
+++ b/Sources/TuistKit/Commands/VersionCommand.swift
@@ -4,18 +4,18 @@ import TSCBasic
 
 public struct VersionCommand: ParsableCommand {
     // MARK: - Configuration
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "version",
             abstract: "Outputs the current version of tuist"
         )
     }
-    
+
     // MARK: - Init
-    
+
     public init() {}
-    
+
     // MARK: - ParseableCommand
 
     public func run() throws {

--- a/Sources/TuistKit/Services/BuildService.swift
+++ b/Sources/TuistKit/Services/BuildService.swift
@@ -7,12 +7,12 @@ import TuistGraph
 import TuistLoader
 import TuistSupport
 
-enum BuildServiceError: FatalError {
+public enum BuildServiceError: FatalError {
     case workspaceNotFound(path: String)
     case schemeWithoutBuildableTargets(scheme: String)
     case schemeNotFound(scheme: String, existing: [String])
 
-    var description: String {
+    public var description: String {
         switch self {
         case let .schemeWithoutBuildableTargets(scheme):
             return "The scheme \(scheme) cannot be built because it contains no buildable targets."
@@ -23,7 +23,7 @@ enum BuildServiceError: FatalError {
         }
     }
 
-    var type: ErrorType {
+    public var type: ErrorType {
         switch self {
         case .workspaceNotFound:
             return .bug
@@ -34,7 +34,7 @@ enum BuildServiceError: FatalError {
     }
 }
 
-final class BuildService {
+public final class BuildService {
     private let generatorFactory: GeneratorFactorying
     private let buildGraphInspector: BuildGraphInspecting
     private let targetBuilder: TargetBuilding

--- a/Sources/TuistKit/Services/BuildService.swift
+++ b/Sources/TuistKit/Services/BuildService.swift
@@ -50,7 +50,7 @@ public final class BuildService {
     }
 
     // swiftlint:disable:next function_body_length
-    func run(
+    public func run(
         schemeName: String?,
         generate: Bool,
         clean: Bool,

--- a/Sources/TuistKit/Services/Cache/CachePrintHashesService.swift
+++ b/Sources/TuistKit/Services/Cache/CachePrintHashesService.swift
@@ -6,13 +6,17 @@ import TuistCore
 import TuistLoader
 import TuistSupport
 
-final class CachePrintHashesService {
+public final class CachePrintHashesService {
     private let generatorFactory: GeneratorFactorying
     private let cacheGraphContentHasher: CacheGraphContentHashing
     private let clock: Clock
     private let configLoader: ConfigLoading
+    
+    public convenience init() {
+        self.init(contentHasher: CacheContentHasher())
+    }
 
-    convenience init(contentHasher: ContentHashing = CacheContentHasher()) {
+    convenience init(contentHasher: ContentHashing) {
         self.init(
             generatorFactory: GeneratorFactory(),
             cacheGraphContentHasher: CacheGraphContentHasher(contentHasher: contentHasher),
@@ -41,7 +45,7 @@ final class CachePrintHashesService {
         }
     }
 
-    func run(
+    public func run(
         path: String?,
         xcframeworks: Bool,
         destination: CacheXCFrameworkDestination,

--- a/Sources/TuistKit/Services/Cache/CachePrintHashesService.swift
+++ b/Sources/TuistKit/Services/Cache/CachePrintHashesService.swift
@@ -11,7 +11,7 @@ public final class CachePrintHashesService {
     private let cacheGraphContentHasher: CacheGraphContentHashing
     private let clock: Clock
     private let configLoader: ConfigLoading
-    
+
     public convenience init() {
         self.init(contentHasher: CacheContentHasher())
     }

--- a/Sources/TuistKit/Services/Cache/CacheWarmService.swift
+++ b/Sources/TuistKit/Services/Cache/CacheWarmService.swift
@@ -8,18 +8,18 @@ import TuistLoader
 import TuistPlugin
 import TuistSupport
 
-final class CacheWarmService {
+public final class CacheWarmService {
     private let configLoader: ConfigLoading
     private let manifestLoader: ManifestLoading
     private let pluginService: PluginServicing
 
-    init() {
+    public init() {
         configLoader = ConfigLoader(manifestLoader: ManifestLoader())
         manifestLoader = ManifestLoader()
         pluginService = PluginService()
     }
 
-    func run(
+    public func run(
         path: String?,
         profile: String?,
         xcframeworks: Bool,

--- a/Sources/TuistKit/Services/CleanService.swift
+++ b/Sources/TuistKit/Services/CleanService.swift
@@ -7,7 +7,7 @@ import TuistSupport
 
 public final class CleanService {
     private let cacheDirectoryProviderFactory: CacheDirectoriesProviderFactoring
-    
+
     public init(
         cacheDirectoryProviderFactory: CacheDirectoriesProviderFactoring = CacheDirectoriesProviderFactory()
     ) {

--- a/Sources/TuistKit/Services/CleanService.swift
+++ b/Sources/TuistKit/Services/CleanService.swift
@@ -5,15 +5,16 @@ import TuistGraph
 import TuistLoader
 import TuistSupport
 
-final class CleanService {
+public final class CleanService {
     private let cacheDirectoryProviderFactory: CacheDirectoriesProviderFactoring
-    init(
+    
+    public init(
         cacheDirectoryProviderFactory: CacheDirectoriesProviderFactoring = CacheDirectoriesProviderFactory()
     ) {
         self.cacheDirectoryProviderFactory = cacheDirectoryProviderFactory
     }
 
-    func run(
+    public func run(
         categories: [CleanCategory],
         path: String?
     ) throws {

--- a/Sources/TuistKit/Services/Cloud/CloudAuthService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudAuthService.swift
@@ -4,18 +4,18 @@ import TuistCore
 import TuistLoader
 import TuistSupport
 
-protocol CloudAuthServicing: AnyObject {
+public protocol CloudAuthServicing: AnyObject {
     /// It reads the cloud URL from the project's Config.swift and
     /// authenticates the user on that server storing the credentials
     /// locally on the keychain
     func authenticate() throws
 }
 
-enum CloudAuthServiceError: FatalError, Equatable {
+public enum CloudAuthServiceError: FatalError, Equatable {
     case missingCloudURL
 
     /// Error description.
-    var description: String {
+    public var description: String {
         switch self {
         case .missingCloudURL:
             return "The cloud URL attribute is missing in your project's configuration."
@@ -23,7 +23,7 @@ enum CloudAuthServiceError: FatalError, Equatable {
     }
 
     /// Error type.
-    var type: ErrorType {
+    public var type: ErrorType {
         switch self {
         case .missingCloudURL:
             return .abort
@@ -31,13 +31,13 @@ enum CloudAuthServiceError: FatalError, Equatable {
     }
 }
 
-final class CloudAuthService: CloudAuthServicing {
+public final class CloudAuthService: CloudAuthServicing {
     let cloudSessionController: CloudSessionControlling
     let configLoader: ConfigLoading
 
     // MARK: - Init
 
-    convenience init() {
+    public convenience init() {
         let manifestLoader = ManifestLoader()
         let configLoader = ConfigLoader(manifestLoader: manifestLoader)
         self.init(
@@ -56,7 +56,7 @@ final class CloudAuthService: CloudAuthServicing {
 
     // MARK: - CloudAuthServicing
 
-    func authenticate() throws {
+    public func authenticate() throws {
         let path = FileHandler.shared.currentPath
         let config = try configLoader.loadConfig(path: path)
         guard let cloudURL = config.cloud?.url else {

--- a/Sources/TuistKit/Services/Cloud/CloudCleanService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudCleanService.swift
@@ -42,7 +42,7 @@ public final class CloudCleanService: CloudCleanServicing {
             configLoader: ConfigLoader()
         )
     }
-    
+
     init(
         cloudSessionController: CloudSessionControlling,
         cleanRemoteCacheStorageService: CleanRemoteCacheStorageServicing,
@@ -52,7 +52,7 @@ public final class CloudCleanService: CloudCleanServicing {
         self.cleanRemoteCacheStorageService = cleanRemoteCacheStorageService
         self.configLoader = configLoader
     }
-    
+
     // MARK: - CloudCleanServicing
 
     public func clean(path: String?) async throws {

--- a/Sources/TuistKit/Services/Cloud/CloudCleanService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudCleanService.swift
@@ -4,17 +4,17 @@ import TuistCloud
 import TuistLoader
 import TuistSupport
 
-protocol CloudCleanServicing {
+public protocol CloudCleanServicing {
     func clean(
         path: String?
     ) async throws
 }
 
-enum CloudCleanServiceError: FatalError, Equatable {
+public enum CloudCleanServiceError: FatalError, Equatable {
     case invalidCloudURL(String)
 
     /// Error description.
-    var description: String {
+    public var description: String {
         switch self {
         case let .invalidCloudURL(url):
             return "The cloud URL \(url) is invalid."
@@ -22,7 +22,7 @@ enum CloudCleanServiceError: FatalError, Equatable {
     }
 
     /// Error type.
-    var type: ErrorType {
+    public var type: ErrorType {
         switch self {
         case .invalidCloudURL:
             return .abort
@@ -30,22 +30,32 @@ enum CloudCleanServiceError: FatalError, Equatable {
     }
 }
 
-final class CloudCleanService: CloudCleanServicing {
+public final class CloudCleanService: CloudCleanServicing {
     private let cloudSessionController: CloudSessionControlling
     private let cleanRemoteCacheStorageService: CleanRemoteCacheStorageServicing
     private let configLoader: ConfigLoading
 
+    public convenience init() {
+        self.init(
+            cloudSessionController: CloudSessionController(),
+            cleanRemoteCacheStorageService: CleanRemoteCacheStorageService(),
+            configLoader: ConfigLoader()
+        )
+    }
+    
     init(
-        cloudSessionController: CloudSessionControlling = CloudSessionController(),
-        cleanRemoteCacheStorageService: CleanRemoteCacheStorageServicing = CleanRemoteCacheStorageService(),
+        cloudSessionController: CloudSessionControlling,
+        cleanRemoteCacheStorageService: CleanRemoteCacheStorageServicing,
         configLoader: ConfigLoading = ConfigLoader()
     ) {
         self.cloudSessionController = cloudSessionController
         self.cleanRemoteCacheStorageService = cleanRemoteCacheStorageService
         self.configLoader = configLoader
     }
+    
+    // MARK: - CloudCleanServicing
 
-    func clean(path: String?) async throws {
+    public func clean(path: String?) async throws {
         let path: AbsolutePath = try self.path(path)
         let config = try configLoader.loadConfig(path: path)
 

--- a/Sources/TuistKit/Services/Cloud/CloudInitService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudInitService.swift
@@ -40,7 +40,7 @@ public final class CloudInitService: CloudInitServicing {
     private let cloudSessionController: CloudSessionControlling
     private let createProjectService: CreateProjectServicing
     private let configLoader: ConfigLoading
-    
+
     public convenience init() {
         self.init(
             cloudSessionController: CloudSessionController(),

--- a/Sources/TuistKit/Services/Cloud/CloudInitService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudInitService.swift
@@ -4,7 +4,7 @@ import TuistCloud
 import TuistLoader
 import TuistSupport
 
-protocol CloudInitServicing {
+public protocol CloudInitServicing {
     func createProject(
         name: String,
         owner: String?,
@@ -13,12 +13,12 @@ protocol CloudInitServicing {
     ) async throws
 }
 
-enum CloudInitServiceError: FatalError, Equatable {
+public enum CloudInitServiceError: FatalError, Equatable {
     case invalidCloudURL(String)
     case cloudAlreadySetUp
 
     /// Error description.
-    var description: String {
+    public var description: String {
         switch self {
         case let .invalidCloudURL(url):
             return "The cloud URL \(url) is invalid."
@@ -28,7 +28,7 @@ enum CloudInitServiceError: FatalError, Equatable {
     }
 
     /// Error type.
-    var type: ErrorType {
+    public var type: ErrorType {
         switch self {
         case .invalidCloudURL, .cloudAlreadySetUp:
             return .abort
@@ -36,22 +36,30 @@ enum CloudInitServiceError: FatalError, Equatable {
     }
 }
 
-final class CloudInitService: CloudInitServicing {
+public final class CloudInitService: CloudInitServicing {
     private let cloudSessionController: CloudSessionControlling
     private let createProjectService: CreateProjectServicing
     private let configLoader: ConfigLoading
+    
+    public convenience init() {
+        self.init(
+            cloudSessionController: CloudSessionController(),
+            createProjectService: CreateProjectService(),
+            configLoader: ConfigLoader()
+        )
+    }
 
     init(
-        cloudSessionController: CloudSessionControlling = CloudSessionController(),
-        createProjectService: CreateProjectServicing = CreateProjectService(),
-        configLoader: ConfigLoading = ConfigLoader()
+        cloudSessionController: CloudSessionControlling,
+        createProjectService: CreateProjectServicing,
+        configLoader: ConfigLoading
     ) {
         self.cloudSessionController = cloudSessionController
         self.createProjectService = createProjectService
         self.configLoader = configLoader
     }
 
-    func createProject(
+    public func createProject(
         name: String,
         owner: String?,
         url: String,

--- a/Sources/TuistKit/Services/Cloud/CloudLogoutService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudLogoutService.swift
@@ -4,18 +4,18 @@ import TuistCore
 import TuistLoader
 import TuistSupport
 
-protocol CloudLogoutServicing: AnyObject {
+public protocol CloudLogoutServicing: AnyObject {
     /// It reads the cloud URL from the project's Config.swift and
     /// and it removes any session associated to that domain from
     /// the keychain
     func logout() throws
 }
 
-enum CloudLogoutServiceError: FatalError, Equatable {
+public enum CloudLogoutServiceError: FatalError, Equatable {
     case missingCloudURL
 
     /// Error description.
-    var description: String {
+    public var description: String {
         switch self {
         case .missingCloudURL:
             return "The cloud URL attribute is missing in your project's configuration."
@@ -23,7 +23,7 @@ enum CloudLogoutServiceError: FatalError, Equatable {
     }
 
     /// Error type.
-    var type: ErrorType {
+    public var type: ErrorType {
         switch self {
         case .missingCloudURL:
             return .abort
@@ -31,13 +31,13 @@ enum CloudLogoutServiceError: FatalError, Equatable {
     }
 }
 
-final class CloudLogoutService: CloudLogoutServicing {
+public final class CloudLogoutService: CloudLogoutServicing {
     let cloudSessionController: CloudSessionControlling
     let configLoader: ConfigLoading
 
     // MARK: - Init
 
-    convenience init() {
+    public convenience init() {
         let manifestLoader = ManifestLoader()
         let configLoader = ConfigLoader(manifestLoader: manifestLoader)
         self.init(
@@ -56,7 +56,7 @@ final class CloudLogoutService: CloudLogoutServicing {
 
     // MARK: - CloudAuthServicing
 
-    func logout() throws {
+    public func logout() throws {
         let path = FileHandler.shared.currentPath
         let config = try configLoader.loadConfig(path: path)
         guard let cloudURL = config.cloud?.url else {

--- a/Sources/TuistKit/Services/Cloud/CloudSessionService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudSessionService.swift
@@ -4,18 +4,18 @@ import TuistCore
 import TuistLoader
 import TuistSupport
 
-protocol CloudSessionServicing: AnyObject {
+public protocol CloudSessionServicing: AnyObject {
     /// It reads the cloud URL from the project's Config.swift and
     /// prints any existing session in the keychain to authenticate
     /// on a server identified by that URL.
     func printSession() throws
 }
 
-enum CloudSessionServiceError: FatalError, Equatable {
+public enum CloudSessionServiceError: FatalError, Equatable {
     case missingCloudURL
 
     /// Error description.
-    var description: String {
+    public var description: String {
         switch self {
         case .missingCloudURL:
             return "The cloud URL attribute is missing in your project's configuration."
@@ -23,7 +23,7 @@ enum CloudSessionServiceError: FatalError, Equatable {
     }
 
     /// Error type.
-    var type: ErrorType {
+    public var type: ErrorType {
         switch self {
         case .missingCloudURL:
             return .abort
@@ -31,13 +31,13 @@ enum CloudSessionServiceError: FatalError, Equatable {
     }
 }
 
-final class CloudSessionService: CloudSessionServicing {
+public final class CloudSessionService: CloudSessionServicing {
     let cloudSessionController: CloudSessionControlling
     let configLoader: ConfigLoading
 
     // MARK: - Init
 
-    convenience init() {
+    public convenience init() {
         let manifestLoader = ManifestLoader()
         let configLoader = ConfigLoader(manifestLoader: manifestLoader)
         self.init(
@@ -56,7 +56,7 @@ final class CloudSessionService: CloudSessionServicing {
 
     // MARK: - CloudAuthServicing
 
-    func printSession() throws {
+    public func printSession() throws {
         let path = FileHandler.shared.currentPath
         let config = try configLoader.loadConfig(path: path)
         guard let cloudURL = config.cloud?.url else {

--- a/Sources/TuistKit/Services/DecryptService.swift
+++ b/Sources/TuistKit/Services/DecryptService.swift
@@ -6,7 +6,7 @@ import TuistSupport
 
 public final class DecryptService {
     private let signingCipher: SigningCiphering
-    
+
     public convenience init() {
         self.init(signingCipher: SigningCipher())
     }

--- a/Sources/TuistKit/Services/DecryptService.swift
+++ b/Sources/TuistKit/Services/DecryptService.swift
@@ -4,14 +4,18 @@ import TuistCore
 import TuistSigning
 import TuistSupport
 
-final class DecryptService {
+public final class DecryptService {
     private let signingCipher: SigningCiphering
+    
+    public convenience init() {
+        self.init(signingCipher: SigningCipher())
+    }
 
-    init(signingCipher: SigningCiphering = SigningCipher()) {
+    init(signingCipher: SigningCiphering) {
         self.signingCipher = signingCipher
     }
 
-    func run(path: String?) throws {
+    public func run(path: String?) throws {
         let path = try self.path(path)
         try signingCipher.decryptSigning(at: path, keepFiles: false)
         logger.notice("Successfully decrypted all signing files", metadata: .success)

--- a/Sources/TuistKit/Services/DumpService.swift
+++ b/Sources/TuistKit/Services/DumpService.swift
@@ -5,14 +5,14 @@ import TuistLoader
 import TuistPlugin
 import TuistSupport
 
-final class DumpService {
+public final class DumpService {
     private let manifestLoader: ManifestLoading
 
-    init(manifestLoader: ManifestLoading = ManifestLoader()) {
+    public init(manifestLoader: ManifestLoading = ManifestLoader()) {
         self.manifestLoader = manifestLoader
     }
 
-    func run(path: String?, manifest: DumpableManifest) async throws {
+    public func run(path: String?, manifest: DumpableManifest) async throws {
         let projectPath: AbsolutePath
         if let path = path {
             projectPath = try AbsolutePath(validating: path, relativeTo: AbsolutePath.current)
@@ -48,7 +48,7 @@ final class DumpService {
     }
 }
 
-enum DumpableManifest: String, CaseIterable {
+public enum DumpableManifest: String, CaseIterable {
     case project
     case workspace
     case config

--- a/Sources/TuistKit/Services/EditService.swift
+++ b/Sources/TuistKit/Services/EditService.swift
@@ -32,7 +32,7 @@ public final class EditService {
     private let signalHandler: SignalHandling
 
     private static var temporaryDirectory: AbsolutePath?
-    
+
     public convenience init() {
         self.init(
             projectEditor: ProjectEditor(),

--- a/Sources/TuistKit/Services/EditService.swift
+++ b/Sources/TuistKit/Services/EditService.swift
@@ -6,17 +6,17 @@ import TuistLoader
 import TuistPlugin
 import TuistSupport
 
-enum EditServiceError: FatalError {
+public enum EditServiceError: FatalError {
     case xcodeNotSelected
 
-    var description: String {
+    public var description: String {
         switch self {
         case .xcodeNotSelected:
             return "Couldn't determine the Xcode version to open the project. Make sure your Xcode installation is selected with 'xcode-select -s'."
         }
     }
 
-    var type: ErrorType {
+    public var type: ErrorType {
         switch self {
         case .xcodeNotSelected:
             return .abort
@@ -24,7 +24,7 @@ enum EditServiceError: FatalError {
     }
 }
 
-final class EditService {
+public final class EditService {
     private let projectEditor: ProjectEditing
     private let opener: Opening
     private let configLoader: ConfigLoading
@@ -32,13 +32,23 @@ final class EditService {
     private let signalHandler: SignalHandling
 
     private static var temporaryDirectory: AbsolutePath?
+    
+    public convenience init() {
+        self.init(
+            projectEditor: ProjectEditor(),
+            opener: Opener(),
+            configLoader: ConfigLoader(manifestLoader: ManifestLoader()),
+            pluginService: PluginService(),
+            signalHandler: SignalHandler()
+        )
+    }
 
-    init(
-        projectEditor: ProjectEditing = ProjectEditor(),
-        opener: Opening = Opener(),
-        configLoader: ConfigLoading = ConfigLoader(manifestLoader: ManifestLoader()),
-        pluginService: PluginServicing = PluginService(),
-        signalHandler: SignalHandling = SignalHandler()
+    private init(
+        projectEditor: ProjectEditing,
+        opener: Opening,
+        configLoader: ConfigLoading,
+        pluginService: PluginServicing,
+        signalHandler: SignalHandling
     ) {
         self.projectEditor = projectEditor
         self.opener = opener
@@ -47,7 +57,7 @@ final class EditService {
         self.signalHandler = signalHandler
     }
 
-    func run(
+    public func run(
         path: String?,
         permanent: Bool,
         onlyCurrentDirectory: Bool

--- a/Sources/TuistKit/Services/EncryptService.swift
+++ b/Sources/TuistKit/Services/EncryptService.swift
@@ -4,14 +4,18 @@ import TuistCore
 import TuistSigning
 import TuistSupport
 
-final class EncryptService {
+public final class EncryptService {
     private let signingCipher: SigningCiphering
+    
+    public convenience init() {
+        self.init(signingCipher: SigningCipher())
+    }
 
-    init(signingCipher: SigningCiphering = SigningCipher()) {
+    init(signingCipher: SigningCiphering) {
         self.signingCipher = signingCipher
     }
 
-    func run(path: String?) throws {
+    public func run(path: String?) throws {
         let path = try self.path(path)
         try signingCipher.encryptSigning(at: path, keepFiles: false)
 

--- a/Sources/TuistKit/Services/EncryptService.swift
+++ b/Sources/TuistKit/Services/EncryptService.swift
@@ -6,7 +6,7 @@ import TuistSupport
 
 public final class EncryptService {
     private let signingCipher: SigningCiphering
-    
+
     public convenience init() {
         self.init(signingCipher: SigningCipher())
     }

--- a/Sources/TuistKit/Services/FetchService.swift
+++ b/Sources/TuistKit/Services/FetchService.swift
@@ -22,9 +22,10 @@ public final class FetchService {
             manifestLoader: ManifestLoader(),
             dependenciesController: DependenciesController(),
             dependenciesModelLoader: DependenciesModelLoader(),
-            converter: ManifestModelConverter())
+            converter: ManifestModelConverter()
+        )
     }
-    
+
     init(
         pluginService: PluginServicing,
         configLoader: ConfigLoading,

--- a/Sources/TuistKit/Services/FetchService.swift
+++ b/Sources/TuistKit/Services/FetchService.swift
@@ -41,7 +41,7 @@ public final class FetchService {
         self.converter = converter
     }
 
-    func run(
+    public func run(
         path: String?,
         update: Bool
     ) async throws {

--- a/Sources/TuistKit/Services/FetchService.swift
+++ b/Sources/TuistKit/Services/FetchService.swift
@@ -7,7 +7,7 @@ import TuistLoader
 import TuistPlugin
 import TuistSupport
 
-final class FetchService {
+public final class FetchService {
     private let pluginService: PluginServicing
     private let configLoader: ConfigLoading
     private let manifestLoader: ManifestLoading
@@ -15,13 +15,23 @@ final class FetchService {
     private let dependenciesModelLoader: DependenciesModelLoading
     private let converter: ManifestModelConverting
 
+    public convenience init() {
+        self.init(
+            pluginService: PluginService(),
+            configLoader: ConfigLoader(manifestLoader: CachedManifestLoader()),
+            manifestLoader: ManifestLoader(),
+            dependenciesController: DependenciesController(),
+            dependenciesModelLoader: DependenciesModelLoader(),
+            converter: ManifestModelConverter())
+    }
+    
     init(
-        pluginService: PluginServicing = PluginService(),
-        configLoader: ConfigLoading = ConfigLoader(manifestLoader: CachedManifestLoader()),
-        manifestLoader: ManifestLoading = ManifestLoader(),
-        dependenciesController: DependenciesControlling = DependenciesController(),
-        dependenciesModelLoader: DependenciesModelLoading = DependenciesModelLoader(),
-        converter: ManifestModelConverting = ManifestModelConverter()
+        pluginService: PluginServicing,
+        configLoader: ConfigLoading,
+        manifestLoader: ManifestLoading,
+        dependenciesController: DependenciesControlling,
+        dependenciesModelLoader: DependenciesModelLoading,
+        converter: ManifestModelConverting
     ) {
         self.pluginService = pluginService
         self.configLoader = configLoader

--- a/Sources/TuistKit/Services/GenerateService.swift
+++ b/Sources/TuistKit/Services/GenerateService.swift
@@ -28,7 +28,7 @@ public final class GenerateService {
             pluginService: PluginService()
         )
     }
-    
+
     init(
         clock: Clock,
         timeTakenLoggerFormatter: TimeTakenLoggerFormatting,

--- a/Sources/TuistKit/Services/GenerateService.swift
+++ b/Sources/TuistKit/Services/GenerateService.swift
@@ -8,7 +8,7 @@ import TuistLoader
 import TuistPlugin
 import TuistSupport
 
-final class GenerateService {
+public final class GenerateService {
     private let opener: Opening
     private let clock: Clock
     private let timeTakenLoggerFormatter: TimeTakenLoggerFormatting
@@ -17,14 +17,26 @@ final class GenerateService {
     private let manifestLoader: ManifestLoading
     private let pluginService: PluginServicing
 
+    public convenience init() {
+        self.init(
+            clock: WallClock(),
+            timeTakenLoggerFormatter: TimeTakenLoggerFormatter(),
+            configLoader: ConfigLoader(manifestLoader: ManifestLoader()),
+            manifestLoader: ManifestLoader(),
+            opener: Opener(),
+            generatorFactory: GeneratorFactory(),
+            pluginService: PluginService()
+        )
+    }
+    
     init(
-        clock: Clock = WallClock(),
-        timeTakenLoggerFormatter: TimeTakenLoggerFormatting = TimeTakenLoggerFormatter(),
-        configLoader: ConfigLoading = ConfigLoader(manifestLoader: ManifestLoader()),
-        manifestLoader: ManifestLoading = ManifestLoader(),
-        opener: Opening = Opener(),
-        generatorFactory: GeneratorFactorying = GeneratorFactory(),
-        pluginService: PluginServicing = PluginService()
+        clock: Clock,
+        timeTakenLoggerFormatter: TimeTakenLoggerFormatting,
+        configLoader: ConfigLoading,
+        manifestLoader: ManifestLoading,
+        opener: Opening,
+        generatorFactory: GeneratorFactorying,
+        pluginService: PluginServicing
     ) {
         self.clock = clock
         self.timeTakenLoggerFormatter = timeTakenLoggerFormatter

--- a/Sources/TuistKit/Services/GenerateService.swift
+++ b/Sources/TuistKit/Services/GenerateService.swift
@@ -47,7 +47,7 @@ public final class GenerateService {
         self.pluginService = pluginService
     }
 
-    func run(
+    public func run(
         path: String?,
         sources: Set<String>,
         noOpen: Bool,

--- a/Sources/TuistKit/Services/GraphService.swift
+++ b/Sources/TuistKit/Services/GraphService.swift
@@ -11,11 +11,11 @@ import TuistLoader
 import TuistPlugin
 import TuistSupport
 
-final class GraphService {
+public final class GraphService {
     private let graphVizMapper: GraphToGraphVizMapping
     private let manifestGraphLoader: ManifestGraphLoading
 
-    convenience init() {
+    public convenience init() {
         let manifestLoader = ManifestLoaderFactory()
             .createManifestLoader()
         let manifestGraphLoader = ManifestGraphLoader(
@@ -38,7 +38,7 @@ final class GraphService {
         self.manifestGraphLoader = manifestGraphLoader
     }
 
-    func run(
+    public func run(
         format: GraphFormat,
         layoutAlgorithm: GraphViz.LayoutAlgorithm,
         skipTestTargets: Bool,

--- a/Sources/TuistKit/Services/InitService.swift
+++ b/Sources/TuistKit/Services/InitService.swift
@@ -5,23 +5,23 @@ import TuistLoader
 import TuistScaffold
 import TuistSupport
 
-enum InitServiceError: FatalError, Equatable {
+public enum InitServiceError: FatalError, Equatable {
     case ungettableProjectName(AbsolutePath)
     case nonEmptyDirectory(AbsolutePath)
     case templateNotFound(String)
     case templateNotProvided
     case attributeNotProvided(String)
     case invalidValue(argument: String, error: String)
-
-    var type: ErrorType {
+    
+    public var type: ErrorType {
         switch self {
         case .ungettableProjectName, .nonEmptyDirectory, .templateNotFound, .templateNotProvided, .attributeNotProvided,
-             .invalidValue:
+                .invalidValue:
             return .abort
         }
     }
-
-    var description: String {
+    
+    public var description: String {
         switch self {
         case let .templateNotFound(template):
             return "Could not find template \(template). Make sure it exists at Tuist/Templates/\(template)"
@@ -39,13 +39,13 @@ enum InitServiceError: FatalError, Equatable {
     }
 }
 
-class InitService {
+public class InitService {
     private let templateLoader: TemplateLoading
     private let templatesDirectoryLocator: TemplatesDirectoryLocating
     private let templateGenerator: TemplateGenerating
     private let templateGitLoader: TemplateGitLoading
-
-    init(
+    
+    public init(
         templateLoader: TemplateLoading = TemplateLoader(),
         templatesDirectoryLocator: TemplatesDirectoryLocating = TemplatesDirectoryLocator(),
         templateGenerator: TemplateGenerating = TemplateGenerator(),
@@ -56,7 +56,7 @@ class InitService {
         self.templateGenerator = templateGenerator
         self.templateGitLoader = templateGitLoader
     }
-
+    
     func loadTemplateOptions(
         templateName: String,
         path: String?
@@ -67,7 +67,7 @@ class InitService {
         let path = try self.path(path)
         let directories = try templatesDirectoryLocator.templateDirectories(at: path)
         var attributes: [Template.Attribute] = []
-
+        
         if templateName.isGitURL {
             try templateGitLoader.loadTemplate(from: templateName) { template in
                 attributes = template.attributes
@@ -77,11 +77,11 @@ class InitService {
                 templateDirectories: directories,
                 template: templateName
             )
-
+            
             let template = try templateLoader.loadTemplate(at: templateDirectory)
             attributes = template.attributes
         }
-
+        
         return attributes
             .reduce(into: (required: [], optional: [])) { currentValue, attribute in
                 // name and platform attributes have default values, so add them to the optional
@@ -97,8 +97,8 @@ class InitService {
                 }
             }
     }
-
-    func run(
+    
+    public func run(
         name: String?,
         platform: String?,
         path: String?,
@@ -111,7 +111,7 @@ class InitService {
         let name = try self.name(name, path: path)
         let templateName = templateName ?? "default"
         try verifyDirectoryIsEmpty(path: path)
-
+        
         if templateName.isGitURL {
             try templateGitLoader.loadTemplate(from: templateName, closure: { template in
                 let parsedAttributes = try parseAttributes(
@@ -121,7 +121,7 @@ class InitService {
                     optionalTemplateOptions: optionalTemplateOptions,
                     template: template
                 )
-
+                
                 try templateGenerator.generate(
                     template: template,
                     to: path,
@@ -132,7 +132,7 @@ class InitService {
             let directories = try templatesDirectoryLocator.templateDirectories(at: path)
             guard let templateDirectory = directories.first(where: { $0.basename == templateName })
             else { throw InitServiceError.templateNotFound(templateName) }
-
+            
             let template = try templateLoader.loadTemplate(at: templateDirectory)
             let parsedAttributes = try parseAttributes(
                 name: name,
@@ -141,19 +141,19 @@ class InitService {
                 optionalTemplateOptions: optionalTemplateOptions,
                 template: template
             )
-
+            
             try templateGenerator.generate(
                 template: template,
                 to: path,
                 attributes: parsedAttributes
             )
         }
-
+        
         logger.notice("Project generated at path \(path.pathString).", metadata: .success)
     }
-
+    
     // MARK: - Helpers
-
+    
     /// Checks if the given directory is empty, essentially that it doesn't contain any file or directory.
     ///
     /// - Parameter path: Directory to be checked.
@@ -163,7 +163,7 @@ class InitService {
             throw InitServiceError.nonEmptyDirectory(path)
         }
     }
-
+    
     /// Parses all `attributes` from `template`
     /// If those attributes are optional, they default to `default` if not provided
     /// - Returns: Array of parsed attributes
@@ -195,7 +195,7 @@ class InitService {
             }
         }
     }
-
+    
     /// Finds template directory
     /// - Parameters:
     ///     - templateDirectories: Paths of available templates
@@ -206,7 +206,7 @@ class InitService {
         else { throw InitServiceError.templateNotFound(template) }
         return templateDirectory
     }
-
+    
     private func name(_ name: String?, path: AbsolutePath) throws -> String {
         let initName: String
         if let name = name {
@@ -218,7 +218,7 @@ class InitService {
         }
         return initName.camelized.uppercasingFirst
     }
-
+    
     private func path(_ path: String?) throws -> AbsolutePath {
         if let path = path {
             return try AbsolutePath(validating: path, relativeTo: FileHandler.shared.currentPath)
@@ -226,7 +226,7 @@ class InitService {
             return FileHandler.shared.currentPath
         }
     }
-
+    
     private func platform(_ platform: String?) throws -> Platform {
         if let platformString = platform {
             if let platform = Platform(rawValue: platformString) {

--- a/Sources/TuistKit/Services/InitService.swift
+++ b/Sources/TuistKit/Services/InitService.swift
@@ -12,15 +12,15 @@ public enum InitServiceError: FatalError, Equatable {
     case templateNotProvided
     case attributeNotProvided(String)
     case invalidValue(argument: String, error: String)
-    
+
     public var type: ErrorType {
         switch self {
         case .ungettableProjectName, .nonEmptyDirectory, .templateNotFound, .templateNotProvided, .attributeNotProvided,
-                .invalidValue:
+             .invalidValue:
             return .abort
         }
     }
-    
+
     public var description: String {
         switch self {
         case let .templateNotFound(template):
@@ -44,7 +44,7 @@ public class InitService {
     private let templatesDirectoryLocator: TemplatesDirectoryLocating
     private let templateGenerator: TemplateGenerating
     private let templateGitLoader: TemplateGitLoading
-    
+
     public init(
         templateLoader: TemplateLoading = TemplateLoader(),
         templatesDirectoryLocator: TemplatesDirectoryLocating = TemplatesDirectoryLocator(),
@@ -56,7 +56,7 @@ public class InitService {
         self.templateGenerator = templateGenerator
         self.templateGitLoader = templateGitLoader
     }
-    
+
     func loadTemplateOptions(
         templateName: String,
         path: String?
@@ -67,7 +67,7 @@ public class InitService {
         let path = try self.path(path)
         let directories = try templatesDirectoryLocator.templateDirectories(at: path)
         var attributes: [Template.Attribute] = []
-        
+
         if templateName.isGitURL {
             try templateGitLoader.loadTemplate(from: templateName) { template in
                 attributes = template.attributes
@@ -77,11 +77,11 @@ public class InitService {
                 templateDirectories: directories,
                 template: templateName
             )
-            
+
             let template = try templateLoader.loadTemplate(at: templateDirectory)
             attributes = template.attributes
         }
-        
+
         return attributes
             .reduce(into: (required: [], optional: [])) { currentValue, attribute in
                 // name and platform attributes have default values, so add them to the optional
@@ -97,7 +97,7 @@ public class InitService {
                 }
             }
     }
-    
+
     public func run(
         name: String?,
         platform: String?,
@@ -111,7 +111,7 @@ public class InitService {
         let name = try self.name(name, path: path)
         let templateName = templateName ?? "default"
         try verifyDirectoryIsEmpty(path: path)
-        
+
         if templateName.isGitURL {
             try templateGitLoader.loadTemplate(from: templateName, closure: { template in
                 let parsedAttributes = try parseAttributes(
@@ -121,7 +121,7 @@ public class InitService {
                     optionalTemplateOptions: optionalTemplateOptions,
                     template: template
                 )
-                
+
                 try templateGenerator.generate(
                     template: template,
                     to: path,
@@ -132,7 +132,7 @@ public class InitService {
             let directories = try templatesDirectoryLocator.templateDirectories(at: path)
             guard let templateDirectory = directories.first(where: { $0.basename == templateName })
             else { throw InitServiceError.templateNotFound(templateName) }
-            
+
             let template = try templateLoader.loadTemplate(at: templateDirectory)
             let parsedAttributes = try parseAttributes(
                 name: name,
@@ -141,19 +141,19 @@ public class InitService {
                 optionalTemplateOptions: optionalTemplateOptions,
                 template: template
             )
-            
+
             try templateGenerator.generate(
                 template: template,
                 to: path,
                 attributes: parsedAttributes
             )
         }
-        
+
         logger.notice("Project generated at path \(path.pathString).", metadata: .success)
     }
-    
+
     // MARK: - Helpers
-    
+
     /// Checks if the given directory is empty, essentially that it doesn't contain any file or directory.
     ///
     /// - Parameter path: Directory to be checked.
@@ -163,7 +163,7 @@ public class InitService {
             throw InitServiceError.nonEmptyDirectory(path)
         }
     }
-    
+
     /// Parses all `attributes` from `template`
     /// If those attributes are optional, they default to `default` if not provided
     /// - Returns: Array of parsed attributes
@@ -195,7 +195,7 @@ public class InitService {
             }
         }
     }
-    
+
     /// Finds template directory
     /// - Parameters:
     ///     - templateDirectories: Paths of available templates
@@ -206,7 +206,7 @@ public class InitService {
         else { throw InitServiceError.templateNotFound(template) }
         return templateDirectory
     }
-    
+
     private func name(_ name: String?, path: AbsolutePath) throws -> String {
         let initName: String
         if let name = name {
@@ -218,7 +218,7 @@ public class InitService {
         }
         return initName.camelized.uppercasingFirst
     }
-    
+
     private func path(_ path: String?) throws -> AbsolutePath {
         if let path = path {
             return try AbsolutePath(validating: path, relativeTo: FileHandler.shared.currentPath)
@@ -226,7 +226,7 @@ public class InitService {
             return FileHandler.shared.currentPath
         }
     }
-    
+
     private func platform(_ platform: String?) throws -> Platform {
         if let platformString = platform {
             if let platform = Platform(rawValue: platformString) {

--- a/Sources/TuistKit/Services/ListService.swift
+++ b/Sources/TuistKit/Services/ListService.swift
@@ -6,10 +6,10 @@ import TuistPlugin
 import TuistScaffold
 import TuistSupport
 
-class ListService {
+public class ListService {
     // MARK: - OutputFormat
 
-    enum OutputFormat {
+    public enum OutputFormat {
         case table
         case json
     }
@@ -18,12 +18,21 @@ class ListService {
     private let pluginService: PluginServicing
     private let templatesDirectoryLocator: TemplatesDirectoryLocating
     private let templateLoader: TemplateLoading
+    
+    public convenience init() {
+        self.init(
+            configLoader: ConfigLoader(manifestLoader: ManifestLoader()),
+            pluginService: PluginService(),
+            templatesDirectoryLocator: TemplatesDirectoryLocator(),
+            templateLoader: TemplateLoader()
+        )
+    }
 
     init(
-        configLoader: ConfigLoading = ConfigLoader(manifestLoader: ManifestLoader()),
-        pluginService: PluginServicing = PluginService(),
-        templatesDirectoryLocator: TemplatesDirectoryLocating = TemplatesDirectoryLocator(),
-        templateLoader: TemplateLoading = TemplateLoader()
+        configLoader: ConfigLoading,
+        pluginService: PluginServicing,
+        templatesDirectoryLocator: TemplatesDirectoryLocating,
+        templateLoader: TemplateLoading
     ) {
         self.configLoader = configLoader
         self.pluginService = pluginService
@@ -31,7 +40,7 @@ class ListService {
         self.templateLoader = templateLoader
     }
 
-    func run(path: String?, outputFormat format: OutputFormat) async throws {
+    public func run(path: String?, outputFormat format: OutputFormat) async throws {
         let path = try self.path(path)
 
         let plugins = try await loadPlugins(at: path)

--- a/Sources/TuistKit/Services/ListService.swift
+++ b/Sources/TuistKit/Services/ListService.swift
@@ -18,7 +18,7 @@ public class ListService {
     private let pluginService: PluginServicing
     private let templatesDirectoryLocator: TemplatesDirectoryLocating
     private let templateLoader: TemplateLoading
-    
+
     public convenience init() {
         self.init(
             configLoader: ConfigLoader(manifestLoader: ManifestLoader()),

--- a/Sources/TuistKit/Services/Migration/MigrationCheckEmptyBuildSettingsService.swift
+++ b/Sources/TuistKit/Services/Migration/MigrationCheckEmptyBuildSettingsService.swift
@@ -3,20 +3,24 @@ import TSCBasic
 import TuistMigration
 import TuistSupport
 
-class MigrationCheckEmptyBuildSettingsService {
+public class MigrationCheckEmptyBuildSettingsService {
     // MARK: - Attributes
 
     private let emptyBuildSettingsChecker: EmptyBuildSettingsChecking
 
     // MARK: - Init
+    
+    public convenience init() {
+        self.init(emptyBuildSettingsChecker: EmptyBuildSettingsChecker())
+    }
 
-    init(emptyBuildSettingsChecker: EmptyBuildSettingsChecking = EmptyBuildSettingsChecker()) {
+    init(emptyBuildSettingsChecker: EmptyBuildSettingsChecking) {
         self.emptyBuildSettingsChecker = emptyBuildSettingsChecker
     }
 
     // MARK: - Internal
 
-    func run(xcodeprojPath: AbsolutePath, target: String?) throws {
+    public func run(xcodeprojPath: AbsolutePath, target: String?) throws {
         try emptyBuildSettingsChecker.check(xcodeprojPath: xcodeprojPath, targetName: target)
     }
 }

--- a/Sources/TuistKit/Services/Migration/MigrationCheckEmptyBuildSettingsService.swift
+++ b/Sources/TuistKit/Services/Migration/MigrationCheckEmptyBuildSettingsService.swift
@@ -9,7 +9,7 @@ public class MigrationCheckEmptyBuildSettingsService {
     private let emptyBuildSettingsChecker: EmptyBuildSettingsChecking
 
     // MARK: - Init
-    
+
     public convenience init() {
         self.init(emptyBuildSettingsChecker: EmptyBuildSettingsChecker())
     }

--- a/Sources/TuistKit/Services/Migration/MigrationSettingsToXCConfigService.swift
+++ b/Sources/TuistKit/Services/Migration/MigrationSettingsToXCConfigService.swift
@@ -9,7 +9,7 @@ public class MigrationSettingsToXCConfigService {
     private let settingsToXCConfigExtractor: SettingsToXCConfigExtracting
 
     // MARK: - Init
-    
+
     public convenience init() {
         self.init(settingsToXCConfigExtractor: SettingsToXCConfigExtractor())
     }

--- a/Sources/TuistKit/Services/Migration/MigrationSettingsToXCConfigService.swift
+++ b/Sources/TuistKit/Services/Migration/MigrationSettingsToXCConfigService.swift
@@ -3,20 +3,24 @@ import TSCBasic
 import TuistMigration
 import TuistSupport
 
-class MigrationSettingsToXCConfigService {
+public class MigrationSettingsToXCConfigService {
     // MARK: - Attributes
 
     private let settingsToXCConfigExtractor: SettingsToXCConfigExtracting
 
     // MARK: - Init
+    
+    public convenience init() {
+        self.init(settingsToXCConfigExtractor: SettingsToXCConfigExtractor())
+    }
 
-    init(settingsToXCConfigExtractor: SettingsToXCConfigExtracting = SettingsToXCConfigExtractor()) {
+    init(settingsToXCConfigExtractor: SettingsToXCConfigExtracting) {
         self.settingsToXCConfigExtractor = settingsToXCConfigExtractor
     }
 
     // MARK: - Internal
 
-    func run(xcodeprojPath: String, xcconfigPath: String, target: String?) throws {
+    public func run(xcodeprojPath: String, xcconfigPath: String, target: String?) throws {
         try settingsToXCConfigExtractor.extract(
             xcodeprojPath: try AbsolutePath(validating: xcodeprojPath, relativeTo: FileHandler.shared.currentPath),
             targetName: target,

--- a/Sources/TuistKit/Services/Migration/MigrationTargetsByDependenciesService.swift
+++ b/Sources/TuistKit/Services/Migration/MigrationTargetsByDependenciesService.swift
@@ -9,7 +9,7 @@ public final class MigrationTargetsByDependenciesService {
     private let targetsExtractor: TargetsExtracting
 
     // MARK: - Init
-    
+
     public convenience init() {
         self.init(targetsExtractor: TargetsExtractor())
     }

--- a/Sources/TuistKit/Services/Migration/MigrationTargetsByDependenciesService.swift
+++ b/Sources/TuistKit/Services/Migration/MigrationTargetsByDependenciesService.swift
@@ -3,20 +3,24 @@ import TSCBasic
 import TuistMigration
 import TuistSupport
 
-final class MigrationTargetsByDependenciesService {
+public final class MigrationTargetsByDependenciesService {
     // MARK: - Attributes
 
     private let targetsExtractor: TargetsExtracting
 
     // MARK: - Init
+    
+    public convenience init() {
+        self.init(targetsExtractor: TargetsExtractor())
+    }
 
-    init(targetsExtractor: TargetsExtracting = TargetsExtractor()) {
+    init(targetsExtractor: TargetsExtracting) {
         self.targetsExtractor = targetsExtractor
     }
 
     // MARK: - Internal
 
-    func run(xcodeprojPath: AbsolutePath) throws {
+    public func run(xcodeprojPath: AbsolutePath) throws {
         let sortedTargets = try targetsExtractor.targetsSortedByDependencies(xcodeprojPath: xcodeprojPath)
         let sortedTargetsJson = try makeJson(from: sortedTargets)
         logger.info("\(sortedTargetsJson)")

--- a/Sources/TuistKit/Services/Plugin/PluginArchiveService.swift
+++ b/Sources/TuistKit/Services/Plugin/PluginArchiveService.swift
@@ -5,22 +5,29 @@ import TuistDependencies
 import TuistLoader
 import TuistSupport
 
-final class PluginArchiveService {
+public final class PluginArchiveService {
     private let swiftPackageManagerController: SwiftPackageManagerControlling
     private let manifestLoader: ManifestLoading
     private let fileArchiverFactory: FileArchivingFactorying
+    
+    public convenience init() {
+        self.init(swiftPackageManagerController: SwiftPackageManagerController(),
+                  manifestLoader: ManifestLoader(),
+                  fileArchiverFactory: FileArchivingFactory()
+        )
+    }
 
     init(
-        swiftPackageManagerController: SwiftPackageManagerControlling = SwiftPackageManagerController(),
-        manifestLoader: ManifestLoading = ManifestLoader(),
-        fileArchiverFactory: FileArchivingFactorying = FileArchivingFactory()
+        swiftPackageManagerController: SwiftPackageManagerControlling,
+        manifestLoader: ManifestLoading,
+        fileArchiverFactory: FileArchivingFactorying
     ) {
         self.swiftPackageManagerController = swiftPackageManagerController
         self.manifestLoader = manifestLoader
         self.fileArchiverFactory = fileArchiverFactory
     }
 
-    func run(path: String?) throws {
+    public func run(path: String?) throws {
         let path = try self.path(path)
 
         let packageInfo = try swiftPackageManagerController.loadPackageInfo(at: path)

--- a/Sources/TuistKit/Services/Plugin/PluginArchiveService.swift
+++ b/Sources/TuistKit/Services/Plugin/PluginArchiveService.swift
@@ -9,11 +9,12 @@ public final class PluginArchiveService {
     private let swiftPackageManagerController: SwiftPackageManagerControlling
     private let manifestLoader: ManifestLoading
     private let fileArchiverFactory: FileArchivingFactorying
-    
+
     public convenience init() {
-        self.init(swiftPackageManagerController: SwiftPackageManagerController(),
-                  manifestLoader: ManifestLoader(),
-                  fileArchiverFactory: FileArchivingFactory()
+        self.init(
+            swiftPackageManagerController: SwiftPackageManagerController(),
+            manifestLoader: ManifestLoader(),
+            fileArchiverFactory: FileArchivingFactory()
         )
     }
 

--- a/Sources/TuistKit/Services/Plugin/PluginBuildService.swift
+++ b/Sources/TuistKit/Services/Plugin/PluginBuildService.swift
@@ -3,7 +3,7 @@ import TuistSupport
 
 public final class PluginBuildService {
     public init() {}
-    
+
     public func run(
         path: String?,
         configuration: PluginCommand.PackageConfiguration,

--- a/Sources/TuistKit/Services/Plugin/PluginBuildService.swift
+++ b/Sources/TuistKit/Services/Plugin/PluginBuildService.swift
@@ -1,8 +1,10 @@
 import TSCBasic
 import TuistSupport
 
-final class PluginBuildService {
-    func run(
+public final class PluginBuildService {
+    public init() {}
+    
+    public func run(
         path: String?,
         configuration: PluginCommand.PackageConfiguration,
         buildTests: Bool,

--- a/Sources/TuistKit/Services/Plugin/PluginRunService.swift
+++ b/Sources/TuistKit/Services/Plugin/PluginRunService.swift
@@ -3,7 +3,7 @@ import TuistSupport
 
 public final class PluginRunService {
     public init() {}
-    
+
     public func run(
         path: String?,
         configuration: PluginCommand.PackageConfiguration,

--- a/Sources/TuistKit/Services/Plugin/PluginRunService.swift
+++ b/Sources/TuistKit/Services/Plugin/PluginRunService.swift
@@ -1,8 +1,10 @@
 import TSCBasic
 import TuistSupport
 
-final class PluginRunService {
-    func run(
+public final class PluginRunService {
+    public init() {}
+    
+    public func run(
         path: String?,
         configuration: PluginCommand.PackageConfiguration,
         buildTests: Bool,

--- a/Sources/TuistKit/Services/Plugin/PluginTestService.swift
+++ b/Sources/TuistKit/Services/Plugin/PluginTestService.swift
@@ -3,7 +3,7 @@ import TuistSupport
 
 public final class PluginTestService {
     public init() {}
-    
+
     public func run(
         path: String?,
         configuration: PluginCommand.PackageConfiguration,

--- a/Sources/TuistKit/Services/Plugin/PluginTestService.swift
+++ b/Sources/TuistKit/Services/Plugin/PluginTestService.swift
@@ -1,8 +1,10 @@
 import TSCBasic
 import TuistSupport
 
-final class PluginTestService {
-    func run(
+public final class PluginTestService {
+    public init() {}
+    
+    public func run(
         path: String?,
         configuration: PluginCommand.PackageConfiguration,
         buildTests: Bool,

--- a/Sources/TuistKit/Services/RunService.swift
+++ b/Sources/TuistKit/Services/RunService.swift
@@ -8,13 +8,13 @@ import TuistGraph
 import TuistLoader
 import TuistSupport
 
-enum RunServiceError: FatalError {
+public enum RunServiceError: FatalError {
     case schemeNotFound(scheme: String, existing: [String])
     case schemeWithoutRunnableTarget(scheme: String)
     case invalidVersion(String)
     case workspaceNotFound(path: String)
 
-    var description: String {
+    public var description: String {
         switch self {
         case let .schemeNotFound(scheme, existing):
             return "Couldn't find scheme \(scheme). The available schemes are: \(existing.joined(separator: ", "))."
@@ -27,7 +27,7 @@ enum RunServiceError: FatalError {
         }
     }
 
-    var type: ErrorType {
+    public var type: ErrorType {
         switch self {
         case .schemeNotFound,
              .schemeWithoutRunnableTarget,
@@ -39,17 +39,26 @@ enum RunServiceError: FatalError {
     }
 }
 
-final class RunService {
+public final class RunService {
     private let generatorFactory: GeneratorFactorying
     private let buildGraphInspector: BuildGraphInspecting
     private let targetBuilder: TargetBuilding
     private let targetRunner: TargetRunning
+    
+    public convenience init() {
+        self.init(
+            generatorFactory: GeneratorFactory(),
+            buildGraphInspector: BuildGraphInspector(),
+            targetBuilder: TargetBuilder(),
+            targetRunner: TargetRunner()
+        )
+    }
 
     init(
-        generatorFactory: GeneratorFactorying = GeneratorFactory(),
-        buildGraphInspector: BuildGraphInspecting = BuildGraphInspector(),
-        targetBuilder: TargetBuilding = TargetBuilder(),
-        targetRunner: TargetRunning = TargetRunner()
+        generatorFactory: GeneratorFactorying,
+        buildGraphInspector: BuildGraphInspecting,
+        targetBuilder: TargetBuilding,
+        targetRunner: TargetRunning
     ) {
         self.generatorFactory = generatorFactory
         self.buildGraphInspector = buildGraphInspector
@@ -58,7 +67,7 @@ final class RunService {
     }
 
     // swiftlint:disable:next function_body_length
-    func run(
+    public func run(
         path: String?,
         schemeName: String,
         generate: Bool,

--- a/Sources/TuistKit/Services/RunService.swift
+++ b/Sources/TuistKit/Services/RunService.swift
@@ -44,7 +44,7 @@ public final class RunService {
     private let buildGraphInspector: BuildGraphInspecting
     private let targetBuilder: TargetBuilding
     private let targetRunner: TargetRunning
-    
+
     public convenience init() {
         self.init(
             generatorFactory: GeneratorFactory(),

--- a/Sources/TuistKit/Services/ScaffoldService.swift
+++ b/Sources/TuistKit/Services/ScaffoldService.swift
@@ -17,7 +17,7 @@ public enum ScaffoldServiceError: FatalError, Equatable {
             return .abort
         }
     }
-    
+
     public var description: String {
         switch self {
         case let .templateNotFound(template, searchPaths):
@@ -39,10 +39,10 @@ public final class ScaffoldService {
     private let templateGenerator: TemplateGenerating
     private let configLoader: ConfigLoading
     private let pluginService: PluginServicing
-    
+
     public convenience init() {
         self.init(
-            templateLoader:TemplateLoader(),
+            templateLoader: TemplateLoader(),
             templatesDirectoryLocator: TemplatesDirectoryLocator(),
             templateGenerator: TemplateGenerator(),
             configLoader: ConfigLoader(manifestLoader: ManifestLoader()),

--- a/Sources/TuistKit/Services/ScaffoldService.swift
+++ b/Sources/TuistKit/Services/ScaffoldService.swift
@@ -6,19 +6,19 @@ import TuistPlugin
 import TuistScaffold
 import TuistSupport
 
-enum ScaffoldServiceError: FatalError, Equatable {
-    var type: ErrorType {
+public enum ScaffoldServiceError: FatalError, Equatable {
+    case templateNotFound(String, searchPaths: [AbsolutePath])
+    case nonEmptyDirectory(AbsolutePath)
+    case attributeNotProvided(String)
+
+    public var type: ErrorType {
         switch self {
         case .templateNotFound, .nonEmptyDirectory, .attributeNotProvided:
             return .abort
         }
     }
-
-    case templateNotFound(String, searchPaths: [AbsolutePath])
-    case nonEmptyDirectory(AbsolutePath)
-    case attributeNotProvided(String)
-
-    var description: String {
+    
+    public var description: String {
         switch self {
         case let .templateNotFound(template, searchPaths):
             let searchDirectories = searchPaths
@@ -33,19 +33,29 @@ enum ScaffoldServiceError: FatalError, Equatable {
     }
 }
 
-final class ScaffoldService {
+public final class ScaffoldService {
     private let templateLoader: TemplateLoading
     private let templatesDirectoryLocator: TemplatesDirectoryLocating
     private let templateGenerator: TemplateGenerating
     private let configLoader: ConfigLoading
     private let pluginService: PluginServicing
+    
+    public convenience init() {
+        self.init(
+            templateLoader:TemplateLoader(),
+            templatesDirectoryLocator: TemplatesDirectoryLocator(),
+            templateGenerator: TemplateGenerator(),
+            configLoader: ConfigLoader(manifestLoader: ManifestLoader()),
+            pluginService: PluginService()
+        )
+    }
 
     init(
-        templateLoader: TemplateLoading = TemplateLoader(),
-        templatesDirectoryLocator: TemplatesDirectoryLocating = TemplatesDirectoryLocator(),
-        templateGenerator: TemplateGenerating = TemplateGenerator(),
-        configLoader: ConfigLoading = ConfigLoader(manifestLoader: ManifestLoader()),
-        pluginService: PluginServicing = PluginService()
+        templateLoader: TemplateLoading,
+        templatesDirectoryLocator: TemplatesDirectoryLocating,
+        templateGenerator: TemplateGenerating,
+        configLoader: ConfigLoading,
+        pluginService: PluginServicing
     ) {
         self.templateLoader = templateLoader
         self.templatesDirectoryLocator = templatesDirectoryLocator
@@ -78,7 +88,7 @@ final class ScaffoldService {
         }
     }
 
-    func run(
+    public func run(
         path: String?,
         templateName: String,
         requiredTemplateOptions: [String: String],

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -8,12 +8,12 @@ import TuistGraph
 import TuistLoader
 import TuistSupport
 
-enum TestServiceError: FatalError {
+public enum TestServiceError: FatalError {
     case schemeNotFound(scheme: String, existing: [String])
     case schemeWithoutTestableTargets(scheme: String)
 
     // Error description
-    var description: String {
+    public var description: String {
         switch self {
         case let .schemeNotFound(scheme, existing):
             return "Couldn't find scheme \(scheme). The available schemes are: \(existing.joined(separator: ", "))."
@@ -23,7 +23,7 @@ enum TestServiceError: FatalError {
     }
 
     // Error type
-    var type: ErrorType {
+    public var type: ErrorType {
         switch self {
         case .schemeNotFound, .schemeWithoutTestableTargets:
             return .abort
@@ -31,7 +31,7 @@ enum TestServiceError: FatalError {
     }
 }
 
-final class TestService {
+public final class TestService {
     private let generatorFactory: GeneratorFactorying
     private let xcodebuildController: XcodeBuildControlling
     private let buildGraphInspector: BuildGraphInspecting
@@ -41,7 +41,7 @@ final class TestService {
     private let testsCacheTemporaryDirectory: TemporaryDirectory
     private let cacheDirectoryProviderFactory: CacheDirectoriesProviderFactoring
 
-    convenience init() throws {
+    public convenience init() throws {
         let testsCacheTemporaryDirectory = try TemporaryDirectory(removeTreeOnDeinit: true)
         self.init(
             testsCacheTemporaryDirectory: testsCacheTemporaryDirectory,
@@ -68,7 +68,7 @@ final class TestService {
     }
 
     // swiftlint:disable:next function_body_length
-    func run(
+    public func run(
         schemeName: String?,
         clean: Bool,
         configuration: String?,

--- a/Sources/TuistKit/Services/VersionService.swift
+++ b/Sources/TuistKit/Services/VersionService.swift
@@ -2,8 +2,8 @@ import Foundation
 import TSCBasic
 import TuistSupport
 
-final class VersionService {
-    func run() throws {
+public final class VersionService {
+    public func run() throws {
         logger.notice("\(Constants.version)")
     }
 }

--- a/Tests/TuistKitTests/Services/FetchServiceTests.swift
+++ b/Tests/TuistKitTests/Services/FetchServiceTests.swift
@@ -39,7 +39,8 @@ final class FetchServiceTests: TuistUnitTestCase {
             configLoader: configLoader,
             manifestLoader: manifestLoader,
             dependenciesController: dependenciesController,
-            dependenciesModelLoader: dependenciesModelLoader
+            dependenciesModelLoader: dependenciesModelLoader,
+            converter:  ManifestModelConverter()
         )
     }
 

--- a/Tests/TuistKitTests/Services/FetchServiceTests.swift
+++ b/Tests/TuistKitTests/Services/FetchServiceTests.swift
@@ -40,7 +40,7 @@ final class FetchServiceTests: TuistUnitTestCase {
             manifestLoader: manifestLoader,
             dependenciesController: dependenciesController,
             dependenciesModelLoader: dependenciesModelLoader,
-            converter:  ManifestModelConverter()
+            converter: ManifestModelConverter()
         )
     }
 

--- a/Tests/TuistKitTests/Services/GenerateServiceTests.swift
+++ b/Tests/TuistKitTests/Services/GenerateServiceTests.swift
@@ -3,8 +3,8 @@ import TSCBasic
 import TuistCore
 import TuistGraph
 import TuistLoader
-import TuistSupport
 import TuistPlugin
+import TuistSupport
 import XcodeProj
 import XCTest
 @testable import TuistCoreTesting

--- a/Tests/TuistKitTests/Services/GenerateServiceTests.swift
+++ b/Tests/TuistKitTests/Services/GenerateServiceTests.swift
@@ -3,6 +3,8 @@ import TSCBasic
 import TuistCore
 import TuistGraph
 import TuistLoader
+import TuistSupport
+import TuistPlugin
 import XcodeProj
 import XCTest
 @testable import TuistCoreTesting
@@ -31,7 +33,15 @@ final class GenerateServiceTests: TuistUnitTestCase {
         generatorFactory = MockGeneratorFactory()
         generatorFactory.stubbedFocusResult = generator
         clock = StubClock()
-        subject = GenerateService(clock: clock, opener: opener, generatorFactory: generatorFactory)
+        subject = GenerateService(
+            clock: clock,
+            timeTakenLoggerFormatter: TimeTakenLoggerFormatter(),
+            configLoader: ConfigLoader(manifestLoader: ManifestLoader()),
+            manifestLoader: ManifestLoader(),
+            opener: opener,
+            generatorFactory: generatorFactory,
+            pluginService: PluginService()
+        )
     }
 
     override func tearDown() {

--- a/Tests/TuistKitTests/Services/ListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/ListServiceTests.swift
@@ -1,8 +1,8 @@
 import TSCBasic
 import TuistGraph
 import TuistGraphTesting
-import TuistPluginTesting
 import TuistLoader
+import TuistPluginTesting
 import XCTest
 
 @testable import TuistCore

--- a/Tests/TuistKitTests/Services/ListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/ListServiceTests.swift
@@ -2,6 +2,7 @@ import TSCBasic
 import TuistGraph
 import TuistGraphTesting
 import TuistPluginTesting
+import TuistLoader
 import XCTest
 
 @testable import TuistCore
@@ -22,6 +23,7 @@ final class ListServiceTests: TuistUnitTestCase {
         templateLoader = MockTemplateLoader()
         templatesDirectoryLocator = MockTemplatesDirectoryLocator()
         subject = ListService(
+            configLoader: ConfigLoader(manifestLoader: ManifestLoader()),
             pluginService: pluginService,
             templatesDirectoryLocator: templatesDirectoryLocator,
             templateLoader: templateLoader


### PR DESCRIPTION
### Short description 📝
I'm prototyping a UI-based interface (macOS app) for Tuist projects, and that requires the targets and some of its classes to be public. Therefore I'm making `TuistKit` services and commands public and adding a new product, `TuistKit` that other projects can add as dependency.

### How to test the changes locally 🧐

The `Package` and Tuist projects should build and test successfully.

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
