### PR TITLE
Add glob support for `inputPaths` in `TargetScript`

### DIFF
--- a/Sources/ProjectDescription/TargetScript.swift
+++ b/Sources/ProjectDescription/TargetScript.swift
@@ -34,7 +34,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
     public let order: Order
 
     /// List of input file paths
-    public let inputPaths: [Path]
+    public let inputPaths: [FileListGlob]
 
     /// List of input filelist paths
     public let inputFileListPaths: [Path]
@@ -63,7 +63,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
     ///   - name: Name of the build phase when the project gets generated.
     ///   - script: The script to be executed.
     ///   - order: Target script order
-    ///   - inputPaths: List of input file paths.
+    ///   - inputPaths: Glob pattern to the files.
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
@@ -75,7 +75,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
         name: String,
         script: Script = .embedded(""),
         order: Order,
-        inputPaths: [Path] = [],
+        inputPaths: [FileListGlob] = [],
         inputFileListPaths: [Path] = [],
         outputPaths: [Path] = [],
         outputFileListPaths: [Path] = [],
@@ -105,7 +105,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
     ///   - path: Path to the script to execute.
     ///   - arguments: Arguments that to be passed.
     ///   - name: Name of the build phase when the project gets generated.
-    ///   - inputPaths: List of input file paths.
+    ///   - inputPaths: Glob pattern to the files.
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
@@ -118,7 +118,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
         path: Path,
         arguments: String...,
         name: String,
-        inputPaths: [Path] = [],
+        inputPaths: [FileListGlob] = [],
         inputFileListPaths: [Path] = [],
         outputPaths: [Path] = [],
         outputFileListPaths: [Path] = [],
@@ -148,7 +148,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
     ///   - path: Path to the script to execute.
     ///   - arguments: Arguments that to be passed.
     ///   - name: Name of the build phase when the project gets generated.
-    ///   - inputPaths: List of input file paths.
+    ///   - inputPaths: Glob pattern to the files.
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
@@ -161,7 +161,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
         path: Path,
         arguments: [String],
         name: String,
-        inputPaths: [Path] = [],
+        inputPaths: [FileListGlob] = [],
         inputFileListPaths: [Path] = [],
         outputPaths: [Path] = [],
         outputFileListPaths: [Path] = [],
@@ -191,7 +191,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
     ///   - path: Path to the script to execute.
     ///   - arguments: Arguments that to be passed.
     ///   - name: Name of the build phase when the project gets generated.
-    ///   - inputPaths: List of input file paths.
+    ///   - inputPaths: Glob pattern to the files.
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
@@ -204,7 +204,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
         path: Path,
         arguments: String...,
         name: String,
-        inputPaths: [Path] = [],
+        inputPaths: [FileListGlob] = [],
         inputFileListPaths: [Path] = [],
         outputPaths: [Path] = [],
         outputFileListPaths: [Path] = [],
@@ -234,7 +234,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
     ///   - path: Path to the script to execute.
     ///   - arguments: Arguments that to be passed.
     ///   - name: Name of the build phase when the project gets generated.
-    ///   - inputPaths: List of input file paths.
+    ///   - inputPaths: Glob pattern to the files.
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
@@ -247,7 +247,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
         path: Path,
         arguments: [String],
         name: String,
-        inputPaths: [Path] = [],
+        inputPaths: [FileListGlob] = [],
         inputFileListPaths: [Path] = [],
         outputPaths: [Path] = [],
         outputFileListPaths: [Path] = [],
@@ -279,7 +279,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
     ///   - tool: Name of the tool to execute. Tuist will look up the tool on the environment's PATH.
     ///   - arguments: Arguments that to be passed.
     ///   - name: Name of the build phase when the project gets generated.
-    ///   - inputPaths: List of input file paths.
+    ///   - inputPaths: Glob pattern to the files.
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
@@ -292,7 +292,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
         tool: String,
         arguments: String...,
         name: String,
-        inputPaths: [Path] = [],
+        inputPaths: [FileListGlob] = [],
         inputFileListPaths: [Path] = [],
         outputPaths: [Path] = [],
         outputFileListPaths: [Path] = [],
@@ -322,7 +322,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
     ///   - tool: Name of the tool to execute. Tuist will look up the tool on the environment's PATH.
     ///   - arguments: Arguments that to be passed.
     ///   - name: Name of the build phase when the project gets generated.
-    ///   - inputPaths: List of input file paths.
+    ///   - inputPaths: Glob pattern to the files.
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
@@ -335,7 +335,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
         tool: String,
         arguments: [String],
         name: String,
