### PR TITLE
Generate TuistStrings+Module for correct localisation strings file

### DIFF
--- a/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
@@ -149,7 +149,6 @@ public final class SynthesizedResourceInterfaceProjectMapper: ProjectMapping { /
     private func paths(
         for resourceSynthesizer: ResourceSynthesizer,
         target: Target,
-        defaultKnownRegions: [String]?,
         developmentRegion: String?
     ) -> [AbsolutePath] {
         let resourcesPaths = target.resources
@@ -162,7 +161,8 @@ public final class SynthesizedResourceInterfaceProjectMapper: ProjectMapping { /
         switch resourceSynthesizer.parser {
         case .strings:
             // This file kind is localizable, let's order files based on it
-            var regionPriorityQueue = defaultKnownRegions ?? ["Base", "en"]
+            var regionPriorityQueue: [String] = []
+            
             if let developmentRegion = developmentRegion {
                 regionPriorityQueue.insert(developmentRegion, at: 0)
             }
@@ -225,7 +225,6 @@ public final class SynthesizedResourceInterfaceProjectMapper: ProjectMapping { /
         let paths = try paths(
             for: resourceSynthesizer,
             target: target,
-            defaultKnownRegions: project.defaultKnownRegions,
             developmentRegion: project.developmentRegion
         )
         .filter(isResourceEmpty)

--- a/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
@@ -162,7 +162,7 @@ public final class SynthesizedResourceInterfaceProjectMapper: ProjectMapping { /
         case .strings:
             // This file kind is localizable, let's order files based on it
             var regionPriorityQueue: [String] = []
-            
+
             if let developmentRegion = developmentRegion {
                 regionPriorityQueue.insert(developmentRegion, at: 0)
             }

--- a/projects/tuist/features/generate-2.feature
+++ b/projects/tuist/features/generate-2.feature
@@ -41,3 +41,17 @@ Feature: Generate a new project using Tuist (suite 2)
     Then a file App/Derived/Sources/TuistFonts+App.swift exists
     Then a file App/Derived/Sources/TuistPlists+App.swift exists
     Then a file StaticFramework3/Derived/Sources/TuistAssets+StaticFramework3.swift exists
+
+ Scenario: The project is an iOS application with custom development region that has resources (ios_app_with_custom_development_region)
+    Given that tuist is available
+    And I have a working directory
+    Then I copy the fixture ios_app_with_custom_development_region into the working directory
+    Then tuist generates the project
+    Then I should be able to build for iOS the scheme App
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'en.lproj/Greetings.strings'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'fr.lproj/Greetings.strings'
+    Then a file Derived/Sources/TuistStrings+App.swift exists
+    Then content of a file named TuistStrings+App.swift in a directory Derived/Sources should contain:
+      """
+      public static let evening = AppStrings.tr("Greetings", "evening")
+      """

--- a/projects/tuist/features/step_definitions/generate.rb
+++ b/projects/tuist/features/step_definitions/generate.rb
@@ -181,3 +181,7 @@ the appClip {string} without architecture {string}") do |product, destination, a
   assert(status.success?, err)
   refute(out.include?(architecture))
 end
+
+Then(/content of a file named (.+) in a directory (.+) should contain:$/) do |file, dir, content|
+  assert_equal File.readlines(File.join(@dir, dir, file)).any?{ |l| l[content] }, true
+end

--- a/projects/tuist/fixtures/ios_app_with_custom_development_region/App/Resources/en.lproj/Greetings.strings
+++ b/projects/tuist/fixtures/ios_app_with_custom_development_region/App/Resources/en.lproj/Greetings.strings
@@ -1,0 +1,1 @@
+"morning" = "Good Morning";

--- a/projects/tuist/fixtures/ios_app_with_custom_development_region/App/Resources/fr.lproj/Greetings.strings
+++ b/projects/tuist/fixtures/ios_app_with_custom_development_region/App/Resources/fr.lproj/Greetings.strings
@@ -1,0 +1,2 @@
+"morning" = "Bonjour";
+"evening" = "Bonsoir";

--- a/projects/tuist/fixtures/ios_app_with_custom_development_region/App/Sources/AppDelegate.swift
+++ b/projects/tuist/fixtures/ios_app_with_custom_development_region/App/Sources/AppDelegate.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(
+        _: UIApplication,
+        didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        let viewController = UIViewController()
+        viewController.view.backgroundColor = .white
+        window?.rootViewController = viewController
+        window?.makeKeyAndVisible()
+        return true
+    }
+}

--- a/projects/tuist/fixtures/ios_app_with_custom_development_region/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_custom_development_region/Project.swift
@@ -1,0 +1,21 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    options: .options(
+        developmentRegion: "fr"
+    ),
+    targets: [
+        Target(
+            name: "App",
+            platform: .iOS,
+            product: .app,
+            bundleId: "io.tuist.app",
+            infoPlist: .default,
+            sources: ["App/Sources/**"],
+            resources: [
+                "App/Resources/**/*.strings",
+            ]
+        ),
+    ]
+)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4627

### Short description 📝

> Do not rely on defaultKnownRegions property during string resources generation

### How to test the changes locally 🧐

1. Use `ios_app_with_custom_development_region` fixture
2. Notice `fr.lproj` strings has 2 keys, but `en.lproj` has only 1
3. When `fr` is set as `developmentRegion`, `TuistStrings+App.swift` should contain variables for both keys from strings file

### Contributor checklist ✅

- [x] The code has been linted using run `./fourier lint tuist --fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
