### PR TITLE
Support for specifying the target for variable expansion in the RunAction

### DIFF
--- a/Sources/ProjectDescription/RunAction.swift
+++ b/Sources/ProjectDescription/RunAction.swift
@@ -30,6 +30,9 @@ public struct RunAction: Equatable, Codable {
 
     /// List of diagnostics options to set to the action.
     public let diagnosticsOptions: [SchemeDiagnosticsOption]
+    
+    /// A target that will be used to expand the variables defined inside Environment Variables definition (e.g. $SOURCE_ROOT)
+    public let expandVariableFromTarget: TargetReference?
 
     init(
         configuration: ConfigurationName,
@@ -40,7 +43,8 @@ public struct RunAction: Equatable, Codable {
         executable: TargetReference? = nil,
         arguments: Arguments? = nil,
         options: RunActionOptions = .options(),
-        diagnosticsOptions: [SchemeDiagnosticsOption] = [.mainThreadChecker, .performanceAntipatternChecker]
+        diagnosticsOptions: [SchemeDiagnosticsOption] = [.mainThreadChecker, .performanceAntipatternChecker],
+        expandVariableFromTarget: TargetReference? = nil
     ) {
         self.configuration = configuration
         self.attachDebugger = attachDebugger
@@ -51,6 +55,7 @@ public struct RunAction: Equatable, Codable {
         self.arguments = arguments
         self.options = options
         self.diagnosticsOptions = diagnosticsOptions
+        self.expandVariableFromTarget = expandVariableFromTarget
     }
 
     /// Returns a run action.
@@ -63,6 +68,7 @@ public struct RunAction: Equatable, Codable {
     ///   - arguments: Command line arguments passed on launch and environment variables.
     ///   - options: List of options to set to the action.
     ///   - diagnosticsOptions: List of diagnostics options to set to the action.
+    ///   - expandVariableFromTarget: A target that will be used to expand the variables defined inside Environment Variables definition (e.g. $SOURCE_ROOT)
     /// - Returns: Run action.
     public static func runAction(
         configuration: ConfigurationName = .debug,
@@ -73,7 +79,8 @@ public struct RunAction: Equatable, Codable {
         executable: TargetReference? = nil,
         arguments: Arguments? = nil,
         options: RunActionOptions = .options(),
-        diagnosticsOptions: [SchemeDiagnosticsOption] = [.mainThreadChecker]
+        diagnosticsOptions: [SchemeDiagnosticsOption] = [.mainThreadChecker],
+        expandVariableFromTarget: TargetReference? = nil
     ) -> RunAction {
         RunAction(
             configuration: configuration,
@@ -84,7 +91,9 @@ public struct RunAction: Equatable, Codable {
             executable: executable,
             arguments: arguments,
             options: options,
-            diagnosticsOptions: diagnosticsOptions
+            diagnosticsOptions: diagnosticsOptions,
+            expandVariableFromTarget: expandVariableFromTarget
         )
     }
 }
+

--- a/Sources/ProjectDescription/RunAction.swift
+++ b/Sources/ProjectDescription/RunAction.swift
@@ -30,7 +30,7 @@ public struct RunAction: Equatable, Codable {
 
     /// List of diagnostics options to set to the action.
     public let diagnosticsOptions: [SchemeDiagnosticsOption]
-    
+
     /// A target that will be used to expand the variables defined inside Environment Variables definition (e.g. $SOURCE_ROOT)
     public let expandVariableFromTarget: TargetReference?
 
@@ -96,4 +96,3 @@ public struct RunAction: Equatable, Codable {
         )
     }
 }
-

--- a/Sources/ProjectDescription/RunAction.swift
+++ b/Sources/ProjectDescription/RunAction.swift
@@ -68,7 +68,7 @@ public struct RunAction: Equatable, Codable {
     ///   - arguments: Command line arguments passed on launch and environment variables.
     ///   - options: List of options to set to the action.
     ///   - diagnosticsOptions: List of diagnostics options to set to the action.
-    ///   - expandVariableFromTarget: A target that will be used to expand the variables defined inside Environment Variables definition (e.g. $SOURCE_ROOT)
+    ///   - expandVariableFromTarget: A target that will be used to expand the variables defined inside Environment Variables definition (e.g. $SOURCE_ROOT). When nil, it does not expand any variables.
     /// - Returns: Run action.
     public static func runAction(
         configuration: ConfigurationName = .debug,

--- a/Sources/ProjectDescription/TestAction.swift
+++ b/Sources/ProjectDescription/TestAction.swift
@@ -64,7 +64,7 @@ public struct TestAction: Equatable, Codable {
     ///   - arguments: Arguments passed when running the tests.
     ///   - configuration: Configuration to be used.
     ///   - attachDebugger: A boolean controlling whether a debugger is attached to the process running the tests.
-    ///   - expandVariableFromTarget: A target that will be used to expand the variables defined inside Environment Variables definition
+    ///   - expandVariableFromTarget: A target that will be used to expand the variables defined inside Environment Variables definition. When nil, it does not expand any variables.
     ///   - preActions: Actions to execute before running the tests.
     ///   - postActions: Actions to execute after running the tests.
     ///   - options: Test options.

--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -458,6 +458,22 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
                 macroExpansion = buildableReference
             }
         }
+        
+        if let expandVariableFromTarget = scheme.runAction?.expandVariableFromTarget {
+            guard let graphTarget = graphTraverser.target(
+                path: expandVariableFromTarget.projectPath,
+                name: expandVariableFromTarget.name
+            ) else { return nil }
+            
+            guard let buildableReference = try createBuildableReference(
+                graphTarget: graphTarget,
+                graphTraverser: graphTraverser,
+                rootPath: rootPath,
+                generatedProjects: generatedProjects
+            ) else { return nil }
+            
+            macroExpansion = buildableReference
+        }
 
         var commandlineArguments: XCScheme.CommandLineArguments?
         var environments: [XCScheme.EnvironmentVariable]?
@@ -968,3 +984,4 @@ extension TestAction {
         )
     }
 }
+

--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -472,7 +472,12 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
                 generatedProjects: generatedProjects
             ) else { return nil }
 
-            macroExpansion = buildableReference
+            // Xcode assigns the runnable target to the expand variables target by default.
+            // Assigning the runnable target to macro expansion can lead to an unstable .xcscheme.
+            // Initially, macroExpansion is added, but when the edit scheme editor is opened and closed, macroExpansion gets removed.
+            if buildableProductRunnable?.buildableReference != buildableReference {
+                macroExpansion = buildableReference
+            }
         }
 
         var commandlineArguments: XCScheme.CommandLineArguments?

--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -459,19 +459,17 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
             }
         }
 