-        inputPaths: [Path] = [],
+        inputPaths: [FileListGlob] = [],
         inputFileListPaths: [Path] = [],
         outputPaths: [Path] = [],
         outputFileListPaths: [Path] = [],
@@ -365,7 +365,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
     ///   - tool: Name of the tool to execute. Tuist will look up the tool on the environment's PATH.
     ///   - arguments: Arguments that to be passed.
     ///   - name: Name of the build phase when the project gets generated.
-    ///   - inputPaths: List of input file paths.
+    ///   - inputPaths: Glob pattern to the files.
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
@@ -378,7 +378,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
         tool: String,
         arguments: String...,
         name: String,
-        inputPaths: [Path] = [],
+        inputPaths: [FileListGlob] = [],
         inputFileListPaths: [Path] = [],
         outputPaths: [Path] = [],
         outputFileListPaths: [Path] = [],
@@ -408,7 +408,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
     ///   - tool: Name of the tool to execute. Tuist will look up the tool on the environment's PATH.
     ///   - arguments: Arguments that to be passed.
     ///   - name: Name of the build phase when the project gets generated.
-    ///   - inputPaths: List of input file paths.
+    ///   - inputPaths: Glob pattern to the files.
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
@@ -421,7 +421,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
         tool: String,
         arguments: [String],
         name: String,
-        inputPaths: [Path] = [],
+        inputPaths: [FileListGlob] = [],
         inputFileListPaths: [Path] = [],
         outputPaths: [Path] = [],
         outputFileListPaths: [Path] = [],
@@ -453,7 +453,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
     ///   - script: The text of the script to run. This should be kept small.
     ///   - arguments: Arguments that to be passed.
     ///   - name: Name of the build phase when the project gets generated.
-    ///   - inputPaths: List of input file paths.
+    ///   - inputPaths: Glob pattern to the files.
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
@@ -465,7 +465,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
     public static func pre(
         script: String,
         name: String,
-        inputPaths: [Path] = [],
+        inputPaths: [FileListGlob] = [],
         inputFileListPaths: [Path] = [],
         outputPaths: [Path] = [],
         outputFileListPaths: [Path] = [],
@@ -494,7 +494,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
     /// - Parameters:
     ///   - script: The script to be executed.
     ///   - name: Name of the build phase when the project gets generated.
-    ///   - inputPaths: List of input file paths.
+    ///   - inputPaths: Glob pattern to the files.
     ///   - inputFileListPaths: List of input filelist paths.
     ///   - outputPaths: List of output file paths.
     ///   - outputFileListPaths: List of output filelist paths.
@@ -506,7 +506,7 @@ public struct TargetScript: Codable, Equatable { // swiftlint:disable:this type_
     public static func post(
         script: String,
         name: String,
-        inputPaths: [Path] = [],
+        inputPaths: [FileListGlob] = [],
         inputFileListPaths: [Path] = [],
         outputPaths: [Path] = [],
         outputFileListPaths: [Path] = [],

--- a/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
@@ -15,7 +15,7 @@ extension TuistGraph.TargetScript {
     {
         let name = manifest.name
         let order = TuistGraph.TargetScript.Order.from(manifest: manifest.order)
-        let inputPaths = try absolutePaths(for: manifest.inputPaths, generatorPaths: generatorPaths)
+        let inputPaths = manifest.inputPaths.compactMap{try? $0.unfold(generatorPaths: generatorPaths)}.flatMap{$0}
         let inputFileListPaths = try absolutePaths(for: manifest.inputFileListPaths, generatorPaths: generatorPaths)
         let outputPaths = try absolutePaths(for: manifest.outputPaths, generatorPaths: generatorPaths)
         let outputFileListPaths = try absolutePaths(for: manifest.outputFileListPaths, generatorPaths: generatorPaths)

--- a/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
@@ -15,7 +15,7 @@ extension TuistGraph.TargetScript {
     {
         let name = manifest.name
         let order = TuistGraph.TargetScript.Order.from(manifest: manifest.order)
-        let inputPaths = manifest.inputPaths.compactMap{try? $0.unfold(generatorPaths: generatorPaths)}.flatMap{$0}
+        let inputPaths = manifest.inputPaths.compactMap { try? $0.unfold(generatorPaths: generatorPaths) }.flatMap { $0 }
         let inputFileListPaths = try absolutePaths(for: manifest.inputFileListPaths, generatorPaths: generatorPaths)
         let outputPaths = try absolutePaths(for: manifest.outputPaths, generatorPaths: generatorPaths)
         let outputFileListPaths = try absolutePaths(for: manifest.outputFileListPaths, generatorPaths: generatorPaths)

--- a/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
+++ b/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
@@ -102,7 +102,7 @@ extension TargetScript {
         tool: String = "",
         order: Order = .pre,
         arguments: [String] = [],
-        inputPaths: [Path] = [],
+        inputPaths: [FileListGlob] = [],
         inputFileListPaths: [Path] = [],
         outputPaths: [Path] = [],
         outputFileListPaths: [Path] = [],

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/TargetScript+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/TargetScript+ManifestMapperTests.swift
@@ -40,9 +40,9 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
             "foo/bar/bTests.swift",
             "foo/bar/kTests.kt",
             "foo/bar/c/c.swift",
-            "foo/bar/c/cTests.swift"
+            "foo/bar/c/cTests.swift",
         ])
-        
+
         let manifest = ProjectDescription.TargetScript.test(
             name: "MyScript",
             tool: "my_tool",
@@ -55,7 +55,7 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
         )
         // When
         let model = try TuistGraph.TargetScript.from(manifest: manifest, generatorPaths: generatorPaths)
-        
+
         // Then
         let relativeSources = model.inputPaths.map { $0.relative(to: temporaryPath).pathString }
 
@@ -65,9 +65,9 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
             "foo/bar/aTests.swift",
             "foo/bar/bTests.swift",
             "foo/bar/c/c.swift",
-            "foo/bar/c/cTests.swift"
+            "foo/bar/c/cTests.swift",
         ]))
-        
+
         // Then
         XCTAssertEqual(model.name, "MyScript")
         XCTAssertEqual(model.script, .tool(path: "my_tool", args: ["arg1", "arg2"]))
@@ -76,7 +76,7 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
         XCTAssertEqual(model.outputPaths, [temporaryPath.appending(RelativePath("$(SRCROOT)/foo/bar/**/*.swift"))])
         XCTAssertEqual(model.outputFileListPaths, [temporaryPath.appending(RelativePath("$(SRCROOT)/foo/bar/**/*.swift"))])
     }
-    
+
     func test_glob_whenExcluding() throws {
         // Given
         let temporaryPath = try temporaryPath()
@@ -88,9 +88,9 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
             "foo/bar/bTests.swift",
             "foo/bar/kTests.kt",
             "foo/bar/c/c.swift",
-            "foo/bar/c/cTests.swift"
+            "foo/bar/c/cTests.swift",
         ])
-        
+
         let manifest = ProjectDescription.TargetScript.test(
             name: "MyScript",
             tool: "my_tool",
@@ -101,9 +101,9 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
                     "foo/bar/**/*.swift",
                     excluding: [
                         "foo/bar/**/*Tests.swift",
-                        "foo/bar/**/*b.swift"
+                        "foo/bar/**/*b.swift",
                     ]
-                )
+                ),
             ],
             inputFileListPaths: ["$(SRCROOT)/foo/bar/**/*.swift"],
             outputPaths: ["$(SRCROOT)/foo/bar/**/*.swift"],
