### PR TITLE
Support SwiftGen ParserOptions in ResourceSynthesizer

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -86,6 +86,7 @@ func targets() -> [Target] {
             name: "TuistSupport",
             hasIntegrationTests: true,
             dependencies: [
+                .external(name: "AnyCodable"),
                 .external(name: "ArgumentParser"),
                 .external(name: "Checksum"),
                 .external(name: "CombineExt"),

--- a/Project.swift
+++ b/Project.swift
@@ -98,8 +98,8 @@ func targets() -> [Target] {
                 .external(name: "Queuer"),
                 .external(name: "Stencil"),
                 .external(name: "StencilSwiftKit"),
-                .external(name: "Swifter"),
                 .external(name: "SwiftToolsSupport"),
+                .external(name: "Swifter"),
                 .external(name: "XcodeProj"),
                 .external(name: "ZIPFoundation"),
                 .target(name: "ProjectDescription"),
@@ -356,7 +356,7 @@ func targets() -> [Target] {
                 .target(name: "TuistCore"),
                 .target(name: "TuistGraph"),
                 .target(name: "TuistLoader"),
-                .external(name: "AnyCodable"),
+                .target(name: "TuistSupport"),
             ]),
             testDependencies: [
                 .target(name: "TuistSupportTesting"),
@@ -458,7 +458,7 @@ func targets() -> [Target] {
                 .target(name: "TuistCoreTesting"),
                 .target(name: "TuistGraphTesting"),
             ]
-        ).flatMap { $0 })
+        ).compactMap { $0 })
     }
     return executableTargets + moduleTargets
 }

--- a/Sources/ProjectDescription/ResourceSynthesizer.swift
+++ b/Sources/ProjectDescription/ResourceSynthesizer.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 /// For example to synthesize resource accessors for strings, you can use:
 /// - `.strings()` for tuist's default
-/// - `.strings(parserOptions: ["separator": .stringValue("/")])` to use strings template with SwiftGen Parser Options
+/// - `.strings(parserOptions: ["separator": "/"])` to use strings template with SwiftGen Parser Options
 /// - `.strings(plugin: "MyPlugin")` to use strings template from a plugin
 /// - `.strings(templatePath: "Templates/Strings.stencil")` to use strings template at a given path
 public struct ResourceSynthesizer: Codable, Equatable {
@@ -42,10 +42,18 @@ public struct ResourceSynthesizer: Codable, Equatable {
         case files
 
         public enum Option: Equatable, Codable {
-            case stringValue(String)
-            case intValue(Int)
-            case boolValue(Bool)
-            case doubleValue(Double)
+            /// It represents a string value.
+            case string(String)
+            /// It represents an integer value.
+            case integer(Int)
+            /// It represents a floating value.
+            case double(Double)
+            /// It represents a boolean value.
+            case boolean(Bool)
+            /// It represents a dictionary value.
+            case dictionary([String: Option])
+            /// It represents an array value.
+            case array([Option])
         }
     }
 
@@ -399,5 +407,53 @@ extension [ResourceSynthesizer] {
             .plists(),
             .fonts(),
         ]
+    }
+}
+
+// MARK: - ResourceSynthesizer.Parser.Option - ExpressibleByStringInterpolation
+
+extension ResourceSynthesizer.Parser.Option: ExpressibleByStringInterpolation {
+    public init(stringLiteral value: String) {
+        self = .string(value)
+    }
+}
+
+// MARK: - ResourceSynthesizer.Parser.Option - ExpressibleByIntegerLiteral
+
+extension ResourceSynthesizer.Parser.Option: ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: Int) {
+        self = .integer(value)
+    }
+}
+
+// MARK: - ResourceSynthesizer.Parser.Option - ExpressibleByFloatLiteral
+
+extension ResourceSynthesizer.Parser.Option: ExpressibleByFloatLiteral {
+    public init(floatLiteral value: Double) {
+        self = .double(value)
+    }
+}
+
+// MARK: - ResourceSynthesizer.Parser.Option - ExpressibleByBooleanLiteral
+
+extension ResourceSynthesizer.Parser.Option: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) {
+        self = .boolean(value)
+    }
+}
+
+// MARK: - ResourceSynthesizer.Parser.Option - ExpressibleByDictionaryLiteral
+
+extension ResourceSynthesizer.Parser.Option: ExpressibleByDictionaryLiteral {
+    public init(dictionaryLiteral elements: (String, Self)...) {
+        self = .dictionary(Dictionary(uniqueKeysWithValues: elements))
+    }
+}
+
+// MARK: - ResourceSynthesizer.Parser.Option - ExpressibleByArrayLiteral
+
+extension ResourceSynthesizer.Parser.Option: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: Self...) {
+        self = .array(elements)
     }
 }

--- a/Sources/ProjectDescription/ResourceSynthesizer.swift
+++ b/Sources/ProjectDescription/ResourceSynthesizer.swift
@@ -4,12 +4,14 @@ import Foundation
 ///
 /// For example to synthesize resource accessors for strings, you can use:
 /// - `.strings()` for tuist's default
