### PR TITLE
Fix missing input file paths in generated script build phases

### DIFF
--- a/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetAction+ManifestMapper.swift
@@ -15,7 +15,7 @@ extension TuistGraph.TargetScript {
     {
         let name = manifest.name
         let order = TuistGraph.TargetScript.Order.from(manifest: manifest.order)
-        let inputPaths = manifest.inputPaths.compactMap { try? $0.unfold(generatorPaths: generatorPaths) }.flatMap { $0 }
+        let inputPaths = try manifest.inputPaths.compactMap { try $0.unfold(generatorPaths: generatorPaths) }.flatMap { $0 }
         let inputFileListPaths = try absolutePaths(for: manifest.inputFileListPaths, generatorPaths: generatorPaths)
         let outputPaths = try absolutePaths(for: manifest.outputPaths, generatorPaths: generatorPaths)
         let outputFileListPaths = try absolutePaths(for: manifest.outputFileListPaths, generatorPaths: generatorPaths)

--- a/Sources/TuistLoader/Models/FileListGlob+Unfold.swift
+++ b/Sources/TuistLoader/Models/FileListGlob+Unfold.swift
@@ -9,11 +9,6 @@ extension FileListGlob {
         generatorPaths: GeneratorPaths,
         filter: ((AbsolutePath) -> Bool)? = nil
     ) throws -> [AbsolutePath] {
-        /**
-         If a glob contains variables, those are resolved at build-time and therefore we cannot unfold them.
-         In that case they are made absolute by appending them to the root directory, and relativized
-         again when the Xcode project is generated.
-         */
         if glob.pathString.contains("$") {
             return [try generatorPaths.resolve(path: glob)]
         }

--- a/Sources/TuistLoader/Models/FileListGlob+Unfold.swift
+++ b/Sources/TuistLoader/Models/FileListGlob+Unfold.swift
@@ -9,9 +9,19 @@ extension FileListGlob {
         generatorPaths: GeneratorPaths,
         filter: ((AbsolutePath) -> Bool)? = nil
     ) throws -> [AbsolutePath] {
+        /**
+         If a glob contains variables, those are resolved at build-time and therefore we cannot unfold them.
+         In that case they are made absolute by appending them to the root directory, and relativized
+         again when the Xcode project is generated.
+         */
+        if glob.pathString.contains("$") {
+            return [try generatorPaths.resolve(path: glob)]
+        }
+
         let resolvedPath = try generatorPaths.resolve(path: glob)
         let resolvedExcluding = try resolvedExcluding(generatorPaths: generatorPaths)
         let pattern = String(resolvedPath.pathString.dropFirst())
+
         return FileHandler.shared.glob(AbsolutePath.root, glob: pattern).filter { path in
             guard !resolvedExcluding.contains(path) else {
                 return false

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/TargetScript+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/TargetScript+ManifestMapperTests.swift
@@ -48,7 +48,10 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
             tool: "my_tool",
             order: .pre,
             arguments: ["arg1", "arg2"],
-            inputPaths: ["foo/bar/**/*.swift"],
+            inputPaths: [
+                "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}",
+                "foo/bar/**/*.swift",
+            ],
             inputFileListPaths: ["$(SRCROOT)/foo/bar/**/*.swift"],
             outputPaths: ["$(SRCROOT)/foo/bar/**/*.swift"],
             outputFileListPaths: ["$(SRCROOT)/foo/bar/**/*.swift"]
@@ -60,6 +63,7 @@ final class TargetScriptManifestMapperTests: TuistUnitTestCase {
         let relativeSources = model.inputPaths.map { $0.relative(to: temporaryPath).pathString }
 
         XCTAssertEqual(Set(relativeSources), Set([
+            "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}",
             "foo/bar/a.swift",
             "foo/bar/b.swift",
             "foo/bar/aTests.swift",


### PR DESCRIPTION
### Short description 📝

[This change](https://github.com/tuist/tuist/pull/5364/files#diff-c581b4b5f39559189aeff3e9f5a387e343540297aef284e77e7367a37212931eR18) to support globs in script build phases input paths introduced a regression for users that used values that are resolved at build time, for example `${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}`, that can't be resolved at generation time. This PR fixes the issue.

### How to test the changes locally 🧐

You can either create a project with a script build phase that uses variables in the input paths, or run the tests in `TargetScript+ManifestMapperTests.swift` that includes an scenario like the one that's causing the issue.

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
