### PR TITLE
Adding new isRootManifest flag to Tuist manifest files

### DIFF
--- a/Sources/TuistKit/Services/DumpService.swift
+++ b/Sources/TuistKit/Services/DumpService.swift
@@ -30,7 +30,7 @@ final class DumpService {
         let encoded: Encodable
         switch manifest {
         case .project:
-            encoded = try manifestLoader.loadProject(at: projectPath)
+            encoded = try manifestLoader.loadProject(at: projectPath, rootPath: nil)
         case .workspace:
             encoded = try manifestLoader.loadWorkspace(at: projectPath)
         case .config:

--- a/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -66,9 +66,9 @@ public class CachedManifestLoader: ManifestLoading {
         }
     }
 
-    public func loadProject(at path: AbsolutePath) throws -> Project {
+    public func loadProject(at path: AbsolutePath, rootPath: AbsolutePath? = nil) throws -> Project {
         try load(manifest: .project, at: path) {
-            try manifestLoader.loadProject(at: path)
+            try manifestLoader.loadProject(at: path, rootPath: rootPath)
         }
     }
 

--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -281,10 +281,12 @@ public class ManifestLoader: ManifestLoading {
 
         do {
             var envVars = environment.manifestLoadingVariables
+            envVars["TUIST_MANIFEST_PATH"] = "\(path)"
 
             // Pass in the flag to manifest file if it is being loaded as the root manifest or from a subfolder like Pods/ folder
             if let rootPath, manifest == .project && rootPath == path {
                 envVars["TUIST_IS_ROOT_MANIFEST"] = "true"
+                envVars["TUIST_ROOT_MANIFEST_PATH"] = "\(rootPath)"
             }
 
             let string = try System.shared.capture(arguments, verbose: false, environment: envVars)

--- a/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
@@ -51,7 +51,7 @@ public class RecursiveManifestLoader: RecursiveManifestLoading {
             manifestLoader.manifests(at: $0).contains(.project)
         }
 
-        let projects = try loadProjects(paths: projectPaths)
+        let projects = try loadProjects(rootPath: path, paths: projectPaths)
         let workspace: ProjectDescription.Workspace
         if let loadedWorkspace = loadedWorkspace {
             workspace = loadedWorkspace
@@ -69,14 +69,14 @@ public class RecursiveManifestLoader: RecursiveManifestLoading {
 
     // MARK: - Private
 
-    private func loadProjects(paths: [AbsolutePath]) throws -> LoadedProjects {
+    private func loadProjects(rootPath: AbsolutePath, paths: [AbsolutePath]) throws -> LoadedProjects {
         var cache = [AbsolutePath: ProjectDescription.Project]()
 
         var paths = Set(paths)
         while !paths.isEmpty {
             paths.subtract(cache.keys)
             let projects = try Array(paths).map(context: ExecutionContext.concurrent) {
-                try manifestLoader.loadProject(at: $0)
+                return try manifestLoader.loadProject(at: $0, rootPath: rootPath)
             }
             var newDependenciesPaths = Set<AbsolutePath>()
             try zip(paths, projects).forEach { path, project in


### PR DESCRIPTION
Hi,

we are not sure if anybody else needs this feature, but we are currently trying to migrate 100+ internal Cocoapods to use Tuist as dependency integrator.

As discussed with @pepicrft on Slack, here is my initial implementation showing the new flag in action that we would require for our Cocoapods --> Tuist migration approach. See links below for example manifest files for usage.

Resolves https://github.com/tuist/tuist/issues/YYY (didn't create a ticket)

### Short description 📝

> In short, this PR adds and injects a new ENV var `TUIST_IS_ROOT_MANIFEST` during manifest loading phase from `tuist generate`. This flag can then be used by the manifest files.

#### Explanation 🤓

> As we are using Cocoapods and have 100+ of them, they are all in their own git repos. For the migration, we thought of just using Cocoapods to download the pods source code and then use Tuist to generate and integrate the dependencies. We are shipping their manifest files in the podspec `s.preserve_path = 'Project.swift'` and then integrating these dependencies in Tuist using `.project(name:, path:)` dependency from the local `Pods/` folder:

```swift
     dependencies: [
         .project(target: "TuistExampleLoggingLibrary", path: "Pods/TuistExampleLoggingLibrary"),
     ]
```

> But we then faced some some issues in the manifest file from `Pods/TuistExampleLoggingLibrary/Project.swift`. We needed a way to distinguish if the manifest file is being generated from local folder or being integrated from `Pods/` folder. And depending on that, set different settings in the manifest file:

```swift
let isRootManifest = Environment.isRootManifest.getBoolean(default: false)

// Header search path needs to be adapted depending on how its integrated: local vs pods dependency
let headerPrefix = isRootManifest ? "" : "../../"

let targetSettings: Settings = .settings(
    base: [
        "OTHER_LDFLAGS": "-ObjC",
        "HEADER_SEARCH_PATHS": ["$(inherited)",
                                "\(headerPrefix)Tuist/Dependencies/SwiftPackageManager/.build/checkouts/CocoaLumberjack/Sources/**",
                               ]
    ]
)

// we don't want to generate the test targets if integrated using `.project()` dependency
let targets = isRootManifest ? [mainTarget, testTarget] : [mainTarget]

/** Main Xcode Project **/
let project = Project.makeProject(name: mainTargetName,
                                  targets: targets)
```

#### Example Code

> These example repos shows the flag in action.

Example App:
* https://github.com/Buju77/TuistRootManifestFileExample/blob/main/Project.swift#L34
* https://github.com/Buju77/TuistRootManifestFileExample/blob/main/Pods/TuistExampleLoggingLibrary/Project.swift#L19-L28

Integrated Pod Dependency:
* https://github.com/Buju77/TuistExampleLoggingLibrary/blob/main/Project.swift#L55-L62

Simplifier Tuist Plugin:
* https://github.com/Buju77/playground-tuist-simplifier/tree/0.0.5

### How to test the changes locally 🧐

1. Clone https://github.com/Buju77/TuistRootManifestFileExample
2. `tuist fetch`
3. `tuist generate`
4. Execute `UnitTests` target ✅

Observe:
* That the schemes from logging pod is not generated
* Only the schemes from example app are
* But the Pods/ dependencies are properly linked and setup and pod code can be used by example app/tests

### Contributor checklist ✅

- [ ] The code has been linted using run `./fourier lint tuist --fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
