### PR TITLE
Add cloud organization create command

### DIFF
--- a/Sources/TuistCloud/Models/CloudOrganization.swift
+++ b/Sources/TuistCloud/Models/CloudOrganization.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Cloud organization
+public struct CloudOrganization {
+    public let id: Int
+    public let name: String
+}
+
+extension CloudOrganization {
+    init(_ organization: Components.Schemas.Organization) {
+        id = Int(organization.id)
+        name = organization.name
+    }
+}

--- a/Sources/TuistCloud/OpenAPI/Client.swift
+++ b/Sources/TuistCloud/OpenAPI/Client.swift
@@ -137,4 +137,64 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// - Remark: HTTP `POST /api/organizations`.
+    /// - Remark: Generated from `#/paths//api/organizations/post(createOrganization)`.
+    public func createOrganization(_ input: Operations.createOrganization.Input) async throws
+        -> Operations.createOrganization.Output
+    {
+        try await client.send(
+            input: input,
+            forOperation: Operations.createOrganization.id,
+            serializer: { input in
+                let path = try converter.renderedRequestPath(
+                    template: "/api/organizations",
+                    parameters: []
+                )
+                var request: OpenAPIRuntime.Request = .init(path: path, method: .post)
+                suppressMutabilityWarning(&request)
+                try converter.setQueryItemAsText(
+                    in: &request,
+                    name: "name",
+                    value: input.query.name
+                )
+                try converter.setHeaderFieldAsText(
+                    in: &request.headerFields,
+                    name: "accept",
+                    value: "application/json"
+                )
+                return request
+            },
+            deserializer: { response in
+                switch response.statusCode {
+                case 200:
+                    let headers: Operations.createOrganization.Output.Ok.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.createOrganization.Output.Ok.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas.Organization.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .ok(.init(headers: headers, body: body))
+                case 400:
+                    let headers: Operations.createOrganization.Output.BadRequest.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.createOrganization.Output.BadRequest.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .badRequest(.init(headers: headers, body: body))
+                default: return .undocumented(statusCode: response.statusCode, .init())
+                }
+            }
+        )
+    }
 }

--- a/Sources/TuistCloud/OpenAPI/Types.swift
+++ b/Sources/TuistCloud/OpenAPI/Types.swift
@@ -15,6 +15,10 @@ public protocol APIProtocol: Sendable {
     /// - Remark: Generated from `#/paths//api/projects/post(createProject)`.
     func createProject(_ input: Operations.createProject.Input) async throws
         -> Operations.createProject.Output
+    /// - Remark: HTTP `POST /api/organizations`.
+    /// - Remark: Generated from `#/paths//api/organizations/post(createOrganization)`.
+    func createOrganization(_ input: Operations.createOrganization.Input) async throws
+        -> Operations.createOrganization.Output
 }
 /// Server URLs defined in the OpenAPI document.
 public enum Servers {
@@ -56,6 +60,26 @@ public enum Components {
             public enum CodingKeys: String, CodingKey {
                 case id
                 case full_name
+            }
+        }
+        /// - Remark: Generated from `#/components/schemas/Organization`.
+        public struct Organization: Codable, Equatable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/Organization/id`.
+            public var id: Swift.Double
+            /// - Remark: Generated from `#/components/schemas/Organization/name`.
+            public var name: Swift.String
+            /// Creates a new `Organization`.
+            ///
+            /// - Parameters:
+            ///   - id:
+            ///   - name:
+            public init(id: Swift.Double, name: Swift.String) {
+                self.id = id
+                self.name = name
+            }
+            public enum CodingKeys: String, CodingKey {
+                case id
+                case name
             }
         }
         /// - Remark: Generated from `#/components/schemas/Error`.
