### PR TITLE
Fix XcodeProj-based Swift Macros not working with non-macOS targets

### DIFF
--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -212,16 +212,8 @@ public final class PackageInfoMapper: PackageInfoMapping {
                     guard !alreadyProcessed else {
                         continue
                     }
-                    let targetInfo = packageInfo.targets.first(where: { $0.name == target })!
-                    if targetInfo.type == .macro {
-                        result[target, default: []].insert(.init(name: target,
-                                                                 type: .executable,
-                                                                 targets: [target]))
-                    } else {
-                        result[target, default: []].insert(product)
-                    }
-                    
-                    let dependencies = targetInfo.dependencies
+                    result[target, default: []].insert(product)
+                    let dependencies = packageInfo.targets.first(where: { $0.name == target })!.dependencies
                     for dependency in dependencies {
                         switch dependency {
                         case let .target(name, _):

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -122,7 +122,7 @@ final class LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_
          Target -> MyMacro (Static framework) -> MyMacro (Executable)
 
          The executable is compiled transitively through the static library, and we place it inside the framework to make it available to the target depending on the framework
-         to point it with the `-load-plugin-executable $BUILT_PRODUCTS_DIR/ExecutableName\#ExecutableName` build setting.
+         to point it with the `-load-plugin-executable $SYMROOT/$CONFIGURATION/ExecutableName\#ExecutableName` build setting.
          */
         let directSwiftMacroExecutables = graphTraverser.directSwiftMacroExecutables(path: path, name: target.name).sorted()
         try generateCopySwiftMacroExecutableScriptBuildPhase(
@@ -519,7 +519,7 @@ final class LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_
             default:
                 return nil
             }
-        }.map { ("$BUILT_PRODUCTS_DIR/\($0)", "$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/Macros/\($0)") }
+        }.map { ("$SYMROOT/$CONFIGURATION/\($0)", "$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/Macros/\($0)") }
 
         copySwiftMacrosBuildPhase.shellScript = filesToCopy.map { "cp \($0.0) \($0.1)" }.joined(separator: "\n")
         copySwiftMacrosBuildPhase.inputPaths = filesToCopy.map(\.0)

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -750,7 +750,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             targetSettingsResult,
             .array([
                 "-load-plugin-executable",
-                "$BUILT_PRODUCTS_DIR/\(macroFramework.productNameWithExtension)/Macros/\(macroExecutable.productName)/#\(macroExecutable.productName)",
+                "$SYMROOT/$CONFIGURATION/\(macroFramework.productNameWithExtension)/Macros/\(macroExecutable.productName)/#\(macroExecutable.productName)",
             ])
         )
     }

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -988,9 +988,9 @@ final class LinkGeneratorTests: XCTestCase {
         XCTAssertNotNil(buildPhase)
 
         let expectedScript =
-            "cp $BUILT_PRODUCTS_DIR/\(macroExecutable.productName) $BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/Macros/\(macroExecutable.productName)"
+            "cp $SYMROOT/$CONFIGURATION/\(macroExecutable.productName) $BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/Macros/\(macroExecutable.productName)"
         XCTAssertTrue(buildPhase?.shellScript?.contains(expectedScript) == true)
-        XCTAssertTrue(buildPhase?.inputPaths.contains("$BUILT_PRODUCTS_DIR/\(macroExecutable.productName)") == true)
+        XCTAssertTrue(buildPhase?.inputPaths.contains("$SYMROOT/$CONFIGURATION/\(macroExecutable.productName)") == true)
         XCTAssertTrue(
             buildPhase?.outputPaths
                 .contains("$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/Macros/\(macroExecutable.productName)") == true

--- a/fixtures/framework_with_native_swift_macro/Project.swift
+++ b/fixtures/framework_with_native_swift_macro/Project.swift
@@ -5,7 +5,7 @@ let project = Project(
     targets: [
         Target(
             name: "Framework",
-            platform: .macOS,
+            platform: .iOS,
             product: .staticLibrary,
             bundleId: "io.tuist.FrameworkWithSwiftMacro",
             sources: ["Sources/**/*"],

--- a/fixtures/framework_with_native_swift_macro/Tuist/Dependencies.swift
+++ b/fixtures/framework_with_native_swift_macro/Tuist/Dependencies.swift
@@ -4,5 +4,5 @@ let dependencies = Dependencies(
     swiftPackageManager: .init(
         targetSettings: [:]
     ),
-    platforms: [.macOS]
+    platforms: [.iOS]
 )


### PR DESCRIPTION
### Short description 📝
When I worked on adding XcodeProj-based support for Swift Macros, I focused on the `macOS` target without realizing that the implementation didn't work on iOS. After some debugging, it turns out that we are not taking into account which targets of the packages graph should be `macOS` when generating the targets. This leads to issues in the graph like `executable` targets for the `iOS` platform, or libraries that the macro depends on, directly or indirectly, that are generated as iOS.

This PR aims to address that by taking the `macOS` information into account when generating the graph. 

### How to test the changes locally 🧐
You should be able to generate the project at `fixtures/framework_with_native_swift_macro` and get a project that compiles.

### Contributor checklist ✅

- [ ] The code has been linted using run `make workspace/lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
