### PR TITLE
Use Cloud env token only on the CI

### DIFF
--- a/Sources/TuistCloud/Utilities/CloudAuthenticationController.swift
+++ b/Sources/TuistCloud/Utilities/CloudAuthenticationController.swift
@@ -21,12 +21,11 @@ public final class CloudAuthenticationController: CloudAuthenticationControlling
     }
 
     public func authenticationToken(serverURL: URL) throws -> String? {
-        let environment = environmentVariables()
-        let tokenFromEnvironment = environment[Constants.EnvironmentVariables.cloudToken]
         if ciChecker.isCI() {
-            return tokenFromEnvironment
+            let environment = environmentVariables()
+            return environment[Constants.EnvironmentVariables.cloudToken]
         } else {
-            return try tokenFromEnvironment ?? credentialsStore.read(serverURL: serverURL)?.token
+            return try credentialsStore.read(serverURL: serverURL)?.token
         }
     }
 }


### PR DESCRIPTION
Related https://github.com/tuist/cloud/issues/137

### Short description 📝

The env token is only meant to be used on the CI. To respect that, I'm changing the logic when authenticating users with Tuist Cloud.

### How to test the changes locally 🧐

A `TUIST_CONFIG_CLOUD_TOKEN` shouldn't be usable outside the CI environment.

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
