### PR TITLE
Add workflows to `up` and `down` the local environment to work on Tuist Cloud

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,4 +29,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run
-        run: make lint/lockfiles
+        run: make shared/lint/lockfiles

--- a/.github/workflows/meta-tuist.yml
+++ b/.github/workflows/meta-tuist.yml
@@ -74,8 +74,8 @@ jobs:
           bundle install --jobs 4 --retry 3
       - name: Generate
         run: |
-          make fetch
-          ARGS="--no-open tuist" make generate
+          make tuist/fetch
+          ARGS="--no-open tuist" make tuist/generate
   test:
     name: Test with Xcode
     runs-on: macos-13
@@ -106,4 +106,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run
-        run: make lint/lockfiles
+        run: make shared/lint/lockfiles

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - name: Run
-        run: make lint
+        run: make shared/lint
   
   lint-lockfiles:
     name: Lint lockfiles
@@ -166,4 +166,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run
-        run: make lint/lockfiles
+        run: make shared/lint/lockfiles

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ Tuist/Dependencies/graph.json
 # Release artifacts
 vendor/
 .bundle
+
+# Tuist Cloud
+./cloud

--- a/.gitignore
+++ b/.gitignore
@@ -108,4 +108,5 @@ vendor/
 .bundle
 
 # Tuist Cloud
-./cloud
+cloud
+!make/tasks/cloud

--- a/.tuist-cloud-version
+++ b/.tuist-cloud-version
@@ -1,0 +1,1 @@
+1d96ed4ef1c40250cebaeeec218e82701f656f0e

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,11 @@ tuist/generate/with-cloud:
 	TUIST_INCLUDE_TUIST_CLOUD=1 ./make/tasks/generate.sh $(ARGS)
 tuist/run:
 	./make/tasks/run.sh $(ARGS)
-
+# Cloud
+cloud/up:
+	./make/tasks/cloud/up.sh
+cloud/down:
+	./make/tasks/cloud/down.sh
 # Shared
 shared/lint-fix:
 	./make/tasks/shared/lint-fix.sh

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,28 @@
+# Documentation
 docs/tuist/preview:
 	./make/tasks/docs/tuist/preview.sh
 docs/tuist/build:
 	./make/tasks/docs/tuist/build.sh
-edit:
-	./make/tasks/edit.sh
-fetch:
+
+# Tuist
+tuist/edit:
+	./make/tasks/tuist/edit.sh
+tuist/fetch:
 	./make/tasks/fetch.sh $(ARGS)
-generate:
+tuist/generate:
 	./make/tasks/generate.sh $(ARGS)
-generate/with-cloud:
+tuist/generate/with-cloud:
 	TUIST_INCLUDE_TUIST_CLOUD=1 ./make/tasks/generate.sh $(ARGS)
-run:
+tuist/run:
 	./make/tasks/run.sh $(ARGS)
-generate/cloud-openapi-code:
-	./make/tasks/generate/cloud-openapi-code.sh
-lint-fix:
-	./make/tasks/lint-fix.sh
-lint:
-	./make/tasks/lint.sh
-lint/lockfiles:
-	./make/tasks/lint/lockfiles.sh
-pull/cloud:
-	git submodule update --init submodules/TuistCloud
+
+# Shared
+shared/lint-fix:
+	./make/tasks/shared/lint-fix.sh
+shared/lint:
+	./make/tasks/shared/lint.sh
+shared/lint/lockfiles:
+	./make/tasks/shared/lint/lockfiles.sh
+shared/generate/cloud-openapi-code:
+	./make/tasks/shared/generate/cloud-openapi-code.sh
+

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: cloud/up
+
 # Documentation
 docs/tuist/preview:
 	./make/tasks/docs/tuist/preview.sh

