### PR TITLE
Increase the timeout for uploading and downloading files

### DIFF
--- a/Sources/TuistSupport/HTTP/FileClient.swift
+++ b/Sources/TuistSupport/HTTP/FileClient.swift
@@ -54,8 +54,19 @@ public class FileClient: FileClienting {
 
     // MARK: - Init
 
-    public init(session: URLSession = URLSession.shared) {
+    public convenience init() {
+        self.init(session: FileClient.defaultSession())
+    }
+
+    private init(session: URLSession) {
         self.session = session
+    }
+
+    private static func defaultSession() -> URLSession {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 30
+        configuration.timeoutIntervalForResource = 180
+        return URLSession(configuration: configuration)
     }
 
     // MARK: - Public


### PR DESCRIPTION
### Short description 📝

I'm increasing the timeout of `FileClient`, which is used to pushing and pulling binaries from the Internet.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
