### PR TITLE
Add cal.com badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
   <img src="https://img.shields.io/badge/Powered%20by-Tuist-blue" alt="Powered by Tuist">
 </div>
 
+<div align="center">
+  <a href="https://cal.com/team/tuist/cloud" target="_blank"><img alt="Book us with Cal.com" src="https://cal.com/book-with-cal-dark.svg" /></a>
+</div>
+
 ## What's Tuist 🕺
 
 Tuist is a command line tool that helps you **generate**, **maintain** and **interact** with Xcode projects.


### PR DESCRIPTION
### Short description 📝
We started using [cal.com](https://cal.com) with users interested in trying Tuist Cloud. Cal.com is a paid service but has a free plan for [open source projects](https://cal.com/docs/how-to-guides/can-calcom-sponsor-my-open-source-project#sponsorship-criteria). The only requirement is to add a link to Cal.com to the README and to the website. This PR adds the badge to the README.