--- a/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
+++ b/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
@@ -113,7 +113,7 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
     fileprivate func baseScript() -> String {
         """
         #!/bin/sh
-        set -e
+        set -euo pipefail
         set -u
         set -o pipefail
 

--- a/make/tasks/cloud/_clean.sh
+++ b/make/tasks/cloud/_clean.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR=$($SCRIPT_DIR/../../utilities/root_dir.sh)
+DERIVED_DATA_PATH=$($ROOT_DIR/make/utilities/derived_data_path.sh)
+
+rm -rf $ROOT_DIR/.build
+for dir in "$DERIVED_DATA_PATH"/tuist-*; do
+    # Check if it is a directory before deleting
+    if [[ -d "$dir" ]]; then
+        echo "Deleting directory: $dir"
+        rm -rf "$dir"
+    fi
+done
+for dir in "$DERIVED_DATA_PATH"/Tuist-*; do
+    # Check if it is a directory before deleting
+    if [[ -d "$dir" ]]; then
+        echo "Deleting directory: $dir"
+        rm -rf "$dir"
+    fi
+done

--- a/make/tasks/cloud/down.sh
+++ b/make/tasks/cloud/down.sh
@@ -14,3 +14,6 @@ $SCRIPT_DIR/_clean.sh
 # Disabling Tuist Cloud
 sed -i '' -e 's/let includeTuistCloud = true/let includeTuistCloud = false/' $ROOT_DIR/Package.swift
 sed -i '' -e 's/Environment.includeTuistCloud.getBoolean(default: true)/Environment.includeTuistCloud.getBoolean(default: false)/' $ROOT_DIR/Project.swift
+
+# Remove the pre-commit hook
+rm -f $ROOT_DIR/.git/hooks/pre-commit

--- a/make/tasks/cloud/down.sh
+++ b/make/tasks/cloud/down.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR=$($SCRIPT_DIR/../../utilities/root_dir.sh)
+
+# Remove directory
+rm -rf $ROOT_DIR/cloud
+
+# Removing SPM and Xcode caches
+$SCRIPT_DIR/_clean.sh
+
+# Disabling Tuist Cloud
+sed -i '' -e 's/let includeTuistCloud = true/let includeTuistCloud = false/' $ROOT_DIR/Package.swift
+sed -i '' -e 's/Environment.includeTuistCloud.getBoolean(default: true)/Environment.includeTuistCloud.getBoolean(default: false)/' $ROOT_DIR/Project.swift

--- a/make/tasks/cloud/up.sh
+++ b/make/tasks/cloud/up.sh
@@ -25,6 +25,37 @@ git --git-dir="$CLONE_DIR/.git" --work-tree="$CLONE_DIR" reset --hard "$COMMIT_S
 # Removing SPM and Xcode caches
 $SCRIPT_DIR/_clean.sh
 
+PACKAGE_SWIFT_PATH=$ROOT_DIR/Package.swift
+PROJECT_SWIFT_PATH=$ROOT_DIR/Project.swift
+
 # Enabling Tuist Cloud
-sed -i '' -e 's/let includeTuistCloud = false/let includeTuistCloud = true/' $ROOT_DIR/Package.swift
-sed -i '' -e 's/Environment.includeTuistCloud.getBoolean(default: false)/Environment.includeTuistCloud.getBoolean(default: true)/' $ROOT_DIR/Project.swift
+sed -i '' -e 's/let includeTuistCloud = false/let includeTuistCloud = true/' $PACKAGE_SWIFT_PATH
+sed -i '' -e 's/Environment.includeTuistCloud.getBoolean(default: false)/Environment.includeTuistCloud.getBoolean(default: true)/' $PROJECT_SWIFT_PATH
+
+# Create the pre-commit file in the hooks directory
+HOOKS_DIR=$ROOT_DIR/.git/hooks
+FORBIDDEN_PACKAGE_SWIFT_LINE="let includeTuistCloud = true"
+FORBIDDEN_PROJECT_SWIFT_LINE="Environment.includeTuistCloud.getBoolean(default: true)"
+
+cat > "${HOOKS_DIR}/pre-commit" <<EOF
+#!/bin/bash
+
+# Check if the forbidden line is in the first target file
+if grep -Fq "$FORBIDDEN_PACKAGE_SWIFT_LINE" "$PACKAGE_SWIFT_PATH"; then
+    echo "Error: $PACKAGE_SWIFT_PATH must NOT contain: $FORBIDDEN_PACKAGE_SWIFT_LINE"
+    echo "Ensure that Tuist Cloud changes are persisted upstream and run make cloud/down"
+    exit 1
+fi
+
+# Check if the expected line is in the second target file
+if grep -Fq "$FORBIDDEN_PROJECT_SWIFT_LINE" "$PROJECT_SWIFT_PATH"; then
+    echo "Error: $PROJECT_SWIFT_PATH must NOT contain: $FORBIDDEN_PROJECT_SWIFT_LINE"
+    echo "Ensure that Tuist Cloud changes are persisted upstream and run make cloud/down"
+    exit 1
+fi
+EOF
+
+# Make the pre-commit hook executable
+chmod +x "${HOOKS_DIR}/pre-commit"
+
+echo "Pre-commit hook has been installed."

--- a/make/tasks/cloud/up.sh
+++ b/make/tasks/cloud/up.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR=$($SCRIPT_DIR/../../utilities/root_dir.sh)
+
+# Variables
+REPO_URL="https://github.com/tuist/cloud"
+CLONE_DIR=$ROOT_DIR/cloud
+COMMIT_SHA=$(cat $ROOT_DIR/.tuist-cloud-version) 
+
+# Check if 'cloud' directory exists
+if [ ! -d "$CLONE_DIR" ]; then
+    echo "Directory $CLONE_DIR does not exist. Cloning the repository..."
+    git clone "$REPO_URL" "$CLONE_DIR"
+else
+    echo "Directory $CLONE_DIR already exists. Skipping clone."
+fi
+
+# Discard all local changes and checkout the specific commit SHA
+echo "Checking out commit $COMMIT_SHA and discarding all local changes..."
+git --git-dir="$CLONE_DIR/.git" --work-tree="$CLONE_DIR" reset --hard "$COMMIT_SHA"
+
+# Removing SPM and Xcode caches
+$SCRIPT_DIR/_clean.sh
+
+# Enabling Tuist Cloud
+sed -i '' -e 's/let includeTuistCloud = false/let includeTuistCloud = true/' $ROOT_DIR/Package.swift
+sed -i '' -e 's/Environment.includeTuistCloud.getBoolean(default: false)/Environment.includeTuistCloud.getBoolean(default: true)/' $ROOT_DIR/Project.swift

--- a/make/tasks/docs/tuist/build.sh
+++ b/make/tasks/docs/tuist/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$($SCRIPT_DIR/../../../utilities/root_dir.sh)

--- a/make/tasks/docs/tuist/preview.sh
+++ b/make/tasks/docs/tuist/preview.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$($SCRIPT_DIR/../../../utilities/root_dir.sh)

--- a/make/tasks/github/cancel-workflows.sh
+++ b/make/tasks/github/cancel-workflows.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$($SCRIPT_DIR/../../utilities/root_dir.sh)

--- a/make/tasks/shared/generate/cloud-openapi-code.sh
+++ b/make/tasks/shared/generate/cloud-openapi-code.sh
@@ -3,6 +3,6 @@
 set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT_DIR=$($SCRIPT_DIR/../../utilities/root_dir.sh)
+ROOT_DIR=$($SCRIPT_DIR/../../../utilities/root_dir.sh)
 
 swift run --package-path $ROOT_DIR swift-openapi-generator generate --mode types --mode client --output-directory $ROOT_DIR/Sources/TuistCloud/OpenAPI Sources/TuistCloud/OpenAPI/cloud.yml

--- a/make/tasks/shared/generate/cloud-openapi-code.sh
+++ b/make/tasks/shared/generate/cloud-openapi-code.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$($SCRIPT_DIR/../../../utilities/root_dir.sh)

--- a/make/tasks/shared/lint-fix.sh
+++ b/make/tasks/shared/lint-fix.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$($SCRIPT_DIR/../../utilities/root_dir.sh)

--- a/make/tasks/shared/lint-fix.sh
+++ b/make/tasks/shared/lint-fix.sh
@@ -3,7 +3,7 @@
 set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT_DIR=$($SCRIPT_DIR/../utilities/root_dir.sh)
+ROOT_DIR=$($SCRIPT_DIR/../../utilities/root_dir.sh)
 
 swift run --package-path $ROOT_DIR/projects/tuist/vendor swiftformat $ROOT_DIR
 swift run --package-path $ROOT_DIR/projects/tuist/vendor swiftlint lint --fix --quiet --config $ROOT_DIR/.swiftlint.yml $ROOT_DIR/Sources

--- a/make/tasks/shared/lint.sh
+++ b/make/tasks/shared/lint.sh
@@ -3,7 +3,7 @@
 set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT_DIR=$($SCRIPT_DIR/../utilities/root_dir.sh)
+ROOT_DIR=$($SCRIPT_DIR/../../utilities/root_dir.sh)
 
 swift run --package-path $ROOT_DIR/projects/tuist/vendor swiftformat $ROOT_DIR --lint
 swift run --package-path $ROOT_DIR/projects/tuist/vendor swiftlint lint --quiet --config $ROOT_DIR/.swiftlint.yml $ROOT_DIR/Sources

--- a/make/tasks/shared/lint.sh
+++ b/make/tasks/shared/lint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$($SCRIPT_DIR/../../utilities/root_dir.sh)

--- a/make/tasks/shared/lint/lockfiles.sh
+++ b/make/tasks/shared/lint/lockfiles.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$($SCRIPT_DIR/../../../utilities/root_dir.sh)

--- a/make/tasks/shared/lint/lockfiles.sh
+++ b/make/tasks/shared/lint/lockfiles.sh
@@ -3,7 +3,7 @@
 set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT_DIR=$($SCRIPT_DIR/../../utilities/root_dir.sh)
+ROOT_DIR=$($SCRIPT_DIR/../../../utilities/root_dir.sh)
 
 assert_same_packages_count() {
     spm_count=$(jq '.pins | length' "$spm_lockfile")

--- a/make/tasks/tuist/edit.sh
+++ b/make/tasks/tuist/edit.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$($SCRIPT_DIR/../../utilities/root_dir.sh)

--- a/make/tasks/tuist/edit.sh
+++ b/make/tasks/tuist/edit.sh
@@ -3,7 +3,7 @@
 set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT_DIR=$($SCRIPT_DIR/../utilities/root_dir.sh)
+ROOT_DIR=$($SCRIPT_DIR/../../utilities/root_dir.sh)
 
 swift build --package-path $ROOT_DIR
 $ROOT_DIR/.build/debug/tuist edit --path $ROOT_DIR --only-current-directory

--- a/make/tasks/tuist/fetch.sh
+++ b/make/tasks/tuist/fetch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$($SCRIPT_DIR/../../utilities/root_dir.sh)

--- a/make/tasks/tuist/fetch.sh
+++ b/make/tasks/tuist/fetch.sh
@@ -3,7 +3,7 @@
 set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT_DIR=$($SCRIPT_DIR/../utilities/root_dir.sh)
+ROOT_DIR=$($SCRIPT_DIR/../../utilities/root_dir.sh)
 
 swift build --package-path $ROOT_DIR
-$ROOT_DIR/.build/debug/tuist $@
+$ROOT_DIR/.build/debug/tuist fetch --path $ROOT_DIR

--- a/make/tasks/tuist/generate.sh
+++ b/make/tasks/tuist/generate.sh
@@ -3,7 +3,7 @@
 set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT_DIR=$($SCRIPT_DIR/../utilities/root_dir.sh)
+ROOT_DIR=$($SCRIPT_DIR/../../utilities/root_dir.sh)
 
 swift build --package-path $ROOT_DIR
 $ROOT_DIR/.build/debug/tuist generate --path $ROOT_DIR --xcframeworks $@

--- a/make/tasks/tuist/generate.sh
+++ b/make/tasks/tuist/generate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$($SCRIPT_DIR/../../utilities/root_dir.sh)

--- a/make/tasks/tuist/run.sh
+++ b/make/tasks/tuist/run.sh
@@ -3,7 +3,7 @@
 set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT_DIR=$($SCRIPT_DIR/../utilities/root_dir.sh)
+ROOT_DIR=$($SCRIPT_DIR/../../utilities/root_dir.sh)
 
 swift build --package-path $ROOT_DIR
-$ROOT_DIR/.build/debug/tuist fetch --path $ROOT_DIR
+$ROOT_DIR/.build/debug/tuist $@

--- a/make/tasks/tuist/run.sh
+++ b/make/tasks/tuist/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$($SCRIPT_DIR/../../utilities/root_dir.sh)

--- a/make/utilities/derived_data_path.sh
+++ b/make/utilities/derived_data_path.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+DERIVED_DATA_PATH=$(defaults read com.apple.dt.Xcode IDECustomDerivedDataLocation 2>/dev/null)
+
+# Check if the path is set
+if [ -z "$DERIVED_DATA_PATH" ]; then
+    echo "$HOME/Library/Developer/Xcode/DerivedData/"
+else
+    echo "$DERIVED_DATA_PATH"
+fi

--- a/make/utilities/root_dir.sh
+++ b/make/utilities/root_dir.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"

--- a/script/install
+++ b/script/install
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 shell_join() {
   local arg

--- a/script/uninstall
+++ b/script/uninstall
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 shell_join() {
   local arg


### PR DESCRIPTION
### Short description 📝
Since Git Submodules cause troubles to downstream users of Tuist packages, we opted out of it. Instead, the repository has to be manually cloned by the developer. To improve the ergonomics, I'm adding two new Make tasks:

- `make cloud/up`: Configures the environment to work on Tuist Cloud, ensuring it pulls the version the repository is pinned to. It also installs a `pre-commit` hook to ensure changes are not pushed upstream with cloud-enabled in the client.
- `make cloud/down`: Reverts all the changes are done by `cloud/up`, deleting the repository and the pre-commit git hook.

I'll open another PR shortly that runs integration tests for every commit landing in `main` to ensure new changes are not breaking the contract with the Tuist Cloud client code.