### PR TITLE
Add tuist cloud organization billing command

### DIFF
--- a/Sources/TuistCloud/Models/CloudOrganization.swift
+++ b/Sources/TuistCloud/Models/CloudOrganization.swift
@@ -2,6 +2,28 @@ import Foundation
 
 /// Cloud organization
 public struct CloudOrganization: Codable {
+    public enum Plan: Codable, RawRepresentable {
+        case team, none
+
+        public init(rawValue: String) {
+            switch rawValue {
+            case "team":
+                self = .team
+            default:
+                self = .none
+            }
+        }
+
+        public var rawValue: String {
+            switch self {
+            case .team:
+                return "team"
+            case .none:
+                return "none"
+            }
+        }
+    }
+
     public struct Member: Codable {
         public enum Role: Codable, RawRepresentable {
             case user, admin
@@ -47,17 +69,20 @@ public struct CloudOrganization: Codable {
 
     public let id: Int
     public let name: String
+    public let plan: Plan
     public let members: [Member]
     public let invitations: [CloudInvitation]
 
     public init(
         id: Int,
         name: String,
+        plan: Plan,
         members: [Member],
         invitations: [CloudInvitation]
     ) {
         self.id = id
         self.name = name
+        self.plan = plan
         self.members = members
         self.invitations = invitations
     }
@@ -67,6 +92,7 @@ extension CloudOrganization {
     init(_ organization: Components.Schemas.Organization) {
         id = Int(organization.id)
         name = organization.name
+        plan = organization.plan.map(\.rawValue).map(Plan.init) ?? .none
         members = organization.members.map(Member.init)
         invitations = organization.invitations.map(CloudInvitation.init)
     }

--- a/Sources/TuistCloud/OpenAPI/Types.swift
+++ b/Sources/TuistCloud/OpenAPI/Types.swift
@@ -322,6 +322,30 @@ public enum Components {
             public var id: Swift.Double
             /// - Remark: Generated from `#/components/schemas/Organization/name`.
             public var name: Swift.String
+            /// - Remark: Generated from `#/components/schemas/Organization/plan`.
+            @frozen
+            public enum planPayload: RawRepresentable, Codable, Equatable, Hashable, Sendable,
+                _AutoLosslessStringConvertible, CaseIterable
+            {
+                case team
+                /// Parsed a raw value that was not defined in the OpenAPI document.
+                case undocumented(String)
+                public init?(rawValue: String) {
+                    switch rawValue {
+                    case "team": self = .team
+                    default: self = .undocumented(rawValue)
+                    }
+                }
+                public var rawValue: String {
+                    switch self {
+                    case let .undocumented(string): return string
+                    case .team: return "team"
+                    }
+                }
+                public static var allCases: [planPayload] { [.team] }
+            }
+            /// - Remark: Generated from `#/components/schemas/Organization/plan`.
+            public var plan: Components.Schemas.Organization.planPayload?
             /// - Remark: Generated from `#/components/schemas/Organization/members`.
             public var members: [Components.Schemas.OrganizationMember]
             /// - Remark: Generated from `#/components/schemas/Organization/invitations`.
@@ -331,22 +355,26 @@ public enum Components {
             /// - Parameters:
             ///   - id:
             ///   - name:
+            ///   - plan:
             ///   - members:
             ///   - invitations:
             public init(
                 id: Swift.Double,
                 name: Swift.String,
+                plan: Components.Schemas.Organization.planPayload? = nil,
                 members: [Components.Schemas.OrganizationMember],
                 invitations: [Components.Schemas.Invitation]
             ) {
                 self.id = id
                 self.name = name
+                self.plan = plan
                 self.members = members
                 self.invitations = invitations
             }
             public enum CodingKeys: String, CodingKey {
                 case id
                 case name
+                case plan
                 case members
                 case invitations
             }

--- a/Sources/TuistCloud/OpenAPI/cloud.yml
+++ b/Sources/TuistCloud/OpenAPI/cloud.yml
@@ -679,6 +679,10 @@ components:
           type: number
         name:
           type: string
+        plan:
+          type: string
+          enum:
+            - team
         members:
             type: array
             items:

--- a/Sources/TuistCloudTesting/Models/CloudOrganization+TestData.swift
+++ b/Sources/TuistCloudTesting/Models/CloudOrganization+TestData.swift
@@ -4,12 +4,14 @@ extension CloudOrganization {
     public static func test(
         id: Int = 0,
         name: String = "test",
+        plan: Plan = .team,
         members: [Member] = [],
         invitations: [CloudInvitation] = []
     ) -> Self {
         .init(
             id: id,
             name: name,
+            plan: plan,
             members: members,
             invitations: invitations
         )

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationBillingCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationBillingCommand.swift
@@ -1,0 +1,32 @@
+import ArgumentParser
+import Foundation
+import TSCBasic
+import TuistSupport
+
+struct CloudOrganizationBillingCommand: AsyncParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "billing",
+            _superCommandName: "organization",
+            abstract: "Open billing dashboard for the specified organization."
+        )
+    }
+
+    @Argument(
+        help: "The name of the organization to show billing dashboard for."
+    )
+    var organizationName: String
+
+    @Option(
+        name: .long,
+        help: "URL to the cloud server."
+    )
+    var serverURL: String?
+
+    func run() async throws {
+        try await CloudOrganizationBillingService().run(
+            organizationName: organizationName,
+            serverURL: serverURL
+        )
+    }
+}

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationCommand.swift
@@ -16,6 +16,7 @@ struct CloudOrganizationCommand: ParsableCommand {
                 CloudOrganizationInviteCommand.self,
                 CloudOrganizationRemoveCommand.self,
                 CloudOrganizationUpdateCommand.self,
+                CloudOrganizationBillingCommand.self,
             ]
         )
     }

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationBillingService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationBillingService.swift
@@ -1,0 +1,39 @@
+import Foundation
+import TSCBasic
+import TuistCloud
+import TuistLoader
+import TuistSupport
+
+protocol CloudOrganizationBillingServicing {
+    func run(
+        organizationName: String,
+        serverURL: String?
+    ) async throws
+}
+
+final class CloudOrganizationBillingService: CloudOrganizationBillingServicing {
+    private let cloudURLService: CloudURLServicing
+    private let opener: Opening
+
+    init(
+        cloudURLService: CloudURLServicing = CloudURLService(),
+        opener: Opening = Opener()
+    ) {
+        self.cloudURLService = cloudURLService
+        self.opener = opener
+    }
+
+    func run(
+        organizationName: String,
+        serverURL: String?
+    ) async throws {
+        let cloudURL = try cloudURLService.url(serverURL: serverURL)
+        try opener.open(
+            url: cloudURL
+                .appendingPathComponent("organizations")
+                .appendingPathComponent(organizationName)
+                .appendingPathComponent("billing")
+                .appendingPathComponent("plan")
+        )
+    }
+}

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationShowService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationShowService.swift
@@ -64,6 +64,7 @@ final class CloudOrganizationShowService: CloudOrganizationShowServicing {
         logger.info("""
         \("Organization".bold())
         Name: \(organization.name)
+        Plan: \(organization.plan.rawValue.capitalized)
 
         \("Organization members".bold()) (total number: \(organization.members.count))
         \(membersTable)

--- a/Tests/TuistKitTests/Services/Cloud/CloudOrganizationShowServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudOrganizationShowServiceTests.swift
@@ -31,6 +31,7 @@ final class CloudOrganizationShowServiceTests: TuistUnitTestCase {
         getOrganizationService.getOrganizationStub = { _, _ in
             .test(
                 name: "test-one",
+                plan: .team,
                 members: [
                     .test(
                         name: "name-one",
@@ -63,6 +64,7 @@ final class CloudOrganizationShowServiceTests: TuistUnitTestCase {
         XCTAssertPrinterOutputContains("""
         \(TerminalStyle.bold.open)Organization\(TerminalStyle.reset.open)
         Name: test-one
+        Plan: Team
 
         \(TerminalStyle.bold.open)Organization members\(TerminalStyle.reset.open) (total number: 2)
         username  email              role


### PR DESCRIPTION
### Short description 📝

- Adds a new command `tuist cloud organization billing some-org` that shows the billing dashboard for a given org.
- Shows the plan of the organization as part of the `tuist cloud organization show` command.

### How to test the changes locally 🧐

The plan for any organization in production is currently `None`. You can test the changes properly if you have access to a local `cloud` server.

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
