### PR TITLE
Fix cache issues when the graph contains transitive static libraries and frameworks

### DIFF
--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -822,20 +822,15 @@ public class GraphTraverser: GraphTraversing {
         path: AbsolutePath,
         name: String
     ) -> [GraphDependencyReference] {
-        let precompiledStatic = graph.dependencies[.target(name: name, path: path), default: []]
-            .filter { dependency in
-                switch dependency {
-                case let .xcframework(_, _, _, linking: linking):
-                    return linking == .static
-                case .framework, .library, .bundle, .packageProduct, .target, .sdk:
-                    return false
-                }
+        let dependencies = filterDependencies(from: .target(name: name, path: path), test: { dependency in
+            switch dependency {
+            case let .xcframework(_, _, _, linking: linking):
+                return linking == .static
+            case .framework, .library, .bundle, .packageProduct, .target, .sdk:
+                return false
             }
-
-        let precompiledDependencies = precompiledStatic
-            .flatMap { filterDependencies(from: $0) }
-
-        return Set(precompiledStatic + precompiledDependencies)
+        })
+        return Set(dependencies)
             .compactMap(dependencyReference)
     }
 }

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -822,14 +822,25 @@ public class GraphTraverser: GraphTraversing {
         path: AbsolutePath,
         name: String
     ) -> [GraphDependencyReference] {
-        let dependencies = filterDependencies(from: .target(name: name, path: path), test: { dependency in
-            switch dependency {
-            case let .xcframework(_, _, _, linking: linking):
-                return linking == .static
-            case .framework, .library, .bundle, .packageProduct, .target, .sdk:
-                return false
+        let dependencies = filterDependencies(
+            from: .target(name: name, path: path),
+            test: { dependency in
+                switch dependency {
+                case let .xcframework(_, _, _, linking: linking):
+                    return linking == .static
+                case .framework, .library, .bundle, .packageProduct, .target, .sdk:
+                    return false
+                }
+            },
+            skip: { dependency in
+                switch dependency {
+                case .xcframework:
+                    return false
+                case .framework, .library, .bundle, .packageProduct, .target, .sdk:
+                    return true
+                }
             }
-        }, skip: canDependencyLinkStaticProducts)
+        )
         return Set(dependencies)
             .compactMap(dependencyReference)
     }

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -829,7 +829,7 @@ public class GraphTraverser: GraphTraversing {
             case .framework, .library, .bundle, .packageProduct, .target, .sdk:
                 return false
             }
-        })
+        }, skip: canDependencyLinkStaticProducts)
         return Set(dependencies)
             .compactMap(dependencyReference)
     }


### PR DESCRIPTION
### Short description 📝
@mstfy reported that when a target has transitive static dependencies, for example, a static library or framework, the generated project with pre-compiled binaries from the cache causes compilation issues. To reproduce it, you can use [this project](https://github.com/tuist/tuist/files/12586529/regression.zip) and run the following sequence of commands:

1. Fetch the dependencies `tuist fetch`.
2. Warm the cache `tuist warm`.
3. Generate the project with the focus on RegressionUI `tuist generate RegressionUI`
4. In the generated project `RegressionUI` doesn't compile because linked dependencies are missing. 

It turns out that the the logic that copies the xcframeworks into the products directory for the Xcode build process to resolve interfaces at build-time was not accounting for transitive static xcframework dependencies.

### How to test the changes locally 🧐
Run the same above commands with the changes in this PR.

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
