### PR TITLE
Fix StoreKit Configuration file paths

### DIFF
--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -500,11 +500,9 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
             customLLDBInitFilePath = nil
         }
 
-        if let storeKitFilePath = scheme.runAction?.options.storeKitConfigurationPath,
-           let graphTarget = graphTarget
-        {
+        if let storeKitFilePath = scheme.runAction?.options.storeKitConfigurationPath {
             // the identifier is the relative path between the storekit file, and the xcode project
-            let fileRelativePath = storeKitFilePath.relative(to: graphTarget.project.xcodeProjPath)
+            let fileRelativePath = storeKitFilePath.relative(to: graphTraverser.workspace.xcWorkspacePath)
             storeKitConfigurationFileReference = .init(identifier: fileRelativePath.pathString)
         }
 

--- a/projects/tuist/fixtures/ios_app_with_custom_scheme/App/Config/ProjectStoreKitConfig.storekit
+++ b/projects/tuist/fixtures/ios_app_with_custom_scheme/App/Config/ProjectStoreKitConfig.storekit
@@ -1,0 +1,19 @@
+{
+  "identifier" : "6F3E7EE0",
+  "nonRenewingSubscriptions" : [
+
+  ],
+  "products" : [
+
+  ],
+  "settings" : {
+
+  },
+  "subscriptionGroups" : [
+
+  ],
+  "version" : {
+    "major" : 2,
+    "minor" : 0
+  }
+}

--- a/projects/tuist/fixtures/ios_app_with_custom_scheme/App/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_custom_scheme/App/Project.swift
@@ -11,9 +11,13 @@ let debugScheme = Scheme(
     ),
     testAction: TestAction.targets(["AppTests"]),
     runAction: .runAction(
-        customLLDBInitFile: .relativeToManifest("../Scripts/lldb/_lldbinit"),
+        customLLDBInitFile: "../Scripts/lldb/_lldbinit",
         executable: "App",
-        options: .options(simulatedLocation: .johannesburg, enableGPUFrameCaptureMode: .metal),
+        options: .options(
+            storeKitConfigurationPath: "Config/ProjectStoreKitConfig.storekit",
+            simulatedLocation: .johannesburg,
+            enableGPUFrameCaptureMode: .metal
+        ),
         diagnosticsOptions: [.mainThreadChecker]
     )
 )

--- a/projects/tuist/fixtures/ios_app_with_custom_scheme/Workspace.swift
+++ b/projects/tuist/fixtures/ios_app_with_custom_scheme/Workspace.swift
@@ -34,7 +34,12 @@ let customAppScheme = Scheme(
             target: "Framework2Tests"
         )),
     ]),
-    runAction: .runAction(executable: .project(path: "App", target: "App")),
+    runAction: .runAction(
+        executable: .project(path: "App", target: "App"),
+        options: .options(
+            storeKitConfigurationPath: "App/Config/ProjectStoreKitConfig.storekit"
+        )
+    ),
     archiveAction: .archiveAction(configuration: "Debug", customArchiveName: "Something2")
 )
 


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/5401

### Short description 📝

- StoreKit Configuration files can be specified as one of Run Action Options
- Those files need to have paths relative to the .xcworkspace file being used even if they are defined with a project's scheme
- The generated paths have been corrected accordingly
- The fixture `ios_app_with_custom_scheme` has been updated to leverage a storekit configuration file to aid testing and verifying the intended behaviour

### How to test the changes locally 🧐

- Generate the fixture `ios_app_with_custom_scheme`

```sh
swift build
swift run tuist generate --path projects/tuist/fixtures/ios_app_with_custom_scheme
```

- Inspect the schemes `App-debug` and `Workspace-App`
- Verify the StoreKit configuration files with the Run Action Options appears and is valid (not marked red by Xcode)

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
-  ~~In case the PR introduces changes that affect users, the documentation has been updated~~

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
