### PR TITLE
Migrate lint and format to Makefile

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ Resolves https://github.com/tuist/tuist/issues/YYY
 
 ### Contributor checklist ✅
 
-- [ ] The code has been linted using run `./fourier lint tuist --fix`
+- [ ] The code has been linted using run `make lint-fix`
 - [ ] The change is tested via unit testing or acceptance testing, or both
 - [ ] The title of the PR is formulated in a way that is usable as a changelog entry
 - [ ] In case the PR introduces changes that affect users, the documentation has been updated

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -156,23 +156,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-      - uses: actions/cache@v3
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-${{ env.RUBY_VERSION }}${{ hashFiles('Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.RUBY_VERSION }}-gems-
-      - name: Bundle install
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
-      - name: Install Bundler dependencies
-        run: bundle install
       - name: Run
-        run: ./fourier lint tuist
+        run: make lint
   
   lint-lockfiles:
     name: Lint lockfiles

--- a/.swiftformat
+++ b/.swiftformat
@@ -2,6 +2,7 @@
 
 --symlinks ignore
 --exclude Tests/XCTestManifests.swift,projects/tuist/features,Sources/TuistSupport/Vendored,projects/tuist/fixtures/Targets/SlothCreator,Sources/TuistCloud/OpenAPI,Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+--exclude projects/tuist/fixtures/tuist_plugin
 
 # format options
 

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,7 @@ run:
 	./make/tasks/run.sh $(ARGS)
 generate/cloud-openapi-code:
 	./make/tasks/generate/cloud-openapi-code.sh
+lint-fix:
+	./make/tasks/lint-fix.sh
+lint:
+	./make/tasks/lint.sh

--- a/make/tasks/lint-fix.sh
+++ b/make/tasks/lint-fix.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR=$($SCRIPT_DIR/../utilities/root_dir.sh)
+
+$ROOT_DIR/projects/fourier/vendor/swiftformat/swiftformat $ROOT_DIR
+$ROOT_DIR/projects/fourier/vendor/swiftlint/swiftlint --fix --path $ROOT_DIR/Sources --quiet --config $ROOT_DIR/.swiftlint.yml

--- a/make/tasks/lint.sh
+++ b/make/tasks/lint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR=$($SCRIPT_DIR/../utilities/root_dir.sh)
+
+$ROOT_DIR/projects/fourier/vendor/swiftformat/swiftformat $ROOT_DIR --lint
+$ROOT_DIR/projects/fourier/vendor/swiftlint/swiftlint --path $ROOT_DIR/Sources --quiet --config $ROOT_DIR/.swiftlint.yml


### PR DESCRIPTION
### Short description 📝

- To ease contributions to those that don't have a ruby setup, the SwiftLint and Swiftformat shell calls have been migrated to the Makefile
- The SwiftFormat config was updated to exclude one of the fixtures that is added as a submodule
- The github token was moved to the github step to avoid requiring it for all makefile incovations

### How to test the changes locally 🧐

- Modify any Swift source file to introduce formatting errors
- Run `make lint`
- Verify errors are flagged and the exit code is non-zero
- Run `make lint-fix`
- Verify the formatting errors are corrected
- Run `make lint`
- Verify it passes and the exist code is zero

### Contributor checklist ✅

- [ ] The code has been linted using run `./fourier lint tuist --fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
