### PR TITLE
Remove weird space typo in `FileElement+ManifestMapper.swift` document

### DIFF
--- a/Sources/TuistLoader/Models+ManifestMappers/FileElement+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/FileElement+ManifestMapper.swift
@@ -9,7 +9,7 @@ extension TuistGraph.FileElement {
     /// Maps a ProjectDescription.FileElement instance into a [TuistGraph.FileElement] instance.
     /// Glob patterns in file elements are unfolded as part of the mapping.
     /// - Parameters:
-    ///   - manifest: Manifest representation of  the file element.
+    ///   - manifest: Manifest representation of the file element.
     ///   - generatorPaths: Generator paths.
     static func from(
         manifest: ProjectDescription.FileElement,


### PR DESCRIPTION
### Short description 📝
Removed a weird space typo in the documentation of the from function in `TuistLoader/Models+ManifestMappers/FileElement+ManifestMapper.swift`.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

### Contributor checklist ✅

- [x] The code has been linted using run `make lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
