### PR TITLE
Add tuist cloud organization delete command

### DIFF
--- a/Sources/TuistCloud/OpenAPI/Client.swift
+++ b/Sources/TuistCloud/OpenAPI/Client.swift
@@ -375,4 +375,62 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// - Remark: HTTP `DELETE /api/organizations/{organization_name}`.
+    /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/delete(deleteOrganization)`.
+    public func deleteOrganization(_ input: Operations.deleteOrganization.Input) async throws
+        -> Operations.deleteOrganization.Output
+    {
+        try await client.send(
+            input: input,
+            forOperation: Operations.deleteOrganization.id,
+            serializer: { input in
+                let path = try converter.renderedRequestPath(
+                    template: "/api/organizations/{}",
+                    parameters: [input.path.organization_name]
+                )
+                var request: OpenAPIRuntime.Request = .init(path: path, method: .delete)
+                suppressMutabilityWarning(&request)
+                try converter.setHeaderFieldAsText(
+                    in: &request.headerFields,
+                    name: "accept",
+                    value: "application/json"
+                )
+                return request
+            },
+            deserializer: { response in
+                switch response.statusCode {
+                case 204:
+                    let headers: Operations.deleteOrganization.Output.NoContent.Headers = .init()
+                    return .noContent(.init(headers: headers, body: nil))
+                case 404:
+                    let headers: Operations.deleteOrganization.Output.NotFound.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.deleteOrganization.Output.NotFound.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .notFound(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.deleteOrganization.Output.Unauthorized.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.deleteOrganization.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
+                default: return .undocumented(statusCode: response.statusCode, .init())
+                }
+            }
+        )
+    }
 }

--- a/Sources/TuistCloud/OpenAPI/Types.swift
+++ b/Sources/TuistCloud/OpenAPI/Types.swift
@@ -31,6 +31,10 @@ public protocol APIProtocol: Sendable {
     /// - Remark: Generated from `#/paths//api/projects/{account_name}/{project_name}/get(getProject)`.
     func getProject(_ input: Operations.getProject.Input) async throws
         -> Operations.getProject.Output
