### PR TITLE
Remove the `--server-url` flag from Tuist Cloud commands

### DIFF
--- a/Sources/TuistKit/Commands/Cloud/CloudAuthCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudAuthCommand.swift
@@ -13,14 +13,15 @@
         }
 
         @Option(
-            name: .long,
-            help: "URL to the cloud server."
+            name: .shortAndLong,
+            help: "The path to the directory or a subdirectory of the project.",
+            completion: .directory
         )
-        var serverURL: String?
+        var path: String?
 
         func run() throws {
             try CloudAuthService().authenticate(
-                serverURL: serverURL
+                directory: self.path
             )
         }
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudAuthCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudAuthCommand.swift
@@ -21,7 +21,7 @@
 
         func run() throws {
             try CloudAuthService().authenticate(
-                directory: self.path
+                directory: path
             )
         }
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudInitCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudInitCommand.swift
@@ -33,7 +33,7 @@
 
         @Option(
             name: .shortAndLong,
-            help: "The path to the Tuist Cloud project.",
+            help: "The path to the directory or a subdirectory of the project.",
             completion: .directory
         )
         var path: String?
@@ -42,8 +42,7 @@
             try await CloudInitService().createProject(
                 name: name,
                 organization: organization,
-                serverURL: serverURL,
-                path: path
+                directory: path
             )
         }
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudLogoutCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudLogoutCommand.swift
@@ -13,14 +13,15 @@
         }
 
         @Option(
-            name: .long,
-            help: "URL to the cloud server."
+            name: .shortAndLong,
+            help: "The path to the directory or a subdirectory of the project.",
+            completion: .directory
         )
-        var serverURL: String?
+        var path: String?
 
         func run() throws {
             try CloudLogoutService().logout(
-                serverURL: serverURL
+                directory: path
             )
         }
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationBillingCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationBillingCommand.swift
@@ -19,15 +19,16 @@
         var organizationName: String
 
         @Option(
-            name: .long,
-            help: "URL to the cloud server."
+            name: .shortAndLong,
+            help: "The path to the directory or a subdirectory of the project.",
+            completion: .directory
         )
-        var serverURL: String?
+        var path: String?
 
         func run() async throws {
             try await CloudOrganizationBillingService().run(
                 organizationName: organizationName,
-                serverURL: serverURL
+                directory: path
             )
         }
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationCreateCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationCreateCommand.swift
@@ -19,15 +19,16 @@
         var organizationName: String
 
         @Option(
-            name: .long,
-            help: "URL to the cloud server."
+            name: .shortAndLong,
+            help: "The path to the directory or a subdirectory of the project.",
+            completion: .directory
         )
-        var serverURL: String?
+        var path: String?
 
         func run() async throws {
             try await CloudOrganizationCreateService().run(
                 organizationName: organizationName,
-                serverURL: serverURL
+                directory: path
             )
         }
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationDeleteCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationDeleteCommand.swift
@@ -25,7 +25,7 @@
             completion: .directory
         )
         var path: String?
-        
+
         func run() async throws {
             try await CloudOrganizationDeleteService().run(
                 organizationName: organizationName,

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationDeleteCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationDeleteCommand.swift
@@ -20,15 +20,16 @@
         var organizationName: String
 
         @Option(
-            name: .long,
-            help: "URL to the cloud server."
+            name: .shortAndLong,
+            help: "The path to the directory or a subdirectory of the project.",
+            completion: .directory
         )
-        var serverURL: String?
-
+        var path: String?
+        
         func run() async throws {
             try await CloudOrganizationDeleteService().run(
                 organizationName: organizationName,
-                serverURL: serverURL
+                directory: path
             )
         }
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationInviteCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationInviteCommand.swift
@@ -24,16 +24,17 @@
         var email: String
 
         @Option(
-            name: .long,
-            help: "URL to the cloud server."
+            name: .shortAndLong,
+            help: "The path to the directory or a subdirectory of the project.",
+            completion: .directory
         )
-        var serverURL: String?
+        var path: String?
 
         func run() async throws {
             try await CloudOrganizationInviteService().run(
                 organizationName: organizationName,
                 email: email,
-                serverURL: serverURL
+                directory: path
             )
         }
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationListCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationListCommand.swift
@@ -19,15 +19,16 @@
         var json: Bool = false
 
         @Option(
-            name: .long,
-            help: "URL to the cloud server."
+            name: .shortAndLong,
+            help: "The path to the directory or a subdirectory of the project.",
+            completion: .directory
         )
-        var serverURL: String?
-
+        var path: String?
+        
         func run() async throws {
             try await CloudOrganizationListService().run(
                 json: json,
-                serverURL: serverURL
+                directory: path
             )
         }
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationListCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationListCommand.swift
@@ -24,7 +24,7 @@
             completion: .directory
         )
         var path: String?
-        
+
         func run() async throws {
             try await CloudOrganizationListService().run(
                 json: json,

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationRemoveInviteCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationRemoveInviteCommand.swift
@@ -24,16 +24,17 @@
         var email: String
 
         @Option(
-            name: .long,
-            help: "URL to the cloud server."
+            name: .shortAndLong,
+            help: "The path to the directory or a subdirectory of the project.",
+            completion: .directory
         )
-        var serverURL: String?
+        var path: String?
 
         func run() async throws {
             try await CloudOrganizationRemoveInviteService().run(
                 organizationName: organizationName,
                 email: email,
-                serverURL: serverURL
+                directory: path
             )
         }
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationRemoveMemberCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationRemoveMemberCommand.swift
@@ -24,16 +24,17 @@
         var username: String
 
         @Option(
-            name: .long,
-            help: "URL to the cloud server."
+            name: .shortAndLong,
+            help: "The path to the directory or a subdirectory of the project.",
+            completion: .directory
         )
-        var serverURL: String?
+        var path: String?
 
         func run() async throws {
             try await CloudOrganizationRemoveMemberService().run(
                 organizationName: organizationName,
                 username: username,
-                serverURL: serverURL
+                directory: path
             )
         }
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationShowCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationShowCommand.swift
@@ -24,16 +24,17 @@
         var json: Bool = false
 
         @Option(
-            name: .long,
-            help: "URL to the cloud server."
+            name: .shortAndLong,
+            help: "The path to the directory or a subdirectory of the project.",
+            completion: .directory
         )
-        var serverURL: String?
+        var path: String?
 
         func run() async throws {
             try await CloudOrganizationShowService().run(
                 organizationName: organizationName,
                 json: json,
-                serverURL: serverURL
+                directory: path
             )
         }
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudOrganizationUpdateMemberCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudOrganizationUpdateMemberCommand.swift
@@ -31,17 +31,18 @@
         var role: String
 
         @Option(
-            name: .long,
-            help: "URL to the cloud server."
+            name: .shortAndLong,
+            help: "The path to the directory or a subdirectory of the project.",
+            completion: .directory
         )
-        var serverURL: String?
+        var path: String?
 
         func run() async throws {
             try await CloudOrganizationUpdateMemberService().run(
                 organizationName: organizationName,
                 username: username,
                 role: role,
-                serverURL: serverURL
+                directory: path
             )
         }
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudProjectCreateCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudProjectCreateCommand.swift
@@ -26,16 +26,17 @@
         var organization: String?
 
         @Option(
-            name: .long,
-            help: "URL to the cloud server."
+            name: .shortAndLong,
+            help: "The path to the directory or a subdirectory of the project.",
+            completion: .directory
         )
-        var serverURL: String?
+        var path: String?
 
         func run() async throws {
             try await CloudProjectCreateService().run(
                 name: name,
                 organization: organization,
-                serverURL: serverURL
+                directory: path
             )
         }
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudProjectDeleteCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudProjectDeleteCommand.swift
@@ -25,16 +25,17 @@
         var organization: String?
 
         @Option(
-            name: .long,
-            help: "URL to the cloud server."
+            name: .shortAndLong,
+            help: "The path to the directory or a subdirectory of the project.",
+            completion: .directory
         )
-        var serverURL: String?
+        var path: String?
 
         func run() async throws {
             try await CloudProjectDeleteService().run(
                 projectName: project,
                 organizationName: organization,
-                serverURL: serverURL
+                directory: path
             )
         }
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudProjectListCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudProjectListCommand.swift
@@ -19,15 +19,16 @@
         var json: Bool = false
 
         @Option(
-            name: .long,
-            help: "URL to the cloud server."
+            name: .shortAndLong,
+            help: "The path to the directory or a subdirectory of the project.",
+            completion: .directory
         )
-        var serverURL: String?
+        var path: String?
 
         func run() async throws {
             try await CloudProjectListService().run(
                 json: json,
-                serverURL: serverURL
+                directory: path
             )
         }
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudProjectTokenCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudProjectTokenCommand.swift
@@ -26,16 +26,17 @@
         var organizationName: String?
 
         @Option(
-            name: .long,
-            help: "URL to the cloud server."
+            name: .shortAndLong,
+            help: "The path to the directory or a subdirectory of the project.",
+            completion: .directory
         )
-        var serverURL: String?
+        var path: String?
 
         func run() async throws {
             try await CloudProjectTokenService().run(
                 projectName: projectName,
                 organizationName: organizationName,
-                serverURL: serverURL
+                directory: path
             )
         }
     }

--- a/Sources/TuistKit/Commands/Cloud/CloudSessionCommand.swift
+++ b/Sources/TuistKit/Commands/Cloud/CloudSessionCommand.swift
@@ -13,14 +13,15 @@
         }
 
         @Option(
-            name: .long,
-            help: "URL to the cloud server."
+            name: .shortAndLong,
+            help: "The path to the directory or a subdirectory of the project.",
+            completion: .directory
         )
-        var serverURL: String?
+        var path: String?
 
         func run() throws {
             try CloudSessionService().printSession(
-                serverURL: serverURL
+                directory: path
             )
         }
     }

