### PR TITLE
Fix issue #5237 by adding `toValidSwiftIdentifier()` extension to `String`

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -78,7 +78,7 @@ public class ResourcesProjectMapper: ProjectMapping {
         let filePath = project.path
             .appending(component: Constants.DerivedDirectory.name)
             .appending(component: Constants.DerivedDirectory.sources)
-            .appending(component: "TuistBundle+\(target.name.camelized.uppercasingFirst).swift")
+            .appending(component: "TuistBundle+\(target.name.toValidSwiftIdentifier()).swift")
 
         let content: String = ResourcesProjectMapper.fileContent(
             targetName: target.name,
@@ -126,7 +126,7 @@ public class ResourcesProjectMapper: ProjectMapping {
             // MARK: - Objective-C Bundle Accessor
 
             @objc
-            public class \(target.productName.camelized.uppercasingFirst)Resources: NSObject {
+            public class \(target.productName.toValidSwiftIdentifier())Resources: NSObject {
                 @objc public class var bundle: Bundle {
                     return .module
                 }
@@ -155,7 +155,7 @@ public class ResourcesProjectMapper: ProjectMapping {
             // MARK: - Objective-C Bundle Accessor
 
             @objc
-            public class \(target.productName.camelized.uppercasingFirst)Resources: NSObject {
+            public class \(target.productName.toValidSwiftIdentifier())Resources: NSObject {
                 @objc public class var bundle: Bundle {
                     return .module
                 }

--- a/Sources/TuistSupport/Extensions/String+Extras.swift
+++ b/Sources/TuistSupport/Extensions/String+Extras.swift
@@ -123,20 +123,20 @@ extension String {
 
         return ([first] + rest).joined(separator: "")
     }
-    
+
     /// Make the string a valid Swift identifier (class name)
     public func toValidSwiftIdentifier() -> String {
         // Step 1: Start with a capital letter
         let capitalized = camelized.uppercasingFirst
-        
+
         // Step 2: Remove invalid characters with underscores
         let sanitized = capitalized.replacingOccurrences(of: "[^A-Za-z0-9_]", with: "", options: .regularExpression)
-        
+
         // Step 3: Add underscore prefix if the string starts with a number
         if sanitized.first?.isNumber == true {
             return "_" + sanitized
         }
-        
+
         return sanitized
     }
 

--- a/Sources/TuistSupport/Extensions/String+Extras.swift
+++ b/Sources/TuistSupport/Extensions/String+Extras.swift
@@ -129,7 +129,7 @@ extension String {
         // Step 1: Start with a capital letter
         let capitalized = camelized.uppercasingFirst
 
-        // Step 2: Remove invalid characters with underscores
+        // Step 2: Remove invalid characters
         let sanitized = capitalized.replacingOccurrences(of: "[^A-Za-z0-9_]", with: "", options: .regularExpression)
 
         // Step 3: Add underscore prefix if the string starts with a number

--- a/Sources/TuistSupport/Extensions/String+Extras.swift
+++ b/Sources/TuistSupport/Extensions/String+Extras.swift
@@ -123,6 +123,22 @@ extension String {
 
         return ([first] + rest).joined(separator: "")
     }
+    
+    /// Make the string a valid Swift identifier (class name)
+    public func toValidSwiftIdentifier() -> String {
+        // Step 1: Start with a capital letter
+        let capitalized = camelized.uppercasingFirst
+        
+        // Step 2: Remove invalid characters with underscores
+        let sanitized = capitalized.replacingOccurrences(of: "[^A-Za-z0-9_]", with: "", options: .regularExpression)
+        
+        // Step 3: Add underscore prefix if the string starts with a number
+        if sanitized.first?.isNumber == true {
+            return "_" + sanitized
+        }
+        
+        return sanitized
+    }
 
     public func camelCaseToKebabCase() -> String {
         convertCamelCase(separator: "-")

--- a/Tests/TuistSupportTests/Extensions/String+ExtrasTests.swift
+++ b/Tests/TuistSupportTests/Extensions/String+ExtrasTests.swift
@@ -29,26 +29,48 @@ final class StringExtrasTests: TuistUnitTestCase {
         XCTAssertEqual(got, "_1Flow")
     }
 
-    func test_to_valid_swift_identifier() {
-        // Test Case 1: String starting with lowercase letter
-        let str1 = "classname"
-        XCTAssertEqual(str1.toValidSwiftIdentifier(), "Classname", "Expected 'Classname'")
+    func test_to_valid_swift_identifier_starting_with_lowercase_letter() {
+        // Given
+        let subject = "classname"
 
-        // Test Case 2: String starting with numbers
-        let str2 = "123invalidName"
-        XCTAssertEqual(str2.toValidSwiftIdentifier(), "_123invalidName", "Expected '_123invalidName'")
+        // When
+        let got = subject.toValidSwiftIdentifier()
 
-        // Test Case 3: String is a Swift reserved word
-        let str3 = "class"
-        XCTAssertEqual(str3.toValidSwiftIdentifier(), "Class", "Expected 'Class'")
+        // Then
+        XCTAssertEqual(got, "Classname")
+    }
 
-        // Test Case 4: String with special characters
-        let str4 = "class$name"
-        XCTAssertEqual(str4.toValidSwiftIdentifier(), "ClassName", "Expected 'ClassName'")
+    func test_to_valid_swift_identifier_string_starting_with_numbers() {
+        // Given
+        let subject = "123invalidName"
 
-        // Test Case 5: String is already a valid Swift Identifier
-        let str5 = "ValidClassName"
-        XCTAssertEqual(str5.toValidSwiftIdentifier(), "ValidClassName", "Expected 'ValidClassName'")
+        // When
+        let got = subject.toValidSwiftIdentifier()
+
+        // Then
+        XCTAssertEqual(got, "_123invalidName")
+    }
+
+    func test_to_valid_swift_identifier_string_with_special_characters() {
+        // Given
+        let subject = "class$name"
+
+        // When
+        let got = subject.toValidSwiftIdentifier()
+
+        // Then
+        XCTAssertEqual(got, "ClassName")
+    }
+
+    func test_to_valid_swift_identifier_string_is_already_a_valid_swift_identifier() {
+        // Given
+        let subject = "ValidClassName"
+
+        // When
+        let got = subject.toValidSwiftIdentifier()
+
+        // Then
+        XCTAssertEqual(got, "ValidClassName")
     }
 
     func test_string_doesnt_match_GitURL_regex() {

--- a/Tests/TuistSupportTests/Extensions/String+ExtrasTests.swift
+++ b/Tests/TuistSupportTests/Extensions/String+ExtrasTests.swift
@@ -29,6 +29,29 @@ final class StringExtrasTests: TuistUnitTestCase {
         XCTAssertEqual(got, "_1Flow")
     }
 
+    func test_to_valid_swift_identifier() {
+        
+        // Test Case 1: String starting with lowercase letter
+        let str1 = "classname"
+        XCTAssertEqual(str1.toValidSwiftIdentifier(), "Classname", "Expected 'Classname'")
+        
+        // Test Case 2: String starting with numbers
+        let str2 = "123invalidName"
+        XCTAssertEqual(str2.toValidSwiftIdentifier(), "_123invalidName", "Expected '_123invalidName'")
+        
+        // Test Case 3: String is a Swift reserved word
+        let str3 = "class"
+        XCTAssertEqual(str3.toValidSwiftIdentifier(), "Class", "Expected 'Class'")
+        
+        // Test Case 4: String with special characters
+        let str4 = "class$name"
+        XCTAssertEqual(str4.toValidSwiftIdentifier(), "ClassName", "Expected 'ClassName'")
+        
+        // Test Case 5: String is already a valid Swift Identifier
+        let str5 = "ValidClassName"
+        XCTAssertEqual(str5.toValidSwiftIdentifier(), "ValidClassName", "Expected 'ValidClassName'")
+    }
+    
     func test_string_doesnt_match_GitURL_regex() {
         // Given
         let stringToEvaluate = "not a url string"

--- a/Tests/TuistSupportTests/Extensions/String+ExtrasTests.swift
+++ b/Tests/TuistSupportTests/Extensions/String+ExtrasTests.swift
@@ -30,28 +30,27 @@ final class StringExtrasTests: TuistUnitTestCase {
     }
 
     func test_to_valid_swift_identifier() {
-        
         // Test Case 1: String starting with lowercase letter
         let str1 = "classname"
         XCTAssertEqual(str1.toValidSwiftIdentifier(), "Classname", "Expected 'Classname'")
-        
+
         // Test Case 2: String starting with numbers
         let str2 = "123invalidName"
         XCTAssertEqual(str2.toValidSwiftIdentifier(), "_123invalidName", "Expected '_123invalidName'")
-        
+
         // Test Case 3: String is a Swift reserved word
         let str3 = "class"
         XCTAssertEqual(str3.toValidSwiftIdentifier(), "Class", "Expected 'Class'")
-        
+
         // Test Case 4: String with special characters
         let str4 = "class$name"
         XCTAssertEqual(str4.toValidSwiftIdentifier(), "ClassName", "Expected 'ClassName'")
-        
+
         // Test Case 5: String is already a valid Swift Identifier
         let str5 = "ValidClassName"
         XCTAssertEqual(str5.toValidSwiftIdentifier(), "ValidClassName", "Expected 'ValidClassName'")
     }
-    
+
     func test_string_doesnt_match_GitURL_regex() {
         // Given
         let stringToEvaluate = "not a url string"


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5237

### Short description 📝

I previously submitted a [PR](https://github.com/tuist/tuist/pull/5256), but unfortunately, it didn't completely resolve the issue. To fully address this, I have now extended the solution in the current PR. I added a new method `toValidSwiftIdentifier()` to the `String` type and used this method in place of `camelized.uppercasingFirst` in the `ResourcesProjectMapper` class.

### How to test the changes locally 🧐

`StringExtrasTests.test_to_valid_swift_identifier...()` methods.

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
