### PR TITLE
Fix issue with file template generator removing spaces after update to stencil 0.15.1

### DIFF
--- a/Sources/TuistGenerator/Templates/FilesTemplate.swift
+++ b/Sources/TuistGenerator/Templates/FilesTemplate.swift
@@ -25,8 +25,8 @@ extension SynthesizedResourceInterfaceTemplates {
       {% endfor %}
     {% endmacro %}
     {% macro fileBlock file %}
-      /// {% if file.path and param.preservePath %}{{file.path}}/{% endif %}{{file.name}}{% if file.ext %}.{{file.ext}}{% endif %}
-      {% set identifier %}{{ file.name }}{% if useExt %}.{{ file.ext }}{% endif %}{% endset %}
+      /// {%+ if file.path and param.preservePath %}{{file.path}}/{% endif %}{{file.name}}{% if file.ext %}.{{file.ext}}{% endif %}
+      {% set identifier %}{{ file.name }}{% if useExt %}.{{ file.ext }}{% endif %}{% endset +%}
       {{accessModifier}} static let {{identifier|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{resourceType}}(name: "{{file.name}}", ext: {% if file.ext %}"{{file.ext}}"{% else %}nil{% endif %}, relativePath: "{{file.path if param.preservePath}}", mimeType: "{{file.mimeType}}")
     {% endmacro %}
     {% macro dirBlock directory parent %}

--- a/projects/tuist/fixtures/app_with_plugins/Resources/File.txt
+++ b/projects/tuist/fixtures/app_with_plugins/Resources/File.txt
@@ -1,0 +1,1 @@
+Hello world!

--- a/projects/tuist/fixtures/app_with_plugins/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/projects/tuist/fixtures/app_with_plugins/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -28,6 +28,7 @@ extension Project {
             targets: [mainTarget],
             resourceSynthesizers: [
                 .strings(plugin: "LocalPlugin"),
+                .files(extensions: ["txt"]),
                 .custom(
                     name: "Lottie",
                     parser: .json,


### PR DESCRIPTION
### Short description 📝

Issue after updating Stencil, we noticed spaces are removed from the generated file.

Reproduced in tuist `3.21.0` and `3.22.0`, works fine in older version before the stencil update. 

Current generated file:
```
///File.txt  public static let fileTxt = File(name: "File", ext:"txt", relativePath: "", mimeType: "text/plain")
```

After suggested change:
```
/// File.txt
public static let fileTxt = File(name: "File", ext:"txt", relativePath: "", mimeType: "text/plain")
```

### How to test the changes locally 🧐
Not sure how to best show the error. Decided to reuse on of the fixtures already using the resource synthesizers to show case the issue, please advice in how I could include this as an example or test.

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
