### PR TITLE
Print URL when inviting a user

### DIFF
--- a/Sources/TuistCloud/Models/CloudInvitation.swift
+++ b/Sources/TuistCloud/Models/CloudInvitation.swift
@@ -6,18 +6,21 @@ public struct CloudInvitation: Codable {
         id: Int,
         inviteeEmail: String,
         inviter: CloudUser,
-        organizationId: Int
+        organizationId: Int,
+        token: String
     ) {
         self.id = id
         self.inviteeEmail = inviteeEmail
         self.inviter = inviter
         self.organizationId = organizationId
+        self.token = token
     }
 
     public let id: Int
     public let inviteeEmail: String
     public let inviter: CloudUser
     public let organizationId: Int
+    public let token: String
 }
 
 extension CloudInvitation {
@@ -26,5 +29,6 @@ extension CloudInvitation {
         inviteeEmail = invitation.invitee_email
         inviter = CloudUser(invitation.inviter)
         organizationId = Int(invitation.organization_id)
+        token = invitation.token
     }
 }

--- a/Sources/TuistCloud/OpenAPI/Types.swift
+++ b/Sources/TuistCloud/OpenAPI/Types.swift
@@ -104,6 +104,8 @@ public enum Components {
             public var invitee_email: Swift.String
             /// - Remark: Generated from `#/components/schemas/Invitation/organization_id`.
             public var organization_id: Swift.Double
+            /// - Remark: Generated from `#/components/schemas/Invitation/token`.
+            public var token: Swift.String
             /// - Remark: Generated from `#/components/schemas/Invitation/inviter`.
             public var inviter: Components.Schemas.User
             /// Creates a new `Invitation`.
@@ -112,22 +114,26 @@ public enum Components {
             ///   - id:
             ///   - invitee_email:
             ///   - organization_id:
+            ///   - token:
             ///   - inviter:
             public init(
                 id: Swift.Double,
                 invitee_email: Swift.String,
                 organization_id: Swift.Double,
+                token: Swift.String,
                 inviter: Components.Schemas.User
             ) {
                 self.id = id
                 self.invitee_email = invitee_email
                 self.organization_id = organization_id
+                self.token = token
                 self.inviter = inviter
             }
             public enum CodingKeys: String, CodingKey {
                 case id
                 case invitee_email
                 case organization_id
+                case token
                 case inviter
             }
         }

--- a/Sources/TuistCloud/OpenAPI/cloud.yml
+++ b/Sources/TuistCloud/OpenAPI/cloud.yml
@@ -412,6 +412,8 @@ components:
           type: string
         organization_id:
           type: number
+        token:
+          type: string
         inviter:
           type: object
           $ref: "#/components/schemas/User"
@@ -420,6 +422,7 @@ components:
         - invitee_email
         - organization_id
         - inviter
+        - token
     OrganizationMember:
       type: object
       properties:

--- a/Sources/TuistCloudTesting/Models/CloudInvitation+TestData.swift
+++ b/Sources/TuistCloudTesting/Models/CloudInvitation+TestData.swift
@@ -5,13 +5,15 @@ extension CloudInvitation {
         id: Int = 0,
         inviteeEmail: String = "test@tuist.io",
         inviter: CloudUser = .test(),
-        organizationId: Int = 0
+        organizationId: Int = 0,
+        token: String = "token"
     ) -> Self {
         .init(
             id: id,
             inviteeEmail: inviteeEmail,
             inviter: inviter,
-            organizationId: organizationId
+            organizationId: organizationId,
+            token: token
         )
     }
 }

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationInviteService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationInviteService.swift
@@ -37,6 +37,10 @@ final class CloudOrganizationInviteService: CloudOrganizationInviteServicing {
             serverURL: cloudURL
         )
 
-        logger.info("\(invitation.inviteeEmail) was successfully invited to the \(organizationName) organization 🎉")
+        logger.info("""
+        \(invitation.inviteeEmail) was successfully invited to the \(organizationName) organization 🎉
+
+        You can also share with them the invite link directly: \(cloudURL)/invitations/\(invitation.token)
+        """)
     }
 }


### PR DESCRIPTION
### Short description 📝

To make it easier to invite users, we will also now provide the URL they can send directly instead of using an email. Additionally, this means an email might not be necessary for self-hosting.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

`tuist cloud invite some-user` -> you should see an output along the lines of:
```
invited@user.com was successfully invited to the test organization 🎉

You can also share with them the invite link directly: https://cloud.tuist.io/invitations/jWr2q3vaqmJgx74D
```

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