--- a/Sources/TuistKit/Commands/FetchCommand.swift
+++ b/Sources/TuistKit/Commands/FetchCommand.swift
@@ -18,7 +18,7 @@ struct FetchCommand: AsyncParsableCommand {
 
     @Option(
         name: .shortAndLong,
-        help: "The path to the directory that contains the definition of the project.",
+        help: "The path to the directory or a subdirectory of the project.",
         completion: .directory
     )
     var path: String?

--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -19,7 +19,7 @@ struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
 
     @Option(
         name: .shortAndLong,
-        help: "The path to the directory that contains the definition of the project.",
+        help: "The path to the directory or a subdirectory of the project.",
         completion: .directory
     )
     var path: String?

--- a/Sources/TuistKit/Services/Cloud/CloudAuthService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudAuthService.swift
@@ -4,31 +4,42 @@
     import TuistCore
     import TuistLoader
     import TuistSupport
+    import TSCBasic
 
     protocol CloudAuthServicing: AnyObject {
         func authenticate(
-            serverURL: String?
+            directory: String?
         ) throws
     }
 
     final class CloudAuthService: CloudAuthServicing {
         private let cloudSessionController: CloudSessionControlling
         private let cloudURLService: CloudURLServicing
-
+        private let configLoader: ConfigLoading
+        
         init(
             cloudSessionController: CloudSessionControlling = CloudSessionController(),
-            cloudURLService: CloudURLServicing = CloudURLService()
+            cloudURLService: CloudURLServicing = CloudURLService(),
+            configLoader: ConfigLoading = ConfigLoader()
         ) {
             self.cloudSessionController = cloudSessionController
             self.cloudURLService = cloudURLService
+            self.configLoader = configLoader
         }
 
         // MARK: - CloudAuthServicing
 
         func authenticate(
-            serverURL: String?
+            directory: String?
         ) throws {
-            let cloudURL = try cloudURLService.url(serverURL: serverURL)
+            let directoryPath: AbsolutePath
+            if let directory {
+                directoryPath = try AbsolutePath(validating: directory, relativeTo: FileHandler.shared.currentPath)
+            } else {
+                directoryPath = FileHandler.shared.currentPath
+            }
+            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
             try cloudSessionController.authenticate(serverURL: cloudURL)
         }
     }

--- a/Sources/TuistKit/Services/Cloud/CloudAuthService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudAuthService.swift
@@ -1,10 +1,10 @@
 #if canImport(TuistCloud)
     import Foundation
+    import TSCBasic
     import TuistCloud
     import TuistCore
     import TuistLoader
     import TuistSupport
-    import TSCBasic
 
     protocol CloudAuthServicing: AnyObject {
         func authenticate(
@@ -16,7 +16,7 @@
         private let cloudSessionController: CloudSessionControlling
         private let cloudURLService: CloudURLServicing
         private let configLoader: ConfigLoading
-        
+
         init(
             cloudSessionController: CloudSessionControlling = CloudSessionController(),
             cloudURLService: CloudURLServicing = CloudURLService(),
@@ -38,7 +38,7 @@
             } else {
                 directoryPath = FileHandler.shared.currentPath
             }
-            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let config = try configLoader.loadConfig(path: directoryPath)
             let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
             try cloudSessionController.authenticate(serverURL: cloudURL)
         }

--- a/Sources/TuistKit/Services/Cloud/CloudInitService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudInitService.swift
@@ -62,7 +62,7 @@
             } else {
                 directoryPath = FileHandler.shared.currentPath
             }
-            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let config = try configLoader.loadConfig(path: directoryPath)
             let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
             if config.cloud != nil {

--- a/Sources/TuistKit/Services/Cloud/CloudLogoutService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudLogoutService.swift
@@ -1,10 +1,10 @@
 #if canImport(TuistCloud)
     import Foundation
+    import TSCBasic
     import TuistCloud
     import TuistCore
     import TuistLoader
     import TuistSupport
-    import TSCBasic
 
     protocol CloudLogoutServicing: AnyObject {
         /// It removes any session associated to that domain from
@@ -38,7 +38,7 @@
             } else {
                 directoryPath = FileHandler.shared.currentPath
             }
-            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let config = try configLoader.loadConfig(path: directoryPath)
             let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
             try cloudSessionController.logout(serverURL: cloudURL)
         }

--- a/Sources/TuistKit/Services/Cloud/CloudLogoutService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudLogoutService.swift
@@ -4,31 +4,42 @@
     import TuistCore
     import TuistLoader
     import TuistSupport
+    import TSCBasic
 
     protocol CloudLogoutServicing: AnyObject {
         /// It removes any session associated to that domain from
         /// the keychain
         func logout(
-            serverURL: String?
+            directory: String?
         ) throws
     }
 
     final class CloudLogoutService: CloudLogoutServicing {
         private let cloudSessionController: CloudSessionControlling
         private let cloudURLService: CloudURLServicing
+        private let configLoader: ConfigLoading
 
         init(
             cloudSessionController: CloudSessionControlling = CloudSessionController(),
-            cloudURLService: CloudURLServicing = CloudURLService()
+            cloudURLService: CloudURLServicing = CloudURLService(),
+            configLoader: ConfigLoading = ConfigLoader()
         ) {
             self.cloudSessionController = cloudSessionController
             self.cloudURLService = cloudURLService
+            self.configLoader = configLoader
         }
 
         func logout(
-            serverURL: String?
+            directory: String?
         ) throws {
-            let cloudURL = try cloudURLService.url(serverURL: serverURL)
+            let directoryPath: AbsolutePath
+            if let directory {
+                directoryPath = try AbsolutePath(validating: directory, relativeTo: FileHandler.shared.currentPath)
+            } else {
+                directoryPath = FileHandler.shared.currentPath
+            }
+            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
             try cloudSessionController.logout(serverURL: cloudURL)
         }
     }

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationBillingService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationBillingService.swift
@@ -37,7 +37,7 @@
             } else {
                 directoryPath = FileHandler.shared.currentPath
             }