+/// - `.strings(parserOptions: ["separator": .stringValue("/")])` to use strings template with SwiftGen Parser Options
 /// - `.strings(plugin: "MyPlugin")` to use strings template from a plugin
 /// - `.strings(templatePath: "Templates/Strings.stencil")` to use strings template at a given path
 public struct ResourceSynthesizer: Codable, Equatable {
     /// Templates can be of multiple types
     public let templateType: TemplateType
     public let parser: Parser
+    public let parserOptions: [String: Parser.Option]
     public let extensions: Set<String>
 
     /// Templates can be either a local template file, from a plugin, or a default template from tuist
@@ -38,212 +40,312 @@ public struct ResourceSynthesizer: Codable, Equatable {
         case json
         case yaml
         case files
+
+        public enum Option: Equatable, Codable {
+            case stringValue(String)
+            case intValue(Int)
+            case boolValue(Bool)
+            case doubleValue(Double)
+        }
     }
 
     /// Default strings synthesizer defined in `Tuist/{ProjectName}` or tuist itself
-    public static func strings() -> Self {
-        .strings(templateType: .defaultTemplate(resourceName: "Strings"))
+    public static func strings(parserOptions: [String: Parser.Option] = [:]) -> Self {
+        .strings(
+            templateType: .defaultTemplate(resourceName: "Strings"),
+            parserOptions: parserOptions
+        )
     }
 
     /// Strings synthesizer defined in a plugin
-    public static func strings(plugin: String) -> Self {
+    public static func strings(
+        plugin: String,
+        parserOptions: [String: Parser.Option] = [:]
+    ) -> Self {
         .strings(
             templateType: .plugin(
                 name: plugin,
                 resourceName: "Strings"
-            )
+            ),
+            parserOptions: parserOptions
         )
     }
 
-    private static func strings(templateType: TemplateType) -> Self {
+    private static func strings(
+        templateType: TemplateType,
+        parserOptions: [String: Parser.Option] = [:]
+    ) -> Self {
         .init(
             templateType: templateType,
             parser: .strings,
+            parserOptions: parserOptions,
             extensions: ["strings", "stringsdict"]
         )
     }
 
     /// Default assets synthesizer defined in `Tuist/{ProjectName}` or tuist itself
-    public static func assets() -> Self {
-        .assets(templateType: .defaultTemplate(resourceName: "Assets"))
+    public static func assets(parserOptions: [String: Parser.Option] = [:]) -> Self {
+        .assets(
+            templateType: .defaultTemplate(resourceName: "Assets"),
+            parserOptions: parserOptions
+        )
     }
 
     /// Assets synthesizer defined in a plugin
-    public static func assets(plugin: String) -> Self {
+    public static func assets(
+        plugin: String,
+        parserOptions: [String: Parser.Option] = [:]
+    ) -> Self {
         .assets(
             templateType: .plugin(
                 name: plugin,
                 resourceName: "Assets"
-            )
+            ),
+            parserOptions: parserOptions
         )
     }
 
-    private static func assets(templateType: TemplateType) -> Self {
+    private static func assets(
+        templateType: TemplateType,
+        parserOptions: [String: Parser.Option] = [:]
+    ) -> Self {
         .init(
             templateType: templateType,
             parser: .assets,
+            parserOptions: parserOptions,
             extensions: ["xcassets"]
         )
     }
 
     /// Default fonts synthesizer defined in `Tuist/{ProjectName}` or tuist itself
-    public static func fonts() -> Self {
-        .fonts(templateType: .defaultTemplate(resourceName: "Fonts"))
+    public static func fonts(parserOptions: [String: Parser.Option] = [:]) -> Self {
+        .fonts(templateType: .defaultTemplate(resourceName: "Fonts"), parserOptions: parserOptions)
     }
 
     /// Fonts synthesizer defined in a plugin
-    public static func fonts(plugin: String) -> Self {
+    public static func fonts(
+        plugin: String,
+        parserOptions: [String: Parser.Option] = [:]
+    ) -> Self {
         .fonts(
             templateType: .plugin(
                 name: plugin,
                 resourceName: "Fonts"
-            )
+            ),
+            parserOptions: parserOptions
         )
     }
 
-    private static func fonts(templateType: TemplateType) -> Self {
+    private static func fonts(
+        templateType: TemplateType,
+        parserOptions: [String: Parser.Option] = [:]
+    ) -> Self {
         .init(
             templateType: templateType,
             parser: .fonts,
+            parserOptions: parserOptions,
             extensions: ["otf", "ttc", "ttf"]
         )
     }
 
     /// Default plists synthesizer defined in `Tuist/{ProjectName}` or tuist itself
-    public static func plists() -> Self {
-        .plists(templateType: .defaultTemplate(resourceName: "Plists"))
+    public static func plists(parserOptions: [String: Parser.Option] = [:]) -> Self {
+        .plists(
+            templateType: .defaultTemplate(resourceName: "Plists"),
+            parserOptions: parserOptions
+        )
     }
 
     /// Plists synthesizer defined in a plugin
-    public static func plists(plugin: String) -> Self {
+    public static func plists(
+        plugin: String,
+        parserOptions: [String: Parser.Option] = [:]
+    ) -> Self {
         .plists(
             templateType: .plugin(
                 name: plugin,
                 resourceName: "Plists"
-            )
+            ),
+            parserOptions: parserOptions
         )
     }
 
-    private static func plists(templateType: TemplateType) -> Self {
+    private static func plists(
+        templateType: TemplateType,
+        parserOptions: [String: Parser.Option] = [:]
+    ) -> Self {
         .init(
             templateType: templateType,
             parser: .plists,
+            parserOptions: parserOptions,
             extensions: ["plist"]
         )
     }
 
     /// CoreData synthesizer defined in a plugin
-    public static func coreData(plugin: String) -> Self {
+    public static func coreData(
+        plugin: String,
+        parserOptions: [String: Parser.Option] = [:]
+    ) -> Self {
         .coreData(
             templateType: .plugin(
                 name: plugin,
                 resourceName: "CoreData"
-            )
+            ),
+            parserOptions: parserOptions
         )
     }
 
     /// Default CoreData synthesizer defined in `Tuist/{ProjectName}`
-    public static func coreData() -> Self {
-        .coreData(templateType: .defaultTemplate(resourceName: "CoreData"))
+    public static func coreData(parserOptions: [String: Parser.Option] = [:]) -> Self {
+        .coreData(
+            templateType: .defaultTemplate(resourceName: "CoreData"),
+            parserOptions: parserOptions
+        )
     }
 
-    private static func coreData(templateType: TemplateType) -> Self {
+    private static func coreData(
+        templateType: TemplateType,
+        parserOptions: [String: Parser.Option] = [:]
+    ) -> Self {
         .init(
             templateType: templateType,
             parser: .coreData,
+            parserOptions: parserOptions,
             extensions: ["xcdatamodeld"]
         )
     }
 
     /// InterfaceBuilder synthesizer defined in a plugin
-    public static func interfaceBuilder(plugin: String) -> Self {
+    public static func interfaceBuilder(
+        plugin: String,
+        parserOptions: [String: Parser.Option] = [:]
+    ) -> Self {
         .interfaceBuilder(
             templateType: .plugin(
                 name: plugin,
                 resourceName: "InterfaceBuilder"
-            )
+            ),
+            parserOptions: parserOptions
         )
     }
 
     /// InterfaceBuilder synthesizer with a template defined in `Tuist/{ProjectName}`
-    public static func interfaceBuilder() -> Self {
-        .interfaceBuilder(templateType: .defaultTemplate(resourceName: "InterfaceBuilder"))
+    public static func interfaceBuilder(parserOptions: [String: Parser.Option] = [:]) -> Self {
+        .interfaceBuilder(
+            templateType: .defaultTemplate(resourceName: "InterfaceBuilder"),
+            parserOptions: parserOptions
+        )
     }
 
-    private static func interfaceBuilder(templateType: TemplateType) -> Self {
+    private static func interfaceBuilder(
+        templateType: TemplateType,
+        parserOptions: [String: Parser.Option] = [:]
+    ) -> Self {
         .init(
             templateType: templateType,
             parser: .interfaceBuilder,
+            parserOptions: parserOptions,
             extensions: ["storyboard"]
         )
     }
 
     /// JSON synthesizer defined in a plugin
-    public static func json(plugin: String) -> Self {
+    public static func json(plugin: String, parserOptions: [String: Parser.Option] = [:]) -> Self {
         .coreData(
             templateType: .plugin(
                 name: plugin,
                 resourceName: "JSON"
-            )
+            ),
+            parserOptions: parserOptions
         )
     }
 
     /// JSON synthesizer with a template defined in `Tuist/{ProjectName}`
-    public static func json() -> Self {
-        .json(templateType: .defaultTemplate(resourceName: "JSON"))
+    public static func json(parserOptions: [String: Parser.Option] = [:]) -> Self {
+        .json(
+            templateType: .defaultTemplate(resourceName: "JSON"),
+            parserOptions: parserOptions
+        )
     }
 
-    private static func json(templateType: TemplateType) -> Self {
+    private static func json(
+        templateType: TemplateType,
+        parserOptions: [String: Parser.Option] = [:]
+    ) -> Self {
         .init(
             templateType: templateType,
             parser: .json,
+            parserOptions: parserOptions,
             extensions: ["json"]
         )
     }
 
     /// YAML synthesizer defined in a plugin
-    public static func yaml(plugin: String) -> Self {
+    public static func yaml(plugin: String, parserOptions: [String: Parser.Option] = [:]) -> Self {
         .yaml(
             templateType: .plugin(
                 name: plugin,
                 resourceName: "YAML"
-            )
+            ),
+            parserOptions: parserOptions
         )
     }
 
     /// CoreData synthesizer with a template defined in `Tuist/{ProjectName}`
-    public static func yaml() -> Self {
-        .yaml(templateType: .defaultTemplate(resourceName: "YAML"))
+    public static func yaml(parserOptions: [String: Parser.Option] = [:]) -> Self {
+        .yaml(templateType: .defaultTemplate(resourceName: "YAML"), parserOptions: parserOptions)
     }
 
-    private static func yaml(templateType: TemplateType) -> Self {
+    private static func yaml(
+        templateType: TemplateType,
+        parserOptions: [String: Parser.Option] = [:]
+    ) -> Self {
         .init(
             templateType: templateType,
             parser: .yaml,
+            parserOptions: parserOptions,
             extensions: ["yml"]
         )
     }
 
     /// Files synthesizer defined in a plugin
-    public static func files(plugin: String, extensions: Set<String>) -> Self {
+    public static func files(
+        plugin: String,
+        parserOptions: [String: Parser.Option] = [:],
+        extensions: Set<String>
+    ) -> Self {
         .files(
             templateType: .plugin(
                 name: plugin,
                 resourceName: "Files"
             ),
+            parserOptions: parserOptions,
             extensions: extensions
         )
     }
 
     /// Files synthesizer with a template defined in `Tuist/{ProjectName}`
-    public static func files(extensions: Set<String>) -> Self {
-        .files(templateType: .defaultTemplate(resourceName: "Files"), extensions: extensions)
+    public static func files(
+        parserOptions: [String: Parser.Option] = [:],
+        extensions: Set<String>
+    ) -> Self {
+        .files(
+            templateType: .defaultTemplate(resourceName: "Files"),
+            parserOptions: parserOptions,
+            extensions: extensions
+        )
     }
 
-    private static func files(templateType: TemplateType, extensions: Set<String>) -> Self {
+    private static func files(
+        templateType: TemplateType,
+        parserOptions: [String: Parser.Option] = [:],
+        extensions: Set<String>
+    ) -> Self {
         .init(
             templateType: templateType,
             parser: .files,
+            parserOptions: parserOptions,
             extensions: extensions
         )
     }
@@ -257,12 +359,14 @@ public struct ResourceSynthesizer: Codable, Equatable {
     public static func custom(
         plugin: String,
         parser: Parser,
+        parserOptions: [String: Parser.Option] = [:],
         extensions: Set<String>,
         resourceName: String
     ) -> Self {
         .init(
             templateType: .plugin(name: plugin, resourceName: resourceName),
             parser: parser,
+            parserOptions: parserOptions,
             extensions: extensions
         )
     }
@@ -275,11 +379,13 @@ public struct ResourceSynthesizer: Codable, Equatable {
     public static func custom(
         name: String,
         parser: Parser,
+        parserOptions: [String: Parser.Option] = [:],
         extensions: Set<String>
     ) -> Self {
         .init(
             templateType: .defaultTemplate(resourceName: name),
             parser: parser,
+            parserOptions: parserOptions,
             extensions: extensions
         )
     }

--- a/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
@@ -247,6 +247,7 @@ public final class SynthesizedResourceInterfaceProjectMapper: ProjectMapping { /
                     "Tuist\(templateName)+\(name)",
                     try synthesizedResourceInterfacesGenerator.render(
                         parser: resourceSynthesizer.parser,
+                        parserOptions: resourceSynthesizer.parserOptions,
                         templateString: templateString,
                         name: target.productName.camelized.uppercasingFirst,
                         bundleName: project.options.disableBundleAccessors ? nil : "Bundle.module",

--- a/Sources/TuistGenerator/Utils/SynthesizedResourceInterfacesGenerator.swift
+++ b/Sources/TuistGenerator/Utils/SynthesizedResourceInterfacesGenerator.swift
@@ -9,6 +9,7 @@ import TuistSupport
 protocol SynthesizedResourceInterfacesGenerating {
     func render(
         parser: ResourceSynthesizer.Parser,
+        parserOptions: [String: ResourceSynthesizer.Parser.Option],
         templateString: String,
         name: String,
         bundleName: String?,
@@ -19,6 +20,7 @@ protocol SynthesizedResourceInterfacesGenerating {
 final class SynthesizedResourceInterfacesGenerator: SynthesizedResourceInterfacesGenerating {
     func render(
         parser: ResourceSynthesizer.Parser,
+        parserOptions: [String: ResourceSynthesizer.Parser.Option],
         templateString: String,
         name: String,
         bundleName: String?,
@@ -29,7 +31,7 @@ final class SynthesizedResourceInterfacesGenerator: SynthesizedResourceInterface
             environment: stencilSwiftEnvironment()
         )
 
-        let parser = try self.parser(for: parser)
+        let parser = try self.parser(for: parser, with: parserOptions)
 
         try paths.forEach { try parser.parse(path: Path($0.pathString), relativeTo: Path("")) }
         var context = parser.stencilContext()
@@ -42,26 +44,30 @@ final class SynthesizedResourceInterfacesGenerator: SynthesizedResourceInterface
 
     // MARK: - Helpers
 
-    private func parser(for parser: ResourceSynthesizer.Parser) throws -> Parser {
+    private func parser(
+        for parser: ResourceSynthesizer.Parser,
+        with parserOptions: [String: ResourceSynthesizer.Parser.Option]
+    ) throws -> Parser {
+        let options = parserOptions.mapValues(\.value)
         switch parser {
         case .assets:
-            return try AssetsCatalog.Parser()
+            return try AssetsCatalog.Parser(options: options)
         case .strings:
-            return try Strings.Parser()
+            return try Strings.Parser(options: options)
         case .plists:
-            return try Plist.Parser()
+            return try Plist.Parser(options: options)
         case .fonts:
-            return try Fonts.Parser()
+            return try Fonts.Parser(options: options)
         case .coreData:
-            return try CoreData.Parser()
+            return try CoreData.Parser(options: options)
         case .interfaceBuilder:
-            return try InterfaceBuilder.Parser()
+            return try InterfaceBuilder.Parser(options: options)
         case .json:
-            return try JSON.Parser()
+            return try JSON.Parser(options: options)
         case .yaml:
-            return try Yaml.Parser()
+            return try Yaml.Parser(options: options)
         case .files:
-            return try Files.Parser()
+            return try Files.Parser(options: options)
         }
     }
 

--- a/Sources/TuistGraph/Models/ResourceSynthesizer.swift
+++ b/Sources/TuistGraph/Models/ResourceSynthesizer.swift
@@ -1,8 +1,10 @@
+import AnyCodable
 import Foundation
 import TSCBasic
 
 public struct ResourceSynthesizer: Equatable, Hashable, Codable {
     public let parser: Parser
+    public let parserOptions: [String: Parser.Option]
     public let extensions: Set<String>
     public let template: Template
 
@@ -21,14 +23,25 @@ public struct ResourceSynthesizer: Equatable, Hashable, Codable {
         case json
         case yaml
         case files
+
+        public struct Option: Equatable, Hashable, Codable {
+            public var value: Any { anyCodableValue.value }
+            private let anyCodableValue: AnyCodable
+
+            public init(value: some Any) {
+                anyCodableValue = AnyCodable(value)
+            }
+        }
     }
 
     public init(
         parser: Parser,
+        parserOptions: [String: Parser.Option],
         extensions: Set<String>,
         template: Template
     ) {
         self.parser = parser
+        self.parserOptions = parserOptions
         self.extensions = extensions
         self.template = template
     }

--- a/Sources/TuistGraph/Models/ResourceSynthesizer.swift
+++ b/Sources/TuistGraph/Models/ResourceSynthesizer.swift
@@ -46,3 +46,51 @@ public struct ResourceSynthesizer: Equatable, Hashable, Codable {
         self.template = template
     }
 }
+
+// MARK: - ResourceSynthesizer.Parser.Option - ExpressibleByStringInterpolation
+
+extension ResourceSynthesizer.Parser.Option: ExpressibleByStringInterpolation {
+    public init(stringLiteral value: String) {
+        self = .init(value: value)
+    }
+}
+
+// MARK: - ResourceSynthesizer.Parser.Option - ExpressibleByIntegerLiteral
+
+extension ResourceSynthesizer.Parser.Option: ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: Int) {
+        self = .init(value: value)
+    }
+}
+
+// MARK: - ResourceSynthesizer.Parser.Option - ExpressibleByFloatLiteral
+
+extension ResourceSynthesizer.Parser.Option: ExpressibleByFloatLiteral {
+    public init(floatLiteral value: Double) {
+        self = .init(value: value)
+    }
+}
+
+// MARK: - ResourceSynthesizer.Parser.Option - ExpressibleByBooleanLiteral
+
+extension ResourceSynthesizer.Parser.Option: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) {
+        self = .init(value: value)
+    }
+}
+
+// MARK: - ResourceSynthesizer.Parser.Option - ExpressibleByDictionaryLiteral
+
+extension ResourceSynthesizer.Parser.Option: ExpressibleByDictionaryLiteral {
+    public init(dictionaryLiteral elements: (String, Self)...) {
+        self = .init(value: Dictionary(uniqueKeysWithValues: elements))
+    }
+}
+
+// MARK: - ResourceSynthesizer.Parser.Option - ExpressibleByArrayLiteral
+
+extension ResourceSynthesizer.Parser.Option: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: Self...) {
+        self = .init(value: elements)
+    }
+}

--- a/Sources/TuistGraphTesting/Models/ResourceSynthesizers+TestData.swift
+++ b/Sources/TuistGraphTesting/Models/ResourceSynthesizers+TestData.swift
@@ -4,9 +4,10 @@ import Foundation
 extension TuistGraph.ResourceSynthesizer {
     public static func test(
         parser: Parser = .assets,
+        parserOptions: [String: Parser.Option] = [:],
         extensions: Set<String> = ["xcassets"],
         template: Template = .defaultTemplate("Assets")
     ) -> Self {
-        ResourceSynthesizer(parser: parser, extensions: extensions, template: template)
+        ResourceSynthesizer(parser: parser, parserOptions: parserOptions, extensions: extensions, template: template)
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/ResourceSynthesizer+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/ResourceSynthesizer+ManifestMapper.swift
@@ -28,8 +28,14 @@ extension TuistGraph.ResourceSynthesizer {
             )
             template = .file(path)
         }
+
+        let parserOptions = manifest.parserOptions
+            .compactMapValues { TuistGraph.ResourceSynthesizer.Parser.Option.from(manifest: $0)
+            }
+
         return .init(
             parser: TuistGraph.ResourceSynthesizer.Parser.from(manifest: manifest.parser),
+            parserOptions: parserOptions,
             extensions: manifest.extensions,
             template: template
         )
@@ -59,6 +65,23 @@ extension TuistGraph.ResourceSynthesizer.Parser {
             return .yaml
         case .files:
             return .files
+        }
+    }
+}
+
+extension TuistGraph.ResourceSynthesizer.Parser.Option {
+    static func from(
+        manifest: ProjectDescription.ResourceSynthesizer.Parser.Option
+    ) -> Self {
+        switch manifest {
+        case let .stringValue(stringValue):
+            return .init(value: stringValue)
+        case let .intValue(intValue):
+            return .init(value: intValue)
+        case let .boolValue(boolValue):
+            return .init(value: boolValue)
+        case let .doubleValue(doubleValue):
+            return .init(value: doubleValue)
         }
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/ResourceSynthesizer+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/ResourceSynthesizer+ManifestMapper.swift
@@ -74,14 +74,18 @@ extension TuistGraph.ResourceSynthesizer.Parser.Option {
         manifest: ProjectDescription.ResourceSynthesizer.Parser.Option
     ) -> Self {
         switch manifest {
-        case let .stringValue(stringValue):
-            return .init(value: stringValue)
-        case let .intValue(intValue):
-            return .init(value: intValue)
-        case let .boolValue(boolValue):
-            return .init(value: boolValue)
-        case let .doubleValue(doubleValue):
-            return .init(value: doubleValue)
+        case .string(let value):
+            return .init(value: value)
+        case .integer(let value):
+            return .init(value: value)
+        case .double(let value):
+            return .init(value: value)
+        case .boolean(let value):
+            return .init(value: value)
+        case .dictionary(let value):
+            return .init(value: value)
+        case .array(let value):
+            return .init(value: value)
         }
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/ResourceSynthesizer+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/ResourceSynthesizer+ManifestMapper.swift
@@ -74,17 +74,17 @@ extension TuistGraph.ResourceSynthesizer.Parser.Option {
         manifest: ProjectDescription.ResourceSynthesizer.Parser.Option
     ) -> Self {
         switch manifest {
-        case .string(let value):
+        case let .string(value):
             return .init(value: value)
-        case .integer(let value):
+        case let .integer(value):
             return .init(value: value)
-        case .double(let value):
+        case let .double(value):
             return .init(value: value)
-        case .boolean(let value):
+        case let .boolean(value):
             return .init(value: value)
-        case .dictionary(let value):
+        case let .dictionary(value):
             return .init(value: value)
-        case .array(let value):
+        case let .array(value):
             return .init(value: value)
         }
     }

--- a/Tests/ProjectDescriptionTests/ResourceSynthesizerTests.swift
+++ b/Tests/ProjectDescriptionTests/ResourceSynthesizerTests.swift
@@ -18,7 +18,7 @@ final class ResourceSynthesizerTests: XCTestCase {
 
     func test_codable_when_parserOptions() {
         XCTAssertCodable(
-            ResourceSynthesizer.strings(parserOptions: ["separator": .stringValue("/")])
+            ResourceSynthesizer.strings(parserOptions: ["separator": "/"])
         )
     }
 
@@ -27,7 +27,7 @@ final class ResourceSynthesizerTests: XCTestCase {
             ResourceSynthesizer.custom(
                 name: "Custom",
                 parser: .json,
-                parserOptions: ["key": .stringValue("value")],
+                parserOptions: ["key": "value"],
                 extensions: ["lottie"]
             )
         )

--- a/Tests/ProjectDescriptionTests/ResourceSynthesizerTests.swift
+++ b/Tests/ProjectDescriptionTests/ResourceSynthesizerTests.swift
@@ -16,11 +16,18 @@ final class ResourceSynthesizerTests: XCTestCase {
         )
     }
 
+    func test_codable_when_parserOptions() {
+        XCTAssertCodable(
+            ResourceSynthesizer.strings(parserOptions: ["separator": .stringValue("/")])
+        )
+    }
+
     func test_codable_when_custom() {
         XCTAssertCodable(
             ResourceSynthesizer.custom(
                 name: "Custom",
                 parser: .json,
+                parserOptions: ["key": .stringValue("value")],
                 extensions: ["lottie"]
             )
         )

--- a/Tests/TuistGeneratorTests/ProjectMappers/SynthesizedResourceInterfaceProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/SynthesizedResourceInterfaceProjectMapperTests.swift
@@ -36,8 +36,10 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
     func test_map() throws {
         // Given
         var templateStrings: [String] = []
-        synthesizedResourceInterfacesGenerator.renderStub = { _, templateString, _, _, paths in
+        var parserOptionsStrings: [ResourceSynthesizer.Parser: String] = [:]
+        synthesizedResourceInterfacesGenerator.renderStub = { parser, parserOptions, templateString, _, _, paths in
             templateStrings.append(templateString)
+            parserOptionsStrings[parser] = parserOptions.map { "\($0.key): \($0.value.value)" }.sorted().joined(separator: ", ")
             let content = paths.map { $0.components.suffix(2).joined(separator: "/") }.joined(separator: ", ")
             return content
         }
@@ -98,26 +100,56 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
         let resourceSynthesizers: [ResourceSynthesizer] = [
             .init(
                 parser: .assets,
+                parserOptions: [
+                    "stringValue": .init(value: "test"),
+                    "intValue": .init(value: 999),
+                    "boolValue": .init(value: true),
+                    "doubleValue": .init(value: 1.0),
+                ],
                 extensions: ["xcassets"],
                 template: .defaultTemplate("Assets")
             ),
             .init(
                 parser: .strings,
+                parserOptions: [
+                    "stringValue": .init(value: "test"),
+                    "intValue": .init(value: 999),
+                    "boolValue": .init(value: true),
+                    "doubleValue": .init(value: 1.0),
+                ],
                 extensions: ["strings", "stringsdict"],
                 template: .file(stringsTemplatePath)
             ),
             .init(
                 parser: .plists,
+                parserOptions: [
+                    "stringValue": .init(value: "test"),
+                    "intValue": .init(value: 999),
+                    "boolValue": .init(value: true),
+                    "doubleValue": .init(value: 1.0),
+                ],
                 extensions: ["plist"],
                 template: .defaultTemplate("Plists")
             ),
             .init(
                 parser: .fonts,
+                parserOptions: [
+                    "stringValue": .init(value: "test"),
+                    "intValue": .init(value: 999),
+                    "boolValue": .init(value: true),
+                    "doubleValue": .init(value: 1.0),
+                ],
                 extensions: ["otf", "ttc", "ttf"],
                 template: .defaultTemplate("Fonts")
             ),
             .init(
                 parser: .json,
+                parserOptions: [
+                    "stringValue": .init(value: "test"),
+                    "intValue": .init(value: 999),
+                    "boolValue": .init(value: true),
+                    "doubleValue": .init(value: 1.0),
+                ],
                 extensions: ["lottie"],
                 template: .file(lottieTemplatePath)
             ),
@@ -233,7 +265,18 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
                 "lottie template",
             ]
         )
-
+        [
+            ResourceSynthesizer.Parser.assets,
+            ResourceSynthesizer.Parser.strings,
+            ResourceSynthesizer.Parser.plists,
+            ResourceSynthesizer.Parser.fonts,
+            ResourceSynthesizer.Parser.json,
+        ].forEach { parser in
+            XCTAssertEqual(
+                parserOptionsStrings[parser],
+                "boolValue: true, doubleValue: 1.0, intValue: 999, stringValue: test"
+            )
+        }
         XCTAssertPrinterContains(
             "Skipping synthesizing accessors for \(emptyPlist.pathString) because its contents are empty.",
             at: .warning,
@@ -244,7 +287,7 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
     func testMap_whenDisableSynthesizedResourceAccessors() throws {
         // Given
         var templateStrings: [String] = []
-        synthesizedResourceInterfacesGenerator.renderStub = { _, templateString, _, _, paths in
+        synthesizedResourceInterfacesGenerator.renderStub = { _, _, templateString, _, _, paths in
             templateStrings.append(templateString)
             let content = paths.map { $0.components.suffix(2).joined(separator: "/") }.joined(separator: ", ")
             return content
@@ -358,7 +401,7 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
     func testMap_bundleName_whenBundleAccessorsAreEnabled() throws {
         // Given
         var bundleNames: [String?] = []
-        synthesizedResourceInterfacesGenerator.renderStub = { _, _, _, bundleName, _ in
+        synthesizedResourceInterfacesGenerator.renderStub = { _, _, _, _, bundleName, _ in
             bundleNames.append(bundleName)
             return ""
         }
@@ -395,7 +438,7 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
     func testMap_bundleName_whenBundleAccessorsAreDisabled() throws {
         // Given
         var bundleNames: [String?] = []
-        synthesizedResourceInterfacesGenerator.renderStub = { _, _, _, bundleName, _ in
+        synthesizedResourceInterfacesGenerator.renderStub = { _, _, _, _, bundleName, _ in
             bundleNames.append(bundleName)
             return ""
         }

--- a/Tests/TuistGeneratorTests/ProjectMappers/SynthesizedResourceInterfaceProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/SynthesizedResourceInterfaceProjectMapperTests.swift
@@ -306,26 +306,31 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
         let resourceSynthesizers: [ResourceSynthesizer] = [
             .init(
                 parser: .assets,
+                parserOptions: [:],
                 extensions: ["xcassets"],
                 template: .defaultTemplate("Assets")
             ),
             .init(
                 parser: .strings,
+                parserOptions: [:],
                 extensions: ["strings", "stringsdict"],
                 template: .file(stringsTemplatePath)
             ),
             .init(
                 parser: .plists,
+                parserOptions: [:],
                 extensions: ["plist"],
                 template: .defaultTemplate("Plists")
             ),
             .init(
                 parser: .fonts,
+                parserOptions: [:],
                 extensions: ["otf", "ttc", "ttf"],
                 template: .defaultTemplate("Fonts")
             ),
             .init(
                 parser: .json,
+                parserOptions: [:],
                 extensions: ["lottie"],
                 template: .file(lottieTemplatePath)
             ),
@@ -435,16 +440,19 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
         [
             .init(
                 parser: .assets,
+                parserOptions: [:],
                 extensions: ["xcassets"],
                 template: .defaultTemplate("Assets")
             ),
             .init(
                 parser: .plists,
+                parserOptions: [:],
                 extensions: ["plist"],
                 template: .defaultTemplate("Plists")
             ),
             .init(
                 parser: .fonts,
+                parserOptions: [:],
                 extensions: ["otf", "ttc", "ttf"],
                 template: .defaultTemplate("Fonts")
             ),

--- a/Tests/TuistGeneratorTests/ProjectMappers/SynthesizedResourceInterfaceProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/SynthesizedResourceInterfaceProjectMapperTests.swift
@@ -101,10 +101,10 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
             .init(
                 parser: .assets,
                 parserOptions: [
-                    "stringValue": .init(value: "test"),
-                    "intValue": .init(value: 999),
-                    "boolValue": .init(value: true),
-                    "doubleValue": .init(value: 1.0),
+                    "stringValue": "test",
+                    "intValue": 999,
+                    "boolValue": true,
+                    "doubleValue": 1.0,
                 ],
                 extensions: ["xcassets"],
                 template: .defaultTemplate("Assets")
@@ -112,10 +112,10 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
             .init(
                 parser: .strings,
                 parserOptions: [
-                    "stringValue": .init(value: "test"),
-                    "intValue": .init(value: 999),
-                    "boolValue": .init(value: true),
-                    "doubleValue": .init(value: 1.0),
+                    "stringValue": "test",
+                    "intValue": 999,
+                    "boolValue": true,
+                    "doubleValue": 1.0,
                 ],
                 extensions: ["strings", "stringsdict"],
                 template: .file(stringsTemplatePath)
@@ -123,10 +123,10 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
             .init(
                 parser: .plists,
                 parserOptions: [
-                    "stringValue": .init(value: "test"),
-                    "intValue": .init(value: 999),
-                    "boolValue": .init(value: true),
-                    "doubleValue": .init(value: 1.0),
+                    "stringValue": "test",
+                    "intValue": 999,
+                    "boolValue": true,
+                    "doubleValue": 1.0,
                 ],
                 extensions: ["plist"],
                 template: .defaultTemplate("Plists")
@@ -134,10 +134,10 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
             .init(
                 parser: .fonts,
                 parserOptions: [
-                    "stringValue": .init(value: "test"),
-                    "intValue": .init(value: 999),
-                    "boolValue": .init(value: true),
-                    "doubleValue": .init(value: 1.0),
+                    "stringValue": "test",
+                    "intValue": 999,
+                    "boolValue": true,
+                    "doubleValue": 1.0,
                 ],
                 extensions: ["otf", "ttc", "ttf"],
                 template: .defaultTemplate("Fonts")
@@ -145,10 +145,10 @@ final class SynthesizedResourceInterfaceProjectMapperTests: TuistUnitTestCase {
             .init(
                 parser: .json,
                 parserOptions: [
-                    "stringValue": .init(value: "test"),
-                    "intValue": .init(value: 999),
-                    "boolValue": .init(value: true),
-                    "doubleValue": .init(value: 1.0),
+                    "stringValue": "test",
+                    "intValue": 999,
+                    "boolValue": true,
+                    "doubleValue": 1.0,
                 ],
                 extensions: ["lottie"],
                 template: .file(lottieTemplatePath)

--- a/Tests/TuistGeneratorTests/Utils/Mocks/MockSynthesizedResourceInterfaceGenerator.swift
+++ b/Tests/TuistGeneratorTests/Utils/Mocks/MockSynthesizedResourceInterfaceGenerator.swift
@@ -3,14 +3,22 @@ import TuistGraph
 @testable import TuistGenerator
 
 final class MockSynthesizedResourceInterfaceGenerator: SynthesizedResourceInterfacesGenerating {
-    var renderStub: ((ResourceSynthesizer.Parser, String, String, String?, [AbsolutePath]) throws -> String)?
+    var renderStub: ((
+        ResourceSynthesizer.Parser,
+        [String: ResourceSynthesizer.Parser.Option],
+        String,
+        String,
+        String?,
+        [AbsolutePath]
+    ) throws -> String)?
     func render(
         parser: ResourceSynthesizer.Parser,
+        parserOptions: [String: ResourceSynthesizer.Parser.Option],
         templateString: String,
         name: String,
         bundleName: String?,
         paths: [AbsolutePath]
     ) throws -> String {
-        try renderStub?(parser, templateString, name, bundleName, paths) ?? ""
+        try renderStub?(parser, parserOptions, templateString, name, bundleName, paths) ?? ""
     }
 }

--- a/Tests/TuistGraphTests/Models/ResourceSynthesizerTests.swift
+++ b/Tests/TuistGraphTests/Models/ResourceSynthesizerTests.swift
@@ -9,6 +9,7 @@ final class ResourceSynthesizerTests: TuistUnitTestCase {
         // Given
         let subject = ResourceSynthesizer(
             parser: .coreData,
+            parserOptions: ["key": ResourceSynthesizer.Parser.Option(value: "value")],
             extensions: [
                 "extension1",
                 "extension2",

--- a/Tests/TuistGraphTests/Models/ResourceSynthesizerTests.swift
+++ b/Tests/TuistGraphTests/Models/ResourceSynthesizerTests.swift
@@ -9,7 +9,7 @@ final class ResourceSynthesizerTests: TuistUnitTestCase {
         // Given
         let subject = ResourceSynthesizer(
             parser: .coreData,
-            parserOptions: ["key": ResourceSynthesizer.Parser.Option(value: "value")],
+            parserOptions: ["key": "value"],
             extensions: [
                 "extension1",
                 "extension2",

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceSynthesizer+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceSynthesizer+ManifestMapperTests.swift
@@ -43,6 +43,42 @@ final class ResourceSynthesizerManifestMapperTests: TuistUnitTestCase {
             got,
             .init(
                 parser: .strings,
+                parserOptions: [:],
+                extensions: ["strings", "stringsdict"],
+                template: .defaultTemplate("Strings")
+            )
+        )
+    }
+
+    func test_from_when_default_strings_with_parserOptions() throws {
+        // Given
+        let parserOptions: [String: ProjectDescription.ResourceSynthesizer.Parser.Option] = [
+            "stringValue": .stringValue("test"),
+            "intValue": .intValue(999),
+            "boolValue": .boolValue(true),
+            "doubleValue": .doubleValue(1.0),
+        ]
+        let manifestDirectory = try temporaryPath()
+
+        // When
+        let got = try ResourceSynthesizer.from(
+            manifest: .strings(parserOptions: parserOptions),
+            generatorPaths: GeneratorPaths(manifestDirectory: manifestDirectory),
+            plugins: .none,
+            resourceSynthesizerPathLocator: resourceSynthesizerPathLocator
+        )
+
+        // Then
+        XCTAssertEqual(
+            got,
+            .init(
+                parser: .strings,
+                parserOptions: [
+                    "stringValue": .init(value: "test"),
+                    "intValue": .init(value: 999),
+                    "boolValue": .init(value: true),
+                    "doubleValue": .init(value: 1.0),
+                ],
                 extensions: ["strings", "stringsdict"],
                 template: .defaultTemplate("Strings")
             )
@@ -71,6 +107,7 @@ final class ResourceSynthesizerManifestMapperTests: TuistUnitTestCase {
             got,
             .init(
                 parser: .strings,
+                parserOptions: [:],
                 extensions: ["strings", "stringsdict"],
                 template: .file(manifestDirectory.appending(component: "Template.stencil"))
             )
@@ -80,6 +117,12 @@ final class ResourceSynthesizerManifestMapperTests: TuistUnitTestCase {
 
     func test_from_when_assets_plugin() throws {
         // Given
+        let parserOptions: [String: ProjectDescription.ResourceSynthesizer.Parser.Option] = [
+            "stringValue": .stringValue("test"),
+            "intValue": .intValue(999),
+            "boolValue": .boolValue(true),
+            "doubleValue": .doubleValue(1.0),
+        ]
         let manifestDirectory = try temporaryPath()
         var invokedPluginNames: [String] = []
         var invokedResourceNames: [String] = []
@@ -93,7 +136,7 @@ final class ResourceSynthesizerManifestMapperTests: TuistUnitTestCase {
 
         // When
         let got = try ResourceSynthesizer.from(
-            manifest: .assets(plugin: "Plugin"),
+            manifest: .assets(plugin: "Plugin", parserOptions: parserOptions),
             generatorPaths: GeneratorPaths(manifestDirectory: manifestDirectory),
             plugins: .test(
                 resourceSynthesizers: [
@@ -108,6 +151,12 @@ final class ResourceSynthesizerManifestMapperTests: TuistUnitTestCase {
             got,
             .init(
                 parser: .assets,
+                parserOptions: [
+                    "stringValue": .init(value: "test"),
+                    "intValue": .init(value: 999),
+                    "boolValue": .init(value: true),
+                    "doubleValue": .init(value: 1.0),
+                ],
                 extensions: ["xcassets"],
                 template: .file(manifestDirectory.appending(component: "PluginTemplate.stencil"))
             )

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceSynthesizer+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/ResourceSynthesizer+ManifestMapperTests.swift
@@ -53,10 +53,10 @@ final class ResourceSynthesizerManifestMapperTests: TuistUnitTestCase {
     func test_from_when_default_strings_with_parserOptions() throws {
         // Given
         let parserOptions: [String: ProjectDescription.ResourceSynthesizer.Parser.Option] = [
-            "stringValue": .stringValue("test"),
-            "intValue": .intValue(999),
-            "boolValue": .boolValue(true),
-            "doubleValue": .doubleValue(1.0),
+            "stringValue": "test",
+            "intValue": 999,
+            "boolValue": true,
+            "doubleValue": 1.0,
         ]
         let manifestDirectory = try temporaryPath()
 
@@ -74,10 +74,10 @@ final class ResourceSynthesizerManifestMapperTests: TuistUnitTestCase {
             .init(
                 parser: .strings,
                 parserOptions: [
-                    "stringValue": .init(value: "test"),
-                    "intValue": .init(value: 999),
-                    "boolValue": .init(value: true),
-                    "doubleValue": .init(value: 1.0),
+                    "stringValue": "test",
+                    "intValue": 999,
+                    "boolValue": true,
+                    "doubleValue": 1.0,
                 ],
                 extensions: ["strings", "stringsdict"],
                 template: .defaultTemplate("Strings")
@@ -118,10 +118,10 @@ final class ResourceSynthesizerManifestMapperTests: TuistUnitTestCase {
     func test_from_when_assets_plugin() throws {
         // Given
         let parserOptions: [String: ProjectDescription.ResourceSynthesizer.Parser.Option] = [
-            "stringValue": .stringValue("test"),
-            "intValue": .intValue(999),
-            "boolValue": .boolValue(true),
-            "doubleValue": .doubleValue(1.0),
+            "stringValue": "test",
+            "intValue": 999,
+            "boolValue": true,
+            "doubleValue": 1.0,
         ]
         let manifestDirectory = try temporaryPath()
         var invokedPluginNames: [String] = []

--- a/projects/tuist/features/generate-2.feature
+++ b/projects/tuist/features/generate-2.feature
@@ -55,3 +55,25 @@ Feature: Generate a new project using Tuist (suite 2)
       """
       public static let evening = AppStrings.tr("Greetings", "evening")
       """
+
+ Scenario: The project is an iOS application with custom development region that has resources (ios_app_with_custom_resource_parser_options)
+    Given that tuist is available
+    And I have a working directory
+    Then I copy the fixture ios_app_with_custom_resource_parser_options into the working directory
+    Then tuist generates the project
+    Then I should be able to build for iOS the scheme App
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'en.lproj/Greetings.strings'
+    Then the product 'App.app' with destination 'Debug-iphonesimulator' contains resource 'fr.lproj/Greetings.strings'
+    Then a file Derived/Sources/TuistStrings+App.swift exists
+    Then content of a file named TuistStrings+App.swift in a directory Derived/Sources should contain:
+      """
+      public enum Good {
+      """
+    Then content of a file named TuistStrings+App.swift in a directory Derived/Sources should contain:
+      """
+      public static let evening = AppStrings.tr("Greetings", "Good/evening")
+      """
+    Then content of a file named TuistStrings+App.swift in a directory Derived/Sources should contain:
+      """
+      public static let morning = AppStrings.tr("Greetings", "Good/morning")
+      """

--- a/projects/tuist/fixtures/ios_app_with_custom_resource_parser_options/App/Resources/en.lproj/Greetings.strings
+++ b/projects/tuist/fixtures/ios_app_with_custom_resource_parser_options/App/Resources/en.lproj/Greetings.strings
@@ -1,0 +1,1 @@
+"Good/morning" = "Good Morning";

--- a/projects/tuist/fixtures/ios_app_with_custom_resource_parser_options/App/Resources/fr.lproj/Greetings.strings
+++ b/projects/tuist/fixtures/ios_app_with_custom_resource_parser_options/App/Resources/fr.lproj/Greetings.strings
@@ -1,0 +1,2 @@
+"Good/morning" = "Bonjour";
+"Good/evening" = "Bonsoir";

--- a/projects/tuist/fixtures/ios_app_with_custom_resource_parser_options/App/Sources/AppDelegate.swift
+++ b/projects/tuist/fixtures/ios_app_with_custom_resource_parser_options/App/Sources/AppDelegate.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(
+        _: UIApplication,
+        didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        let viewController = UIViewController()
+        viewController.view.backgroundColor = .white
+        window?.rootViewController = viewController
+        window?.makeKeyAndVisible()
+        return true
+    }
+}

--- a/projects/tuist/fixtures/ios_app_with_custom_resource_parser_options/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_custom_resource_parser_options/Project.swift
@@ -1,0 +1,24 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    options: .options(
+        developmentRegion: "fr"
+    ),
+    targets: [
+        Target(
+            name: "App",
+            platform: .iOS,
+            product: .app,
+            bundleId: "io.tuist.app",
+            infoPlist: .default,
+            sources: ["App/Sources/**"],
+            resources: [
+                "App/Resources/**/*.strings",
+            ]
+        ),
+    ],
+    resourceSynthesizers: [
+        .strings(parserOptions: ["separator": .stringValue("/")]),
+    ]
+)

--- a/projects/tuist/fixtures/ios_app_with_custom_resource_parser_options/Project.swift
+++ b/projects/tuist/fixtures/ios_app_with_custom_resource_parser_options/Project.swift
@@ -19,6 +19,6 @@ let project = Project(
         ),
     ],
     resourceSynthesizers: [
-        .strings(parserOptions: ["separator": .stringValue("/")]),
+        .strings(parserOptions: ["separator": "/"]),
     ]
 )


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5470

### Short description 📝

Add a parameter to passing SwiftGen ParserOptions to ResourceSynthesizer

1. usecase: [Strings Parser Option](https://github.com/SwiftGen/SwiftGen/blob/stable/Documentation/Parsers/strings.md#customization)
2. usecase: [Colors Parser Option](https://github.com/SwiftGen/SwiftGen/blob/stable/Documentation/Parsers/colors.md#customization)

- ParserOptions parameter is passing the default parameters, so existing users are not impacted.

### How to test the changes locally 🧐

`$ ./fourier test tuist acceptance projects/tuist/features/generate-1.feature:59`

### Contributor checklist ✅

- [x] The code has been linted using run `make lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
