### PR TITLE
Fix linking of precompiled static xcframeworks that are transitive dependencies of a static framework

### DIFF
--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -857,7 +857,7 @@ public class GraphTraverser: GraphTraversing {
                     return false
                 }
             },
-            skip: { $0.isDynamicPrecompiled }
+            skip: { $0.isDynamicPrecompiled || !$0.isPrecompiled }
         )
         return Set(dependencies)
             .compactMap(dependencyReference)

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -857,14 +857,7 @@ public class GraphTraverser: GraphTraversing {
                     return false
                 }
             },
-            skip: { dependency in
-                switch dependency {
-                case .xcframework:
-                    return false
-                case .framework, .library, .bundle, .packageProduct, .target, .sdk:
-                    return true
-                }
-            }
+            skip: { $0.isDynamicPrecompiled }
         )
         return Set(dependencies)
             .compactMap(dependencyReference)

--- a/Sources/TuistGenerator/Linter/PackageLinter.swift
+++ b/Sources/TuistGenerator/Linter/PackageLinter.swift
@@ -22,7 +22,7 @@ class PackageLinter: PackageLinting {
                 severity: .error
             )
             return [issue]
-        } else if case let .remote(url, _) = package, URL(string: url) == nil {
+        } else if case let .remote(url, _) = package, !URL.isValid(url) {
             let issue = LintingIssue(
                 reason: "Package with remote URL (\(url)) does not have a valid URL.",
                 severity: .error

--- a/Sources/TuistGraph/Graph/GraphDependency.swift
+++ b/Sources/TuistGraph/Graph/GraphDependency.swift
@@ -87,6 +87,36 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         }
     }
 
