### PR TITLE
Ensure multi-destination generated projects are stable

### DIFF
--- a/Sources/TuistCore/Graph/GraphLoader.swift
+++ b/Sources/TuistCore/Graph/GraphLoader.swift
@@ -159,14 +159,14 @@ public final class GraphLoader: GraphLoading {
             return try loadXCFramework(path: frameworkPath, cache: cache)
 
         case let .sdk(name, status):
-            return try platforms.map { platform in
+            return try platforms.sorted().first.map { platform in
                 try loadSDK(
                     name: name,
                     platform: platform,
                     status: status,
                     source: .system
                 )
-            }.first
+            }
         case let .package(product):
             return try loadPackage(fromPath: path, productName: product, isPlugin: false)
 

--- a/Sources/TuistGraph/Models/Platform.swift
+++ b/Sources/TuistGraph/Models/Platform.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum Platform: String, CaseIterable, Codable {
+public enum Platform: String, CaseIterable, Codable, Comparable {
     case iOS = "ios"
     case macOS = "macos"
     case tvOS = "tvos"
@@ -38,6 +38,10 @@ public enum Platform: String, CaseIterable, Codable {
             .watchOS: "4.0",
             .visionOS: "1.0",
         ]
+    }
+
+    public static func < (lhs: Platform, rhs: Platform) -> Bool {
+        lhs.rawValue < rhs.rawValue
     }
 }
 

--- a/Tests/TuistIntegrationTests/Generator/TestModelGenerator.swift
+++ b/Tests/TuistIntegrationTests/Generator/TestModelGenerator.swift
@@ -260,7 +260,7 @@ final class TestModelGenerator {
     ) throws -> Target {
         Target(
             name: name,
-            destinations: .iOS,
+            destinations: [.iPhone, .iPad, .mac],
             product: product,
             productName: nil,
             bundleId: "test.bundle.\(name)",
@@ -277,8 +277,15 @@ final class TestModelGenerator {
             .map { TargetDependency.framework(path: path.appending(RelativePath($0))) }
 
         let libraries = try createLibraries(relativeTo: path)
-
-        return (frameworks + libraries).shuffled()
+        let sdks: [TargetDependency] = [
+            .sdk(name: "Accelerate.framework", status: .required),
+            .sdk(name: "AVKit.framework", status: .required),
+            .sdk(name: "Intents.framework", status: .optional),
+            .sdk(name: "HealthKit.framework", status: .optional),
+            .sdk(name: "libc++.tbd", status: .required),
+            .sdk(name: "libxml2.tbd", status: .required),
+        ]
+        return (frameworks + libraries + sdks).shuffled()
     }
 
     private func createLibraries(relativeTo path: AbsolutePath) throws -> [TargetDependency] {


### PR DESCRIPTION
### Short description 📝

- Projects that have `.sdk` dependencies weren't stable as the first from a set of platforms was used to determine the `.sdk` path
- Sets and dictionaries don't have a stable order, the "first" element will differ per run
- To mitigate this `Platform` is now comparable, and the first from the sorted list of platforms is used to determine the `.sdk` path
- Integration tests were extended to cater for this scenario and catch these instabilities in the future

### How to test the changes locally 🧐

- Verify `TuistIntegrationTests` pass

### Contributor checklist ✅

- [ ] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
