### PR TITLE
Introduce support of mergeable libraries

### DIFF
--- a/Sources/TuistCore/Graph/GraphDependencyReference.swift
+++ b/Sources/TuistCore/Graph/GraphDependencyReference.swift
@@ -49,7 +49,7 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
                 architectures: architectures,
                 product: (linking == .static) ? .staticLibrary : .dynamicLibrary
             )
-        case let .xcframework(path, infoPlist, primaryBinaryPath, _):
+        case let .xcframework(path, infoPlist, primaryBinaryPath, _, _):
             self = .xcframework(
                 path: path,
                 infoPlist: infoPlist,

--- a/Sources/TuistCore/Graph/GraphLoader.swift
+++ b/Sources/TuistCore/Graph/GraphLoader.swift
@@ -224,7 +224,8 @@ public final class GraphLoader: GraphLoading {
             path: metadata.path,
             infoPlist: metadata.infoPlist,
             primaryBinaryPath: metadata.primaryBinaryPath,
-            linking: metadata.linking
+            linking: metadata.linking,
+            isMergeable: metadata.mergeable
         )
         cache.add(xcframework: xcframework, at: path)
         return xcframework

--- a/Sources/TuistCore/MetadataProviders/XCFrameworkMetadataProvider.swift
+++ b/Sources/TuistCore/MetadataProviders/XCFrameworkMetadataProvider.swift
@@ -73,7 +73,8 @@ public final class XCFrameworkMetadataProvider: PrecompiledMetadataProvider, XCF
             path: path,
             infoPlist: infoPlist,
             primaryBinaryPath: primaryBinaryPath,
-            linking: linking
+            linking: linking,
+            mergeable: infoPlist.libraries.allSatisfy(\.mergeableMetadata)
         )
     }
 

--- a/Sources/TuistCore/NodeLoaders/XCFrameworkLoader.swift
+++ b/Sources/TuistCore/NodeLoaders/XCFrameworkLoader.swift
@@ -52,7 +52,8 @@ public final class XCFrameworkLoader: XCFrameworkLoading {
             path: path,
             infoPlist: metadata.infoPlist,
             primaryBinaryPath: metadata.primaryBinaryPath,
-            linking: metadata.linking
+            linking: metadata.linking,
+            isMergeable: metadata.mergeable
         )
     }
 }

