### PR TITLE
Fix cloud auth race condition

### DIFF
--- a/Sources/TuistSupport/Utils/HTTPRedirectListener.swift
+++ b/Sources/TuistSupport/Utils/HTTPRedirectListener.swift
@@ -61,12 +61,14 @@ public final class HTTPRedirectListener: HTTPRedirectListening {
         runningSemaphore = DispatchSemaphore(value: 0)
         httpServer[path] = { request in
             result = .success(request.queryParams.reduce(into: [String: String]()) { $0[$1.0] = $1.1 })
-            DispatchQueue.global().async { runningSemaphore.signal() }
+            DispatchQueue.global().async { runningSemaphore?.signal() }
             return HttpResponse.ok(.html(self.html(logoURL: logoURL, redirectMessage: redirectMessage)))
         }
 
         // Stop the server if the user sends an interruption signal by pressing CTRL+C
-        signalHandler.trap { _ in runningSemaphore.signal() }
+        signalHandler.trap { _ in
+            runningSemaphore.signal()
+        }
 
         do {
             logger.pretty("Press \(.keystroke("CTRL + C")) once to cancel the process.")


### PR DESCRIPTION
### Short description 📝

Fixes a race condition where a semaphore was called twice in quick succession, the second call leading to a crash. This in turn lead to credentials not being saved properly.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

Run `tuist cloud auth` -> session should be stored properly.

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
