### PR TITLE
Fix acceptance test failures due to build tool plugins

### DIFF
--- a/projects/tuist/features/step_definitions/shared/xcode.rb
+++ b/projects/tuist/features/step_definitions/shared/xcode.rb
@@ -24,6 +24,8 @@ Then(/I should be able to (.+) for (iOS|macOS|tvOS|watchOS) the scheme (.+)/) do
   end
 
   args.concat(["-derivedDataPath", @derived_data_path])
+  
+  args << "-skipPackagePluginValidation"
 
   args << "clean"
   args << action


### PR DESCRIPTION
### Short description 📝

- The acceptance tests were failing on main with the following error:

```
Validate plug-in “SwiftLintPlugin” in package “swiftlint”
error: “SwiftLintPlugin” must be enabled before it can be used
```

- This is due to one of the fixtures leveraging a build tool plugin (`ios_app_with_actions`)
- Xcode requires users to validate and trust plugins before it can load and use them
- This is typically a user prompt in the Xcode UI
- On CI however additional paramters are needed to the `xcodebuild` commands to skip this prompt

### References:

- https://forums.swift.org/t/telling-xcode-14-beta-4-to-trust-build-tool-plugins-programatically/59305/7

### How to test the changes locally 🧐

- Verify CI checks pass

### Contributor checklist ✅

- [ ] The code has been linted using run `./fourier lint tuist --fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
