### PR TITLE
Add cloud organization update member command

### DIFF
--- a/Sources/TuistCloud/OpenAPI/Client.swift
+++ b/Sources/TuistCloud/OpenAPI/Client.swift
@@ -672,6 +672,89 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// - Remark: HTTP `PUT /api/organizations/{organization_name}/members/{username}`.
+    /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/members/{username}/put(updateOrganizationMember)`.
+    public func updateOrganizationMember(_ input: Operations.updateOrganizationMember.Input)
+        async throws -> Operations.updateOrganizationMember.Output
+    {
+        try await client.send(
+            input: input,
+            forOperation: Operations.updateOrganizationMember.id,
+            serializer: { input in
+                let path = try converter.renderedRequestPath(
+                    template: "/api/organizations/{}/members/{}",
+                    parameters: [input.path.organization_name, input.path.username]
+                )
+                var request: OpenAPIRuntime.Request = .init(path: path, method: .put)
+                suppressMutabilityWarning(&request)
+                try converter.setHeaderFieldAsText(
+                    in: &request.headerFields,
+                    name: "accept",
+                    value: "application/json"
+                )
+                request.body = try converter.setRequiredRequestBodyAsJSON(
+                    input.body,
+                    headerFields: &request.headerFields,
+                    transforming: { wrapped in
+                        switch wrapped {
+                        case let .json(value):
+                            return .init(
+                                value: value,
+                                contentType: "application/json; charset=utf-8"
+                            )
+                        }
+                    }
+                )
+                return request
+            },
+            deserializer: { response in
+                switch response.statusCode {
+                case 200:
+                    let headers: Operations.updateOrganizationMember.Output.Ok.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.updateOrganizationMember.Output.Ok.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas.OrganizationMember.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .ok(.init(headers: headers, body: body))
+                case 404:
+                    let headers: Operations.updateOrganizationMember.Output.NotFound.Headers =
+                        .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.updateOrganizationMember.Output.NotFound.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .notFound(.init(headers: headers, body: body))
+                case 401:
+                    let headers: Operations.updateOrganizationMember.Output.Unauthorized.Headers =
+                        .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.updateOrganizationMember.Output.Unauthorized.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .unauthorized(.init(headers: headers, body: body))
+                default: return .undocumented(statusCode: response.statusCode, .init())
+                }
+            }
+        )
+    }
     /// - Remark: HTTP `DELETE /api/organizations/{organization_name}/members/{username}`.
     /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/members/{username}/delete(removeOrganizationMember)`.
     public func removeOrganizationMember(_ input: Operations.removeOrganizationMember.Input)