-            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let config = try configLoader.loadConfig(path: directoryPath)
             let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
             try opener.open(
                 url: cloudURL

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationBillingService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationBillingService.swift
@@ -8,27 +8,37 @@
     protocol CloudOrganizationBillingServicing {
         func run(
             organizationName: String,
-            serverURL: String?
+            directory: String?
         ) async throws
     }
 
     final class CloudOrganizationBillingService: CloudOrganizationBillingServicing {
         private let cloudURLService: CloudURLServicing
         private let opener: Opening
+        private let configLoader: ConfigLoading
 
         init(
             cloudURLService: CloudURLServicing = CloudURLService(),
-            opener: Opening = Opener()
+            opener: Opening = Opener(),
+            configLoader: ConfigLoading = ConfigLoader()
         ) {
             self.cloudURLService = cloudURLService
             self.opener = opener
+            self.configLoader = configLoader
         }
 
         func run(
             organizationName: String,
-            serverURL: String?
+            directory: String?
         ) async throws {
-            let cloudURL = try cloudURLService.url(serverURL: serverURL)
+            let directoryPath: AbsolutePath
+            if let directory {
+                directoryPath = try AbsolutePath(validating: directory, relativeTo: FileHandler.shared.currentPath)
+            } else {
+                directoryPath = FileHandler.shared.currentPath
+            }
+            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
             try opener.open(
                 url: cloudURL
                     .appendingPathComponent("organizations")

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationCreateService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationCreateService.swift
@@ -8,27 +8,37 @@
     protocol CloudOrganizationCreateServicing {
         func run(
             organizationName: String,
-            serverURL: String?
+            directory: String?
         ) async throws
     }
 
     final class CloudOrganizationCreateService: CloudOrganizationCreateServicing {
         private let createOrganizationService: CreateOrganizationServicing
         private let cloudURLService: CloudURLServicing
-
+        private let configLoader: ConfigLoading
+        
         init(
             createOrganizationService: CreateOrganizationServicing = CreateOrganizationService(),
-            cloudURLService: CloudURLServicing = CloudURLService()
+            cloudURLService: CloudURLServicing = CloudURLService(),
+            configLoader: ConfigLoading = ConfigLoader()
         ) {
             self.createOrganizationService = createOrganizationService
             self.cloudURLService = cloudURLService
+            self.configLoader = configLoader
         }
 
         func run(
             organizationName: String,
-            serverURL: String?
+            directory: String?
         ) async throws {
-            let cloudURL = try cloudURLService.url(serverURL: serverURL)
+            let directoryPath: AbsolutePath
+            if let directory {
+                directoryPath = try AbsolutePath(validating: directory, relativeTo: FileHandler.shared.currentPath)
+            } else {
+                directoryPath = FileHandler.shared.currentPath
+            }
+            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
             let organization = try await createOrganizationService.createOrganization(
                 name: organizationName,

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationCreateService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationCreateService.swift
@@ -16,7 +16,7 @@
         private let createOrganizationService: CreateOrganizationServicing
         private let cloudURLService: CloudURLServicing
         private let configLoader: ConfigLoading
-        
+
         init(
             createOrganizationService: CreateOrganizationServicing = CreateOrganizationService(),
             cloudURLService: CloudURLServicing = CloudURLService(),
@@ -37,7 +37,7 @@
             } else {
                 directoryPath = FileHandler.shared.currentPath
             }
-            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let config = try configLoader.loadConfig(path: directoryPath)
             let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
             let organization = try await createOrganizationService.createOrganization(

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationDeleteService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationDeleteService.swift
@@ -37,9 +37,9 @@
             } else {
                 directoryPath = FileHandler.shared.currentPath
             }
-            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let config = try configLoader.loadConfig(path: directoryPath)
             let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
-            
+
             try await deleteOrganizationService.deleteOrganization(
                 name: organizationName,
                 serverURL: cloudURL

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationDeleteService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationDeleteService.swift
@@ -8,28 +8,38 @@
     protocol CloudOrganizationDeleteServicing {
         func run(
             organizationName: String,
-            serverURL: String?
+            directory: String?
         ) async throws
     }
 
     final class CloudOrganizationDeleteService: CloudOrganizationDeleteServicing {
         private let deleteOrganizationService: DeleteOrganizationServicing
         private let cloudURLService: CloudURLServicing
+        private let configLoader: ConfigLoading
 
         init(
             deleteOrganizationService: DeleteOrganizationServicing = DeleteOrganizationService(),
-            cloudURLService: CloudURLServicing = CloudURLService()
+            cloudURLService: CloudURLServicing = CloudURLService(),
+            configLoader: ConfigLoading = ConfigLoader()
         ) {
             self.deleteOrganizationService = deleteOrganizationService
             self.cloudURLService = cloudURLService
+            self.configLoader = configLoader
         }
 
         func run(
             organizationName: String,
-            serverURL: String?
+            directory: String?
         ) async throws {
-            let cloudURL = try cloudURLService.url(serverURL: serverURL)
-
+            let directoryPath: AbsolutePath
+            if let directory {
+                directoryPath = try AbsolutePath(validating: directory, relativeTo: FileHandler.shared.currentPath)
+            } else {
+                directoryPath = FileHandler.shared.currentPath
+            }
+            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
+            
             try await deleteOrganizationService.deleteOrganization(
                 name: organizationName,
                 serverURL: cloudURL

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationInviteService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationInviteService.swift
@@ -9,28 +9,39 @@
         func run(
             organizationName: String,
             email: String,
-            serverURL: String?
+            directory: String?
         ) async throws
     }
 
     final class CloudOrganizationInviteService: CloudOrganizationInviteServicing {
         private let createOrganizationInviteService: CreateOrganizationInviteServicing
         private let cloudURLService: CloudURLServicing
-
+        private let configLoader: ConfigLoading
+        
         init(
             createOrganizationInviteService: CreateOrganizationInviteServicing = CreateOrganizationInviteService(),
-            cloudURLService: CloudURLServicing = CloudURLService()
+            cloudURLService: CloudURLServicing = CloudURLService(),
+            configLoader: ConfigLoading = ConfigLoader()
         ) {
             self.createOrganizationInviteService = createOrganizationInviteService
             self.cloudURLService = cloudURLService
+            self.configLoader = configLoader
         }
 
         func run(
             organizationName: String,
             email: String,
-            serverURL: String?
+            directory: String?
         ) async throws {
-            let cloudURL = try cloudURLService.url(serverURL: serverURL)
+            let directoryPath: AbsolutePath
+            if let directory {
+                directoryPath = try AbsolutePath(validating: directory, relativeTo: FileHandler.shared.currentPath)
+            } else {
+                directoryPath = FileHandler.shared.currentPath
+            }
+            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
+
 
             let invitation = try await createOrganizationInviteService.createOrganizationInvite(
                 organizationName: organizationName,

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationInviteService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationInviteService.swift
@@ -17,7 +17,7 @@
         private let createOrganizationInviteService: CreateOrganizationInviteServicing
         private let cloudURLService: CloudURLServicing
         private let configLoader: ConfigLoading
-        
+
         init(
             createOrganizationInviteService: CreateOrganizationInviteServicing = CreateOrganizationInviteService(),
             cloudURLService: CloudURLServicing = CloudURLService(),
@@ -39,9 +39,8 @@
             } else {
                 directoryPath = FileHandler.shared.currentPath
             }
-            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let config = try configLoader.loadConfig(path: directoryPath)
             let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
-
 
             let invitation = try await createOrganizationInviteService.createOrganizationInvite(
                 organizationName: organizationName,

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationListService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationListService.swift
@@ -8,27 +8,37 @@
     protocol CloudOrganizationListServicing {
         func run(
             json: Bool,
-            serverURL: String?
+            directory: String?
         ) async throws
     }
 
     final class CloudOrganizationListService: CloudOrganizationListServicing {
         private let listOrganizationsService: ListOrganizationsServicing
         private let cloudURLService: CloudURLServicing
-
+        private let configLoader: ConfigLoading
+        
         init(
             listOrganizationsService: ListOrganizationsServicing = ListOrganizationsService(),
-            cloudURLService: CloudURLServicing = CloudURLService()
+            cloudURLService: CloudURLServicing = CloudURLService(),
+            configLoader: ConfigLoading = ConfigLoader()
         ) {
             self.listOrganizationsService = listOrganizationsService
             self.cloudURLService = cloudURLService
+            self.configLoader = configLoader
         }
 
         func run(
             json: Bool,
-            serverURL: String?
+            directory: String?
         ) async throws {
-            let cloudURL = try cloudURLService.url(serverURL: serverURL)
+            let directoryPath: AbsolutePath
+            if let directory {
+                directoryPath = try AbsolutePath(validating: directory, relativeTo: FileHandler.shared.currentPath)
+            } else {
+                directoryPath = FileHandler.shared.currentPath
+            }
+            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
             let organizations = try await listOrganizationsService.listOrganizations(
                 serverURL: cloudURL

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationListService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationListService.swift
@@ -16,7 +16,7 @@
         private let listOrganizationsService: ListOrganizationsServicing
         private let cloudURLService: CloudURLServicing
         private let configLoader: ConfigLoading
-        
+
         init(
             listOrganizationsService: ListOrganizationsServicing = ListOrganizationsService(),
             cloudURLService: CloudURLServicing = CloudURLService(),
@@ -37,7 +37,7 @@
             } else {
                 directoryPath = FileHandler.shared.currentPath
             }
-            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let config = try configLoader.loadConfig(path: directoryPath)
             let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
             let organizations = try await listOrganizationsService.listOrganizations(

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationRemoveInviteService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationRemoveInviteService.swift
@@ -17,7 +17,7 @@
         private let cancelOrganizationRemoveInviteService: CancelOrganizationInviteServicing
         private let cloudURLService: CloudURLServicing
         private let configLoader: ConfigLoading
-        
+
         init(
             cancelOrganizationRemoveInviteService: CancelOrganizationInviteServicing = CancelOrganizationInviteService(),
             cloudURLService: CloudURLServicing = CloudURLService(),
@@ -39,7 +39,7 @@
             } else {
                 directoryPath = FileHandler.shared.currentPath
             }
-            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let config = try configLoader.loadConfig(path: directoryPath)
             let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
             try await cancelOrganizationRemoveInviteService.cancelOrganizationInvite(

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationRemoveInviteService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationRemoveInviteService.swift
@@ -9,28 +9,38 @@
         func run(
             organizationName: String,
             email: String,
-            serverURL: String?
+            directory: String?
         ) async throws
     }
 
     final class CloudOrganizationRemoveInviteService: CloudOrganizationRemoveInviteServicing {
         private let cancelOrganizationRemoveInviteService: CancelOrganizationInviteServicing
         private let cloudURLService: CloudURLServicing
-
+        private let configLoader: ConfigLoading
+        
         init(
             cancelOrganizationRemoveInviteService: CancelOrganizationInviteServicing = CancelOrganizationInviteService(),
-            cloudURLService: CloudURLServicing = CloudURLService()
+            cloudURLService: CloudURLServicing = CloudURLService(),
+            configLoader: ConfigLoading = ConfigLoader()
         ) {
             self.cancelOrganizationRemoveInviteService = cancelOrganizationRemoveInviteService
             self.cloudURLService = cloudURLService
+            self.configLoader = configLoader
         }
 
         func run(
             organizationName: String,
             email: String,
-            serverURL: String?
+            directory: String?
         ) async throws {
-            let cloudURL = try cloudURLService.url(serverURL: serverURL)
+            let directoryPath: AbsolutePath
+            if let directory {
+                directoryPath = try AbsolutePath(validating: directory, relativeTo: FileHandler.shared.currentPath)
+            } else {
+                directoryPath = FileHandler.shared.currentPath
+            }
+            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
             try await cancelOrganizationRemoveInviteService.cancelOrganizationInvite(
                 organizationName: organizationName,

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationRemoveMemberService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationRemoveMemberService.swift
@@ -9,28 +9,38 @@
         func run(
             organizationName: String,
             username: String,
-            serverURL: String?
+            directory: String?
         ) async throws
     }
 
     final class CloudOrganizationRemoveMemberService: CloudOrganizationRemoveMemberServicing {
         private let removeOrganizationMemberService: RemoveOrganizationMemberServicing
         private let cloudURLService: CloudURLServicing
-
+        private let configLoader: ConfigLoading
+        
         init(
             removeOrganizationMemberService: RemoveOrganizationMemberServicing = RemoveOrganizationMemberService(),
-            cloudURLService: CloudURLServicing = CloudURLService()
+            cloudURLService: CloudURLServicing = CloudURLService(),
+            configLoader: ConfigLoading = ConfigLoader()
         ) {
             self.removeOrganizationMemberService = removeOrganizationMemberService
             self.cloudURLService = cloudURLService
+            self.configLoader = configLoader
         }
 
         func run(
             organizationName: String,
             username: String,
-            serverURL: String?
+            directory: String?
         ) async throws {
-            let cloudURL = try cloudURLService.url(serverURL: serverURL)
+            let directoryPath: AbsolutePath
+            if let directory {
+                directoryPath = try AbsolutePath(validating: directory, relativeTo: FileHandler.shared.currentPath)
+            } else {
+                directoryPath = FileHandler.shared.currentPath
+            }
+            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
             try await removeOrganizationMemberService.removeOrganizationMember(
                 organizationName: organizationName,

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationRemoveMemberService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationRemoveMemberService.swift
@@ -17,7 +17,7 @@
         private let removeOrganizationMemberService: RemoveOrganizationMemberServicing
         private let cloudURLService: CloudURLServicing
         private let configLoader: ConfigLoading
-        
+
         init(
             removeOrganizationMemberService: RemoveOrganizationMemberServicing = RemoveOrganizationMemberService(),
             cloudURLService: CloudURLServicing = CloudURLService(),
@@ -39,7 +39,7 @@
             } else {
                 directoryPath = FileHandler.shared.currentPath
             }
-            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let config = try configLoader.loadConfig(path: directoryPath)
             let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
             try await removeOrganizationMemberService.removeOrganizationMember(

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationShowService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationShowService.swift
@@ -39,7 +39,7 @@
             } else {
                 directoryPath = FileHandler.shared.currentPath
             }
-            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let config = try configLoader.loadConfig(path: directoryPath)
             let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
             let organization = try await getOrganizationService.getOrganization(

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationShowService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationShowService.swift
@@ -9,28 +9,38 @@
         func run(
             organizationName: String,
             json: Bool,
-            serverURL: String?
+            directory: String?
         ) async throws
     }
 
     final class CloudOrganizationShowService: CloudOrganizationShowServicing {
         private let getOrganizationService: GetOrganizationServicing
         private let cloudURLService: CloudURLServicing
+        private let configLoader: ConfigLoading
 
         init(
             getOrganizationService: GetOrganizationServicing = GetOrganizationService(),
-            cloudURLService: CloudURLServicing = CloudURLService()
+            cloudURLService: CloudURLServicing = CloudURLService(),
+            configLoader: ConfigLoading = ConfigLoader()
         ) {
             self.getOrganizationService = getOrganizationService
             self.cloudURLService = cloudURLService
+            self.configLoader = configLoader
         }
 
         func run(
             organizationName: String,
             json: Bool,
-            serverURL: String?
+            directory: String?
         ) async throws {
-            let cloudURL = try cloudURLService.url(serverURL: serverURL)
+            let directoryPath: AbsolutePath
+            if let directory {
+                directoryPath = try AbsolutePath(validating: directory, relativeTo: FileHandler.shared.currentPath)
+            } else {
+                directoryPath = FileHandler.shared.currentPath
+            }
+            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
             let organization = try await getOrganizationService.getOrganization(
                 organizationName: organizationName,

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationUpdateMemberService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationUpdateMemberService.swift
@@ -10,30 +10,40 @@
             organizationName: String,
             username: String,
             role: String,
-            serverURL: String?
+            directory: String?
         ) async throws
     }
 
     final class CloudOrganizationUpdateMemberService: CloudOrganizationUpdateMemberServicing {
         private let updateOrganizationMemberService: UpdateOrganizationMemberServicing
         private let cloudURLService: CloudURLServicing
-
+        private let configLoader: ConfigLoading
+        
         init(
             updateOrganizationMemberService: UpdateOrganizationMemberServicing = UpdateOrganizationMemberService(),
-            cloudURLService: CloudURLServicing = CloudURLService()
+            cloudURLService: CloudURLServicing = CloudURLService(),
+            configLoader: ConfigLoading = ConfigLoader()
         ) {
             self.updateOrganizationMemberService = updateOrganizationMemberService
             self.cloudURLService = cloudURLService
+            self.configLoader = configLoader
         }
 
         func run(
             organizationName: String,
             username: String,
             role: String,
-            serverURL: String?
+            directory: String?
         ) async throws {
-            let cloudURL = try cloudURLService.url(serverURL: serverURL)
-
+            let directoryPath: AbsolutePath
+            if let directory {
+                directoryPath = try AbsolutePath(validating: directory, relativeTo: FileHandler.shared.currentPath)
+            } else {
+                directoryPath = FileHandler.shared.currentPath
+            }
+            let config = try self.configLoader.loadConfig(path: directoryPath)
+            
+            let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
             let member = try await updateOrganizationMemberService.updateOrganizationMember(
                 organizationName: organizationName,
                 username: username,

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationUpdateMemberService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationUpdateMemberService.swift
@@ -18,7 +18,7 @@
         private let updateOrganizationMemberService: UpdateOrganizationMemberServicing
         private let cloudURLService: CloudURLServicing
         private let configLoader: ConfigLoading
-        
+
         init(
             updateOrganizationMemberService: UpdateOrganizationMemberServicing = UpdateOrganizationMemberService(),
             cloudURLService: CloudURLServicing = CloudURLService(),
@@ -41,8 +41,8 @@
             } else {
                 directoryPath = FileHandler.shared.currentPath
             }
-            let config = try self.configLoader.loadConfig(path: directoryPath)
-            
+            let config = try configLoader.loadConfig(path: directoryPath)
+
             let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
             let member = try await updateOrganizationMemberService.updateOrganizationMember(
                 organizationName: organizationName,

--- a/Sources/TuistKit/Services/Cloud/CloudProjectCreateService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudProjectCreateService.swift
@@ -17,7 +17,7 @@
         private let createProjectService: CreateProjectServicing
         private let cloudURLService: CloudURLServicing
         private let configLoader: ConfigLoading
-        
+
         init(
             createProjectService: CreateProjectServicing = CreateProjectService(),
             cloudURLService: CloudURLServicing = CloudURLService(),
@@ -39,8 +39,8 @@
             } else {
                 directoryPath = FileHandler.shared.currentPath
             }
-            let config = try self.configLoader.loadConfig(path: directoryPath)
-            
+            let config = try configLoader.loadConfig(path: directoryPath)
+
             let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
             let project = try await createProjectService.createProject(

--- a/Sources/TuistKit/Services/Cloud/CloudProjectCreateService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudProjectCreateService.swift
@@ -9,28 +9,39 @@
         func run(
             name: String,
             organization: String?,
-            serverURL: String?
+            directory: String?
         ) async throws
     }
 
     final class CloudProjectCreateService: CloudProjectCreateServicing {
         private let createProjectService: CreateProjectServicing
         private let cloudURLService: CloudURLServicing
-
+        private let configLoader: ConfigLoading
+        
         init(
             createProjectService: CreateProjectServicing = CreateProjectService(),
-            cloudURLService: CloudURLServicing = CloudURLService()
+            cloudURLService: CloudURLServicing = CloudURLService(),
+            configLoader: ConfigLoading = ConfigLoader()
         ) {
             self.createProjectService = createProjectService
             self.cloudURLService = cloudURLService
+            self.configLoader = configLoader
         }
 
         func run(
             name: String,
             organization: String?,
-            serverURL: String?
+            directory: String?
         ) async throws {
-            let cloudURL = try cloudURLService.url(serverURL: serverURL)
+            let directoryPath: AbsolutePath
+            if let directory {
+                directoryPath = try AbsolutePath(validating: directory, relativeTo: FileHandler.shared.currentPath)
+            } else {
+                directoryPath = FileHandler.shared.currentPath
+            }
+            let config = try self.configLoader.loadConfig(path: directoryPath)
+            
+            let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
             let project = try await createProjectService.createProject(
                 name: name,

--- a/Sources/TuistKit/Services/Cloud/CloudProjectDeleteService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudProjectDeleteService.swift
@@ -9,7 +9,7 @@
         func run(
             projectName: String,
             organizationName: String?,
-            serverURL: String?
+            directory: String?
         ) async throws
     }
 
@@ -18,25 +18,35 @@
         private let getProjectService: GetProjectServicing
         private let credentialsStore: CredentialsStoring
         private let cloudURLService: CloudURLServicing
-
+        private let configLoader: ConfigLoading
+        
         init(
             deleteProjectService: DeleteProjectServicing = DeleteProjectService(),
             getProjectService: GetProjectServicing = GetProjectService(),
             credentialsStore: CredentialsStoring = CredentialsStore(),
-            cloudURLService: CloudURLServicing = CloudURLService()
+            cloudURLService: CloudURLServicing = CloudURLService(),
+            configLoader: ConfigLoading = ConfigLoader()
         ) {
             self.deleteProjectService = deleteProjectService
             self.getProjectService = getProjectService
             self.credentialsStore = credentialsStore
             self.cloudURLService = cloudURLService
+            self.configLoader = configLoader
         }
 
         func run(
             projectName: String,
             organizationName: String?,
-            serverURL: String?
+            directory: String?
         ) async throws {
-            let cloudURL = try cloudURLService.url(serverURL: serverURL)
+            let directoryPath: AbsolutePath
+            if let directory {
+                directoryPath = try AbsolutePath(validating: directory, relativeTo: FileHandler.shared.currentPath)
+            } else {
+                directoryPath = FileHandler.shared.currentPath
+            }
+            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
             let accountName: String
             if let organizationName {

--- a/Sources/TuistKit/Services/Cloud/CloudProjectDeleteService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudProjectDeleteService.swift
@@ -19,7 +19,7 @@
         private let credentialsStore: CredentialsStoring
         private let cloudURLService: CloudURLServicing
         private let configLoader: ConfigLoading
-        
+
         init(
             deleteProjectService: DeleteProjectServicing = DeleteProjectService(),
             getProjectService: GetProjectServicing = GetProjectService(),
@@ -45,7 +45,7 @@
             } else {
                 directoryPath = FileHandler.shared.currentPath
             }
-            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let config = try configLoader.loadConfig(path: directoryPath)
             let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
             let accountName: String

--- a/Sources/TuistKit/Services/Cloud/CloudProjectListService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudProjectListService.swift
@@ -8,27 +8,37 @@
     protocol CloudProjectListServicing {
         func run(
             json: Bool,
-            serverURL: String?
+            directory: String?
         ) async throws
     }
 
     final class CloudProjectListService: CloudProjectListServicing {
         private let listProjectsService: ListProjectsServicing
         private let cloudURLService: CloudURLServicing
+        private let configLoader: ConfigLoading
 
         init(
             listProjectsService: ListProjectsServicing = ListProjectsService(),
-            cloudURLService: CloudURLServicing = CloudURLService()
+            cloudURLService: CloudURLServicing = CloudURLService(),
+            configLoader: ConfigLoading = ConfigLoader()
         ) {
             self.listProjectsService = listProjectsService
             self.cloudURLService = cloudURLService
+            self.configLoader = configLoader
         }
 
         func run(
             json: Bool,
-            serverURL: String?
+            directory: String?
         ) async throws {
-            let cloudURL = try cloudURLService.url(serverURL: serverURL)
+            let directoryPath: AbsolutePath
+            if let directory {
+                directoryPath = try AbsolutePath(validating: directory, relativeTo: FileHandler.shared.currentPath)
+            } else {
+                directoryPath = FileHandler.shared.currentPath
+            }
+            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
             let projects = try await listProjectsService.listProjects(
                 serverURL: cloudURL

--- a/Sources/TuistKit/Services/Cloud/CloudProjectListService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudProjectListService.swift
@@ -37,7 +37,7 @@
             } else {
                 directoryPath = FileHandler.shared.currentPath
             }
-            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let config = try configLoader.loadConfig(path: directoryPath)
             let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
             let projects = try await listProjectsService.listProjects(

--- a/Sources/TuistKit/Services/Cloud/CloudProjectTokenService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudProjectTokenService.swift
@@ -18,7 +18,7 @@
         private let credentialsStore: CredentialsStoring
         private let cloudURLService: CloudURLServicing
         private let configLoader: ConfigLoading
-        
+
         init(
             getProjectService: GetProjectServicing = GetProjectService(),
             credentialsStore: CredentialsStoring = CredentialsStore(),
@@ -42,7 +42,7 @@
             } else {
                 directoryPath = FileHandler.shared.currentPath
             }
-            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let config = try configLoader.loadConfig(path: directoryPath)
             let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
             let accountName: String

--- a/Sources/TuistKit/Services/Cloud/CloudProjectTokenService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudProjectTokenService.swift
@@ -9,7 +9,7 @@
         func run(
             projectName: String,
             organizationName: String?,
-            serverURL: String?
+            directory: String?
         ) async throws
     }
 
@@ -17,23 +17,33 @@
         private let getProjectService: GetProjectServicing
         private let credentialsStore: CredentialsStoring
         private let cloudURLService: CloudURLServicing
-
+        private let configLoader: ConfigLoading
+        
         init(
             getProjectService: GetProjectServicing = GetProjectService(),
             credentialsStore: CredentialsStoring = CredentialsStore(),
-            cloudURLService: CloudURLServicing = CloudURLService()
+            cloudURLService: CloudURLServicing = CloudURLService(),
+            configLoader: ConfigLoading = ConfigLoader()
         ) {
             self.getProjectService = getProjectService
             self.credentialsStore = credentialsStore
             self.cloudURLService = cloudURLService
+            self.configLoader = configLoader
         }
 
         func run(
             projectName: String,
             organizationName: String?,
-            serverURL: String?
+            directory: String?
         ) async throws {
-            let cloudURL = try cloudURLService.url(serverURL: serverURL)
+            let directoryPath: AbsolutePath
+            if let directory {
+                directoryPath = try AbsolutePath(validating: directory, relativeTo: FileHandler.shared.currentPath)
+            } else {
+                directoryPath = FileHandler.shared.currentPath
+            }
+            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
             let accountName: String
             if let organizationName {

--- a/Sources/TuistKit/Services/Cloud/CloudSessionService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudSessionService.swift
@@ -1,10 +1,10 @@
 #if canImport(TuistCloud)
     import Foundation
+    import TSCBasic
     import TuistCloud
     import TuistCore
     import TuistLoader
     import TuistSupport
-    import TSCBasic
 
     protocol CloudSessionServicing: AnyObject {
         /// It prints any existing session in the keychain to authenticate
@@ -42,7 +42,7 @@
             } else {
                 directoryPath = FileHandler.shared.currentPath
             }
-            let config = try self.configLoader.loadConfig(path: directoryPath)
+            let config = try configLoader.loadConfig(path: directoryPath)
             let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
             try cloudSessionController.printSession(serverURL: cloudURL)
         }

--- a/Tests/TuistKitTests/Services/Cloud/CloudAuthServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudAuthServiceTests.swift
@@ -10,37 +10,45 @@
     import TuistLoaderTesting
     import TuistSupport
     import XCTest
-
+    
     @testable import TuistKit
     @testable import TuistSupportTesting
 
     final class CloudAuthServiceTests: TuistUnitTestCase {
-        var cloudSessionController: MockCloudSessionController!
-        var subject: CloudAuthService!
-
+        private var cloudSessionController: MockCloudSessionController!
+        private var configLoader: MockConfigLoader!
+        private var cloudURL: URL!
+        private var subject: CloudAuthService!
+        
         override func setUp() {
             super.setUp()
             cloudSessionController = MockCloudSessionController()
+            configLoader = MockConfigLoader()
+            cloudURL = URL(string: "https://test.cloud.tuist.io")!
+            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL))}
+            
             subject = CloudAuthService(
-                cloudSessionController: cloudSessionController
+                cloudSessionController: cloudSessionController,
+                configLoader: configLoader
             )
         }
 
         override func tearDown() {
             cloudSessionController = nil
+            configLoader = nil
+            cloudURL = nil
             subject = nil
             super.tearDown()
         }
 
         func test_authenticate() throws {
             // When
-            try subject.authenticate(serverURL: nil)
+            
+            try subject.authenticate(directory: nil)
 
             // Then
             XCTAssertTrue(
-                cloudSessionController.authenticateArgs.contains(
-                    URL(string: Constants.tuistCloudURL)!
-                )
+                cloudSessionController.authenticateArgs.contains(cloudURL)
             )
         }
     }

--- a/Tests/TuistKitTests/Services/Cloud/CloudAuthServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudAuthServiceTests.swift
@@ -10,7 +10,6 @@
     import TuistLoaderTesting
     import TuistSupport
     import XCTest
-    
     @testable import TuistKit
     @testable import TuistSupportTesting
 
@@ -19,14 +18,14 @@
         private var configLoader: MockConfigLoader!
         private var cloudURL: URL!
         private var subject: CloudAuthService!
-        
+
         override func setUp() {
             super.setUp()
             cloudSessionController = MockCloudSessionController()
             configLoader = MockConfigLoader()
             cloudURL = URL(string: "https://test.cloud.tuist.io")!
-            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL))}
-            
+            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL)) }
+
             subject = CloudAuthService(
                 cloudSessionController: cloudSessionController,
                 configLoader: configLoader
@@ -43,7 +42,7 @@
 
         func test_authenticate() throws {
             // When
-            
+
             try subject.authenticate(directory: nil)
 
             // Then

--- a/Tests/TuistKitTests/Services/Cloud/CloudInitServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudInitServiceTests.swift
@@ -14,6 +14,7 @@
         private var cloudSessionController: MockCloudSessionController!
         private var createProjectService: MockCreateProjectService!
         private var configLoader: MockConfigLoader!
+        private var cloudURL: URL!
         private var subject: CloudInitService!
 
         override func setUp() {
@@ -21,7 +22,7 @@
             cloudSessionController = MockCloudSessionController()
             createProjectService = MockCreateProjectService()
             configLoader = MockConfigLoader()
-
+            cloudURL = URL(string: "https://test.cloud.tuist.io")!
             subject = CloudInitService(
                 cloudSessionController: cloudSessionController,
                 createProjectService: createProjectService,
@@ -56,8 +57,7 @@
             try await subject.createProject(
                 name: "tuist",
                 organization: "tuist-org",
-                serverURL: nil,
-                path: nil
+                directory: nil
             )
 
             // Then
@@ -81,8 +81,7 @@
             try await subject.createProject(
                 name: "tuist",
                 organization: "tuist-org",
-                serverURL: nil,
-                path: nil
+                directory: nil
             )
 
             // Then
@@ -100,7 +99,7 @@
         func test_cloud_init_when_cloud_exists() async throws {
             // Given
             configLoader.loadConfigStub = { _ in
-                Config.test(cloud: Cloud.test())
+                Config.test(cloud: Cloud.test(url: self.cloudURL))
             }
 
             // When / Then
@@ -108,8 +107,7 @@
                 try await subject.createProject(
                     name: "tuist",
                     organization: "tuist-org",
-                    serverURL: Constants.tuistCloudURL,
-                    path: nil
+                    directory: nil
                 ),
                 CloudInitServiceError.cloudAlreadySetUp
             )

--- a/Tests/TuistKitTests/Services/Cloud/CloudLogoutServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudLogoutServiceTests.swift
@@ -17,27 +17,35 @@
     final class CloudLogoutServiceTests: TuistUnitTestCase {
         private var cloudSessionController: MockCloudSessionController!
         private var subject: CloudLogoutService!
-
+        private var configLoader: MockConfigLoader!
+        private var cloudURL: URL!
+        
         override func setUp() {
             super.setUp()
             cloudSessionController = MockCloudSessionController()
+            configLoader = MockConfigLoader()
+            cloudURL = URL(string: "https://test.cloud.tuist.io")!
+            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL))}
             subject = CloudLogoutService(
-                cloudSessionController: cloudSessionController
+                cloudSessionController: cloudSessionController,
+                configLoader: configLoader
             )
         }
 
         override func tearDown() {
             cloudSessionController = nil
+            cloudURL = nil
+            configLoader = nil
             subject = nil
             super.tearDown()
         }
 
         func test_logout() throws {
             // When
-            try subject.logout(serverURL: nil)
+            try subject.logout(directory: nil)
 
             // Then
-            XCTAssertTrue(cloudSessionController.logoutArgs.contains(URL(string: Constants.tuistCloudURL)!))
+            XCTAssertTrue(cloudSessionController.logoutArgs.contains(cloudURL))
         }
     }
 #endif

--- a/Tests/TuistKitTests/Services/Cloud/CloudLogoutServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudLogoutServiceTests.swift
@@ -19,13 +19,13 @@
         private var subject: CloudLogoutService!
         private var configLoader: MockConfigLoader!
         private var cloudURL: URL!
-        
+
         override func setUp() {
             super.setUp()
             cloudSessionController = MockCloudSessionController()
             configLoader = MockConfigLoader()
             cloudURL = URL(string: "https://test.cloud.tuist.io")!
-            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL))}
+            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL)) }
             subject = CloudLogoutService(
                 cloudSessionController: cloudSessionController,
                 configLoader: configLoader

--- a/Tests/TuistKitTests/Services/Cloud/CloudOrganizationInviteServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudOrganizationInviteServiceTests.swift
@@ -2,9 +2,9 @@
     import Foundation
     import TuistCloud
     import TuistCloudTesting
-    import TuistSupportTesting
-    import TuistLoaderTesting
     import TuistGraph
+    import TuistLoaderTesting
+    import TuistSupportTesting
     import XCTest
     @testable import TuistKit
 
@@ -13,14 +13,14 @@
         private var subject: CloudOrganizationInviteService!
         private var configLoader: MockConfigLoader!
         private var cloudURL: URL!
-        
+
         override func setUp() {
             super.setUp()
 
             createOrganizationInviteService = .init()
             configLoader = MockConfigLoader()
             cloudURL = URL(string: "https://test.cloud.tuist.io")!
-            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL))}
+            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL)) }
             subject = CloudOrganizationInviteService(
                 createOrganizationInviteService: createOrganizationInviteService,
                 configLoader: configLoader

--- a/Tests/TuistKitTests/Services/Cloud/CloudOrganizationInviteServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudOrganizationInviteServiceTests.swift
@@ -3,26 +3,35 @@
     import TuistCloud
     import TuistCloudTesting
     import TuistSupportTesting
+    import TuistLoaderTesting
+    import TuistGraph
     import XCTest
     @testable import TuistKit
 
     final class CloudOrganizationInviteServiceTests: TuistUnitTestCase {
         private var createOrganizationInviteService: MockCreateOrganizationInviteService!
         private var subject: CloudOrganizationInviteService!
-
+        private var configLoader: MockConfigLoader!
+        private var cloudURL: URL!
+        
         override func setUp() {
             super.setUp()
 
             createOrganizationInviteService = .init()
+            configLoader = MockConfigLoader()
+            cloudURL = URL(string: "https://test.cloud.tuist.io")!
+            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL))}
             subject = CloudOrganizationInviteService(
-                createOrganizationInviteService: createOrganizationInviteService
+                createOrganizationInviteService: createOrganizationInviteService,
+                configLoader: configLoader
             )
         }
 
         override func tearDown() {
             createOrganizationInviteService = nil
+            configLoader = nil
+            cloudURL = nil
             subject = nil
-
             super.tearDown()
         }
 
@@ -39,14 +48,14 @@
             try await subject.run(
                 organizationName: "tuist",
                 email: "tuist@test.io",
-                serverURL: nil
+                directory: nil
             )
 
             // Then
             XCTAssertPrinterOutputContains("""
             tuist@test.io was successfully invited to the tuist organization 🎉
 
-            You can also share with them the invite link directly: https://cloud.tuist.io/auth/invitations/invitation-token
+            You can also share with them the invite link directly: \(cloudURL.absoluteString)/auth/invitations/invitation-token
             """)
         }
     }

--- a/Tests/TuistKitTests/Services/Cloud/CloudOrganizationListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudOrganizationListServiceTests.swift
@@ -2,9 +2,9 @@
     import Foundation
     import TuistCloud
     import TuistCloudTesting
-    import TuistSupportTesting
-    import TuistLoaderTesting
     import TuistGraph
+    import TuistLoaderTesting
+    import TuistSupportTesting
     import XCTest
     @testable import TuistKit
 
@@ -13,15 +13,15 @@
         private var subject: CloudOrganizationListService!
         private var configLoader: MockConfigLoader!
         private var cloudURL: URL!
-        
+
         override func setUp() {
             super.setUp()
 
             listOrganizationsService = .init()
             configLoader = MockConfigLoader()
             cloudURL = URL(string: "https://test.cloud.tuist.io")!
-            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL))}
-            
+            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL)) }
+
             subject = CloudOrganizationListService(
                 listOrganizationsService: listOrganizationsService,
                 configLoader: configLoader

--- a/Tests/TuistKitTests/Services/Cloud/CloudOrganizationListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudOrganizationListServiceTests.swift
@@ -3,19 +3,28 @@
     import TuistCloud
     import TuistCloudTesting
     import TuistSupportTesting
+    import TuistLoaderTesting
+    import TuistGraph
     import XCTest
     @testable import TuistKit
 
     final class CloudOrganizationListServiceTests: TuistUnitTestCase {
         private var listOrganizationsService: MockListOrganizationsService!
         private var subject: CloudOrganizationListService!
-
+        private var configLoader: MockConfigLoader!
+        private var cloudURL: URL!
+        
         override func setUp() {
             super.setUp()
 
             listOrganizationsService = .init()
+            configLoader = MockConfigLoader()
+            cloudURL = URL(string: "https://test.cloud.tuist.io")!
+            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL))}
+            
             subject = CloudOrganizationListService(
-                listOrganizationsService: listOrganizationsService
+                listOrganizationsService: listOrganizationsService,
+                configLoader: configLoader
             )
         }
 
@@ -36,7 +45,7 @@
             }
 
             // When
-            try await subject.run(json: false, serverURL: nil)
+            try await subject.run(json: false, directory: nil)
 
             // Then
             XCTAssertPrinterOutputContains("""
@@ -53,7 +62,7 @@
             }
 
             // When
-            try await subject.run(json: false, serverURL: nil)
+            try await subject.run(json: false, directory: nil)
 
             // Then
             XCTAssertPrinterOutputContains(

--- a/Tests/TuistKitTests/Services/Cloud/CloudOrganizationShowServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudOrganizationShowServiceTests.swift
@@ -5,23 +5,32 @@
     import TuistSupport
     import TuistSupportTesting
     import XCTest
+    import TuistLoaderTesting
+    import TuistGraph
     @testable import TuistKit
 
     final class CloudOrganizationShowServiceTests: TuistUnitTestCase {
         private var getOrganizationService: MockGetOrganizationService!
         private var subject: CloudOrganizationShowService!
-
+        private var configLoader: MockConfigLoader!
+        private var cloudURL: URL!
+        
         override func setUp() {
             super.setUp()
-
             getOrganizationService = .init()
+            configLoader = MockConfigLoader()
+            cloudURL = URL(string: "https://test.cloud.tuist.io")!
+            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL))}
             subject = CloudOrganizationShowService(
-                getOrganizationService: getOrganizationService
+                getOrganizationService: getOrganizationService,
+                configLoader: configLoader
             )
         }
 
         override func tearDown() {
             getOrganizationService = nil
+            configLoader = nil
+            cloudURL = nil
             subject = nil
 
             super.tearDown()
@@ -58,7 +67,7 @@
             try await subject.run(
                 organizationName: "tuist",
                 json: false,
-                serverURL: nil
+                directory: nil
             )
 
             // Then

--- a/Tests/TuistKitTests/Services/Cloud/CloudOrganizationShowServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudOrganizationShowServiceTests.swift
@@ -2,11 +2,11 @@
     import Foundation
     import TuistCloud
     import TuistCloudTesting
+    import TuistGraph
+    import TuistLoaderTesting
     import TuistSupport
     import TuistSupportTesting
     import XCTest
-    import TuistLoaderTesting
-    import TuistGraph
     @testable import TuistKit
 
     final class CloudOrganizationShowServiceTests: TuistUnitTestCase {
@@ -14,13 +14,13 @@
         private var subject: CloudOrganizationShowService!
         private var configLoader: MockConfigLoader!
         private var cloudURL: URL!
-        
+
         override func setUp() {
             super.setUp()
             getOrganizationService = .init()
             configLoader = MockConfigLoader()
             cloudURL = URL(string: "https://test.cloud.tuist.io")!
-            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL))}
+            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL)) }
             subject = CloudOrganizationShowService(
                 getOrganizationService: getOrganizationService,
                 configLoader: configLoader

--- a/Tests/TuistKitTests/Services/Cloud/CloudProjectDeleteServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudProjectDeleteServiceTests.swift
@@ -2,10 +2,10 @@
     import Foundation
     import TuistCloud
     import TuistCloudTesting
+    import TuistGraph
+    import TuistLoaderTesting
     import TuistSupport
     import TuistSupportTesting
-    import TuistLoaderTesting
-    import TuistGraph
     import XCTest
 
     @testable import TuistKit
@@ -26,7 +26,7 @@
             credentialsStore = .init()
             configLoader = MockConfigLoader()
             cloudURL = URL(string: "https://test.cloud.tuist.io")!
-            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL))}
+            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL)) }
             subject = CloudProjectDeleteService(
                 deleteProjectService: deleteProjectService,
                 getProjectService: getProjectService,

--- a/Tests/TuistKitTests/Services/Cloud/CloudProjectDeleteServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudProjectDeleteServiceTests.swift
@@ -4,13 +4,18 @@
     import TuistCloudTesting
     import TuistSupport
     import TuistSupportTesting
+    import TuistLoaderTesting
+    import TuistGraph
     import XCTest
+
     @testable import TuistKit
 
     final class CloudProjectDeleteServiceTests: TuistUnitTestCase {
         private var getProjectService: MockGetProjectService!
         private var deleteProjectService: MockDeleteProjectService!
         private var credentialsStore: MockCredentialsStore!
+        private var configLoader: MockConfigLoader!
+        private var cloudURL: URL!
         private var subject: CloudProjectDeleteService!
 
         override func setUp() {
@@ -19,10 +24,14 @@
             getProjectService = .init()
             deleteProjectService = .init()
             credentialsStore = .init()
+            configLoader = MockConfigLoader()
+            cloudURL = URL(string: "https://test.cloud.tuist.io")!
+            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL))}
             subject = CloudProjectDeleteService(
                 deleteProjectService: deleteProjectService,
                 getProjectService: getProjectService,
-                credentialsStore: credentialsStore
+                credentialsStore: credentialsStore,
+                configLoader: configLoader
             )
         }
 
@@ -30,6 +39,8 @@
             deleteProjectService = nil
             getProjectService = nil
             credentialsStore = nil
+            configLoader = nil
+            cloudURL = nil
             subject = nil
 
             super.tearDown()
@@ -49,7 +60,7 @@
             ] = .init(token: "token", account: "account")
 
             // When
-            try await subject.run(projectName: "project", organizationName: "tuist", serverURL: nil)
+            try await subject.run(projectName: "project", organizationName: "tuist", directory: nil)
 
             // Then
             XCTAssertEqual(0, gotProjectId)

--- a/Tests/TuistKitTests/Services/Cloud/CloudProjectListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudProjectListServiceTests.swift
@@ -2,9 +2,9 @@
     import Foundation
     import TuistCloud
     import TuistCloudTesting
-    import TuistSupportTesting
-    import TuistLoaderTesting
     import TuistGraph
+    import TuistLoaderTesting
+    import TuistSupportTesting
     import XCTest
     @testable import TuistKit
 
@@ -13,13 +13,13 @@
         private var subject: CloudProjectListService!
         private var configLoader: MockConfigLoader!
         private var cloudURL: URL!
-        
+
         override func setUp() {
             super.setUp()
             listProjectsService = .init()
             configLoader = MockConfigLoader()
             cloudURL = URL(string: "https://test.cloud.tuist.io")!
-            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL))}
+            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL)) }
             subject = CloudProjectListService(
                 listProjectsService: listProjectsService,
                 configLoader: configLoader

--- a/Tests/TuistKitTests/Services/Cloud/CloudProjectListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudProjectListServiceTests.swift
@@ -3,24 +3,33 @@
     import TuistCloud
     import TuistCloudTesting
     import TuistSupportTesting
+    import TuistLoaderTesting
+    import TuistGraph
     import XCTest
     @testable import TuistKit
 
     final class CloudProjectListServiceTests: TuistUnitTestCase {
         private var listProjectsService: MockListProjectsService!
         private var subject: CloudProjectListService!
-
+        private var configLoader: MockConfigLoader!
+        private var cloudURL: URL!
+        
         override func setUp() {
             super.setUp()
-
             listProjectsService = .init()
+            configLoader = MockConfigLoader()
+            cloudURL = URL(string: "https://test.cloud.tuist.io")!
+            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL))}
             subject = CloudProjectListService(
-                listProjectsService: listProjectsService
+                listProjectsService: listProjectsService,
+                configLoader: configLoader
             )
         }
 
         override func tearDown() {
             listProjectsService = nil
+            configLoader = nil
+            cloudURL = nil
             subject = nil
 
             super.tearDown()
@@ -36,7 +45,7 @@
             }
 
             // When
-            try await subject.run(json: false, serverURL: nil)
+            try await subject.run(json: false, directory: nil)
 
             // Then
             XCTAssertPrinterOutputContains("""
@@ -53,7 +62,7 @@
             }
 
             // When
-            try await subject.run(json: false, serverURL: nil)
+            try await subject.run(json: false, directory: nil)
 
             // Then
             XCTAssertPrinterOutputContains(

--- a/Tests/TuistKitTests/Services/Cloud/CloudSessionServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudSessionServiceTests.swift
@@ -19,13 +19,13 @@
         private var subject: CloudSessionService!
         private var configLoader: MockConfigLoader!
         private var cloudURL: URL!
-        
+
         override func setUp() {
             super.setUp()
             cloudSessionController = MockCloudSessionController()
             configLoader = MockConfigLoader()
             cloudURL = URL(string: "https://test.cloud.tuist.io")!
-            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL))}
+            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL)) }
             subject = CloudSessionService(
                 cloudSessionController: cloudSessionController,
                 configLoader: configLoader

--- a/Tests/TuistKitTests/Services/Cloud/CloudSessionServiceTests.swift
+++ b/Tests/TuistKitTests/Services/Cloud/CloudSessionServiceTests.swift
@@ -17,27 +17,35 @@
     final class CloudSessionServiceTests: TuistUnitTestCase {
         private var cloudSessionController: MockCloudSessionController!
         private var subject: CloudSessionService!
-
+        private var configLoader: MockConfigLoader!
+        private var cloudURL: URL!
+        
         override func setUp() {
             super.setUp()
             cloudSessionController = MockCloudSessionController()
+            configLoader = MockConfigLoader()
+            cloudURL = URL(string: "https://test.cloud.tuist.io")!
+            configLoader.loadConfigStub = { _ in Config.test(cloud: .test(url: self.cloudURL))}
             subject = CloudSessionService(
-                cloudSessionController: cloudSessionController
+                cloudSessionController: cloudSessionController,
+                configLoader: configLoader
             )
         }
 
         override func tearDown() {
             cloudSessionController = nil
+            configLoader = nil
+            cloudURL = nil
             subject = nil
             super.tearDown()
         }
 
         func test_printSession() throws {
             // When
-            try subject.printSession(serverURL: nil)
+            try subject.printSession(directory: nil)
 
             // Then
-            XCTAssertTrue(cloudSessionController.printSessionArgs.contains(URL(string: Constants.tuistCloudURL)!))
+            XCTAssertTrue(cloudSessionController.printSessionArgs.contains(cloudURL))
         }
     }
 #endif


### PR DESCRIPTION
### Short description 📝
I'm removing the `--server-url` commands from the `cloud` commands in favor of reading the value from the `Config.swift` file. The motivations are:

- Most users will use the default cloud instance, https://cloud.tuist.io
- Enterprise customers of Tuist Cloud can configure a different instance directly in the `Config.swift`, which ties a project to a cloud environment.
- In the case of `tuist/tuist`, where we need to point to production and staging dynamically, we support overriding the value via an environment variable.

As part of this work I've introduced the `--path` flag in every cloud command to support running those commands from a directory other than the project's.

### How to test the changes locally 🧐
You should see a new flag `--path` in any of the cloud commands and they should pick the URL defined in the configuration file automatically.

### Contributor checklist ✅

- [x] The code has been linted using run `make lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
