### PR TITLE
Fix wording in documentation regarding Entitlements

### DIFF
--- a/Sources/ProjectDescription/Entitlements.swift
+++ b/Sources/ProjectDescription/Entitlements.swift
@@ -3,10 +3,10 @@ import Foundation
 // MARK: - Entitlements
 
 public enum Entitlements: Codable, Equatable {
-    /// The path to an existing Info.plist file.
+    /// The path to an existing .entitlements file.
     case file(path: Path)
 
-    /// A dictionary with the Info.plist content. Tuist generates the Info.plist file at the generation time.
+    /// A dictionary with the entitlements content. Tuist generates the .entitlements file at the generation time.
     case dictionary([String: Plist.Value])
 
     // MARK: - Error

--- a/Sources/ProjectDescription/Plist.swift
+++ b/Sources/ProjectDescription/Plist.swift
@@ -3,8 +3,8 @@ import Foundation
 // MARK: - Plist
 
 public enum Plist {
-    /// It represents the values of the Plist file dictionary.
-    /// It ensures that the values used to define the content of the dynamically generated Info.plist files are valid
+    /// It represents the values of the .plist or .entitlements file dictionary.
+    /// It ensures that the values used to define the content of the dynamically generated .plist or .entitlements files are valid
     public indirect enum Value: Codable, Equatable {
         /// It represents a string value.
         case string(String)

--- a/Sources/TuistGenerator/Mappers/GenerateEntitlementsProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/GenerateEntitlementsProjectMapper.swift
@@ -39,7 +39,7 @@ public final class GenerateEntitlementsProjectMapper: ProjectMapping {
             return (target, [])
         }
 
-        // Get the Info.plist that needs to be generated
+        // Get the entitlements that needs to be generated
         guard let dictionary = entitlementsDictionary(
             entitlements: entitlements
         )

--- a/Sources/TuistGraph/Models/Plist.swift
+++ b/Sources/TuistGraph/Models/Plist.swift
@@ -130,14 +130,14 @@ extension InfoPlist: ExpressibleByStringLiteral {
 // MARK: - Entitlements
 
 public enum Entitlements: Equatable, Codable {
-    // Path to a user defined info.plist file (already exists on disk).
+    // Path to a user defined .entitlements file (already exists on disk).
     case file(path: AbsolutePath)
 
-    // Path to a generated info.plist file (may not exist on disk at the time of project generation).
+    // Path to a generated .entitlements file (may not exist on disk at the time of project generation).
     // Data of the generated file
     case generatedFile(path: AbsolutePath, data: Data)
 
-    // User defined dictionary of keys/values for an info.plist file.
+    // User defined dictionary of keys/values for an .entitlements file.
     case dictionary([String: Plist.Value])
 
     // MARK: - Public


### PR DESCRIPTION
### Short description 📝

I noticed [here](https://tuist.github.io/tuist/main/documentation/projectdescription/entitlements) that the wording in the comment was wrong (`Info.plist` instead of `entitlements`). So I went through https://github.com/tuist/tuist/pull/5377 where this was caused and tried to fix all of those I could find. 

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