-        if let expandVariableFromTarget = scheme.runAction?.expandVariableFromTarget {
-            guard let graphTarget = graphTraverser.target(
-                path: expandVariableFromTarget.projectPath,
-                name: expandVariableFromTarget.name
-            ) else { return nil }
-
-            guard let buildableReference = try createBuildableReference(
-                graphTarget: graphTarget,
-                graphTraverser: graphTraverser,
-                rootPath: rootPath,
-                generatedProjects: generatedProjects
-            ) else { return nil }
-
+        if let expandVariableFromTarget = scheme.runAction?.expandVariableFromTarget,
+           let graphTarget = graphTraverser.target(
+               path: expandVariableFromTarget.projectPath,
+               name: expandVariableFromTarget.name
+           ),
+           let buildableReference = try createBuildableReference(
+               graphTarget: graphTarget,
+               graphTraverser: graphTraverser,
+               rootPath: rootPath,
+               generatedProjects: generatedProjects
+           ) {
             // Xcode assigns the runnable target to the expand variables target by default.
             // Assigning the runnable target to macro expansion can lead to an unstable .xcscheme.
             // Initially, macroExpansion is added, but when the edit scheme editor is opened and closed, macroExpansion gets removed.

--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -469,7 +469,8 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
                graphTraverser: graphTraverser,
                rootPath: rootPath,
                generatedProjects: generatedProjects
-           ) {
+           )
+        {
             // Xcode assigns the runnable target to the expand variables target by default.
             // Assigning the runnable target to macro expansion can lead to an unstable .xcscheme.
             // Initially, macroExpansion is added, but when the edit scheme editor is opened and closed, macroExpansion gets removed.

--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -458,20 +458,20 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
                 macroExpansion = buildableReference
             }
         }
