### PR TITLE
Document the `/ready` endpoint

### DIFF
--- a/Sources/tuist/tuist.docc/Tutorials/Tuist Cloud Tutorial/Tuist Cloud Tutorial Enterprise/Tuist Cloud Tutorial - Enterprise Deployment.tutorial
+++ b/Sources/tuist/tuist.docc/Tutorials/Tuist Cloud Tutorial/Tuist Cloud Tutorial Enterprise/Tuist Cloud Tutorial - Enterprise Deployment.tutorial
@@ -30,6 +30,7 @@
 
         Subsequent sections provide examples of deployments using popular cloud providers.
         
+        > Important: If your deployment pipeline needs to validate that the server is up and running, you can send a `GET` HTTP request to `/ready` and assert a `200` status code in the response. 
         
         ### Fly
         


### PR DESCRIPTION
### Short description 📝
We've added a `/ready` endpoint to Tuist Cloud which organizations self-hosting can use to verify that the service is up and running. This PR documents the endpoint and its behaviour.
