### PR TITLE
Add support for SwiftPackageManager `enableExperimentalFeature` target setting

### DIFF
--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -870,11 +870,8 @@ extension ProjectDescription.TargetDependency {
                 return .sdk(name: setting.value[0], type: .framework, status: .required)
             case (.linker, .linkedLibrary):
                 return .sdk(name: setting.value[0], type: .library, status: .required)
-            case (.c, _), (.cxx, _), (_, .enableUpcomingFeature), (.swift, _), (.linker, .headerSearchPath), (.linker, .define), (
-                _,
-                .enableExperimentalFeature
-            ),
-            (.linker, .unsafeFlags):
+            case (.c, _), (.cxx, _), (_, .enableUpcomingFeature), (.swift, _), (.linker, .headerSearchPath),
+                 (.linker, .define), (.linker, .unsafeFlags), (_, .enableExperimentalFeature):
                 return nil
             }
         }

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -870,8 +870,11 @@ extension ProjectDescription.TargetDependency {
                 return .sdk(name: setting.value[0], type: .framework, status: .required)
             case (.linker, .linkedLibrary):
                 return .sdk(name: setting.value[0], type: .library, status: .required)
-            case (.c, _), (.cxx, _), (_, .enableUpcomingFeature), (.swift, _), (.linker, .headerSearchPath), (.linker, .define), (_, .enableExperimentalFeature),
-                 (.linker, .unsafeFlags):
+            case (.c, _), (.cxx, _), (_, .enableUpcomingFeature), (.swift, _), (.linker, .headerSearchPath), (.linker, .define), (
+                _,
+                .enableExperimentalFeature
+            ),
+            (.linker, .unsafeFlags):
                 return nil
             }
         }
@@ -990,7 +993,8 @@ extension ProjectDescription.Settings {
 
                 case (.c, .linkedFramework), (.c, .linkedLibrary), (.cxx, .linkedFramework), (.cxx, .linkedLibrary),
                      (.swift, .headerSearchPath), (.swift, .linkedFramework), (.swift, .linkedLibrary),
-                    (.linker, .headerSearchPath), (.linker, .define), (_, .enableUpcomingFeature), (_, .enableExperimentalFeature):
+                     (.linker, .headerSearchPath), (.linker, .define), (_, .enableUpcomingFeature),
+                     (_, .enableExperimentalFeature):
                     throw PackageInfoMapperError.unsupportedSetting(setting.tool, setting.name)
                 }
             }

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -870,7 +870,7 @@ extension ProjectDescription.TargetDependency {
                 return .sdk(name: setting.value[0], type: .framework, status: .required)
             case (.linker, .linkedLibrary):
                 return .sdk(name: setting.value[0], type: .library, status: .required)
-            case (.c, _), (.cxx, _), (_, .enableUpcomingFeature), (.swift, _), (.linker, .headerSearchPath), (.linker, .define),
+            case (.c, _), (.cxx, _), (_, .enableUpcomingFeature), (.swift, _), (.linker, .headerSearchPath), (.linker, .define), (_, .enableExperimentalFeature),
                  (.linker, .unsafeFlags):
                 return nil
             }
@@ -980,6 +980,8 @@ extension ProjectDescription.Settings {
                     swiftFlags.append(contentsOf: setting.value)
                 case (.swift, .enableUpcomingFeature):
                     swiftFlags.append("-enable-upcoming-feature \(setting.value[0])")
+                case (.swift, .enableExperimentalFeature):
+                    swiftFlags.append("-enable-experimental-feature \(setting.value[0])")
                 case (.linker, .unsafeFlags):
                     linkerFlags.append(contentsOf: setting.value)
                 case (.linker, .linkedFramework), (.linker, .linkedLibrary):
@@ -988,7 +990,7 @@ extension ProjectDescription.Settings {
 
                 case (.c, .linkedFramework), (.c, .linkedLibrary), (.cxx, .linkedFramework), (.cxx, .linkedLibrary),
                      (.swift, .headerSearchPath), (.swift, .linkedFramework), (.swift, .linkedLibrary),
-                     (.linker, .headerSearchPath), (.linker, .define), (_, .enableUpcomingFeature):
+                    (.linker, .headerSearchPath), (.linker, .define), (_, .enableUpcomingFeature), (_, .enableExperimentalFeature):
                     throw PackageInfoMapperError.unsupportedSetting(setting.tool, setting.name)
                 }
             }