-        
+
         if let expandVariableFromTarget = scheme.runAction?.expandVariableFromTarget {
             guard let graphTarget = graphTraverser.target(
                 path: expandVariableFromTarget.projectPath,
                 name: expandVariableFromTarget.name
             ) else { return nil }
-            
+
             guard let buildableReference = try createBuildableReference(
                 graphTarget: graphTarget,
                 graphTraverser: graphTraverser,
                 rootPath: rootPath,
                 generatedProjects: generatedProjects
             ) else { return nil }
-            
+
             macroExpansion = buildableReference
         }
 
@@ -984,4 +984,3 @@ extension TestAction {
         )
     }
 }
-

--- a/Sources/TuistGenerator/Linter/SchemeLinter.swift
+++ b/Sources/TuistGenerator/Linter/SchemeLinter.swift
@@ -86,8 +86,13 @@ extension SchemeLinter {
 
         for scheme in schemes {
             if let testAction = scheme.testAction,
-               let target = testAction.expandVariableFromTarget
-            {
+               let target = testAction.expandVariableFromTarget {
+                if !targetNames.contains(target.name) {
+                    issues.append(missingExpandVariablesTargetIssue(missingTargetName: target.name, schemaName: scheme.name))
+                }
+            }
+            if let runAction = scheme.runAction,
+               let target = runAction.expandVariableFromTarget {
                 if !targetNames.contains(target.name) {
                     issues.append(missingExpandVariablesTargetIssue(missingTargetName: target.name, schemaName: scheme.name))
                 }
@@ -142,3 +147,4 @@ extension SchemeLinter {
         return issues
     }
 }
+

--- a/Sources/TuistGenerator/Linter/SchemeLinter.swift
+++ b/Sources/TuistGenerator/Linter/SchemeLinter.swift
@@ -97,6 +97,9 @@ extension SchemeLinter {
             {
                 if !targetNames.contains(target.name) {
                     issues.append(missingExpandVariablesTargetIssue(missingTargetName: target.name, schemaName: scheme.name))
+                } else if let buildTargetNames = scheme.buildAction?.targets.map(\.name),
+                          !buildTargetNames.contains(target.name) {
+                    issues.append(missingExpandVariablesTargetInBuildActionIssue(missingTargetName: target.name, schemaName: scheme.name))
                 }
             }
         }
@@ -130,6 +133,11 @@ extension SchemeLinter {
         return LintingIssue(reason: reason, severity: .error)
     }
 
+    private func missingExpandVariablesTargetInBuildActionIssue(missingTargetName: String, schemaName: String) -> LintingIssue {
+        let reason = "The target '\(missingTargetName)' specified in \(schemaName) expandVariableFromTarget isn't defined in the scheme's build action."
+        return LintingIssue(reason: reason, severity: .error)
+    }
+    
     private func projectSchemeCantReferenceRemoteTargets(schemes: [Scheme], project: Project) -> [LintingIssue] {
         schemes.flatMap { projectSchemeCantReferenceRemoteTargets(scheme: $0, project: project) }
     }

--- a/Sources/TuistGenerator/Linter/SchemeLinter.swift
+++ b/Sources/TuistGenerator/Linter/SchemeLinter.swift
@@ -86,13 +86,15 @@ extension SchemeLinter {
 
         for scheme in schemes {
             if let testAction = scheme.testAction,
-               let target = testAction.expandVariableFromTarget {
+               let target = testAction.expandVariableFromTarget
+            {
                 if !targetNames.contains(target.name) {
                     issues.append(missingExpandVariablesTargetIssue(missingTargetName: target.name, schemaName: scheme.name))
                 }
             }
             if let runAction = scheme.runAction,
-               let target = runAction.expandVariableFromTarget {
+               let target = runAction.expandVariableFromTarget
+            {
                 if !targetNames.contains(target.name) {
                     issues.append(missingExpandVariablesTargetIssue(missingTargetName: target.name, schemaName: scheme.name))
                 }
@@ -147,4 +149,3 @@ extension SchemeLinter {
         return issues
     }
 }
-

--- a/Sources/TuistGenerator/Linter/SchemeLinter.swift
+++ b/Sources/TuistGenerator/Linter/SchemeLinter.swift
@@ -98,8 +98,13 @@ extension SchemeLinter {
                 if !targetNames.contains(target.name) {
                     issues.append(missingExpandVariablesTargetIssue(missingTargetName: target.name, schemaName: scheme.name))
                 } else if let buildTargetNames = scheme.buildAction?.targets.map(\.name),
-                          !buildTargetNames.contains(target.name) {
-                    issues.append(missingExpandVariablesTargetInBuildActionIssue(missingTargetName: target.name, schemaName: scheme.name))
+                          !buildTargetNames.contains(target.name)
+                {
+                    issues
+                        .append(missingExpandVariablesTargetInBuildActionIssue(
+                            missingTargetName: target.name,
+                            schemaName: scheme.name
+                        ))
                 }
             }
         }
@@ -134,10 +139,11 @@ extension SchemeLinter {
     }
 
     private func missingExpandVariablesTargetInBuildActionIssue(missingTargetName: String, schemaName: String) -> LintingIssue {
-        let reason = "The target '\(missingTargetName)' specified in \(schemaName) expandVariableFromTarget isn't defined in the scheme's build action."
+        let reason =
+            "The target '\(missingTargetName)' specified in \(schemaName) expandVariableFromTarget isn't defined in the scheme's build action."
         return LintingIssue(reason: reason, severity: .error)
     }
-    
+
     private func projectSchemeCantReferenceRemoteTargets(schemes: [Scheme], project: Project) -> [LintingIssue] {
         schemes.flatMap { projectSchemeCantReferenceRemoteTargets(scheme: $0, project: project) }
     }

--- a/Sources/TuistGraph/Models/RunAction.swift
+++ b/Sources/TuistGraph/Models/RunAction.swift
@@ -14,6 +14,7 @@ public struct RunAction: Equatable, Codable {
     public let arguments: Arguments?
     public let options: RunActionOptions
     public let diagnosticsOptions: Set<SchemeDiagnosticsOption>
+    public let expandVariableFromTarget: TargetReference?
 
     // MARK: - Init
 
@@ -27,7 +28,8 @@ public struct RunAction: Equatable, Codable {
         filePath: AbsolutePath?,
         arguments: Arguments?,
         options: RunActionOptions = .init(),
-        diagnosticsOptions: Set<SchemeDiagnosticsOption>
+        diagnosticsOptions: Set<SchemeDiagnosticsOption>,
+        expandVariableFromTarget: TargetReference? = nil
     ) {
         self.configurationName = configurationName
         self.attachDebugger = attachDebugger
@@ -39,5 +41,6 @@ public struct RunAction: Equatable, Codable {
         self.arguments = arguments
         self.options = options
         self.diagnosticsOptions = diagnosticsOptions
+        self.expandVariableFromTarget = expandVariableFromTarget
     }
 }

--- a/Sources/TuistGraphTesting/Models/RunAction+TestData.swift
+++ b/Sources/TuistGraphTesting/Models/RunAction+TestData.swift
@@ -32,4 +32,3 @@ extension RunAction {
         )
     }
 }
-

--- a/Sources/TuistGraphTesting/Models/RunAction+TestData.swift
+++ b/Sources/TuistGraphTesting/Models/RunAction+TestData.swift
@@ -14,7 +14,8 @@ extension RunAction {
         filePath: AbsolutePath? = nil,
         arguments: Arguments? = Arguments.test(),
         options: RunActionOptions = .init(),
-        diagnosticsOptions: Set<SchemeDiagnosticsOption> = [.mainThreadChecker, .performanceAntipatternChecker]
+        diagnosticsOptions: Set<SchemeDiagnosticsOption> = [.mainThreadChecker, .performanceAntipatternChecker],
+        expandVariableFromTarget: TargetReference? = nil
     ) -> RunAction {
         RunAction(
             configurationName: configurationName,
@@ -26,7 +27,9 @@ extension RunAction {
             filePath: filePath,
             arguments: arguments,
             options: options,
-            diagnosticsOptions: diagnosticsOptions
+            diagnosticsOptions: diagnosticsOptions,
+            expandVariableFromTarget: expandVariableFromTarget
         )
     }
 }
+

--- a/Sources/TuistLoader/Models+ManifestMappers/RunAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/RunAction+ManifestMapper.swift
@@ -54,7 +54,7 @@ extension TuistGraph.RunAction {
                 name: $0.targetName
             )
         }
-        
+
         return TuistGraph.RunAction(
             configurationName: configurationName,
             attachDebugger: manifest.attachDebugger,
@@ -70,4 +70,3 @@ extension TuistGraph.RunAction {
         )
     }
 }
-

--- a/Sources/TuistLoader/Models+ManifestMappers/RunAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/RunAction+ManifestMapper.swift
@@ -47,6 +47,14 @@ extension TuistGraph.RunAction {
 
         let diagnosticsOptions = Set(manifest.diagnosticsOptions.map { TuistGraph.SchemeDiagnosticsOption.from(manifest: $0) })
 
+        let expandVariablesFromTarget: TuistGraph.TargetReference?
+        expandVariablesFromTarget = try manifest.expandVariableFromTarget.map {
+            TuistGraph.TargetReference(
+                projectPath: try generatorPaths.resolveSchemeActionProjectPath($0.projectPath),
+                name: $0.targetName
+            )
+        }
+        
         return TuistGraph.RunAction(
             configurationName: configurationName,
             attachDebugger: manifest.attachDebugger,
@@ -57,7 +65,9 @@ extension TuistGraph.RunAction {
             filePath: nil,
             arguments: arguments,
             options: options,
-            diagnosticsOptions: diagnosticsOptions
+            diagnosticsOptions: diagnosticsOptions,
+            expandVariableFromTarget: expandVariablesFromTarget
         )
     }
 }
+

--- a/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -490,7 +490,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let projectPath = try AbsolutePath(validating: "/Project")
         let app = Target.test(name: "App", product: .app)
         let framework = Target.test(name: "Framework", product: .framework)
-        
+
         let runAction = RunAction.test(
             executable: TargetReference(projectPath: projectPath, name: "App"),
             filePath: projectPath,
@@ -504,17 +504,17 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
             targets: [
                 project.path: [
                     app.name: app,
-                    framework.name: framework
+                    framework.name: framework,
                 ],
             ],
             dependencies: [
                 .target(name: app.name, path: projectPath): [
                     .target(name: framework.name, path: projectPath),
-                ]
+                ],
             ]
         )
         let graphTraverser = GraphTraverser(graph: graph)
-        
+
         // When
         let got = try subject.schemeLaunchAction(
             scheme: scheme,
@@ -525,7 +525,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
 
         // Then
         let result = try XCTUnwrap(got)
-        
+
         XCTAssertEqual(result.buildConfiguration, "Debug")
         XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
         XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
@@ -534,8 +534,8 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         XCTAssertEqual(result.macroExpansion?.blueprintName, "Framework")
         XCTAssertEqual(result.macroExpansion?.referencedContainer, "container:Project.xcodeproj")
         XCTAssertEqual(result.macroExpansion?.buildableIdentifier, "primary")
-     }
-    
+    }
+
     func test_schemeTestAction_with_codeCoverageTargets() throws {
         // Given
         let projectPath = try AbsolutePath(validating: "/somepath/Project")

--- a/projects/tuist/fixtures/ios_app_with_custom_scheme/Workspace.swift
+++ b/projects/tuist/fixtures/ios_app_with_custom_scheme/Workspace.swift
@@ -39,9 +39,11 @@ let customAppScheme = Scheme(
     ),
     runAction: .runAction(
         executable: .project(path: "App", target: "App"),
+        arguments: Arguments(environment: ["path": "$(SRCROOT)"], launchArguments: []),
         options: .options(
             storeKitConfigurationPath: "App/Config/ProjectStoreKitConfig.storekit"
-        )
+        ),
+        expandVariableFromTarget: .project(path: "Frameworks/Framework1", target: "Framework1")
     ),
     archiveAction: .archiveAction(configuration: "Debug", customArchiveName: "Something2")
 )


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/3510

### Short description 📝
This PR introduces a new property called `expandVariableFromTarget` to the RunAction. 
With this feature, users can specify a target from which variables will be expanded in the scheme's run action.

### How to test the changes locally 🧐
1. Generate a project with defined `expandVariableFromTarget` for RunAction.
2. Go to `Edit scheme` -> `Run` and verify if the `Expand Variable Based On` field is correctly set.

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
