### PR TITLE
Add cloud organization remove invite command

### DIFF
--- a/Sources/TuistCloud/OpenAPI/Client.swift
+++ b/Sources/TuistCloud/OpenAPI/Client.swift
@@ -598,4 +598,78 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// - Remark: HTTP `DELETE /api/organizations/{organization_name}/invitations`.
+    /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/invitations/delete(cancelOrganizationInvite)`.
+    public func cancelOrganizationInvite(_ input: Operations.cancelOrganizationInvite.Input)
+        async throws -> Operations.cancelOrganizationInvite.Output
+    {
+        try await client.send(
+            input: input,
+            forOperation: Operations.cancelOrganizationInvite.id,
+            serializer: { input in
+                let path = try converter.renderedRequestPath(
+                    template: "/api/organizations/{}/invitations",
+                    parameters: [input.path.organization_name]
+                )
+                var request: OpenAPIRuntime.Request = .init(path: path, method: .delete)
+                suppressMutabilityWarning(&request)
+                try converter.setHeaderFieldAsText(
+                    in: &request.headerFields,
+                    name: "accept",
+                    value: "application/json"
+                )
+                request.body = try converter.setRequiredRequestBodyAsJSON(
+                    input.body,
+                    headerFields: &request.headerFields,
+                    transforming: { wrapped in
+                        switch wrapped {
+                        case let .json(value):
+                            return .init(
+                                value: value,
+                                contentType: "application/json; charset=utf-8"
+                            )
+                        }
+                    }
+                )
+                return request
+            },
+            deserializer: { response in
+                switch response.statusCode {
+                case 204:
+                    let headers: Operations.cancelOrganizationInvite.Output.NoContent.Headers =
+                        .init()
+                    return .noContent(.init(headers: headers, body: nil))
+                case 404:
+                    let headers: Operations.cancelOrganizationInvite.Output.NotFound.Headers =
+                        .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.cancelOrganizationInvite.Output.NotFound.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .notFound(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.cancelOrganizationInvite.Output.Unauthorized.Headers =
+                        .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.cancelOrganizationInvite.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
+                default: return .undocumented(statusCode: response.statusCode, .init())
+                }
+            }
+        )
+    }
 }

--- a/Sources/TuistCloud/OpenAPI/Types.swift
+++ b/Sources/TuistCloud/OpenAPI/Types.swift
@@ -43,6 +43,10 @@ public protocol APIProtocol: Sendable {
     /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/invitations/post(createOrganizationInvite)`.
     func createOrganizationInvite(_ input: Operations.createOrganizationInvite.Input) async throws
         -> Operations.createOrganizationInvite.Output
