### PR TITLE
Fix TEST_HOST with double // after BUNDLE_EXECUTABLE_FOLDER_PATH

### DIFF
--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -276,11 +276,21 @@ final class ConfigGenerator: ConfigGenerating {
         var settings: SettingsDictionary = [:]
         settings["TEST_TARGET_NAME"] = .string("\(app.target.name)")
         if target.product == .unitTests {
-            settings["TEST_HOST"] =
-                .string(
-                    "$(BUILT_PRODUCTS_DIR)/\(app.target.productNameWithExtension)/$(BUNDLE_EXECUTABLE_FOLDER_PATH)\(app.target.productName)"
+            do {
+                let path = try AbsolutePath(validating: "$(BUILT_PRODUCTS_DIR)")
+
+                settings["TEST_HOST"] = .string(
+                    path
+                        .appending(component: "$(BUNDLE_EXECUTABLE_FOLDER_PATH)")
+                        .appending(component: app.target.productNameWithExtension)
+                        .appending(component: app.target.productName)
+                        .pathString
                 )
-            settings["BUNDLE_LOADER"] = "$(TEST_HOST)"
+
+                settings["BUNDLE_LOADER"] = "$(TEST_HOST)"
+            } catch {
+                return [:]
+            }
         }
 
         return settings

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -278,7 +278,7 @@ final class ConfigGenerator: ConfigGenerating {
         if target.product == .unitTests {
             settings["TEST_HOST"] =
                 .string(
-                    "$(BUILT_PRODUCTS_DIR)/\(app.target.productNameWithExtension)/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/\(app.target.productName)"
+                    "$(BUILT_PRODUCTS_DIR)/\(app.target.productNameWithExtension)/$(BUNDLE_EXECUTABLE_FOLDER_PATH)\(app.target.productName)"
                 )
             settings["BUNDLE_LOADER"] = "$(TEST_HOST)"
         }

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -279,9 +279,17 @@ final class ConfigGenerator: ConfigGenerating {
             do {
                 let path = try AbsolutePath(validating: "$(BUILT_PRODUCTS_DIR)")
 
+                #if os(iOS) || os(tvOS) || os(watchOS)
+                let bundleExecutableFolderPath = "$(BUNDLE_EXECUTABLE_FOLDER_PATH)"
+                #elseif os(macOS)
+                let bundleExecutableFolderPath = "$(BUNDLE_EXECUTABLE_FOLDER_PATH)/"
+                #else
+                let bundleExecutableFolderPath = "$(BUNDLE_EXECUTABLE_FOLDER_PATH)/"
+                #endif
+
                 settings["TEST_HOST"] = .string(
                     path
-                        .appending(component: "$(BUNDLE_EXECUTABLE_FOLDER_PATH)")
+                        .appending(component: bundleExecutableFolderPath)
                         .appending(component: app.target.productNameWithExtension)
                         .appending(component: app.target.productName)
                         .pathString

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -142,7 +142,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
 
     func test_generateTestTargetConfiguration_iOS() throws {
         // Given / When
-        try generateTestTargetConfig(appName: "App")
+        try generateTestTargetConfig(appName: "App", destinations: .iOS)
 
         let configurationList = pbxTarget.buildConfigurationList
         let debugConfig = configurationList?.configuration(name: "Debug")


### PR DESCRIPTION
### Short description 📝

with version 3.22.0 the TEST_HOST has a double // because BUNDLE_EXECUTABLE_FOLDER_PATH has already a / at the end.

$(BUILT_PRODUCTS_DIR)/XXXDebug.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/XXXDebug
results in
build/Release-iphoneos/XXXDebug.app//XXXDebug

was introduced here

settings[“TEST_HOST”] =
                .string(
                    “$(BUILT_PRODUCTS_DIR)/\(app.target.productNameWithExtension)/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/\(app.target.productName)”
                )