--- a/Sources/TuistCloud/OpenAPI/Types.swift
+++ b/Sources/TuistCloud/OpenAPI/Types.swift
@@ -47,6 +47,10 @@ public protocol APIProtocol: Sendable {
     /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/invitations/delete(cancelOrganizationInvite)`.
     func cancelOrganizationInvite(_ input: Operations.cancelOrganizationInvite.Input) async throws
         -> Operations.cancelOrganizationInvite.Output
+    /// - Remark: HTTP `PUT /api/organizations/{organization_name}/members/{username}`.
+    /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/members/{username}/put(updateOrganizationMember)`.
+    func updateOrganizationMember(_ input: Operations.updateOrganizationMember.Input) async throws
+        -> Operations.updateOrganizationMember.Output
     /// - Remark: HTTP `DELETE /api/organizations/{organization_name}/members/{username}`.
     /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/members/{username}/delete(removeOrganizationMember)`.
     func removeOrganizationMember(_ input: Operations.removeOrganizationMember.Input) async throws
@@ -1706,6 +1710,180 @@ public enum Operations {
             case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
         }
     }
+    /// - Remark: HTTP `PUT /api/organizations/{organization_name}/members/{username}`.
+    /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/members/{username}/put(updateOrganizationMember)`.
+    public enum updateOrganizationMember {
+        public static let id: String = "updateOrganizationMember"
+        public struct Input: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Equatable, Hashable {
+                public var organization_name: Swift.String
+                public var username: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - organization_name:
+                ///   - username:
+                public init(organization_name: Swift.String, username: Swift.String) {
+                    self.organization_name = organization_name
+                    self.username = username
+                }
+            }
+            public var path: Operations.updateOrganizationMember.Input.Path
+            public struct Query: Sendable, Equatable, Hashable {
+                /// Creates a new `Query`.
+                public init() {}
+            }
+            public var query: Operations.updateOrganizationMember.Input.Query
+            public struct Headers: Sendable, Equatable, Hashable {
+                /// Creates a new `Headers`.
+                public init() {}
+            }
+            public var headers: Operations.updateOrganizationMember.Input.Headers
+            public struct Cookies: Sendable, Equatable, Hashable {
+                /// Creates a new `Cookies`.
+                public init() {}
+            }
+            public var cookies: Operations.updateOrganizationMember.Input.Cookies
+            @frozen public enum Body: Sendable, Equatable, Hashable {
+                /// - Remark: Generated from `#/paths/api/organizations/{organization_name}/members/{username}/PUT/json`.
+                public struct jsonPayload: Codable, Equatable, Hashable, Sendable {
+                    /// The new role of the member.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/organizations/{organization_name}/members/{username}/PUT/json/role`.
+                    public var role: OpenAPIRuntime.OpenAPIValueContainer
+                    /// Creates a new `jsonPayload`.
+                    ///
+                    /// - Parameters:
+                    ///   - role: The new role of the member.
+                    public init(role: OpenAPIRuntime.OpenAPIValueContainer) { self.role = role }
+                    public enum CodingKeys: String, CodingKey { case role }
+                }
+                case json(Operations.updateOrganizationMember.Input.Body.jsonPayload)
+            }
+            public var body: Operations.updateOrganizationMember.Input.Body
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - query:
+            ///   - headers:
+            ///   - cookies:
+            ///   - body:
+            public init(
+                path: Operations.updateOrganizationMember.Input.Path,
+                query: Operations.updateOrganizationMember.Input.Query = .init(),
+                headers: Operations.updateOrganizationMember.Input.Headers = .init(),
+                cookies: Operations.updateOrganizationMember.Input.Cookies = .init(),
+                body: Operations.updateOrganizationMember.Input.Body
+            ) {
+                self.path = path
+                self.query = query
+                self.headers = headers
+                self.cookies = cookies
+                self.body = body
+            }
+        }
+        @frozen public enum Output: Sendable, Equatable, Hashable {
+            public struct Ok: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.updateOrganizationMember.Output.Ok.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas.OrganizationMember)
+                }
+                /// Received HTTP response body
+                public var body: Operations.updateOrganizationMember.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.updateOrganizationMember.Output.Ok.Headers = .init(),
+                    body: Operations.updateOrganizationMember.Output.Ok.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The member was successfully updated.
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/members/{username}/put(updateOrganizationMember)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.updateOrganizationMember.Output.Ok)
+            public struct NotFound: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.updateOrganizationMember.Output.NotFound.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.updateOrganizationMember.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.updateOrganizationMember.Output.NotFound.Headers = .init(),
+                    body: Operations.updateOrganizationMember.Output.NotFound.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The organization or the member were not found.
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/members/{username}/put(updateOrganizationMember)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.updateOrganizationMember.Output.NotFound)
+            public struct Unauthorized: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.updateOrganizationMember.Output.Unauthorized.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.updateOrganizationMember.Output.Unauthorized.Body
+                /// Creates a new `Unauthorized`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.updateOrganizationMember.Output.Unauthorized.Headers =
+                        .init(),
+                    body: Operations.updateOrganizationMember.Output.Unauthorized.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The member could not be updated because the user is not authorized to do the action.
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/members/{username}/put(updateOrganizationMember)/responses/401`.
+            ///
+            /// HTTP response code: `401 unauthorized`.
+            case unauthorized(Operations.updateOrganizationMember.Output.Unauthorized)
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+    }
     /// - Remark: HTTP `DELETE /api/organizations/{organization_name}/members/{username}`.
     /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/members/{username}/delete(removeOrganizationMember)`.
     public enum removeOrganizationMember {
@@ -1819,7 +1997,7 @@ public enum Operations {
                     self.body = body
                 }
             }
