### PR TITLE
Fix failing test_printAndThrowErrorsIfNeeded test

### DIFF
--- a/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
+++ b/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
@@ -130,6 +130,7 @@ open class TuistTestCase: XCTestCase {
 
     override open func tearDown() {
         temporaryDirectory = nil
+        TestingLogHandler.reset()
         super.tearDown()
     }
 

--- a/Sources/TuistSupportTesting/Utils/TestingLogHandler.swift
+++ b/Sources/TuistSupportTesting/Utils/TestingLogHandler.swift
@@ -36,6 +36,12 @@ public struct TestingLogHandler: LogHandler {
         get { metadata[key] }
         set { metadata[key] = newValue }
     }
+
+    public static func reset() {
+        TestingLogHandler.collectionQueue.async {
+            TestingLogHandler.collectedLogs = [:]
+        }
+    }
 }
 
 extension Dictionary where Key == Logger.Level, Value == [String] {


### PR DESCRIPTION
### Short description 📝

`swift test` produces one failing test – `test_printAndThrowErrorsIfNeeded`:

```
> swift test | xcbeautify
...
LintingIssueTests
    ✔ test_description (0.001 seconds)
    ✔ test_printAndThrowErrorsIfNeeded_whenErrorsOnly (0.000 seconds)
    ✖ test_printAndThrowErrorsIfNeeded, XCTAssertFalse failed - The output:
❌ Error: typeMismatch(Swift.Array<Any>, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "externalDependencies", intValue: nil)], debugDescription: "Expected to decode Array<Any> but found a dictionary instead.", underlyingError: nil))
    ✔ test_printWarningsIfNeeded (0.002 seconds)
...
Tests Failed: 1 failed, 0 skipped, 1845 total (76.028 seconds)
```

This test in isolation works fine.

This happens because `test_printAndThrowErrorsIfNeeded` checks strings in the logs, and logs not cleaned between tests. So logs output polluted by other tests, more specifically by `CacheGraphLinterTests.test_lint`.

```
swift test --filter "(LintingIssueTests.test_printAndThrowErrorsIfNeeded$)|(CacheGraphLinterTests)" | xcbeautify
Building for debugging...
[7/7] Linking tuistPackageTests
Build complete! (1.54s)
Selected tests
tuistPackageTests.xctest
CacheGraphLinterTests
    ✔ test_lint (0.003 seconds)
LintingIssueTests
    ✖ test_printAndThrowErrorsIfNeeded, XCTAssertFalse failed - The output:
```

The fix is simple – reset collected logs between tests runs.

### How to test the changes locally 🧐

Run `swift test`

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
