### PR TITLE
Add tuist cloud project delete command

### DIFF
--- a/Sources/TuistCloud/OpenAPI/Client.swift
+++ b/Sources/TuistCloud/OpenAPI/Client.swift
@@ -45,6 +45,16 @@ public struct Client: APIProtocol {
                 )
                 var request: OpenAPIRuntime.Request = .init(path: path, method: .get)
                 suppressMutabilityWarning(&request)
+                try converter.setQueryItemAsText(
+                    in: &request,
+                    name: "account_name",
+                    value: input.query.account_name
+                )
+                try converter.setQueryItemAsText(
+                    in: &request,
+                    name: "project_name",
+                    value: input.query.project_name
+                )
                 try converter.setHeaderFieldAsText(
                     in: &request.headerFields,
                     name: "accept",
@@ -234,6 +244,132 @@ public struct Client: APIProtocol {
                             transforming: { value in .json(value) }
                         )
                     return .badRequest(.init(headers: headers, body: body))
+                default: return .undocumented(statusCode: response.statusCode, .init())
+                }
+            }
+        )
+    }
+    /// - Remark: HTTP `DELETE /api/projects/{id}`.
+    /// - Remark: Generated from `#/paths//api/projects/{id}/delete(deleteProject)`.
+    public func deleteProject(_ input: Operations.deleteProject.Input) async throws
+        -> Operations.deleteProject.Output
+    {
+        try await client.send(
+            input: input,
+            forOperation: Operations.deleteProject.id,
+            serializer: { input in
+                let path = try converter.renderedRequestPath(
+                    template: "/api/projects/{}",
+                    parameters: [input.path.id]
+                )
+                var request: OpenAPIRuntime.Request = .init(path: path, method: .delete)
+                suppressMutabilityWarning(&request)
+                try converter.setHeaderFieldAsText(
+                    in: &request.headerFields,
+                    name: "accept",
+                    value: "application/json"
+                )
+                return request
+            },
+            deserializer: { response in
+                switch response.statusCode {
+                case 204:
+                    let headers: Operations.deleteProject.Output.NoContent.Headers = .init()
+                    return .noContent(.init(headers: headers, body: nil))
+                case 404:
+                    let headers: Operations.deleteProject.Output.NotFound.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.deleteProject.Output.NotFound.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .notFound(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.deleteProject.Output.Unauthorized.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.deleteProject.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
+                default: return .undocumented(statusCode: response.statusCode, .init())
+                }
+            }
+        )
+    }
+    /// - Remark: HTTP `GET /api/projects/{account_name}/{project_name}`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_name}/{project_name}/get(getProject)`.
+    public func getProject(_ input: Operations.getProject.Input) async throws
+        -> Operations.getProject.Output
+    {
+        try await client.send(
+            input: input,
+            forOperation: Operations.getProject.id,
+            serializer: { input in
+                let path = try converter.renderedRequestPath(
+                    template: "/api/projects/{}/{}",
+                    parameters: [input.path.account_name, input.path.project_name]
+                )
+                var request: OpenAPIRuntime.Request = .init(path: path, method: .get)
+                suppressMutabilityWarning(&request)
+                try converter.setHeaderFieldAsText(
+                    in: &request.headerFields,
+                    name: "accept",
+                    value: "application/json"
+                )
+                return request
+            },
+            deserializer: { response in
+                switch response.statusCode {
+                case 200:
+                    let headers: Operations.getProject.Output.Ok.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.getProject.Output.Ok.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas.Project.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .ok(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.getProject.Output.Unauthorized.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.getProject.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
+                case 404:
+                    let headers: Operations.getProject.Output.NotFound.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.getProject.Output.NotFound.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .notFound(.init(headers: headers, body: body))
                 default: return .undocumented(statusCode: response.statusCode, .init())
                 }
             }

--- a/Sources/TuistCloud/OpenAPI/Types.swift
+++ b/Sources/TuistCloud/OpenAPI/Types.swift
@@ -23,6 +23,14 @@ public protocol APIProtocol: Sendable {
     /// - Remark: Generated from `#/paths//api/organizations/post(createOrganization)`.
     func createOrganization(_ input: Operations.createOrganization.Input) async throws
         -> Operations.createOrganization.Output
+    /// - Remark: HTTP `DELETE /api/projects/{id}`.
+    /// - Remark: Generated from `#/paths//api/projects/{id}/delete(deleteProject)`.
+    func deleteProject(_ input: Operations.deleteProject.Input) async throws
+        -> Operations.deleteProject.Output
+    /// - Remark: HTTP `GET /api/projects/{account_name}/{project_name}`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_name}/{project_name}/get(getProject)`.
+    func getProject(_ input: Operations.getProject.Input) async throws
+        -> Operations.getProject.Output
 }
 /// Server URLs defined in the OpenAPI document.
 public enum Servers {
@@ -133,8 +141,17 @@ public enum Operations {
             }
             public var path: Operations.listProjects.Input.Path
             public struct Query: Sendable, Equatable, Hashable {
+                public var account_name: Swift.String?
+                public var project_name: Swift.String?
                 /// Creates a new `Query`.
-                public init() {}
+                ///
+                /// - Parameters:
+                ///   - account_name:
+                ///   - project_name:
+                public init(account_name: Swift.String? = nil, project_name: Swift.String? = nil) {
+                    self.account_name = account_name
+                    self.project_name = project_name
+                }
             }
             public var query: Operations.listProjects.Input.Query
             public struct Headers: Sendable, Equatable, Hashable {
@@ -533,12 +550,321 @@ public enum Operations {
                     self.body = body
                 }
             }
-            /// The project could not be created because of a validation error.
+            /// The organization could not be created because of a validation error.
             ///
             /// - Remark: Generated from `#/paths//api/organizations/post(createOrganization)/responses/400`.
             ///
             /// HTTP response code: `400 badRequest`.
             case badRequest(Operations.createOrganization.Output.BadRequest)
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+    }
+    /// - Remark: HTTP `DELETE /api/projects/{id}`.
+    /// - Remark: Generated from `#/paths//api/projects/{id}/delete(deleteProject)`.
+    public enum deleteProject {
+        public static let id: String = "deleteProject"
+        public struct Input: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Equatable, Hashable {
+                public var id: Swift.Int
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - id:
+                public init(id: Swift.Int) { self.id = id }
+            }
+            public var path: Operations.deleteProject.Input.Path
+            public struct Query: Sendable, Equatable, Hashable {
+                /// Creates a new `Query`.
+                public init() {}
+            }
+            public var query: Operations.deleteProject.Input.Query
+            public struct Headers: Sendable, Equatable, Hashable {
+                /// Creates a new `Headers`.
+                public init() {}
+            }
+            public var headers: Operations.deleteProject.Input.Headers
+            public struct Cookies: Sendable, Equatable, Hashable {
+                /// Creates a new `Cookies`.
+                public init() {}
+            }
+            public var cookies: Operations.deleteProject.Input.Cookies
+            @frozen public enum Body: Sendable, Equatable, Hashable {}
+            public var body: Operations.deleteProject.Input.Body?
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - query:
+            ///   - headers:
+            ///   - cookies:
+            ///   - body:
+            public init(
+                path: Operations.deleteProject.Input.Path,
+                query: Operations.deleteProject.Input.Query = .init(),
+                headers: Operations.deleteProject.Input.Headers = .init(),
+                cookies: Operations.deleteProject.Input.Cookies = .init(),
+                body: Operations.deleteProject.Input.Body? = nil
+            ) {
+                self.path = path
+                self.query = query
+                self.headers = headers
+                self.cookies = cookies
+                self.body = body
+            }
+        }
+        @frozen public enum Output: Sendable, Equatable, Hashable {
+            public struct NoContent: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.deleteProject.Output.NoContent.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {}
+                /// Received HTTP response body
+                public var body: Operations.deleteProject.Output.NoContent.Body?
+                /// Creates a new `NoContent`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.deleteProject.Output.NoContent.Headers = .init(),
+                    body: Operations.deleteProject.Output.NoContent.Body? = nil
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// A project was successfully deleted.
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{id}/delete(deleteProject)/responses/204`.
+            ///
+            /// HTTP response code: `204 noContent`.
+            case noContent(Operations.deleteProject.Output.NoContent)
+            public struct NotFound: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.deleteProject.Output.NotFound.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.deleteProject.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.deleteProject.Output.NotFound.Headers = .init(),
+                    body: Operations.deleteProject.Output.NotFound.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The project could not be deleted because it was not found.
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{id}/delete(deleteProject)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.deleteProject.Output.NotFound)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.deleteProject.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.deleteProject.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.deleteProject.Output.Unauthorized.Headers = .init(),
+                    body: Operations.deleteProject.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The project could not be created because the user is not authorized to do the action.
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{id}/delete(deleteProject)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.deleteProject.Output.Unauthorized)
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+    }
+    /// - Remark: HTTP `GET /api/projects/{account_name}/{project_name}`.
+    /// - Remark: Generated from `#/paths//api/projects/{account_name}/{project_name}/get(getProject)`.
+    public enum getProject {
+        public static let id: String = "getProject"
+        public struct Input: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Equatable, Hashable {
+                public var account_name: Swift.String
+                public var project_name: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - account_name:
+                ///   - project_name:
+                public init(account_name: Swift.String, project_name: Swift.String) {
+                    self.account_name = account_name
+                    self.project_name = project_name
+                }
+            }
+            public var path: Operations.getProject.Input.Path
+            public struct Query: Sendable, Equatable, Hashable {
+                /// Creates a new `Query`.
+                public init() {}
+            }
+            public var query: Operations.getProject.Input.Query
+            public struct Headers: Sendable, Equatable, Hashable {
+                /// Creates a new `Headers`.
+                public init() {}
+            }
+            public var headers: Operations.getProject.Input.Headers
+            public struct Cookies: Sendable, Equatable, Hashable {
+                /// Creates a new `Cookies`.
+                public init() {}
+            }
+            public var cookies: Operations.getProject.Input.Cookies
+            @frozen public enum Body: Sendable, Equatable, Hashable {}
+            public var body: Operations.getProject.Input.Body?
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - query:
+            ///   - headers:
+            ///   - cookies:
+            ///   - body:
+            public init(
+                path: Operations.getProject.Input.Path,
+                query: Operations.getProject.Input.Query = .init(),
+                headers: Operations.getProject.Input.Headers = .init(),
+                cookies: Operations.getProject.Input.Cookies = .init(),
+                body: Operations.getProject.Input.Body? = nil
+            ) {
+                self.path = path
+                self.query = query
+                self.headers = headers
+                self.cookies = cookies
+                self.body = body
+            }
+        }
+        @frozen public enum Output: Sendable, Equatable, Hashable {
+            public struct Ok: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.getProject.Output.Ok.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas.Project)
+                }
+                /// Received HTTP response body
+                public var body: Operations.getProject.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.getProject.Output.Ok.Headers = .init(),
+                    body: Operations.getProject.Output.Ok.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// A success response with the project.
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_name}/{project_name}/get(getProject)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.getProject.Output.Ok)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.getProject.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.getProject.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.getProject.Output.Unauthorized.Headers = .init(),
+                    body: Operations.getProject.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// You don't have the permission to view the project.
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_name}/{project_name}/get(getProject)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.getProject.Output.Unauthorized)
+            public struct NotFound: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.getProject.Output.NotFound.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.getProject.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.getProject.Output.NotFound.Headers = .init(),
+                    body: Operations.getProject.Output.NotFound.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The project was not found.
+            ///
+            /// - Remark: Generated from `#/paths//api/projects/{account_name}/{project_name}/get(getProject)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.getProject.Output.NotFound)
             /// Undocumented response.
             ///
             /// A response with a code that is not documented in the OpenAPI document.

