### PR TITLE
Config.swift defaults to `https://cloud.tuist.io` as the Tuist Cloud URL

### DIFF
--- a/Sources/ProjectDescription/Cloud.swift
+++ b/Sources/ProjectDescription/Cloud.swift
@@ -36,7 +36,7 @@ public struct Cloud: Codable, Equatable {
     ///   - url: Base URL to the Cloud server.
     ///   - options: Cloud options.
     /// - Returns: A Cloud instance.
-    public static func cloud(projectId: String, url: String, options: [Option] = []) -> Cloud {
+    public static func cloud(projectId: String, url: String = "https://cloud.tuist.io", options: [Option] = []) -> Cloud {
         Cloud(url: url, projectId: projectId, options: options)
     }
 }

--- a/Sources/tuist/tuist.docc/Articles/Tuist Cloud/Tuist Cloud - Binary caching.md
+++ b/Sources/tuist/tuist.docc/Articles/Tuist Cloud/Tuist Cloud - Binary caching.md
@@ -45,7 +45,7 @@ After creating the project, modify your `Tuist/Config.swift` file to reference t
 ```swift
 import ProjectDescription
 
-let config = Config(cloud: .cloud(projectId: "my-organization/my-project", url: "https://cloud.tuist.io"))
+let config = Config(cloud: .cloud(projectId: "my-organization/my-project"))
 ```
 
 Developers on your team can access the cache if they are authenticated and added as members of the organization, which you can do using the Tuist CLI. For CI environments, authentication is managed differently; it's done using **project-scoped tokens**. These tokens possess restricted permissions compared to those of the organization, including the ability to warm the cache with binaries. To obtain this token, you can execute the following command:

--- a/Sources/tuist/tuist.docc/Articles/Tuist Cloud/Tuist Cloud - Binary caching.md
+++ b/Sources/tuist/tuist.docc/Articles/Tuist Cloud/Tuist Cloud - Binary caching.md
@@ -45,7 +45,7 @@ After creating the project, modify your `Tuist/Config.swift` file to reference t
 ```swift
 import ProjectDescription
 
-let config = Config(cloud: .cloud(projectId: "my-organization/my-project"))
+let config = Config(cloud: .cloud(projectId: "my-organization/my-project", url: "https://cloud.tuist.io"))
 ```
 
 Developers on your team can access the cache if they are authenticated and added as members of the organization, which you can do using the Tuist CLI. For CI environments, authentication is managed differently; it's done using **project-scoped tokens**. These tokens possess restricted permissions compared to those of the organization, including the ability to warm the cache with binaries. To obtain this token, you can execute the following command:


### PR DESCRIPTION
### Short description 📝
We support passing the URL for enterprise users that will host their own Tuist Cloud instance. However, the default is `https://cloud.tuist.io` and we shouldn't require users to pass it when configuring their projects. This PR fixes it by setting that as the default value.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
