### PR TITLE
Set permissions to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ env:
   RUBY_VERSION: '3.0.3'
   TUIST_STATS_OPT_OUT: true
 
+permissions:
+  contents: write
+  pull-requests: read
+  statuses: write
+
 jobs:
   prepare-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Short description 📝
I noticed we were using a personal token in GitHub Actions to elevate the permissions given by GitHub by default through the `GITHUB_TOKEN` token. This is no longer necessary unless we want to perform actions against another repository because GitHub now supports assigning [permissions to GitHub Actions](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs).

I removed the token from the Tuist organization and adjusted the release workflow to set the necessary permissions.

### How to test the changes locally 🧐
These changes are hard to test locally. My advice is that the person doing the next release keeps an eye on the workflow and pushes any necessary fixes directly to `main`.