--- a/Sources/TuistCloud/OpenAPI/cloud.yml
+++ b/Sources/TuistCloud/OpenAPI/cloud.yml
@@ -9,6 +9,17 @@ paths:
   /api/projects:
     get:
       operationId: listProjects
+      parameters:
+          - name: account_name
+            in: query
+            description: Filter items by account name
+            schema:
+              type: string
+          - name: project_name
+            in: query
+            description: Filter items by project name
+            schema:
+              type: string
       responses:
         "200":
           description: A success response with all available cloud projects.
@@ -71,7 +82,67 @@ paths:
               schema:
                 $ref: "#/components/schemas/Organization"
         "400":
-          description: The project could not be created because of a validation error.
+          description: The organization could not be created because of a validation error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/projects/{id}:
+    delete:
+      operationId: deleteProject
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: The id of the project that should be deleted.
+          schema:
+            type: integer
+      responses:
+        "204":
+          description: A project was successfully deleted.
+        "404":
+          description: The project could not be deleted because it was not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: The project could not be created because the user is not authorized to do the action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /api/projects/{account_name}/{project_name}:
+    get:
+      operationId: getProject
+      parameters:
+        - in: path
+          name: account_name
+          required: true
+          description: The account name of the project to show.
+          schema:
+            type: string
+        - in: path
+          name: project_name
+          required: true
+          description: The name of the project to show.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A success response with the project.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "401":
+          description: You don't have the permission to view the project.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: The project was not found.
           content:
             application/json:
               schema:

