### PR TITLE
Flatten the workspace groups hierarchy for dependencies

### DIFF
--- a/Sources/TuistGenerator/Generator/WorkspaceDescriptorGenerator.swift
+++ b/Sources/TuistGenerator/Generator/WorkspaceDescriptorGenerator.swift
@@ -238,7 +238,14 @@ final class WorkspaceDescriptorGenerator: WorkspaceDescriptorGenerating {
             )
 
             return .group(groupReference)
-
+        case let .virtualGroup(name, contents):
+            return .group(.init(location: .container(""), name: name, children: try contents.map {
+                try recursiveChildElement(
+                    generatedProjects: generatedProjects,
+                    element: $0,
+                    path: path
+                )
+            }.sorted(by: workspaceDataElementSort)))
         case let .project(path: projectPath):
             guard generatedProjects[projectPath] != nil else {
                 throw WorkspaceDescriptorGeneratorError.projectNotFound(path: projectPath)

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
@@ -285,6 +285,34 @@ final class WorkspaceStructureGeneratorTests: XCTestCase {
         ])
     }
 
+    func test_generateStructure_addsDependenciesToADependenciesGroup() throws {
+        // Given
+        let xcodeProjPaths = try createFolders([
+            "/path/to/workspace/Tuist/Dependencies/SwiftPackageManager/.build/checkouts/AEXML/AEXML.xcodeproj",
+            "/path/to/workspace/Tuist/Dependencies/SwiftPackageManager/.build/checkouts/SwiftSyntax/SwiftSyntax.xcodeproj",
+        ])
+
+        let workspace = Workspace.test()
+
+        // When
+        let structure = subject.generateStructure(
+            path: "/path/to/workspace",
+            workspace: workspace,
+            xcodeProjPaths: xcodeProjPaths,
+            fileHandler: fileHandler
+        )
+
+        // Then
+        XCTAssertEqual(structure.contents, [
+            .virtualGroup(name: "Dependencies", contents: [
+                .project("/path/to/workspace/Tuist/Dependencies/SwiftPackageManager/.build/checkouts/AEXML/AEXML.xcodeproj"),
+                .project(
+                    "/path/to/workspace/Tuist/Dependencies/SwiftPackageManager/.build/checkouts/SwiftSyntax/SwiftSyntax.xcodeproj"
+                ),
+            ]),
+        ])
+    }
+
     // MARK: - Helpers
 
     @discardableResult


### PR DESCRIPTION
### Short description 📝
When we include the Tuist-managed dependencies (via SPM) in the generated workspace, we generate a hierarchy that reveals the internals of how packages are managed, which is non-relevant to users of Tuist. This PR changes that behavior to flatten the `Dependencies` structure under a `Dependencies` group at the root where each child is a package-generated Xcode project. Here's an screenshot of the new structure.

![image](https://github.com/tuist/tuist/assets/663605/82200bd8-1aae-418b-9b91-2e20ea1775ee)

### How to test the changes locally 🧐

You can run Tuist against Tuist and you should see a directory structure similar to the one above.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
