### PR TITLE
Don't change the cache directory from acceptance tests

### DIFF
--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
@@ -26,11 +26,6 @@ open class TuistAcceptanceTestCase: TuistTestCase {
 
         cacheDirectory = try! TemporaryDirectory(removeTreeOnDeinit: true).path
         derivedDataPath = try! TemporaryDirectory(removeTreeOnDeinit: true).path
-        setenv(
-            Constants.EnvironmentVariables.forceConfigCacheDirectory,
-            cacheDirectory.pathString,
-            1
-        )
 
         sourceRootPath = try! AbsolutePath(
             validating: ProcessInfo.processInfo.environment[

--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
@@ -17,14 +17,12 @@ open class TuistAcceptanceTestCase: TuistTestCase {
     public var workspacePath: AbsolutePath!
     public var fixturePath: AbsolutePath!
     public var derivedDataPath: AbsolutePath!
-    public var cacheDirectory: AbsolutePath!
 
     private var sourceRootPath: AbsolutePath!
 
     override open func setUp() {
         super.setUp()
 
-        cacheDirectory = try! TemporaryDirectory(removeTreeOnDeinit: true).path
         derivedDataPath = try! TemporaryDirectory(removeTreeOnDeinit: true).path
 
         sourceRootPath = try! AbsolutePath(
@@ -46,7 +44,6 @@ open class TuistAcceptanceTestCase: TuistTestCase {
         workspacePath = nil
         fixturePath = nil
         derivedDataPath = nil
-        cacheDirectory = nil
 
         try await super.tearDown()
     }


### PR DESCRIPTION
### Short description 📝
We recently merged the foundation to write acceptance tests in Swift. One of the pieces was `TuistAcceptanceTestCase`, the class that every acceptance test inherits from. One of the things that this class does as part of the `setup`, is setting the environment variable `TUIST_CONFIG_FORCE_CONFIG_CACHE_DIRECTORY` to set a different caching directory per test class. However, I noticed that the variable leaks across tests when they are being executed in parallel potentially causing sporadic flakiness. 

We pondered two approaches to tackle the problem:
1. Passing it as a flag to the commands, which would then dependency-inject it down to the components that make use of it.
2. Reuse the same directory across all the tests.

We ultimately decided for the 2. because **it's closer to what users would have in their system**, and where they expect Tuist's caching logic to be smart enough to be able to isolate every project within the cache directory. Failing to achieve this per-project-target isolation would be a bug that needs to be investigated. If we had chosen 2, those errors would be swallowed and would be harder to diagnose and fix.
