### PR TITLE
Automatically use the github-actions renderer

### DIFF
--- a/Sources/TuistCore/Utils/BinaryLocator.swift
+++ b/Sources/TuistCore/Utils/BinaryLocator.swift
@@ -35,6 +35,10 @@ public final class BinaryLocator: BinaryLocating {
     public init() {}
 
     public func xcbeautifyExecutable() throws -> SwiftPackageExecutable {
+        try xcbeautifyExecutable(environment: Environment.shared)
+    }
+
+    public func xcbeautifyExecutable(environment: Environmenting) throws -> SwiftPackageExecutable {
         var bundlePath = try AbsolutePath(validating: Bundle(for: BinaryLocator.self).bundleURL.path)
         let candidatebinariesPath = [
             bundlePath,
@@ -74,13 +78,25 @@ public final class BinaryLocator: BinaryLocating {
                 "/usr/bin/xcrun", "swift", "build", "--configuration", "debug", "--package-path", bundlePath.pathString,
                 "--product", "xcbeautify",
             ]
-            let executionCommand = [
+
+            var executionCommand = [
                 // swiftlint:disable:next force_try
                 bundlePath.appending(try! RelativePath(validating: ".build/debug/xcbeautify")).pathString,
             ]
+            if let renderer = renderer(environment: environment) {
+                executionCommand.append(contentsOf: ["--renderer", "github-actions"])
+            }
+
             return SwiftPackageExecutable(compilation: compilationCommand, execution: executionCommand)
         } else {
             throw BinaryLocatorError.xcbeautifyNotFound
         }
+    }
+
+    private func renderer(environment: Environmenting) -> String? {
+        if environment.isGitHubActions {
+            return "github-actions"
+        }
+        return nil
     }
 }

--- a/Sources/TuistSupport/Utils/Environment.swift
+++ b/Sources/TuistSupport/Utils/Environment.swift
@@ -36,6 +36,9 @@ public protocol Environmenting: AnyObject {
     /// Returns true unless the user specifically opted out from stats
     var isStatsEnabled: Bool { get }
 
+    /// Returns true if the environment is a GitHub Actions environment
+    var isGitHubActions: Bool { get }
+
     /// Sets up the local environment.
     func bootstrap() throws
 }
@@ -92,6 +95,15 @@ public class Environment: Environmenting {
             return Constants.trueValues.contains(coloredOutput)
         } else {
             return isStandardOutputInteractive
+        }
+    }
+
+    /// Returns true if the environment represents a GitHub Actions environment
+    public var isGitHubActions: Bool {
+        if let githubActions = ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] {
+            return Constants.trueValues.contains(githubActions)
+        } else {
+            return false
         }
     }
 

--- a/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
+++ b/Sources/TuistSupportTesting/Utils/MockEnvironment.swift
@@ -25,6 +25,7 @@ public class MockEnvironment: Environmenting {
     public var tuistConfigVariables: [String: String] = [:]
     public var manifestLoadingVariables: [String: String] = [:]
     public var isStatsEnabled: Bool = true
+    public var isGitHubActions: Bool = false
 
     public var versionsDirectory: AbsolutePath {
         directory.path.appending(component: "Versions")


### PR DESCRIPTION
### Short description 📝
@cpisciotta did an amazing job adding a renderer to `xcbeautify` for GitHub actions and we were not using it 🫢. So this PR changes that because the renderer is very cool. It outputs `xcodebuild` errors following a convention that GitHub Actions uses to surface the errors in the UI. That'll make the debugging experience better for users and also for our meta pipelines.
I implemented it to opt-in automatically if we detect it's a GitHub Actions environment. If users don't like this approach and prefer to manually opt-in, we can revisit the default. 

### How to test the changes locally 🧐
It's a bit hard to test, but if you use the `GITHUB_ACTIONS=true` environment variable and run a failing build with `tuist build`, you should see the error logs contain a prefix.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
