### PR TITLE
Use stencil to render filenames during scaffold generation

### DIFF
--- a/Sources/TuistScaffold/TemplateGenerator.swift
+++ b/Sources/TuistScaffold/TemplateGenerator.swift
@@ -52,30 +52,32 @@ public final class TemplateGenerator: TemplateGenerating {
         template: Template,
         attributes: [String: String]
     ) throws -> [Template.Item] {
-        try attributes.reduce(template.items) { items, attribute in
+        let environment = stencilSwiftEnvironment()
+        return try attributes.reduce(template.items) { items, attribute in
             try items.map {
-                let path = RelativePath(
-                    $0.path.pathString
-                        .replacingOccurrences(of: "{{ \(attribute.key) }}", with: attribute.value)
+                let renderedPathString = try environment.renderTemplate(
+                    string: $0.path.pathString,
+                    context: attributes
                 )
+                let path = RelativePath(renderedPathString)
 
                 var contents = $0.contents
                 if case let Template.Contents.file(path) = contents {
+                    let renderedPathString = try environment.renderTemplate(
+                        string: path.pathString,
+                        context: attributes
+                    )
                     contents = .file(
-                        try AbsolutePath(
-                            validating: path.pathString.replacingOccurrences(
-                                of: "{{ \(attribute.key) }}", with: attribute.value
-                            )
-                        )
+                        try AbsolutePath(validating: renderedPathString)
                     )
                 }
                 if case let Template.Contents.directory(path) = contents {
+                    let renderedPathString = try environment.renderTemplate(
+                        string: path.pathString,
+                        context: attributes
+                    )
                     contents = .directory(
-                        try AbsolutePath(
-                            validating: path.pathString.replacingOccurrences(
-                                of: "{{ \(attribute.key) }}", with: attribute.value
-                            )
-                        )
+                        try AbsolutePath(validating: renderedPathString)
                     )
                 }
 

--- a/Tests/TuistScaffoldTests/TemplateGeneratorTests.swift
+++ b/Tests/TuistScaffoldTests/TemplateGeneratorTests.swift
@@ -46,7 +46,11 @@ final class TemplateGeneratorTests: TuistTestCase {
 
     func test_directories_with_attributes() throws {
         // Given
-        let directories = [RelativePath("{{ name|lowercase }}"), RelativePath("{{ aName }}"), RelativePath("{{ name }}/{{ bName }}")]
+        let directories = [
+            RelativePath("{{ name|lowercase }}"),
+            RelativePath("{{ aName }}"),
+            RelativePath("{{ name }}/{{ bName }}"),
+        ]
         let items = directories.map {
             Template.Item.test(path: RelativePath($0.pathString + "/file.swift"))
         }

--- a/Tests/TuistScaffoldTests/TemplateGeneratorTests.swift
+++ b/Tests/TuistScaffoldTests/TemplateGeneratorTests.swift
@@ -46,7 +46,7 @@ final class TemplateGeneratorTests: TuistTestCase {
 
     func test_directories_with_attributes() throws {
         // Given
-        let directories = [RelativePath("{{ name }}"), RelativePath("{{ aName }}"), RelativePath("{{ name }}/{{ bName }}")]
+        let directories = [RelativePath("{{ name|lowercase }}"), RelativePath("{{ aName }}"), RelativePath("{{ name }}/{{ bName }}")]
         let items = directories.map {
             Template.Item.test(path: RelativePath($0.pathString + "/file.swift"))
         }
@@ -63,7 +63,7 @@ final class TemplateGeneratorTests: TuistTestCase {
             template: template,
             to: destinationPath,
             attributes: [
-                "name": "test_name",
+                "name": "Test_Name",
                 "aName": "test",
                 "bName": "nested_dir",
             ]


### PR DESCRIPTION
### Short description 📝

This PR uses stencil to render filenames for scaffold generation rather than string substitution. This enables the use of stencil modifiers in filenames.

See slack discussion [here](https://tuistapp.slack.com/archives/C018QG7U7SN/p1690530667850049?thread_ts=1689272380.354639&cid=C018QG7U7SN)

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