--- a/Sources/TuistGenerator/GraphViz/GraphToGraphVizMapper.swift
+++ b/Sources/TuistGenerator/GraphViz/GraphToGraphVizMapper.swift
@@ -84,7 +84,8 @@ extension GraphDependency {
             path: path,
             infoPlist: _,
             primaryBinaryPath: _,
-            linking: _
+            linking: _,
+            isMergeable: _
         ):
             return path.basenameWithoutExt
         case let .library(

--- a/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -138,7 +138,7 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
 
     private func isStaticProduct(_ dependency: GraphDependency, graphTraverser: GraphTraversing) -> Bool {
         switch dependency {
-        case let .xcframework(_, _, _, linking):
+        case let .xcframework(_, _, _, linking, _):
             return linking == .static
         case let .framework(_, _, _, _, linking, _, _):
             return linking == .static

--- a/Sources/TuistGraph/Graph/GraphDependency.swift
+++ b/Sources/TuistGraph/Graph/GraphDependency.swift
@@ -7,7 +7,8 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         path: AbsolutePath,
         infoPlist: XCFrameworkInfoPlist,
         primaryBinaryPath: AbsolutePath,
-        linking: BinaryLinking
+        linking: BinaryLinking,
+        isMergeable: Bool
     )
 
     /// A dependency that represents a pre-compiled framework.
@@ -44,7 +45,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
 
     public func hash(into hasher: inout Hasher) {
         switch self {
-        case let .xcframework(path, _, _, _):
+        case let .xcframework(path, _, _, _, _):
             hasher.combine("xcframework")
             hasher.combine(path)
         case let .framework(path, _, _, _, _, _, _):
@@ -112,7 +113,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
 
     public var description: String {
         switch self {
-        case let .xcframework(path, _, _, _):
+        case let .xcframework(path, _, _, _, _):
             return "xcframework '\(path.basename)'"
         case let .framework(path, _, _, _, _, _, _):
             return "framework '\(path.basename)'"

--- a/Sources/TuistGraph/Models/Metadata/XCFrameworkMetadata.swift
+++ b/Sources/TuistGraph/Models/Metadata/XCFrameworkMetadata.swift
@@ -7,16 +7,19 @@ public struct XCFrameworkMetadata: Equatable {
     public var infoPlist: XCFrameworkInfoPlist
     public var primaryBinaryPath: AbsolutePath
     public var linking: BinaryLinking
+    public var mergeable: Bool
 
     public init(
         path: AbsolutePath,
         infoPlist: XCFrameworkInfoPlist,
         primaryBinaryPath: AbsolutePath,
-        linking: BinaryLinking
+        linking: BinaryLinking,
+        mergeable: Bool
     ) {
         self.path = path
         self.infoPlist = infoPlist
         self.primaryBinaryPath = primaryBinaryPath
         self.linking = linking
+        self.mergeable = mergeable
     }
 }

--- a/Sources/TuistGraph/Models/Target.swift
+++ b/Sources/TuistGraph/Models/Target.swift
@@ -104,6 +104,12 @@ public struct Target: Equatable, Hashable, Comparable, Codable {
         [.dynamicLibrary, .staticLibrary, .framework, .staticFramework].contains(product)
     }
 
+    /// Notifies if the target can group dependencies
+    public func mergesDependencies() -> Bool {
+        let setting = settings?.base["MERGED_BINARY_TYPE"]
+        return setting == .string("manual") || setting == .string("automatic")
+    }
+
     /// Returns whether a target is exclusive to a single platform
     public func isExclusiveTo(_ platform: Platform) -> Bool {
         destinations.map(\.platform).allSatisfy { $0 == platform }

--- a/Sources/TuistGraph/Models/XCFrameworkInfoPlist.swift
+++ b/Sources/TuistGraph/Models/XCFrameworkInfoPlist.swift
@@ -13,6 +13,7 @@ public struct XCFrameworkInfoPlist: Codable, Equatable {
             case identifier = "LibraryIdentifier"
             case path = "LibraryPath"
             case architectures = "SupportedArchitectures"
+            case mergeableMetadata = "MergeableMetadata"
         }
 
         /// It represents the library's platform.
@@ -26,6 +27,9 @@ public struct XCFrameworkInfoPlist: Codable, Equatable {
         /// Path to the library.
         public let path: RelativePath
 
+        /// Declares if the library is mergeable or not
+        public let mergeableMetadata: Bool
+
         /// Architectures the binary is built for.
         public let architectures: [BinaryArchitecture]
 
@@ -33,6 +37,7 @@ public struct XCFrameworkInfoPlist: Codable, Equatable {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(identifier, forKey: .identifier)
             try container.encode(path, forKey: .path)
+            try container.encode(mergeableMetadata, forKey: .mergeableMetadata)
             try container.encode(architectures, forKey: .architectures)
         }
     }

--- a/Sources/TuistGraphTesting/Graph/GraphDependency+TestData.swift
+++ b/Sources/TuistGraphTesting/Graph/GraphDependency+TestData.swift
@@ -35,7 +35,8 @@ extension GraphDependency {
             path: path,
             infoPlist: infoPlist,
             primaryBinaryPath: primaryBinaryPath,
-            linking: linking
+            linking: linking,
+            isMergeable: false
         )
     }
 

--- a/Sources/TuistGraphTesting/Models/Metadata/XCFrameworkMetadata+TestData.swift
+++ b/Sources/TuistGraphTesting/Models/Metadata/XCFrameworkMetadata+TestData.swift
@@ -8,13 +8,15 @@ extension XCFrameworkMetadata {
         path: AbsolutePath = "/XCFrameworks/XCFramework.xcframework",
         infoPlist: XCFrameworkInfoPlist = .test(),
         primaryBinaryPath: AbsolutePath = "/XCFrameworks/XCFramework.xcframework/ios-arm64/XCFramework",
-        linking: BinaryLinking = .dynamic
+        linking: BinaryLinking = .dynamic,
+        mergeable: Bool = false
     ) -> XCFrameworkMetadata {
         XCFrameworkMetadata(
             path: path,
             infoPlist: infoPlist,
             primaryBinaryPath: primaryBinaryPath,
-            linking: linking
+            linking: linking,
+            mergeable: mergeable
         )
     }
 }

--- a/Sources/TuistGraphTesting/Models/XCFrameworkInfoPlist+TestData.swift
+++ b/Sources/TuistGraphTesting/Models/XCFrameworkInfoPlist+TestData.swift
@@ -13,11 +13,13 @@ extension XCFrameworkInfoPlist.Library {
     public static func test(
         identifier: String = "test",
         path: RelativePath = RelativePath("relative/to/library"),
+        mergeableMetadata: Bool = false,
         architectures: [BinaryArchitecture] = [.i386]
     ) -> XCFrameworkInfoPlist.Library {
         XCFrameworkInfoPlist.Library(
             identifier: identifier,
             path: path,
+            mergeableMetadata: mergeableMetadata,
             architectures: architectures
         )
     }

--- a/Tests/TuistCoreTests/Graph/GraphLoaderTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphLoaderTests.swift
@@ -360,7 +360,8 @@ final class GraphLoaderTests: TuistUnitTestCase {
                 path: "/XCFrameworks/XF1.xcframework",
                 infoPlist: .test(),
                 primaryBinaryPath: "/XCFrameworks/XF1.xcframework/ios-arm64/XF1",
-                linking: .dynamic
+                linking: .dynamic,
+                mergeable: false
             )
         )
 
@@ -381,7 +382,8 @@ final class GraphLoaderTests: TuistUnitTestCase {
                     path: "/XCFrameworks/XF1.xcframework",
                     infoPlist: .test(),
                     primaryBinaryPath: "/XCFrameworks/XF1.xcframework/ios-arm64/XF1",
-                    linking: .dynamic
+                    linking: .dynamic,
+                    isMergeable: false
                 ),
             ]),
         ])

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -1175,13 +1175,15 @@ final class GraphTraverserTests: TuistUnitTestCase {
             path: "/xcframeworks/c.xcframework",
             infoPlist: .test(libraries: [.test(identifier: "id", path: RelativePath("path"), architectures: [.arm64])]),
             primaryBinaryPath: "/xcframeworks/c.xcframework/c",
-            linking: .dynamic
+            linking: .dynamic,
+            isMergeable: false
         )
         let dDependency = GraphDependency.xcframework(
             path: "/xcframeworks/d.xcframework",
             infoPlist: .test(libraries: [.test(identifier: "id", path: RelativePath("path"), architectures: [.arm64])]),
             primaryBinaryPath: "/xcframeworks/d.xcframework/d",
-            linking: .dynamic
+            linking: .dynamic,
+            isMergeable: false
         )
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
             .target(name: app.name, path: project.path): Set(arrayLiteral: cDependency),

--- a/Tests/TuistCoreTests/MetadataProviders/XCFrameworkMetadataProviderTests.swift
+++ b/Tests/TuistCoreTests/MetadataProviders/XCFrameworkMetadataProviderTests.swift
@@ -27,11 +27,13 @@ final class XCFrameworkMetadataProviderTests: TuistTestCase {
             .init(
                 identifier: "ios-x86_64-simulator",
                 path: RelativePath("MyFramework.framework"),
+                mergeableMetadata: false,
                 architectures: [.x8664]
             ),
             .init(
                 identifier: "ios-arm64",
                 path: RelativePath("MyFramework.framework"),
+                mergeableMetadata: false,
                 architectures: [.arm64]
             ),
         ])
