### PR TITLE
Revert stencil template changes in 3.21

### DIFF
--- a/Sources/TuistGenerator/Templates/PlistsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/PlistsTemplate.swift
@@ -19,65 +19,59 @@ extension SynthesizedResourceInterfaceTemplates {
     {% macro documentBlock file document %}
       {% set rootType %}{% call typeBlock document.metadata %}{% endset %}
       {% if document.metadata.type == "Array" %}
-      {{accessModifier}} static let items: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
+      {{accessModifier}} static let items: {{rootType}} = {% call valueBlock document.data document.metadata %}
       {% elif document.metadata.type == "Dictionary" %}
       {% for key,value in document.metadata.properties %}
-      {{accessModifier}} {%+ call propertyBlock key value document.data %}
+      {{accessModifier}} {% call propertyBlock key value document.data %}
       {% endfor %}
       {% else %}
-      {{accessModifier}} static let value: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
+      {{accessModifier}} static let value: {{rootType}} = {% call valueBlock document.data document.metadata %}
       {% endif %}
     {% endmacro %}
-    {% macro typeBlock metadata %}
-      {%- if metadata.type == "Array" -%}
+    {% macro typeBlock metadata %}{% filter removeNewlines:"leading" %}
+      {% if metadata.type == "Array" %}
         [{% call typeBlock metadata.element %}]
-      {%- elif metadata.type == "Dictionary" -%}
+      {% elif metadata.type == "Dictionary" %}
         [String: Any]
-      {%- else -%}
+      {% else %}
         {{metadata.type}}
-      {%- endif -%}
-    {% endmacro %}
-    {% macro propertyBlock key metadata data %}
-      {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
-      {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
-      static let {{propertyName}}: {{propertyType}} = {%+ call valueBlock data[key] metadata +%}
-    {% endmacro %}
-    {% macro valueBlock value metadata %}
-      {%- if metadata.type == "String" -%}
+      {% endif %}
+    {% endfilter %}{% endmacro %}
+    {% macro propertyBlock key metadata data %}{% filter removeNewlines:"leading" %}
+      {% set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
+      {% set propertyType %}{% call typeBlock metadata %}{% endset %}
+      static let {{propertyName}}: {{propertyType}} = {% call valueBlock data[key] metadata %}
+    {% endfilter %}{% endmacro %}
+    {% macro valueBlock value metadata %}{% filter removeNewlines:"leading" %}
+      {% if metadata.type == "String" %}
         "{{ value }}"
-      {%- elif metadata.type == "Date" -%}
+      {% elif metadata.type == "Date" %}
         Date(timeIntervalSinceReferenceDate: {{ value.timeIntervalSinceReferenceDate }})
-      {%- elif metadata.type == "Optional" -%}
+      {% elif metadata.type == "Optional" %}
         nil
-      {%- elif metadata.type == "Array" and value -%}
-        [{% for value in value -%}
-          {%- call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element -%}
+      {% elif metadata.type == "Array" and value %}
+        [{% for value in value %}
+          {% call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element %}
           {{ ", " if not forloop.last }}
-        {%- endfor %}]
-      {%- elif metadata.type == "Dictionary" -%}
-        [{% for key,value in value -%}
-          "{{key}}": {%+ call valueBlock value metadata.properties[key] -%}
+        {% endfor %}]
+      {% elif metadata.type == "Dictionary" %}
+        [{% for key,value in value %}
+          "{{key}}": {% call valueBlock value metadata.properties[key] %}
           {{ ", " if not forloop.last }}
-        {%- empty -%}
+        {% empty %}
           :
-        {%- endfor %}]
-      {%- elif metadata.type == "Bool" -%}
-        {%- if value %}true{% else %}false{% endif -%}
-      {%- else -%}
+        {% endfor %}]
+      {% else %}
         {{ value }}
-      {%- endif -%}
-    {% endmacro %}
+      {% endif %}
+    {% endfilter %}{% endmacro %}
 
     // swiftlint:disable identifier_name line_length number_separator type_body_length
-    {% if files.count > 1 or param.forceFileNameEnum %}
     {% for file in files %}
     {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-      {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
+      {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}
     }
     {% endfor %}
-    {% else %}
-    {% call fileBlock files.first %}
-    {% endif %}
     // swiftlint:enable identifier_name line_length number_separator type_body_length
     {% else %}
     // No files found


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY

### Short description 📝

Tuist 3.21 introduced a regression when generating Swift content from Info.plist.
It seems the outer type encapsulating the static let(s) is gone.

3.20:
![image](https://github.com/tuist/tuist/assets/605076/3b9827d7-069b-4aab-a020-fd255f7eb299)

3.21:
![image](https://github.com/tuist/tuist/assets/605076/a0183107-0074-4153-8026-2132a901898f)

Was decided to revert the specific stencil template with @pepicrft 
