### PR TITLE
Fix plist code generation for single file case.

### DIFF
--- a/Sources/TuistGenerator/Templates/PlistsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/PlistsTemplate.swift
@@ -69,15 +69,11 @@ extension SynthesizedResourceInterfaceTemplates {
     {% endmacro %}
 
     // swiftlint:disable identifier_name line_length number_separator type_body_length
-    {% if files.count > 1 or param.forceFileNameEnum %}
     {% for file in files %}
     {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
       {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
     }
     {% endfor %}
-    {% else %}
-    {% call fileBlock files.first %}
-    {% endif %}
     // swiftlint:enable identifier_name line_length number_separator type_body_length
     {% else %}
     // No files found

--- a/projects/tuist/fixtures/ios_app_with_framework_and_resources/Framework1/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_framework_and_resources/Framework1/Project.swift
@@ -6,6 +6,7 @@ import ProjectDescription
 let resourcesDirectory = "Resources"
 let resources: [ResourceFileElement] = [
     "\(resourcesDirectory)/framework_resource.txt",
+    "\(resourcesDirectory)/AnotherPlist.plist",
 ]
 
 let project = Project(

--- a/projects/tuist/fixtures/ios_app_with_framework_and_resources/Framework1/Resources/AnotherPlist.plist
+++ b/projects/tuist/fixtures/ios_app_with_framework_and_resources/Framework1/Resources/AnotherPlist.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>my_bool_key</key>
+	<false/>
+	<key>some_Number</key>
+	<integer>5</integer>
+	<key>this_is_a_date</key>
+	<date>2023-06-30T16:19:51Z</date>
+	<key>my_dictionary</key>
+	<dict>
+		<key>key2</key>
+		<integer>0</integer>
+		<key>key1</key>
+		<string>value1</string>
+	</dict>
+	<key>my_array</key>
+	<array>
+		<string>a string</string>
+	</array>
+	<key>my_key</key>
+	<string>This is my secret key from another Plist!</string>
+</dict>
+</plist>


### PR DESCRIPTION

### Short description 📝

Fixes regression in plist generation template and adds failing test case (which is now fixed)

### How to test the changes locally 🧐

Run a tuist (from this branch) against `tuist/projects/tuist/fixtures/ios_app_with_framework_and_resources`

Observe both `Framework1` and `MainApp` targets have derived plist accessors that are valid Swift.

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
