### PR TITLE
Fix invitation link

### DIFF
--- a/Sources/TuistCloudTesting/Services/MockCreateOrganizationInviteService.swift
+++ b/Sources/TuistCloudTesting/Services/MockCreateOrganizationInviteService.swift
@@ -1,0 +1,15 @@
+import Foundation
+import TuistCloud
+
+public final class MockCreateOrganizationInviteService: CreateOrganizationInviteServicing {
+    public init() {}
+
+    public var createOrganizationInviteStub: ((String, String, URL) async throws -> CloudInvitation)?
+    public func createOrganizationInvite(
+        organizationName: String,
+        email: String,
+        serverURL: URL
+    ) async throws -> CloudInvitation {
+        try await createOrganizationInviteStub?(organizationName, email, serverURL) ?? .test()
+    }
+}

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationInviteService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationInviteService.swift
@@ -37,10 +37,15 @@ final class CloudOrganizationInviteService: CloudOrganizationInviteServicing {
             serverURL: cloudURL
         )
 
+        let invitationURL = cloudURL
+            .appendingPathComponent("auth")
+            .appendingPathComponent("invitations")
+            .appendingPathComponent(invitation.token)
+
         logger.info("""
         \(invitation.inviteeEmail) was successfully invited to the \(organizationName) organization 🎉
 
-        You can also share with them the invite link directly: \(cloudURL)/auth/invitations/\(invitation.token)
+        You can also share with them the invite link directly: \(invitationURL.absoluteString)
         """)
     }
 }

--- a/Tests/TuistKitTests/Services/Cloud/CloudOrganizationInviteServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudOrganizationInviteServiceTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import TuistCloud
+import TuistCloudTesting
+import TuistSupportTesting
+import XCTest
+@testable import TuistKit
+
+final class CloudOrganizationInviteServiceTests: TuistUnitTestCase {
+    private var createOrganizationInviteService: MockCreateOrganizationInviteService!
+    private var subject: CloudOrganizationInviteService!
+
+    override func setUp() {
+        super.setUp()
+
+        createOrganizationInviteService = .init()
+        subject = CloudOrganizationInviteService(
+            createOrganizationInviteService: createOrganizationInviteService
+        )
+    }
+
+    override func tearDown() {
+        createOrganizationInviteService = nil
+        subject = nil
+
+        super.tearDown()
+    }
+
+    func test_invite() async throws {
+        // Given
+        createOrganizationInviteService.createOrganizationInviteStub = { _, _, _ in
+            .test(
+                inviteeEmail: "tuist@test.io",
+                token: "invitation-token"
+            )
+        }
+
+        // When
+        try await subject.run(
+            organizationName: "tuist",
+            email: "tuist@test.io",
+            serverURL: nil
+        )
+
+        // Then
+        XCTAssertPrinterOutputContains("""
+        tuist@test.io was successfully invited to the tuist organization 🎉
+
+        You can also share with them the invite link directly: https://cloud.tuist.io/auth/invitations/invitation-token
+        """)
+    }
+}


### PR DESCRIPTION
### Short description 📝

Resolves https://github.com/tuist/cloud/issues/252

The invitation link due to wrong string interpolation.

The link was `https://cloud.tuist.io//auth/invitations/some-token`. The double backslash should be removed.

### How to test the changes locally 🧐

Run `tuist cloud organization invite some-org some-email` and look at the URL.

### Contributor checklist ✅

- [x] The code has been linted using run `make lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