+    /**
+     When the graph dependency represents a pre-compiled static binary.
+     */
+    public var isStaticPrecompiled: Bool {
+        switch self {
+        case let .xcframework(_, _, _, linking, _): return linking == .static
+        case let .framework(_, _, _, _, linking, _, _): return linking == .static
+        case let .library(_, _, linking, _, _): return linking == .static
+        case .bundle: return false
+        case .packageProduct: return false
+        case .target: return false
+        case .sdk: return false
+        }
+    }
+
+    /**
+     When the graph dependency represents a dynamic precompiled binary, it returns true.
+     */
+    public var isDynamicPrecompiled: Bool {
+        switch self {
+        case let .xcframework(_, _, _, linking, _): return linking == .dynamic
+        case let .framework(_, _, _, _, linking, _, _): return linking == .dynamic
+        case let .library(_, _, linking, _, _): return linking == .dynamic
+        case .bundle: return false
+        case .packageProduct: return false
+        case .target: return false
+        case .sdk: return false
+        }
+    }
+
     public var isPrecompiled: Bool {
         switch self {
         case .xcframework: return true

--- a/Sources/TuistGraph/Graph/GraphDependency.swift
+++ b/Sources/TuistGraph/Graph/GraphDependency.swift
@@ -92,9 +92,8 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
      */
     public var isStaticPrecompiled: Bool {
         switch self {
-        case let .xcframework(_, _, _, linking, _): return linking == .static
-        case let .framework(_, _, _, _, linking, _, _): return linking == .static
-        case let .library(_, _, linking, _, _): return linking == .static
+        case let .xcframework(_, _, _, linking, _), let .framework(_, _, _, _, linking, _, _),
+             let .library(_, _, linking, _, _): return linking == .static
         case .bundle: return false
         case .packageProduct: return false
         case .target: return false
@@ -107,9 +106,9 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
      */
     public var isDynamicPrecompiled: Bool {
         switch self {
-        case let .xcframework(_, _, _, linking, _): return linking == .dynamic
-        case let .framework(_, _, _, _, linking, _, _): return linking == .dynamic
-        case let .library(_, _, linking, _, _): return linking == .dynamic
+        case let .xcframework(_, _, _, linking, _),
+             let .framework(_, _, _, _, linking, _, _),
+             let .library(_, _, linking, _, _): return linking == .dynamic
         case .bundle: return false
         case .packageProduct: return false
         case .target: return false

--- a/Sources/TuistSupport/Extensions/URL+Extras.swift
+++ b/Sources/TuistSupport/Extensions/URL+Extras.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension URL {
+    public static func isValid(_ url: String) -> Bool {
+        var valid = false
+        /**
+         Xcode 15 introduced breaking changes in the URL constructor that we need to account for.
+         */
+        if #available(macOS 14.0, *) {
+            valid = URL(string: url, encodingInvalidCharacters: false) != nil
+        } else {
+            valid = URL(string: url) != nil
+        }
+        return valid
+    }
+}

--- a/Tests/TuistCoreTests/Graph/GraphDependencyTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphDependencyTests.swift
@@ -23,4 +23,22 @@ final class GraphDependencyTests: TuistUnitTestCase {
         XCTAssertFalse(GraphDependency.testTarget().isPrecompiled)
         XCTAssertFalse(GraphDependency.testSDK().isPrecompiled)
     }
+
+    func test_isStaticPrecompiled() {
+        XCTAssertTrue(GraphDependency.testXCFramework(linking: .static).isStaticPrecompiled)
+        XCTAssertTrue(GraphDependency.testFramework(linking: .static).isStaticPrecompiled)
+        XCTAssertTrue(GraphDependency.testLibrary(linking: .static).isStaticPrecompiled)
+        XCTAssertFalse(GraphDependency.testPackageProduct().isStaticPrecompiled)
+        XCTAssertFalse(GraphDependency.testTarget().isStaticPrecompiled)
+        XCTAssertFalse(GraphDependency.testSDK().isStaticPrecompiled)
+    }
+
+    func test_isDynamicPrecompiled() {
+        XCTAssertTrue(GraphDependency.testXCFramework(linking: .dynamic).isDynamicPrecompiled)
+        XCTAssertTrue(GraphDependency.testFramework(linking: .dynamic).isDynamicPrecompiled)
+        XCTAssertTrue(GraphDependency.testLibrary(linking: .dynamic).isDynamicPrecompiled)
+        XCTAssertFalse(GraphDependency.testPackageProduct().isDynamicPrecompiled)
+        XCTAssertFalse(GraphDependency.testTarget().isDynamicPrecompiled)
+        XCTAssertFalse(GraphDependency.testSDK().isDynamicPrecompiled)
+    }
 }

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -4051,7 +4051,17 @@ final class GraphTraverserTests: TuistUnitTestCase {
                 primaryBinaryPath: "/xcframeworks/transitive.xcframework/transitive",
                 binaryPath: "/xcframeworks/transitive.xcframework/transitive"
             ),
-        ])
+            .xcframework(
+                path: "/xcframeworks/framework-transitive.xcframework",
+                infoPlist: .test(libraries: [.test(
+                    identifier: "id",
+                    path: RelativePath("path"),
+                    architectures: [.arm64]
+                )]),
+                primaryBinaryPath: "/xcframeworks/framework-transitive.xcframework/framework-transitive",
+                binaryPath: "/xcframeworks/framework-transitive.xcframework/framework-transitive"
+            ),
+        ].sorted())
     }
 
     func test_copyProductDependencies_when_targetHasDirectStaticDependencies() throws {

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -3965,6 +3965,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
          */
         // Given
         let staticLibrary = Target.test(name: "StaticLibrary", product: .staticLibrary)
+        let staticFramework = Target.test(name: "StaticFramework", product: .staticFramework)
+
         let project = Project.test(targets: [staticLibrary])
         let directXCFramework = GraphDependency.xcframework(
             path: "/xcframeworks/direct.xcframework",
@@ -3985,6 +3987,18 @@ final class GraphTraverserTests: TuistUnitTestCase {
             linking: .static,
             architectures: [.arm64],
             isCarthage: false
+        )
+        let directFrameworkTarget = GraphDependency.target(name: staticFramework.name, path: project.path)
+        let transitiveFrameworkTargetXCFramework = GraphDependency.xcframework(
+            path: "/xcframeworks/transitive-framework-target-xcframework.xcframework",
+            infoPlist: .test(libraries: [.test(
+                identifier: "id",
+                path: try RelativePath(validating: "path"),
+                architectures: [.arm64]
+            )]),
+            primaryBinaryPath: "/xcframeworks/transitive-framework-target-xcframework.xcframework/transitive",
+            linking: .static,
+            mergeable: false
         )
         let transitiveXCFramework = GraphDependency.xcframework(
             path: "/xcframeworks/transitive.xcframework",
@@ -4010,7 +4024,12 @@ final class GraphTraverserTests: TuistUnitTestCase {
         )
 
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
-            .target(name: staticLibrary.name, path: project.path): Set([directXCFramework, directFramework]),
+            .target(name: staticLibrary.name, path: project.path): Set([
+                directXCFramework,
+                directFramework,
+                directFrameworkTarget,
+            ]),
+            directFrameworkTarget: Set([transitiveFrameworkTargetXCFramework]),
             directXCFramework: Set([transitiveXCFramework]),
             directFramework: Set([frameworkTransitiveXCFramework]),
         ]


### PR DESCRIPTION
Related https://github.com/tuist/tuist/pull/5412

### Short description 📝

[This PR](https://github.com/tuist/tuist/pull/5412) only solved the issue partially. When in a dependency graph we have a static framework with a static precompiled xcframework as a transitive dependency, the generated project was missing a build phase to resolve the transitive module at compile-time. The linked PR addressed it for targets that are xcframeworks, but we should have included the other scenarios.

### How to test the changes locally 🧐

Get the project [mentioned in this issue](https://github.com/tuist/tuist/pull/5412) and run the described steps there.

### Contributor checklist ✅

- [x] The code has been linted using run `make lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
