### PR TITLE
Derive platform filters based on the specified destinations

### DIFF
--- a/Sources/TuistGenerator/Extensions/Xcodeproj+Extras.swift
+++ b/Sources/TuistGenerator/Extensions/Xcodeproj+Extras.swift
@@ -29,6 +29,16 @@ extension PBXFileElement {
 
 extension PBXBuildFile {
     /// Apply platform filters either `platformFilter` or `platformFilters` depending on count
+    public func applyPlatformFilters(_ filters: PlatformFilters, applicableTo target: Target) {
+        // If the dependency fewer platforms, apply filters.
+        let dependingTargetPlatformFilters = target.dependencyPlatformFilters
+        if filters.isSubset(of: dependingTargetPlatformFilters) {
+            let applicableFilters = dependingTargetPlatformFilters.intersection(filters)
+            applyPlatformFilters(applicableFilters)
+        }
+    }
+
+    /// Apply platform filters either `platformFilter` or `platformFilters` depending on count
     public func applyPlatformFilters(_ filters: PlatformFilters) {
         guard !filters.isEmpty else { return }
 

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -221,15 +221,15 @@ final class LinkGenerator: LinkGenerating {
                 )
                 pbxproj.add(object: buildFile)
                 embedPhase.files?.append(buildFile)
-            case let .product(target, _, platformFilters):
-                guard let fileRef = fileElements.product(target: target) else {
-                    throw LinkGeneratorError.missingProduct(name: target)
+            case let .product(dependencyTarget, _, platformFilters):
+                guard let fileRef = fileElements.product(target: dependencyTarget) else {
+                    throw LinkGeneratorError.missingProduct(name: dependencyTarget)
                 }
                 let buildFile = PBXBuildFile(
                     file: fileRef,
                     settings: ["ATTRIBUTES": ["CodeSignOnCopy", "RemoveHeadersOnCopy"]]
                 )
-                buildFile.applyPlatformFilters(platformFilters)
+                buildFile.applyPlatformFilters(platformFilters, applicableTo: target)
                 pbxproj.add(object: buildFile)
                 embedPhase.files?.append(buildFile)
             case .library, .bundle, .sdk:
@@ -407,12 +407,12 @@ final class LinkGenerator: LinkGenerating {
                     try addBuildFile(path)
                 case .bundle:
                     break
-                case let .product(target, _, platformFilters):
-                    guard let fileRef = fileElements.product(target: target) else {
-                        throw LinkGeneratorError.missingProduct(name: target)
+                case let .product(dependencyTarget, _, platformFilters):
+                    guard let fileRef = fileElements.product(target: dependencyTarget) else {
+                        throw LinkGeneratorError.missingProduct(name: dependencyTarget)
                     }
                     let buildFile = PBXBuildFile(file: fileRef)
-                    buildFile.applyPlatformFilters(platformFilters)
+                    buildFile.applyPlatformFilters(platformFilters, applicableTo: target)
                     pbxproj.add(object: buildFile)
                     buildPhase.files?.append(buildFile)
                 case let .sdk(sdkPath, sdkStatus, _):
@@ -452,6 +452,7 @@ final class LinkGenerator: LinkGenerating {
         // "Copy Bundle Resources" phase.
         try generateDependenciesBuildPhase(
             dependencies: dependencies,
+            target: target,
             pbxTarget: pbxTarget,
             pbxproj: pbxproj,
             fileElements: fileElements
@@ -482,6 +483,7 @@ final class LinkGenerator: LinkGenerating {
 
     private func generateDependenciesBuildPhase(
         dependencies: [GraphDependencyReference],
+        target: Target,
         pbxTarget: PBXTarget,
         pbxproj: PBXProj,
         fileElements: ProjectFileElements
@@ -490,13 +492,13 @@ final class LinkGenerator: LinkGenerating {
 
         for dependency in dependencies.sorted() {
             switch dependency {
-            case let .product(target: target, _, platformFilters: platformFilters):
-                guard let fileRef = fileElements.product(target: target) else {
-                    throw LinkGeneratorError.missingProduct(name: target)
+            case let .product(target: dependencyTarget, _, platformFilters: platformFilters):
+                guard let fileRef = fileElements.product(target: dependencyTarget) else {
+                    throw LinkGeneratorError.missingProduct(name: dependencyTarget)
                 }
 
                 let buildFile = PBXBuildFile(file: fileRef)
-                buildFile.applyPlatformFilters(platformFilters)
+                buildFile.applyPlatformFilters(platformFilters, applicableTo: target)
                 pbxproj.add(object: buildFile)
                 files.append(buildFile)
             case let .framework(path: path, _, _, _, _, _, _, _),

--- a/Sources/TuistGraph/Models/Destination.swift
+++ b/Sources/TuistGraph/Models/Destination.swift
@@ -43,6 +43,23 @@ public enum Destination: String, Codable, Equatable, CaseIterable {
             return .visionOS
         }
     }
+
+    var platformFilter: PlatformFilter {
+        switch self {
+        case .iPad, .iPhone, .macWithiPadDesign, .appleVisionWithiPadDesign:
+            return .ios
+        case .macCatalyst:
+            return .catalyst
+        case .mac:
+            return .macos
+        case .appleTv:
+            return .tvos
+        case .appleWatch:
+            return .watchos
+        case .appleVision:
+            return .visionos
+        }
+    }
 }
 
 extension Collection where Element == Destination {

--- a/Sources/TuistGraph/Models/PlatformFilter.swift
+++ b/Sources/TuistGraph/Models/PlatformFilter.swift
@@ -19,6 +19,7 @@ public enum PlatformFilter: Comparable, Hashable, Codable {
     case catalyst
     case driverkit
     case watchos
+    case visionos
 
     public var xcodeprojValue: String {
         switch self {
@@ -34,6 +35,8 @@ public enum PlatformFilter: Comparable, Hashable, Codable {
             return "driverkit"
         case .watchos:
             return "watchos"
+        case .visionos:
+            return "xros"
         }
     }
 }

--- a/Sources/TuistGraph/Models/Target.swift
+++ b/Sources/TuistGraph/Models/Target.swift
@@ -243,21 +243,11 @@ public struct Target: Equatable, Hashable, Comparable, Codable {
         isExclusiveTo(.macOS) && product == .app
     }
 
-    /// For iOS targets that support macOS (Catalyst), this value is used
-    /// in the generated build files of the target dependency products to
-    /// indicate the build system that the dependency should be compiled
-    /// with Catalyst compatibility.
+    /// Return the a set of PlatformFilters to control linking based on what platform is being compiled
+    /// This allows a target to link against a dependency conditionally when it is being compiled for a compatible platform
+    /// E.g. An app linking against CarPlay only when built for iOS.
     public var dependencyPlatformFilters: PlatformFilters {
-        // is iOS only and has the equivalent of `.all` devices from `ProjectDescription.DeploymentTarget`
-        if isExclusiveTo(.iOS), destinations != .iOS {
-            if destinations.contains(.macCatalyst) {
-                return [.catalyst]
-            } else {
-                return [.ios]
-            }
-        } else {
-            return []
-        }
+        Set(destinations.map(\.platformFilter))
     }
 
     // MARK: - Equatable


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5356

### Short description 📝

Update how we compute `dependencyPlatformFilters` to create them based on the set of specified destinations of a target.

### How to test the changes locally 🧐

Verify the project attached in #5356 generates with no platform filters applied to the dependency and builds

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
