### PR TITLE
Add cloud organization remove member command

### DIFF
--- a/Sources/TuistCloud/OpenAPI/Client.swift
+++ b/Sources/TuistCloud/OpenAPI/Client.swift
@@ -672,4 +672,65 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// - Remark: HTTP `DELETE /api/organizations/{organization_name}/members/{username}`.
+    /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/members/{username}/delete(removeOrganizationMember)`.
+    public func removeOrganizationMember(_ input: Operations.removeOrganizationMember.Input)
+        async throws -> Operations.removeOrganizationMember.Output
+    {
+        try await client.send(
+            input: input,
+            forOperation: Operations.removeOrganizationMember.id,
+            serializer: { input in
+                let path = try converter.renderedRequestPath(
+                    template: "/api/organizations/{}/members/{}",
+                    parameters: [input.path.organization_name, input.path.username]
+                )
+                var request: OpenAPIRuntime.Request = .init(path: path, method: .delete)
+                suppressMutabilityWarning(&request)
+                try converter.setHeaderFieldAsText(
+                    in: &request.headerFields,
+                    name: "accept",
+                    value: "application/json"
+                )
+                return request
+            },
+            deserializer: { response in
+                switch response.statusCode {
+                case 204:
+                    let headers: Operations.removeOrganizationMember.Output.NoContent.Headers =
+                        .init()
+                    return .noContent(.init(headers: headers, body: nil))
+                case 404:
+                    let headers: Operations.removeOrganizationMember.Output.NotFound.Headers =
+                        .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.removeOrganizationMember.Output.NotFound.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .notFound(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.removeOrganizationMember.Output.Unauthorized.Headers =
+                        .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.removeOrganizationMember.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
+                default: return .undocumented(statusCode: response.statusCode, .init())
+                }
+            }
+        )
+    }
 }

--- a/Sources/TuistCloud/OpenAPI/Types.swift
+++ b/Sources/TuistCloud/OpenAPI/Types.swift
@@ -47,6 +47,10 @@ public protocol APIProtocol: Sendable {
     /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/invitations/delete(cancelOrganizationInvite)`.
     func cancelOrganizationInvite(_ input: Operations.cancelOrganizationInvite.Input) async throws
         -> Operations.cancelOrganizationInvite.Output
