### PR TITLE
Remove `.packagePlugin`

### DIFF
--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -31,8 +31,15 @@ public enum SDKType: String, Codable, Hashable {
 /// A target dependency.
 public enum TargetDependency: Codable, Hashable {
     public enum PackageType: Codable, Hashable {
+        /// A runtime package type represents a standard package whose sources are linked at runtime.
+        /// For example importing the framework and consuming from dependent targets.
         case runtime
+        
+        /// A plugin package represents a package that's loaded by the build system at compile-time to
+        /// extend the compilation process.
         case plugin
+        
+        /// A macro package represents a package that contains a Swift Macro.
         case macro
     }
 

--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -30,6 +30,12 @@ public enum SDKType: String, Codable, Hashable {
 
 /// A target dependency.
 public enum TargetDependency: Codable, Hashable {
+    public enum PackageType: Codable, Hashable {
+        case runtime
+        case plugin
+        case macro
+    }
+
     /// Dependency on another target within the same project
     ///
     /// - Parameters:
@@ -64,7 +70,8 @@ public enum TargetDependency: Codable, Hashable {
     /// - Parameters:
     ///   - product: The name of the output product. ${PRODUCT_NAME} inside Xcode.
     ///              e.g. RxSwift
-    case package(product: String)
+    ///   - type: The type of package being integrated.
+    case package(product: String, type: PackageType = .runtime)
 
     /// Dependency on a swift package manager plugin product using Xcode native integration.
     ///
@@ -72,14 +79,6 @@ public enum TargetDependency: Codable, Hashable {
     ///   - product: The name of the output product. ${PRODUCT_NAME} inside Xcode.
     ///              e.g. RxSwift
     case packagePlugin(product: String)
-
-    /// Dependency on a Swift Package Manager Swift Macro using Xcode native integration.
-    ///
-    /// - Parameters:
-    ///   - product: The name of the output product. ${PRODUCT_NAME} inside Xcode.
-    ///              e.g. StructBuilder
-    ///
-    case packageMacro(product: String)
 
     /// Dependency on system library or framework
     ///
@@ -136,8 +135,6 @@ public enum TargetDependency: Codable, Hashable {
             return "package"
         case .packagePlugin:
             return "packagePlugin"
-        case .packageMacro:
-            return "packageMacro"
         case .sdk:
             return "sdk"
         case .xcframework:

--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -34,11 +34,11 @@ public enum TargetDependency: Codable, Hashable {
         /// A runtime package type represents a standard package whose sources are linked at runtime.
         /// For example importing the framework and consuming from dependent targets.
         case runtime
-        
+
         /// A plugin package represents a package that's loaded by the build system at compile-time to
         /// extend the compilation process.
         case plugin
-        
+
         /// A macro package represents a package that contains a Swift Macro.
         case macro
     }

--- a/Sources/TuistCore/Graph/CircularDependencyLinter.swift
+++ b/Sources/TuistCore/Graph/CircularDependencyLinter.swift
@@ -114,7 +114,7 @@ public class CircularDependencyLinter: CircularDependencyLinting {
                 cache: cache,
                 cycleDetector: cycleDetector
             )
-        case .framework, .xcframework, .library, .package, .packagePlugin, .packageMacro, .sdk, .xctest:
+        case .framework, .xcframework, .library, .package, .sdk, .xctest:
             break
         }
     }

--- a/Sources/TuistCore/Graph/GraphLoader.swift
+++ b/Sources/TuistCore/Graph/GraphLoader.swift
@@ -175,15 +175,15 @@ public final class GraphLoader: GraphLoading {
                     source: .system
                 )
             }
-        case let .package(product):
-            return try loadPackage(fromPath: path, productName: product, type: .sources)
-
-        case let .packagePlugin(product):
-            return try loadPackage(fromPath: path, productName: product, type: .plugin)
-
-        case let .packageMacro(product):
-            return try loadPackage(fromPath: path, productName: product, type: .macro)
-
+        case let .package(product, type):
+            switch type {
+            case .macro:
+                return try loadPackage(fromPath: path, productName: product, type: .macro)
+            case .runtime:
+                return try loadPackage(fromPath: path, productName: product, type: .runtime)
+            case .plugin:
+                return try loadPackage(fromPath: path, productName: product, type: .plugin)
+            }
         case .xctest:
             return try platforms.map { platform in
                 try loadXCTestSDK(platform: platform)

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -178,12 +178,8 @@ final class LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_
     ) throws {
         for dependency in target.dependencies {
             switch dependency {
-            case let .package(product: product):
-                try pbxTarget.addSwiftPackageProduct(productName: product, isPlugin: false, pbxproj: pbxproj)
-            case let .packagePlugin(product: product):
-                try pbxTarget.addSwiftPackageProduct(productName: product, isPlugin: true, pbxproj: pbxproj)
-            case let .packageMacro(product: product):
-                try pbxTarget.addSwiftPackageProduct(productName: product, isPlugin: false, pbxproj: pbxproj)
+            case let .package(product: product, type: type):
+                try pbxTarget.addSwiftPackageProduct(productName: product, isPlugin: type == .plugin, pbxproj: pbxproj)
             case .framework, .library, .project, .sdk, .target, .xcframework, .xctest:
                 break
             }

--- a/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -149,7 +149,7 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
         case let .packageProduct(_, _, type):
             switch type {
             // Swift package products are currently assumed to be static
-            case .sources: return true
+            case .runtime: return true
             case .macro: return false
             case .plugin: return false
             }

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -302,12 +302,8 @@ extension TargetDependency {
             return "framework"
         case .library:
             return "library"
-        case .package:
-            return "package"
-        case .packagePlugin:
-            return "packagePlugin"
-        case .packageMacro:
-            return "packageMacro"
+        case let .package(_, type):
+            return "\(type.rawValue) package"
         case .sdk:
             return "sdk"
         case .xcframework:
@@ -329,11 +325,7 @@ extension TargetDependency {
             return path.basename
         case let .library(path, _, _):
             return path.basename
-        case let .package(product):
-            return product
-        case let .packagePlugin(product):
-            return product
-        case let .packageMacro(product):
+        case let .package(product, _):
             return product
         case let .sdk(name, _):
             return name

--- a/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -177,7 +177,7 @@ public final class ModuleMapMapper: WorkspaceMapping {
                 }
                 dependentProject = dependentProjectFromPath
                 dependentTarget = dependentTargetFromName
-            case .framework, .xcframework, .library, .package, .packagePlugin, .packageMacro, .sdk, .xctest:
+            case .framework, .xcframework, .library, .package, .sdk, .xctest:
                 continue
             }
 

--- a/Sources/TuistGraph/Graph/GraphDependency.swift
+++ b/Sources/TuistGraph/Graph/GraphDependency.swift
@@ -7,7 +7,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
             rawValue
         }
 
-        case sources = "sources package product"
+        case runtime = "runtime package product"
         case plugin = "plugin package product"
         case macro = "macro package product"
 

--- a/Sources/TuistGraph/Models/TargetDependency.swift
+++ b/Sources/TuistGraph/Models/TargetDependency.swift
@@ -12,14 +12,18 @@ public enum SDKStatus: String, Codable {
 }
 
 public enum TargetDependency: Equatable, Hashable, Codable {
+    public enum PackageType: String, Equatable, Hashable, Codable {
+        case runtime
+        case plugin
+        case macro
+    }
+
     case target(name: String)
     case project(target: String, path: AbsolutePath)
     case framework(path: AbsolutePath, status: FrameworkStatus)
     case xcframework(path: AbsolutePath, status: FrameworkStatus)
     case library(path: AbsolutePath, publicHeaders: AbsolutePath, swiftModuleMap: AbsolutePath?)
-    case package(product: String)
-    case packagePlugin(product: String)
-    case packageMacro(product: String)
+    case package(product: String, type: PackageType)
     case sdk(name: String, status: SDKStatus)
     case xctest
 }

--- a/Sources/TuistGraphTesting/Graph/GraphDependency+TestData.swift
+++ b/Sources/TuistGraphTesting/Graph/GraphDependency+TestData.swift
@@ -93,7 +93,7 @@ extension GraphDependency {
         .packageProduct(
             path: path,
             product: product,
-            type: .sources
+            type: .runtime
         )
     }
 }

--- a/Sources/TuistKit/Services/GraphService.swift
+++ b/Sources/TuistKit/Services/GraphService.swift
@@ -252,12 +252,15 @@ extension ProjectAutomation.Target {
                 publicHeaders: publicHeaders.pathString,
                 swiftModuleMap: swiftModuleMap?.pathString
             )
-        case let .package(product):
-            return .package(product: product)
-        case let .packagePlugin(product):
-            return .packagePlugin(product: product)
-        case let .packageMacro(product):
-            return .packageMacro(product: product)
+        case let .package(product, type):
+            switch type {
+            case .macro:
+                return .packageMacro(product: product)
+            case .plugin:
+                return .packagePlugin(product: product)
+            case .runtime:
+                return .package(product: product)
+            }
         case let .sdk(name, status):
             let projectAutomationStatus: ProjectAutomation.SDKStatus
             switch status {

--- a/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
@@ -52,12 +52,18 @@ extension TuistGraph.TargetDependency {
                     swiftModuleMap: try swiftModuleMap.map { try generatorPaths.resolve(path: $0) }
                 ),
             ]
-        case let .package(product):
-            return [.package(product: product)]
+        case let .package(product, type):
+            switch type {
+            case .macro:
+                return [.package(product: product, type: .macro)]
+            case .runtime:
+                return [.package(product: product, type: .runtime)]
+            case .plugin:
+                return [.package(product: product, type: .plugin)]
+            }
         case let .packagePlugin(product):
-            return [.packagePlugin(product: product)]
-        case let .packageMacro(product):
-            return [.packageMacro(product: product)]
+            logger.warning(".packagePlugin is deprecated. Use .package(product:, type: .plugin) instead.")
+            return [.package(product: product, type: .plugin)]
         case let .sdk(name, type, status):
             return [
                 .sdk(

--- a/Tests/TuistCoreTests/Graph/GraphLoaderTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphLoaderTests.swift
@@ -495,13 +495,13 @@ final class GraphLoaderTests: TuistUnitTestCase {
     func test_loadWorkspace_packages() throws {
         // Given
         let targetA = Target.test(name: "A", dependencies: [
-            .package(product: "PackageLibraryA1"),
+            .package(product: "PackageLibraryA1", type: .runtime),
         ])
         let targetB = Target.test(name: "B", dependencies: [
-            .package(product: "PackageLibraryA2"),
+            .package(product: "PackageLibraryA2", type: .runtime),
         ])
         let targetC = Target.test(name: "C", dependencies: [
-            .package(product: "PackageLibraryB"),
+            .package(product: "PackageLibraryB", type: .runtime),
         ])
         let projectA = Project.test(path: "/A", name: "A", targets: [targetA], packages: [
             .local(path: "/Packages/PackageLibraryA"),
@@ -541,13 +541,13 @@ final class GraphLoaderTests: TuistUnitTestCase {
         ])
         XCTAssertEqual(graph.dependencies, [
             .target(name: "A", path: "/A"): Set([
-                .packageProduct(path: "/A", product: "PackageLibraryA1", type: .sources),
+                .packageProduct(path: "/A", product: "PackageLibraryA1", type: .runtime),
             ]),
             .target(name: "B", path: "/B"): Set([
-                .packageProduct(path: "/B", product: "PackageLibraryA2", type: .sources),
+                .packageProduct(path: "/B", product: "PackageLibraryA2", type: .runtime),
             ]),
             .target(name: "C", path: "/C"): Set([
-                .packageProduct(path: "/C", product: "PackageLibraryB", type: .sources),
+                .packageProduct(path: "/C", product: "PackageLibraryB", type: .runtime),
             ]),
         ])
     }
@@ -555,7 +555,7 @@ final class GraphLoaderTests: TuistUnitTestCase {
     func test_loadWorkspace_package_plugin() throws {
         // Given
         let targetA = Target.test(name: "A", dependencies: [
-            .packagePlugin(product: "PackagePlugin"),
+            .package(product: "PackagePlugin", type: .plugin),
         ])
 
         let projectA = Project.test(path: "/A", name: "A", targets: [targetA], packages: [

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -3919,7 +3919,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let package = Package.remote(url: "https://git.tuist.io", requirement: .branch("main"))
         let graph = Graph.test(
             packages: [path: ["Test": package]],
-            dependencies: [.packageProduct(path: path, product: "Test", type: .sources): Set()]
+            dependencies: [.packageProduct(path: path, product: "Test", type: .runtime): Set()]
         )
         let graphTraverser = GraphTraverser(graph: graph)
 

--- a/Tests/TuistGeneratorIntegrationTests/Generator/SwiftPackageManagerInteractorTests.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Generator/SwiftPackageManagerInteractorTests.swift
@@ -28,7 +28,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         // Given
         let temporaryPath = try temporaryPath()
         let target = anyTarget(dependencies: [
-            .package(product: "Example"),
+            .package(product: "Example", type: .runtime),
         ])
         let package = Package.remote(url: "http://some.remote/repo.git", requirement: .exact("branch"))
         let project = Project.test(
@@ -41,7 +41,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         let graph = Graph.test(
             path: project.path,
             packages: [project.path: ["Test": package]],
-            dependencies: [GraphDependency.packageProduct(path: project.path, product: "Test", type: .sources): Set()]
+            dependencies: [GraphDependency.packageProduct(path: project.path, product: "Test", type: .runtime): Set()]
         )
         let graphTraverser = GraphTraverser(graph: graph)
 
@@ -70,7 +70,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         )
 
         let target = anyTarget(dependencies: [
-            .package(product: "Example"),
+            .package(product: "Example", type: .runtime),
         ])
         let package = Package.remote(url: "http://some.remote/repo.git", requirement: .exact("branch"))
         let project = Project.test(
@@ -111,7 +111,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         // Given
         let temporaryPath = try temporaryPath()
         let target = anyTarget(dependencies: [
-            .package(product: "Example"),
+            .package(product: "Example", type: .runtime),
         ])
         let package = Package.remote(url: "http://some.remote/repo.git", requirement: .exact("branch"))
         let project = Project.test(
@@ -126,7 +126,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         let graph = Graph.test(
             path: project.path,
             packages: [project.path: ["Test": package]],
-            dependencies: [GraphDependency.packageProduct(path: project.path, product: "Test", type: .sources): Set()]
+            dependencies: [GraphDependency.packageProduct(path: project.path, product: "Test", type: .runtime): Set()]
         )
         let graphTraverser = GraphTraverser(graph: graph)
 
@@ -195,7 +195,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
 
         let spmPath = temporaryPath.appending(component: "spm")
         let target = anyTarget(dependencies: [
-            .package(product: "Example"),
+            .package(product: "Example", type: .runtime),
         ])
         let package = Package.remote(url: "http://some.remote/repo.git", requirement: .exact("branch"))
         let project = Project.test(
@@ -208,7 +208,7 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         let graph = Graph.test(
             path: project.path,
             packages: [project.path: ["Test": package]],
-            dependencies: [GraphDependency.packageProduct(path: project.path, product: "Test", type: .sources): Set()]
+            dependencies: [GraphDependency.packageProduct(path: project.path, product: "Test", type: .runtime): Set()]
         )
         let graphTraverser = GraphTraverser(graph: graph)
 

--- a/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectDescriptorGeneratorTests.swift
@@ -96,7 +96,7 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
         let project = Project.test(
             path: temporaryPath,
             name: "Project",
-            targets: [.test(dependencies: [.package(product: "A")])],
+            targets: [.test(dependencies: [.package(product: "A", type: .runtime)])],
             packages: [.remote(url: "A", requirement: .exact("0.1"))]
         )
 
@@ -116,7 +116,7 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
             ],
             dependencies: [
                 .target(name: graphTarget.target.name, path: graphTarget.path): [
-                    .packageProduct(path: project.path, product: "A", type: .sources),
+                    .packageProduct(path: project.path, product: "A", type: .runtime),
                 ],
             ]
         )
@@ -343,7 +343,7 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
             path: projectPath,
             sourceRootPath: projectPath,
             name: "Project",
-            targets: [.test(dependencies: [.package(product: "A")])],
+            targets: [.test(dependencies: [.package(product: "A", type: .runtime)])],
             packages: [.local(path: localPackagePath)]
         )
 
@@ -363,7 +363,7 @@ final class ProjectDescriptorGeneratorTests: TuistUnitTestCase {
             ],
             dependencies: [
                 .target(name: graphTarget.target.name, path: graphTarget.path): [
-                    .packageProduct(path: project.path, product: "A", type: .sources),
+                    .packageProduct(path: project.path, product: "A", type: .runtime),
                 ],
             ]
         )

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -832,7 +832,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
             ],
             dependencies: [
                 .target(name: graphTarget.target.name, path: graphTarget.path): [
-                    .packageProduct(path: project.path, product: "A", type: .sources),
+                    .packageProduct(path: project.path, product: "A", type: .runtime),
                 ],
             ]
         )

--- a/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
@@ -32,9 +32,9 @@ class StaticProductsGraphLinterTests: XCTestCase {
         let frameworkDependency = GraphDependency.target(name: framework.name, path: path)
 
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
-            appDependency: Set([frameworkDependency, .packageProduct(path: path, product: "Package", type: .sources)]),
-            frameworkDependency: Set([.packageProduct(path: path, product: "Package", type: .sources)]),
-            .packageProduct(path: path, product: "Package", type: .sources): Set(),
+            appDependency: Set([frameworkDependency, .packageProduct(path: path, product: "Package", type: .runtime)]),
+            frameworkDependency: Set([.packageProduct(path: path, product: "Package", type: .runtime)]),
+            .packageProduct(path: path, product: "Package", type: .runtime): Set(),
         ]
         let graph = Graph.test(
             path: path,
@@ -1091,7 +1091,7 @@ class StaticProductsGraphLinterTests: XCTestCase {
         let appDependency = GraphDependency.target(name: app.name, path: path)
         let watchAppDependency = GraphDependency.target(name: watchApp.name, path: path)
         let watchAppExtensionDependency = GraphDependency.target(name: watchAppExtension.name, path: path)
-        let swiftPackage = GraphDependency.packageProduct(path: "/path/to/package", product: "LocalPackage", type: .sources)
+        let swiftPackage = GraphDependency.packageProduct(path: "/path/to/package", product: "LocalPackage", type: .runtime)
 
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
             // apps declare they bundle watch apps via dependencies
@@ -1132,7 +1132,7 @@ class StaticProductsGraphLinterTests: XCTestCase {
         let watchAppDependency = GraphDependency.target(name: watchApp.name, path: path)
         let watchAppExtensionDependency = GraphDependency.target(name: watchAppExtension.name, path: path)
         let watchFrameworkDependency = GraphDependency.target(name: watchFramework.name, path: path)
-        let swiftPackage = GraphDependency.packageProduct(path: "/path/to/package", product: "LocalPackage", type: .sources)
+        let swiftPackage = GraphDependency.packageProduct(path: "/path/to/package", product: "LocalPackage", type: .runtime)
 
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
             // apps declare they bundle watch apps via dependencies


### PR DESCRIPTION
### Short description 📝
In a recent PR to add support for Swift Macros using Xcode's default integration, I introduced a new case, `TargetDependency.macroPackage` to model a Swift Package of type macro. However, as @fortmarek pointed out, it's more ergonomic to reuse the existing `TargetDependency.package` case, with an additional attribute, `type:` that can be either `runtime`, `plugin`, or `macro`. Because the change hasn't been released yet, I'm removing the `TargetDependency.macroPackage` and also adding  deprecation warning for people using `TargetDependency.pluginPackage`. We can remove this last one as part of the Tuist 4 release.

### How to test the changes locally 🧐
Tests should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