@@ -73,11 +75,13 @@ final class XCFrameworkMetadataProviderTests: TuistTestCase {
             .init(
                 identifier: "ios-x86_64-simulator",
                 path: RelativePath("libMyStaticLibrary.a"),
+                mergeableMetadata: false,
                 architectures: [.x8664]
             ),
             .init(
                 identifier: "ios-arm64",
                 path: RelativePath("libMyStaticLibrary.a"),
+                mergeableMetadata: false,
                 architectures: [.arm64]
             ),
         ])
@@ -108,11 +112,13 @@ final class XCFrameworkMetadataProviderTests: TuistTestCase {
             .init(
                 identifier: "ios-x86_64-simulator",
                 path: RelativePath("MyFramework.framework"),
+                mergeableMetadata: false,
                 architectures: [.x8664]
             ),
             .init(
                 identifier: "ios-arm64",
                 path: RelativePath("MyFramework.framework"),
+                mergeableMetadata: false,
                 architectures: [.arm64]
             ),
         ])
@@ -121,7 +127,8 @@ final class XCFrameworkMetadataProviderTests: TuistTestCase {
             path: frameworkPath,
             infoPlist: expectedInfoPlist,
             primaryBinaryPath: expectedBinaryPath,
-            linking: .dynamic
+            linking: .dynamic,
+            mergeable: false
         ))
     }
 