+    /// - Remark: HTTP `DELETE /api/organizations/{organization_name}/invitations`.
+    /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/invitations/delete(cancelOrganizationInvite)`.
+    func cancelOrganizationInvite(_ input: Operations.cancelOrganizationInvite.Input) async throws
+        -> Operations.cancelOrganizationInvite.Output
 }
 /// Server URLs defined in the OpenAPI document.
 public enum Servers {
@@ -1523,6 +1527,175 @@ public enum Operations {
             ///
             /// HTTP response code: `400 badRequest`.
             case badRequest(Operations.createOrganizationInvite.Output.BadRequest)
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+    }
+    /// - Remark: HTTP `DELETE /api/organizations/{organization_name}/invitations`.
+    /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/invitations/delete(cancelOrganizationInvite)`.
+    public enum cancelOrganizationInvite {
+        public static let id: String = "cancelOrganizationInvite"
+        public struct Input: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Equatable, Hashable {
+                public var organization_name: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - organization_name:
+                public init(organization_name: Swift.String) {
+                    self.organization_name = organization_name
+                }
+            }
+            public var path: Operations.cancelOrganizationInvite.Input.Path
+            public struct Query: Sendable, Equatable, Hashable {
+                /// Creates a new `Query`.
+                public init() {}
+            }
+            public var query: Operations.cancelOrganizationInvite.Input.Query
+            public struct Headers: Sendable, Equatable, Hashable {
+                /// Creates a new `Headers`.
+                public init() {}
+            }
+            public var headers: Operations.cancelOrganizationInvite.Input.Headers
+            public struct Cookies: Sendable, Equatable, Hashable {
+                /// Creates a new `Cookies`.
+                public init() {}
+            }
+            public var cookies: Operations.cancelOrganizationInvite.Input.Cookies
+            @frozen public enum Body: Sendable, Equatable, Hashable {
+                /// - Remark: Generated from `#/paths/api/organizations/{organization_name}/invitations/DELETE/json`.
+                public struct jsonPayload: Codable, Equatable, Hashable, Sendable {
+                    /// Email of the user to cancel the invite for.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/organizations/{organization_name}/invitations/DELETE/json/invitee_email`.
+                    public var invitee_email: Swift.String
+                    /// Creates a new `jsonPayload`.
+                    ///
+                    /// - Parameters:
+                    ///   - invitee_email: Email of the user to cancel the invite for.
+                    public init(invitee_email: Swift.String) { self.invitee_email = invitee_email }
+                    public enum CodingKeys: String, CodingKey { case invitee_email }
+                }
+                case json(Operations.cancelOrganizationInvite.Input.Body.jsonPayload)
+            }
+            public var body: Operations.cancelOrganizationInvite.Input.Body
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - query:
+            ///   - headers:
+            ///   - cookies:
+            ///   - body:
+            public init(
+                path: Operations.cancelOrganizationInvite.Input.Path,
+                query: Operations.cancelOrganizationInvite.Input.Query = .init(),
+                headers: Operations.cancelOrganizationInvite.Input.Headers = .init(),
+                cookies: Operations.cancelOrganizationInvite.Input.Cookies = .init(),
+                body: Operations.cancelOrganizationInvite.Input.Body
+            ) {
+                self.path = path
+                self.query = query
+                self.headers = headers
+                self.cookies = cookies
+                self.body = body
+            }
+        }
+        @frozen public enum Output: Sendable, Equatable, Hashable {
+            public struct NoContent: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.cancelOrganizationInvite.Output.NoContent.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {}
+                /// Received HTTP response body
+                public var body: Operations.cancelOrganizationInvite.Output.NoContent.Body?
+                /// Creates a new `NoContent`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.cancelOrganizationInvite.Output.NoContent.Headers = .init(),
+                    body: Operations.cancelOrganizationInvite.Output.NoContent.Body? = nil
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The invitations was successfully cancelled.
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/invitations/delete(cancelOrganizationInvite)/responses/204`.
+            ///
+            /// HTTP response code: `204 noContent`.
+            case noContent(Operations.cancelOrganizationInvite.Output.NoContent)
+            public struct NotFound: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.cancelOrganizationInvite.Output.NotFound.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.cancelOrganizationInvite.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.cancelOrganizationInvite.Output.NotFound.Headers = .init(),
+                    body: Operations.cancelOrganizationInvite.Output.NotFound.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The invitation could not be deleted because it was not found.
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/invitations/delete(cancelOrganizationInvite)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.cancelOrganizationInvite.Output.NotFound)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.cancelOrganizationInvite.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.cancelOrganizationInvite.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.cancelOrganizationInvite.Output.Unauthorized.Headers =
+                        .init(),
+                    body: Operations.cancelOrganizationInvite.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The invitation could not be cancelled because the user is not authorized to do the action.
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/invitations/delete(cancelOrganizationInvite)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.cancelOrganizationInvite.Output.Unauthorized)
             /// Undocumented response.
             ///
             /// A response with a code that is not documented in the OpenAPI document.

--- a/Sources/TuistCloud/OpenAPI/cloud.yml
+++ b/Sources/TuistCloud/OpenAPI/cloud.yml
@@ -247,6 +247,42 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+    delete:
+      operationId: cancelOrganizationInvite
+      parameters:
+        - in: path
+          name: organization_name
+          required: true
+          description: The organization to invite the user to.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                invitee_email:
+                  type: string
+                  description: Email of the user to cancel the invite for.
+              required:
+                - invitee_email
+      responses:
+        "204":
+          description: The invitations was successfully cancelled.
+        "404":
+          description: The invitation could not be deleted because it was not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: The invitation could not be cancelled because the user is not authorized to do the action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 components:
   schemas:
     User:

--- a/Sources/TuistCloud/Services/CancelOrganizationInviteService.swift
+++ b/Sources/TuistCloud/Services/CancelOrganizationInviteService.swift
@@ -1,0 +1,71 @@
+import Foundation
+import OpenAPIURLSession
+import TuistSupport
+
+public protocol CancelOrganizationInviteServicing {
+    func cancelOrganizationInvite(
+        organizationName: String,
+        email: String,
+        serverURL: URL
+    ) async throws
+}
+
+enum CancelOrganizationInviteServiceError: FatalError {
+    case unknownError(Int)
+    case notFound(String)
+    case unauthorized(String)
+
+    var type: ErrorType {
+        switch self {
+        case .unknownError:
+            return .bug
+        case .notFound, .unauthorized:
+            return .abort
+        }
+    }
+
+    var description: String {
+        switch self {
+        case let .unknownError(statusCode):
+            return "The invitation could not be cancelled due to an unknown cloud response of \(statusCode)."
+        case let .notFound(message), let .unauthorized(message):
+            return message
+        }
+    }
+}
+
+public final class CancelOrganizationInviteService: CancelOrganizationInviteServicing {
+    public init() {}
+
+    public func cancelOrganizationInvite(
+        organizationName: String,
+        email: String,
+        serverURL: URL
+    ) async throws {
+        let client = Client.cloud(serverURL: serverURL)
+
+        let response = try await client.cancelOrganizationInvite(
+            .init(
+                path: .init(organization_name: organizationName),
+                body: .json(.init(invitee_email: email))
+            )
+        )
+        switch response {
+        case .noContent:
+            // noop
+            break
+        case let .notFound(notFoundResponse):
+            switch notFoundResponse.body {
+            case let .json(error):
+                throw CancelOrganizationInviteServiceError.notFound(error.message)
+            }
+        case let .unauthorized(unauthorizedResponse):
+            switch unauthorizedResponse.body {
+            case let .json(error):
+                throw CancelOrganizationInviteServiceError.unauthorized(error.message)
+            }
+        case let .undocumented(statusCode: statusCode, _):
+            throw CancelOrganizationInviteServiceError.unknownError(statusCode)
+        }
+    }
+}

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationCommand.swift
@@ -14,6 +14,7 @@ struct CloudOrganizationCommand: ParsableCommand {
                 CloudOrganizationDeleteCommand.self,
                 CloudOrganizationShowCommand.self,
                 CloudOrganizationInviteCommand.self,
+                CloudOrganizationRemoveCommand.self,
             ]
         )
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationRemoveCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationRemoveCommand.swift
@@ -1,0 +1,16 @@
+import ArgumentParser
+import Foundation
+import TSCBasic
+
+struct CloudOrganizationRemoveCommand: ParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "remove",
+            _superCommandName: "organization",
+            abstract: "A set of commands to remove members or cancel pending invitations.",
+            subcommands: [
+                CloudOrganizationRemoveInviteCommand.self,
+            ]
+        )
+    }
+}

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationRemoveInviteCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationRemoveInviteCommand.swift
@@ -1,0 +1,38 @@
+import ArgumentParser
+import Foundation
+import TSCBasic
+import TuistSupport
+
+struct CloudOrganizationRemoveInviteCommand: AsyncParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "invite",
+            _superCommandName: "remove",
+            abstract: "Cancel pending invitation."
+        )
+    }
+
+    @Argument(
+        help: "The name of the organization to cancel the invitation for."
+    )
+    var organizationName: String
+
+    @Argument(
+        help: "The email of the user to cancel the invitation for."
+    )
+    var email: String
+
+    @Option(
+        name: .long,
+        help: "URL to the cloud server."
+    )
+    var serverURL: String?
+
+    func run() async throws {
+        try await CloudOrganizationRemoveInviteService().run(
+            organizationName: organizationName,
+            email: email,
+            serverURL: serverURL
+        )
+    }
+}

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationRemoveInviteService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationRemoveInviteService.swift
@@ -1,0 +1,42 @@
+import Foundation
+import TSCBasic
+import TuistCloud
+import TuistLoader
+import TuistSupport
+
+protocol CloudOrganizationRemoveInviteServicing {
+    func run(
+        organizationName: String,
+        email: String,
+        serverURL: String?
+    ) async throws
+}
+
+final class CloudOrganizationRemoveInviteService: CloudOrganizationRemoveInviteServicing {
+    private let cancelOrganizationRemoveInviteService: CancelOrganizationInviteServicing
+    private let cloudURLService: CloudURLServicing
+
+    init(
+        cancelOrganizationRemoveInviteService: CancelOrganizationInviteServicing = CancelOrganizationInviteService(),
+        cloudURLService: CloudURLServicing = CloudURLService()
+    ) {
+        self.cancelOrganizationRemoveInviteService = cancelOrganizationRemoveInviteService
+        self.cloudURLService = cloudURLService
+    }
+
+    func run(
+        organizationName: String,
+        email: String,
+        serverURL: String?
+    ) async throws {
+        let cloudURL = try cloudURLService.url(serverURL: serverURL)
+
+        try await cancelOrganizationRemoveInviteService.cancelOrganizationInvite(
+            organizationName: organizationName,
+            email: email,
+            serverURL: cloudURL
+        )
+
+        logger.info("The invitation for \(email) to the \(organizationName) organization was successfully cancelled.")
+    }
+}


### PR DESCRIPTION
### Short description 📝

Adds a new `tuist cloud organization remove invite` command

### How to test the changes locally 🧐

- `tuist cloud organization invite your-org some@email.io`
- `tuist cloud organization show your-org` should now include invitation for that email.
- `tuist cloud organization remove your-org some@email.io` should cancel the invitation
- `tuist cloud organization show your-org` you should no longer see the invitation in the output

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
