### PR TITLE
Support for using a `Package.swift` instead of defining packages directly in Dependencies.swift

### DIFF
--- a/Sources/ProjectDescription/Dependencies/SwiftPackageManagerDependencies.swift
+++ b/Sources/ProjectDescription/Dependencies/SwiftPackageManagerDependencies.swift
@@ -1,21 +1,23 @@
 import Foundation
 
+public enum PackagesOrManifestPath: Codable, Equatable {
+    case packages([Package])
+    case manifest(Path)
+}
+
 /// A collection of Swift Package Manager dependencies.
 ///
 /// For example, to enabled resource accessors on projects generated from Swift Package Manager:
 ///
 /// ```swift
 /// let packageManager = SwiftPackageManagerDependencies(
-///     packages: [
-///         .local(path: "MySwiftPackage")
-///     ],
+///     "Package.swift",
 ///     projectOptions: ["MySwiftPackage":  .options(disableSynthesizedResourceAccessors: false)]
 /// )
 /// ```
-
 public struct SwiftPackageManagerDependencies: Codable, Equatable {
-    /// List of packages that will be installed using Swift Package Manager.
-    public let packages: [Package]
+    /// The path to the `Package.swift` manifest defining the dependencies, or the list of packages that will be installed using Swift Package Manager.
+    public let packagesOrManifestPath: PackagesOrManifestPath
 
     /// The custom `Product` type to be used for SPM targets.
     public let productTypes: [String: Product]
@@ -35,7 +37,7 @@ public struct SwiftPackageManagerDependencies: Codable, Equatable {
     /// - Parameter baseSettings: Additional settings to be added to targets generated from SwiftPackageManager.
     /// - Parameter targetSettings: Additional settings to be added to targets generated from SwiftPackageManager.
     /// - Parameter projectOptions: Custom project configurations to be used for projects generated from SwiftPackageManager.
-
+    @available(*, deprecated, message: "Use init with manifest path instead")
     public init(
         _ packages: [Package],
         productTypes: [String: Product] = [:],
@@ -43,7 +45,27 @@ public struct SwiftPackageManagerDependencies: Codable, Equatable {
         targetSettings: [String: SettingsDictionary] = [:],
         projectOptions: [String: ProjectDescription.Project.Options] = [:]
     ) {
-        self.packages = packages
+        self.packagesOrManifestPath = .packages(packages)
+        self.productTypes = productTypes
+        self.baseSettings = baseSettings
+        self.targetSettings = targetSettings
+        self.projectOptions = projectOptions
+    }
+
+    /// Creates `SwiftPackageManagerDependencies` instance.
+    /// - Parameter manifest: The path to the `Package.swift` manifest defining the dependencies.
+    /// - Parameter productTypes: The custom `Product` types to be used for SPM targets.
+    /// - Parameter baseSettings: Additional settings to be added to targets generated from SwiftPackageManager.
+    /// - Parameter targetSettings: Additional settings to be added to targets generated from SwiftPackageManager.
+    /// - Parameter projectOptions: Custom project configurations to be used for projects generated from SwiftPackageManager.
+    public init(
+        manifest: Path = "Package.swift",
+        productTypes: [String: Product] = [:],
+        baseSettings: Settings = .settings(),
+        targetSettings: [String: SettingsDictionary] = [:],
+        projectOptions: [String: ProjectDescription.Project.Options] = [:]
+    ) {
+        self.packagesOrManifestPath = .manifest(manifest)
         self.productTypes = productTypes
         self.baseSettings = baseSettings
         self.targetSettings = targetSettings

--- a/Sources/TuistDependencies/DependenciesController.swift
+++ b/Sources/TuistDependencies/DependenciesController.swift
@@ -167,9 +167,7 @@ public final class DependenciesController: DependenciesControlling {
             try carthageInteractor.clean(dependenciesDirectory: dependenciesDirectory)
         }
 
-        if let swiftPackageManagerDependencies = dependencies.swiftPackageManager,
-           !swiftPackageManagerDependencies.packages.isEmpty
-        {
+        if let swiftPackageManagerDependencies = dependencies.swiftPackageManager {
             let swiftPackageManagerDependenciesGraph = try swiftPackageManagerInteractor.install(
                 dependenciesDirectory: dependenciesDirectory,
                 dependencies: swiftPackageManagerDependencies,

--- a/Sources/TuistGraph/Models/Dependencies/SwiftPackageManagerDependencies.swift
+++ b/Sources/TuistGraph/Models/Dependencies/SwiftPackageManagerDependencies.swift
@@ -1,25 +1,15 @@
 import Foundation
 import TSCBasic
 
-/// Contains the description of a dependency that can be installed using Swift Package Manager.
-///
-/// Example:
-///
-/// ```swift
-/// let packageManager = SwiftPackageManagerDependencies(
-///     packages: [
-///         .package(url: "https://github.com/Alamofire/Alamofire", .upToNextMajor(from: "5.6.0")),
-///         .local(path: "MySwiftPackage")
-///     ],
-///     baseSettings: .settings(configurations: [.debug(name: .debug), .release(name: .release)]),
-///     targetSettings: ["MySwiftPackageTarget": ["IPHONEOS_DEPLOYMENT_TARGET": SettingValue.string("13.0")]],
-///     projectOptions: ["MySwiftPackage":  .options(disableSynthesizedResourceAccessors: false)]
-/// )
-/// ```
+public enum PackagesOrManifestPath: Equatable {
+    case packages([Package])
+    case manifest(AbsolutePath)
+}
 
+/// Contains the description of a dependency that can be installed using Swift Package Manager.
 public struct SwiftPackageManagerDependencies: Equatable {
-    /// List of packages that will be installed using Swift Package Manager.
-    public let packages: [Package]
+    /// The path to the `Package.swift` manifest defining the dependencies, or the list of packages that will be installed using Swift Package Manager.
+    public let packagesOrManifest: PackagesOrManifestPath
 
     /// The custom `Product` types to be used for SPM targets.
     public let productTypes: [String: Product]
@@ -35,20 +25,20 @@ public struct SwiftPackageManagerDependencies: Equatable {
 
     /// Initializes a new `SwiftPackageManagerDependencies` instance.
     /// - Parameters:
-    ///    - packages: List of packages that will be installed using Swift Package Manager.
+    ///    - packagesOrManifestPath: The path to the `Package.swift` manifest defining the dependencies, or the list of packages that will be installed using Swift Package Manager.
     ///    - productTypes: The custom `Product` types to be used for SPM targets.
     ///    - baseSettings: The base settings to be used for targets generated from SwiftPackageManager
     ///    - targetSettings: The custom `SettingsDictionary` to be applied to denoted targets
     ///    - projectOptions: The custom project options for each project generated from a swift package
 
     public init(
-        _ packages: [Package],
+        _ packagesOrManifest: PackagesOrManifestPath,
         productTypes: [String: Product],
         baseSettings: Settings,
         targetSettings: [String: SettingsDictionary],
         projectOptions: [String: TuistGraph.Project.Options] = [:]
     ) {
-        self.packages = packages
+        self.packagesOrManifest = packagesOrManifest
         self.productTypes = productTypes
         self.baseSettings = baseSettings
         self.targetSettings = targetSettings
@@ -57,21 +47,32 @@ public struct SwiftPackageManagerDependencies: Equatable {
 }
 
 extension SwiftPackageManagerDependencies {
-    /// Returns `Package.swift` representation.
-    public func manifestValue(isLegacy: Bool, packageManifestFolder: AbsolutePath) -> String {
-        """
-        import PackageDescription
+    public enum Manifest: Equatable {
+        case content(String)
+        case path(AbsolutePath)
+    }
 
-        let package = Package(
-            name: "PackageName",
-            dependencies: [
-                \(packages.map {
-                    let manifest = $0.manifestValue(isLegacy: isLegacy, packageManifestFolder: packageManifestFolder)
-                    return manifest + ","
-                }.joined(separator: "\n        "))
-            ]
-        )
-        """
+    /// Returns `Package.swift` representation.
+    public func manifest(isLegacy: Bool, packageManifestFolder: AbsolutePath) -> Manifest {
+        switch self.packagesOrManifest {
+        case .packages(let packages):
+            return .content("""
+                import PackageDescription
+
+                let package = Package(
+                    name: "PackageName",
+                    dependencies: [
+                        \(packages.map {
+                            let manifest = $0.manifestValue(isLegacy: isLegacy, packageManifestFolder: packageManifestFolder)
+                            return manifest + ","
+                        }.joined(separator: "\n        "))
+                    ]
+                )
+                """
+            )
+        case .manifest(let path):
+            return .path(path)
+        }
     }
 }
 

--- a/Sources/TuistLoader/Models+ManifestMappers/SwiftPackageManagerDependencies+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/SwiftPackageManagerDependencies+ManifestMapper.swift
@@ -12,7 +12,13 @@ extension TuistGraph.SwiftPackageManagerDependencies {
         manifest: ProjectDescription.SwiftPackageManagerDependencies,
         generatorPaths: GeneratorPaths
     ) throws -> Self {
-        let packages = try manifest.packages.map { try TuistGraph.Package.from(manifest: $0, generatorPaths: generatorPaths) }
+        let packagesOrManifestPath: TuistGraph.PackagesOrManifestPath
+        switch manifest.packagesOrManifestPath {
+        case .packages(let packages):
+            packagesOrManifestPath = .packages(try packages.map { try TuistGraph.Package.from(manifest: $0, generatorPaths: generatorPaths) })
+        case .manifest(let path):
+            packagesOrManifestPath = .manifest(try generatorPaths.resolve(path: path))
+        }
         let productTypes = manifest.productTypes.mapValues { TuistGraph.Product.from(manifest: $0) }
         let baseSettings = try TuistGraph.Settings.from(manifest: manifest.baseSettings, generatorPaths: generatorPaths)
         let targetSettings = manifest.targetSettings.mapValues { TuistGraph.SettingsDictionary.from(manifest: $0) }
@@ -21,7 +27,7 @@ extension TuistGraph.SwiftPackageManagerDependencies {
             .mapValues { .from(manifest: $0) }
 
         return .init(
-            packages,
+            packagesOrManifestPath,
             productTypes: productTypes,
             baseSettings: baseSettings,
             targetSettings: targetSettings,

--- a/Tests/TuistDependenciesTests/DependenciesControllerTests.swift
+++ b/Tests/TuistDependenciesTests/DependenciesControllerTests.swift
@@ -95,10 +95,10 @@ final class DependenciesControllerTests: TuistUnitTestCase {
 
         let platforms: Set<TuistGraph.Platform> = [.iOS]
         let swiftPackageManagerDependencies = SwiftPackageManagerDependencies(
-            [
+            .packages([
                 .remote(url: "Moya", requirement: .exact("2.3.4")),
                 .remote(url: "Alamofire", requirement: .upToNextMajor("5.0.0")),
-            ],
+            ]),
             productTypes: [:],
             baseSettings: .default,
             targetSettings: [:]
@@ -147,10 +147,10 @@ final class DependenciesControllerTests: TuistUnitTestCase {
             ]
         )
         let swiftPackageManagerDependencies = SwiftPackageManagerDependencies(
-            [
+            .packages([
                 .remote(url: "Moya", requirement: .exact("2.3.4")),
                 .remote(url: "Alamofire", requirement: .upToNextMajor("5.0.0")),
-            ],
+            ]),
             productTypes: [:],
             baseSettings: .default,
             targetSettings: [:]
@@ -217,9 +217,9 @@ final class DependenciesControllerTests: TuistUnitTestCase {
                 ]
             ),
             swiftPackageManager: .init(
-                [
+                .packages([
                     .remote(url: "Moya", requirement: .exact("2.3.4")),
-                ],
+                ]),
                 productTypes: [:],
                 baseSettings: .default,
                 targetSettings: [:]
@@ -268,7 +268,7 @@ final class DependenciesControllerTests: TuistUnitTestCase {
 
         let dependencies = TuistGraph.Dependencies(
             carthage: .init([]),
-            swiftPackageManager: .init([], productTypes: [:], baseSettings: .default, targetSettings: [:]),
+            swiftPackageManager: .init(.packages([]), productTypes: [:], baseSettings: .default, targetSettings: [:]),
             platforms: []
         )
 
@@ -285,7 +285,7 @@ final class DependenciesControllerTests: TuistUnitTestCase {
 
         let dependencies = TuistGraph.Dependencies(
             carthage: .init([]),
-            swiftPackageManager: .init([], productTypes: [:], baseSettings: .default, targetSettings: [:]),
+            swiftPackageManager: .init(.packages([]), productTypes: [:], baseSettings: .default, targetSettings: [:]),
             platforms: [.iOS]
         )
 
@@ -296,9 +296,6 @@ final class DependenciesControllerTests: TuistUnitTestCase {
         XCTAssertEqual(graphManifest, .none)
         XCTAssertFalse(carthageInteractor.invokedInstall)
         XCTAssertTrue(carthageInteractor.invokedClean)
-
-        XCTAssertFalse(swiftPackageManagerInteractor.invokedInstall)
-        XCTAssertTrue(swiftPackageManagerInteractor.invokedClean)
     }
 
     // MARK: - Update
@@ -354,10 +351,10 @@ final class DependenciesControllerTests: TuistUnitTestCase {
 
         let platforms: Set<TuistGraph.Platform> = [.iOS]
         let swiftPackageManagerDependencies = SwiftPackageManagerDependencies(
-            [
+            .packages([
                 .remote(url: "Moya", requirement: .exact("2.3.4")),
                 .remote(url: "Alamofire", requirement: .upToNextMajor("5.0.0")),
-            ],
+            ]),
             productTypes: [:],
             baseSettings: .default,
             targetSettings: [:]
@@ -405,10 +402,10 @@ final class DependenciesControllerTests: TuistUnitTestCase {
             ]
         )
         let swiftPackageManagerDependencies = SwiftPackageManagerDependencies(
-            [
+            .packages([
                 .remote(url: "Moya", requirement: .exact("2.3.4")),
                 .remote(url: "Alamofire", requirement: .upToNextMajor("5.0.0")),
-            ],
+            ]),
             productTypes: [:],
             baseSettings: .default,
             targetSettings: [:]
@@ -456,7 +453,7 @@ final class DependenciesControllerTests: TuistUnitTestCase {
 
         let dependencies = TuistGraph.Dependencies(
             carthage: .init([]),
-            swiftPackageManager: .init([], productTypes: [:], baseSettings: .default, targetSettings: [:]),
+            swiftPackageManager: .init(.packages([]), productTypes: [:], baseSettings: .default, targetSettings: [:]),
             platforms: []
         )
 
@@ -473,7 +470,7 @@ final class DependenciesControllerTests: TuistUnitTestCase {
 
         let dependencies = TuistGraph.Dependencies(
             carthage: .init([]),
-            swiftPackageManager: .init([], productTypes: [:], baseSettings: .default, targetSettings: [:]),
+            swiftPackageManager: .init(.packages([]), productTypes: [:], baseSettings: .default, targetSettings: [:]),
             platforms: [.iOS]
         )
 
@@ -484,9 +481,6 @@ final class DependenciesControllerTests: TuistUnitTestCase {
         XCTAssertEqual(graphManifest, .none)
         XCTAssertFalse(carthageInteractor.invokedInstall)
         XCTAssertTrue(carthageInteractor.invokedClean)
-
-        XCTAssertFalse(swiftPackageManagerInteractor.invokedInstall)
-        XCTAssertTrue(swiftPackageManagerInteractor.invokedClean)
     }
 
     func test_save() throws {

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
@@ -45,9 +45,9 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         let swiftPackageManagerBuildDirectory = swiftPackageManagerDirectory.appending(component: ".build")
 
         let dependencies = SwiftPackageManagerDependencies(
-            [
+            .packages([
                 .remote(url: "https://github.com/Alamofire/Alamofire.git", requirement: .upToNextMajor("5.2.0")),
-            ],
+            ]),
             productTypes: [:],
             baseSettings: .default,
             targetSettings: [:]
@@ -137,9 +137,9 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
 
         let swiftToolsVersion = TSCUtility.Version(5, 3, 0)
         let dependencies = SwiftPackageManagerDependencies(
-            [
+            .packages([
                 .remote(url: "https://github.com/Alamofire/Alamofire.git", requirement: .upToNextMajor("5.2.0")),
-            ],
+            ]),
             productTypes: [:],
             baseSettings: .default,
             targetSettings: [:]
@@ -227,9 +227,9 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         let swiftPackageManagerBuildDirectory = swiftPackageManagerDirectory.appending(component: ".build")
 
         let dependencies = SwiftPackageManagerDependencies(
-            [
+            .packages([
                 .remote(url: "https://github.com/Alamofire/Alamofire.git", requirement: .upToNextMajor("5.2.0")),
-            ],
+            ]),
             productTypes: [:],
             baseSettings: .default,
             targetSettings: [:]

--- a/Tests/TuistKitTests/Services/FetchServiceTests.swift
+++ b/Tests/TuistKitTests/Services/FetchServiceTests.swift
@@ -64,9 +64,9 @@ final class FetchServiceTests: TuistUnitTestCase {
                 ]
             ),
             swiftPackageManager: .init(
-                [
+                .packages([
                     .remote(url: "Dependency1/Dependency1", requirement: .upToNextMajor("1.2.3")),
-                ],
+                ]),
                 productTypes: [:], baseSettings: .default,
                 targetSettings: [:]
             ),
@@ -147,9 +147,9 @@ final class FetchServiceTests: TuistUnitTestCase {
                 ]
             ),
             swiftPackageManager: .init(
-                [
+                .packages([
                     .remote(url: "Dependency1/Dependency1", requirement: .upToNextMajor("1.2.3")),
-                ],
+                ]),
                 productTypes: [:],
                 baseSettings: .default,
                 targetSettings: [:]

--- a/Tests/TuistLoaderTests/Loaders/DependenciesModelLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/DependenciesModelLoaderTests.swift
@@ -64,10 +64,10 @@ final class DependenciesModelLoaderTests: TuistUnitTestCase {
                 ]
             ),
             swiftPackageManager: .init(
-                [
+                .packages([
                     .local(path: localSwiftPackagePath),
                     .remote(url: "RemoteUrl.com", requirement: .exact("1.2.3")),
-                ],
+                ]),
                 productTypes: [:],
                 baseSettings: .init(configurations: [
                     .debug: .init(settings: [:], xcconfig: nil),

--- a/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerDependenciesTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/SwiftPackageManagerDependenciesTests.swift
@@ -4,12 +4,12 @@ import XCTest
 @testable import TuistSupportTesting
 
 final class SwiftPackageManagerDependenciesTests: TuistUnitTestCase {
-    func test_manifestValue_singleDependency() {
+    func test_manifestValue_singleDependency() throws {
         // Given
         let subject = SwiftPackageManagerDependencies(
-            [
+            .packages([
                 .remote(url: "url/url/url", requirement: .branch("branch")),
-            ],
+            ]),
             productTypes: [:],
             baseSettings: .init(configurations: [:]),
             targetSettings: [:],
@@ -17,10 +17,10 @@ final class SwiftPackageManagerDependenciesTests: TuistUnitTestCase {
         )
 
         // When
-        let got = subject.manifestValue(isLegacy: false, packageManifestFolder: "/")
+        let got = subject.manifest(isLegacy: false, packageManifestFolder: "/")
 
         // Then
-        let expected = """
+        let expected = SwiftPackageManagerDependencies.Manifest.content("""
         import PackageDescription
 
         let package = Package(
@@ -29,14 +29,14 @@ final class SwiftPackageManagerDependenciesTests: TuistUnitTestCase {
                 .package(url: "url/url/url", branch: "branch"),
             ]
         )
-        """
+        """)
         XCTAssertEqual(got, expected)
     }
 
-    func test_manifestValue_multipleDependencies() {
+    func test_manifestValue_multipleDependencies() throws {
         // Given
         let subject = SwiftPackageManagerDependencies(
-            [
+            .packages([
                 .remote(url: "xyz", requirement: .exact("10.10.10")),
                 .remote(url: "foo/foo", requirement: .upToNextMinor("1.2.3")),
                 .remote(url: "bar/bar", requirement: .upToNextMajor("3.2.1")),
@@ -44,7 +44,7 @@ final class SwiftPackageManagerDependenciesTests: TuistUnitTestCase {
                 .remote(url: "https://www.google.com/", requirement: .revision("a083aa1435eb35d8a1cb369115a7636cb4b65135")),
                 .remote(url: "url/url/url", requirement: .range(from: "1.2.3", to: "5.2.1")),
                 .local(path: "/path/path/path"),
-            ],
+            ]),
             productTypes: [:],
             baseSettings: .init(configurations: [:]),
             targetSettings: [:],
@@ -52,10 +52,10 @@ final class SwiftPackageManagerDependenciesTests: TuistUnitTestCase {
         )
 
         // When
-        let got = subject.manifestValue(isLegacy: false, packageManifestFolder: "/path")
+        let got = subject.manifest(isLegacy: false, packageManifestFolder: "/path")
 
         // Then
-        let expected = """
+        let expected = SwiftPackageManagerDependencies.Manifest.content("""
         import PackageDescription
 
         let package = Package(
@@ -70,16 +70,16 @@ final class SwiftPackageManagerDependenciesTests: TuistUnitTestCase {
                 .package(path: "path/path"),
             ]
         )
-        """
+        """)
         XCTAssertEqual(got, expected)
     }
 
-    func test_legacyManifestValue_singleDependency() {
+    func test_legacyManifest_singleDependency() throws {
         // Given
         let subject = SwiftPackageManagerDependencies(
-            [
+            .packages([
                 .remote(url: "url/url/url", requirement: .branch("branch")),
-            ],
+            ]),
             productTypes: [:],
             baseSettings: .init(configurations: [:]),
             targetSettings: [:],
@@ -87,10 +87,10 @@ final class SwiftPackageManagerDependenciesTests: TuistUnitTestCase {
         )
 
         // When
-        let got = subject.manifestValue(isLegacy: true, packageManifestFolder: "/path")
+        let got = subject.manifest(isLegacy: true, packageManifestFolder: "/path")
 
         // Then
-        let expected = """
+        let expected = SwiftPackageManagerDependencies.Manifest.content("""
         import PackageDescription
 
         let package = Package(
@@ -99,14 +99,14 @@ final class SwiftPackageManagerDependenciesTests: TuistUnitTestCase {
                 .package(url: "url/url/url", .branch("branch")),
             ]
         )
-        """
+        """)
         XCTAssertEqual(got, expected)
     }
 
-    func test_legacyManifestValue_multipleDependencies() {
+    func test_legacyManifest_multipleDependencies() throws {
         // Given
         let subject = SwiftPackageManagerDependencies(
-            [
+            .packages([
                 .remote(url: "xyz", requirement: .exact("10.10.10")),
                 .remote(url: "foo/foo", requirement: .upToNextMinor("1.2.3")),
                 .remote(url: "bar/bar", requirement: .upToNextMajor("3.2.1")),
@@ -114,7 +114,7 @@ final class SwiftPackageManagerDependenciesTests: TuistUnitTestCase {
                 .remote(url: "https://www.google.com/", requirement: .revision("a083aa1435eb35d8a1cb369115a7636cb4b65135")),
                 .remote(url: "url/url/url", requirement: .range(from: "1.2.3", to: "5.2.1")),
                 .local(path: "/path/path/path"),
-            ],
+            ]),
             productTypes: [:],
             baseSettings: .init(configurations: [:]),
             targetSettings: [:],
@@ -122,10 +122,10 @@ final class SwiftPackageManagerDependenciesTests: TuistUnitTestCase {
         )
 
         // When
-        let got = subject.manifestValue(isLegacy: true, packageManifestFolder: "/path")
+        let got = subject.manifest(isLegacy: true, packageManifestFolder: "/path")
 
         // Then
-        let expected = """
+        let expected = SwiftPackageManagerDependencies.Manifest.content("""
         import PackageDescription
 
         let package = Package(
@@ -140,7 +140,7 @@ final class SwiftPackageManagerDependenciesTests: TuistUnitTestCase {
                 .package(path: "path/path"),
             ]
         )
-        """
+        """)
         XCTAssertEqual(got, expected)
     }
 }

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/DependenciesManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/DependenciesManifestMapperTests.swift
@@ -44,10 +44,10 @@ final class DependenciesManifestMapperTests: TuistUnitTestCase {
                 ]
             ),
             swiftPackageManager: .init(
-                [
+                .packages([
                     .local(path: localPackagePath),
                     .remote(url: "RemotePackage.com", requirement: .exact("1.2.3")),
-                ],
+                ]),
                 productTypes: [:],
                 baseSettings: .init(configurations: [
                     .debug: .init(settings: [:], xcconfig: nil),

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -1,26 +1,6 @@
 import ProjectDescription
 
 let dependencies = Dependencies(
-    swiftPackageManager: [
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.3"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"),
-        .package(url: "https://github.com/apple/swift-log", from: "1.5.3"),
-        .package(url: "https://github.com/apple/swift-tools-support-core", from: "0.6.1"),
-        .package(url: "https://github.com/CombineCommunity/CombineExt", from: "1.8.1"),
-        .package(url: "https://github.com/FabrizioBrancati/Queuer", from: "2.1.1"),
-        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.7"),
-        .package(url: "https://github.com/weichsel/ZIPFoundation", from: "0.9.17"),
-        .package(url: "https://github.com/httpswift/swifter", .revision("1e4f51c92d7ca486242d8bf0722b99de2c3531aa")),
-        .package(url: "https://github.com/kishikawakatsumi/KeychainAccess", from: "4.2.2"),
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift", from: "1.8.0"),
-        .package(url: "https://github.com/rnine/Checksum", from: "1.0.2"),
-        .package(url: "https://github.com/stencilproject/Stencil", from: "0.15.1"),
-        .package(url: "https://github.com/SwiftDocOrg/GraphViz", .exact("0.2.0")),
-        .package(url: "https://github.com/SwiftGen/StencilSwiftKit", from: "2.10.1"),
-        .package(url: "https://github.com/SwiftGen/SwiftGen", from: "6.6.2"),
-        .package(url: "https://github.com/tuist/XcodeProj", from: "8.15.0"),
-        .package(url: "https://github.com/tuist/swift-openapi-runtime", .branch("swift-tools-version")),
-        .package(url: "https://github.com/tuist/swift-openapi-urlsession", .branch("swift-tools-version")),
-    ],
+    swiftPackageManager: .init(manifest: "Package.swift"),
     platforms: [.macOS]
 )

--- a/Tuist/Dependencies/Package.swift
+++ b/Tuist/Dependencies/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 5.8
+import PackageDescription
+
+let package = Package(
+    name: "PackageName",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.3"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"),
+        .package(url: "https://github.com/apple/swift-log", from: "1.5.3"),
+        .package(url: "https://github.com/apple/swift-tools-support-core", from: "0.6.1"),
+        .package(url: "https://github.com/CombineCommunity/CombineExt", from: "1.8.1"),
+        .package(url: "https://github.com/FabrizioBrancati/Queuer", from: "2.1.1"),
+        .package(url: "https://github.com/Flight-School/AnyCodable", from: "0.6.7"),
+        .package(url: "https://github.com/weichsel/ZIPFoundation", from: "0.9.17"),
+        .package(url: "https://github.com/httpswift/swifter", revision: "1e4f51c92d7ca486242d8bf0722b99de2c3531aa"),
+        .package(url: "https://github.com/kishikawakatsumi/KeychainAccess", from: "4.2.2"),
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift", from: "1.8.0"),
+        .package(url: "https://github.com/rnine/Checksum", from: "1.0.2"),
+        .package(url: "https://github.com/stencilproject/Stencil", from: "0.15.1"),
+        .package(url: "https://github.com/SwiftDocOrg/GraphViz", exact: "0.2.0"),
+        .package(url: "https://github.com/SwiftGen/StencilSwiftKit", from: "2.10.1"),
+        .package(url: "https://github.com/SwiftGen/SwiftGen", from: "6.6.2"),
+        .package(url: "https://github.com/tuist/XcodeProj", from: "8.15.0"),
+        .package(url: "https://github.com/tuist/swift-openapi-runtime", branch: "swift-tools-version"),
+        .package(url: "https://github.com/tuist/swift-openapi-urlsession", branch: "swift-tools-version"),
+    ]
+)

--- a/projects/tuist/fixtures/app_with_spm_dependencies/Tuist/Dependencies.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/Tuist/Dependencies.swift
@@ -17,7 +17,7 @@ let packages: [Package] = [
 
 let dependencies = Dependencies(
     swiftPackageManager: .init(
-        packages,
+        manifest: "Package.swift",
         baseSettings: .targetSettings,
         projectOptions: [
             "LocalSwiftPackage": .options(disableSynthesizedResourceAccessors: false),

--- a/projects/tuist/fixtures/app_with_spm_dependencies/Tuist/Package.swift
+++ b/projects/tuist/fixtures/app_with_spm_dependencies/Tuist/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "PackageName",
+    dependencies: [
+        .package(url: "https://github.com/Alamofire/Alamofire", from: "5.8.0"),
+        .package(url: "https://github.com/facebook/facebook-ios-sdk", from: "16.1.3"),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.15.0"),
+        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", .upToNextMinor(from: "1.0.0")),
+        .package(url: "https://github.com/iterable/swift-sdk", from: "6.4.15"),
+        .package(url: "https://github.com/Trendyol/ios-components", revision: "c9260bfe203a16a278eca5542c98455eece98aa4"),
+        .package(url: "https://github.com/stripe/stripe-ios", from: "23.12.0"),
+        .package(path: "../../../LocalSwiftPackage"),
+        .package(url: "https://github.com/groue/GRDB.swift", from: "6.16.0"),
+        .package(path: "../../../StringifyMacro"),
+    ]
+)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5280

### Short description 📝

Using Package.swift provides better integration with existing 3rd party tools such as Snyk

### How to test the changes locally 🧐

Change is integrated into Tuist own Dependencies.swift

### Contributor checklist ✅

- [x] The code has been linted using run `make lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
