### PR TITLE
Update `TEST_HOST` to use BUNDLE_EXECUTABLE_FOLDER_PATH from Xcode 14

### DIFF
--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -270,7 +270,10 @@ final class ConfigGenerator: ConfigGenerating {
         var settings: SettingsDictionary = [:]
         settings["TEST_TARGET_NAME"] = .string("\(app.target.name)")
         if target.product == .unitTests {
-            settings["TEST_HOST"] = .string("$(BUILT_PRODUCTS_DIR)/\(app.target.productNameWithExtension)/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/\(app.target.productName)")
+            settings["TEST_HOST"] =
+                .string(
+                    "$(BUILT_PRODUCTS_DIR)/\(app.target.productNameWithExtension)/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/\(app.target.productName)"
+                )
             settings["BUNDLE_LOADER"] = "$(TEST_HOST)"
         }
 

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -270,13 +270,7 @@ final class ConfigGenerator: ConfigGenerating {
         var settings: SettingsDictionary = [:]
         settings["TEST_TARGET_NAME"] = .string("\(app.target.name)")
         if target.product == .unitTests {
-            var testHostPath = "$(BUILT_PRODUCTS_DIR)/\(app.target.productNameWithExtension)"
-
-            if target.platform == .macOS {
-                testHostPath += "/Contents/MacOS"
-            }
-
-            settings["TEST_HOST"] = .string("\(testHostPath)/\(app.target.productName)")
+            settings["TEST_HOST"] = .string("$(BUILT_PRODUCTS_DIR)/\(app.target.productNameWithExtension)/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/\(app.target.productName)")
             settings["BUNDLE_LOADER"] = "$(TEST_HOST)"
         }
 

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -149,7 +149,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         let releaseConfig = configurationList?.configuration(name: "Release")
 
         let testHostSettings = [
-            "TEST_HOST": "$(BUILT_PRODUCTS_DIR)/App.app/App",
+            "TEST_HOST": "$(BUILT_PRODUCTS_DIR)/App.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/App",
             "BUNDLE_LOADER": "$(TEST_HOST)",
         ]
 
@@ -166,7 +166,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         let releaseConfig = configurationList?.configuration(name: "Release")
 
         let testHostSettings = [
-            "TEST_HOST": "$(BUILT_PRODUCTS_DIR)/App.app/Contents/MacOS/App",
+            "TEST_HOST": "$(BUILT_PRODUCTS_DIR)/App.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/App",
             "BUNDLE_LOADER": "$(TEST_HOST)",
         ]
 
@@ -186,7 +186,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         let releaseConfig = configurationList?.configuration(name: "Release")
 
         let testHostSettings = [
-            "TEST_HOST": "$(BUILT_PRODUCTS_DIR)/App_dash.app/App_dash",
+            "TEST_HOST": "$(BUILT_PRODUCTS_DIR)/App_dash.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/App_dash",
             "BUNDLE_LOADER": "$(TEST_HOST)",
         ]
 


### PR DESCRIPTION
Related to #4531 

### Short description 📝

Update `TEST_HOST` to use `BUNDLE_EXECUTABLE_FOLDER_PATH` to allow for multi-platform tests.

### How to test the changes locally 🧐

Run tests. 
Verify unit test target `TEST_HOST` build setting includes `BUNDLE_EXECUTABLE_FOLDER_PATH`

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
