### PR TITLE
Fix limit mergeable to framework instead of dynamic library

### DIFF
--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -281,9 +281,9 @@ class TargetLinter: TargetLinting {
     }
 
     private func lintMergeableLibrariesOnlyAppliesToDynamicTargets(target: Target) -> [LintingIssue] {
-        if target.mergeable, target.product != .dynamicLibrary {
+        if target.mergeable, target.product != .framework {
             return [LintingIssue(
-                reason: "Target \(target.name) be marked as mergeable because it is not a dynamic library",
+                reason: "Target \(target.name) can't be marked as mergeable because it is not a dynamic target",
                 severity: .error
             )]
         }


### PR DESCRIPTION
### Short description 📝

Mergeable libraries is limiting the mergeable flag to just dynamicLibraries instead of only frameworks. Thus we're not able to enable it properly

### How to test the changes locally 🧐

1. Create a target (A) which has been compiled with -make_mergeable linker flag (available on Xcode 15+)
2. Set A as dependency on the application and enable MERGED_BINARY_TYPE to manual

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
