### PR TITLE
Add cloud project token command

### DIFF
--- a/Sources/TuistCloud/Models/CloudProject.swift
+++ b/Sources/TuistCloud/Models/CloudProject.swift
@@ -4,19 +4,23 @@ import Foundation
 public struct CloudProject: Codable {
     public init(
         id: Int,
-        fullName: String
+        fullName: String,
+        token: String
     ) {
         self.id = id
         self.fullName = fullName
+        self.token = token
     }
 
     public let id: Int
     public let fullName: String
+    public let token: String
 }
 
 extension CloudProject {
     init(_ project: Components.Schemas.Project) {
         id = Int(project.id)
         fullName = project.full_name
+        token = project.token
     }
 }

--- a/Sources/TuistCloud/OpenAPI/Client.swift
+++ b/Sources/TuistCloud/OpenAPI/Client.swift
@@ -97,20 +97,23 @@ public struct Client: APIProtocol {
                 )
                 var request: OpenAPIRuntime.Request = .init(path: path, method: .post)
                 suppressMutabilityWarning(&request)
-                try converter.setQueryItemAsText(
-                    in: &request,
-                    name: "name",
-                    value: input.query.name
-                )
-                try converter.setQueryItemAsText(
-                    in: &request,
-                    name: "organization",
-                    value: input.query.organization
-                )
                 try converter.setHeaderFieldAsText(
                     in: &request.headerFields,
                     name: "accept",
                     value: "application/json"
+                )
+                request.body = try converter.setRequiredRequestBodyAsJSON(
+                    input.body,
+                    headerFields: &request.headerFields,
+                    transforming: { wrapped in
+                        switch wrapped {
+                        case let .json(value):
+                            return .init(
+                                value: value,
+                                contentType: "application/json; charset=utf-8"
+                            )
+                        }
+                    }
                 )
                 return request
             },
@@ -204,15 +207,23 @@ public struct Client: APIProtocol {
                 )
                 var request: OpenAPIRuntime.Request = .init(path: path, method: .post)
                 suppressMutabilityWarning(&request)
-                try converter.setQueryItemAsText(
-                    in: &request,
-                    name: "name",
-                    value: input.query.name
-                )
                 try converter.setHeaderFieldAsText(
                     in: &request.headerFields,
                     name: "accept",
                     value: "application/json"
+                )
+                request.body = try converter.setRequiredRequestBodyAsJSON(
+                    input.body,
+                    headerFields: &request.headerFields,
+                    transforming: { wrapped in
+                        switch wrapped {
+                        case let .json(value):
+                            return .init(
+                                value: value,
+                                contentType: "application/json; charset=utf-8"
+                            )
+                        }
+                    }
                 )
                 return request
             },

