### PR TITLE
Remove empty trailing line from resource templates

### DIFF
--- a/Sources/TuistGenerator/Templates/AssetsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/AssetsTemplate.swift
@@ -313,6 +313,5 @@ extension SynthesizedResourceInterfaceTemplates {
     {% endif %}
     // swiftlint:enable all
     // swiftformat:enable all
-
     """
 }

--- a/Sources/TuistGenerator/Templates/FilesTemplate.swift
+++ b/Sources/TuistGenerator/Templates/FilesTemplate.swift
@@ -111,6 +111,5 @@ extension SynthesizedResourceInterfaceTemplates {
     {% endif %}
     // swiftlint:enable all
     // swiftformat:enable all
-
     """
 }

--- a/Sources/TuistGenerator/Templates/FontsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/FontsTemplate.swift
@@ -126,6 +126,5 @@ extension SynthesizedResourceInterfaceTemplates {
     {% endif %}
     // swiftlint:enable all
     // swiftformat:enable all
-
     """
 }

--- a/Sources/TuistGenerator/Templates/PlistsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/PlistsTemplate.swift
@@ -80,6 +80,5 @@ extension SynthesizedResourceInterfaceTemplates {
     {% endif %}
     // swiftlint:enable all
     // swiftformat:enable all
-
     """
 }

--- a/Sources/TuistGenerator/Templates/StringsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/StringsTemplate.swift
@@ -97,6 +97,5 @@ extension SynthesizedResourceInterfaceTemplates {
     {% endif %}
     // swiftlint:enable all
     // swiftformat:enable all
-
     """
 }


### PR DESCRIPTION
### Short description 📝

Per [discussion on Slack](https://tuistapp.slack.com/archives/C018QG7U7SN/p1692267127501909?thread_ts=1692262514.078489&cid=C018QG7U7SN) - there is an empty trailing line in all resource templates file, right after the SwiftFormat/SwiftLint disable comments, which causes SwiftLint to trigger a warning on that emtpy line.

### How to test the changes locally 🧐

`swift run tuist generate` with resource synthesizer

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