-            /// The organizatino or the member were not found.
+            /// The organization or the member were not found.
             ///
             /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/members/{username}/delete(removeOrganizationMember)/responses/404`.
             ///

--- a/Sources/TuistCloud/OpenAPI/cloud.yml
+++ b/Sources/TuistCloud/OpenAPI/cloud.yml
@@ -303,13 +303,61 @@ paths:
         "204":
           description: The member was successfully removed.
         "404":
-          description: The organizatino or the member were not found.
+          description: The organization or the member were not found.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
         "401":
           description: The member could not be removed because the user is not authorized to do the action.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    put:
+      operationId: updateOrganizationMember
+      parameters:
+        - in: path
+          name: organization_name
+          required: true
+          description: The organization of the member to update.
+          schema:
+            type: string
+        - in: path
+          name: username
+          required: true
+          description: The username of the member to update.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                role:
+                  enum:
+                    - admin
+                    - user
+                  description: The new role of the member.
+              required:
+                - role
+      responses:
+        "200":
+          description: The member was successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OrganizationMember"
+        "404":
+          description: The organization or the member were not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: The member could not be updated because the user is not authorized to do the action.
           content:
             application/json:
               schema:

--- a/Sources/TuistCloud/Services/UpdateOrganizationMemberService.swift
+++ b/Sources/TuistCloud/Services/UpdateOrganizationMemberService.swift
@@ -1,0 +1,78 @@
+import Foundation
+import OpenAPIURLSession
+import TuistSupport
+
+public protocol UpdateOrganizationMemberServicing {
+    func updateOrganizationMember(
+        organizationName: String,
+        username: String,
+        role: CloudOrganization.Member.Role,
+        serverURL: URL
+    ) async throws -> CloudOrganization.Member
+}
+
+enum UpdateOrganizationMemberServiceError: FatalError {
+    case unknownError(Int)
+    case notFound(String)
+    case unauthorized(String)
+
+    var type: ErrorType {
+        switch self {
+        case .unknownError:
+            return .bug
+        case .notFound, .unauthorized:
+            return .abort
+        }
+    }
+
+    var description: String {
+        switch self {
+        case let .unknownError(statusCode):
+            return "The member could not be updated due to an unknown cloud response of \(statusCode)."
+        case let .notFound(message), let .unauthorized(message):
+            return message
+        }
+    }
+}
+
+public final class UpdateOrganizationMemberService: UpdateOrganizationMemberServicing {
+    public init() {}
+
+    public func updateOrganizationMember(
+        organizationName: String,
+        username: String,
+        role: CloudOrganization.Member.Role,
+        serverURL: URL
+    ) async throws -> CloudOrganization.Member {
+        let client = Client.cloud(serverURL: serverURL)
+
+        let response = try await client.updateOrganizationMember(
+            .init(
+                path: .init(
+                    organization_name: organizationName,
+                    username: username
+                ),
+                body: .json(.init(role: .init(stringLiteral: role.rawValue)))
+            )
+        )
+        switch response {
+        case let .ok(okResponse):
+            switch okResponse.body {
+            case let .json(organizationMember):
+                return CloudOrganization.Member(organizationMember)
+            }
+        case let .notFound(notFoundResponse):
+            switch notFoundResponse.body {
+            case let .json(error):
+                throw UpdateOrganizationMemberServiceError.notFound(error.message)
+            }
+        case let .unauthorized(unauthorizedResponse):
+            switch unauthorizedResponse.body {
+            case let .json(error):
+                throw UpdateOrganizationMemberServiceError.unauthorized(error.message)
+            }
+        case let .undocumented(statusCode: statusCode, _):
+            throw UpdateOrganizationMemberServiceError.unknownError(statusCode)
+        }
+    }
+}

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationCommand.swift
@@ -15,6 +15,7 @@ struct CloudOrganizationCommand: ParsableCommand {
                 CloudOrganizationShowCommand.self,
                 CloudOrganizationInviteCommand.self,
                 CloudOrganizationRemoveCommand.self,
+                CloudOrganizationUpdateCommand.self,
             ]
         )
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationUpdateCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationUpdateCommand.swift
@@ -1,0 +1,16 @@
+import ArgumentParser
+import Foundation
+import TSCBasic
+
+struct CloudOrganizationUpdateCommand: ParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "update",
+            _superCommandName: "organization",
+            abstract: "A set of commands to update the organization.",
+            subcommands: [
+                CloudOrganizationUpdateMemberCommand.self,
+            ]
+        )
+    }
+}

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationUpdateMemberCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationUpdateMemberCommand.swift
@@ -1,0 +1,46 @@
+import ArgumentParser
+import Foundation
+import TSCBasic
+import TuistCloud
+import TuistSupport
+
+struct CloudOrganizationUpdateMemberCommand: AsyncParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "member",
+            _superCommandName: "remove",
+            abstract: "Update a member from your organization."
+        )
+    }
+
+    @Argument(
+        help: "The name of the organization for which you want to update the member for."
+    )
+    var organizationName: String
+
+    @Argument(
+        help: "The username of the member you want to update."
+    )
+    var username: String
+
+    @Option(
+        help: "The new member role",
+        completion: .list(["admin", "user"])
+    )
+    var role: String
+
+    @Option(
+        name: .long,
+        help: "URL to the cloud server."
+    )
+    var serverURL: String?
+
+    func run() async throws {
+        try await CloudOrganizationUpdateMemberService().run(
+            organizationName: organizationName,
+            username: username,
+            role: role,
+            serverURL: serverURL
+        )
+    }
+}

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationUpdateMemberService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationUpdateMemberService.swift
@@ -1,0 +1,45 @@
+import Foundation
+import TSCBasic
+import TuistCloud
+import TuistLoader
+import TuistSupport
+
+protocol CloudOrganizationUpdateMemberServicing {
+    func run(
+        organizationName: String,
+        username: String,
+        role: String,
+        serverURL: String?
+    ) async throws
+}
+
+final class CloudOrganizationUpdateMemberService: CloudOrganizationUpdateMemberServicing {
+    private let updateOrganizationMemberService: UpdateOrganizationMemberServicing
+    private let cloudURLService: CloudURLServicing
+
+    init(
+        updateOrganizationMemberService: UpdateOrganizationMemberServicing = UpdateOrganizationMemberService(),
+        cloudURLService: CloudURLServicing = CloudURLService()
+    ) {
+        self.updateOrganizationMemberService = updateOrganizationMemberService
+        self.cloudURLService = cloudURLService
+    }
+
+    func run(
+        organizationName: String,
+        username: String,
+        role: String,
+        serverURL: String?
+    ) async throws {
+        let cloudURL = try cloudURLService.url(serverURL: serverURL)
+
+        let member = try await updateOrganizationMemberService.updateOrganizationMember(
+            organizationName: organizationName,
+            username: username,
+            role: CloudOrganization.Member.Role(rawValue: role) ?? .user,
+            serverURL: cloudURL
+        )
+
+        logger.info("The member \(username) role was successfully updated to \(member.role.rawValue).")
+    }
+}


### PR DESCRIPTION
### Short description 📝

Adds a new command `tuist cloud organization update member some-org some-username --role admin`

### How to test the changes locally 🧐

- Update your organization to include at least one regular member (`user` role)
- Run `tuist cloud organization update member your-org username --role admin`
- `tuist cloud organization show your-org` -> The user should now have the admin role.

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
