### PR TITLE
Add cloud organization invite command

### DIFF
--- a/Sources/TuistCloud/Models/CloudInvitation.swift
+++ b/Sources/TuistCloud/Models/CloudInvitation.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Cloud invitation
+public struct CloudInvitation: Codable {
+    public init(
+        id: Int,
+        inviteeEmail: String,
+        inviter: CloudUser,
+        organizationId: Int
+    ) {
+        self.id = id
+        self.inviteeEmail = inviteeEmail
+        self.inviter = inviter
+        self.organizationId = organizationId
+    }
+
+    public let id: Int
+    public let inviteeEmail: String
+    public let inviter: CloudUser
+    public let organizationId: Int
+}
+
+extension CloudInvitation {
+    init(_ invitation: Components.Schemas.Invitation) {
+        id = Int(invitation.id)
+        inviteeEmail = invitation.invitee_email
+        inviter = CloudUser(invitation.inviter)
+        organizationId = Int(invitation.organization_id)
+    }
+}

--- a/Sources/TuistCloud/Models/CloudOrganization.swift
+++ b/Sources/TuistCloud/Models/CloudOrganization.swift
@@ -48,15 +48,18 @@ public struct CloudOrganization: Codable {
     public let id: Int
     public let name: String
     public let members: [Member]
+    public let invitations: [CloudInvitation]
 
     public init(
         id: Int,
         name: String,
-        members: [Member]
+        members: [Member],
+        invitations: [CloudInvitation]
     ) {
         self.id = id
         self.name = name
         self.members = members
+        self.invitations = invitations
     }
 }
 
@@ -65,6 +68,7 @@ extension CloudOrganization {
         id = Int(organization.id)
         name = organization.name
         members = organization.members.map(Member.init)
+        invitations = organization.invitations.map(CloudInvitation.init)
     }
 }
 

--- a/Sources/TuistCloud/Models/CloudUser.swift
+++ b/Sources/TuistCloud/Models/CloudUser.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Cloud user
+public struct CloudUser: Codable {
+    public let id: Int
+    public let name: String
+    public let email: String
+
+    public init(
+        id: Int,
+        name: String,
+        email: String
+    ) {
+        self.id = id
+        self.name = name
+        self.email = email
+    }
+}
+
+extension CloudUser {
+    init(_ user: Components.Schemas.User) {
+        id = Int(user.id)
+        name = user.name
+        email = user.email
+    }
+}

--- a/Sources/TuistCloud/OpenAPI/Client.swift
+++ b/Sources/TuistCloud/OpenAPI/Client.swift
@@ -501,4 +501,101 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// - Remark: HTTP `POST /api/organizations/{organization_name}/invitations`.
+    /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/invitations/post(createOrganizationInvite)`.
+    public func createOrganizationInvite(_ input: Operations.createOrganizationInvite.Input)
+        async throws -> Operations.createOrganizationInvite.Output
+    {
+        try await client.send(
+            input: input,
+            forOperation: Operations.createOrganizationInvite.id,
+            serializer: { input in
+                let path = try converter.renderedRequestPath(
+                    template: "/api/organizations/{}/invitations",
+                    parameters: [input.path.organization_name]
+                )
+                var request: OpenAPIRuntime.Request = .init(path: path, method: .post)
+                suppressMutabilityWarning(&request)
+                try converter.setHeaderFieldAsText(
+                    in: &request.headerFields,
+                    name: "accept",
+                    value: "application/json"
+                )
+                request.body = try converter.setRequiredRequestBodyAsJSON(
+                    input.body,
+                    headerFields: &request.headerFields,
+                    transforming: { wrapped in
+                        switch wrapped {
+                        case let .json(value):
+                            return .init(
+                                value: value,
+                                contentType: "application/json; charset=utf-8"
+                            )
+                        }
+                    }
+                )
+                return request
+            },
+            deserializer: { response in
+                switch response.statusCode {
+                case 200:
+                    let headers: Operations.createOrganizationInvite.Output.Ok.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.createOrganizationInvite.Output.Ok.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas.Invitation.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .ok(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.createOrganizationInvite.Output.Unauthorized.Headers =
+                        .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.createOrganizationInvite.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
+                case 404:
+                    let headers: Operations.createOrganizationInvite.Output.NotFound.Headers =
+                        .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.createOrganizationInvite.Output.NotFound.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .notFound(.init(headers: headers, body: body))
+                case 400:
+                    let headers: Operations.createOrganizationInvite.Output.BadRequest.Headers =
+                        .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.createOrganizationInvite.Output.BadRequest.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .badRequest(.init(headers: headers, body: body))
+                default: return .undocumented(statusCode: response.statusCode, .init())
+                }
+            }
+        )
+    }
 }

--- a/Sources/TuistCloud/OpenAPI/Types.swift
+++ b/Sources/TuistCloud/OpenAPI/Types.swift
@@ -39,6 +39,10 @@ public protocol APIProtocol: Sendable {
     /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/delete(deleteOrganization)`.
     func deleteOrganization(_ input: Operations.deleteOrganization.Input) async throws
         -> Operations.deleteOrganization.Output