--- a/Sources/TuistSupport/SwiftPackageManager/PackageInfo.swift
+++ b/Sources/TuistSupport/SwiftPackageManager/PackageInfo.swift
@@ -364,6 +364,7 @@ extension PackageInfo.Target {
             case linkedFramework
             case unsafeFlags
             case enableUpcomingFeature
+            case enableExperimentalFeature
         }
 
         /// An individual build setting.
@@ -408,6 +409,7 @@ extension PackageInfo.Target {
                     case linkedFramework(String)
                     case unsafeFlags([String])
                     case enableUpcomingFeature(String)
+                    case enableExperimentalFeature(String)
                 }
 
                 let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -433,6 +435,9 @@ extension PackageInfo.Target {
                         self.value = value
                     case let .enableUpcomingFeature(value):
                         name = .enableUpcomingFeature
+                        self.value = [value]
+                    case let .enableExperimentalFeature(value):
+                        name = .enableExperimentalFeature
                         self.value = [value]
                     }
                 } else {

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -1946,6 +1946,44 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             )
         )
     }
+    
+    func testMap_whenSettingsContainsEnableExperimentalFeature_mapsToOtherSwiftFlags() throws {
+        let basePath = try temporaryPath()
+        let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))
+        try fileHandler.createFolder(sourcesPath)
+        let project = try subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageInfos: [
+                "Package": .init(
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(
+                            name: "Target1",
+                            settings: [
+                                .init(tool: .swift, name: .enableExperimentalFeature, condition: nil, value: ["Foo"]),
+                            ]
+                        ),
+                    ],
+                    platforms: [],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+        XCTAssertEqual(
+            project,
+            .testWithDefaultConfigs(
+                name: "Package",
+                targets: [
+                    .test("Target1", basePath: basePath, customSettings: ["OTHER_SWIFT_FLAGS": ["-enable-experimental-feature Foo"]]),
+                ]
+            )
+        )
+    }
 
     func testMap_whenSettingsContainsLinkerUnsafeFlags_mapsToOtherLdFlags() throws {
         let basePath = try temporaryPath()

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -1946,7 +1946,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             )
         )
     }
-    
+
     func testMap_whenSettingsContainsEnableExperimentalFeature_mapsToOtherSwiftFlags() throws {
         let basePath = try temporaryPath()
         let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))
@@ -1979,7 +1979,11 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             .testWithDefaultConfigs(
                 name: "Package",
                 targets: [
-                    .test("Target1", basePath: basePath, customSettings: ["OTHER_SWIFT_FLAGS": ["-enable-experimental-feature Foo"]]),
+                    .test(
+                        "Target1",
+                        basePath: basePath,
+                        customSettings: ["OTHER_SWIFT_FLAGS": ["-enable-experimental-feature Foo"]]
+                    ),
                 ]
             )
         )


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5478

### Short description 📝

Swift 5.8 (5.9?) has added another target setting, `enableExperimentalFeature`. This addition was triggering a decode error as this kind of setting was not supported by Tuist, causing it to fall into the `else` scope [here](https://github.com/tuist/tuist/blob/main/Sources/TuistSupport/SwiftPackageManager/PackageInfo.swift#L417-L441) and fail.

I think a future improvement here would be to drop the `try?` and catch the decode error on an unsupported setting. It could then throw a more useful error - I went a bit nuts trying to figure out why I was getting an error because of no `name` on a setting that looked to be just fine. Took some time to realise the actual issue was an unsupported `Kind` and a fallback to unrelated code.

### How to test the changes locally 🧐

`./fourier test tuist unit` should pass the new `testMap_whenSettingsContainsEnableExperimentalFeature_mapsToOtherSwiftFlags` in `PackageInfoMapperTests`

### Contributor checklist ✅

- [x] The code has been linted using run `make lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
