### PR TITLE
Refactor duplicate code in the 'swift target dependency' property dec…

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,14 +41,14 @@ var targets: [Target] = [
         name: "tuistbenchmark",
         dependencies: [
             argumentParserDependency,
-            .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+            swiftToolsSupportDependency,
         ]
     ),
     .executableTarget(
         name: "tuistfixturegenerator",
         dependencies: [
             argumentParserDependency,
-            .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+            swiftToolsSupportDependency,
         ]
     ),
     .target(


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY

### Short description 📝

The same content already declared as the 'swiftToolsSupportDepending' property has been duplicated and changed.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

### Contributor checklist ✅

- [x] The code has been linted using run `make lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