@@ -289,6 +313,128 @@ public enum Operations {
             ///
             /// HTTP response code: `400 badRequest`.
             case badRequest(Operations.createProject.Output.BadRequest)
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+    }
+    /// - Remark: HTTP `POST /api/organizations`.
+    /// - Remark: Generated from `#/paths//api/organizations/post(createOrganization)`.
+    public enum createOrganization {
+        public static let id: String = "createOrganization"
+        public struct Input: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Equatable, Hashable {
+                /// Creates a new `Path`.
+                public init() {}
+            }
+            public var path: Operations.createOrganization.Input.Path
+            public struct Query: Sendable, Equatable, Hashable {
+                public var name: Swift.String
+                /// Creates a new `Query`.
+                ///
+                /// - Parameters:
+                ///   - name:
+                public init(name: Swift.String) { self.name = name }
+            }
+            public var query: Operations.createOrganization.Input.Query
+            public struct Headers: Sendable, Equatable, Hashable {
+                /// Creates a new `Headers`.
+                public init() {}
+            }
+            public var headers: Operations.createOrganization.Input.Headers
+            public struct Cookies: Sendable, Equatable, Hashable {
+                /// Creates a new `Cookies`.
+                public init() {}
+            }
+            public var cookies: Operations.createOrganization.Input.Cookies
+            @frozen public enum Body: Sendable, Equatable, Hashable {}
+            public var body: Operations.createOrganization.Input.Body?
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - query:
+            ///   - headers:
+            ///   - cookies:
+            ///   - body:
+            public init(
+                path: Operations.createOrganization.Input.Path = .init(),
+                query: Operations.createOrganization.Input.Query,
+                headers: Operations.createOrganization.Input.Headers = .init(),
+                cookies: Operations.createOrganization.Input.Cookies = .init(),
+                body: Operations.createOrganization.Input.Body? = nil
+            ) {
+                self.path = path
+                self.query = query
+                self.headers = headers
+                self.cookies = cookies
+                self.body = body
+            }
+        }
+        @frozen public enum Output: Sendable, Equatable, Hashable {
+            public struct Ok: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.createOrganization.Output.Ok.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas.Organization)
+                }
+                /// Received HTTP response body
+                public var body: Operations.createOrganization.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.createOrganization.Output.Ok.Headers = .init(),
+                    body: Operations.createOrganization.Output.Ok.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// A success response with the created organization.
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/post(createOrganization)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.createOrganization.Output.Ok)
+            public struct BadRequest: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.createOrganization.Output.BadRequest.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.createOrganization.Output.BadRequest.Body
+                /// Creates a new `BadRequest`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.createOrganization.Output.BadRequest.Headers = .init(),
+                    body: Operations.createOrganization.Output.BadRequest.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The project could not be created because of a validation error.
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/post(createOrganization)/responses/400`.
+            ///
+            /// HTTP response code: `400 badRequest`.
+            case badRequest(Operations.createOrganization.Output.BadRequest)
             /// Undocumented response.
             ///
             /// A response with a code that is not documented in the OpenAPI document.

--- a/Sources/TuistCloud/OpenAPI/cloud.yml
+++ b/Sources/TuistCloud/OpenAPI/cloud.yml
@@ -44,6 +44,29 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/organizations:
+    post:
+      operationId: createOrganization
+      parameters:
+        - name: name
+          required: true
+          in: query
+          description: The name of the organization that should be created.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A success response with the created organization.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Organization"
+        "400":
+          description: The project could not be created because of a validation error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 components:
   schemas:
     Projects:
@@ -65,6 +88,16 @@ components:
       required:
         - id
         - full_name
+    Organization:
+      type: object
+      properties:
+        id:
+          type: number
+        name:
+          type: string
+      required:
+        - id
+        - name
     Error:
       type: object
       properties:

--- a/Sources/TuistCloud/Services/CreateOrganizationService.swift
+++ b/Sources/TuistCloud/Services/CreateOrganizationService.swift
@@ -1,0 +1,66 @@
+import Foundation
+import OpenAPIURLSession
+import TuistSupport
+
+public protocol CreateOrganizationServicing {
+    func createOrganization(
+        name: String,
+        serverURL: URL
+    ) async throws -> CloudOrganization
+}
+
+enum CreateOrganizationServiceError: FatalError {
+    case unknownError(Int)
+    case badRequest(String)
+
+    var type: ErrorType {
+        switch self {
+        case .unknownError:
+            return .bug
+        case .badRequest:
+            return .abort
+        }
+    }
+
+    var description: String {
+        switch self {
+        case let .unknownError(statusCode):
+            return "The organization could not be created due to an unknown cloud response of \(statusCode)."
+        case let .badRequest(message):
+            return message
+        }
+    }
+}
+
+public final class CreateOrganizationService: CreateOrganizationServicing {
+    public init() {}
+
+    public func createOrganization(
+        name: String,
+        serverURL: URL
+    ) async throws -> CloudOrganization {
+        let client = Client.cloud(serverURL: serverURL)
+
+        let response = try await client.createOrganization(
+            .init(
+                query: .init(
+                    name: name
+                )
+            )
+        )
+        switch response {
+        case let .ok(okResponse):
+            switch okResponse.body {
+            case let .json(organization):
+                return CloudOrganization(organization)
+            }
+        case let .badRequest(badRequestResponse):
+            switch badRequestResponse.body {
+            case let .json(error):
+                throw CreateOrganizationServiceError.badRequest(error.message)
+            }
+        case let .undocumented(statusCode: statusCode, _):
+            throw CreateOrganizationServiceError.unknownError(statusCode)
+        }
+    }
+}

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationCommand.swift
@@ -1,0 +1,16 @@
+import ArgumentParser
+import Foundation
+import TSCBasic
+
+struct CloudOrganizationCommand: ParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "organization",
+            _superCommandName: "cloud",
+            abstract: "A set of commands to manage your Cloud organizations.",
+            subcommands: [
+                CloudOrganizationCreateCommand.self,
+            ]
+        )
+    }
+}

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationCreateCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationCreateCommand.swift
@@ -1,0 +1,33 @@
+import ArgumentParser
+import Foundation
+import TSCBasic
+import TuistSupport
+
+struct CloudOrganizationCreateCommand: AsyncParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "create",
+            _superCommandName: "organization",
+            abstract: "Create a new organization."
+        )
+    }
+
+    @Argument(
+        help: "The name of the organization to create.",
+        completion: .directory
+    )
+    var organizationName: String
+
+    @Option(
+        name: .long,
+        help: "URL to the cloud server."
+    )
+    var serverURL: String?
+
+    func run() async throws {
+        try await CloudOrganizationCreateService().run(
+            organizationName: organizationName,
+            serverURL: serverURL
+        )
+    }
+}

--- a/Sources/TuistKit/Commands/CloudCommand.swift
+++ b/Sources/TuistKit/Commands/CloudCommand.swift
@@ -14,6 +14,7 @@ struct CloudCommand: ParsableCommand {
                 CloudInitCommand.self,
                 CloudCleanCommand.self,
                 CloudProjectCommand.self,
+                CloudOrganizationCommand.self,
             ]
         )
     }

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationCreateService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationCreateService.swift
@@ -1,0 +1,39 @@
+import Foundation
+import TSCBasic
+import TuistCloud
+import TuistLoader
+import TuistSupport
+
+protocol CloudOrganizationCreateServicing {
+    func run(
+        organizationName: String,
+        serverURL: String?
+    ) async throws
+}
+
+final class CloudOrganizationCreateService: CloudOrganizationCreateServicing {
+    private let createOrganizationService: CreateOrganizationServicing
+    private let cloudURLService: CloudURLServicing
+
+    init(
+        createOrganizationService: CreateOrganizationServicing = CreateOrganizationService(),
+        cloudURLService: CloudURLServicing = CloudURLService()
+    ) {
+        self.createOrganizationService = createOrganizationService
+        self.cloudURLService = cloudURLService
+    }
+
+    func run(
+        organizationName: String,
+        serverURL: String?
+    ) async throws {
+        let cloudURL = try cloudURLService.url(serverURL: serverURL)
+
+        let organization = try await createOrganizationService.createOrganization(
+            name: organizationName,
+            serverURL: cloudURL
+        )
+
+        logger.info("Cloud organization \(organization.name) was successfully created 🎉")
+    }
+}


### PR DESCRIPTION
### Short description 📝

Adds a new command to create a Cloud organization: `tuist cloud organization create some-org-name`.

### How to test the changes locally 🧐

- Run `tuist cloud organization some-org-name`
- If the organization name is available, it will be available under your account. Otherwise, you will get a meaningful error message.

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
