### PR TITLE
Add support for SPM `Build Tool Plug-ins`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -245,10 +245,10 @@
     {
       "identity" : "xcodeproj",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/BarredEwe/XcodeProj.git",
+      "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "branch" : "feature/build-tool-plugin",
-        "revision" : "371857a81153371abdb9e398b912cc4d173c4a48"
+        "branch" : "main",
+        "revision" : "6e60fb55271c80f83a186c9b1b4982fd991cfc0a"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -245,10 +245,10 @@
     {
       "identity" : "xcodeproj",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tuist/XcodeProj.git",
+      "location" : "https://github.com/BarredEwe/XcodeProj.git",
       "state" : {
-        "revision" : "59c7f8d4201a7bd37ef509edebd5777811c7de78",
-        "version" : "8.11.0"
+        "branch" : "feature/build-tool-plugin",
+        "revision" : "371857a81153371abdb9e398b912cc4d173c4a48"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -247,8 +247,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "revision" : "6e60fb55271c80f83a186c9b1b4982fd991cfc0a",
-        "version" : "8.13.0"
+        "revision" : "d5c0c2770d62f9aab78be071f13f3364835d5a65",
+        "version" : "8.14.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -247,8 +247,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "6e60fb55271c80f83a186c9b1b4982fd991cfc0a"
+        "revision" : "6e60fb55271c80f83a186c9b1b4982fd991cfc0a",
+        "version" : "8.13.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -63,7 +63,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", exact: "0.2.0"),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", exact: "2.10.1"),
         .package(url: "https://github.com/SwiftGen/SwiftGen", exact: "6.5.1"),
-        .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.13.0"),
+        .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.14.0"),
         .package(url: "https://github.com/tuist/swift-openapi-runtime", branch: "swift-tools-version"),
         .package(url: "https://github.com/tuist/swift-openapi-urlsession", branch: "swift-tools-version"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -63,7 +63,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", exact: "0.2.0"),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", exact: "2.10.1"),
         .package(url: "https://github.com/SwiftGen/SwiftGen", exact: "6.5.1"),
-        .package(url: "https://github.com/tuist/XcodeProj.git", branch: "main"),
+        .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.13.0"),
         .package(url: "https://github.com/tuist/swift-openapi-runtime", branch: "swift-tools-version"),
         .package(url: "https://github.com/tuist/swift-openapi-urlsession", branch: "swift-tools-version"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -63,7 +63,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", exact: "0.2.0"),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", exact: "2.10.1"),
         .package(url: "https://github.com/SwiftGen/SwiftGen", exact: "6.5.1"),
-        .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.11.0"),
+        .package(url: "https://github.com/tuist/XcodeProj.git", branch: "main"),
         .package(url: "https://github.com/tuist/swift-openapi-runtime", branch: "swift-tools-version"),
         .package(url: "https://github.com/tuist/swift-openapi-urlsession", branch: "swift-tools-version"),
     ],

--- a/Sources/ProjectAutomation/TargetDependency.swift
+++ b/Sources/ProjectAutomation/TargetDependency.swift
@@ -11,7 +11,8 @@ public enum TargetDependency: Equatable, Hashable, Codable {
     case framework(path: String)
     case xcframework(path: String)
     case library(path: String, publicHeaders: String, swiftModuleMap: String?)
-    case package(product: String, isPlugin: Bool)
+    case package(product: String)
+    case packagePlugin(product: String)
     case sdk(name: String, status: SDKStatus)
     case xctest
 }

--- a/Sources/ProjectAutomation/TargetDependency.swift
+++ b/Sources/ProjectAutomation/TargetDependency.swift
@@ -11,7 +11,7 @@ public enum TargetDependency: Equatable, Hashable, Codable {
     case framework(path: String)
     case xcframework(path: String)
     case library(path: String, publicHeaders: String, swiftModuleMap: String?)
-    case package(product: String)
+    case package(product: String, isPlugin: Bool)
     case sdk(name: String, status: SDKStatus)
     case xctest
 }

--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -53,8 +53,14 @@ public enum TargetDependency: Codable, Hashable {
     /// - Parameters:
     ///   - product: The name of the output product. ${PRODUCT_NAME} inside Xcode.
     ///              e.g. RxSwift
-    ///   - isPlugin: Must be explicitly set to `true` if this is a plugin to generate the Xcode project correctly.
-    case package(product: String, isPlugin: Bool = false)
+    case package(product: String)
+
+    /// Dependency on a swift package manager plugin product using Xcode native integration.
+    ///
+    /// - Parameters:
+    ///   - product: The name of the output product. ${PRODUCT_NAME} inside Xcode.
+    ///              e.g. RxSwift
+    case packagePlugin(product: String)
 
     /// Dependency on system library or framework
     ///
@@ -108,6 +114,8 @@ public enum TargetDependency: Codable, Hashable {
             return "library"
         case .package:
             return "package"
+        case .packagePlugin:
+            return "packagePlugin"
         case .sdk:
             return "sdk"
         case .xcframework:

--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -53,7 +53,8 @@ public enum TargetDependency: Codable, Hashable {
     /// - Parameters:
     ///   - product: The name of the output product. ${PRODUCT_NAME} inside Xcode.
     ///              e.g. RxSwift
-    case package(product: String)
+    ///   - isPlugin: Must be explicitly set to `true` if this is a plugin to generate the Xcode project correctly.
+    case package(product: String, isPlugin: Bool = false)
 
     /// Dependency on system library or framework
     ///

--- a/Sources/TuistCache/ContentHashing/DependenciesContentHasher.swift
+++ b/Sources/TuistCache/ContentHashing/DependenciesContentHasher.swift
@@ -105,7 +105,7 @@ public final class DependenciesContentHasher: DependenciesContentHashing {
             } else {
                 return try contentHasher.hash("library-\(libraryHash)-\(publicHeadersHash)")
             }
-        case let .package(product):
+        case let .package(product), let .packagePlugin(product):
             return try contentHasher.hash("package-\(product)")
         case let .sdk(name, status):
             return try contentHasher.hash("sdk-\(name)-\(status)")

--- a/Sources/TuistCore/Graph/CircularDependencyLinter.swift
+++ b/Sources/TuistCore/Graph/CircularDependencyLinter.swift
@@ -114,7 +114,7 @@ public class CircularDependencyLinter: CircularDependencyLinting {
                 cache: cache,
                 cycleDetector: cycleDetector
             )
-        case .framework, .xcframework, .library, .package, .sdk, .xctest:
+        case .framework, .xcframework, .library, .package, .packagePlugin, .sdk, .xctest:
             break
         }
     }

--- a/Sources/TuistCore/Graph/GraphLoader.swift
+++ b/Sources/TuistCore/Graph/GraphLoader.swift
@@ -161,8 +161,8 @@ public final class GraphLoader: GraphLoading {
         case let .sdk(name, status):
             return try loadSDK(name: name, platform: fromPlatform, status: status, source: .system)
 
-        case let .package(product, _):
-            return try loadPackage(fromPath: path, productName: product)
+        case let .package(product, isPlugin):
+            return try loadPackage(fromPath: path, productName: product, isPlugin: isPlugin)
 
         case .xctest:
             return try loadXCTestSDK(platform: fromPlatform)
@@ -250,13 +250,14 @@ public final class GraphLoader: GraphLoading {
         return .sdk(name: metadata.name, path: metadata.path, status: metadata.status, source: metadata.source)
     }
 
-    private func loadPackage(fromPath: AbsolutePath, productName: String) throws -> GraphDependency {
+    private func loadPackage(fromPath: AbsolutePath, productName: String, isPlugin: Bool) throws -> GraphDependency {
         // TODO: `fromPath` isn't quite correct as it reflects the path where the dependency was declared
         // and doesn't uniquely identify it. It's been copied from the previous implementation to maintain
         // existing behaviour and should be fixed separately
         .packageProduct(
             path: fromPath,
-            product: productName
+            product: productName,
+            isPlugin: isPlugin
         )
     }
 

--- a/Sources/TuistCore/Graph/GraphLoader.swift
+++ b/Sources/TuistCore/Graph/GraphLoader.swift
@@ -161,7 +161,7 @@ public final class GraphLoader: GraphLoading {
         case let .sdk(name, status):
             return try loadSDK(name: name, platform: fromPlatform, status: status, source: .system)
 
-        case let .package(product):
+        case let .package(product, _):
             return try loadPackage(fromPath: path, productName: product)
 
         case .xctest:

--- a/Sources/TuistCore/Graph/GraphLoader.swift
+++ b/Sources/TuistCore/Graph/GraphLoader.swift
@@ -161,8 +161,11 @@ public final class GraphLoader: GraphLoading {
         case let .sdk(name, status):
             return try loadSDK(name: name, platform: fromPlatform, status: status, source: .system)
 
-        case let .package(product, isPlugin):
-            return try loadPackage(fromPath: path, productName: product, isPlugin: isPlugin)
+        case let .package(product):
+            return try loadPackage(fromPath: path, productName: product, isPlugin: false)
+
+        case let .packagePlugin(product):
+            return try loadPackage(fromPath: path, productName: product, isPlugin: true)
 
         case .xctest:
             return try loadXCTestSDK(platform: fromPlatform)

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -610,7 +610,7 @@ extension PBXTarget {
             // Build file
             let buildFile = PBXBuildFile(product: productDependency)
             pbxproj.add(object: buildFile)
-            
+
             packageProductDependencies.append(productDependency)
 
             // Link the product

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -179,8 +179,10 @@ final class LinkGenerator: LinkGenerating {
     ) throws {
         for dependency in target.dependencies {
             switch dependency {
-            case let .package(product: product, isPlugin):
-                try pbxTarget.addSwiftPackageProduct(productName: product, isPlugin: isPlugin, pbxproj: pbxproj)
+            case let .package(product: product):
+                try pbxTarget.addSwiftPackageProduct(productName: product, isPlugin: false, pbxproj: pbxproj)
+            case let .packagePlugin(product: product):
+                try pbxTarget.addSwiftPackageProduct(productName: product, isPlugin: true, pbxproj: pbxproj)
             default:
                 break
             }

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -601,16 +601,16 @@ extension PBXTarget {
         let productDependency = XCSwiftPackageProductDependency(productName: productName, isPlugin: isPlugin)
         pbxproj.add(object: productDependency)
 
-        // Build file
-        let buildFile = PBXBuildFile(product: productDependency)
-        pbxproj.add(object: buildFile)
-
         if isPlugin {
             let pluginDependency = PBXTargetDependency(product: productDependency)
             pbxproj.add(object: pluginDependency)
 
             dependencies.append(pluginDependency)
         } else {
+            // Build file
+            let buildFile = PBXBuildFile(product: productDependency)
+            pbxproj.add(object: buildFile)
+            
             packageProductDependencies.append(productDependency)
 
             // Link the product

--- a/Sources/TuistGenerator/GraphViz/GraphToGraphVizMapper.swift
+++ b/Sources/TuistGenerator/GraphViz/GraphToGraphVizMapper.swift
@@ -97,7 +97,7 @@ extension GraphDependency {
             return path.basenameWithoutExt
         case let .bundle(path):
             return path.basenameWithoutExt
-        case let .packageProduct(path: _, product: product):
+        case let .packageProduct(path: _, product: product, _):
             return product
         case let .sdk(
             name: name,

--- a/Sources/TuistGenerator/GraphViz/GraphToGraphVizMapper.swift
+++ b/Sources/TuistGenerator/GraphViz/GraphToGraphVizMapper.swift
@@ -97,7 +97,7 @@ extension GraphDependency {
             return path.basenameWithoutExt
         case let .bundle(path):
             return path.basenameWithoutExt
-        case let .packageProduct(path: _, product: product, _):
+        case let .packageProduct(path: _, product: product, isPlugin: _):
             return product
         case let .sdk(
             name: name,

--- a/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -146,9 +146,9 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
             return linking == .static
         case .bundle:
             return true
-        case .packageProduct:
+        case let .packageProduct(_, _, isPlugin):
             // Swift package products are currently assumed to be static
-            return true
+            return !isPlugin
         case let .target(name, path):
             guard let target = graphTraverser.target(path: path, name: name) else { return false }
             return target.target.product.isStatic

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -286,6 +286,8 @@ extension TargetDependency {
             return "library"
         case .package:
             return "package"
+        case .packagePlugin:
+            return "packagePlugin"
         case .sdk:
             return "sdk"
         case .xcframework:
@@ -307,7 +309,9 @@ extension TargetDependency {
             return path.basename
         case let .library(path, _, _):
             return path.basename
-        case let .package(product, _):
+        case let .package(product):
+            return product
+        case let .packagePlugin(product):
             return product
         case let .sdk(name, _):
             return name

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -307,7 +307,7 @@ extension TargetDependency {
             return path.basename
         case let .library(path, _, _):
             return path.basename
-        case let .package(product):
+        case let .package(product, _):
             return product
         case let .sdk(name, _):
             return name

--- a/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -173,7 +173,7 @@ public final class ModuleMapMapper: WorkspaceMapping {
                 }
                 dependentProject = dependentProjectFromPath
                 dependentTarget = dependentTargetFromName
-            case .framework, .xcframework, .library, .package, .sdk, .xctest:
+            case .framework, .xcframework, .library, .package, .packagePlugin, .sdk, .xctest:
                 continue
             }
 

--- a/Sources/TuistGraph/Graph/GraphDependency.swift
+++ b/Sources/TuistGraph/Graph/GraphDependency.swift
@@ -34,7 +34,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
     case bundle(path: AbsolutePath)
 
     /// A dependency that represents a package product.
-    case packageProduct(path: AbsolutePath, product: String)
+    case packageProduct(path: AbsolutePath, product: String, isPlugin: Bool = false)
 
     /// A dependency that represents a target that is defined in the project at the given path.
     case target(name: String, path: AbsolutePath)
@@ -56,10 +56,11 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         case let .bundle(path):
             hasher.combine("bundle")
             hasher.combine(path)
-        case let .packageProduct(path, product):
+        case let .packageProduct(path, product, isPlugin):
             hasher.combine("package")
             hasher.combine(path)
             hasher.combine(product)
+            hasher.combine(isPlugin)
         case let .target(name, path):
             hasher.combine("target")
             hasher.combine(name)
@@ -120,7 +121,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
             return "library '\(path.basename)'"
         case let .bundle(path):
             return "bundle '\(path.basename)'"
-        case let .packageProduct(_, product):
+        case let .packageProduct(_, product, _):
             return "package '\(product)'"
         case let .target(name, _):
             return "target '\(name)'"

--- a/Sources/TuistGraph/Models/TargetDependency.swift
+++ b/Sources/TuistGraph/Models/TargetDependency.swift
@@ -12,7 +12,7 @@ public enum TargetDependency: Equatable, Hashable, Codable {
     case framework(path: AbsolutePath)
     case xcframework(path: AbsolutePath)
     case library(path: AbsolutePath, publicHeaders: AbsolutePath, swiftModuleMap: AbsolutePath?)
-    case package(product: String)
+    case package(product: String, isPlugin: Bool = false)
     case sdk(name: String, status: SDKStatus)
     case xctest
 }

--- a/Sources/TuistGraph/Models/TargetDependency.swift
+++ b/Sources/TuistGraph/Models/TargetDependency.swift
@@ -12,7 +12,8 @@ public enum TargetDependency: Equatable, Hashable, Codable {
     case framework(path: AbsolutePath)
     case xcframework(path: AbsolutePath)
     case library(path: AbsolutePath, publicHeaders: AbsolutePath, swiftModuleMap: AbsolutePath?)
-    case package(product: String, isPlugin: Bool = false)
+    case package(product: String)
+    case packagePlugin(product: String)
     case sdk(name: String, status: SDKStatus)
     case xctest
 }

--- a/Sources/TuistKit/Services/GraphService.swift
+++ b/Sources/TuistKit/Services/GraphService.swift
@@ -239,9 +239,9 @@ extension ProjectAutomation.Target {
                 swiftModuleMap: swiftModuleMap?.pathString
             )
         case let .package(product):
-            return .package(product: product, isPlugin: false)
+            return .package(product: product)
         case let .packagePlugin(product):
-            return .package(product: product, isPlugin: true)
+            return .packagePlugin(product: product)
         case let .sdk(name, status):
             let projectAutomationStatus: ProjectAutomation.SDKStatus
             switch status {

--- a/Sources/TuistKit/Services/GraphService.swift
+++ b/Sources/TuistKit/Services/GraphService.swift
@@ -238,8 +238,10 @@ extension ProjectAutomation.Target {
                 publicHeaders: publicHeaders.pathString,
                 swiftModuleMap: swiftModuleMap?.pathString
             )
-        case let .package(product, isPlugin):
-            return .package(product: product, isPlugin: isPlugin)
+        case let .package(product):
+            return .package(product: product, isPlugin: false)
+        case let .packagePlugin(product):
+            return .package(product: product, isPlugin: true)
         case let .sdk(name, status):
             let projectAutomationStatus: ProjectAutomation.SDKStatus
             switch status {

--- a/Sources/TuistKit/Services/GraphService.swift
+++ b/Sources/TuistKit/Services/GraphService.swift
@@ -238,8 +238,8 @@ extension ProjectAutomation.Target {
                 publicHeaders: publicHeaders.pathString,
                 swiftModuleMap: swiftModuleMap?.pathString
             )
-        case let .package(product):
-            return .package(product: product)
+        case let .package(product, isPlugin):
+            return .package(product: product, isPlugin: isPlugin)
         case let .sdk(name, status):
             let projectAutomationStatus: ProjectAutomation.SDKStatus
             switch status {

--- a/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
@@ -47,8 +47,8 @@ extension TuistGraph.TargetDependency {
                     swiftModuleMap: try swiftModuleMap.map { try generatorPaths.resolve(path: $0) }
                 ),
             ]
-        case let .package(product):
-            return [.package(product: product)]
+        case let .package(product, isPlugin):
+            return [.package(product: product, isPlugin: isPlugin)]
         case let .sdk(name, type, status):
             return [
                 .sdk(

--- a/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
@@ -47,8 +47,10 @@ extension TuistGraph.TargetDependency {
                     swiftModuleMap: try swiftModuleMap.map { try generatorPaths.resolve(path: $0) }
                 ),
             ]
-        case let .package(product, isPlugin):
-            return [.package(product: product, isPlugin: isPlugin)]
+        case let .package(product):
+            return [.package(product: product, isPlugin: false)]
+        case let .packagePlugin(product):
+            return [.package(product: product, isPlugin: true)]
         case let .sdk(name, type, status):
             return [
                 .sdk(

--- a/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
@@ -48,9 +48,9 @@ extension TuistGraph.TargetDependency {
                 ),
             ]
         case let .package(product):
-            return [.package(product: product, isPlugin: false)]
+            return [.package(product: product)]
         case let .packagePlugin(product):
-            return [.package(product: product, isPlugin: true)]
+            return [.packagePlugin(product: product)]
         case let .sdk(name, type, status):
             return [
                 .sdk(

--- a/Tests/TuistCoreTests/Graph/GraphLoaderTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphLoaderTests.swift
@@ -526,7 +526,7 @@ final class GraphLoaderTests: TuistUnitTestCase {
         XCTAssertEqual(graph.dependencies, [
             .target(name: "A", path: "/A"): Set([
                 .packageProduct(path: "/A", product: "PackagePlugin", isPlugin: true),
-            ])
+            ]),
         ])
     }
 

--- a/Tests/TuistCoreTests/Graph/GraphLoaderTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphLoaderTests.swift
@@ -500,7 +500,7 @@ final class GraphLoaderTests: TuistUnitTestCase {
     func test_loadWorkspace_package_plugin() throws {
         // Given
         let targetA = Target.test(name: "A", dependencies: [
-            .package(product: "PackagePlugin", isPlugin: true),
+            .packagePlugin(product: "PackagePlugin"),
         ])
 
         let projectA = Project.test(path: "/A", name: "A", targets: [targetA], packages: [

--- a/Tests/TuistCoreTests/Graph/GraphLoaderTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphLoaderTests.swift
@@ -497,6 +497,39 @@ final class GraphLoaderTests: TuistUnitTestCase {
         ])
     }
 
+    func test_loadWorkspace_package_plugin() throws {
+        // Given
+        let targetA = Target.test(name: "A", dependencies: [
+            .package(product: "PackagePlugin", isPlugin: true),
+        ])
+
+        let projectA = Project.test(path: "/A", name: "A", targets: [targetA], packages: [
+            .local(path: "/Packages/PackagePlugin"),
+        ])
+
+        let workspace = Workspace.test(path: "/", name: "Workspace", projects: ["/A"])
+
+        let subject = makeSubject()
+
+        // When
+        let graph = try subject.loadWorkspace(
+            workspace: workspace,
+            projects: [
+                projectA,
+            ]
+        )
+
+        // Then
+        XCTAssertEqual(graph.packages, [
+            "/A": ["/Packages/PackagePlugin": .local(path: "/Packages/PackagePlugin")],
+        ])
+        XCTAssertEqual(graph.dependencies, [
+            .target(name: "A", path: "/A"): Set([
+                .packageProduct(path: "/A", product: "PackagePlugin", isPlugin: true),
+            ])
+        ])
+    }
+
     // MARK: - Error Cases
 
     func test_loadWorkspace_missingProjectReferenceInWorkspace() throws {

--- a/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
@@ -71,7 +71,7 @@ class StaticProductsGraphLinterTests: XCTestCase {
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
             appDependency: Set([frameworkDependency, plugin]),
             frameworkDependency: Set([plugin]),
-            plugin : Set(),
+            plugin: Set(),
         ]
         let graph = Graph.test(
             path: path,

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -17,7 +17,7 @@ let dependencies = Dependencies(
         .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", .exact("0.2.0")),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .exact("2.10.1")),
         .package(url: "https://github.com/SwiftGen/SwiftGen", .exact("6.5.1")),
-        .package(url: "https://github.com/tuist/XcodeProj.git", .exact("8.11.0")),
+        .package(url: "https://github.com/tuist/XcodeProj.git", .exact("8.14.0")),
         .package(url: "https://github.com/tuist/swift-openapi-runtime", .branch("swift-tools-version")),
         .package(url: "https://github.com/tuist/swift-openapi-urlsession", .branch("swift-tools-version")),
     ],

--- a/Tuist/Dependencies/Lockfiles/Package.resolved
+++ b/Tuist/Dependencies/Lockfiles/Package.resolved
@@ -229,8 +229,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "revision" : "59c7f8d4201a7bd37ef509edebd5777811c7de78",
-        "version" : "8.11.0"
+        "revision" : "d5c0c2770d62f9aab78be071f13f3364835d5a65",
+        "version" : "8.14.0"
       }
     },
     {

--- a/projects/tuist/fixtures/ios_app_with_actions/App/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_actions/App/Project.swift
@@ -2,6 +2,9 @@ import ProjectDescription
 
 let project = Project(
     name: "App",
+    packages: [
+        .remote(url: "https://github.com/realm/SwiftLint", requirement: .exact("0.52.4"))
+    ],
     targets: [
         Target(
             name: "App",
@@ -36,6 +39,9 @@ let project = Project(
                 .post(tool: "/bin/echo", arguments: ["rocks"], name: "Rocks"),
                 .pre(path: "script.sh", name: "Run script"),
                 .pre(script: "echo 'Hello World'", name: "Embedded script"),
+            ],
+            dependencies: [
+                .packagePlugin(product: "SwiftLintPlugin")
             ]
         ),
     ]

--- a/projects/tuist/fixtures/ios_app_with_actions/App/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_actions/App/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App",
     packages: [
-        .remote(url: "https://github.com/realm/SwiftLint", requirement: .exact("0.52.4"))
+        .remote(url: "https://github.com/realm/SwiftLint", requirement: .exact("0.52.4")),
     ],
     targets: [
         Target(
@@ -41,7 +41,7 @@ let project = Project(
                 .pre(script: "echo 'Hello World'", name: "Embedded script"),
             ],
             dependencies: [
-                .packagePlugin(product: "SwiftLintPlugin")
+                .packagePlugin(product: "SwiftLintPlugin"),
             ]
         ),
     ]


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4909 (needs https://github.com/tuist/XcodeProj/pull/784)

### Short description 📝

Allow users to run Swift Package Manager Plugins when building a Target.

### How to test the changes locally 🧐

Integrate a SPM Package that contains a Plugin Product and add it as a dependency to a Target using `.packagePlugin(product: "<PluginName>")`
Observe how the Xcode Target now contains an item "<PluginName>" in "Run Build Tool Plug-ins" section in "Build Phases" tab.

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
