### PR TITLE
Add tuist cloud analytics command

### DIFF
--- a/Sources/TuistKit/Commands/Cloud/CloudAnalyticsCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudAnalyticsCommand.swift
@@ -1,0 +1,27 @@
+import ArgumentParser
+import Foundation
+import TSCBasic
+import TuistSupport
+
+struct CloudAnalyticsCommand: AsyncParsableCommand {
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "analytics",
+            _superCommandName: "cloud",
+            abstract: "Open Tuist Cloud analytics dashboard."
+        )
+    }
+
+    @Option(
+        name: .shortAndLong,
+        help: "The path to the Tuist Cloud project.",
+        completion: .directory
+    )
+    var path: String?
+
+    func run() async throws {
+        try await CloudAnalyticsService().run(
+            path: path
+        )
+    }
+}

--- a/Sources/TuistKit/Commands/CloudCommand.swift
+++ b/Sources/TuistKit/Commands/CloudCommand.swift
@@ -15,6 +15,7 @@ struct CloudCommand: ParsableCommand {
                 CloudCleanCommand.self,
                 CloudProjectCommand.self,
                 CloudOrganizationCommand.self,
+                CloudAnalyticsCommand.self,
             ]
         )
     }

--- a/Sources/TuistKit/Services/Cloud/CloudAnalyticsService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudAnalyticsService.swift
@@ -1,0 +1,48 @@
+import Foundation
+import TSCBasic
+import TuistCloud
+import TuistLoader
+import TuistSupport
+
+protocol CloudAnalyticsServicing {
+    func run(
+        path: String?
+    ) async throws
+}
+
+final class CloudAnalyticsService: CloudAnalyticsServicing {
+    private let configLoader: ConfigLoading
+    private let opener: Opening
+
+    init(
+        configLoader: ConfigLoading = ConfigLoader(),
+        opener: Opening = Opener()
+    ) {
+        self.configLoader = configLoader
+        self.opener = opener
+    }
+
+    func run(
+        path: String?
+    ) async throws {
+        let path: AbsolutePath = try self.path(path)
+        let config = try configLoader.loadConfig(path: path)
+
+        guard let cloud = config.cloud else { throw CloudCleanServiceError.cloudNotFound }
+        try opener.open(
+            url: cloud.url
+                .appendingPathComponent(cloud.projectId)
+                .appendingPathComponent("analytics")
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func path(_ path: String?) throws -> AbsolutePath {
+        if let path {
+            return try AbsolutePath(validating: path, relativeTo: FileHandler.shared.currentPath)
+        } else {
+            return FileHandler.shared.currentPath
+        }
+    }
+}


### PR DESCRIPTION
### Short description 📝

Adding a new `tuist cloud` command that opens the analytics dashboard.

### How to test the changes locally 🧐

Run `tuist cloud analytics` and the analytics dashboard will be opened (once it's available in production)

### Contributor checklist ✅

- [x] The code has been linted using run `make lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
