### PR TITLE
Fix GraphViz layout algorithm documentation name typo

### DIFF
--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -51,7 +51,7 @@ struct GraphCommand: AsyncParsableCommand, HasTrackableParameters {
 
     @Option(
         name: [.customShort("a"), .customLong("algorithm")],
-        help: "Available formats: dot, neato, twopi, circo, fdp, sfddp, patchwork"
+        help: "Available formats: dot, neato, twopi, circo, fdp, sfdp, patchwork"
     )
     var layoutAlgorithm: GraphViz.LayoutAlgorithm = .dot
 


### PR DESCRIPTION
### Short description 📝

`tuist graph --help` command shows that `sfddp` is a valid algorithm. But when using it you get the following error:
```
tuist graph -t -d -a sffdp

Error: The value 'sffdp' is invalid for '-a <algorithm>'
Help:  -a <algorithm>  Available formats: dot, neato, twopi, circo, fdp, sfddp, patchwork
Usage: tuist graph [--skip-test-targets] [--skip-external-dependencies] [--platform <platform>] [--format <format>] [--no-open] [--algorithm <algorithm>] [<targets> ...] [--path <path>] [--output-path <output-path>]
  See 'tuist graph --help' for more information.
```

https://github.com/SwiftDocOrg/GraphViz/blob/74b6cbd8c5ecea9f64d84c4e1c88d65604dd033f/Sources/GraphViz/Core/Rendering/LayoutAlgorithm.swift#L19 the correct value is `sfdp`

### How to test the changes locally 🧐

* `swift run tuist graph --help` shows the correct algorithm name `sfdp`

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