@@ -111,15 +111,15 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
         )
         // When
         let model = try TuistGraph.TargetScript.from(manifest: manifest, generatorPaths: generatorPaths)
-        
+
         // Then
         let relativeSources = model.inputPaths.map { $0.relative(to: temporaryPath).pathString }
 
         XCTAssertEqual(Set(relativeSources), Set([
             "foo/bar/a.swift",
-            "foo/bar/c/c.swift"
+            "foo/bar/c/c.swift",
         ]))
-        
+
         // Then
         XCTAssertEqual(model.name, "MyScript")
         XCTAssertEqual(model.script, .tool(path: "my_tool", args: ["arg1", "arg2"]))

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/TargetScript+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/TargetScript+ManifestMapperTests.swift
@@ -33,24 +33,97 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
         // Given
         let temporaryPath = try temporaryPath()
         let generatorPaths = GeneratorPaths(manifestDirectory: temporaryPath)
+        try createFiles([
+            "foo/bar/a.swift",
+            "foo/bar/b.swift",
+            "foo/bar/aTests.swift",
+            "foo/bar/bTests.swift",
+            "foo/bar/kTests.kt",
+            "foo/bar/c/c.swift",
+            "foo/bar/c/cTests.swift"
+        ])
+        
         let manifest = ProjectDescription.TargetScript.test(
             name: "MyScript",
             tool: "my_tool",
             order: .pre,
             arguments: ["arg1", "arg2"],
-            inputPaths: ["$(SRCROOT)/foo/bar/**/*.swift"],
+            inputPaths: ["foo/bar/**/*.swift"],
             inputFileListPaths: ["$(SRCROOT)/foo/bar/**/*.swift"],
             outputPaths: ["$(SRCROOT)/foo/bar/**/*.swift"],
             outputFileListPaths: ["$(SRCROOT)/foo/bar/**/*.swift"]
         )
         // When
         let model = try TuistGraph.TargetScript.from(manifest: manifest, generatorPaths: generatorPaths)
