### PR TITLE
Add supported platforms build setting when specifying multiple destinations

### DIFF
--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -256,6 +256,15 @@ final class ConfigGenerator: ConfigGenerating {
             settings["SDKROOT"] = "auto"
         }
 
+        if target.supportedPlatforms.count > 1 {
+            let simulatorSDKs = target.supportedPlatforms.compactMap(\.xcodeSimulatorSDK)
+            let platformSDKs = target.supportedPlatforms.map(\.xcodeDeviceSDK)
+            settings["SUPPORTED_PLATFORMS"] = .string(
+                [simulatorSDKs, platformSDKs].flatMap { $0 }.sorted()
+                    .joined(separator: " ")
+            )
+        }
+
         if target.product == .staticFramework {
             settings["MACH_O_TYPE"] = "staticlib"
         }

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -542,6 +542,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         let expectedSettings: SettingsDictionary = [
             "SDKROOT": "auto",
             "TARGETED_DEVICE_FAMILY": "1,2",
+            "SUPPORTED_PLATFORMS": "iphoneos iphonesimulator macosx",
             "LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]": ["$(inherited)", "@executable_path/../Frameworks"],
             "LD_RUNPATH_SEARCH_PATHS": ["$(inherited)", "@executable_path/Frameworks"],
         ]


### PR DESCRIPTION
### Short description 📝

- When specifying multiple destination, the `SUPPORTED_PLATFORMS` build setting needs to be set to include the various sdks for both simulator and device

### How to test the changes locally 🧐

- Multiple destinations is not yet exposed via public as such can only be validated with unit tests at this time


### Notes 📝

- This was cherry-picked from a draft PR for multi-platform support https://github.com/tuist/tuist/pull/5381

### Contributor checklist ✅

- [ ] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
