### PR TITLE
[Multiplatform]  Update `Graph` to store filter data in edges. 

### DIFF
--- a/Sources/TuistCore/Graph/GraphDependencyReference.swift
+++ b/Sources/TuistCore/Graph/GraphDependencyReference.swift
@@ -3,6 +3,22 @@ import TSCBasic
 import TuistGraph
 
 public enum GraphDependencyReference: Equatable, Comparable, Hashable {
+    var platformFilters: PlatformFilters {
+        switch self {
+        case let .framework(_, _, _, _, _, _, _, _, _, platformFilters),
+             let .library(_, _, _, _, platformFilters),
+             let .xcframework(_, _, _, _, _, platformFilters),
+             let .bundle(_, platformFilters),
+             let .product(_, _, platformFilters),
+             let .sdk(_, _, _, platformFilters):
+            return platformFilters
+        }
+    }
+
+    var isValid: Bool {
+        platformFilters != .invalid
+    }
+
     case xcframework(
         path: AbsolutePath,
         infoPlist: XCFrameworkInfoPlist,
@@ -99,7 +115,6 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
     private enum Synthesized: Comparable, Hashable {
         case sdk(path: AbsolutePath, platformFilters: PlatformFilters)
         case product(target: String, productName: String, platformFilters: PlatformFilters)
-        case productWithPlatformFilters(target: String, productName: String, platformFilters: PlatformFilters)
         case library(path: AbsolutePath, platformFilters: PlatformFilters)
         case framework(path: AbsolutePath, platformFilters: PlatformFilters)
         case xcframework(path: AbsolutePath, platformFilters: PlatformFilters)
@@ -134,11 +149,7 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
             case let .bundle(path: path, platformFilters):
                 self = .bundle(path: path, platformFilters: platformFilters)
             case let .product(target: target, productName: productName, platformFilters: platformFilters):
-                if !platformFilters.isEmpty {
-                    self = .productWithPlatformFilters(target: target, productName: productName, platformFilters: platformFilters)
-                } else {
-                    self = .product(target: target, productName: productName, platformFilters: platformFilters)
-                }
+                self = .product(target: target, productName: productName, platformFilters: platformFilters)
             case .sdk(path: let path, status: _, source: _, platformFilters: let platformFilters):
                 self = .sdk(path: path, platformFilters: platformFilters)
             }

--- a/Sources/TuistCore/Graph/GraphDependencyReference.swift
+++ b/Sources/TuistCore/Graph/GraphDependencyReference.swift
@@ -34,7 +34,7 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
     case product(target: String, productName: String, platformFilters: PlatformFilters)
     case sdk(path: AbsolutePath, status: SDKStatus, source: SDKSource, platformFilters: PlatformFilters)
 
-    init(_ dependency: GraphDependency, filters: PlatformFilters = []) {
+    init(_ dependency: GraphDependency, filters: PlatformFilters = .all) {
         switch dependency {
         case let .framework(path, binaryPath, dsymPath, bcsymbolmapPaths, linking, architectures, isCarthage, status):
             self = .framework(

--- a/Sources/TuistCore/Graph/GraphDependencyReference.swift
+++ b/Sources/TuistCore/Graph/GraphDependencyReference.swift
@@ -30,7 +30,7 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
         status: FrameworkStatus,
         platformFilters: PlatformFilters
     )
-    case bundle(path: AbsolutePath, platformFilters: PlatformFilters )
+    case bundle(path: AbsolutePath, platformFilters: PlatformFilters)
     case product(target: String, productName: String, platformFilters: PlatformFilters)
     case sdk(path: AbsolutePath, status: SDKStatus, source: SDKSource, platformFilters: PlatformFilters)
 
@@ -145,4 +145,3 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
         }
     }
 }
-

--- a/Sources/TuistCore/Graph/GraphDependencyReference.swift
+++ b/Sources/TuistCore/Graph/GraphDependencyReference.swift
@@ -8,13 +8,15 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
         infoPlist: XCFrameworkInfoPlist,
         primaryBinaryPath: AbsolutePath,
         binaryPath: AbsolutePath,
-        status: FrameworkStatus
+        status: FrameworkStatus,
+        platformFilters: PlatformFilters
     )
     case library(
         path: AbsolutePath,
         linking: BinaryLinking,
         architectures: [BinaryArchitecture],
-        product: Product
+        product: Product,
+        platformFilters: PlatformFilters
     )
     case framework(
         path: AbsolutePath,
@@ -25,13 +27,14 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
         linking: BinaryLinking,
         architectures: [BinaryArchitecture],
         product: Product,
-        status: FrameworkStatus
+        status: FrameworkStatus,
+        platformFilters: PlatformFilters
     )
-    case bundle(path: AbsolutePath)
-    case product(target: String, productName: String, platformFilters: PlatformFilters = [])
-    case sdk(path: AbsolutePath, status: SDKStatus, source: SDKSource)
+    case bundle(path: AbsolutePath, platformFilters: PlatformFilters )
+    case product(target: String, productName: String, platformFilters: PlatformFilters)
+    case sdk(path: AbsolutePath, status: SDKStatus, source: SDKSource, platformFilters: PlatformFilters)
 
-    init(_ dependency: GraphDependency) {
+    init(_ dependency: GraphDependency, filters: PlatformFilters = []) {
         switch dependency {
         case let .framework(path, binaryPath, dsymPath, bcsymbolmapPaths, linking, architectures, isCarthage, status):
             self = .framework(
@@ -43,14 +46,16 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
                 linking: linking,
                 architectures: architectures,
                 product: (linking == .static) ? .staticFramework : .framework,
-                status: status
+                status: status,
+                platformFilters: filters
             )
         case let .library(path, _, linking, architectures, _):
             self = .library(
                 path: path,
                 linking: linking,
                 architectures: architectures,
-                product: (linking == .static) ? .staticLibrary : .dynamicLibrary
+                product: (linking == .static) ? .staticLibrary : .dynamicLibrary,
+                platformFilters: filters
             )
         case let .xcframework(path, infoPlist, primaryBinaryPath, _, _, status):
             self = .xcframework(
@@ -58,7 +63,8 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
                 infoPlist: infoPlist,
                 primaryBinaryPath: primaryBinaryPath,
                 binaryPath: primaryBinaryPath,
-                status: status
+                status: status,
+                platformFilters: filters
             )
         default:
             preconditionFailure("unsupported dependencies")
@@ -73,11 +79,11 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
     /// this attribute returns the path to them.
     public var precompiledPath: AbsolutePath? {
         switch self {
-        case let .framework(path, _, _, _, _, _, _, _, _):
+        case let .framework(path, _, _, _, _, _, _, _, _, _):
             return path
-        case let .library(path, _, _, _):
+        case let .library(path, _, _, _, _):
             return path
-        case let .xcframework(path, _, _, _, _):
+        case let .xcframework(path, _, _, _, _, _):
             return path
         default:
             return nil
@@ -91,13 +97,13 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
     // Private helper type to auto-synthesize the hashable & comparable implementations
     // where only the required subset of properties are used.
     private enum Synthesized: Comparable, Hashable {
-        case sdk(path: AbsolutePath)
-        case product(target: String, productName: String)
+        case sdk(path: AbsolutePath, platformFilters: PlatformFilters)
+        case product(target: String, productName: String, platformFilters: PlatformFilters)
         case productWithPlatformFilters(target: String, productName: String, platformFilters: PlatformFilters)
-        case library(path: AbsolutePath)
-        case framework(path: AbsolutePath)
-        case xcframework(path: AbsolutePath)
-        case bundle(path: AbsolutePath)
+        case library(path: AbsolutePath, platformFilters: PlatformFilters)
+        case framework(path: AbsolutePath, platformFilters: PlatformFilters)
+        case xcframework(path: AbsolutePath, platformFilters: PlatformFilters)
+        case bundle(path: AbsolutePath, platformFilters: PlatformFilters)
 
         init(dependencyReference: GraphDependencyReference) {
             switch dependencyReference {
@@ -106,11 +112,12 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
                 infoPlist: _,
                 primaryBinaryPath: _,
                 binaryPath: _,
-                status: _
+                status: _,
+                platformFilters: let platformFilters
             ):
-                self = .xcframework(path: path)
-            case .library(path: let path, linking: _, architectures: _, product: _):
-                self = .library(path: path)
+                self = .xcframework(path: path, platformFilters: platformFilters)
+            case let .library(path: path, _, _, _, platformFilters):
+                self = .library(path: path, platformFilters: platformFilters)
             case .framework(
                 path: let path,
                 binaryPath: _,
@@ -120,20 +127,22 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
                 linking: _,
                 architectures: _,
                 product: _,
-                status: _
+                status: _,
+                platformFilters: let platformFilters
             ):
-                self = .framework(path: path)
-            case let .bundle(path: path):
-                self = .bundle(path: path)
+                self = .framework(path: path, platformFilters: platformFilters)
+            case let .bundle(path: path, platformFilters):
+                self = .bundle(path: path, platformFilters: platformFilters)
             case let .product(target: target, productName: productName, platformFilters: platformFilters):
                 if !platformFilters.isEmpty {
                     self = .productWithPlatformFilters(target: target, productName: productName, platformFilters: platformFilters)
                 } else {
-                    self = .product(target: target, productName: productName)
+                    self = .product(target: target, productName: productName, platformFilters: platformFilters)
                 }
-            case .sdk(path: let path, status: _, source: _):
-                self = .sdk(path: path)
+            case .sdk(path: let path, status: _, source: _, platformFilters: let platformFilters):
+                self = .sdk(path: path, platformFilters: platformFilters)
             }
         }
     }
 }
+

--- a/Sources/TuistCore/Graph/GraphLoader.swift
+++ b/Sources/TuistCore/Graph/GraphLoader.swift
@@ -58,7 +58,8 @@ public final class GraphLoader: GraphLoading {
             projects: cache.loadedProjects,
             packages: cache.packages,
             targets: cache.loadedTargets,
-            dependencies: cache.dependencies
+            dependencies: cache.dependencies,
+            edges: cache.edges
         )
         return graph
     }
@@ -311,6 +312,7 @@ public final class GraphLoader: GraphLoading {
         var loadedProjects: [AbsolutePath: Project] = [:]
         var loadedTargets: [AbsolutePath: [String: Target]] = [:]
         var dependencies: [GraphDependency: Set<GraphDependency>] = [:]
+        var edges: [GraphEdge: PlatformFilters] = [:]
         var frameworks: [AbsolutePath: GraphDependency] = [:]
         var libraries: [AbsolutePath: GraphDependency] = [:]
         var xcframeworks: [AbsolutePath: GraphDependency] = [:]

--- a/Sources/TuistCore/Graph/GraphLoader.swift
+++ b/Sources/TuistCore/Graph/GraphLoader.swift
@@ -59,7 +59,7 @@ public final class GraphLoader: GraphLoading {
             packages: cache.packages,
             targets: cache.loadedTargets,
             dependencies: cache.dependencies,
-            edges: cache.edges
+            dependencyPlatformFilters: cache.dependencyPlatformFilters
         )
         return graph
     }
@@ -312,7 +312,7 @@ public final class GraphLoader: GraphLoading {
         var loadedProjects: [AbsolutePath: Project] = [:]
         var loadedTargets: [AbsolutePath: [String: Target]] = [:]
         var dependencies: [GraphDependency: Set<GraphDependency>] = [:]
-        var edges: [GraphEdge: PlatformFilters] = [:]
+        var dependencyPlatformFilters: [GraphEdge: PlatformFilters] = [:]
         var frameworks: [AbsolutePath: GraphDependency] = [:]
         var libraries: [AbsolutePath: GraphDependency] = [:]
         var xcframeworks: [AbsolutePath: GraphDependency] = [:]

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -639,12 +639,11 @@ public class GraphTraverser: GraphTraversing {
     /// set of platform filters.
     func platformFilters(from rootDependency: GraphDependency, to transitiveDependency: GraphDependency) -> PlatformFilters? {
         var visited: Set<GraphDependency> = []
-        struct NoSharedPlatforms: Error {}
-
+        
         func find(from root: GraphDependency, to other: GraphDependency) -> PlatformFilters? {
-            guard !visited.contains(root) else { return [] }
+            guard !visited.contains(root) else { return nil }
             visited.insert(root)
-            guard let dependencies = graph.dependencies[root] else { return [] }
+            guard let dependencies = graph.dependencies[root] else { return nil }
 
             if dependencies.contains(other) {
                 // If we reach the end and there's no filters,

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -152,7 +152,7 @@ public class GraphTraverser: GraphTraversing {
             test: isDependencyResourceBundle,
             skip: canHostResources
         )
-        return Set(bundles.compactMap(dependencyReference))
+        return Set(bundles.compactMap { dependencyReference(to: $0, from: .target(name: name, path: path)) })
     }
 
     public func target(from dependency: GraphDependency) -> GraphTarget? {
@@ -207,19 +207,17 @@ public class GraphTraverser: GraphTraversing {
     public func directStaticDependencies(path: AbsolutePath, name: String) -> Set<GraphDependencyReference> {
         Set(
             graph.dependencies[.target(name: name, path: path)]?
-                .compactMap { (dependency: GraphDependency) -> (path: AbsolutePath, name: String)? in
-                    guard case let GraphDependency.target(name, path) = dependency else {
+                .compactMap { (dependency: GraphDependency) -> GraphDependencyReference? in
+                    guard case let GraphDependency.target(dependencyName, dependencyPath) = dependency,
+                          let target = graph.targets[dependencyPath]?[dependencyName],
+                          target.product.isStatic
+                    else {
                         return nil
                     }
-                    return (path, name)
-                }
-                .compactMap { graph.targets[$0.path]?[$0.name] }
-                .filter(\.product.isStatic)
-                .map {
-                    .product(
-                        target: $0.name,
-                        productName: $0.productNameWithExtension,
-                        platformFilters: $0.dependencyPlatformFilters
+
+                    return dependencyReference(
+                        to: .target(name: dependencyName, path: dependencyPath),
+                        from: .target(name: name, path: path)
                     )
                 }
                 ?? []
@@ -242,8 +240,11 @@ public class GraphTraverser: GraphTraversing {
             precompiledFrameworks = precompiledFrameworks
                 .filter { !isXCFrameworkMerged(dependency: $0, expectedMergedBinaries: dependenciesToMerge) }
         }
-        references.formUnion(precompiledFrameworks.lazy.compactMap(dependencyReference))
-
+        references.formUnion(precompiledFrameworks.lazy.compactMap { self.dependencyReference(
+            to: $0,
+            from: .target(name: name, path: path)
+        ) })
+        
         /// Other targets' frameworks.
         var otherTargetFrameworks = filterDependencies(
             from: .target(name: name, path: path),
@@ -254,8 +255,10 @@ public class GraphTraverser: GraphTraversing {
         if target.target.mergedBinaryType != .disabled {
             otherTargetFrameworks = otherTargetFrameworks.filter(isDependencyDynamicNonMergeableTarget)
         }
-        references.formUnion(otherTargetFrameworks.lazy.compactMap(dependencyReference))
-
+        references.formUnion(precompiledFrameworks.lazy.compactMap { self.dependencyReference(
+            to: $0,
+            from: .target(name: name, path: path)
+        ) })
         // Exclude any products embed in unit test host apps
         if target.target.product == .unitTests {
             if let hostApp = unitTestHost(path: path, name: name) {
@@ -286,15 +289,21 @@ public class GraphTraverser: GraphTraversing {
         guard let target = target(path: path, name: name) else { return Set() }
 
         var references = Set<GraphDependencyReference>()
+        let targetGraphDependency = GraphDependency.target(name: name, path: path)
 
         // System libraries and frameworks
         if target.target.canLinkStaticProducts() {
-            let transitiveSystemLibraries = transitiveStaticDependencies(from: .target(name: name, path: path))
+            let transitiveSystemLibraries = transitiveStaticDependencies(from: targetGraphDependency)
                 .flatMap { dependency -> [GraphDependencyReference] in
                     let dependencies = self.graph.dependencies[dependency, default: []]
                     return dependencies.compactMap { dependencyDependency -> GraphDependencyReference? in
                         guard case let GraphDependency.sdk(_, path, status, source) = dependencyDependency else { return nil }
-                        return .sdk(path: path, status: status, source: source)
+                        return .sdk(
+                            path: path,
+                            status: status,
+                            source: source
+                         //   platformFilters: platformFilters(from: targetGraphDependency, to: dependencyDependency)
+                        )
                     }
                 }
             references.formUnion(transitiveSystemLibraries)
@@ -317,7 +326,7 @@ public class GraphTraverser: GraphTraversing {
         }
 
         // Direct system libraries and frameworks
-        let directSystemLibrariesAndFrameworks = graph.dependencies[.target(name: name, path: path), default: []]
+        let directSystemLibrariesAndFrameworks = graph.dependencies[targetGraphDependency, default: []]
             .compactMap { dependency -> GraphDependencyReference? in
                 guard case let GraphDependency.sdk(_, path, status, source) = dependency else { return nil }
                 return .sdk(path: path, status: status, source: source)
@@ -334,13 +343,13 @@ public class GraphTraverser: GraphTraversing {
 
         let precompiledLibrariesAndFrameworks = Set(precompiled + precompiledDependencies)
             .filter(isDependencyPrecompiledDynamicAndLinkable)
-            .compactMap(dependencyReference)
+            .compactMap { dependencyReference(to: $0, from: targetGraphDependency) }
 
         references.formUnion(precompiledLibrariesAndFrameworks)
 
         // Static libraries and frameworks / Static libraries' dynamic libraries
         if target.target.canLinkStaticProducts() {
-            let transitiveStaticTargetReferences = transitiveStaticDependencies(from: .target(name: name, path: path))
+            let transitiveStaticTargetReferences = transitiveStaticDependencies(from: targetGraphDependency)
 
             // Exclude any static products linked in a host application
             // however, for search paths it's fine to keep them included
@@ -375,17 +384,18 @@ public class GraphTraverser: GraphTraversing {
 
             references.formUnion(
                 allDependencies
-                    .compactMap(dependencyReference)
+                    .compactMap { dependencyReference(to: $0, from: targetGraphDependency) }
             )
             references.subtract(
-                hostApplicationStaticTargets.compactMap(dependencyReference)
+                hostApplicationStaticTargets
+                    .compactMap { dependencyReference(to: $0, from: targetGraphDependency) }
             )
         }
 
         // Link dynamic libraries and frameworks
         let dynamicLibrariesAndFrameworks = graph.dependencies[.target(name: name, path: path), default: []]
             .filter(or(isDependencyDynamicLibrary, isDependencyFramework))
-            .compactMap(dependencyReference)
+            .compactMap { dependencyReference(to: $0, from: targetGraphDependency) }
         references.formUnion(dynamicLibrariesAndFrameworks)
 
         return references
@@ -611,7 +621,36 @@ public class GraphTraverser: GraphTraversing {
 
         return references
     }
+    
+    /// Recursively find platform filters within transitive dependencies
+    /// - Parameters:
+    ///   - rootDependency: dependency whose platform filters we need when depending on `transitiveDependency`
+    ///   - transitiveDependency: target dependency
+    /// - Returns: PlatformFilters to apply to transitive dependency
+    func platformFilters(from rootDependency: GraphDependency, to transitiveDependency: GraphDependency) -> PlatformFilters {
+        var visited: Set<GraphDependency> = []
 
+        func find(from root: GraphDependency, to other: GraphDependency) -> PlatformFilters {
+            guard !visited.contains(root) else { return [] }
+            visited.insert(root)
+            guard let dependencies = graph.dependencies[root] else { return [] }
+
+            if dependencies.contains(other) {
+                return graph.edges[(root, other)]
+            } else {
+                let filters = dependencies.map { node in
+                    find(from: node, to: other)
+                }
+
+                return filters.reduce(Set<PlatformFilter>()) { result, otherFilters in
+                    result.union(otherFilters)
+                }
+            }
+        }
+
+        return find(from: rootDependency, to: transitiveDependency)
+    }
+    
     func allDependenciesSatisfy(from rootDependency: GraphDependency, meets: (GraphDependency) -> Bool) -> Bool {
         var allSatisfy = true
         _ = filterDependencies(from: rootDependency, test: { dependency in
@@ -772,8 +811,13 @@ public class GraphTraverser: GraphTraversing {
         return validProducts.contains(target.product)
     }
 
-    func dependencyReference(dependency: GraphDependency) -> GraphDependencyReference? {
-        switch dependency {
+    func dependencyReference(
+        to toDependency: GraphDependency,
+        from fromDependency: GraphDependency
+    ) -> GraphDependencyReference? {
+        let platformFilters = platformFilters(from: fromDependency, to: toDependency)
+
+        switch toDependency {
         case let .framework(path, binaryPath, dsymPath, bcsymbolmapPaths, linking, architectures, isCarthage, status):
             return .framework(
                 path: path,
@@ -861,7 +905,7 @@ public class GraphTraverser: GraphTraversing {
             .flatMap { filterDependencies(from: $0) }
 
         return Set(precompiledStatic + precompiledDependencies)
-            .compactMap(dependencyReference)
+            .compactMap { dependencyReference(to: $0, from: .target(name: name, path: path)) }
     }
 
     private func staticPrecompiledXCFrameworksDependencies(
@@ -881,7 +925,7 @@ public class GraphTraverser: GraphTraversing {
             skip: { $0.isDynamicPrecompiled || !$0.isPrecompiled }
         )
         return Set(dependencies)
-            .compactMap(dependencyReference)
+            .compactMap { dependencyReference(to: $0, from: .target(name: name, path: path)) }
     }
 }
 

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -244,7 +244,7 @@ public class GraphTraverser: GraphTraversing {
             to: $0,
             from: .target(name: name, path: path)
         ) })
-        
+
         /// Other targets' frameworks.
         var otherTargetFrameworks = filterDependencies(
             from: .target(name: name, path: path),
@@ -330,10 +330,12 @@ public class GraphTraverser: GraphTraversing {
         let directSystemLibrariesAndFrameworks = graph.dependencies[targetGraphDependency, default: []]
             .compactMap { dependency -> GraphDependencyReference? in
                 guard case let GraphDependency.sdk(_, path, status, source) = dependency else { return nil }
-                return .sdk(path: path,
-                            status: status,
-                            source: source,
-                            platformFilters: platformFilters(from: targetGraphDependency, to: dependency))
+                return .sdk(
+                    path: path,
+                    status: status,
+                    source: source,
+                    platformFilters: platformFilters(from: targetGraphDependency, to: dependency)
+                )
             }
         references.formUnion(directSystemLibrariesAndFrameworks)
 
@@ -625,7 +627,7 @@ public class GraphTraverser: GraphTraversing {
 
         return references
     }
-    
+
     /// Recursively find platform filters within transitive dependencies
     /// - Parameters:
     ///   - rootDependency: dependency whose platform filters we need when depending on `transitiveDependency`
@@ -654,7 +656,7 @@ public class GraphTraverser: GraphTraversing {
 
         return find(from: rootDependency, to: transitiveDependency)
     }
-    
+
     func allDependenciesSatisfy(from rootDependency: GraphDependency, meets: (GraphDependency) -> Bool) -> Bool {
         var allSatisfy = true
         _ = filterDependencies(from: rootDependency, test: { dependency in
@@ -859,7 +861,7 @@ public class GraphTraverser: GraphTraversing {
             return .product(
                 target: target.target.name,
                 productName: target.target.productNameWithExtension,
-                platformFilters: target.target.dependencyPlatformFilters //This will be platformFilters when we 
+                platformFilters: target.target.dependencyPlatformFilters // This will be platformFilters when we
             )
         case let .xcframework(path, infoPlist, primaryBinaryPath, _, _, status):
             return .xcframework(

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -298,7 +298,8 @@ public class GraphTraverser: GraphTraversing {
                     let dependencies = self.graph.dependencies[dependency, default: []]
                     return dependencies.compactMap { dependencyDependency -> GraphDependencyReference? in
                         guard case let GraphDependency.sdk(_, path, status, source) = dependencyDependency,
-                              let filters =  platformFilters(from: targetGraphDependency, to: dependencyDependency) else { return nil }
+                              let filters = platformFilters(from: targetGraphDependency, to: dependencyDependency)
+                        else { return nil }
                         return .sdk(
                             path: path,
                             status: status,
@@ -331,7 +332,7 @@ public class GraphTraverser: GraphTraversing {
         let directSystemLibrariesAndFrameworks = graph.dependencies[targetGraphDependency, default: []]
             .compactMap { dependency -> GraphDependencyReference? in
                 guard case let GraphDependency.sdk(_, path, status, source) = dependency,
-                let filters = platformFilters(from: targetGraphDependency, to: dependency)else { return nil }
+                      let filters = platformFilters(from: targetGraphDependency, to: dependency) else { return nil }
                 return .sdk(
                     path: path,
                     status: status,
@@ -634,11 +635,12 @@ public class GraphTraverser: GraphTraversing {
     /// - Parameters:
     ///   - rootDependency: dependency whose platform filters we need when depending on `transitiveDependency`
     ///   - transitiveDependency: target dependency
-    /// - Returns: PlatformFilters to apply to transitive dependency or `nil` if the path to a dependency results in a disjoint set of platform filters.
+    /// - Returns: PlatformFilters to apply to transitive dependency or `nil` if the path to a dependency results in a disjoint
+    /// set of platform filters.
     func platformFilters(from rootDependency: GraphDependency, to transitiveDependency: GraphDependency) -> PlatformFilters? {
         var visited: Set<GraphDependency> = []
-        struct NoSharedPlatforms: Error { }
-        
+        struct NoSharedPlatforms: Error {}
+
         func find(from root: GraphDependency, to other: GraphDependency) -> PlatformFilters? {
             guard !visited.contains(root) else { return [] }
             visited.insert(root)
@@ -649,7 +651,7 @@ public class GraphTraverser: GraphTraversing {
                 // return empty to signify the dependency has no filters
                 return graph.edges[(root, other)] ?? []
             } else {
-                let filters = dependencies.map { (node) -> PlatformFilters? in
+                let filters = dependencies.map { node -> PlatformFilters? in
 
                     // If an intervening dependency has filters, we need to constrain downstream filters to a subset of those.
                     if let currentDependencyPlatformFilters = graph.edges[(root, node)] {
@@ -663,13 +665,12 @@ public class GraphTraverser: GraphTraversing {
                             let intersection = transitive.intersection(currentDependencyPlatformFilters)
                             return intersection.isEmpty ? nil : intersection
                         } else {
-                           return currentDependencyPlatformFilters
+                            return currentDependencyPlatformFilters
                         }
                     } else { // Otherwise, just find the filters for this
                         return find(from: node, to: other)
                     }
                 }
-
 
                 let transitiveFilters = filters.reduce(Set<PlatformFilter>?(nil)) { result, otherFilters in
                     if let result {
@@ -678,7 +679,7 @@ public class GraphTraverser: GraphTraversing {
                         return otherFilters
                     }
                 }
-                
+
                 return transitiveFilters
             }
         }

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -625,7 +625,7 @@ public class GraphTraverser: GraphTraversing {
     /// - Returns: PlatformFilters to apply to transitive dependency or `nil` if there isnt a path or path to a dependency results
     /// in a disjoint
     /// set of platform filters
-    func platformFilters(from rootDependency: GraphDependency, to transitiveDependency: GraphDependency) -> PlatformFilters {
+    func platformFilters(to transitiveDependency: GraphDependency, from rootDependency: GraphDependency) -> PlatformFilters {
         var visited: Set<GraphDependency> = []
 
         func find(from root: GraphDependency, to other: GraphDependency) -> PlatformFilters {
@@ -830,7 +830,7 @@ public class GraphTraverser: GraphTraversing {
         to toDependency: GraphDependency,
         from fromDependency: GraphDependency
     ) -> GraphDependencyReference? {
-        let platformFilters = platformFilters(from: fromDependency, to: toDependency)
+        let platformFilters = platformFilters(to: toDependency, from: fromDependency)
         guard platformFilters != .invalid else {
             return nil
         }

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -649,12 +649,12 @@ public class GraphTraverser: GraphTraversing {
             if dependencies.contains(other) {
                 // If we reach the end and there's no filters,
                 // return empty to signify the dependency has no filters
-                return graph.edges[(root, other)] ?? []
+                return graph.dependencyPlatformFilters[(root, other)] ?? []
             } else {
                 let filters = dependencies.map { node -> PlatformFilters? in
 
                     // If an intervening dependency has filters, we need to constrain downstream filters to a subset of those.
-                    if let currentDependencyPlatformFilters = graph.edges[(root, node)] {
+                    if let currentDependencyPlatformFilters = graph.dependencyPlatformFilters[(root, node)] {
                         guard let transitive = find(from: node, to: other) else {
                             return nil
                         }

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -639,7 +639,7 @@ public class GraphTraverser: GraphTraversing {
     /// set of platform filters.
     func platformFilters(from rootDependency: GraphDependency, to transitiveDependency: GraphDependency) -> PlatformFilters? {
         var visited: Set<GraphDependency> = []
-        
+
         func find(from root: GraphDependency, to other: GraphDependency) -> PlatformFilters? {
             guard !visited.contains(root) else { return nil }
             visited.insert(root)

--- a/Sources/TuistCoreTesting/Graph/GraphDependencyReference+TestData.swift
+++ b/Sources/TuistCoreTesting/Graph/GraphDependencyReference+TestData.swift
@@ -16,7 +16,7 @@ extension GraphDependencyReference {
         architectures: [BinaryArchitecture] = [.arm64],
         product: Product = .framework,
         status: FrameworkStatus = .required,
-        platformFilters: PlatformFilters = []
+        platformFilters: PlatformFilters = .all
     ) -> GraphDependencyReference {
         GraphDependencyReference.framework(
             path: path,
@@ -39,7 +39,7 @@ extension GraphDependencyReference {
         binaryPath: AbsolutePath = "/frameworks/tuist.xcframework/ios-arm64/tuist",
         linking _: BinaryLinking = .dynamic,
         status: FrameworkStatus = .required,
-        platformFilters: PlatformFilters = []
+        platformFilters: PlatformFilters = .all
     ) -> GraphDependencyReference {
         GraphDependencyReference.xcframework(
             path: path,
@@ -56,7 +56,7 @@ extension GraphDependencyReference {
         linking: BinaryLinking = .static,
         architectures: [BinaryArchitecture] = [BinaryArchitecture.arm64],
         product: Product = .staticLibrary,
-        platformFilters: PlatformFilters = []
+        platformFilters: PlatformFilters = .all
     ) -> GraphDependencyReference {
         GraphDependencyReference.library(
             path: path,
@@ -71,7 +71,7 @@ extension GraphDependencyReference {
         path: AbsolutePath = "/path/CoreData.framework",
         status: SDKStatus = .required,
         source: SDKSource = .system,
-        platformFilters: PlatformFilters = []
+        platformFilters: PlatformFilters = .all
     ) -> GraphDependencyReference {
         GraphDependencyReference.sdk(
             path: path,
@@ -84,7 +84,7 @@ extension GraphDependencyReference {
     public static func testProduct(
         target: String = "Target",
         productName: String = "Target.framework",
-        platformFilters: PlatformFilters = []
+        platformFilters: PlatformFilters = .all
     ) -> GraphDependencyReference {
         GraphDependencyReference.product(
             target: target,

--- a/Sources/TuistCoreTesting/Graph/GraphDependencyReference+TestData.swift
+++ b/Sources/TuistCoreTesting/Graph/GraphDependencyReference+TestData.swift
@@ -15,7 +15,8 @@ extension GraphDependencyReference {
         linking: BinaryLinking = .dynamic,
         architectures: [BinaryArchitecture] = [.arm64],
         product: Product = .framework,
-        status: FrameworkStatus = .required
+        status: FrameworkStatus = .required,
+        platformFilters: PlatformFilters = []
     ) -> GraphDependencyReference {
         GraphDependencyReference.framework(
             path: path,
@@ -26,7 +27,8 @@ extension GraphDependencyReference {
             linking: linking,
             architectures: architectures,
             product: product,
-            status: status
+            status: status,
+            platformFilters: platformFilters
         )
     }
 
@@ -36,14 +38,16 @@ extension GraphDependencyReference {
         primaryBinaryPath: AbsolutePath = "/frameworks/tuist.xcframework/ios-arm64/tuist",
         binaryPath: AbsolutePath = "/frameworks/tuist.xcframework/ios-arm64/tuist",
         linking _: BinaryLinking = .dynamic,
-        status: FrameworkStatus = .required
+        status: FrameworkStatus = .required,
+        platformFilters: PlatformFilters = []
     ) -> GraphDependencyReference {
         GraphDependencyReference.xcframework(
             path: path,
             infoPlist: infoPlist,
             primaryBinaryPath: primaryBinaryPath,
             binaryPath: binaryPath,
-            status: status
+            status: status,
+            platformFilters: platformFilters
         )
     }
 
@@ -51,32 +55,36 @@ extension GraphDependencyReference {
         path: AbsolutePath = "/libraries/library.a",
         linking: BinaryLinking = .static,
         architectures: [BinaryArchitecture] = [BinaryArchitecture.arm64],
-        product: Product = .staticLibrary
+        product: Product = .staticLibrary,
+        platformFilters: PlatformFilters = []
     ) -> GraphDependencyReference {
         GraphDependencyReference.library(
             path: path,
             linking: linking,
             architectures: architectures,
-            product: product
+            product: product,
+            platformFilters: platformFilters
         )
     }
 
     public static func testSDK(
         path: AbsolutePath = "/path/CoreData.framework",
         status: SDKStatus = .required,
-        source: SDKSource = .system
+        source: SDKSource = .system,
+        platformFilters: PlatformFilters = []
     ) -> GraphDependencyReference {
         GraphDependencyReference.sdk(
             path: path,
             status: status,
-            source: source
+            source: source,
+            platformFilters: platformFilters
         )
     }
 
     public static func testProduct(
         target: String = "Target",
         productName: String = "Target.framework",
-        platformFilters: PlatformFilters = [.ios]
+        platformFilters: PlatformFilters = []
     ) -> GraphDependencyReference {
         GraphDependencyReference.product(
             target: target,

--- a/Sources/TuistGenerator/Extensions/Xcodeproj+Extras.swift
+++ b/Sources/TuistGenerator/Extensions/Xcodeproj+Extras.swift
@@ -47,7 +47,8 @@ extension PBXBuildFile {
 
     /// Apply platform filters either `platformFilter` or `platformFilters` depending on count
     public func applyPlatformFilters(_ filters: PlatformFilters) {
-        guard !filters.isEmpty else { return }
+        // Xcode expects no filters to be set if a `PBXBuildFile` applies to all platforms
+        guard !filters.isEmpty, filters != .all else { return }
 
         if filters.count == 1,
            let filter = filters.first,

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -484,7 +484,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
             .sorted()
         let fileReferences = bundles.compactMap { dependency -> PBXFileReference? in
             switch dependency {
-            case let .bundle(path: path):
+            case let .bundle(path: path, _):
                 return fileElements.file(path: path)
             case let .product(target: target, _, _):
                 return fileElements.product(target: target)
@@ -494,6 +494,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
         }
 
         return fileReferences.map {
+            // Should we add platform filters here?
             PBXBuildFile(file: $0)
         }
     }

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -75,7 +75,7 @@ class ProjectFileElements {
 
         // Products
         let directProducts = project.targets.map {
-            GraphDependencyReference.product(target: $0.name, productName: $0.productNameWithExtension)
+            GraphDependencyReference.product(target: $0.name, productName: $0.productNameWithExtension, platformFilters: [])
         }
 
         // Dependencies
@@ -221,15 +221,15 @@ class ProjectFileElements {
 
         try sortedDependencies.forEach { dependency in
             switch dependency {
-            case let .xcframework(path, _, _, _, _):
+            case let .xcframework(path, _, _, _, _, _):
                 try generatePrecompiled(path)
-            case let .framework(path, _, _, _, _, _, _, _, _):
+            case let .framework(path, _, _, _, _, _, _, _, _, _):
                 try generatePrecompiled(path)
-            case let .library(path, _, _, _):
+            case let .library(path, _, _, _, _):
                 try generatePrecompiled(path)
-            case let .bundle(path):
+            case let .bundle(path, _):
                 try generatePrecompiled(path)
-            case let .sdk(sdkNodePath, _, _):
+            case let .sdk(sdkNodePath, _, _, _):
                 generateSDKFileElement(
                     sdkNodePath: sdkNodePath,
                     toGroup: groups.frameworks,

--- a/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
+++ b/Sources/TuistGenerator/Utils/EmbedScriptGenerator.swift
@@ -79,7 +79,7 @@ final class EmbedScriptGenerator: EmbedScriptGenerating {
 
         for frameworkReference in frameworkReferences {
             guard case let GraphDependencyReference
-                .framework(path, _, _, dsymPath, bcsymbolmapPaths, _, _, _, _) = frameworkReference
+                .framework(path, _, _, dsymPath, bcsymbolmapPaths, _, _, _, _, _) = frameworkReference
             else {
                 preconditionFailure("references need to be of type framework")
                 break

--- a/Sources/TuistGraph/Graph/Graph.swift
+++ b/Sources/TuistGraph/Graph/Graph.swift
@@ -12,9 +12,9 @@ public struct GraphEdge: Hashable, Codable {
 }
 
 extension [GraphEdge: PlatformFilters] {
-    public subscript(_ edge: (GraphDependency, GraphDependency)) -> PlatformFilters? {
+    public subscript(_ edge: (GraphDependency, GraphDependency)) -> PlatformFilters {
         get {
-            self[GraphEdge(from: edge.0, to: edge.1)]
+            self[GraphEdge(from: edge.0, to: edge.1)] ?? .all
         }
         set {
             self[GraphEdge(from: edge.0, to: edge.1)] = newValue

--- a/Sources/TuistGraph/Graph/Graph.swift
+++ b/Sources/TuistGraph/Graph/Graph.swift
@@ -12,9 +12,9 @@ public struct GraphEdge: Hashable, Codable {
 }
 
 extension [GraphEdge: PlatformFilters] {
-    public subscript(_ edge: (GraphDependency, GraphDependency)) -> PlatformFilters {
+    public subscript(_ edge: (GraphDependency, GraphDependency)) -> PlatformFilters? {
         get {
-            self[GraphEdge(from: edge.0, to: edge.1)] ?? []
+            self[GraphEdge(from: edge.0, to: edge.1)]
         }
         set {
             self[GraphEdge(from: edge.0, to: edge.1)] = newValue

--- a/Sources/TuistGraph/Graph/Graph.swift
+++ b/Sources/TuistGraph/Graph/Graph.swift
@@ -1,6 +1,24 @@
 import Foundation
 import TSCBasic
 
+
+/// A directed edge linking representing a dependent relationship
+public struct GraphEdge: Hashable, Codable {
+    public let from: GraphDependency
+    public let to: GraphDependency
+}
+
+extension [GraphEdge: PlatformFilters] {
+    public subscript(_ edge: (GraphDependency, GraphDependency)) -> PlatformFilters {
+        get {
+            self[GraphEdge(from: edge.0, to: edge.1)] ?? []
+        }
+        set {
+            self[GraphEdge(from: edge.0, to: edge.1)] = newValue
+        }
+    }
+}
+
 /// A directed acyclic graph (DAG) that Tuist uses to represent the dependency tree.
 public struct Graph: Equatable, Codable {
     /// The name of the graph
@@ -27,6 +45,9 @@ public struct Graph: Equatable, Codable {
     /// A dictionary that contains the one-to-many dependencies that represent the graph.
     public var dependencies: [GraphDependency: Set<GraphDependency>]
 
+    /// A dictionary that contains the platform filters to apply to a dependency relationship
+    public var edges: [GraphEdge: PlatformFilters]
+    
     public init(
         name: String,
         path: AbsolutePath,
@@ -34,7 +55,8 @@ public struct Graph: Equatable, Codable {
         projects: [AbsolutePath: Project],
         packages: [AbsolutePath: [String: Package]],
         targets: [AbsolutePath: [String: Target]],
-        dependencies: [GraphDependency: Set<GraphDependency>]
+        dependencies: [GraphDependency: Set<GraphDependency>],
+        edges: [GraphEdge: PlatformFilters]
     ) {
         self.name = name
         self.path = path
@@ -43,5 +65,6 @@ public struct Graph: Equatable, Codable {
         self.packages = packages
         self.targets = targets
         self.dependencies = dependencies
+        self.edges = edges
     }
 }

--- a/Sources/TuistGraph/Graph/Graph.swift
+++ b/Sources/TuistGraph/Graph/Graph.swift
@@ -1,7 +1,6 @@
 import Foundation
 import TSCBasic
 
-
 /// A directed edge linking representing a dependent relationship
 public struct GraphEdge: Hashable, Codable {
     public let from: GraphDependency
@@ -47,7 +46,7 @@ public struct Graph: Equatable, Codable {
 
     /// A dictionary that contains the platform filters to apply to a dependency relationship
     public var edges: [GraphEdge: PlatformFilters]
-    
+
     public init(
         name: String,
         path: AbsolutePath,

--- a/Sources/TuistGraph/Graph/Graph.swift
+++ b/Sources/TuistGraph/Graph/Graph.swift
@@ -5,6 +5,10 @@ import TSCBasic
 public struct GraphEdge: Hashable, Codable {
     public let from: GraphDependency
     public let to: GraphDependency
+    public init(from: GraphDependency, to: GraphDependency) {
+        self.from = from
+        self.to = to
+    }
 }
 
 extension [GraphEdge: PlatformFilters] {

--- a/Sources/TuistGraph/Graph/Graph.swift
+++ b/Sources/TuistGraph/Graph/Graph.swift
@@ -49,7 +49,7 @@ public struct Graph: Equatable, Codable {
     public var dependencies: [GraphDependency: Set<GraphDependency>]
 
     /// A dictionary that contains the platform filters to apply to a dependency relationship
-    public var edges: [GraphEdge: PlatformFilters]
+    public var dependencyPlatformFilters: [GraphEdge: PlatformFilters]
 
     public init(
         name: String,
@@ -59,7 +59,7 @@ public struct Graph: Equatable, Codable {
         packages: [AbsolutePath: [String: Package]],
         targets: [AbsolutePath: [String: Target]],
         dependencies: [GraphDependency: Set<GraphDependency>],
-        edges: [GraphEdge: PlatformFilters]
+        dependencyPlatformFilters: [GraphEdge: PlatformFilters]
     ) {
         self.name = name
         self.path = path
@@ -68,6 +68,6 @@ public struct Graph: Equatable, Codable {
         self.packages = packages
         self.targets = targets
         self.dependencies = dependencies
-        self.edges = edges
+        self.dependencyPlatformFilters = dependencyPlatformFilters
     }
 }

--- a/Sources/TuistGraph/Models/PlatformFilter.swift
+++ b/Sources/TuistGraph/Models/PlatformFilter.swift
@@ -7,7 +7,7 @@ extension PlatformFilters: Comparable {
     public static func < (lhs: Set<Element>, rhs: Set<Element>) -> Bool {
         lhs.map(\.xcodeprojValue).sorted().joined() < rhs.map(\.xcodeprojValue).sorted().joined()
     }
-    
+
     public static let all = Set(PlatformFilter.allCases)
 }
 

--- a/Sources/TuistGraph/Models/PlatformFilter.swift
+++ b/Sources/TuistGraph/Models/PlatformFilter.swift
@@ -7,12 +7,14 @@ extension PlatformFilters: Comparable {
     public static func < (lhs: Set<Element>, rhs: Set<Element>) -> Bool {
         lhs.map(\.xcodeprojValue).sorted().joined() < rhs.map(\.xcodeprojValue).sorted().joined()
     }
+    
+    public static let all = Set(PlatformFilter.allCases)
 }
 
 /// Defines a set of platforms that can be used to limit where things
 /// like build files, resources, and dependencies are used.
 /// Context: https://github.com/tuist/tuist/pull/3152
-public enum PlatformFilter: Comparable, Hashable, Codable {
+public enum PlatformFilter: Comparable, Hashable, Codable, CaseIterable {
     case ios
     case macos
     case tvos

--- a/Sources/TuistGraph/Models/PlatformFilter.swift
+++ b/Sources/TuistGraph/Models/PlatformFilter.swift
@@ -9,6 +9,7 @@ extension PlatformFilters: Comparable {
     }
 
     public static let all = Set(PlatformFilter.allCases)
+    public static let invalid = Set<PlatformFilter>()
 }
 
 /// Defines a set of platforms that can be used to limit where things

--- a/Sources/TuistGraphTesting/Graph/Graph+TestData.swift
+++ b/Sources/TuistGraphTesting/Graph/Graph+TestData.swift
@@ -10,7 +10,8 @@ extension Graph {
         projects: [AbsolutePath: Project] = [:],
         packages: [AbsolutePath: [String: Package]] = [:],
         targets: [AbsolutePath: [String: Target]] = [:],
-        dependencies: [GraphDependency: Set<GraphDependency>] = [:]
+        dependencies: [GraphDependency: Set<GraphDependency>] = [:],
+        edges: [GraphEdge: PlatformFilters] = [:]
     ) -> Graph {
         Graph(
             name: name,
@@ -19,7 +20,8 @@ extension Graph {
             projects: projects,
             packages: packages,
             targets: targets,
-            dependencies: dependencies
+            dependencies: dependencies,
+            edges: edges
         )
     }
 }

--- a/Sources/TuistGraphTesting/Graph/Graph+TestData.swift
+++ b/Sources/TuistGraphTesting/Graph/Graph+TestData.swift
@@ -11,7 +11,7 @@ extension Graph {
         packages: [AbsolutePath: [String: Package]] = [:],
         targets: [AbsolutePath: [String: Target]] = [:],
         dependencies: [GraphDependency: Set<GraphDependency>] = [:],
-        edges: [GraphEdge: PlatformFilters] = [:]
+        dependencyPlatformFilters: [GraphEdge: PlatformFilters] = [:]
     ) -> Graph {
         Graph(
             name: name,
@@ -21,7 +21,7 @@ extension Graph {
             packages: packages,
             targets: targets,
             dependencies: dependencies,
-            edges: edges
+            dependencyPlatformFilters: dependencyPlatformFilters
         )
     }
 }

--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -123,7 +123,8 @@ final class ProjectEditorMapper: ProjectEditorMapping {
             projects: graphProjects,
             packages: [:],
             targets: Dictionary(uniqueKeysWithValues: graphTargets),
-            dependencies: Dictionary(uniqueKeysWithValues: graphDependencies)
+            dependencies: Dictionary(uniqueKeysWithValues: graphDependencies),
+            edges: [:] // What goes here?
         )
     }
 

--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -124,7 +124,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
             packages: [:],
             targets: Dictionary(uniqueKeysWithValues: graphTargets),
             dependencies: Dictionary(uniqueKeysWithValues: graphDependencies),
-            edges: [:] // What goes here?
+            dependencyPlatformFilters: [:] // What goes here?
         )
     }
 

--- a/Tests/TuistCoreTests/Graph/GraphDependencyReferenceTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphDependencyReferenceTests.swift
@@ -17,30 +17,30 @@ final class GraphDependencyReferenceTests: TuistUnitTestCase {
             .testFramework(path: "/frameworks/B.framework"),
             .testLibrary(path: "/libraries/A.library"),
             .testLibrary(path: "/libraries/B.library"),
-            .product(target: "A", productName: "A.framework"),
-            .product(target: "B", productName: "B.framework"),
-            .sdk(path: "/A.framework", status: .required, source: .developer),
-            .sdk(path: "/B.framework", status: .optional, source: .developer),
-            .bundle(path: "/A.bundle"),
-            .bundle(path: "/B.bundle"),
+            .product(target: "A", productName: "A.framework", platformFilters: []),
+            .product(target: "B", productName: "B.framework", platformFilters: []),
+            .sdk(path: "/A.framework", status: .required, source: .developer, platformFilters: []),
+            .sdk(path: "/B.framework", status: .optional, source: .developer, platformFilters: []),
+            .bundle(path: "/A.bundle", platformFilters: []),
+            .bundle(path: "/B.bundle", platformFilters: []),
         ]
 
         // When
         let results = subject.shuffled().sorted()
 
         XCTAssertEqual(results, [
-            .sdk(path: "/A.framework", status: .required, source: .developer),
-            .sdk(path: "/B.framework", status: .optional, source: .developer),
-            .product(target: "A", productName: "A.framework"),
-            .product(target: "B", productName: "B.framework"),
+            .sdk(path: "/A.framework", status: .required, source: .developer, platformFilters: []),
+            .sdk(path: "/B.framework", status: .optional, source: .developer, platformFilters: []),
+            .product(target: "A", productName: "A.framework", platformFilters: []),
+            .product(target: "B", productName: "B.framework", platformFilters: []),
             .testLibrary(path: "/libraries/A.library"),
             .testLibrary(path: "/libraries/B.library"),
             .testFramework(path: "/frameworks/A.framework"),
             .testFramework(path: "/frameworks/B.framework"),
             .testXCFramework(path: "/xcframeworks/A.xcframework"),
             .testXCFramework(path: "/xcframeworks/B.xcframework"),
-            .bundle(path: "/A.bundle"),
-            .bundle(path: "/B.bundle"),
+            .bundle(path: "/A.bundle", platformFilters: []),
+            .bundle(path: "/B.bundle", platformFilters: []),
         ])
     }
 
@@ -84,7 +84,7 @@ private enum KnownGraphDependencyReference: CaseIterable {
         case .framework:
             return [.testFramework(path: try! AbsolutePath(validating: "/dependencies/\(name).framework"))]
         case .bundle:
-            return [.bundle(path: try! AbsolutePath(validating: "/dependencies/\(name).bundle"))]
+            return [.bundle(path: try! AbsolutePath(validating: "/dependencies/\(name).bundle"), platformFilters: [])]
         case .library:
             return [.testLibrary(path: try! AbsolutePath(validating: "/dependencies/lib\(name).a"))]
         case .product:
@@ -98,8 +98,8 @@ private enum KnownGraphDependencyReference: CaseIterable {
             ]
         case .sdk:
             return [
-                .sdk(path: try! AbsolutePath(validating: "/sdks/\(name).framework"), status: .required, source: .system),
-                .sdk(path: try! AbsolutePath(validating: "/sdks/\(name).tbd"), status: .required, source: .system),
+                .sdk(path: try! AbsolutePath(validating: "/sdks/\(name).framework"), status: .required, source: .system, platformFilters: []),
+                .sdk(path: try! AbsolutePath(validating: "/sdks/\(name).tbd"), status: .required, source: .system, platformFilters: []),
             ]
         }
     }

--- a/Tests/TuistCoreTests/Graph/GraphDependencyReferenceTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphDependencyReferenceTests.swift
@@ -98,8 +98,18 @@ private enum KnownGraphDependencyReference: CaseIterable {
             ]
         case .sdk:
             return [
-                .sdk(path: try! AbsolutePath(validating: "/sdks/\(name).framework"), status: .required, source: .system, platformFilters: []),
-                .sdk(path: try! AbsolutePath(validating: "/sdks/\(name).tbd"), status: .required, source: .system, platformFilters: []),
+                .sdk(
+                    path: try! AbsolutePath(validating: "/sdks/\(name).framework"),
+                    status: .required,
+                    source: .system,
+                    platformFilters: []
+                ),
+                .sdk(
+                    path: try! AbsolutePath(validating: "/sdks/\(name).tbd"),
+                    status: .required,
+                    source: .system,
+                    platformFilters: []
+                ),
             ]
         }
     }

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -4330,53 +4330,53 @@ final class GraphTraverserTests: TuistUnitTestCase {
         // Then
         XCTAssertNil(results)
     }
-    
+
     func test_platformFilters_transitivePlatformFilter() throws {
-            // Given
-            let app = Target.test(name: "App", destinations: [.iPad, .iPhone, .mac], product: .app)
-            let staticFramework = Target.test(
-                name: "StaticFramework",
-                destinations: [.iPad, .iPhone, .mac],
-                product: .staticLibrary
-            )
-            
-            let project = Project.test(targets: [app, staticFramework])
-            
-            let appkGraphDependency: GraphDependency = .target(name: app.name, path: project.path)
-            let staticFrameworkGraphDependency: GraphDependency = .target(name: staticFramework.name, path: project.path)
-            let sdkGraphDependency: GraphDependency = .testSDK(name: "CoreTelephony.framework")
-            
-            let graph = Graph.test(
-                path: project.path,
-                projects: [project.path: project],
-                targets: [
-                    project.path: [
-                        app.name: app,
-                        staticFramework.name: staticFramework,
-                    ]
+        // Given
+        let app = Target.test(name: "App", destinations: [.iPad, .iPhone, .mac], product: .app)
+        let staticFramework = Target.test(
+            name: "StaticFramework",
+            destinations: [.iPad, .iPhone, .mac],
+            product: .staticLibrary
+        )
+
+        let project = Project.test(targets: [app, staticFramework])
+
+        let appkGraphDependency: GraphDependency = .target(name: app.name, path: project.path)
+        let staticFrameworkGraphDependency: GraphDependency = .target(name: staticFramework.name, path: project.path)
+        let sdkGraphDependency: GraphDependency = .testSDK(name: "CoreTelephony.framework")
+
+        let graph = Graph.test(
+            path: project.path,
+            projects: [project.path: project],
+            targets: [
+                project.path: [
+                    app.name: app,
+                    staticFramework.name: staticFramework,
                 ],
-                dependencies: [
-                    appkGraphDependency: [
-                        staticFrameworkGraphDependency,
-                    ],
-                    staticFrameworkGraphDependency: [
-                        sdkGraphDependency,
-                    ]
+            ],
+            dependencies: [
+                appkGraphDependency: [
+                    staticFrameworkGraphDependency,
                 ],
-                edges: [
-                    GraphEdge(from: staticFrameworkGraphDependency, to: sdkGraphDependency): [.ios],
-                ]
-            )
-            let subject = GraphTraverser(graph: graph)
-            
-            // When
-            let results = subject.platformFilters(from: appkGraphDependency, to: sdkGraphDependency)
-            
-            // Then
-            XCTAssertEqual(results?.sorted(), [
-                .ios
-            ])
-        }
+                staticFrameworkGraphDependency: [
+                    sdkGraphDependency,
+                ],
+            ],
+            edges: [
+                GraphEdge(from: staticFrameworkGraphDependency, to: sdkGraphDependency): [.ios],
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let results = subject.platformFilters(from: appkGraphDependency, to: sdkGraphDependency)
+
+        // Then
+        XCTAssertEqual(results?.sorted(), [
+            .ios,
+        ])
+    }
 
     func test_directSwiftMacroExecutables_when_targetHasDirectMacroDependencies() {
         // Given

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -183,6 +183,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
 
     func test_directStaticDependencies() {
         // Given
+        let project = Project.test()
         let path = AbsolutePath.root
         let framework = Target.test(name: "Framework", product: .framework)
         let staticLibrary = Target.test(name: "StaticLibrary", product: .staticLibrary)
@@ -199,6 +200,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         // Given: Value Graph
         let graph = Graph.test(
             path: path,
+            projects: [path: project],
             targets: targets,
             dependencies: dependencies
         )
@@ -724,7 +726,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(appTestResults, [
-            .bundle(path: bundlePath),
+            .bundle(path: bundlePath, platformFilters: []),
         ])
         XCTAssertEqual(frameworkResults, [])
     }
@@ -784,7 +786,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(appResults, [
-            .bundle(path: bundlePath),
+            .bundle(path: bundlePath, platformFilters: []),
         ])
         XCTAssertEqual(frameworkResults, [])
     }
@@ -845,7 +847,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         // Then
         XCTAssertEqual(appResults, [])
         XCTAssertEqual(frameworkResults, [
-            .bundle(path: bundlePath),
+            .bundle(path: bundlePath, platformFilters: []),
         ])
     }
 
@@ -902,8 +904,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(Set(got), Set([
-            .testProduct(target: bundle.name, productName: bundle.productNameWithExtension),
-            .testProduct(target: staticLibrary.name, productName: staticLibrary.productNameWithExtension),
+            .testProduct(target: bundle.name, productName: bundle.productNameWithExtension, platformFilters: [.ios]),
+            .testProduct(target: staticLibrary.name, productName: staticLibrary.productNameWithExtension, platformFilters: [.ios]),
         ]))
     }
 
@@ -2732,7 +2734,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
                 linking: .dynamic,
                 architectures: [.arm64],
                 product: .framework,
-                status: .required
+                status: .required,
+                platformFilters: []
             ),
         ])
     }
@@ -3110,7 +3113,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         .path
         XCTAssertEqual(
             got, [
-                .sdk(path: path, status: .required, source: .system),
+                .sdk(path: path, status: .required, source: .system, platformFilters: [.ios]),
             ]
         )
     }
@@ -4081,7 +4084,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
                 )]),
                 primaryBinaryPath: "/xcframeworks/direct.xcframework/direct",
                 binaryPath: "/xcframeworks/direct.xcframework/direct",
-                status: .required
+                status: .required,
+                platformFilters: []
             ),
             .xcframework(
                 path: "/xcframeworks/transitive.xcframework",
@@ -4092,7 +4096,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
                 )]),
                 primaryBinaryPath: "/xcframeworks/transitive.xcframework/transitive",
                 binaryPath: "/xcframeworks/transitive.xcframework/transitive",
-                status: .required
+                status: .required,
+                platformFilters: []
             ),
             .xcframework(
                 path: "/xcframeworks/framework-transitive.xcframework",
@@ -4103,7 +4108,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
                 )]),
                 primaryBinaryPath: "/xcframeworks/framework-transitive.xcframework/framework-transitive",
                 binaryPath: "/xcframeworks/framework-transitive.xcframework/framework-transitive",
-                status: .required
+                status: .required,
+                platformFilters: []
             ),
         ].sorted())
     }
@@ -4293,7 +4299,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
 
     private func sdkDependency(from dependency: GraphDependencyReference) -> SDKPathAndStatus? {
         switch dependency {
-        case let .sdk(path, status, _):
+        case let .sdk(path, status, _, _):
             return SDKPathAndStatus(name: path.basename, status: status)
         default:
             return nil

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -4182,7 +4182,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
     
     func test_platformFilterResolution_when_targetHasTransitiveDependencies() throws {
         // Given
-        let app = Target.test(name: "App", destinations: [.iPhone], product: .app)
+        let app = Target.test(name: "App", destinations: [.iPhone, .iPad, .mac], product: .app)
         let project = Project.test(targets: [app])
         let multiPlatformFramework = Target.test(name: "MultiplatformFramework", destinations: [.iPhone, .mac], product: .framework)
         let macFramework = Target.test(name: "MacFramework", destinations: [.mac], product: .framework)
@@ -4224,6 +4224,100 @@ final class GraphTraverserTests: TuistUnitTestCase {
             .product(target: macFramework.name, productName: macFramework.productNameWithExtension, platformFilters: [.macos]),
             .product(target: multiPlatformFramework.name, productName: multiPlatformFramework.productNameWithExtension, platformFilters: [.macos, .ios]),
         ])
+    }
+    
+    func test_platformFilters_transitiveDependencyInheritedPlatformFilter() throws {
+        // Given
+        let app = Target.test(name: "App", destinations: [.iPad, .iPhone, .mac], product: .app)
+        let staticFramework = Target.test(
+            name: "StaticFramework",
+            destinations: [.iPad, .iPhone],
+            product: .staticLibrary
+        )
+        
+        let project = Project.test(targets: [app, staticFramework])
+        
+        let appkGraphDependency: GraphDependency = .target(name: app.name, path: project.path)
+        let staticFrameworkGraphDependency: GraphDependency = .target(name: staticFramework.name, path: project.path)
+        let sdkGraphDependency: GraphDependency = .testSDK(name: "CoreTelephony.framework")
+        
+        let graph = Graph.test(
+            path: project.path,
+            projects: [project.path: project],
+            targets: [
+                project.path: [
+                    app.name: app,
+                    staticFramework.name: staticFramework,
+                ]
+            ],
+            dependencies: [
+                appkGraphDependency: [
+                    staticFrameworkGraphDependency,
+                ],
+                staticFrameworkGraphDependency: [
+                    sdkGraphDependency,
+                ]
+            ],
+            edges: [
+                GraphEdge(from: appkGraphDependency, to: staticFrameworkGraphDependency): [.ios],
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+        
+        // When
+        let results = try XCTUnwrap(subject.platformFilters(from: appkGraphDependency, to: sdkGraphDependency))
+        
+        // Then
+        XCTAssertEqual(results.sorted(), [
+            .ios
+        ])
+    }
+    
+    // Given A -> B -> C, if A -> B has a filter of [.ios], and B -> C has a filter of `[.macos]`, A->C should return `nil` for platform filters
+    func test_platformFilters_transitiveDependencyHasNilPlatformFilters_whenDependencyHasDisjointFilters() throws {
+        // Given
+        let app = Target.test(name: "App", destinations: [.mac], product: .app)
+        let staticFramework = Target.test(
+            name: "StaticFramework",
+            destinations: [.iPad, .iPhone, .mac],
+            product: .staticLibrary
+        )
+        
+        let project = Project.test(targets: [app, staticFramework])
+        
+        let appkGraphDependency: GraphDependency = .target(name: app.name, path: project.path)
+        let staticFrameworkGraphDependency: GraphDependency = .target(name: staticFramework.name, path: project.path)
+        let sdkGraphDependency: GraphDependency = .testSDK(name: "CoreTelephony.framework")
+        
+        let graph = Graph.test(
+            path: project.path,
+            projects: [project.path: project],
+            targets: [
+                project.path: [
+                    app.name: app,
+                    staticFramework.name: staticFramework,
+                ]
+            ],
+            dependencies: [
+                appkGraphDependency: [
+                    staticFrameworkGraphDependency,
+                ],
+                staticFrameworkGraphDependency: [
+                    sdkGraphDependency,
+                ]
+            ],
+            edges: [
+                GraphEdge(from: appkGraphDependency, to: staticFrameworkGraphDependency): [.macos],
+                GraphEdge(from: staticFrameworkGraphDependency, to: sdkGraphDependency): [.ios],
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+        
+        // When
+        let results = subject.platformFilters(from: appkGraphDependency, to: sdkGraphDependency)
+        
+        // Then
+        XCTAssertNil(results)
     }
 
     func test_directSwiftMacroExecutables_when_targetHasDirectMacroDependencies() {

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -3073,21 +3073,28 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let project = Project.test(path: "/path/a")
 
         // Given: Value Graph
+        let sdkDependency: GraphDependency = .sdk(
+            name: "AppClip.framework",
+            path: "/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/AppClip.framework",
+            status: .required,
+            source: .system
+        )
+
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
             .target(name: target.name, path: project.path): [
-                .sdk(
-                    name: "AppClip.framework",
-                    path: "/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/AppClip.framework",
-                    status: .required,
-                    source: .system
-                ),
+                sdkDependency,
             ],
         ]
+        var edges: [GraphEdge: PlatformFilters] = [:]
+        edges[(.target(name: target.name, path: project.path), sdkDependency)] = [.ios]
+
         let graph = Graph.test(
             projects: [project.path: project],
             targets: [project.path: [target.name: target]],
-            dependencies: dependencies
+            dependencies: dependencies,
+            edges: edges
         )
+
         let subject = GraphTraverser(graph: graph)
 
         // When

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -905,7 +905,11 @@ final class GraphTraverserTests: TuistUnitTestCase {
         // Then
         XCTAssertEqual(Set(got), Set([
             .testProduct(target: bundle.name, productName: bundle.productNameWithExtension, platformFilters: [.ios]),
-            .testProduct(target: staticLibrary.name, productName: staticLibrary.productNameWithExtension, platformFilters: [.ios]),
+            .testProduct(
+                target: staticLibrary.name,
+                productName: staticLibrary.productNameWithExtension,
+                platformFilters: [.ios]
+            ),
         ]))
     }
 

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -726,7 +726,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(appTestResults, [
-            .bundle(path: bundlePath, platformFilters: []),
+            .bundle(path: bundlePath, platformFilters: .all),
         ])
         XCTAssertEqual(frameworkResults, [])
     }
@@ -786,7 +786,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(appResults, [
-            .bundle(path: bundlePath, platformFilters: []),
+            .bundle(path: bundlePath, platformFilters: .all),
         ])
         XCTAssertEqual(frameworkResults, [])
     }
@@ -847,7 +847,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         // Then
         XCTAssertEqual(appResults, [])
         XCTAssertEqual(frameworkResults, [
-            .bundle(path: bundlePath, platformFilters: []),
+            .bundle(path: bundlePath, platformFilters: .all),
         ])
     }
 
@@ -2739,7 +2739,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
                 architectures: [.arm64],
                 product: .framework,
                 status: .required,
-                platformFilters: []
+                platformFilters: .all
             ),
         ])
     }
@@ -4089,7 +4089,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
                 primaryBinaryPath: "/xcframeworks/direct.xcframework/direct",
                 binaryPath: "/xcframeworks/direct.xcframework/direct",
                 status: .required,
-                platformFilters: []
+                platformFilters: .all
             ),
             .xcframework(
                 path: "/xcframeworks/transitive.xcframework",
@@ -4101,7 +4101,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
                 primaryBinaryPath: "/xcframeworks/transitive.xcframework/transitive",
                 binaryPath: "/xcframeworks/transitive.xcframework/transitive",
                 status: .required,
-                platformFilters: []
+                platformFilters: .all
             ),
             .xcframework(
                 path: "/xcframeworks/framework-transitive.xcframework",
@@ -4113,7 +4113,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
                 primaryBinaryPath: "/xcframeworks/framework-transitive.xcframework/framework-transitive",
                 binaryPath: "/xcframeworks/framework-transitive.xcframework/framework-transitive",
                 status: .required,
-                platformFilters: []
+                platformFilters: .all
             ),
         ].sorted())
     }

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -2582,7 +2582,9 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let got = try subject.linkableDependencies(path: project.path, name: app.name).sorted()
 
         // Then
-        XCTAssertEqual(got.compactMap(sdkDependency), [SDKPathAndStatus(name: "some.framework", status: .optional)])
+        XCTAssertEqual(got.compactMap(sdkDependency), [
+            SDKPathAndStatus(name: "some.framework", status: .optional),
+        ])
     }
 
     func test_linkableDependencies_transitiveSDKDependenciesImmediateDependencies() throws {
@@ -4328,7 +4330,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let results = subject.platformFilters(from: appkGraphDependency, to: sdkGraphDependency)
 
         // Then
-        XCTAssertNil(results)
+        XCTAssertEqual(results, .invalid)
     }
 
     func test_platformFilters_transitivePlatformFilter() throws {
@@ -4373,7 +4375,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let results = subject.platformFilters(from: appkGraphDependency, to: sdkGraphDependency)
 
         // Then
-        XCTAssertEqual(results?.sorted(), [
+        XCTAssertEqual(results.sorted(), [
             .ios,
         ])
     }

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -4277,7 +4277,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let subject = GraphTraverser(graph: graph)
 
         // When
-        let results = try XCTUnwrap(subject.platformFilters(from: appkGraphDependency, to: sdkGraphDependency))
+        let results = try XCTUnwrap(subject.platformFilters(to: sdkGraphDependency, from: appkGraphDependency))
 
         // Then
         XCTAssertEqual(results.sorted(), [
@@ -4327,7 +4327,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let subject = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.platformFilters(from: appkGraphDependency, to: sdkGraphDependency)
+        let results = subject.platformFilters(to: sdkGraphDependency, from: appkGraphDependency)
 
         // Then
         XCTAssertEqual(results, .invalid)
@@ -4372,7 +4372,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let subject = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.platformFilters(from: appkGraphDependency, to: sdkGraphDependency)
+        let results = subject.platformFilters(to: sdkGraphDependency, from: appkGraphDependency)
 
         // Then
         XCTAssertEqual(results.sorted(), [
@@ -4440,13 +4440,13 @@ final class GraphTraverserTests: TuistUnitTestCase {
 
         // When
         let appToStaticFilters = subject.platformFilters(
-            from: appkGraphDependency,
-            to: staticFrameworkCGraphDependency
+            to: staticFrameworkCGraphDependency,
+            from: appkGraphDependency
         )
 
         let appToSDKFilters = subject.platformFilters(
-            from: appkGraphDependency,
-            to: sdkGraphDependency
+            to: sdkGraphDependency,
+            from: appkGraphDependency
         )
 
         // Then
@@ -4517,7 +4517,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let subject = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.platformFilters(from: appkGraphDependency, to: staticFrameworkCGraphDependency)
+        let results = subject.platformFilters(to: staticFrameworkCGraphDependency, from: appkGraphDependency)
 
         // Then
         XCTAssertEqual(results, .all)

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -4330,6 +4330,53 @@ final class GraphTraverserTests: TuistUnitTestCase {
         // Then
         XCTAssertNil(results)
     }
+    
+    func test_platformFilters_transitivePlatformFilter() throws {
+            // Given
+            let app = Target.test(name: "App", destinations: [.iPad, .iPhone, .mac], product: .app)
+            let staticFramework = Target.test(
+                name: "StaticFramework",
+                destinations: [.iPad, .iPhone, .mac],
+                product: .staticLibrary
+            )
+            
+            let project = Project.test(targets: [app, staticFramework])
+            
+            let appkGraphDependency: GraphDependency = .target(name: app.name, path: project.path)
+            let staticFrameworkGraphDependency: GraphDependency = .target(name: staticFramework.name, path: project.path)
+            let sdkGraphDependency: GraphDependency = .testSDK(name: "CoreTelephony.framework")
+            
+            let graph = Graph.test(
+                path: project.path,
+                projects: [project.path: project],
+                targets: [
+                    project.path: [
+                        app.name: app,
+                        staticFramework.name: staticFramework,
+                    ]
+                ],
+                dependencies: [
+                    appkGraphDependency: [
+                        staticFrameworkGraphDependency,
+                    ],
+                    staticFrameworkGraphDependency: [
+                        sdkGraphDependency,
+                    ]
+                ],
+                edges: [
+                    GraphEdge(from: staticFrameworkGraphDependency, to: sdkGraphDependency): [.ios],
+                ]
+            )
+            let subject = GraphTraverser(graph: graph)
+            
+            // When
+            let results = subject.platformFilters(from: appkGraphDependency, to: sdkGraphDependency)
+            
+            // Then
+            XCTAssertEqual(results?.sorted(), [
+                .ios
+            ])
+        }
 
     func test_directSwiftMacroExecutables_when_targetHasDirectMacroDependencies() {
         // Given

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -4377,7 +4377,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
             .ios,
         ])
     }
-    
+
     func test_platformFilters_transitivePlatformFilter_siblingDependenciesDontImpactEachOther() throws {
         // Given
         let app = Target.test(name: "App", destinations: [.iPad, .iPhone, .mac], product: .app)
@@ -4386,27 +4386,27 @@ final class GraphTraverserTests: TuistUnitTestCase {
             destinations: [.iPad, .iPhone, .mac],
             product: .staticLibrary
         )
-        
+
         let staticFrameworkB = Target.test(
             name: "StaticFrameworkB",
             destinations: [.iPad, .iPhone, .mac],
             product: .staticLibrary
         )
-        
+
         let staticFrameworkC = Target.test(
             name: "StaticFrameworkC",
             destinations: [.iPad, .iPhone, .mac],
             product: .staticLibrary
         )
-        
+
         let project = Project.test(targets: [app, staticFrameworkA, staticFrameworkB, staticFrameworkC])
-        
+
         let appkGraphDependency: GraphDependency = .target(name: app.name, path: project.path)
         let staticFrameworkAGraphDependency: GraphDependency = .target(name: staticFrameworkA.name, path: project.path)
         let staticFrameworkBGraphDependency: GraphDependency = .target(name: staticFrameworkB.name, path: project.path)
         let staticFrameworkCGraphDependency: GraphDependency = .target(name: staticFrameworkC.name, path: project.path)
         let sdkGraphDependency: GraphDependency = .testSDK(name: "CoreTelephony.framework")
-        
+
         let graph = Graph.test(
             path: project.path,
             projects: [project.path: project],
@@ -4416,7 +4416,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
                     staticFrameworkA.name: staticFrameworkA,
                     staticFrameworkB.name: staticFrameworkB,
                     staticFrameworkC.name: staticFrameworkC,
-                ]
+                ],
             ],
             dependencies: [
                 appkGraphDependency: [
@@ -4428,27 +4428,29 @@ final class GraphTraverserTests: TuistUnitTestCase {
                 ],
                 staticFrameworkBGraphDependency: [
                     staticFrameworkCGraphDependency,
-                ]
+                ],
             ],
             dependencyPlatformFilters: [
                 GraphEdge(from: staticFrameworkAGraphDependency, to: sdkGraphDependency): [.ios],
             ]
         )
         let subject = GraphTraverser(graph: graph)
-        
+
         // When
-        let appToStaticFilters = subject.platformFilters(from: appkGraphDependency,
-                                                         to: staticFrameworkCGraphDependency)
-        
-        let appToSDKFilters = subject.platformFilters(from: appkGraphDependency,
-                                                         to: sdkGraphDependency)
-        
+        let appToStaticFilters = subject.platformFilters(
+            from: appkGraphDependency,
+            to: staticFrameworkCGraphDependency
+        )
+
+        let appToSDKFilters = subject.platformFilters(
+            from: appkGraphDependency,
+            to: sdkGraphDependency
+        )
+
         // Then
         XCTAssertEqual(appToStaticFilters?.sorted(), [])
         XCTAssertEqual(appToSDKFilters?.sorted(), [.ios])
-        
     }
-    
 
     func test_directSwiftMacroExecutables_when_targetHasDirectMacroDependencies() {
         // Given

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -4377,6 +4377,78 @@ final class GraphTraverserTests: TuistUnitTestCase {
             .ios,
         ])
     }
+    
+    func test_platformFilters_transitivePlatformFilter_siblingDependenciesDontImpactEachOther() throws {
+        // Given
+        let app = Target.test(name: "App", destinations: [.iPad, .iPhone, .mac], product: .app)
+        let staticFrameworkA = Target.test(
+            name: "StaticFrameworkA",
+            destinations: [.iPad, .iPhone, .mac],
+            product: .staticLibrary
+        )
+        
+        let staticFrameworkB = Target.test(
+            name: "StaticFrameworkB",
+            destinations: [.iPad, .iPhone, .mac],
+            product: .staticLibrary
+        )
+        
+        let staticFrameworkC = Target.test(
+            name: "StaticFrameworkC",
+            destinations: [.iPad, .iPhone, .mac],
+            product: .staticLibrary
+        )
+        
+        let project = Project.test(targets: [app, staticFrameworkA, staticFrameworkB, staticFrameworkC])
+        
+        let appkGraphDependency: GraphDependency = .target(name: app.name, path: project.path)
+        let staticFrameworkAGraphDependency: GraphDependency = .target(name: staticFrameworkA.name, path: project.path)
+        let staticFrameworkBGraphDependency: GraphDependency = .target(name: staticFrameworkB.name, path: project.path)
+        let staticFrameworkCGraphDependency: GraphDependency = .target(name: staticFrameworkC.name, path: project.path)
+        let sdkGraphDependency: GraphDependency = .testSDK(name: "CoreTelephony.framework")
+        
+        let graph = Graph.test(
+            path: project.path,
+            projects: [project.path: project],
+            targets: [
+                project.path: [
+                    app.name: app,
+                    staticFrameworkA.name: staticFrameworkA,
+                    staticFrameworkB.name: staticFrameworkB,
+                    staticFrameworkC.name: staticFrameworkC,
+                ]
+            ],
+            dependencies: [
+                appkGraphDependency: [
+                    staticFrameworkAGraphDependency,
+                    staticFrameworkBGraphDependency,
+                ],
+                staticFrameworkAGraphDependency: [
+                    sdkGraphDependency,
+                ],
+                staticFrameworkBGraphDependency: [
+                    staticFrameworkCGraphDependency,
+                ]
+            ],
+            dependencyPlatformFilters: [
+                GraphEdge(from: staticFrameworkAGraphDependency, to: sdkGraphDependency): [.ios],
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+        
+        // When
+        let appToStaticFilters = subject.platformFilters(from: appkGraphDependency,
+                                                         to: staticFrameworkCGraphDependency)
+        
+        let appToSDKFilters = subject.platformFilters(from: appkGraphDependency,
+                                                         to: sdkGraphDependency)
+        
+        // Then
+        XCTAssertEqual(appToStaticFilters?.sorted(), [])
+        XCTAssertEqual(appToSDKFilters?.sorted(), [.ios])
+        
+    }
+    
 
     func test_directSwiftMacroExecutables_when_targetHasDirectMacroDependencies() {
         // Given

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -3092,14 +3092,14 @@ final class GraphTraverserTests: TuistUnitTestCase {
                 sdkDependency,
             ],
         ]
-        var edges: [GraphEdge: PlatformFilters] = [:]
-        edges[(.target(name: target.name, path: project.path), sdkDependency)] = [.ios]
+        var dependencyPlatformFilters: [GraphEdge: PlatformFilters] = [:]
+        dependencyPlatformFilters[(.target(name: target.name, path: project.path), sdkDependency)] = [.ios]
 
         let graph = Graph.test(
             projects: [project.path: project],
             targets: [project.path: [target.name: target]],
             dependencies: dependencies,
-            edges: edges
+            dependencyPlatformFilters: dependencyPlatformFilters
         )
 
         let subject = GraphTraverser(graph: graph)
@@ -4216,7 +4216,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
                 macFramework.name: macFramework,
             ]],
             dependencies: dependencies,
-            edges: [
+            dependencyPlatformFilters: [
                 multiPlatformToMacEdge: [.macos],
             ]
         )
@@ -4268,7 +4268,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
                     sdkGraphDependency,
                 ],
             ],
-            edges: [
+            dependencyPlatformFilters: [
                 GraphEdge(from: appkGraphDependency, to: staticFrameworkGraphDependency): [.ios],
             ]
         )
@@ -4317,7 +4317,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
                     sdkGraphDependency,
                 ],
             ],
-            edges: [
+            dependencyPlatformFilters: [
                 GraphEdge(from: appkGraphDependency, to: staticFrameworkGraphDependency): [.macos],
                 GraphEdge(from: staticFrameworkGraphDependency, to: sdkGraphDependency): [.ios],
             ]
@@ -4363,7 +4363,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
                     sdkGraphDependency,
                 ],
             ],
-            edges: [
+            dependencyPlatformFilters: [
                 GraphEdge(from: staticFrameworkGraphDependency, to: sdkGraphDependency): [.ios],
             ]
         )

--- a/Tests/TuistGeneratorTests/Extensions/Xcodeproj+ExtrasTests.swift
+++ b/Tests/TuistGeneratorTests/Extensions/Xcodeproj+ExtrasTests.swift
@@ -46,6 +46,32 @@ class XcodeprojExtrasTests: XCTestCase {
         XCTAssertNil(buildFile.platformFilter)
         XCTAssertNil(buildFile.platformFilters)
     }
+    
+    func test_platform_filter_application_when_empty() {
+        // Given
+        let buildFile = PBXBuildFile()
+        let dependencyFilters: PlatformFilters = []
+
+        // When
+        buildFile.applyPlatformFilters(dependencyFilters)
+
+        // Then
+        XCTAssertNil(buildFile.platformFilter)
+        XCTAssertNil(buildFile.platformFilters)
+    }
+    
+    func test_platform_filter_application_when_all() {
+        // Given
+        let buildFile = PBXBuildFile()
+        let dependencyFilters: PlatformFilters = .all
+
+        // When
+        buildFile.applyPlatformFilters(dependencyFilters)
+
+        // Then
+        XCTAssertNil(buildFile.platformFilter)
+        XCTAssertNil(buildFile.platformFilters)
+    }
 
     func test_platform_filter_application_when_target_has_less_than_dependency() {
         // Given

--- a/Tests/TuistGeneratorTests/Extensions/Xcodeproj+ExtrasTests.swift
+++ b/Tests/TuistGeneratorTests/Extensions/Xcodeproj+ExtrasTests.swift
@@ -46,7 +46,7 @@ class XcodeprojExtrasTests: XCTestCase {
         XCTAssertNil(buildFile.platformFilter)
         XCTAssertNil(buildFile.platformFilters)
     }
-    
+
     func test_platform_filter_application_when_empty() {
         // Given
         let buildFile = PBXBuildFile()
@@ -59,7 +59,7 @@ class XcodeprojExtrasTests: XCTestCase {
         XCTAssertNil(buildFile.platformFilter)
         XCTAssertNil(buildFile.platformFilters)
     }
-    
+
     func test_platform_filter_application_when_all() {
         // Given
         let buildFile = PBXBuildFile()

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -61,7 +61,7 @@ final class LinkGeneratorTests: XCTestCase {
         // Given
         var dependencies: Set<GraphDependencyReference> = []
         dependencies.insert(GraphDependencyReference.testFramework())
-        dependencies.insert(GraphDependencyReference.product(target: "Test", productName: "Test.framework"))
+        dependencies.insert(GraphDependencyReference.product(target: "Test", productName: "Test.framework", platformFilters: []))
         let pbxproj = PBXProj()
         let (pbxTarget, target) = createTargets(product: .framework)
         let fileElements = ProjectFileElements()
@@ -112,7 +112,7 @@ final class LinkGeneratorTests: XCTestCase {
     func test_generateEmbedPhaseWithNoEmbeddableFrameworks() throws {
         // Given
         var dependencies: Set<GraphDependencyReference> = []
-        dependencies.insert(GraphDependencyReference.product(target: "Test", productName: "Test.framework"))
+        dependencies.insert(GraphDependencyReference.product(target: "Test", productName: "Test.framework", platformFilters: []))
         let pbxproj = PBXProj()
         let (pbxTarget, target) = createTargets(product: .framework)
         let fileElements = ProjectFileElements()
@@ -158,7 +158,7 @@ final class LinkGeneratorTests: XCTestCase {
 
             var dependencies: Set<GraphDependencyReference> = []
             dependencies.insert(GraphDependencyReference.testFramework())
-            dependencies.insert(GraphDependencyReference.product(target: "Test", productName: "Test.framework"))
+            dependencies.insert(GraphDependencyReference.product(target: "Test", productName: "Test.framework", platformFilters: []))
             let pbxproj = PBXProj()
             let (pbxTarget, target) = createTargets(product: product)
             let fileElements = ProjectFileElements()
@@ -199,7 +199,7 @@ final class LinkGeneratorTests: XCTestCase {
 
             var dependencies: Set<GraphDependencyReference> = []
             dependencies.insert(GraphDependencyReference.testFramework())
-            dependencies.insert(GraphDependencyReference.product(target: "Test", productName: "Test.framework"))
+            dependencies.insert(GraphDependencyReference.product(target: "Test", productName: "Test.framework", platformFilters: []))
             let pbxproj = PBXProj()
             let (pbxTarget, target) = createTargets(product: product)
             let fileElements = ProjectFileElements()
@@ -236,7 +236,7 @@ final class LinkGeneratorTests: XCTestCase {
 
     func test_generateEmbedPhase_throws_when_aProductIsMissing() throws {
         var dependencies: Set<GraphDependencyReference> = []
-        dependencies.insert(GraphDependencyReference.product(target: "Test", productName: "Test.framework"))
+        dependencies.insert(GraphDependencyReference.product(target: "Test", productName: "Test.framework", platformFilters: []))
         let pbxproj = PBXProj()
         let (pbxTarget, target) = createTargets(product: .framework)
         let fileElements = ProjectFileElements()
@@ -597,7 +597,7 @@ final class LinkGeneratorTests: XCTestCase {
     func test_generateLinkingPhase() throws {
         var dependencies: Set<GraphDependencyReference> = []
         dependencies.insert(GraphDependencyReference.testFramework(path: "/test.framework"))
-        dependencies.insert(GraphDependencyReference.product(target: "Test", productName: "Test.framework"))
+        dependencies.insert(GraphDependencyReference.product(target: "Test", productName: "Test.framework", platformFilters: []))
         let pbxproj = PBXProj()
         let (pbxTarget, target) = createTargets(product: .framework)
         let fileElements = ProjectFileElements()
@@ -632,7 +632,7 @@ final class LinkGeneratorTests: XCTestCase {
     func test_generateLinkingPhase_optionalFramework() throws {
         var dependencies: Set<GraphDependencyReference> = []
         dependencies.insert(GraphDependencyReference.testFramework(path: "/test.framework", status: .optional))
-        dependencies.insert(GraphDependencyReference.product(target: "Test", productName: "Test.framework"))
+        dependencies.insert(GraphDependencyReference.product(target: "Test", productName: "Test.framework", platformFilters: []))
         let pbxproj = PBXProj()
         let (pbxTarget, target) = createTargets(product: .framework)
         let fileElements = ProjectFileElements()
@@ -689,7 +689,7 @@ final class LinkGeneratorTests: XCTestCase {
 
     func test_generateLinkingPhase_throws_whenProductIsMissing() throws {
         var dependencies: Set<GraphDependencyReference> = []
-        dependencies.insert(GraphDependencyReference.product(target: "Test", productName: "Test.framework"))
+        dependencies.insert(GraphDependencyReference.product(target: "Test", productName: "Test.framework", platformFilters: []))
         let pbxproj = PBXProj()
         let (pbxTarget, target) = createTargets(product: .framework)
         let fileElements = ProjectFileElements()
@@ -712,8 +712,8 @@ final class LinkGeneratorTests: XCTestCase {
     func test_generateLinkingPhase_sdk() throws {
         // Given
         var dependencies: Set<GraphDependencyReference> = []
-        dependencies.insert(GraphDependencyReference.sdk(path: "/Strong/Foo.framework", status: .required, source: .developer))
-        dependencies.insert(GraphDependencyReference.sdk(path: "/Weak/Bar.framework", status: .optional, source: .developer))
+        dependencies.insert(GraphDependencyReference.sdk(path: "/Strong/Foo.framework", status: .required, source: .developer, platformFilters: []))
+        dependencies.insert(GraphDependencyReference.sdk(path: "/Weak/Bar.framework", status: .optional, source: .developer, platformFilters: []))
         let pbxproj = PBXProj()
         let (pbxTarget, target) = createTargets(product: .framework)
         let fileElements = ProjectFileElements()

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -158,7 +158,11 @@ final class LinkGeneratorTests: XCTestCase {
 
             var dependencies: Set<GraphDependencyReference> = []
             dependencies.insert(GraphDependencyReference.testFramework())
-            dependencies.insert(GraphDependencyReference.product(target: "Test", productName: "Test.framework", platformFilters: []))
+            dependencies.insert(GraphDependencyReference.product(
+                target: "Test",
+                productName: "Test.framework",
+                platformFilters: []
+            ))
             let pbxproj = PBXProj()
             let (pbxTarget, target) = createTargets(product: product)
             let fileElements = ProjectFileElements()
@@ -199,7 +203,11 @@ final class LinkGeneratorTests: XCTestCase {
 
             var dependencies: Set<GraphDependencyReference> = []
             dependencies.insert(GraphDependencyReference.testFramework())
-            dependencies.insert(GraphDependencyReference.product(target: "Test", productName: "Test.framework", platformFilters: []))
+            dependencies.insert(GraphDependencyReference.product(
+                target: "Test",
+                productName: "Test.framework",
+                platformFilters: []
+            ))
             let pbxproj = PBXProj()
             let (pbxTarget, target) = createTargets(product: product)
             let fileElements = ProjectFileElements()
@@ -712,8 +720,18 @@ final class LinkGeneratorTests: XCTestCase {
     func test_generateLinkingPhase_sdk() throws {
         // Given
         var dependencies: Set<GraphDependencyReference> = []
-        dependencies.insert(GraphDependencyReference.sdk(path: "/Strong/Foo.framework", status: .required, source: .developer, platformFilters: []))
-        dependencies.insert(GraphDependencyReference.sdk(path: "/Weak/Bar.framework", status: .optional, source: .developer, platformFilters: []))
+        dependencies.insert(GraphDependencyReference.sdk(
+            path: "/Strong/Foo.framework",
+            status: .required,
+            source: .developer,
+            platformFilters: []
+        ))
+        dependencies.insert(GraphDependencyReference.sdk(
+            path: "/Weak/Bar.framework",
+            status: .optional,
+            source: .developer,
+            platformFilters: []
+        ))
         let pbxproj = PBXProj()
         let (pbxTarget, target) = createTargets(product: .framework)
         let fileElements = ProjectFileElements()

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -776,7 +776,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         let sdkPath = try temporaryPath().appending(component: "ARKit.framework")
         let sdkStatus: SDKStatus = .required
         let sdkSource: SDKSource = .developer
-        let sdkDependency = GraphDependencyReference.sdk(path: sdkPath, status: sdkStatus, source: sdkSource)
+        let sdkDependency = GraphDependencyReference.sdk(path: sdkPath, status: sdkStatus, source: sdkSource, platformFilters: [])
 
         // When
         try subject.generate(


### PR DESCRIPTION
### Short description 📝

This is a component of multiplatform support to capture `PlatformFilter` information within the graph.  These are captured as edges and used when resolving `GraphDependency` into `GraphDependencyReference` types which then are used to generate Xcode projects.  

### How to test the changes locally 🧐

Tests should pass. 

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