+        
+        // Then
+        let relativeSources = model.inputPaths.map { $0.relative(to: temporaryPath).pathString }
 
+        XCTAssertEqual(Set(relativeSources), Set([
+            "foo/bar/a.swift",
+            "foo/bar/b.swift",
+            "foo/bar/aTests.swift",
+            "foo/bar/bTests.swift",
+            "foo/bar/c/c.swift",
+            "foo/bar/c/cTests.swift"
+        ]))
+        
         // Then
         XCTAssertEqual(model.name, "MyScript")
         XCTAssertEqual(model.script, .tool(path: "my_tool", args: ["arg1", "arg2"]))
         XCTAssertEqual(model.order, .pre)
-        XCTAssertEqual(model.inputPaths, [temporaryPath.appending(RelativePath("$(SRCROOT)/foo/bar/**/*.swift"))])
+        XCTAssertEqual(model.inputFileListPaths, [temporaryPath.appending(RelativePath("$(SRCROOT)/foo/bar/**/*.swift"))])
+        XCTAssertEqual(model.outputPaths, [temporaryPath.appending(RelativePath("$(SRCROOT)/foo/bar/**/*.swift"))])
+        XCTAssertEqual(model.outputFileListPaths, [temporaryPath.appending(RelativePath("$(SRCROOT)/foo/bar/**/*.swift"))])
+    }
+    
+    func test_glob_whenExcluding() throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let generatorPaths = GeneratorPaths(manifestDirectory: temporaryPath)
+        try createFiles([
+            "foo/bar/a.swift",
+            "foo/bar/b.swift",
+            "foo/bar/aTests.swift",
+            "foo/bar/bTests.swift",
+            "foo/bar/kTests.kt",
+            "foo/bar/c/c.swift",
+            "foo/bar/c/cTests.swift"
+        ])
+        
+        let manifest = ProjectDescription.TargetScript.test(
+            name: "MyScript",
+            tool: "my_tool",
+            order: .pre,
+            arguments: ["arg1", "arg2"],
+            inputPaths: [
+                .glob(
+                    "foo/bar/**/*.swift",
+                    excluding: [
+                        "foo/bar/**/*Tests.swift",
+                        "foo/bar/**/*b.swift"
+                    ]
+                )
+            ],
+            inputFileListPaths: ["$(SRCROOT)/foo/bar/**/*.swift"],
+            outputPaths: ["$(SRCROOT)/foo/bar/**/*.swift"],
+            outputFileListPaths: ["$(SRCROOT)/foo/bar/**/*.swift"]
+        )
+        // When
+        let model = try TuistGraph.TargetScript.from(manifest: manifest, generatorPaths: generatorPaths)
+        
+        // Then
+        let relativeSources = model.inputPaths.map { $0.relative(to: temporaryPath).pathString }
+
+        XCTAssertEqual(Set(relativeSources), Set([
+            "foo/bar/a.swift",
+            "foo/bar/c/c.swift"
+        ]))
+        
+        // Then
+        XCTAssertEqual(model.name, "MyScript")
+        XCTAssertEqual(model.script, .tool(path: "my_tool", args: ["arg1", "arg2"]))
+        XCTAssertEqual(model.order, .pre)
         XCTAssertEqual(model.inputFileListPaths, [temporaryPath.appending(RelativePath("$(SRCROOT)/foo/bar/**/*.swift"))])
         XCTAssertEqual(model.outputPaths, [temporaryPath.appending(RelativePath("$(SRCROOT)/foo/bar/**/*.swift"))])
         XCTAssertEqual(model.outputFileListPaths, [temporaryPath.appending(RelativePath("$(SRCROOT)/foo/bar/**/*.swift"))])


### PR DESCRIPTION
Hi Team,

It does not resolve any issue. See the slack thread [here](https://tuistapp.slack.com/archives/C018QG7U7SN/p1692195936248819)

### Motivation
I have some auto-generated files in my target and I want to be able to exclude them from the `inputPaths` in the script phase so that It can work properly, meaning that Xcode does not run the script all the time.

### Short description 📝

> This PR aims to add `excluding` capability for `inputPaths` by changing `inputPaths: [Path]` into  `inputPaths: [FileListGlob]` 
> There are some changes in the `ProjectDescription`. However, those changes were made to support backward compatibility. So, there should not be any need to migrate or adopt.

### How to test the changes locally 🧐

> * Check out the source branch 
> * Run the `TargetScriptManifestMapperTests`


### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