+    /// - Remark: HTTP `POST /api/organizations/{organization_name}/invitations`.
+    /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/invitations/post(createOrganizationInvite)`.
+    func createOrganizationInvite(_ input: Operations.createOrganizationInvite.Input) async throws
+        -> Operations.createOrganizationInvite.Output
 }
 /// Server URLs defined in the OpenAPI document.
 public enum Servers {
@@ -51,6 +55,66 @@ public enum Servers {
 public enum Components {
     /// Types generated from the `#/components/schemas` section of the OpenAPI document.
     public enum Schemas {
+        /// - Remark: Generated from `#/components/schemas/User`.
+        public struct User: Codable, Equatable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/User/id`.
+            public var id: Swift.Double
+            /// - Remark: Generated from `#/components/schemas/User/email`.
+            public var email: Swift.String
+            /// - Remark: Generated from `#/components/schemas/User/name`.
+            public var name: Swift.String
+            /// Creates a new `User`.
+            ///
+            /// - Parameters:
+            ///   - id:
+            ///   - email:
+            ///   - name:
+            public init(id: Swift.Double, email: Swift.String, name: Swift.String) {
+                self.id = id
+                self.email = email
+                self.name = name
+            }
+            public enum CodingKeys: String, CodingKey {
+                case id
+                case email
+                case name
+            }
+        }
+        /// - Remark: Generated from `#/components/schemas/Invitation`.
+        public struct Invitation: Codable, Equatable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/Invitation/id`.
+            public var id: Swift.Double
+            /// - Remark: Generated from `#/components/schemas/Invitation/invitee_email`.
+            public var invitee_email: Swift.String
+            /// - Remark: Generated from `#/components/schemas/Invitation/organization_id`.
+            public var organization_id: Swift.Double
+            /// - Remark: Generated from `#/components/schemas/Invitation/inviter`.
+            public var inviter: Components.Schemas.User
+            /// Creates a new `Invitation`.
+            ///
+            /// - Parameters:
+            ///   - id:
+            ///   - invitee_email:
+            ///   - organization_id:
+            ///   - inviter:
+            public init(
+                id: Swift.Double,
+                invitee_email: Swift.String,
+                organization_id: Swift.Double,
+                inviter: Components.Schemas.User
+            ) {
+                self.id = id
+                self.invitee_email = invitee_email
+                self.organization_id = organization_id
+                self.inviter = inviter
+            }
+            public enum CodingKeys: String, CodingKey {
+                case id
+                case invitee_email
+                case organization_id
+                case inviter
+            }
+        }
         /// - Remark: Generated from `#/components/schemas/OrganizationMember`.
         public struct OrganizationMember: Codable, Equatable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/OrganizationMember/id`.
@@ -163,25 +227,31 @@ public enum Components {
             public var name: Swift.String
             /// - Remark: Generated from `#/components/schemas/Organization/members`.
             public var members: [Components.Schemas.OrganizationMember]
+            /// - Remark: Generated from `#/components/schemas/Organization/invitations`.
+            public var invitations: [Components.Schemas.Invitation]
             /// Creates a new `Organization`.
             ///
             /// - Parameters:
             ///   - id:
             ///   - name:
             ///   - members:
+            ///   - invitations:
             public init(
                 id: Swift.Double,
                 name: Swift.String,
-                members: [Components.Schemas.OrganizationMember]
+                members: [Components.Schemas.OrganizationMember],
+                invitations: [Components.Schemas.Invitation]
             ) {
                 self.id = id
                 self.name = name
                 self.members = members
+                self.invitations = invitations
             }
             public enum CodingKeys: String, CodingKey {
                 case id
                 case name
                 case members
+                case invitations
             }
         }
         /// - Remark: Generated from `#/components/schemas/Error`.
@@ -1250,6 +1320,209 @@ public enum Operations {
             ///
             /// HTTP response code: `401 unauthorized`.
             case unauthorized(Operations.deleteOrganization.Output.Unauthorized)
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+    }
+    /// - Remark: HTTP `POST /api/organizations/{organization_name}/invitations`.
+    /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/invitations/post(createOrganizationInvite)`.
+    public enum createOrganizationInvite {
+        public static let id: String = "createOrganizationInvite"
+        public struct Input: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Equatable, Hashable {
+                public var organization_name: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - organization_name:
+                public init(organization_name: Swift.String) {
+                    self.organization_name = organization_name
+                }
+            }
+            public var path: Operations.createOrganizationInvite.Input.Path
+            public struct Query: Sendable, Equatable, Hashable {
+                /// Creates a new `Query`.
+                public init() {}
+            }
+            public var query: Operations.createOrganizationInvite.Input.Query
+            public struct Headers: Sendable, Equatable, Hashable {
+                /// Creates a new `Headers`.
+                public init() {}
+            }
+            public var headers: Operations.createOrganizationInvite.Input.Headers
+            public struct Cookies: Sendable, Equatable, Hashable {
+                /// Creates a new `Cookies`.
+                public init() {}
+            }
+            public var cookies: Operations.createOrganizationInvite.Input.Cookies
+            @frozen public enum Body: Sendable, Equatable, Hashable {
+                /// - Remark: Generated from `#/paths/api/organizations/{organization_name}/invitations/POST/json`.
+                public struct jsonPayload: Codable, Equatable, Hashable, Sendable {
+                    /// Email of the user to invite.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/organizations/{organization_name}/invitations/POST/json/invitee_email`.
+                    public var invitee_email: Swift.String
+                    /// Creates a new `jsonPayload`.
+                    ///
+                    /// - Parameters:
+                    ///   - invitee_email: Email of the user to invite.
+                    public init(invitee_email: Swift.String) { self.invitee_email = invitee_email }
+                    public enum CodingKeys: String, CodingKey { case invitee_email }
+                }
+                case json(Operations.createOrganizationInvite.Input.Body.jsonPayload)
+            }
+            public var body: Operations.createOrganizationInvite.Input.Body
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - query:
+            ///   - headers:
+            ///   - cookies:
+            ///   - body:
+            public init(
+                path: Operations.createOrganizationInvite.Input.Path,
+                query: Operations.createOrganizationInvite.Input.Query = .init(),
+                headers: Operations.createOrganizationInvite.Input.Headers = .init(),
+                cookies: Operations.createOrganizationInvite.Input.Cookies = .init(),
+                body: Operations.createOrganizationInvite.Input.Body
+            ) {
+                self.path = path
+                self.query = query
+                self.headers = headers
+                self.cookies = cookies
+                self.body = body
+            }
+        }
+        @frozen public enum Output: Sendable, Equatable, Hashable {
+            public struct Ok: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.createOrganizationInvite.Output.Ok.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas.Invitation)
+                }
+                /// Received HTTP response body
+                public var body: Operations.createOrganizationInvite.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.createOrganizationInvite.Output.Ok.Headers = .init(),
+                    body: Operations.createOrganizationInvite.Output.Ok.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// A user was successfully invited.
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/invitations/post(createOrganizationInvite)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.createOrganizationInvite.Output.Ok)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.createOrganizationInvite.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.createOrganizationInvite.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.createOrganizationInvite.Output.Unauthorized.Headers =
+                        .init(),
+                    body: Operations.createOrganizationInvite.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The invitation could not be created because the user is not authorized to perform the action.
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/invitations/post(createOrganizationInvite)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.createOrganizationInvite.Output.Unauthorized)
+            public struct NotFound: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.createOrganizationInvite.Output.NotFound.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.createOrganizationInvite.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.createOrganizationInvite.Output.NotFound.Headers = .init(),
+                    body: Operations.createOrganizationInvite.Output.NotFound.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The invitation could not be created because the relevant organization was not found.
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/invitations/post(createOrganizationInvite)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.createOrganizationInvite.Output.NotFound)
+            public struct BadRequest: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.createOrganizationInvite.Output.BadRequest.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.createOrganizationInvite.Output.BadRequest.Body
+                /// Creates a new `BadRequest`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.createOrganizationInvite.Output.BadRequest.Headers =
+                        .init(),
+                    body: Operations.createOrganizationInvite.Output.BadRequest.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The invitation could not be created because of a validation error.
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/invitations/post(createOrganizationInvite)/responses/400`.
+            ///
+            /// HTTP response code: `400 badRequest`.
+            case badRequest(Operations.createOrganizationInvite.Output.BadRequest)
             /// Undocumented response.
             ///
             /// A response with a code that is not documented in the OpenAPI document.

--- a/Sources/TuistCloud/OpenAPI/cloud.yml
+++ b/Sources/TuistCloud/OpenAPI/cloud.yml
@@ -200,8 +200,85 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/organizations/{organization_name}/invitations:
+    post:
+      operationId: createOrganizationInvite
+      parameters:
+        - in: path
+          name: organization_name
+          required: true
+          description: The organization to invite the user to.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                invitee_email:
+                  type: string
+                  description: Email of the user to invite.
+              required:
+                - invitee_email
+      responses:
+        "200":
+          description: A user was successfully invited.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Invitation"
+        "401":
+          description: The invitation could not be created because the user is not authorized to perform the action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: The invitation could not be created because the relevant organization was not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "400":
+          description: The invitation could not be created because of a validation error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 components:
   schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: number
+        email:
+          type: string
+        name:
+          type: string
+      required:
+        - id
+        - email
+        - name
+    Invitation:
+      type: object
+      properties:
+        id:
+          type: number
+        invitee_email:
+          type: string
+        organization_id:
+          type: number
+        inviter:
+          type: object
+          $ref: "#/components/schemas/User"
+      required:
+        - id
+        - invitee_email
+        - organization_id
+        - inviter
     OrganizationMember:
       type: object
       properties:
@@ -260,10 +337,15 @@ components:
             type: array
             items:
               $ref: "#/components/schemas/OrganizationMember"
+        invitations:
+            type: array
+            items:
+              $ref: "#/components/schemas/Invitation"
       required:
         - id
         - name
         - members
+        - invitations
     Error:
       type: object
       properties:

--- a/Sources/TuistCloud/Services/CreateOrganizationInviteService.swift
+++ b/Sources/TuistCloud/Services/CreateOrganizationInviteService.swift
@@ -1,0 +1,79 @@
+import Foundation
+import OpenAPIURLSession
+import TuistSupport
+
+public protocol CreateOrganizationInviteServicing {
+    func createOrganizationInvite(
+        organizationName: String,
+        email: String,
+        serverURL: URL
+    ) async throws -> CloudInvitation
+}
+
+enum CreateOrganizationInviteServiceError: FatalError {
+    case unknownError(Int)
+    case notFound(String)
+    case unauthorized(String)
+    case badRequest(String)
+
+    var type: ErrorType {
+        switch self {
+        case .unknownError:
+            return .bug
+        case .notFound, .unauthorized, .badRequest:
+            return .abort
+        }
+    }
+
+    var description: String {
+        switch self {
+        case let .unknownError(statusCode):
+            return "The user could not be invited due to an unknown cloud response of \(statusCode)."
+        case let .notFound(message), let .unauthorized(message), let .badRequest(message):
+            return message
+        }
+    }
+}
+
+public final class CreateOrganizationInviteService: CreateOrganizationInviteServicing {
+    public init() {}
+
+    public func createOrganizationInvite(
+        organizationName: String,
+        email: String,
+        serverURL: URL
+    ) async throws -> CloudInvitation {
+        let client = Client.cloud(serverURL: serverURL)
+
+        let response = try await client.createOrganizationInvite(
+            .init(
+                path: .init(organization_name: organizationName),
+                body: .json(.init(invitee_email: email))
+            )
+        )
+        switch response {
+        case let .ok(okResponse):
+            switch okResponse.body {
+            case let .json(invitation):
+                return CloudInvitation(invitation)
+            }
+        case let .notFound(notFoundResponse):
+            switch notFoundResponse.body {
+            case let .json(error):
+                throw CreateOrganizationInviteServiceError.notFound(error.message)
+            }
+        case let .unauthorized(unauthorizedResponse):
+            switch unauthorizedResponse.body {
+            case let .json(error):
+                throw CreateOrganizationInviteServiceError.unauthorized(error.message)
+            }
+        case let .badRequest(badRequestResponse):
+            switch badRequestResponse.body {
+            case let .json(error):
+                throw CreateOrganizationInviteServiceError.badRequest(error.message)
+            }
+        case let .undocumented(statusCode: statusCode, _):
+            throw CreateOrganizationInviteServiceError.unknownError(statusCode)
+        }
+    }
+}

--- a/Sources/TuistCloudTesting/Models/CloudInvitation+TestData.swift
+++ b/Sources/TuistCloudTesting/Models/CloudInvitation+TestData.swift
@@ -1,0 +1,17 @@
+import TuistCloud
+
+extension CloudInvitation {
+    public static func test(
+        id: Int = 0,
+        inviteeEmail: String = "test@tuist.io",
+        inviter: CloudUser = .test(),
+        organizationId: Int = 0
+    ) -> Self {
+        .init(
+            id: id,
+            inviteeEmail: inviteeEmail,
+            inviter: inviter,
+            organizationId: organizationId
+        )
+    }
+}

--- a/Sources/TuistCloudTesting/Models/CloudOrganization+TestData.swift
+++ b/Sources/TuistCloudTesting/Models/CloudOrganization+TestData.swift
@@ -4,12 +4,14 @@ extension CloudOrganization {
     public static func test(
         id: Int = 0,
         name: String = "test",
-        members: [Member] = []
+        members: [Member] = [],
+        invitations: [CloudInvitation] = []
     ) -> Self {
         .init(
             id: id,
             name: name,
-            members: members
+            members: members,
+            invitations: invitations
         )
     }
 }

--- a/Sources/TuistCloudTesting/Models/CloudUser+TestData.swift
+++ b/Sources/TuistCloudTesting/Models/CloudUser+TestData.swift
@@ -1,0 +1,15 @@
+import TuistCloud
+
+extension CloudUser {
+    public static func test(
+        id: Int = 0,
+        name: String = "test",
+        email: String = "test@email.io"
+    ) -> Self {
+        .init(
+            id: id,
+            name: name,
+            email: email
+        )
+    }
+}

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationCommand.swift
@@ -13,6 +13,7 @@ struct CloudOrganizationCommand: ParsableCommand {
                 CloudOrganizationListCommand.self,
                 CloudOrganizationDeleteCommand.self,
                 CloudOrganizationShowCommand.self,
+                CloudOrganizationInviteCommand.self,
             ]
         )
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationInviteCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationInviteCommand.swift
@@ -3,19 +3,24 @@ import Foundation
 import TSCBasic
 import TuistSupport
 
-struct CloudOrganizationCreateCommand: AsyncParsableCommand {
+struct CloudOrganizationInviteCommand: AsyncParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(
-            commandName: "create",
+            commandName: "invite",
             _superCommandName: "organization",
-            abstract: "Create a new organization."
+            abstract: "Invite a new member to your organization."
         )
     }
 
     @Argument(
-        help: "The name of the organization to create."
+        help: "The name of the organization to invite the user to."
     )
     var organizationName: String
+
+    @Argument(
+        help: "The email of the user to invite."
+    )
+    var email: String
 
     @Option(
         name: .long,
@@ -24,8 +29,9 @@ struct CloudOrganizationCreateCommand: AsyncParsableCommand {
     var serverURL: String?
 
     func run() async throws {
-        try await CloudOrganizationCreateService().run(
+        try await CloudOrganizationInviteService().run(
             organizationName: organizationName,
+            email: email,
             serverURL: serverURL
         )
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationShowCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationShowCommand.swift
@@ -13,8 +13,7 @@ struct CloudOrganizationShowCommand: AsyncParsableCommand {
     }
 
     @Argument(
-        help: "The name of the organization to show.",
-        completion: .directory
+        help: "The name of the organization to show."
     )
     var organizationName: String
 

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationInviteService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationInviteService.swift
@@ -1,0 +1,42 @@
+import Foundation
+import TSCBasic
+import TuistCloud
+import TuistLoader
+import TuistSupport
+
+protocol CloudOrganizationInviteServicing {
+    func run(
+        organizationName: String,
+        email: String,
+        serverURL: String?
+    ) async throws
+}
+
+final class CloudOrganizationInviteService: CloudOrganizationInviteServicing {
+    private let createOrganizationInviteService: CreateOrganizationInviteServicing
+    private let cloudURLService: CloudURLServicing
+
+    init(
+        createOrganizationInviteService: CreateOrganizationInviteServicing = CreateOrganizationInviteService(),
+        cloudURLService: CloudURLServicing = CloudURLService()
+    ) {
+        self.createOrganizationInviteService = createOrganizationInviteService
+        self.cloudURLService = cloudURLService
+    }
+
+    func run(
+        organizationName: String,
+        email: String,
+        serverURL: String?
+    ) async throws {
+        let cloudURL = try cloudURLService.url(serverURL: serverURL)
+
+        let invitation = try await createOrganizationInviteService.createOrganizationInvite(
+            organizationName: organizationName,
+            email: email,
+            serverURL: cloudURL
+        )
+
+        logger.info("\(invitation.inviteeEmail) was successfully invited to the \(organizationName) organization 🎉")
+    }
+}

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationShowService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationShowService.swift
@@ -42,17 +42,33 @@ final class CloudOrganizationShowService: CloudOrganizationShowServicing {
             return
         }
 
-        let headers = ["username", "email", "role"]
-        let tableString = formatDataToTable(
-            [headers] + organization.members.map { [$0.name, $0.email, $0.role.rawValue] }
+        let membersHeaders = ["username", "email", "role"]
+        let membersTable = formatDataToTable(
+            [membersHeaders] + organization.members.map { [$0.name, $0.email, $0.role.rawValue] }
         )
+
+        let invitationsString: String
+        if organization.invitations.isEmpty {
+            invitationsString = "There are currently no invited users."
+        } else {
+            let invitationsHeaders = ["inviter", "invitee email"]
+            let invitationsTable = formatDataToTable(
+                [invitationsHeaders] + organization.invitations.map { [$0.inviter.name, $0.inviteeEmail] }
+            )
+            invitationsString = """
+            \("Invitations".bold()) (total number: \(organization.invitations.count))
+            \(invitationsTable)
+            """
+        }
 
         logger.info("""
         \("Organization".bold())
         Name: \(organization.name)
 
         \("Organization members".bold()) (total number: \(organization.members.count))
-        \(tableString)
+        \(membersTable)
+
+        \(invitationsString)
         """)
     }
 

--- a/Tests/TuistKitTests/Services/Cloud/CloudOrganizationShowServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudOrganizationShowServiceTests.swift
@@ -42,6 +42,12 @@ final class CloudOrganizationShowServiceTests: TuistUnitTestCase {
                         email: "name-two@email.io",
                         role: .admin
                     ),
+                ],
+                invitations: [
+                    .test(
+                        inviteeEmail: "invitee@email.io",
+                        inviter: .test(name: "some-inviter")
+                    ),
                 ]
             )
         }
@@ -62,6 +68,10 @@ final class CloudOrganizationShowServiceTests: TuistUnitTestCase {
         username  email              role
         name-one  name-one@email.io  user
         name-two  name-two@email.io  admin
+
+        \(TerminalStyle.bold.open)Invitations\(TerminalStyle.reset.open) (total number: 1)
+        inviter       invitee email
+        some-inviter  invitee@email.io
         """)
     }
 }


### PR DESCRIPTION
### Short description 📝

- Adds a new command to invite a user: `tuist cloud organization invite your-org some@email.io`
- `tuist cloud organization show your-org` now outputs also the list of invitations

### How to test the changes locally 🧐

- `tuist cloud organization invite your-org some@email.io`
- `tuist cloud organization show your-org` should now include invitation for that email.
### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
