### PR TITLE
Disable flaky acceptance tests

### DIFF
--- a/Sources/TuistGraph/Models/Platform.swift
+++ b/Sources/TuistGraph/Models/Platform.swift
@@ -20,7 +20,7 @@ public enum Platform: String, CaseIterable, Codable, Comparable {
 
     /// A dictionary that contains the oldest supported version of each platform
     public static func oldestVersions(for swiftVersion: Version) -> [Platform: String] {
-        if (swiftVersion < Version(5, 7, 0)) {
+        if swiftVersion < Version(5, 7, 0) {
             return [
                 .iOS: "9.0",
                 .tvOS: "9.0",
@@ -28,7 +28,7 @@ public enum Platform: String, CaseIterable, Codable, Comparable {
                 .watchOS: "2.0",
                 .visionOS: "1.0",
             ]
-        } else if (swiftVersion < Version(5, 9, 0)) {
+        } else if swiftVersion < Version(5, 9, 0) {
             return [
                 .iOS: "11.0",
                 .tvOS: "11.0",
@@ -44,7 +44,6 @@ public enum Platform: String, CaseIterable, Codable, Comparable {
                 .watchOS: "4.0",
                 .visionOS: "1.0",
             ]
-            
         }
     }
 

--- a/projects/tuist/features/generate-1.feature
+++ b/projects/tuist/features/generate-1.feature
@@ -7,7 +7,6 @@ Feature: Generate a new project using Tuist (suite 1)
     Then tuist generates the project
     Then I should be able to build for iOS the scheme App
     Then I should be able to test for iOS the scheme AppTests
-    Then I should be able to test for iOS the scheme AppUITests
 
   Scenario: The project is an iOS application with frameworks and tests (ios_app_with_frameworks)
     Given that tuist is available

--- a/projects/tuist/features/generate-6.feature
+++ b/projects/tuist/features/generate-6.feature
@@ -30,4 +30,3 @@ Scenario: The project is an iOS application with appclip (ios_app_with_appclip)
     Then the product 'App.app' with destination 'Debug-iphonesimulator' contains the appClip 'AppClip1' without architecture 'armv7'
     Then AppClip1 embeds the framework Framework
     Then I should be able to build for iOS the scheme AppClip1
-    Then I should be able to test for iOS the scheme AppClip1


### PR DESCRIPTION
### Short description 📝
I noticed that flakiness became more apparent recently with the upgrade to Xcode 15. After some digging, it became clear that tests fail when `xcodebuild` tries to launch a simulator to run tests. Errors look like:

```bash
AppClip1UITests-Runner (12162) encountered an error (The test runner failed to initialize for UI testing. (Underlying Error: Timed out waiting for AX loaded notification))
```

We could further invest in making those steps more resilient against failures launching simulators. Still, I'd instead assume `xcodebuild` does the right job if a scheme is properly configured, which we'd test through unit tests. In my experience, simulators are often a cause of race condition and flakiness, and in the context of Tuist where CI is already slow, we can't afford that flakiness prevents a green PR from being merged.
