### PR TITLE
Fixed a bug where turning on and off the rendering of markdown files in Workspace config wouldn't turn off rendering properly and would stay in read-only mode (fixes #5196)

### DIFF
--- a/Sources/TuistKit/Mappers/Workspace/TuistWorkspaceRenderMarkdownMapper.swift
+++ b/Sources/TuistKit/Mappers/Workspace/TuistWorkspaceRenderMarkdownMapper.swift
@@ -5,13 +5,9 @@ import TuistSupport
 /// Tuist Workspace Markdown render Mapper.
 ///
 /// A mapper that includes a .xcodesample.plist file within the generated xcworkspace directory.
-/// This is used to render markdown inside the de workspace.
+/// This is used to render markdown inside the workspace.
 final class TuistWorkspaceRenderMarkdownReadmeMapper: WorkspaceMapping {
     func map(workspace: WorkspaceWithProjects) throws -> (WorkspaceWithProjects, [SideEffectDescriptor]) {
-        guard workspace.workspace.generationOptions.renderMarkdownReadme else {
-            return (workspace, [])
-        }
-
         let tuistGeneratedFileDescriptor = FileDescriptor(
             path: workspace
                 .workspace
@@ -19,7 +15,8 @@ final class TuistWorkspaceRenderMarkdownReadmeMapper: WorkspaceMapping {
                 .appending(
                     component: ".xcodesamplecode.plist"
                 ),
-            contents: try PropertyListEncoder().encode([String]())
+            contents: try PropertyListEncoder().encode([String]()),
+            state: workspace.workspace.generationOptions.renderMarkdownReadme ? .present : .absent // bugfix: #5196
         )
 
         return (workspace, [

--- a/Sources/TuistKit/Mappers/Workspace/TuistWorkspaceRenderMarkdownMapper.swift
+++ b/Sources/TuistKit/Mappers/Workspace/TuistWorkspaceRenderMarkdownMapper.swift
@@ -16,7 +16,7 @@ final class TuistWorkspaceRenderMarkdownReadmeMapper: WorkspaceMapping {
                     component: ".xcodesamplecode.plist"
                 ),
             contents: try PropertyListEncoder().encode([String]()),
-            state: workspace.workspace.generationOptions.renderMarkdownReadme ? .present : .absent // bugfix: #5196
+            state: workspace.workspace.generationOptions.renderMarkdownReadme ? .present : .absent 
         )
 
         return (workspace, [

--- a/Sources/TuistKit/Mappers/Workspace/TuistWorkspaceRenderMarkdownMapper.swift
+++ b/Sources/TuistKit/Mappers/Workspace/TuistWorkspaceRenderMarkdownMapper.swift
@@ -16,7 +16,7 @@ final class TuistWorkspaceRenderMarkdownReadmeMapper: WorkspaceMapping {
                     component: ".xcodesamplecode.plist"
                 ),
             contents: try PropertyListEncoder().encode([String]()),
-            state: workspace.workspace.generationOptions.renderMarkdownReadme ? .present : .absent 
+            state: workspace.workspace.generationOptions.renderMarkdownReadme ? .present : .absent
         )
 
         return (workspace, [

--- a/Tests/TuistKitTests/Mappers/Workspace/TuistWorkspaceRenderMarkdownReadmeMapperTests.swift
+++ b/Tests/TuistKitTests/Mappers/Workspace/TuistWorkspaceRenderMarkdownReadmeMapperTests.swift
@@ -68,6 +68,15 @@ final class TuistWorkspaceRenderMarkdownReadmeMapperTests: TuistUnitTestCase {
             renderMarkdownReadme: false
         ))
 
+        let tuistGeneratedFileDescriptor = FileDescriptor(
+            path: workspace
+                .xcWorkspacePath
+                .appending(
+                    component: ".xcodesamplecode.plist"
+                ),
+            contents: try PropertyListEncoder().encode([String]()),
+            state: .absent // file should be deleted
+        )
         let workspaceWithProjects = WorkspaceWithProjects(workspace: workspace, projects: [])
         // When
         let (gotWorkspaceWithProjects, sideEffects) = try TuistWorkspaceRenderMarkdownReadmeMapper()
@@ -78,6 +87,11 @@ final class TuistWorkspaceRenderMarkdownReadmeMapperTests: TuistUnitTestCase {
             gotWorkspaceWithProjects.workspace.generationOptions.renderMarkdownReadme
         )
         XCTAssertTrue(gotWorkspaceWithProjects.workspace.projects.isEmpty)
-        XCTAssertEqual(sideEffects, [])
+        XCTAssertEqual(
+            sideEffects,
+            [
+                .file(tuistGeneratedFileDescriptor),
+            ]
+        )
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5196

### Short description 📝

> The `.xcodesamplecode.plist` file wasn't removed again when turning off `renderMarkdownReadme` flag in Workspace config.

### How to test the changes locally 🧐

> 1. Create a workspace with `renderMarkdownReadme: true`
> 2. Open the README.md in Xcode and verify it is in read-only mode
> 3. Now change the flag to false `renderMarkdownReadme: false`
> 4. Check the Readme in Xcode again and it should be in edit-mode now (it remained in read-only mode before the fix)

### Contributor checklist ✅

- [✅] The code has been linted using run `./fourier lint tuist --fix`
- [✅] The change is tested via unit testing or acceptance testing, or both
- [✅] The title of the PR is formulated in a way that is usable as a changelog entry
- [✅] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