--- a/Sources/TuistCloud/OpenAPI/Types.swift
+++ b/Sources/TuistCloud/OpenAPI/Types.swift
@@ -204,18 +204,23 @@ public enum Components {
             public var id: Swift.Double
             /// - Remark: Generated from `#/components/schemas/Project/full_name`.
             public var full_name: Swift.String
+            /// - Remark: Generated from `#/components/schemas/Project/token`.
+            public var token: Swift.String
             /// Creates a new `Project`.
             ///
             /// - Parameters:
             ///   - id:
             ///   - full_name:
-            public init(id: Swift.Double, full_name: Swift.String) {
+            ///   - token:
+            public init(id: Swift.Double, full_name: Swift.String, token: Swift.String) {
                 self.id = id
                 self.full_name = full_name
+                self.token = token
             }
             public enum CodingKeys: String, CodingKey {
                 case id
                 case full_name
+                case token
             }
         }
         /// - Remark: Generated from `#/components/schemas/Organizations`.

--- a/Sources/TuistCloud/OpenAPI/Types.swift
+++ b/Sources/TuistCloud/OpenAPI/Types.swift
@@ -401,17 +401,8 @@ public enum Operations {
             }
             public var path: Operations.createProject.Input.Path
             public struct Query: Sendable, Equatable, Hashable {
-                public var name: Swift.String
-                public var organization: Swift.String?
                 /// Creates a new `Query`.
-                ///
-                /// - Parameters:
-                ///   - name:
-                ///   - organization:
-                public init(name: Swift.String, organization: Swift.String? = nil) {
-                    self.name = name
-                    self.organization = organization
-                }
+                public init() {}
             }
             public var query: Operations.createProject.Input.Query
             public struct Headers: Sendable, Equatable, Hashable {
@@ -424,8 +415,34 @@ public enum Operations {
                 public init() {}
             }
             public var cookies: Operations.createProject.Input.Cookies
-            @frozen public enum Body: Sendable, Equatable, Hashable {}
-            public var body: Operations.createProject.Input.Body?
+            @frozen public enum Body: Sendable, Equatable, Hashable {
+                /// - Remark: Generated from `#/paths/api/projects/POST/json`.
+                public struct jsonPayload: Codable, Equatable, Hashable, Sendable {
+                    /// The name of the project that should be created.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/POST/json/name`.
+                    public var name: Swift.String
+                    /// Organization to create the project with. If nil, the project will be created with the current user's personal account.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/projects/POST/json/organization`.
+                    public var organization: Swift.String?
+                    /// Creates a new `jsonPayload`.
+                    ///
+                    /// - Parameters:
+                    ///   - name: The name of the project that should be created.
+                    ///   - organization: Organization to create the project with. If nil, the project will be created with the current user's personal account.
+                    public init(name: Swift.String, organization: Swift.String? = nil) {
+                        self.name = name
+                        self.organization = organization
+                    }
+                    public enum CodingKeys: String, CodingKey {
+                        case name
+                        case organization
+                    }
+                }
+                case json(Operations.createProject.Input.Body.jsonPayload)
+            }
+            public var body: Operations.createProject.Input.Body
             /// Creates a new `Input`.
             ///
             /// - Parameters:
@@ -436,10 +453,10 @@ public enum Operations {
             ///   - body:
             public init(
                 path: Operations.createProject.Input.Path = .init(),
-                query: Operations.createProject.Input.Query,
+                query: Operations.createProject.Input.Query = .init(),
                 headers: Operations.createProject.Input.Headers = .init(),
                 cookies: Operations.createProject.Input.Cookies = .init(),
-                body: Operations.createProject.Input.Body? = nil
+                body: Operations.createProject.Input.Body
             ) {
                 self.path = path
                 self.query = query
@@ -615,12 +632,8 @@ public enum Operations {
             }
             public var path: Operations.createOrganization.Input.Path
             public struct Query: Sendable, Equatable, Hashable {
-                public var name: Swift.String
                 /// Creates a new `Query`.
-                ///
-                /// - Parameters:
-                ///   - name:
-                public init(name: Swift.String) { self.name = name }
+                public init() {}
             }
             public var query: Operations.createOrganization.Input.Query
             public struct Headers: Sendable, Equatable, Hashable {
@@ -633,8 +646,23 @@ public enum Operations {
                 public init() {}
             }
             public var cookies: Operations.createOrganization.Input.Cookies
-            @frozen public enum Body: Sendable, Equatable, Hashable {}
-            public var body: Operations.createOrganization.Input.Body?
+            @frozen public enum Body: Sendable, Equatable, Hashable {
+                /// - Remark: Generated from `#/paths/api/organizations/POST/json`.
+                public struct jsonPayload: Codable, Equatable, Hashable, Sendable {
+                    /// The name of the organization that should be created.
+                    ///
+                    /// - Remark: Generated from `#/paths/api/organizations/POST/json/name`.
+                    public var name: Swift.String
+                    /// Creates a new `jsonPayload`.
+                    ///
+                    /// - Parameters:
+                    ///   - name: The name of the organization that should be created.
+                    public init(name: Swift.String) { self.name = name }
+                    public enum CodingKeys: String, CodingKey { case name }
+                }
+                case json(Operations.createOrganization.Input.Body.jsonPayload)
+            }
+            public var body: Operations.createOrganization.Input.Body
             /// Creates a new `Input`.
             ///
             /// - Parameters:
@@ -645,10 +673,10 @@ public enum Operations {
             ///   - body:
             public init(
                 path: Operations.createOrganization.Input.Path = .init(),
-                query: Operations.createOrganization.Input.Query,
+                query: Operations.createOrganization.Input.Query = .init(),
                 headers: Operations.createOrganization.Input.Headers = .init(),
                 cookies: Operations.createOrganization.Input.Cookies = .init(),
-                body: Operations.createOrganization.Input.Body? = nil
+                body: Operations.createOrganization.Input.Body
             ) {
                 self.path = path
                 self.query = query

--- a/Sources/TuistCloud/OpenAPI/cloud.yml
+++ b/Sources/TuistCloud/OpenAPI/cloud.yml
@@ -429,9 +429,12 @@ components:
           type: number
         full_name:
           type: string
+        token:
+          type: string
       required:
         - id
         - full_name
+        - token
     Organizations:
       type: object
       properties:

--- a/Sources/TuistCloud/OpenAPI/cloud.yml
+++ b/Sources/TuistCloud/OpenAPI/cloud.yml
@@ -29,19 +29,21 @@ paths:
                 $ref: "#/components/schemas/Projects"
     post:
       operationId: createProject
-      parameters:
-        - name: name
-          required: true
-          in: query
-          description: The name of the project that should be created.
-          schema:
-            type: string
-        - name: organization
-          required: false
-          in: query
-          description: Organization to create the project with. If nil, the project will be created with the current user's personal account.
-          schema:
-            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: The name of the project that should be created.
+                organization:
+                  type: string
+                  description: Organization to create the project with. If nil, the project will be created with the current user's personal account.
+              required:
+                - name
       responses:
         "200":
           description: A success response with the created project.
@@ -67,13 +69,18 @@ paths:
                 $ref: "#/components/schemas/Organizations"
     post:
       operationId: createOrganization
-      parameters:
-        - name: name
-          required: true
-          in: query
-          description: The name of the organization that should be created.
-          schema:
-            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: The name of the organization that should be created.
+              required:
+                - name
       responses:
         "200":
           description: A success response with the created organization.

--- a/Sources/TuistCloud/Services/CreateOrganizationService.swift
+++ b/Sources/TuistCloud/Services/CreateOrganizationService.swift
@@ -43,8 +43,10 @@ public final class CreateOrganizationService: CreateOrganizationServicing {
 
         let response = try await client.createOrganization(
             .init(
-                query: .init(
-                    name: name
+                body: .json(
+                    .init(
+                        name: name
+                    )
                 )
             )
         )

--- a/Sources/TuistCloud/Services/CreateProjectServiceNext.swift
+++ b/Sources/TuistCloud/Services/CreateProjectServiceNext.swift
@@ -45,9 +45,11 @@ public final class CreateProjectNextService: CreateProjectNextServicing {
 
         let response = try await client.createProject(
             .init(
-                query: .init(
-                    name: name,
-                    organization: organization
+                body: .json(
+                    .init(
+                        name: name,
+                        organization: organization
+                    )
                 )
             )
         )

--- a/Sources/TuistCloudTesting/Models/CloudProject+TestData.swift
+++ b/Sources/TuistCloudTesting/Models/CloudProject+TestData.swift
@@ -1,0 +1,15 @@
+import TuistCloud
+
+extension CloudProject {
+    public static func test(
+        id: Int = 0,
+        fullName: String = "test/test",
+        token: String = "token"
+    ) -> Self {
+        .init(
+            id: id,
+            fullName: fullName,
+            token: token
+        )
+    }
+}

--- a/Sources/TuistCloudTesting/Services/MockGetProjectService.swift
+++ b/Sources/TuistCloudTesting/Services/MockGetProjectService.swift
@@ -15,6 +15,6 @@ public final class MockGetProjectService: GetProjectServicing {
             accountName,
             projectName,
             serverURL
-        ) ?? CloudProject(id: 0, fullName: "test/test")
+        ) ?? .test()
     }
 }

--- a/Sources/TuistKit/Commands/Cloud/CloudProjectCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudProjectCommand.swift
@@ -12,6 +12,7 @@ struct CloudProjectCommand: ParsableCommand {
                 CloudProjectCreateCommand.self,
                 CloudProjectListCommand.self,
                 CloudProjectDeleteCommand.self,
+                CloudProjectTokenCommand.self,
             ]
         )
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudProjectTokenCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudProjectTokenCommand.swift
@@ -1,0 +1,40 @@
+import ArgumentParser
+import Foundation
+import TSCBasic
+import TuistSupport
+
+struct CloudProjectTokenCommand: AsyncParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "token",
+            _superCommandName: "project",
+            abstract: "Get a project token. You can save this token in the `TUIST_CONFIG_CLOUD_TOKEN` environment variable to use the remote cache on the CI."
+        )
+    }
+
+    @Argument(
+        help: "The name of the project to get the token for.",
+        completion: .directory
+    )
+    var projectName: String
+
+    @Option(
+        name: .shortAndLong,
+        help: "Organization of the project. If not specified, it defaults to your user account."
+    )
+    var organizationName: String?
+
+    @Option(
+        name: .long,
+        help: "URL to the cloud server."
+    )
+    var serverURL: String?
+
+    func run() async throws {
+        try await CloudProjectTokenService().run(
+            projectName: projectName,
+            organizationName: organizationName,
+            serverURL: serverURL
+        )
+    }
+}

--- a/Sources/TuistKit/Services/Cloud/CloudProjectTokenService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudProjectTokenService.swift
@@ -4,7 +4,7 @@ import TuistCloud
 import TuistLoader
 import TuistSupport
 
-protocol CloudProjectDeleteServicing {
+protocol CloudProjectTokenServicing {
     func run(
         projectName: String,
         organizationName: String?,
@@ -12,19 +12,16 @@ protocol CloudProjectDeleteServicing {
     ) async throws
 }
 
-final class CloudProjectDeleteService: CloudProjectDeleteServicing {
-    private let deleteProjectService: DeleteProjectServicing
+final class CloudProjectTokenService: CloudProjectTokenServicing {
     private let getProjectService: GetProjectServicing
     private let credentialsStore: CredentialsStoring
     private let cloudURLService: CloudURLServicing
 
     init(
-        deleteProjectService: DeleteProjectServicing = DeleteProjectService(),
         getProjectService: GetProjectServicing = GetProjectService(),
         credentialsStore: CredentialsStoring = CredentialsStore(),
         cloudURLService: CloudURLServicing = CloudURLService()
     ) {
-        self.deleteProjectService = deleteProjectService
         self.getProjectService = getProjectService
         self.credentialsStore = credentialsStore
         self.cloudURLService = cloudURLService
@@ -51,11 +48,6 @@ final class CloudProjectDeleteService: CloudProjectDeleteServicing {
             serverURL: cloudURL
         )
 
-        try await deleteProjectService.deleteProject(
-            projectId: project.id,
-            serverURL: cloudURL
-        )
-
-        logger.info("Successfully deleted the \(project.fullName) project.")
+        logger.info(.init(stringLiteral: project.token))
     }
 }

--- a/Tests/TuistKitTests/Services/Cloud/CloudProjectDeleteServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudProjectDeleteServiceTests.swift
@@ -37,7 +37,7 @@ final class CloudProjectDeleteServiceTests: TuistUnitTestCase {
     func test_project_delete() async throws {
         // Given
         getProjectService.getProjectStub = { _, _, _ in
-            .init(id: 0, fullName: "tuist/tuist")
+            .test(id: 0, fullName: "tuist/tuist")
         }
         var gotProjectId: Int?
         deleteProjectService.deleteProjectStub = { projectId, _ in

--- a/Tests/TuistKitTests/Services/Cloud/CloudProjectListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudProjectListServiceTests.swift
@@ -29,8 +29,8 @@ final class CloudProjectListServiceTests: TuistUnitTestCase {
         // Given
         listProjectsService.listProjectsStub = { _, _, _ in
             [
-                CloudProject(id: 0, fullName: "tuist/test-one"),
-                CloudProject(id: 1, fullName: "tuist/test-two"),
+                .test(id: 0, fullName: "tuist/test-one"),
+                .test(id: 1, fullName: "tuist/test-two"),
             ]
         }
 


### PR DESCRIPTION
### Short description 📝

Adds `tuist cloud project token` command to get the project specific token that developers can use on the CI to be able to leverage the cloud remote cache.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

- Run `tuist cloud project some-project`. You should get the project token as an output.

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
