### PR TITLE
Instruct the asset locators on how to look up assets when `tuist` is installed by Homebrew

### DIFF
--- a/Sources/TuistCore/Utils/BinaryLocator.swift
+++ b/Sources/TuistCore/Utils/BinaryLocator.swift
@@ -54,7 +54,7 @@ public final class BinaryLocator: BinaryLocating {
                        tuist/
                            vendor
                 */
-            bundlePath.parentDirectory.appending(try! RelativePath(validating: "share/tuist")),
+            bundlePath.parentDirectory.appending(try RelativePath(validating: "share/tuist")),
         ]
     }
 

--- a/Sources/TuistCore/Utils/BinaryLocator.swift
+++ b/Sources/TuistCore/Utils/BinaryLocator.swift
@@ -45,6 +45,16 @@ public final class BinaryLocator: BinaryLocating {
             bundlePath,
             bundlePath.parentDirectory,
             bundlePath.appending(try RelativePath(validating: "vendor")),
+            /**
+                == Homebrew directory structure ==
+                x.y.z/
+                   bin/
+                       tuist
+                   share/
+                       tuist/
+                           vendor
+                */
+            bundlePath.parentDirectory.appending(try! RelativePath(validating: "share/tuist")),
         ]
     }
 

--- a/Sources/TuistLoader/Utils/ResourceLocator.swift
+++ b/Sources/TuistLoader/Utils/ResourceLocator.swift
@@ -46,6 +46,16 @@ public final class ResourceLocator: ResourceLocating {
         let paths = [
             bundlePath,
             bundlePath.parentDirectory,
+            /**
+                == Homebrew directory structure ==
+                x.y.z/
+                   bin/
+                       tuist
+                   lib/
+                       ProjectDescription.framework
+                       ProjectDescription.framework.dSYM
+                */
+            bundlePath.parentDirectory.appending(component: "lib"),
         ]
         let candidates = try paths.flatMap { path in
             try frameworkNames.map { path.appending(try RelativePath(validating: $0)) }

--- a/Sources/TuistScaffold/TemplatesDirectoryLocator.swift
+++ b/Sources/TuistScaffold/TemplatesDirectoryLocator.swift
@@ -44,6 +44,16 @@ public final class TemplatesDirectoryLocator: TemplatesDirectoryLocating {
         let paths = [
             bundlePath,
             bundlePath.parentDirectory,
+            /**
+                == Homebrew directory structure ==
+                x.y.z/
+                   bin/
+                       tuist
+                   share/
+                       tuist/
+                           Templates
+                */
+            bundlePath.parentDirectory.appending(try! RelativePath(validating: "share/tuist")),
         ]
         let candidates = paths.map { path in
             path.appending(component: Constants.templatesDirectoryName)

--- a/Sources/TuistScaffold/TemplatesDirectoryLocator.swift
+++ b/Sources/TuistScaffold/TemplatesDirectoryLocator.swift
@@ -54,6 +54,7 @@ public final class TemplatesDirectoryLocator: TemplatesDirectoryLocating {
                            Templates
                 */
             bundlePath.parentDirectory.appending(try! RelativePath(validating: "share/tuist")),
+            // swiftlint:disable:previous force_try
         ]
         let candidates = paths.map { path in
             path.appending(component: Constants.templatesDirectoryName)


### PR DESCRIPTION
### Short description 📝
While working on supporting installing `tuist` via an official Homebrew formula with `brew install tuist`, I noticed that our logic to look up assets (e.g. templates) and dynamic libraries doesn't work with the directory convention proposed by Homebrew:

```bash
x.y.z/
  bin/
    tuist
  lib/
    ProjectDescription.framework
    ProjectDescription.framework.dSYM
  share/
    tuist/
      Vendor/
      Templates
```

This PR adjusts the utilities that do the lookup to support the above structure.

### How to test the changes locally 🧐

It's a bit tricky to test this one manually. It requires recreating the above structure after Tuist has been compiled, and checking if it works as expected. To save you some time, you can use the `make workspace/release/bundle`, which bundles Tuist for release.

### Contributor checklist ✅

- [x] The code has been linted using run `make lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
