### PR TITLE
Only apply the stale workflow when certain labels are present

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -49,4 +49,5 @@ jobs:
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
           days-before-stale: 30
-          days-before-close: 5
+          days-before-close: 15
+          only-labels: needs-response,needs-reproduction


### PR DESCRIPTION
### Short description 📝
@danyf90 suggested that we tweak the stale workflow to make sure we don't close issues or PRs that are still relevant but have no activity. This PR extends the time between flagging something as stale and closing it, and also limits the logic to only the issues and PRs that have been labeled with `needs-response` and `needs-reproduction` (as suggested by @fortmarek)