@@ -137,11 +144,13 @@ final class XCFrameworkMetadataProviderTests: TuistTestCase {
             .init(
                 identifier: "ios-x86_64-simulator",
                 path: RelativePath("libMyStaticLibrary.a"),
+                mergeableMetadata: false,
                 architectures: [.x8664]
             ),
             .init(
                 identifier: "ios-arm64",
                 path: RelativePath("libMyStaticLibrary.a"),
+                mergeableMetadata: false,
                 architectures: [.arm64]
             ),
         ])
@@ -150,7 +159,8 @@ final class XCFrameworkMetadataProviderTests: TuistTestCase {
             path: frameworkPath,
             infoPlist: expectedInfoPlist,
             primaryBinaryPath: expectedBinaryPath,
-            linking: .static
+            linking: .static,
+            mergeable: false
         ))
     }
 
@@ -166,11 +176,13 @@ final class XCFrameworkMetadataProviderTests: TuistTestCase {
             .init(
                 identifier: "ios-x86_64-simulator", // Not present on disk
                 path: RelativePath("MyFrameworkMissingArch.framework"),
+                mergeableMetadata: false,
                 architectures: [.x8664]
             ),
             .init(
                 identifier: "ios-arm64",
                 path: RelativePath("MyFrameworkMissingArch.framework"),
+                mergeableMetadata: false,
                 architectures: [.arm64]
             ),
         ])
@@ -180,7 +192,8 @@ final class XCFrameworkMetadataProviderTests: TuistTestCase {
             path: frameworkPath,
             infoPlist: expectedInfoPlist,
             primaryBinaryPath: expectedBinaryPath,
-            linking: .dynamic
+            linking: .dynamic,
+            mergeable: false
         ))
 
         XCTAssertPrinterOutputContains("""

--- a/Tests/TuistCoreTests/NodeLoaders/XCFrameworkLoaderTests.swift
+++ b/Tests/TuistCoreTests/NodeLoaders/XCFrameworkLoaderTests.swift
@@ -68,7 +68,8 @@ final class XCFrameworkLoaderTests: TuistUnitTestCase {
                 path: $0,
                 infoPlist: infoPlist,
                 primaryBinaryPath: binaryPath,
-                linking: linking
+                linking: linking,
+                mergeable: false
             )
         }
 
@@ -82,7 +83,8 @@ final class XCFrameworkLoaderTests: TuistUnitTestCase {
                 path: xcframeworkPath,
                 infoPlist: infoPlist,
                 primaryBinaryPath: binaryPath,
-                linking: linking
+                linking: linking,
+                isMergeable: false
             )
         )
     }

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -952,7 +952,7 @@ final class LinkGeneratorTests: XCTestCase {
         let projectFileElements = ProjectFileElements()
         dependencies.forEach { dependency in
             switch dependency {
-            case .xcframework(path: let path, infoPlist: _, primaryBinaryPath: _, linking: _):
+            case .xcframework(path: let path, infoPlist: _, primaryBinaryPath: _, linking: _, isMergeable: _):
                 projectFileElements.elements[path] = PBXFileReference(
                     path: path.relative(to: projectPath).pathString
                 )


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5296

### Short description 📝

With the introduction of mergeable libraries, we no longer need to embed dynamic libraries as part of the final app target when it is declared as mergeable and the libraries can be merged. The code in this PR is going to detect the changes and avoid embedding them into the final target.

### How to test the changes locally 🧐

1.  Create a target (A) which has been compiled with -make_mergeable linker flag (available on Xcode 15+)
2. Set A as dependency on the application.

The expected setup should be having A as dependency but not embedded into the app

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
