### PR TITLE
AssetTemplate's Images struct is missing when synthesizing only symbolset resources

### DIFF
--- a/Sources/TuistGenerator/Templates/AssetsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/AssetsTemplate.swift
@@ -241,7 +241,7 @@ extension SynthesizedResourceInterfaceTemplates {
     #endif
 
     {% endif %}
-    {% if resourceCount.image > 0 %}
+    {% if resourceCount.image > 0 or resourceCount.symbol > 0 %}
     {{accessModifier}} struct {{imageType}} {
       {{accessModifier}} fileprivate(set) var name: String
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY

### Short description 📝

It appears that https://github.com/tuist/tuist/pull/5493 works in general, but the Images struct will not be added if a .xcassets directory comprises only symbolset resources. This is because the jinja condition that would handle this only checks `resourceCount.image` and should additionally check for `resourceCount.symbol`.

### How to test the changes locally 🧐

> Follow same steps in https://github.com/tuist/tuist/pull/5493, but make sure that .xcassets directory does not have anything except symbol assets

### Contributor checklist ✅

- [X] The code has been linted using run `make lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
