### PR TITLE
Adding external Dependencies tutorial improvements

### DIFF
--- a/Sources/tuist/tuist.docc/Tutorials/Tuist Tutorial/Getting-Started/Add External Dependencies/Dependencies.swift
+++ b/Sources/tuist/tuist.docc/Tutorials/Tuist Tutorial/Getting-Started/Add External Dependencies/Dependencies.swift
@@ -1,9 +1,10 @@
 import ProjectDescription
 
 let dependencies = Dependencies(
-    swiftPackageManager: .init(),
+    swiftPackageManager: .init(
+        productTypes: [
+            "Alamofire": .framework, // default is .staticFramework
+        ]
+    ),
     platforms: [.iOS],
-    productTypes: [
-        "Alamofire": .framework, // default is .staticFramework
-    ]
 )


### PR DESCRIPTION
### Short description 📝

I found that there is a mistake in the example code. Tutorial should to be clear, understandable and correct. [There](https://docs.next.tuist.io/tutorials/tuist/tuist-tutorial---add-external-dependencies) shows `productTypes` argument as `Dependency` argument but it is mistake. It should be an argument of the `swiftPackageManager` initialiser. 

wrong way
```swift
let dependencies = Dependencies(
    swiftPackageManager: .init(),
    platforms: [.iOS],
    productTypes: [
        "Alamofire": .framework, // default is .staticFramework
    ]
)
```

correct way
```swift
let dependencies = Dependencies(
    swiftPackageManager: .init(
        productTypes: [
            "Alamofire": .framework, // default is .staticFramework
        ]
    ),
    platforms: [.iOS],
)
```


### Contributor checklist ✅

- [* ] The code has been linted using run `make workspace/lint-fix`
- [ *] The change is tested via unit testing or acceptance testing, or both
- [ *] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
