### PR TITLE
[WIP] Fix compilation issues when integrating Swift Packages with Objective-C code

### DIFF
--- a/projects/tuist/features/build.feature
+++ b/projects/tuist/features/build.feature
@@ -47,3 +47,10 @@ Feature: Build projects using Tuist build
     Then a directory Builds/release-iphonesimulator/App.swiftmodule exists
     Then a directory Builds/release-iphonesimulator/FrameworkA.framework exists
     Then a directory Builds/release-iphonesimulator/FrameworkA.framework.dSYM exists
+
+  Scenario: The project is an iOS application with Objective-C Swift Packages (app_with_objc_packages)
+    Given that tuist is available
+    And I have a working directory
+    Then I copy the fixture app_with_objc_packages into the working directory
+    Then tuist generates the project
+    Then tuist builds the project

--- a/projects/tuist/fixtures/README.md
+++ b/projects/tuist/fixtures/README.md
@@ -313,3 +313,8 @@ A project that contains logs to verify that the logs are forwarded by Tuist.
 ## macos_app_with_extensions
 
 The project contains a macOS app with various types of extensions.
+
+## app_with_objc_packages
+
+The project is an iOS app that depends on Swift Packages that contain Objective-C code.
+As [reported by users](https://github.com/tuist/tuist/issues/4688), when Tuist integrated those packages it led to compilation errors.

--- a/projects/tuist/fixtures/app_with_objc_packages/.gitignore
+++ b/projects/tuist/fixtures/app_with_objc_packages/.gitignore
@@ -1,0 +1,66 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two 
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace
+
+### Tuist managed dependencies ###
+Tuist/Dependencies

--- a/projects/tuist/fixtures/app_with_objc_packages/App/AppDelegate.swift
+++ b/projects/tuist/fixtures/app_with_objc_packages/App/AppDelegate.swift
@@ -1,0 +1,24 @@
+import UIKit
+import GoogleSignInSwift
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        let viewController = UIViewController()
+        viewController.view.backgroundColor = .white
+        window?.rootViewController = viewController
+        window?.makeKeyAndVisible()
+        
+        let swiftButton = GoogleSignInButton {
+        }
+
+        return true
+    }
+
+    func hello() -> String {
+        "AppDelegate.hello()"
+    }
+}

--- a/projects/tuist/fixtures/app_with_objc_packages/Project.swift
+++ b/projects/tuist/fixtures/app_with_objc_packages/Project.swift
@@ -1,0 +1,19 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        Target(
+            name: "App",
+            platform: .iOS,
+            product: .app,
+            bundleId: "io.tuist.app",
+            infoPlist: .default,
+            sources: "App/**",
+            dependencies: [
+                .external(name: "GoogleSignIn"),
+                .external(name: "GoogleSignInSwift"),
+            ]
+        )
+    ]
+)

--- a/projects/tuist/fixtures/app_with_objc_packages/Tuist/Dependencies.swift
+++ b/projects/tuist/fixtures/app_with_objc_packages/Tuist/Dependencies.swift
@@ -1,0 +1,8 @@
+import ProjectDescription
+
+let dependencies = Dependencies(
+    swiftPackageManager: [
+        .package(url: "https://github.com/google/GoogleSignIn-iOS", .upToNextMinor(from: "7.0.0"))
+    ],
+    platforms: [.iOS]
+)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4688

### Short description 📝

We received [many reports](https://github.com/tuist/tuist/issues/4688) about compilation errors when integrating Swift Packages that contain Objective-C code. Based on some users' feedback, it turns out that we are missing some build settings in the generated projects.

### How to test the changes locally 🧐

- Fetch dependencies `swift run tuist fetch --path ./projects/tuist/fixtures/app_with_objc_packages`
- Generate a project `swift run tuist generate --path ./projects/tuist/fixtures/app_with_objc_packages`
- The `App` target should compile successfully.

### Contributor checklist ✅

- [ ] The code has been linted using run `./fourier lint tuist --fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
