### PR TITLE
Add support for Swift Macros using the native integration

### DIFF
--- a/Sources/ProjectAutomation/TargetDependency.swift
+++ b/Sources/ProjectAutomation/TargetDependency.swift
@@ -18,6 +18,7 @@ public enum TargetDependency: Equatable, Hashable, Codable {
     case library(path: String, publicHeaders: String, swiftModuleMap: String?)
     case package(product: String)
     case packagePlugin(product: String)
+    case packageMacro(product: String)
     case sdk(name: String, status: SDKStatus)
     case xctest
 }

--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -72,6 +72,14 @@ public enum TargetDependency: Codable, Hashable {
     ///   - product: The name of the output product. ${PRODUCT_NAME} inside Xcode.
     ///              e.g. RxSwift
     case packagePlugin(product: String)
+    
+    /// Dependency on a Swift Package Manager Swift Macro using Xcode native integration.
+    ///
+    /// - Parameters:
+    ///   - product: The name of the output product. ${PRODUCT_NAME} inside Xcode.
+    ///              e.g. StructBuilder
+    ///
+    case packageMacro(product: String)
 
     /// Dependency on system library or framework
     ///
@@ -128,6 +136,8 @@ public enum TargetDependency: Codable, Hashable {
             return "package"
         case .packagePlugin:
             return "packagePlugin"
+        case .packageMacro:
+            return "packageMacro"
         case .sdk:
             return "sdk"
         case .xcframework:

--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -72,7 +72,7 @@ public enum TargetDependency: Codable, Hashable {
     ///   - product: The name of the output product. ${PRODUCT_NAME} inside Xcode.
     ///              e.g. RxSwift
     case packagePlugin(product: String)
-    
+
     /// Dependency on a Swift Package Manager Swift Macro using Xcode native integration.
     ///
     /// - Parameters:

--- a/Sources/TuistCore/Graph/CircularDependencyLinter.swift
+++ b/Sources/TuistCore/Graph/CircularDependencyLinter.swift
@@ -114,7 +114,7 @@ public class CircularDependencyLinter: CircularDependencyLinting {
                 cache: cache,
                 cycleDetector: cycleDetector
             )
-        case .framework, .xcframework, .library, .package, .packagePlugin, .sdk, .xctest:
+        case .framework, .xcframework, .library, .package, .packagePlugin, .packageMacro, .sdk, .xctest:
             break
         }
     }

--- a/Sources/TuistCore/Graph/GraphLoader.swift
+++ b/Sources/TuistCore/Graph/GraphLoader.swift
@@ -180,7 +180,7 @@ public final class GraphLoader: GraphLoading {
 
         case let .packagePlugin(product):
             return try loadPackage(fromPath: path, productName: product, type: .plugin)
-            
+
         case let .packageMacro(product):
             return try loadPackage(fromPath: path, productName: product, type: .macro)
 
@@ -289,7 +289,11 @@ public final class GraphLoader: GraphLoading {
         return .sdk(name: metadata.name, path: metadata.path, status: metadata.status, source: metadata.source)
     }
 
-    private func loadPackage(fromPath: AbsolutePath, productName: String, type: GraphDependency.PackageProductType) throws -> GraphDependency {
+    private func loadPackage(
+        fromPath: AbsolutePath,
+        productName: String,
+        type: GraphDependency.PackageProductType
+    ) throws -> GraphDependency {
         // TODO: `fromPath` isn't quite correct as it reflects the path where the dependency was declared
         // and doesn't uniquely identify it. It's been copied from the previous implementation to maintain
         // existing behaviour and should be fixed separately

--- a/Sources/TuistCore/Graph/GraphLoader.swift
+++ b/Sources/TuistCore/Graph/GraphLoader.swift
@@ -176,10 +176,13 @@ public final class GraphLoader: GraphLoading {
                 )
             }
         case let .package(product):
-            return try loadPackage(fromPath: path, productName: product, isPlugin: false)
+            return try loadPackage(fromPath: path, productName: product, type: .sources)
 
         case let .packagePlugin(product):
-            return try loadPackage(fromPath: path, productName: product, isPlugin: true)
+            return try loadPackage(fromPath: path, productName: product, type: .plugin)
+            
+        case let .packageMacro(product):
+            return try loadPackage(fromPath: path, productName: product, type: .macro)
 
         case .xctest:
             return try platforms.map { platform in
@@ -286,14 +289,14 @@ public final class GraphLoader: GraphLoading {
         return .sdk(name: metadata.name, path: metadata.path, status: metadata.status, source: metadata.source)
     }
 
-    private func loadPackage(fromPath: AbsolutePath, productName: String, isPlugin: Bool) throws -> GraphDependency {
+    private func loadPackage(fromPath: AbsolutePath, productName: String, type: GraphDependency.PackageProductType) throws -> GraphDependency {
         // TODO: `fromPath` isn't quite correct as it reflects the path where the dependency was declared
         // and doesn't uniquely identify it. It's been copied from the previous implementation to maintain
         // existing behaviour and should be fixed separately
         .packageProduct(
             path: fromPath,
             product: productName,
-            isPlugin: isPlugin
+            type: type
         )
     }
 

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -182,7 +182,9 @@ final class LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_
                 try pbxTarget.addSwiftPackageProduct(productName: product, isPlugin: false, pbxproj: pbxproj)
             case let .packagePlugin(product: product):
                 try pbxTarget.addSwiftPackageProduct(productName: product, isPlugin: true, pbxproj: pbxproj)
-            default:
+            case let .packageMacro(product: product):
+                try pbxTarget.addSwiftPackageProduct(productName: product, isPlugin: false, pbxproj: pbxproj)
+            case .framework, .library, .project, .sdk, .target, .xcframework, .xctest:
                 break
             }
         }

--- a/Sources/TuistGenerator/GraphViz/GraphToGraphVizMapper.swift
+++ b/Sources/TuistGenerator/GraphViz/GraphToGraphVizMapper.swift
@@ -100,7 +100,7 @@ extension GraphDependency {
             return path.basenameWithoutExt
         case let .bundle(path):
             return path.basenameWithoutExt
-        case let .packageProduct(path: _, product: product, isPlugin: _):
+        case let .packageProduct(path: _, product: product, type: _):
             return product
         case let .sdk(
             name: name,

--- a/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -146,9 +146,13 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
             return linking == .static
         case .bundle:
             return true
-        case let .packageProduct(_, _, isPlugin):
+        case let .packageProduct(_, _, type):
+            switch type {
             // Swift package products are currently assumed to be static
-            return !isPlugin
+            case .sources: return true
+            case .macro: return false
+            case .plugin: return false
+            }
         case let .target(name, path):
             guard let target = graphTraverser.target(path: path, name: name) else { return false }
             return target.target.product.isStatic

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -306,6 +306,8 @@ extension TargetDependency {
             return "package"
         case .packagePlugin:
             return "packagePlugin"
+        case .packageMacro:
+            return "packageMacro"
         case .sdk:
             return "sdk"
         case .xcframework:
@@ -330,6 +332,8 @@ extension TargetDependency {
         case let .package(product):
             return product
         case let .packagePlugin(product):
+            return product
+        case let .packageMacro(product):
             return product
         case let .sdk(name, _):
             return name

--- a/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -177,7 +177,7 @@ public final class ModuleMapMapper: WorkspaceMapping {
                 }
                 dependentProject = dependentProjectFromPath
                 dependentTarget = dependentTargetFromName
-            case .framework, .xcframework, .library, .package, .packagePlugin, .sdk, .xctest:
+            case .framework, .xcframework, .library, .package, .packagePlugin, .packageMacro, .sdk, .xctest:
                 continue
             }
 

--- a/Sources/TuistGraph/Graph/GraphDependency.swift
+++ b/Sources/TuistGraph/Graph/GraphDependency.swift
@@ -2,21 +2,20 @@ import Foundation
 import TSCBasic
 
 public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Codable {
-    
     public enum PackageProductType: String, Hashable, CustomStringConvertible, Comparable, Codable {
         public var description: String {
-            return self.rawValue
+            rawValue
         }
-        
+
         case sources = "sources package product"
         case plugin = "plugin package product"
         case macro = "macro package product"
-        
+
         public static func < (lhs: PackageProductType, rhs: PackageProductType) -> Bool {
             lhs.description < rhs.description
         }
     }
-    
+
     /// A dependency that represents a pre-compiled .xcframework.
     case xcframework(
         path: AbsolutePath,

--- a/Sources/TuistGraph/Graph/GraphDependency.swift
+++ b/Sources/TuistGraph/Graph/GraphDependency.swift
@@ -2,6 +2,21 @@ import Foundation
 import TSCBasic
 
 public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Codable {
+    
+    public enum PackageProductType: String, Hashable, CustomStringConvertible, Comparable, Codable {
+        public var description: String {
+            return self.rawValue
+        }
+        
+        case sources = "sources package product"
+        case plugin = "plugin package product"
+        case macro = "macro package product"
+        
+        public static func < (lhs: PackageProductType, rhs: PackageProductType) -> Bool {
+            lhs.description < rhs.description
+        }
+    }
+    
     /// A dependency that represents a pre-compiled .xcframework.
     case xcframework(
         path: AbsolutePath,
@@ -37,7 +52,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
     case bundle(path: AbsolutePath)
 
     /// A dependency that represents a package product.
-    case packageProduct(path: AbsolutePath, product: String, isPlugin: Bool = false)
+    case packageProduct(path: AbsolutePath, product: String, type: PackageProductType)
 
     /// A dependency that represents a target that is defined in the project at the given path.
     case target(name: String, path: AbsolutePath)

--- a/Sources/TuistGraph/Models/TargetDependency.swift
+++ b/Sources/TuistGraph/Models/TargetDependency.swift
@@ -19,6 +19,7 @@ public enum TargetDependency: Equatable, Hashable, Codable {
     case library(path: AbsolutePath, publicHeaders: AbsolutePath, swiftModuleMap: AbsolutePath?)
     case package(product: String)
     case packagePlugin(product: String)
+    case packageMacro(product: String)
     case sdk(name: String, status: SDKStatus)
     case xctest
 }

--- a/Sources/TuistGraphTesting/Graph/GraphDependency+TestData.swift
+++ b/Sources/TuistGraphTesting/Graph/GraphDependency+TestData.swift
@@ -92,7 +92,8 @@ extension GraphDependency {
     ) -> GraphDependency {
         .packageProduct(
             path: path,
-            product: product
+            product: product,
+            type: .sources
         )
     }
 }

--- a/Sources/TuistKit/Services/GraphService.swift
+++ b/Sources/TuistKit/Services/GraphService.swift
@@ -256,6 +256,8 @@ extension ProjectAutomation.Target {
             return .package(product: product)
         case let .packagePlugin(product):
             return .packagePlugin(product: product)
+        case let .packageMacro(product):
+            return .packageMacro(product: product)
         case let .sdk(name, status):
             let projectAutomationStatus: ProjectAutomation.SDKStatus
             switch status {

--- a/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
@@ -56,6 +56,8 @@ extension TuistGraph.TargetDependency {
             return [.package(product: product)]
         case let .packagePlugin(product):
             return [.packagePlugin(product: product)]
+        case let .packageMacro(product):
+            return [.packageMacro(product: product)]
         case let .sdk(name, type, status):
             return [
                 .sdk(

--- a/Tests/TuistCoreTests/Graph/GraphLoaderTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphLoaderTests.swift
@@ -541,13 +541,13 @@ final class GraphLoaderTests: TuistUnitTestCase {
         ])
         XCTAssertEqual(graph.dependencies, [
             .target(name: "A", path: "/A"): Set([
-                .packageProduct(path: "/A", product: "PackageLibraryA1"),
+                .packageProduct(path: "/A", product: "PackageLibraryA1", type: .sources),
             ]),
             .target(name: "B", path: "/B"): Set([
-                .packageProduct(path: "/B", product: "PackageLibraryA2"),
+                .packageProduct(path: "/B", product: "PackageLibraryA2", type: .sources),
             ]),
             .target(name: "C", path: "/C"): Set([
-                .packageProduct(path: "/C", product: "PackageLibraryB"),
+                .packageProduct(path: "/C", product: "PackageLibraryB", type: .sources),
             ]),
         ])
     }
@@ -580,7 +580,7 @@ final class GraphLoaderTests: TuistUnitTestCase {
         ])
         XCTAssertEqual(graph.dependencies, [
             .target(name: "A", path: "/A"): Set([
-                .packageProduct(path: "/A", product: "PackagePlugin", isPlugin: true),
+                .packageProduct(path: "/A", product: "PackagePlugin", type: .plugin),
             ]),
         ])
     }

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -3919,7 +3919,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let package = Package.remote(url: "https://git.tuist.io", requirement: .branch("main"))
         let graph = Graph.test(
             packages: [path: ["Test": package]],
-            dependencies: [.packageProduct(path: path, product: "Test"): Set()]
+            dependencies: [.packageProduct(path: path, product: "Test", type: .sources): Set()]
         )
         let graphTraverser = GraphTraverser(graph: graph)
 

--- a/Tests/TuistGeneratorIntegrationTests/Generator/SwiftPackageManagerInteractorTests.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Generator/SwiftPackageManagerInteractorTests.swift
@@ -41,7 +41,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         let graph = Graph.test(
             path: project.path,
             packages: [project.path: ["Test": package]],
-            dependencies: [GraphDependency.packageProduct(path: project.path, product: "Test"): Set()]
+            dependencies: [GraphDependency.packageProduct(path: project.path, product: "Test", type: .sources): Set()]
         )
         let graphTraverser = GraphTraverser(graph: graph)
 
@@ -83,7 +83,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         let graph = Graph.test(
             path: project.path,
             packages: [project.path: ["Test": package]],
-            dependencies: [GraphDependency.packageProduct(path: project.path, product: "Test"): Set()]
+            dependencies: [GraphDependency.packageProduct(path: project.path, product: "Test", type: .macro): Set()]
         )
         let graphTraverser = GraphTraverser(graph: graph)
 
@@ -126,7 +126,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         let graph = Graph.test(
             path: project.path,
             packages: [project.path: ["Test": package]],
-            dependencies: [GraphDependency.packageProduct(path: project.path, product: "Test"): Set()]
+            dependencies: [GraphDependency.packageProduct(path: project.path, product: "Test", type: .sources): Set()]
         )
         let graphTraverser = GraphTraverser(graph: graph)
 
@@ -208,7 +208,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         let graph = Graph.test(
             path: project.path,
             packages: [project.path: ["Test": package]],
-            dependencies: [GraphDependency.packageProduct(path: project.path, product: "Test"): Set()]
+            dependencies: [GraphDependency.packageProduct(path: project.path, product: "Test", type: .sources): Set()]
         )
         let graphTraverser = GraphTraverser(graph: graph)
 

--- a/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
@@ -116,7 +116,7 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
             ],
             dependencies: [
                 .target(name: graphTarget.target.name, path: graphTarget.path): [
-                    .packageProduct(path: project.path, product: "A"),
+                    .packageProduct(path: project.path, product: "A", type: .sources),
                 ],
             ]
         )
@@ -363,7 +363,7 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
             ],
             dependencies: [
                 .target(name: graphTarget.target.name, path: graphTarget.path): [
-                    .packageProduct(path: project.path, product: "A"),
+                    .packageProduct(path: project.path, product: "A", type: .sources),
                 ],
             ]
         )

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -832,7 +832,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
             ],
             dependencies: [
                 .target(name: graphTarget.target.name, path: graphTarget.path): [
-                    .packageProduct(path: project.path, product: "A"),
+                    .packageProduct(path: project.path, product: "A", type: .sources),
                 ],
             ]
         )

--- a/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
@@ -32,9 +32,9 @@ class StaticProductsGraphLinterTests: XCTestCase {
         let frameworkDependency = GraphDependency.target(name: framework.name, path: path)
 
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
-            appDependency: Set([frameworkDependency, .packageProduct(path: path, product: "Package")]),
-            frameworkDependency: Set([.packageProduct(path: path, product: "Package")]),
-            .packageProduct(path: path, product: "Package"): Set(),
+            appDependency: Set([frameworkDependency, .packageProduct(path: path, product: "Package", type: .sources)]),
+            frameworkDependency: Set([.packageProduct(path: path, product: "Package", type: .sources)]),
+            .packageProduct(path: path, product: "Package", type: .sources): Set(),
         ]
         let graph = Graph.test(
             path: path,
@@ -67,7 +67,7 @@ class StaticProductsGraphLinterTests: XCTestCase {
         let appDependency = GraphDependency.target(name: app.name, path: path)
         let frameworkDependency = GraphDependency.target(name: framework.name, path: path)
 
-        let plugin = GraphDependency.packageProduct(path: path, product: "Package", isPlugin: true)
+        let plugin = GraphDependency.packageProduct(path: path, product: "Package", type: .plugin)
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
             appDependency: Set([frameworkDependency, plugin]),
             frameworkDependency: Set([plugin]),
@@ -1091,7 +1091,7 @@ class StaticProductsGraphLinterTests: XCTestCase {
         let appDependency = GraphDependency.target(name: app.name, path: path)
         let watchAppDependency = GraphDependency.target(name: watchApp.name, path: path)
         let watchAppExtensionDependency = GraphDependency.target(name: watchAppExtension.name, path: path)
-        let swiftPackage = GraphDependency.packageProduct(path: "/path/to/package", product: "LocalPackage")
+        let swiftPackage = GraphDependency.packageProduct(path: "/path/to/package", product: "LocalPackage", type: .sources)
 
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
             // apps declare they bundle watch apps via dependencies
@@ -1132,7 +1132,7 @@ class StaticProductsGraphLinterTests: XCTestCase {
         let watchAppDependency = GraphDependency.target(name: watchApp.name, path: path)
         let watchAppExtensionDependency = GraphDependency.target(name: watchAppExtension.name, path: path)
         let watchFrameworkDependency = GraphDependency.target(name: watchFramework.name, path: path)
-        let swiftPackage = GraphDependency.packageProduct(path: "/path/to/package", product: "LocalPackage")
+        let swiftPackage = GraphDependency.packageProduct(path: "/path/to/package", product: "LocalPackage", type: .sources)
 
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
             // apps declare they bundle watch apps via dependencies

--- a/projects/tuist/features/build.feature
+++ b/projects/tuist/features/build.feature
@@ -48,3 +48,10 @@ Feature: Build projects using Tuist build
     Then a directory Builds/release-iphonesimulator/App.swiftmodule exists
     Then a directory Builds/release-iphonesimulator/FrameworkA.framework exists
     Then a directory Builds/release-iphonesimulator/FrameworkA.framework.dSYM exists
+    
+  Scenario: The project is a ramework with a Swift Macro integrated through the standard method (framework_with_swift_macro)
+    Given that tuist is available
+    And I have a working directory
+    Then I copy the fixture framework_with_swift_macro into the working directory
+    Then tuist generates the project
+    Then tuist builds the scheme Framework from the project

--- a/projects/tuist/features/build.feature
+++ b/projects/tuist/features/build.feature
@@ -48,10 +48,11 @@ Feature: Build projects using Tuist build
     Then a directory Builds/release-iphonesimulator/App.swiftmodule exists
     Then a directory Builds/release-iphonesimulator/FrameworkA.framework exists
     Then a directory Builds/release-iphonesimulator/FrameworkA.framework.dSYM exists
-    
-  Scenario: The project is a ramework with a Swift Macro integrated through the standard method (framework_with_swift_macro)
-    Given that tuist is available
-    And I have a working directory
-    Then I copy the fixture framework_with_swift_macro into the working directory
-    Then tuist generates the project
-    Then tuist builds the scheme Framework from the project
+
+  # TODO: Enable it when we drop support for Xcode 14    
+  # Scenario: The project is a framework with a Swift Macro integrated through the standard method (framework_with_swift_macro)
+  #   Given that tuist is available
+  #   And I have a working directory
+  #   Then I copy the fixture framework_with_swift_macro into the working directory
+  #   Then tuist generates the project
+  #   Then tuist builds the scheme Framework from the project

--- a/projects/tuist/fixtures/framework_with_swift_macro/.package.resolved
+++ b/projects/tuist/fixtures/framework_with_swift_macro/.package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "structbuildermacro",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/alschmut/StructBuilderMacro.git",
+      "state" : {
+        "revision" : "aa0029efe02ce198ebecb2905f67c6340b7d6bb2",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
+        "version" : "509.0.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/projects/tuist/fixtures/framework_with_swift_macro/Project.swift
+++ b/projects/tuist/fixtures/framework_with_swift_macro/Project.swift
@@ -1,0 +1,20 @@
+import ProjectDescription
+
+let project = Project(
+    name: "FrameworkWithSwiftMacro",
+    packages: [
+        .remote(url: "https://github.com/alschmut/StructBuilderMacro.git", requirement: .exact("0.2.0")),
+    ],
+    targets: [
+        Target(
+            name: "Framework",
+            platform: .macOS,
+            product: .staticLibrary,
+            bundleId: "io.tuist.FrameworkWithSwiftMacro",
+            sources: ["Sources/**/*"],
+            dependencies: [
+                .packageMacro(product: "StructBuilder"),
+            ]
+        ),
+    ]
+)

--- a/projects/tuist/fixtures/framework_with_swift_macro/Sources/Framework.swift
+++ b/projects/tuist/fixtures/framework_with_swift_macro/Sources/Framework.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+import StructBuilder
+
+@Buildable
+public struct Person {
+    let name: String
+    let age: Int
+    let hobby: String?
+
+    var likesReading: Bool {
+        hobby == "Reading"
+    }
+
+    static let minimumAge = 21
+}


### PR DESCRIPTION
### Short description 📝
I'm adding support for Swift Macros through a new `TargetDependency` type, `.packageMacro`. Note that the "adding support" is a lie because in reality, they are integrated like standard packages, so `.package` would have led to the same result. However, I introduced a new type in the DSL to make it clear on the user end, and have flexibility in the future to add additional metadata that might specific to just macros.

### How to test the changes locally 🧐
You should be able to generate a project from the fixture:
```
swift build
swift run tuist generate --path ./projects/tuist/fixtures/framework_with_swift_macro
```
And get an Xcode project that compiles

### Contributor checklist ✅

- [x] The code has been linted using run `make lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
