### PR TITLE
Add `--skip-cache` argument to `tuist generate`

### DIFF
--- a/Sources/TuistCache/Mappers/Graph/TargetsToCacheBinariesGraphMapper.swift
+++ b/Sources/TuistCache/Mappers/Graph/TargetsToCacheBinariesGraphMapper.swift
@@ -50,7 +50,7 @@ public final class TargetsToCacheBinariesGraphMapper: GraphMapping {
     private let cacheProfile: TuistGraph.Cache.Profile
 
     /// List of targets that will not use pre-compiled binaries from the cache.
-    private let excludedTargets: Set<String>
+    private let excludedSources: Set<String>
 
     // MARK: - Init
 
@@ -60,7 +60,7 @@ public final class TargetsToCacheBinariesGraphMapper: GraphMapping {
         sources: Set<String>,
         cacheProfile: TuistGraph.Cache.Profile,
         cacheOutputType: CacheOutputType,
-        excludedTargets: Set<String>
+        excludedSources: Set<String>
     ) {
         self.init(
             config: config,
@@ -69,7 +69,7 @@ public final class TargetsToCacheBinariesGraphMapper: GraphMapping {
             sources: sources,
             cacheProfile: cacheProfile,
             cacheOutputType: cacheOutputType,
-            excludedTargets: excludedTargets
+            excludedSources: excludedSources
         )
     }
 
@@ -82,7 +82,7 @@ public final class TargetsToCacheBinariesGraphMapper: GraphMapping {
         cacheProfile: TuistGraph.Cache.Profile,
         cacheOutputType: CacheOutputType,
         cacheGraphMutator: CacheGraphMutating = CacheGraphMutator(),
-        excludedTargets: Set<String>
+        excludedSources: Set<String>
     ) {
         self.config = config
         self.cacheStorageProvider = cacheStorageProvider
@@ -92,7 +92,7 @@ public final class TargetsToCacheBinariesGraphMapper: GraphMapping {
         self.sources = sources
         self.cacheProfile = cacheProfile
         self.cacheOutputType = cacheOutputType
-        self.excludedTargets = excludedTargets
+        self.excludedSources = excludedSources
     }
 
     // MARK: - GraphMapping
@@ -113,7 +113,7 @@ public final class TargetsToCacheBinariesGraphMapper: GraphMapping {
                 availableTargets: availableTargets.sorted()
             )
         }
-        let excludedTargets = excludedTargets.union(sources)
+        let excludedTargets = excludedSources.union(sources)
         let hashes = try cacheGraphContentHasher.contentHashes(
             for: graph,
             cacheProfile: cacheProfile,

--- a/Sources/TuistCache/Mappers/Graph/TargetsToCacheBinariesGraphMapper.swift
+++ b/Sources/TuistCache/Mappers/Graph/TargetsToCacheBinariesGraphMapper.swift
@@ -49,6 +49,9 @@ public final class TargetsToCacheBinariesGraphMapper: GraphMapping {
     /// The caching profile.
     private let cacheProfile: TuistGraph.Cache.Profile
 
+    /// List of targets that will not use pre-compiled binaries from the cache.
+    private let excludedTargets: Set<String>
+
     // MARK: - Init
 
     public convenience init(
@@ -56,7 +59,8 @@ public final class TargetsToCacheBinariesGraphMapper: GraphMapping {
         cacheStorageProvider: CacheStorageProviding,
         sources: Set<String>,
         cacheProfile: TuistGraph.Cache.Profile,
-        cacheOutputType: CacheOutputType
+        cacheOutputType: CacheOutputType,
+        excludedTargets: Set<String>
     ) {
         self.init(
             config: config,
@@ -64,7 +68,8 @@ public final class TargetsToCacheBinariesGraphMapper: GraphMapping {
             cacheGraphContentHasher: CacheGraphContentHasher(),
             sources: sources,
             cacheProfile: cacheProfile,
-            cacheOutputType: cacheOutputType
+            cacheOutputType: cacheOutputType,
+            excludedTargets: excludedTargets
         )
     }
 
@@ -76,7 +81,8 @@ public final class TargetsToCacheBinariesGraphMapper: GraphMapping {
         sources: Set<String>,
         cacheProfile: TuistGraph.Cache.Profile,
         cacheOutputType: CacheOutputType,
-        cacheGraphMutator: CacheGraphMutating = CacheGraphMutator()
+        cacheGraphMutator: CacheGraphMutating = CacheGraphMutator(),
+        excludedTargets: Set<String>
     ) {
         self.config = config
         self.cacheStorageProvider = cacheStorageProvider
@@ -86,6 +92,7 @@ public final class TargetsToCacheBinariesGraphMapper: GraphMapping {
         self.sources = sources
         self.cacheProfile = cacheProfile
         self.cacheOutputType = cacheOutputType
+        self.excludedTargets = excludedTargets
     }
 
     // MARK: - GraphMapping
@@ -106,11 +113,12 @@ public final class TargetsToCacheBinariesGraphMapper: GraphMapping {
                 availableTargets: availableTargets.sorted()
             )
         }
+        let excludedTargets = excludedTargets.union(sources)
         let hashes = try cacheGraphContentHasher.contentHashes(
             for: graph,
             cacheProfile: cacheProfile,
             cacheOutputType: cacheOutputType,
-            excludedTargets: sources
+            excludedTargets: excludedTargets
         )
         let result = try cacheGraphMutator.map(
             graph: graph,

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -62,13 +62,16 @@ struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
 
     @Option(
         name: [.customLong("skip-cache")],
-        help: "A list of targets which will not use cached binaries."
+        help: "A list of targets which will not use cached binaries when using default `sources` list."
     )
     var targetsToSkipCache: [String] = []
 
     func validate() throws {
         if !xcframeworks, destination != [.device, .simulator] {
             throw ValidationError.invalidXCFrameworkOptions
+        }
+        if !sources.isEmpty, !targetsToSkipCache.isEmpty {
+            throw ValidationError.skipCacheWithFocusedTargets
         }
     }
 
@@ -98,11 +101,14 @@ struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
 
     enum ValidationError: LocalizedError {
         case invalidXCFrameworkOptions
+        case skipCacheWithFocusedTargets
 
         var errorDescription: String? {
             switch self {
             case .invalidXCFrameworkOptions:
                 return "--xcframeworks must be enabled when --destination is set"
+            case .skipCacheWithFocusedTargets:
+                return "--skip-cache must not be used when targets to be focused are specified."
             }
         }
     }

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -60,6 +60,12 @@ struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
     )
     var ignoreCache: Bool = false
 
+    @Option(
+        name: [.customLong("skip-cache")],
+        help: "A list of targets which will not use cached binaries."
+    )
+    var targetsToSkipCache: [String] = []
+
     func validate() throws {
         if !xcframeworks, destination != [.device, .simulator] {
             throw ValidationError.invalidXCFrameworkOptions
@@ -74,7 +80,8 @@ struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
             xcframeworks: xcframeworks,
             destination: destination,
             profile: profile,
-            ignoreCache: ignoreCache
+            ignoreCache: ignoreCache,
+            targetsToSkipCache: Set(targetsToSkipCache)
         )
         GenerateCommand.analyticsDelegate?.addParameters(
             [

--- a/Sources/TuistKit/Generator/GeneratorFactory.swift
+++ b/Sources/TuistKit/Generator/GeneratorFactory.swift
@@ -16,13 +16,15 @@ protocol GeneratorFactorying {
     /// - Parameter cacheOutputType: Output type of frameworks to be cached.
     /// - Parameter cacheProfile: The caching profile.
     /// - Parameter ignoreCache: True to not include binaries from the cache.
+    /// - Parameter targetsToSkipCache:The list of targets that should not use cache.
     /// - Returns: The generator for focused projects.
     func focus(
         config: Config,
         sources: Set<String>,
         cacheOutputType: CacheOutputType,
         cacheProfile: TuistGraph.Cache.Profile,
-        ignoreCache: Bool
+        ignoreCache: Bool,
+        targetsToSkipCache: Set<String>
     ) -> Generating
 
     /// Returns the generator to generate a project to run tests on.
@@ -70,7 +72,8 @@ class GeneratorFactory: GeneratorFactorying {
         sources: Set<String>,
         cacheOutputType: CacheOutputType,
         cacheProfile: TuistGraph.Cache.Profile,
-        ignoreCache: Bool
+        ignoreCache: Bool,
+        targetsToSkipCache: Set<String>
     ) -> Generating {
         let contentHasher = ContentHasher()
         let projectMapperFactory = ProjectMapperFactory(contentHasher: contentHasher)
@@ -83,7 +86,8 @@ class GeneratorFactory: GeneratorFactorying {
             cache: !ignoreCache,
             cacheSources: sources,
             cacheProfile: cacheProfile,
-            cacheOutputType: cacheOutputType
+            cacheOutputType: cacheOutputType,
+            targetsToSkipCache: targetsToSkipCache
         )
         let workspaceMappers = workspaceMapperFactory.default()
         let manifestLoader = ManifestLoaderFactory().createManifestLoader()
@@ -144,7 +148,8 @@ class GeneratorFactory: GeneratorFactorying {
                 cache: true,
                 cacheSources: focusedTargets,
                 cacheProfile: cacheProfile,
-                cacheOutputType: cacheOutputType
+                cacheOutputType: cacheOutputType,
+                targetsToSkipCache: []
             ) + graphMapperFactory.cache(includedTargets: includedTargets)
         } else {
             graphMappers = graphMapperFactory.cache(includedTargets: includedTargets)

--- a/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
+++ b/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
@@ -71,7 +71,7 @@ final class GraphMapperFactory: GraphMapperFactorying {
                 sources: cacheSources,
                 cacheProfile: cacheProfile,
                 cacheOutputType: cacheOutputType,
-                excludedTargets: targetsToSkipCache
+                excludedSources: targetsToSkipCache
             )
             mappers.append(focusTargetsGraphMapper)
             mappers.append(TreeShakePrunedTargetsGraphMapper())

--- a/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
+++ b/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
@@ -22,7 +22,8 @@ protocol GraphMapperFactorying {
         cache: Bool,
         cacheSources: Set<String>,
         cacheProfile: TuistGraph.Cache.Profile,
-        cacheOutputType: CacheOutputType
+        cacheOutputType: CacheOutputType,
+        targetsToSkipCache: Set<String>
     ) -> [GraphMapping]
 
     /// Returns the graph mapper whose output project is a cacheable graph.
@@ -57,7 +58,8 @@ final class GraphMapperFactory: GraphMapperFactorying {
         cache: Bool,
         cacheSources: Set<String>,
         cacheProfile: TuistGraph.Cache.Profile,
-        cacheOutputType: CacheOutputType
+        cacheOutputType: CacheOutputType,
+        targetsToSkipCache: Set<String>
     ) -> [GraphMapping] {
         var mappers: [GraphMapping] = []
         mappers.append(FocusTargetsGraphMappers(includedTargets: cacheSources))
@@ -68,7 +70,8 @@ final class GraphMapperFactory: GraphMapperFactorying {
                 cacheStorageProvider: CacheStorageProvider(config: config),
                 sources: cacheSources,
                 cacheProfile: cacheProfile,
-                cacheOutputType: cacheOutputType
+                cacheOutputType: cacheOutputType,
+                excludedTargets: targetsToSkipCache
             )
             mappers.append(focusTargetsGraphMapper)
             mappers.append(TreeShakePrunedTargetsGraphMapper())

--- a/Sources/TuistKit/Services/GenerateService.swift
+++ b/Sources/TuistKit/Services/GenerateService.swift
@@ -42,7 +42,8 @@ final class GenerateService {
         xcframeworks: Bool,
         destination: CacheXCFrameworkDestination,
         profile: String?,
-        ignoreCache: Bool
+        ignoreCache: Bool,
+        targetsToSkipCache: Set<String>
     ) async throws {
         let timer = clock.startTimer()
         let path = try self.path(path)
@@ -54,7 +55,8 @@ final class GenerateService {
             sources: sources,
             cacheOutputType: cacheOutputType,
             cacheProfile: cacheProfile,
-            ignoreCache: ignoreCache
+            ignoreCache: ignoreCache,
+            targetsToSkipCache: targetsToSkipCache
         )
         let workspacePath = try await generator.generate(path: path)
         if !noOpen {

--- a/Tests/TuistCacheTests/Mappers/Graph/TargetsToCacheBinariesGraphMapperTests.swift
+++ b/Tests/TuistCacheTests/Mappers/Graph/TargetsToCacheBinariesGraphMapperTests.swift
@@ -33,7 +33,7 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
             cacheProfile: .test(),
             cacheOutputType: .framework,
             cacheGraphMutator: cacheGraphMutator,
-            excludedTargets: []
+            excludedSources: []
         )
     }
 
@@ -58,7 +58,7 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
             cacheProfile: .test(),
             cacheOutputType: .framework,
             cacheGraphMutator: cacheGraphMutator,
-            excludedTargets: []
+            excludedSources: []
         )
         let projectPath = try temporaryPath()
         let graph = Graph.test(
@@ -262,7 +262,7 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
             cacheProfile: .test(),
             cacheOutputType: .xcframework([.device, .simulator]),
             cacheGraphMutator: cacheGraphMutator,
-            excludedTargets: []
+            excludedSources: []
         )
 
         let cFramework = Target.test(name: "C", platform: .iOS, product: .framework)
@@ -323,7 +323,7 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
             cacheProfile: .test(),
             cacheOutputType: .framework,
             cacheGraphMutator: cacheGraphMutator,
-            excludedTargets: ["B"]
+            excludedSources: ["B"]
         )
 
         let bFramework = Target.test(name: "B", platform: .iOS, product: .framework)

--- a/Tests/TuistCacheTests/Mappers/Graph/TargetsToCacheBinariesGraphMapperTests.swift
+++ b/Tests/TuistCacheTests/Mappers/Graph/TargetsToCacheBinariesGraphMapperTests.swift
@@ -32,7 +32,8 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
             sources: [],
             cacheProfile: .test(),
             cacheOutputType: .framework,
-            cacheGraphMutator: cacheGraphMutator
+            cacheGraphMutator: cacheGraphMutator,
+            excludedTargets: []
         )
     }
 
@@ -56,7 +57,8 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
             sources: ["B", "C", "D"],
             cacheProfile: .test(),
             cacheOutputType: .framework,
-            cacheGraphMutator: cacheGraphMutator
+            cacheGraphMutator: cacheGraphMutator,
+            excludedTargets: []
         )
         let projectPath = try temporaryPath()
         let graph = Graph.test(
@@ -259,7 +261,8 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
             sources: [],
             cacheProfile: .test(),
             cacheOutputType: .xcframework([.device, .simulator]),
-            cacheGraphMutator: cacheGraphMutator
+            cacheGraphMutator: cacheGraphMutator,
+            excludedTargets: []
         )
 
         let cFramework = Target.test(name: "C", platform: .iOS, product: .framework)
@@ -304,5 +307,64 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
         // Then
         XCTAssertEqual(invokedCacheProfile, .test())
         XCTAssertEqual(invokedCacheOutputType, .xcframework([.device, .simulator]))
+    }
+
+    func test_map_when_excluded_targets_are_passed() async throws {
+        let path = try temporaryPath()
+        let project = Project.test(path: path)
+
+        // Given
+        subject = TargetsToCacheBinariesGraphMapper(
+            config: config,
+            cacheStorageProvider: cacheStorageProvider,
+            cacheFactory: cacheFactory,
+            cacheGraphContentHasher: cacheGraphContentHasher,
+            sources: [],
+            cacheProfile: .test(),
+            cacheOutputType: .framework,
+            cacheGraphMutator: cacheGraphMutator,
+            excludedTargets: ["B"]
+        )
+
+        let bFramework = Target.test(name: "B", platform: .iOS, product: .framework)
+        let bGraphTarget = GraphTarget.test(path: path, target: bFramework)
+
+        let cFramework = Target.test(name: "C", platform: .iOS, product: .framework)
+        let cGraphTarget = GraphTarget.test(path: path, target: cFramework)
+
+        let app = Target.test(name: "App", platform: .iOS, product: .app)
+
+        let inputGraph = Graph.test(
+            name: "input",
+            projects: [path: project],
+            targets: [
+                path: [
+                    app.name: app,
+                ],
+            ],
+            dependencies: [
+                .target(name: bFramework.name, path: bGraphTarget.path): [],
+                .target(name: cFramework.name, path: cGraphTarget.path): [],
+            ]
+        )
+        let outputGraph = Graph.test(
+            name: "output",
+            projects: inputGraph.projects,
+            targets: inputGraph.targets,
+            dependencies: inputGraph.dependencies
+        )
+        cacheGraphMutator.stubbedMapResult = outputGraph
+
+        var invokedExcludedTargets: Set<String>?
+        cacheGraphContentHasher.contentHashesStub = { _, _, _, excludedTargets in
+            invokedExcludedTargets = excludedTargets
+            return [:]
+        }
+
+        // When
+        _ = try await subject.map(graph: inputGraph)
+
+        // Then
+        XCTAssertEqual(invokedExcludedTargets, ["App", "B"])
     }
 }

--- a/Tests/TuistKitTests/Generator/Mocks/MockGeneratorFactory.swift
+++ b/Tests/TuistKitTests/Generator/Mocks/MockGeneratorFactory.swift
@@ -12,7 +12,8 @@ final class MockGeneratorFactory: GeneratorFactorying {
         sources: Set<String>,
         cacheOutputType: CacheOutputType,
         cacheProfile: TuistGraph.Cache.Profile,
-        ignoreCache: Bool
+        ignoreCache: Bool,
+        targetsToSkipCache: Set<String>
     )?
     var invokedFocusParametersList =
         [(
@@ -29,11 +30,12 @@ final class MockGeneratorFactory: GeneratorFactorying {
         sources: Set<String>,
         cacheOutputType: CacheOutputType,
         cacheProfile: TuistGraph.Cache.Profile,
-        ignoreCache: Bool
+        ignoreCache: Bool,
+        targetsToSkipCache: Set<String>
     ) -> Generating {
         invokedFocus = true
         invokedFocusCount += 1
-        invokedFocusParameters = (config, sources, cacheOutputType, cacheProfile, ignoreCache)
+        invokedFocusParameters = (config, sources, cacheOutputType, cacheProfile, ignoreCache, targetsToSkipCache)
         invokedFocusParametersList.append((config, sources, cacheOutputType, cacheProfile, ignoreCache))
         return stubbedFocusResult
     }

--- a/Tests/TuistKitTests/Mappers/Factories/GraphMapperFactoryTests.swift
+++ b/Tests/TuistKitTests/Mappers/Factories/GraphMapperFactoryTests.swift
@@ -69,7 +69,8 @@ final class GraphMapperFactoryTests: TuistUnitTestCase {
             cache: true,
             cacheSources: cacheSources,
             cacheProfile: cacheProfile,
-            cacheOutputType: cacheOutputType
+            cacheOutputType: cacheOutputType,
+            targetsToSkipCache: []
         )
 
         // Then
@@ -90,7 +91,8 @@ final class GraphMapperFactoryTests: TuistUnitTestCase {
             cache: true,
             cacheSources: cacheSources,
             cacheProfile: cacheProfile,
-            cacheOutputType: cacheOutputType
+            cacheOutputType: cacheOutputType,
+            targetsToSkipCache: []
         )
 
         // Then
@@ -111,7 +113,8 @@ final class GraphMapperFactoryTests: TuistUnitTestCase {
             cache: true,
             cacheSources: cacheSources,
             cacheProfile: cacheProfile,
-            cacheOutputType: cacheOutputType
+            cacheOutputType: cacheOutputType,
+            targetsToSkipCache: []
         )
 
         // Then

--- a/Tests/TuistKitTests/Services/GenerateServiceTests.swift
+++ b/Tests/TuistKitTests/Services/GenerateServiceTests.swift
@@ -58,7 +58,8 @@ final class GenerateServiceTests: TuistUnitTestCase {
                     xcframeworks: false,
                     destination: [],
                     profile: nil,
-                    ignoreCache: false
+                    ignoreCache: false,
+                    targetsToSkipCache: []
                 )
             XCTFail("Must throw")
         } catch {
@@ -80,7 +81,8 @@ final class GenerateServiceTests: TuistUnitTestCase {
             xcframeworks: false,
             destination: [],
             profile: nil,
-            ignoreCache: false
+            ignoreCache: false,
+            targetsToSkipCache: []
         )
 
         XCTAssertEqual(opener.openArgs.last?.0, workspacePath.pathString)
@@ -106,7 +108,8 @@ final class GenerateServiceTests: TuistUnitTestCase {
             xcframeworks: false,
             destination: [],
             profile: nil,
-            ignoreCache: false
+            ignoreCache: false,
+            targetsToSkipCache: []
         )
 
         // Then


### PR DESCRIPTION
### Short description 📝

Add the `skip-cache` argument to `tuist generate` command to specify targets that will not use the cache.

### How to test the changes locally 🧐

Pass the names of the targets that will not use the cache as arguments to `skip-cache`.
```
$ tuist generate --skip-cache targetA --skip-cache targetB
```

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