+    /// - Remark: HTTP `DELETE /api/organizations/{organization_name}`.
+    /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/delete(deleteOrganization)`.
+    func deleteOrganization(_ input: Operations.deleteOrganization.Input) async throws
+        -> Operations.deleteOrganization.Output
 }
 /// Server URLs defined in the OpenAPI document.
 public enum Servers {
@@ -865,6 +869,159 @@ public enum Operations {
             ///
             /// HTTP response code: `404 notFound`.
             case notFound(Operations.getProject.Output.NotFound)
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+    }
+    /// - Remark: HTTP `DELETE /api/organizations/{organization_name}`.
+    /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/delete(deleteOrganization)`.
+    public enum deleteOrganization {
+        public static let id: String = "deleteOrganization"
+        public struct Input: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Equatable, Hashable {
+                public var organization_name: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - organization_name:
+                public init(organization_name: Swift.String) {
+                    self.organization_name = organization_name
+                }
+            }
+            public var path: Operations.deleteOrganization.Input.Path
+            public struct Query: Sendable, Equatable, Hashable {
+                /// Creates a new `Query`.
+                public init() {}
+            }
+            public var query: Operations.deleteOrganization.Input.Query
+            public struct Headers: Sendable, Equatable, Hashable {
+                /// Creates a new `Headers`.
+                public init() {}
+            }
+            public var headers: Operations.deleteOrganization.Input.Headers
+            public struct Cookies: Sendable, Equatable, Hashable {
+                /// Creates a new `Cookies`.
+                public init() {}
+            }
+            public var cookies: Operations.deleteOrganization.Input.Cookies
+            @frozen public enum Body: Sendable, Equatable, Hashable {}
+            public var body: Operations.deleteOrganization.Input.Body?
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - query:
+            ///   - headers:
+            ///   - cookies:
+            ///   - body:
+            public init(
+                path: Operations.deleteOrganization.Input.Path,
+                query: Operations.deleteOrganization.Input.Query = .init(),
+                headers: Operations.deleteOrganization.Input.Headers = .init(),
+                cookies: Operations.deleteOrganization.Input.Cookies = .init(),
+                body: Operations.deleteOrganization.Input.Body? = nil
+            ) {
+                self.path = path
+                self.query = query
+                self.headers = headers
+                self.cookies = cookies
+                self.body = body
+            }
+        }
+        @frozen public enum Output: Sendable, Equatable, Hashable {
+            public struct NoContent: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.deleteOrganization.Output.NoContent.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {}
+                /// Received HTTP response body
+                public var body: Operations.deleteOrganization.Output.NoContent.Body?
+                /// Creates a new `NoContent`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.deleteOrganization.Output.NoContent.Headers = .init(),
+                    body: Operations.deleteOrganization.Output.NoContent.Body? = nil
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// An organization was successfully deleted.
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/delete(deleteOrganization)/responses/204`.
+            ///
+            /// HTTP response code: `204 noContent`.
+            case noContent(Operations.deleteOrganization.Output.NoContent)
+            public struct NotFound: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.deleteOrganization.Output.NotFound.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.deleteOrganization.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.deleteOrganization.Output.NotFound.Headers = .init(),
+                    body: Operations.deleteOrganization.Output.NotFound.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The organization could not be deleted because it was not found.
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/delete(deleteOrganization)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.deleteOrganization.Output.NotFound)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.deleteOrganization.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.deleteOrganization.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.deleteOrganization.Output.Unauthorized.Headers = .init(),
+                    body: Operations.deleteOrganization.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The organization could not be deleted because the user is not authorized to do the action.
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/delete(deleteOrganization)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.deleteOrganization.Output.Unauthorized)
             /// Undocumented response.
             ///
             /// A response with a code that is not documented in the OpenAPI document.

--- a/Sources/TuistCloud/OpenAPI/cloud.yml
+++ b/Sources/TuistCloud/OpenAPI/cloud.yml
@@ -147,6 +147,31 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/organizations/{organization_name}:
+    delete:
+      operationId: deleteOrganization
+      parameters:
+        - in: path
+          name: organization_name
+          required: true
+          description: The name of the organization that should be deleted.
+          schema:
+            type: string
+      responses:
+        "204":
+          description: An organization was successfully deleted.
+        "404":
+          description: The organization could not be deleted because it was not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: The organization could not be deleted because the user is not authorized to do the action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 components:
   schemas:
     Projects:

--- a/Sources/TuistCloud/Services/DeleteOrganizationService.swift
+++ b/Sources/TuistCloud/Services/DeleteOrganizationService.swift
@@ -1,0 +1,70 @@
+import Foundation
+import OpenAPIURLSession
+import TuistSupport
+
+public protocol DeleteOrganizationServicing {
+    func deleteOrganization(
+        name: String,
+        serverURL: URL
+    ) async throws
+}
+
+enum DeleteOrganizationServiceError: FatalError {
+    case unknownError(Int)
+    case notFound(String)
+    case unauthorized(String)
+
+    var type: ErrorType {
+        switch self {
+        case .unknownError:
+            return .bug
+        case .unauthorized, .notFound:
+            return .abort
+        }
+    }
+
+    var description: String {
+        switch self {
+        case let .unknownError(statusCode):
+            return "The organization could not be deleted due to an unknown cloud response of \(statusCode)."
+        case let .unauthorized(message), let .notFound(message):
+            return message
+        }
+    }
+}
+
+public final class DeleteOrganizationService: DeleteOrganizationServicing {
+    public init() {}
+
+    public func deleteOrganization(
+        name: String,
+        serverURL: URL
+    ) async throws {
+        let client = Client.cloud(serverURL: serverURL)
+
+        let response = try await client.deleteOrganization(
+            .init(
+                path: .init(
+                    organization_name: name
+                )
+            )
+        )
+        switch response {
+        case .noContent:
+            // noop
+            break
+        case let .notFound(notFound):
+            switch notFound.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.notFound(error.message)
+            }
+        case let .unauthorized(unauthorized):
+            switch unauthorized.body {
+            case let .json(error):
+                throw DeleteOrganizationServiceError.notFound(error.message)
+            }
+        case let .undocumented(statusCode: statusCode, _):
+            throw DeleteOrganizationServiceError.unknownError(statusCode)
+        }
+    }
+}

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationCommand.swift
@@ -11,6 +11,7 @@ struct CloudOrganizationCommand: ParsableCommand {
             subcommands: [
                 CloudOrganizationCreateCommand.self,
                 CloudOrganizationListCommand.self,
+                CloudOrganizationDeleteCommand.self,
             ]
         )
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationDeleteCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationDeleteCommand.swift
@@ -1,0 +1,33 @@
+import ArgumentParser
+import Foundation
+import TSCBasic
+import TuistSupport
+
+struct CloudOrganizationDeleteCommand: AsyncParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "delete",
+            _superCommandName: "organization",
+            abstract: "Delete a new organization."
+        )
+    }
+
+    @Argument(
+        help: "The name of the organization to delete.",
+        completion: .directory
+    )
+    var organizationName: String
+
+    @Option(
+        name: .long,
+        help: "URL to the cloud server."
+    )
+    var serverURL: String?
+
+    func run() async throws {
+        try await CloudOrganizationDeleteService().run(
+            organizationName: organizationName,
+            serverURL: serverURL
+        )
+    }
+}

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationDeleteService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationDeleteService.swift
@@ -1,0 +1,39 @@
+import Foundation
+import TSCBasic
+import TuistCloud
+import TuistLoader
+import TuistSupport
+
+protocol CloudOrganizationDeleteServicing {
+    func run(
+        organizationName: String,
+        serverURL: String?
+    ) async throws
+}
+
+final class CloudOrganizationDeleteService: CloudOrganizationDeleteServicing {
+    private let deleteOrganizationService: DeleteOrganizationServicing
+    private let cloudURLService: CloudURLServicing
+
+    init(
+        deleteOrganizationService: DeleteOrganizationServicing = DeleteOrganizationService(),
+        cloudURLService: CloudURLServicing = CloudURLService()
+    ) {
+        self.deleteOrganizationService = deleteOrganizationService
+        self.cloudURLService = cloudURLService
+    }
+
+    func run(
+        organizationName: String,
+        serverURL: String?
+    ) async throws {
+        let cloudURL = try cloudURLService.url(serverURL: serverURL)
+
+        try await deleteOrganizationService.deleteOrganization(
+            name: organizationName,
+            serverURL: cloudURL
+        )
+
+        logger.info("Cloud organization \(organizationName) was successfully deleted.")
+    }
+}


### PR DESCRIPTION
### Short description 📝

Adds a new command `tuist cloud organization delete some-org`.

### How to test the changes locally 🧐

- Run `tuist cloud organization delete some-org` (make sure the org exists – delete an org you don't need)

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