--- a/Sources/TuistCloud/Services/CreateProjectServiceNext.swift
+++ b/Sources/TuistCloud/Services/CreateProjectServiceNext.swift
@@ -26,7 +26,7 @@ enum CreateProjectNextServiceError: FatalError {
     var description: String {
         switch self {
         case let .unknownError(statusCode):
-            return "The project could not be created due to an unknown cloud response of \(statusCode)."
+            return "The project could not be created due to an unknown Cloud response of \(statusCode)."
         case let .badRequest(message):
             return message
         }

--- a/Sources/TuistCloud/Services/DeleteProjectService.swift
+++ b/Sources/TuistCloud/Services/DeleteProjectService.swift
@@ -1,0 +1,68 @@
+import Foundation
+import OpenAPIURLSession
+import TuistSupport
+
+public protocol DeleteProjectServicing {
+    func deleteProject(
+        projectId: Int,
+        serverURL: URL
+    ) async throws
+}
+
+enum DeleteProjectServiceError: FatalError {
+    case unknownError(Int)
+    case notFound(String)
+    case unauthorized(String)
+
+    var type: ErrorType {
+        switch self {
+        case .unknownError:
+            return .bug
+        case .unauthorized, .notFound:
+            return .abort
+        }
+    }
+
+    var description: String {
+        switch self {
+        case let .unknownError(statusCode):
+            return "The project could not be deleted due to an unknown cloud response of \(statusCode)."
+        case let .unauthorized(message), let .notFound(message):
+            return message
+        }
+    }
+}
+
+public final class DeleteProjectService: DeleteProjectServicing {
+    public init() {}
+
+    public func deleteProject(
+        projectId: Int,
+        serverURL: URL
+    ) async throws {
+        let client = Client.cloud(serverURL: serverURL)
+
+        let response = try await client.deleteProject(
+            .init(
+                path: .init(id: projectId)
+            )
+        )
+        switch response {
+        case .noContent:
+            // noop
+            break
+        case let .notFound(notFound):
+            switch notFound.body {
+            case let .json(error):
+                throw DeleteProjectServiceError.notFound(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteProjectServiceError.notFound(error.message)
+            }
+        case let .undocumented(statusCode: statusCode, _):
+            throw CreateProjectNextServiceError.unknownError(statusCode)
+        }
+    }
+}

--- a/Sources/TuistCloud/Services/GetProjectService.swift
+++ b/Sources/TuistCloud/Services/GetProjectService.swift
@@ -1,0 +1,75 @@
+import Foundation
+import OpenAPIURLSession
+import TuistSupport
+
+public protocol GetProjectServicing {
+    func getProject(
+        accountName: String,
+        projectName: String,
+        serverURL: URL
+    ) async throws -> CloudProject
+}
+
+enum GetProjectServiceError: FatalError {
+    case unknownError(Int)
+    case notFound(String)
+    case unauthorized(String)
+
+    var type: ErrorType {
+        switch self {
+        case .unknownError:
+            return .bug
+        case .unauthorized, .notFound:
+            return .abort
+        }
+    }
+
+    var description: String {
+        switch self {
+        case let .unknownError(statusCode):
+            return "We could not get the project due to an unknown cloud response of \(statusCode)."
+        case let .unauthorized(message), let .notFound(message):
+            return message
+        }
+    }
+}
+
+public final class GetProjectService: GetProjectServicing {
+    public init() {}
+
+    public func getProject(
+        accountName: String,
+        projectName: String,
+        serverURL: URL
+    ) async throws -> CloudProject {
+        let client = Client.cloud(serverURL: serverURL)
+
+        let response = try await client.getProject(
+            .init(
+                path: .init(
+                    account_name: accountName,
+                    project_name: projectName
+                )
+            )
+        )
+        switch response {
+        case let .ok(okResponse):
+            switch okResponse.body {
+            case let .json(project):
+                return CloudProject(project)
+            }
+        case let .notFound(notFound):
+            switch notFound.body {
+            case let .json(error):
+                throw GetProjectServiceError.notFound(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw GetProjectServiceError.notFound(error.message)
+            }
+        case let .undocumented(statusCode: statusCode, _):
+            throw GetProjectServiceError.unknownError(statusCode)
+        }
+    }
+}

--- a/Sources/TuistCloud/Services/ListProjectsService.swift
+++ b/Sources/TuistCloud/Services/ListProjectsService.swift
@@ -6,6 +6,12 @@ public protocol ListProjectsServicing {
     func listProjects(
         serverURL: URL
     ) async throws -> [CloudProject]
+
+    func listProjects(
+        serverURL: URL,
+        accountName: String?,
+        projectName: String?
+    ) async throws -> [CloudProject]
 }
 
 enum ListProjectsServiceError: FatalError {
@@ -32,11 +38,26 @@ public final class ListProjectsService: ListProjectsServicing {
     public func listProjects(
         serverURL: URL
     ) async throws -> [CloudProject] {
+        try await listProjects(
+            serverURL: serverURL,
+            accountName: nil,
+            projectName: nil
+        )
+    }
+
+    public func listProjects(
+        serverURL: URL,
+        accountName: String?,
+        projectName: String?
+    ) async throws -> [CloudProject] {
         let client = Client.cloud(serverURL: serverURL)
 
         let response = try await client.listProjects(
             .init(
-                query: .init()
+                query: .init(
+                    account_name: accountName,
+                    project_name: projectName
+                )
             )
         )
         switch response {
@@ -46,7 +67,7 @@ public final class ListProjectsService: ListProjectsServicing {
                 return json.projects.map(CloudProject.init)
             }
         case let .undocumented(statusCode: statusCode, _):
-            throw CreateProjectNextServiceError.unknownError(statusCode)
+            throw ListProjectsServiceError.unknownError(statusCode)
         }
     }
 }

--- a/Sources/TuistCloudTesting/Services/MockDeleteProjectService.swift
+++ b/Sources/TuistCloudTesting/Services/MockDeleteProjectService.swift
@@ -1,0 +1,14 @@
+import Foundation
+import TuistCloud
+
+public final class MockDeleteProjectService: DeleteProjectServicing {
+    public init() {}
+
+    public var deleteProjectStub: ((Int, URL) async throws -> Void)?
+    public func deleteProject(
+        projectId: Int,
+        serverURL: URL
+    ) async throws {
+        try await deleteProjectStub?(projectId, serverURL)
+    }
+}

--- a/Sources/TuistCloudTesting/Services/MockGetProjectService.swift
+++ b/Sources/TuistCloudTesting/Services/MockGetProjectService.swift
@@ -1,0 +1,20 @@
+import Foundation
+import TuistCloud
+
+public final class MockGetProjectService: GetProjectServicing {
+    public init() {}
+
+    // swiftlint:disable:next large_tuple
+    public var getProjectStub: ((String, String, URL) async throws -> CloudProject)?
+    public func getProject(
+        accountName: String,
+        projectName: String,
+        serverURL: URL
+    ) async throws -> CloudProject {
+        try await getProjectStub?(
+            accountName,
+            projectName,
+            serverURL
+        ) ?? CloudProject(id: 0, fullName: "test/test")
+    }
+}

--- a/Sources/TuistCloudTesting/Services/MockListProjectsService.swift
+++ b/Sources/TuistCloudTesting/Services/MockListProjectsService.swift
@@ -4,8 +4,17 @@ import TuistCloud
 public final class MockListProjectsService: ListProjectsServicing {
     public init() {}
 
-    public var listProjectsStub: ((URL) async throws -> [CloudProject])?
-    public func listProjects(serverURL: URL) async throws -> [CloudProject] {
-        try await listProjectsStub?(serverURL) ?? []
+    public func listProjects(serverURL: URL) async throws -> [TuistCloud.CloudProject] {
+        try await listProjectsStub?(serverURL, nil, nil) ?? []
+    }
+
+    // swiftlint:disable:next large_tuple
+    public var listProjectsStub: ((URL, String?, String?) async throws -> [CloudProject])?
+    public func listProjects(
+        serverURL: URL,
+        accountName: String?,
+        projectName: String?
+    ) async throws -> [CloudProject] {
+        try await listProjectsStub?(serverURL, accountName, projectName) ?? []
     }
 }

--- a/Sources/TuistKit/Commands/Cloud/CloudAuthCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudAuthCommand.swift
@@ -7,11 +7,19 @@ struct CloudAuthCommand: ParsableCommand {
         CommandConfiguration(
             commandName: "auth",
             _superCommandName: "cloud",
-            abstract: "Authenticates the user on the server with the URL defined in the Config.swift file"
+            abstract: "Authenticates the user for using Cloud"
         )
     }
 
+    @Option(
+        name: .long,
+        help: "URL to the cloud server."
+    )
+    var serverURL: String?
+
     func run() throws {
-        try CloudAuthService().authenticate()
+        try CloudAuthService().authenticate(
+            serverURL: serverURL
+        )
     }
 }

--- a/Sources/TuistKit/Commands/Cloud/CloudProjectCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudProjectCommand.swift
@@ -11,6 +11,7 @@ struct CloudProjectCommand: ParsableCommand {
             subcommands: [
                 CloudProjectCreateCommand.self,
                 CloudProjectListCommand.self,
+                CloudProjectDeleteCommand.self,
             ]
         )
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudProjectDeleteCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudProjectDeleteCommand.swift
@@ -1,0 +1,39 @@
+import ArgumentParser
+import Foundation
+import TuistSupport
+
+struct CloudProjectDeleteCommand: AsyncParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "delete",
+            _superCommandName: "project",
+            abstract: "Create a new project."
+        )
+    }
+
+    @Argument(
+        help: "The project to delete.",
+        completion: .directory
+    )
+    var project: String
+
+    @Option(
+        name: .shortAndLong,
+        help: "The organization that the project belongs to. By default, this is your personal Cloud account."
+    )
+    var organization: String?
+
+    @Option(
+        name: .long,
+        help: "URL to the cloud server."
+    )
+    var serverURL: String?
+
+    func run() async throws {
+        try await CloudProjectDeleteService().run(
+            projectName: project,
+            organizationName: organization,
+            serverURL: serverURL
+        )
+    }
+}

--- a/Sources/TuistKit/Services/Cloud/CloudAuthService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudAuthService.swift
@@ -5,63 +5,29 @@ import TuistLoader
 import TuistSupport
 
 protocol CloudAuthServicing: AnyObject {
-    /// It reads the cloud URL from the project's Config.swift and
-    /// authenticates the user on that server storing the credentials
-    /// locally on the keychain
-    func authenticate() throws
-}
-
-enum CloudAuthServiceError: FatalError, Equatable {
-    case missingCloudURL
-
-    /// Error description.
-    var description: String {
-        switch self {
-        case .missingCloudURL:
-            return "The cloud URL attribute is missing in your project's configuration."
-        }
-    }
-
-    /// Error type.
-    var type: ErrorType {
-        switch self {
-        case .missingCloudURL:
-            return .abort
-        }
-    }
+    func authenticate(
+        serverURL: String?
+    ) throws
 }
 
 final class CloudAuthService: CloudAuthServicing {
-    let cloudSessionController: CloudSessionControlling
-    let configLoader: ConfigLoading
-
-    // MARK: - Init
-
-    convenience init() {
-        let manifestLoader = ManifestLoader()
-        let configLoader = ConfigLoader(manifestLoader: manifestLoader)
-        self.init(
-            cloudSessionController: CloudSessionController(),
-            configLoader: configLoader
-        )
-    }
+    private let cloudSessionController: CloudSessionControlling
+    private let cloudURLService: CloudURLServicing
 
     init(
-        cloudSessionController: CloudSessionControlling,
-        configLoader: ConfigLoading
+        cloudSessionController: CloudSessionControlling = CloudSessionController(),
+        cloudURLService: CloudURLServicing = CloudURLService()
     ) {
         self.cloudSessionController = cloudSessionController
-        self.configLoader = configLoader
+        self.cloudURLService = cloudURLService
     }
 
     // MARK: - CloudAuthServicing
 
-    func authenticate() throws {
-        let path = FileHandler.shared.currentPath
-        let config = try configLoader.loadConfig(path: path)
-        guard let cloudURL = config.cloud?.url else {
-            throw CloudAuthServiceError.missingCloudURL
-        }
+    func authenticate(
+        serverURL: String?
+    ) throws {
+        let cloudURL = try cloudURLService.url(serverURL: serverURL)
         try cloudSessionController.authenticate(serverURL: cloudURL)
     }
 }

--- a/Sources/TuistKit/Services/Cloud/CloudProjectDeleteService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudProjectDeleteService.swift
@@ -1,0 +1,54 @@
+import Foundation
+import TSCBasic
+import TuistCloud
+import TuistLoader
+import TuistSupport
+
+protocol CloudProjectDeleteServicing {
+    func run(
+        projectName: String,
+        organizationName: String?,
+        serverURL: String?
+    ) async throws
+}
+
+final class CloudProjectDeleteService: CloudProjectDeleteServicing {
+    private let deleteProjectService: DeleteProjectServicing
+    private let getProjectService: GetProjectServicing
+    private let credentialsStore: CredentialsStoring
+    private let cloudURLService: CloudURLServicing
+
+    init(
+        deleteProjectService: DeleteProjectServicing = DeleteProjectService(),
+        getProjectService: GetProjectServicing = GetProjectService(),
+        credentialsStore: CredentialsStoring = CredentialsStore(),
+        cloudURLService: CloudURLServicing = CloudURLService()
+    ) {
+        self.deleteProjectService = deleteProjectService
+        self.getProjectService = getProjectService
+        self.credentialsStore = credentialsStore
+        self.cloudURLService = cloudURLService
+    }
+
+    func run(
+        projectName: String,
+        organizationName _: String?,
+        serverURL: String?
+    ) async throws {
+        let cloudURL = try cloudURLService.url(serverURL: serverURL)
+
+        let credentials = try credentialsStore.get(serverURL: cloudURL)
+        let project = try await getProjectService.getProject(
+            accountName: credentials.account,
+            projectName: projectName,
+            serverURL: cloudURL
+        )
+
+        try await deleteProjectService.deleteProject(
+            projectId: project.id,
+            serverURL: cloudURL
+        )
+
+        logger.info("Successfully deleted the \(project.fullName) project.")
+    }
+}

--- a/Sources/TuistSupportTesting/Credentials/MockCredentialsStore.swift
+++ b/Sources/TuistSupportTesting/Credentials/MockCredentialsStore.swift
@@ -13,6 +13,10 @@ public final class MockCredentialsStore: CredentialsStoring {
         credentials[serverURL]
     }
 
+    public func get(serverURL: URL) throws -> Credentials {
+        credentials[serverURL]!
+    }
+
     public func delete(serverURL: URL) throws {
         credentials.removeValue(forKey: serverURL)
     }

--- a/Tests/TuistKitTests/Services/Cloud/CloudAuthServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudAuthServiceTests.swift
@@ -13,73 +13,33 @@ import XCTest
 @testable import TuistKit
 @testable import TuistSupportTesting
 
-final class CloudAuthServiceErrorTests: TuistUnitTestCase {
-    func test_description_when_missingScaleURL() {
-        // Given
-        let subject = CloudAuthServiceError.missingCloudURL
-
-        // When
-        let got = subject.description
-
-        // Then
-        XCTAssertEqual(got, "The cloud URL attribute is missing in your project's configuration.")
-    }
-
-    func test_type_when_missingCloudURL() {
-        // Given
-        let subject = CloudAuthServiceError.missingCloudURL
-
-        // When
-        let got = subject.type
-
-        // Then
-        XCTAssertEqual(got, .abort)
-    }
-}
-
 final class CloudAuthServiceTests: TuistUnitTestCase {
     var cloudSessionController: MockCloudSessionController!
-    var configLoader: MockConfigLoader!
     var subject: CloudAuthService!
 
     override func setUp() {
         super.setUp()
         cloudSessionController = MockCloudSessionController()
-        configLoader = MockConfigLoader()
         subject = CloudAuthService(
-            cloudSessionController: cloudSessionController,
-            configLoader: configLoader
+            cloudSessionController: cloudSessionController
         )
     }
 
     override func tearDown() {
         cloudSessionController = nil
-        configLoader = nil
         subject = nil
         super.tearDown()
     }
 
-    func test_authenticate_when_cloudURL_is_missing() {
-        // Given
-        configLoader.loadConfigStub = { _ in
-            Config.test(cloud: nil)
-        }
-
-        // Then
-        XCTAssertThrowsSpecific(try subject.authenticate(), CloudAuthServiceError.missingCloudURL)
-    }
-
     func test_authenticate() throws {
-        // Given
-        let cloudURL = URL.test()
-        configLoader.loadConfigStub = { _ in
-            Config.test(cloud: Cloud(url: cloudURL, projectId: "123", options: []))
-        }
-
         // When
-        try subject.authenticate()
+        try subject.authenticate(serverURL: nil)
 
         // Then
-        XCTAssertTrue(cloudSessionController.authenticateArgs.contains(cloudURL))
+        XCTAssertTrue(
+            cloudSessionController.authenticateArgs.contains(
+                URL(string: Constants.tuistCloudURL)!
+            )
+        )
     }
 }

--- a/Tests/TuistKitTests/Services/Cloud/CloudProjectDeleteServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudProjectDeleteServiceTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import TuistCloud
+import TuistCloudTesting
+import TuistSupport
+import TuistSupportTesting
+import XCTest
+@testable import TuistKit
+
+final class CloudProjectDeleteServiceTests: TuistUnitTestCase {
+    private var getProjectService: MockGetProjectService!
+    private var deleteProjectService: MockDeleteProjectService!
+    private var credentialsStore: MockCredentialsStore!
+    private var subject: CloudProjectDeleteService!
+
+    override func setUp() {
+        super.setUp()
+
+        getProjectService = .init()
+        deleteProjectService = .init()
+        credentialsStore = .init()
+        subject = CloudProjectDeleteService(
+            deleteProjectService: deleteProjectService,
+            getProjectService: getProjectService,
+            credentialsStore: credentialsStore
+        )
+    }
+
+    override func tearDown() {
+        deleteProjectService = nil
+        getProjectService = nil
+        credentialsStore = nil
+        subject = nil
+
+        super.tearDown()
+    }
+
+    func test_project_delete() async throws {
+        // Given
+        getProjectService.getProjectStub = { _, _, _ in
+            .init(id: 0, fullName: "tuist/tuist")
+        }
+        var gotProjectId: Int?
+        deleteProjectService.deleteProjectStub = { projectId, _ in
+            gotProjectId = projectId
+        }
+        credentialsStore.credentials[
+            URL(string: Constants.tuistCloudURL)!
+        ] = .init(token: "token", account: "account")
+
+        // When
+        try await subject.run(projectName: "project", organizationName: "tuist", serverURL: nil)
+
+        // Then
+        XCTAssertEqual(0, gotProjectId)
+    }
+}

--- a/Tests/TuistKitTests/Services/Cloud/CloudProjectListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudProjectListServiceTests.swift
@@ -27,7 +27,7 @@ final class CloudProjectListServiceTests: TuistUnitTestCase {
 
     func test_project_list() async throws {
         // Given
-        listProjectsService.listProjectsStub = { _ in
+        listProjectsService.listProjectsStub = { _, _, _ in
             [
                 CloudProject(id: 0, fullName: "tuist/test-one"),
                 CloudProject(id: 1, fullName: "tuist/test-two"),
@@ -47,7 +47,7 @@ final class CloudProjectListServiceTests: TuistUnitTestCase {
 
     func test_project_list_when_none() async throws {
         // Given
-        listProjectsService.listProjectsStub = { _ in
+        listProjectsService.listProjectsStub = { _, _, _ in
             []
         }
 


### PR DESCRIPTION
### Short description 📝

Adds a new command `tuist cloud project delete tuist --organization tuist`.

### How to test the changes locally 🧐

- Create a new project with `tuist cloud project create test`
- The project should be listed via `tuist cloud project list`
- Run `tuist cloud project delete test` (with an optional organization flag)
- Ensure the project is deleted – it shouldn't appear in the `tuist cloud project list` output

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