+    /// - Remark: HTTP `DELETE /api/organizations/{organization_name}/members/{username}`.
+    /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/members/{username}/delete(removeOrganizationMember)`.
+    func removeOrganizationMember(_ input: Operations.removeOrganizationMember.Input) async throws
+        -> Operations.removeOrganizationMember.Output
 }
 /// Server URLs defined in the OpenAPI document.
 public enum Servers {
@@ -1696,6 +1700,163 @@ public enum Operations {
             ///
             /// HTTP response code: `401 unauthorized`.
             case unauthorized(Operations.cancelOrganizationInvite.Output.Unauthorized)
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+    }
+    /// - Remark: HTTP `DELETE /api/organizations/{organization_name}/members/{username}`.
+    /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/members/{username}/delete(removeOrganizationMember)`.
+    public enum removeOrganizationMember {
+        public static let id: String = "removeOrganizationMember"
+        public struct Input: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Equatable, Hashable {
+                public var organization_name: Swift.String
+                public var username: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - organization_name:
+                ///   - username:
+                public init(organization_name: Swift.String, username: Swift.String) {
+                    self.organization_name = organization_name
+                    self.username = username
+                }
+            }
+            public var path: Operations.removeOrganizationMember.Input.Path
+            public struct Query: Sendable, Equatable, Hashable {
+                /// Creates a new `Query`.
+                public init() {}
+            }
+            public var query: Operations.removeOrganizationMember.Input.Query
+            public struct Headers: Sendable, Equatable, Hashable {
+                /// Creates a new `Headers`.
+                public init() {}
+            }
+            public var headers: Operations.removeOrganizationMember.Input.Headers
+            public struct Cookies: Sendable, Equatable, Hashable {
+                /// Creates a new `Cookies`.
+                public init() {}
+            }
+            public var cookies: Operations.removeOrganizationMember.Input.Cookies
+            @frozen public enum Body: Sendable, Equatable, Hashable {}
+            public var body: Operations.removeOrganizationMember.Input.Body?
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - query:
+            ///   - headers:
+            ///   - cookies:
+            ///   - body:
+            public init(
+                path: Operations.removeOrganizationMember.Input.Path,
+                query: Operations.removeOrganizationMember.Input.Query = .init(),
+                headers: Operations.removeOrganizationMember.Input.Headers = .init(),
+                cookies: Operations.removeOrganizationMember.Input.Cookies = .init(),
+                body: Operations.removeOrganizationMember.Input.Body? = nil
+            ) {
+                self.path = path
+                self.query = query
+                self.headers = headers
+                self.cookies = cookies
+                self.body = body
+            }
+        }
+        @frozen public enum Output: Sendable, Equatable, Hashable {
+            public struct NoContent: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.removeOrganizationMember.Output.NoContent.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {}
+                /// Received HTTP response body
+                public var body: Operations.removeOrganizationMember.Output.NoContent.Body?
+                /// Creates a new `NoContent`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.removeOrganizationMember.Output.NoContent.Headers = .init(),
+                    body: Operations.removeOrganizationMember.Output.NoContent.Body? = nil
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The member was successfully removed.
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/members/{username}/delete(removeOrganizationMember)/responses/204`.
+            ///
+            /// HTTP response code: `204 noContent`.
+            case noContent(Operations.removeOrganizationMember.Output.NoContent)
+            public struct NotFound: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.removeOrganizationMember.Output.NotFound.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.removeOrganizationMember.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.removeOrganizationMember.Output.NotFound.Headers = .init(),
+                    body: Operations.removeOrganizationMember.Output.NotFound.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The organizatino or the member were not found.
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/members/{username}/delete(removeOrganizationMember)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.removeOrganizationMember.Output.NotFound)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.removeOrganizationMember.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.removeOrganizationMember.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.removeOrganizationMember.Output.Unauthorized.Headers =
+                        .init(),
+                    body: Operations.removeOrganizationMember.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The member could not be removed because the user is not authorized to do the action.
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/members/{username}/delete(removeOrganizationMember)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.removeOrganizationMember.Output.Unauthorized)
             /// Undocumented response.
             ///
             /// A response with a code that is not documented in the OpenAPI document.

--- a/Sources/TuistCloud/OpenAPI/cloud.yml
+++ b/Sources/TuistCloud/OpenAPI/cloud.yml
@@ -283,6 +283,37 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/organizations/{organization_name}/members/{username}:
+    delete:
+      operationId: removeOrganizationMember
+      parameters:
+        - in: path
+          name: organization_name
+          required: true
+          description: The organization to remove the member from.
+          schema:
+            type: string
+        - in: path
+          name: username
+          required: true
+          description: The username of the member to remove from the organization.
+          schema:
+            type: string
+      responses:
+        "204":
+          description: The member was successfully removed.
+        "404":
+          description: The organizatino or the member were not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: The member could not be removed because the user is not authorized to do the action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 components:
   schemas:
     User:

--- a/Sources/TuistCloud/Services/RemoveOrganizationMemberService.swift
+++ b/Sources/TuistCloud/Services/RemoveOrganizationMemberService.swift
@@ -1,0 +1,73 @@
+import Foundation
+import OpenAPIURLSession
+import TuistSupport
+
+public protocol RemoveOrganizationMemberServicing {
+    func removeOrganizationMember(
+        organizationName: String,
+        username: String,
+        serverURL: URL
+    ) async throws
+}
+
+enum RemoveOrganizationMemberServiceError: FatalError {
+    case unknownError(Int)
+    case notFound(String)
+    case unauthorized(String)
+
+    var type: ErrorType {
+        switch self {
+        case .unknownError:
+            return .bug
+        case .notFound, .unauthorized:
+            return .abort
+        }
+    }
+
+    var description: String {
+        switch self {
+        case let .unknownError(statusCode):
+            return "The member could not be removed due to an unknown cloud response of \(statusCode)."
+        case let .notFound(message), let .unauthorized(message):
+            return message
+        }
+    }
+}
+
+public final class RemoveOrganizationMemberService: RemoveOrganizationMemberServicing {
+    public init() {}
+
+    public func removeOrganizationMember(
+        organizationName: String,
+        username: String,
+        serverURL: URL
+    ) async throws {
+        let client = Client.cloud(serverURL: serverURL)
+
+        let response = try await client.removeOrganizationMember(
+            .init(
+                path: .init(
+                    organization_name: organizationName,
+                    username: username
+                )
+            )
+        )
+        switch response {
+        case .noContent:
+            // noop
+            break
+        case let .notFound(notFoundResponse):
+            switch notFoundResponse.body {
+            case let .json(error):
+                throw RemoveOrganizationMemberServiceError.notFound(error.message)
+            }
+        case let .unauthorized(unauthorizedResponse):
+            switch unauthorizedResponse.body {
+            case let .json(error):
+                throw RemoveOrganizationMemberServiceError.unauthorized(error.message)
+            }
+        case let .undocumented(statusCode: statusCode, _):
+            throw RemoveOrganizationMemberServiceError.unknownError(statusCode)
+        }
+    }
+}

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationRemoveCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationRemoveCommand.swift
@@ -10,6 +10,7 @@ struct CloudOrganizationRemoveCommand: ParsableCommand {
             abstract: "A set of commands to remove members or cancel pending invitations.",
             subcommands: [
                 CloudOrganizationRemoveInviteCommand.self,
+                CloudOrganizationRemoveMemberCommand.self,
             ]
         )
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationRemoveMemberCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationRemoveMemberCommand.swift
@@ -1,0 +1,38 @@
+import ArgumentParser
+import Foundation
+import TSCBasic
+import TuistSupport
+
+struct CloudOrganizationRemoveMemberCommand: AsyncParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "member",
+            _superCommandName: "remove",
+            abstract: "Remove a member from your organization."
+        )
+    }
+
+    @Argument(
+        help: "The name of the organization to remove the organization member from."
+    )
+    var organizationName: String
+
+    @Argument(
+        help: "The username of the member you want to remove from the organization."
+    )
+    var username: String
+
+    @Option(
+        name: .long,
+        help: "URL to the cloud server."
+    )
+    var serverURL: String?
+
+    func run() async throws {
+        try await CloudOrganizationRemoveMemberService().run(
+            organizationName: organizationName,
+            username: username,
+            serverURL: serverURL
+        )
+    }
+}

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationRemoveMemberService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationRemoveMemberService.swift
@@ -1,0 +1,42 @@
+import Foundation
+import TSCBasic
+import TuistCloud
+import TuistLoader
+import TuistSupport
+
+protocol CloudOrganizationRemoveMemberServicing {
+    func run(
+        organizationName: String,
+        username: String,
+        serverURL: String?
+    ) async throws
+}
+
+final class CloudOrganizationRemoveMemberService: CloudOrganizationRemoveMemberServicing {
+    private let removeOrganizationMemberService: RemoveOrganizationMemberServicing
+    private let cloudURLService: CloudURLServicing
+
+    init(
+        removeOrganizationMemberService: RemoveOrganizationMemberServicing = RemoveOrganizationMemberService(),
+        cloudURLService: CloudURLServicing = CloudURLService()
+    ) {
+        self.removeOrganizationMemberService = removeOrganizationMemberService
+        self.cloudURLService = cloudURLService
+    }
+
+    func run(
+        organizationName: String,
+        username: String,
+        serverURL: String?
+    ) async throws {
+        let cloudURL = try cloudURLService.url(serverURL: serverURL)
+
+        try await removeOrganizationMemberService.removeOrganizationMember(
+            organizationName: organizationName,
+            username: username,
+            serverURL: cloudURL
+        )
+
+        logger.info("The member \(username) was successfully removed from the \(organizationName) organization.")
+    }
+}


### PR DESCRIPTION
### Short description 📝

Adds a new command `tuist cloud organization remove member some-org some-username`

### How to test the changes locally 🧐

- Invite a new member through `tuist cloud organization invite some-org user-email`
- Accept the invite (create account if needed)
- `tuist cloud organization show some-org` -> the new user should be listed as a member
- `tuist cloud organization remove member some-org some-username` -> will remove the member from the org

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
