### PR TITLE
Fix caching tuist

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -28,6 +28,7 @@ env:
   RUBY_VERSION: '3.0.3'
   TUIST_STATS_OPT_OUT: true
   NODE_VERSION: 16.17.0
+  TUIST_CONFIG_CLOUD_TOKEN: ${{ secrets.TUIST_CONFIG_CLOUD_TOKEN }}
 
 jobs:
   release_build:
@@ -62,6 +63,44 @@ jobs:
       - name: Test
         run: |
           ARGS="--skip-test-targets TuistBuildAcceptanceTests TuistGenerateOneAcceptanceTests" make tuist/test
+
+  cache-warm:
+    name: Cache warm with latest Tuist
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v3
+      - uses: asdf-vm/actions/install@v2
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
+      - uses: actions/cache@v3
+        name: 'Cache fetched dependencies folder'
+        with:
+          path: Tuist/Dependencies/SwiftPackageManager/.build
+          key: spm-v1-${{ hashFiles('Package.resolved') }}
+          restore-keys: spm-v1-${{ hashFiles('Package.resolved') }}
+      - name: Fetch dependencies
+        run: tuist fetch
+      - name: Cache warm
+        run: tuist cache warm
+
+  cache-warm-silicon:
+    name: Cache warm with latest Tuist on Silicon
+    runs-on: macos-13-xlarge
+    steps:
+      - uses: actions/checkout@v3
+      - uses: asdf-vm/actions/install@v2
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
+      - uses: actions/cache@v3
+        name: 'Cache fetched dependencies folder'
+        with:
+          path: Tuist/Dependencies/SwiftPackageManager/.build
+          key: spm-v1-${{ hashFiles('Package.resolved') }}
+          restore-keys: spm-v1-${{ hashFiles('Package.resolved') }}
+      - name: Fetch dependencies
+        run: tuist fetch
+      - name: Cache warm
+        run: tuist cache warm
 
   acceptance_tests:
     name: ${{ matrix.feature }} acceptance tests with Tuist
@@ -101,7 +140,7 @@ jobs:
       - name: Build xcbeautify
         run: swift build --package-path vendor --product xcbeautify
       - name: Run acceptance tests
-        run: tuist test Tuist${{ matrix.feature }}AcceptanceTests --no-cache
+        run: tuist test Tuist${{ matrix.feature }}AcceptanceTests
       
   cucumber_acceptance_tests:
     name: ${{ matrix.feature }} acceptance tests with Xcode

--- a/Package.resolved
+++ b/Package.resolved
@@ -19,15 +19,6 @@
       }
     },
     {
-      "identity" : "checksum",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/rnine/Checksum.git",
-      "state" : {
-        "revision" : "cd1ae53384dd578a84a0afef492a4f5d6202b068",
-        "version" : "1.0.2"
-      }
-    },
-    {
       "identity" : "combineext",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CombineCommunity/CombineExt.git",

--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,6 @@ var targets: [Target] = [
             "TuistSupport",
             "TuistGraph",
             "XcodeProj",
-            "Checksum",
         ]
     ),
     .target(
@@ -174,7 +173,6 @@ var targets: [Target] = [
             "KeychainAccess",
             swifterDependency,
             "ZIPFoundation",
-            "Checksum",
             "ProjectDescription",
         ]
     ),
@@ -653,7 +651,6 @@ let package = Package(
         .package(url: "https://github.com/httpswift/swifter.git", revision: "1e4f51c92d7ca486242d8bf0722b99de2c3531aa"),
         .package(url: "https://github.com/kishikawakatsumi/KeychainAccess", from: "4.2.2"),
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift", from: "1.8.0"),
-        .package(url: "https://github.com/rnine/Checksum", from: "1.0.2"),
         .package(url: "https://github.com/stencilproject/Stencil", exact: "0.15.1"),
         .package(url: "https://github.com/SwiftDocOrg/GraphViz", exact: "0.2.0"),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit", exact: "2.10.1"),

--- a/Project.swift
+++ b/Project.swift
@@ -33,7 +33,16 @@ func targets() -> [Target] {
                 .external(name: "SystemPackage"),
                 .external(name: "GraphViz"),
                 .external(name: "ArgumentParser"),
-            ]
+            ],
+            settings: .settings(
+                base: [
+                    "LD_RUNPATH_SEARCH_PATHS": "$(FRAMEWORK_SEARCH_PATHS)",
+                ],
+                configurations: [
+                    .debug(name: "Debug", settings: [:], xcconfig: nil),
+                    .release(name: "Release", settings: [:], xcconfig: nil),
+                ]
+            )
         ),
         Target.target(
             name: "tuistbenchmark",
@@ -81,7 +90,6 @@ func targets() -> [Target] {
                 .external(name: "XcodeProj"),
                 .external(name: "KeychainAccess"),
                 .external(name: "CombineExt"),
-                .external(name: "Checksum"),
                 .external(name: "Logging"),
                 .external(name: "ZIPFoundation"),
                 .external(name: "Swifter"),
@@ -190,7 +198,6 @@ func targets() -> [Target] {
                 .target(name: "TuistGraph"),
                 .external(name: "SwiftToolsSupport"),
                 .external(name: "SystemPackage"),
-                .external(name: "Checksum"),
                 .external(name: "XcodeProj"),
             ],
             testDependencies: [
@@ -323,6 +330,7 @@ func targets() -> [Target] {
         Target.module(
             name: "TuistPlugin",
             dependencies: [
+                .target(name: "TuistCore"),
                 .target(name: "TuistGraph"),
                 .target(name: "TuistLoader"),
                 .target(name: "TuistSupport"),
@@ -346,6 +354,7 @@ func targets() -> [Target] {
         ),
         Target.module(
             name: "ProjectDescription",
+            product: .framework,
             hasTesting: false,
             testDependencies: [
                 .target(name: "TuistSupportTesting"),
@@ -354,6 +363,7 @@ func targets() -> [Target] {
         ),
         Target.module(
             name: "ProjectAutomation",
+            product: .framework,
             hasTests: false,
             hasTesting: false,
             dependencies: []
@@ -442,6 +452,7 @@ func targets() -> [Target] {
             ],
             testingDependencies: [
                 .target(name: "TuistGraphTesting"),
+                .target(name: "ProjectDescription"),
             ]
         ),
         Target.module(
@@ -495,9 +506,9 @@ let acceptanceTests: [(target: Target, scheme: Scheme)] = ["Build", "GenerateOne
             name: "Tuist\($0)AcceptanceTests",
             product: .unitTests,
             dependencies: [
-                .target(name: "TuistKit"),
                 .target(name: "TuistAcceptanceTesting"),
                 .target(name: "TuistSupportTesting"),
+                .target(name: "TuistKit"),
                 .external(name: "SwiftToolsSupport"),
                 .external(name: "SystemPackage"),
             ]
@@ -516,7 +527,10 @@ let acceptanceTests: [(target: Target, scheme: Scheme)] = ["Build", "GenerateOne
             ),
             runAction: .runAction(
                 arguments: Arguments(
-                    environmentVariables: ["TUIST_CONFIG_SRCROOT": "$(SRCROOT)"]
+                    environmentVariables: [
+                        "TUIST_CONFIG_SRCROOT": "$(SRCROOT)",
+                        "TUIST_FRAMEWORK_SEARCH_PATHS": "$(FRAMEWORK_SEARCH_PATHS)",
+                    ]
                 )
             )
         )

--- a/Project.swift
+++ b/Project.swift
@@ -29,6 +29,10 @@ func targets() -> [Target] {
                 .target(name: "TuistKit"),
                 .target(name: "ProjectDescription"),
                 .target(name: "ProjectAutomation"),
+                .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
+                .external(name: "GraphViz"),
+                .external(name: "ArgumentParser"),
             ]
         ),
         Target.target(
@@ -37,6 +41,7 @@ func targets() -> [Target] {
             dependencies: [
                 .external(name: "ArgumentParser"),
                 .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
             ]
         ),
         Target.target(
@@ -45,6 +50,7 @@ func targets() -> [Target] {
             dependencies: [
                 .external(name: "ArgumentParser"),
                 .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
             ]
         ),
         Target.target(
@@ -57,6 +63,9 @@ func targets() -> [Target] {
                 .target(name: "TuistCoreTesting"),
                 .target(name: "TuistGraphTesting"),
                 .target(name: "TuistLoaderTesting"),
+                .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
+                .external(name: "XcodeProj"),
             ]
         ),
     ]
@@ -65,23 +74,17 @@ func targets() -> [Target] {
             name: "TuistSupport",
             hasIntegrationTests: true,
             dependencies: [
-                .external(name: "AnyCodable"),
-                .external(name: "ArgumentParser"),
-                .external(name: "Checksum"),
-                .external(name: "CombineExt"),
-                .external(name: "CryptoSwift"),
-                .external(name: "GraphViz"),
-                .external(name: "KeychainAccess"),
-                .external(name: "Logging"),
-                .external(name: "PathKit"),
-                .external(name: "Queuer"),
-                .external(name: "Stencil"),
-                .external(name: "StencilSwiftKit"),
-                .external(name: "SwiftToolsSupport"),
-                .external(name: "Swifter"),
-                .external(name: "XcodeProj"),
-                .external(name: "ZIPFoundation"),
                 .target(name: "ProjectDescription"),
+                .external(name: "AnyCodable"),
+                .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
+                .external(name: "XcodeProj"),
+                .external(name: "KeychainAccess"),
+                .external(name: "CombineExt"),
+                .external(name: "Checksum"),
+                .external(name: "Logging"),
+                .external(name: "ZIPFoundation"),
+                .external(name: "Swifter"),
             ],
             testingDependencies: [
                 .target(name: "TuistCore"),
@@ -107,6 +110,11 @@ func targets() -> [Target] {
                 .target(name: "TuistAnalytics"),
                 .target(name: "TuistPlugin"),
                 .target(name: "TuistGraph"),
+                .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
+                .external(name: "ArgumentParser"),
+                .external(name: "GraphViz"),
+                .external(name: "AnyCodable"),
             ],
             testDependencies: [
                 .target(name: "TuistAutomation"),
@@ -125,6 +133,9 @@ func targets() -> [Target] {
                 .target(name: "TuistGraphTesting"),
                 .target(name: "TuistPlugin"),
                 .target(name: "TuistPluginTesting"),
+                .external(name: "ArgumentParser"),
+                .external(name: "GraphViz"),
+                .external(name: "AnyCodable"),
             ],
             integrationTestsDependencies: [
                 .target(name: "TuistCoreTesting"),
@@ -133,6 +144,7 @@ func targets() -> [Target] {
                 .target(name: "ProjectAutomation"),
                 .target(name: "TuistLoaderTesting"),
                 .target(name: "TuistGraphTesting"),
+                .external(name: "XcodeProj"),
             ]
         ),
         Target.module(
@@ -140,6 +152,9 @@ func targets() -> [Target] {
             hasTesting: false,
             dependencies: [
                 .target(name: "TuistSupport"),
+                .external(name: "ArgumentParser"),
+                .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
             ],
             testDependencies: [
                 .target(name: "TuistSupportTesting"),
@@ -150,16 +165,20 @@ func targets() -> [Target] {
             dependencies: [
                 .target(name: "TuistSupport"),
                 .external(name: "AnyCodable"),
+                .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
             ],
             testDependencies: [
                 .target(name: "TuistCore"),
                 .target(name: "TuistCoreTesting"),
                 .target(name: "TuistSupport"),
                 .target(name: "TuistSupportTesting"),
+                .external(name: "XcodeProj"),
             ],
             testingDependencies: [
                 .target(name: "TuistSupport"),
                 .target(name: "TuistSupportTesting"),
+                .external(name: "XcodeProj"),
             ]
         ),
         Target.module(
@@ -169,6 +188,10 @@ func targets() -> [Target] {
                 .target(name: "ProjectDescription"),
                 .target(name: "TuistSupport"),
                 .target(name: "TuistGraph"),
+                .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
+                .external(name: "Checksum"),
+                .external(name: "XcodeProj"),
             ],
             testDependencies: [
                 .target(name: "TuistSupport"),
@@ -194,22 +217,32 @@ func targets() -> [Target] {
                 .target(name: "TuistGraph"),
                 .target(name: "TuistSupport"),
                 .external(name: "SwiftGenKit"),
+                .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
+                .external(name: "PathKit"),
+                .external(name: "StencilSwiftKit"),
+                .external(name: "XcodeProj"),
+                .external(name: "GraphViz"),
             ],
             testDependencies: [
                 .target(name: "TuistCoreTesting"),
                 .target(name: "TuistSupportTesting"),
                 .target(name: "TuistGraphTesting"),
+                .external(name: "XcodeProj"),
+                .external(name: "GraphViz"),
             ],
             testingDependencies: [
                 .target(name: "TuistCoreTesting"),
                 .target(name: "TuistSupportTesting"),
                 .target(name: "TuistGraphTesting"),
+                .external(name: "XcodeProj"),
             ],
             integrationTestsDependencies: [
                 .target(name: "TuistCoreTesting"),
                 .target(name: "TuistSupportTesting"),
                 .target(name: "TuistGraphTesting"),
                 .target(name: "TuistSigningTesting"),
+                .external(name: "XcodeProj"),
             ]
         ),
         Target.module(
@@ -219,6 +252,10 @@ func targets() -> [Target] {
                 .target(name: "TuistCore"),
                 .target(name: "TuistGraph"),
                 .target(name: "TuistSupport"),
+                .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
+                .external(name: "PathKit"),
+                .external(name: "StencilSwiftKit"),
             ],
             testDependencies: [
                 .target(name: "TuistSupportTesting"),
@@ -241,6 +278,9 @@ func targets() -> [Target] {
                 .target(name: "TuistGraph"),
                 .target(name: "TuistSupport"),
                 .target(name: "ProjectDescription"),
+                .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
+                .external(name: "XcodeProj"),
             ],
             testDependencies: [
                 .target(name: "TuistGraphTesting"),
@@ -265,11 +305,16 @@ func targets() -> [Target] {
                 .target(name: "TuistCore"),
                 .target(name: "TuistGraph"),
                 .target(name: "TuistSupport"),
+                .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
+                .external(name: "Queuer"),
+                .external(name: "XcodeProj"),
             ],
             testDependencies: [
                 .target(name: "TuistSupportTesting"),
                 .target(name: "TuistCoreTesting"),
                 .target(name: "TuistGraphTesting"),
+                .external(name: "Queuer"),
             ],
             testingDependencies: [
                 .target(name: "TuistGraphTesting"),
@@ -282,6 +327,8 @@ func targets() -> [Target] {
                 .target(name: "TuistLoader"),
                 .target(name: "TuistSupport"),
                 .target(name: "TuistScaffold"),
+                .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
             ],
             testDependencies: [
                 .target(name: "ProjectDescription"),
@@ -318,6 +365,9 @@ func targets() -> [Target] {
                 .target(name: "TuistCore"),
                 .target(name: "TuistGraph"),
                 .target(name: "TuistSupport"),
+                .external(name: "CryptoSwift"),
+                .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
             ],
             testDependencies: [
                 .target(name: "TuistSupportTesting"),
@@ -337,8 +387,10 @@ func targets() -> [Target] {
                 .target(name: "TuistCore"),
                 .target(name: "TuistGraph"),
                 .target(name: "TuistLoader"),
-                .external(name: "AnyCodable"),
                 .target(name: "TuistSupport"),
+                .external(name: "AnyCodable"),
+                .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
             ],
             testDependencies: [
                 .target(name: "TuistSupportTesting"),
@@ -353,6 +405,10 @@ func targets() -> [Target] {
                 .target(name: "TuistCore"),
                 .target(name: "TuistGraph"),
                 .target(name: "TuistSupport"),
+                .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
+                .external(name: "PathKit"),
+                .external(name: "XcodeProj"),
             ],
             testDependencies: [
                 .target(name: "TuistSupportTesting"),
@@ -375,6 +431,8 @@ func targets() -> [Target] {
                 .target(name: "TuistCore"),
                 .target(name: "TuistGraph"),
                 .target(name: "TuistSupport"),
+                .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
             ],
             testDependencies: [
                 .target(name: "TuistCoreTesting"),
@@ -393,6 +451,9 @@ func targets() -> [Target] {
                 .target(name: "TuistCore"),
                 .target(name: "TuistGraph"),
                 .target(name: "TuistSupport"),
+                .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
+                .external(name: "XcodeProj"),
             ],
             testDependencies: [
                 .target(name: "TuistSupportTesting"),
@@ -420,6 +481,8 @@ func targets() -> [Target] {
             dependencies: [
                 .target(name: "TuistKit"),
                 .target(name: "TuistSupportTesting"),
+                .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
                 .sdk(name: "XCTest", type: .framework, status: .optional),
             ]
         ),
@@ -435,6 +498,8 @@ let acceptanceTests: [(target: Target, scheme: Scheme)] = ["Build", "GenerateOne
                 .target(name: "TuistKit"),
                 .target(name: "TuistAcceptanceTesting"),
                 .target(name: "TuistSupportTesting"),
+                .external(name: "SwiftToolsSupport"),
+                .external(name: "SystemPackage"),
             ]
         ),
         scheme: Scheme(

--- a/Sources/TuistCore/ContentHashing/ContentHasher.swift
+++ b/Sources/TuistCore/ContentHashing/ContentHasher.swift
@@ -1,4 +1,4 @@
-import Checksum
+import CryptoKit
 import Foundation
 import TSCBasic
 import TuistSupport
@@ -17,18 +17,16 @@ public final class ContentHasher: ContentHashing {
 
     // MARK: - ContentHashing
 
-    public func hash(_ data: Data) throws -> String {
-        guard let hash = data.checksum(algorithm: .md5) else {
-            throw ContentHashingError.dataHashingFailed
-        }
-        return hash
+    public func hash(_ data: Data) -> String {
+        Insecure.MD5.hash(data: data)
+            .compactMap { String(format: "%02x", $0) }.joined()
     }
 
     public func hash(_ string: String) throws -> String {
-        guard let hash = string.checksum(algorithm: .md5) else {
+        guard let data = string.data(using: .utf8) else {
             throw ContentHashingError.stringHashingFailed(string)
         }
-        return hash
+        return hash(data)
     }
 
     public func hash(_ strings: [String]) throws -> String {
@@ -64,10 +62,7 @@ public final class ContentHasher: ContentHashing {
         guard let sourceData = try? fileHandler.readFile(filePath) else {
             throw ContentHashingError.failedToReadFile(filePath)
         }
-        guard let hash = sourceData.checksum(algorithm: .md5) else {
-            throw ContentHashingError.fileHashingFailed(filePath)
-        }
 
-        return hash
+        return hash(sourceData)
     }
 }

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -4,8 +4,9 @@ import TSCBasic
 import TuistSupport
 
 /// Command that builds a target from the project in the current directory.
-struct BuildCommand: AsyncParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct BuildCommand: AsyncParsableCommand {
+    public init() {}
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "build",
             abstract: "Builds a project"
@@ -69,7 +70,7 @@ struct BuildCommand: AsyncParsableCommand {
     )
     var derivedDataPath: String?
 
-    func run() async throws {
+    public func run() async throws {
         let absolutePath: AbsolutePath
         if let path {
             absolutePath = try AbsolutePath(validating: path, relativeTo: FileHandler.shared.currentPath)

--- a/Sources/TuistKit/Commands/FetchCommand.swift
+++ b/Sources/TuistKit/Commands/FetchCommand.swift
@@ -8,8 +8,9 @@ enum FetchCategory: String, CaseIterable, RawRepresentable, ExpressibleByArgumen
 }
 
 /// A command to fetch any remote content necessary to interact with the project.
-struct FetchCommand: AsyncParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct FetchCommand: AsyncParsableCommand {
+    public init() {}
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "fetch",
             abstract: "Fetches any remote content necessary to interact with the project."
@@ -29,7 +30,7 @@ struct FetchCommand: AsyncParsableCommand {
     )
     var update: Bool = false
 
-    func run() async throws {
+    public func run() async throws {
         try await FetchService().run(
             path: path,
             update: update

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -12,15 +12,15 @@ import TuistSupport
 private typealias Platform = TuistGraph.Platform
 private typealias Product = TuistGraph.Product
 
-struct InitCommand: ParsableCommand, HasTrackableParameters {
-    static var configuration: CommandConfiguration {
+public struct InitCommand: ParsableCommand, HasTrackableParameters {
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "init",
             abstract: "Bootstraps a project"
         )
     }
 
-    static var analyticsDelegate: TrackableParametersDelegate?
+    public static var analyticsDelegate: TrackableParametersDelegate?
 
     @Option(
         help: "The platform (ios, tvos, visionos, watchos or macos) the product will be for (Default: ios)",
@@ -50,10 +50,10 @@ struct InitCommand: ParsableCommand, HasTrackableParameters {
     var requiredTemplateOptions: [String: String] = [:]
     var optionalTemplateOptions: [String: String?] = [:]
 
-    init() {}
+    public init() {}
 
     // Custom decoding to decode dynamic options
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         platform = try container.decodeIfPresent(Option<String>.self, forKey: .platform)?.wrappedValue
         name = try container.decodeIfPresent(Option<String>.self, forKey: .name)?.wrappedValue
@@ -73,7 +73,7 @@ struct InitCommand: ParsableCommand, HasTrackableParameters {
         }
     }
 
-    func run() throws {
+    public func run() throws {
         InitCommand.analyticsDelegate?.addParameters(
             [
                 "platform": AnyCodable(platform ?? "unknown"),
@@ -192,7 +192,7 @@ extension InitCommand {
 /// ArgumentParser library gets the list of options from a mirror
 /// Since we do not declare template's options in advance, we need to rewrite the mirror implementation and add them ourselves
 extension InitCommand: CustomReflectable {
-    var customMirror: Mirror {
+    public var customMirror: Mirror {
         let requiredTemplateChildren = InitCommand.requiredTemplateOptions
             .map { Mirror.Child(label: $0.name, value: $0.option) }
         let optionalTemplateChildren = InitCommand.optionalTemplateOptions

--- a/Sources/TuistScaffold/TemplatesDirectoryLocator.swift
+++ b/Sources/TuistScaffold/TemplatesDirectoryLocator.swift
@@ -31,12 +31,17 @@ public final class TemplatesDirectoryLocator: TemplatesDirectoryLocating {
 
     public func locateTuistTemplates() -> AbsolutePath? {
         #if DEBUG
-            // Used only for debug purposes to find templates in your tuist working directory
-            // `bundlePath` points to tuist/Templates
-            let maybeBundlePath = try? AbsolutePath(validating: #file.replacingOccurrences(of: "file://", with: ""))
-                .removingLastComponent()
-                .removingLastComponent()
-                .removingLastComponent()
+            let maybeBundlePath: AbsolutePath?
+            if let sourceRoot = ProcessEnv.vars["TUIST_CONFIG_SRCROOT"] {
+                maybeBundlePath = try? AbsolutePath(validating: sourceRoot).appending(component: "Templates")
+            } else {
+                // Used only for debug purposes to find templates in your tuist working directory
+                // `bundlePath` points to tuist/Templates
+                maybeBundlePath = try? AbsolutePath(validating: #file.replacingOccurrences(of: "file://", with: ""))
+                    .removingLastComponent()
+                    .removingLastComponent()
+                    .removingLastComponent()
+            }
         #else
             let maybeBundlePath = try? AbsolutePath(validating: Bundle(for: TemplatesDirectoryLocator.self).bundleURL.path)
         #endif

--- a/Sources/TuistSupport/MachineEnvironment.swift
+++ b/Sources/TuistSupport/MachineEnvironment.swift
@@ -1,4 +1,4 @@
-import Checksum
+import CryptoKit
 import Foundation
 
 public protocol MachineEnvironmentRetrieving {
@@ -28,7 +28,8 @@ public class MachineEnvironment: MachineEnvironmentRetrieving {
             kCFAllocatorDefault,
             0
         ).takeRetainedValue() as! String // swiftlint:disable:this force_cast
-        return uuid.checksum(algorithm: .md5)!
+        return Insecure.MD5.hash(data: uuid.data(using: .utf8)!)
+            .compactMap { String(format: "%02x", $0) }.joined()
     }()
 
     /// The `macOSVersion` of the machine running Tuist, in the format major.minor.path, e.g: "10.15.7"

--- a/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
@@ -385,4 +385,36 @@ extension XCTestCase {
         )
         return collection[elementIndex] as? T
     }
+
+    /// Asserts that a directory at given path contains expected elements.
+    /// It does not check the contents of a directory recursively.
+    /// - Throws: An error if the directory at given path does not exist.
+    public func XCTAssertDirectoryContentEqual(
+        _ directory: AbsolutePath,
+        _ expected: [String],
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        let directoryContent = try FileHandler.shared
+            .contentsOfDirectory(directory)
+            .map(\.pathString)
+            .sorted()
+
+        let expectedContent = try expected
+            .map { directory.appending(try RelativePath(validating: $0)) }
+            .map(\.pathString)
+            .sorted()
+
+        let message = """
+        The directory content:
+        ===========
+        \(directoryContent.isEmpty ? "<Empty>" : directoryContent.joined(separator: "\n"))
+
+        Doesn't equal to expected:
+        ===========
+        \(expectedContent.isEmpty ? "<Empty>" : expectedContent.joined(separator: "\n"))
+        """
+
+        XCTAssertEqual(directoryContent, expectedContent, message, file: file, line: line)
+    }
 }

--- a/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
+++ b/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
@@ -225,38 +225,6 @@ open class TuistTestCase: XCTestCase {
         XCTAssertFalse(output.contains(notExpected), message, file: file, line: line)
     }
 
-    /// Asserts that a directory at given path contains expected elements.
-    /// It does not check the contents of a directory recursively.
-    /// - Throws: An error if the directory at given path does not exist.
-    public func XCTAssertDirectoryContentEqual(
-        _ directory: AbsolutePath,
-        _ expected: [String],
-        file: StaticString = #file,
-        line: UInt = #line
-    ) throws {
-        let directoryContent = try fileHandler
-            .contentsOfDirectory(directory)
-            .map(\.pathString)
-            .sorted()
-
-        let expectedContent = try expected
-            .map { directory.appending(try RelativePath(validating: $0)) }
-            .map(\.pathString)
-            .sorted()
-
-        let message = """
-        The directory content:
-        ===========
-        \(directoryContent.isEmpty ? "<Empty>" : directoryContent.joined(separator: "\n"))
-
-        Doesn't equal to expected:
-        ===========
-        \(expectedContent.isEmpty ? "<Empty>" : expectedContent.joined(separator: "\n"))
-        """
-
-        XCTAssertEqual(directoryContent, expectedContent, message, file: file, line: line)
-    }
-
     public func temporaryFixture(_ pathString: String) throws -> AbsolutePath {
         let path = try RelativePath(validating: pathString)
         let fixturePath = fixturePath(path: path)

--- a/Tests/TuistBuildAcceptanceTests/BuildAcceptanceTests.swift
+++ b/Tests/TuistBuildAcceptanceTests/BuildAcceptanceTests.swift
@@ -2,11 +2,10 @@ import TSCBasic
 import TuistAcceptanceTesting
 import TuistSupport
 import XCTest
-@testable import TuistKit
 
 /// Build projects using Tuist build
 final class BuildAcceptanceTestWithTemplates: TuistAcceptanceTestCase {
-    func test() async throws {
+    func test_with_templates() async throws {
         try run(InitCommand.self, "--platform", "ios", "--name", "MyApp")
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self)
@@ -16,7 +15,7 @@ final class BuildAcceptanceTestWithTemplates: TuistAcceptanceTestCase {
 }
 
 final class BuildAcceptanceTestAppWithFrameworkAndTests: TuistAcceptanceTestCase {
-    func test() async throws {
+    func test_with_framework_and_tests() async throws {
         try setUpFixture("app_with_framework_and_tests")
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self)
@@ -40,7 +39,7 @@ final class BuildAcceptanceTestAppWithFrameworkAndTests: TuistAcceptanceTestCase
 // }
 
 final class BuildAcceptanceTestiOSAppWithCustomConfigurationAndBuildToCustomDirectory: TuistAcceptanceTestCase {
-    func test() async throws {
+    func test_ios_app_with_custom_and_build_to_custom_directory() async throws {
         try setUpFixture("ios_app_with_custom_configuration")
         try await run(GenerateCommand.self)
         try await run(
@@ -49,9 +48,9 @@ final class BuildAcceptanceTestiOSAppWithCustomConfigurationAndBuildToCustomDire
             "--configuration",
             "debug",
             "--build-output-path",
-            FileHandler.shared.currentPath.appending(component: "Builds").pathString
+            fixturePath.appending(component: "Builds").pathString
         )
-        let debugPath = FileHandler.shared.currentPath.appending(
+        let debugPath = fixturePath.appending(
             try RelativePath(validating: "Builds/debug-iphonesimulator")
         )
         try XCTAssertDirectoryContentEqual(debugPath, ["App.app", "App.swiftmodule", "FrameworkA.framework"])
@@ -61,10 +60,10 @@ final class BuildAcceptanceTestiOSAppWithCustomConfigurationAndBuildToCustomDire
             "--configuration",
             "release",
             "--build-output-path",
-            FileHandler.shared.currentPath.appending(component: "Builds").pathString
+            fixturePath.appending(component: "Builds").pathString
         )
         try XCTAssertDirectoryContentEqual(debugPath, ["App.app", "App.swiftmodule", "FrameworkA.framework"])
-        let releasePath = FileHandler.shared.currentPath.appending(
+        let releasePath = fixturePath.appending(
             try RelativePath(validating: "Builds/release-iphonesimulator")
         )
         try XCTAssertDirectoryContentEqual(
@@ -81,7 +80,7 @@ final class BuildAcceptanceTestiOSAppWithCustomConfigurationAndBuildToCustomDire
 }
 
 final class BuildAcceptanceTestFrameworkWithSwiftMacroIntegratedWithStandardMethod: TuistAcceptanceTestCase {
-    func test() async throws {
+    func test_framework_with_swift_macro_integrated_with_standard_method() async throws {
         try setUpFixture("framework_with_swift_macro")
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self, "Framework")
@@ -89,7 +88,7 @@ final class BuildAcceptanceTestFrameworkWithSwiftMacroIntegratedWithStandardMeth
 }
 
 final class BuildAcceptanceTestFrameworkWithSwiftMacroIntegratedWithXcodeProjPrimitives: TuistAcceptanceTestCase {
-    func test() async throws {
+    func test_framework_with_swift_macro_integrated_with_xcode_proj_primitives() async throws {
         try setUpFixture("framework_with_native_swift_macro")
         try await run(FetchCommand.self)
         try await run(BuildCommand.self, "Framework")

--- a/Tests/TuistGenerateOneAcceptanceTests/GenerateOneAcceptanceTests.swift
+++ b/Tests/TuistGenerateOneAcceptanceTests/GenerateOneAcceptanceTests.swift
@@ -4,8 +4,6 @@ import TuistSupport
 import TuistSupportTesting
 import XCTest
 
-@testable import TuistKit
-
 /// Generate a new project using Tuist (suite 1)
 final class GenerateOneAcceptanceTestiOSAppWithTests: TuistAcceptanceTestCase {
     func test_ios_app_with_tests() async throws {
@@ -42,10 +40,8 @@ final class GenerateOneAcceptanceTestInvalidWorkspaceManifestName: TuistAcceptan
         do {
             try await run(GenerateCommand.self)
             XCTFail("Generate command should have failed")
-        } catch let error as FatalError {
-            XCTAssertEqual(error.description, "Manifest not found at path \(fixturePath.pathString)")
         } catch {
-            XCTFail("Unexpected error thrown: \(error)")
+            XCTAssertEqual(String(describing: error), "Manifest not found at path \(fixturePath.pathString)")
         }
     }
 }

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -3,7 +3,12 @@ import ProjectDescription
 let dependencies = Dependencies(
     swiftPackageManager: .init(
         productTypes: [
-            "ArgumentParser": .framework,
+            "SystemPackage": .staticFramework,
+            "TSCBasic": .staticFramework,
+            "TSCUtility": .staticFramework,
+            "TSCclibc": .staticFramework,
+            "TSCLibc": .staticFramework,
+            "Checksum": .staticFramework,
         ]
     ),
     platforms: [.macOS]

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -8,7 +8,7 @@ let dependencies = Dependencies(
             "TSCUtility": .staticFramework,
             "TSCclibc": .staticFramework,
             "TSCLibc": .staticFramework,
-            "Checksum": .staticFramework,
+            "ArgumentParser": .staticFramework,
         ]
     ),
     platforms: [.macOS]

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -19,15 +19,6 @@
       }
     },
     {
-      "identity" : "checksum",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/rnine/Checksum.git",
-      "state" : {
-        "revision" : "cd1ae53384dd578a84a0afef492a4f5d6202b068",
-        "version" : "1.0.2"
-      }
-    },
-    {
       "identity" : "combineext",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CombineCommunity/CombineExt.git",

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -15,7 +15,6 @@ let package = Package(
         .package(url: "https://github.com/httpswift/swifter", revision: "1e4f51c92d7ca486242d8bf0722b99de2c3531aa"),
         .package(url: "https://github.com/kishikawakatsumi/KeychainAccess", from: "4.2.2"),
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift", from: "1.8.0"),
-        .package(url: "https://github.com/rnine/Checksum", from: "1.0.2"),
         .package(url: "https://github.com/stencilproject/Stencil", from: "0.15.1"),
         .package(url: "https://github.com/SwiftDocOrg/GraphViz", exact: "0.2.0"),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit", from: "2.10.1"),

--- a/Tuist/ProjectDescriptionHelpers/Target+Helpers.swift
+++ b/Tuist/ProjectDescriptionHelpers/Target+Helpers.swift
@@ -43,7 +43,7 @@ extension Target {
     ///     - integrationTestsDependencies: Dependencies for the integration tests.
     public static func module(
         name: String,
-        product: Product = .framework,
+        product: Product = .staticFramework,
         hasTests: Bool = true,
         hasTesting: Bool = true,
         hasIntegrationTests: Bool = false,
@@ -67,6 +67,8 @@ extension Target {
                     product: .unitTests,
                     dependencies: testDependencies + [
                         .target(name: name),
+                        .external(name: "SwiftToolsSupport"),
+                        .external(name: "SystemPackage"),
                     ]
                         + (hasTesting ? [.target(name: "\(name)Testing")] : [])
                 )
@@ -80,6 +82,8 @@ extension Target {
                     product: product,
                     dependencies: testingDependencies + [
                         .target(name: name),
+                        .external(name: "SwiftToolsSupport"),
+                        .external(name: "SystemPackage"),
                         .sdk(name: "XCTest", type: .framework, status: .optional),
                     ]
                 )
@@ -93,6 +97,8 @@ extension Target {
                     product: .unitTests,
                     dependencies: integrationTestsDependencies + [
                         .target(name: name),
+                        .external(name: "SwiftToolsSupport"),
+                        .external(name: "SystemPackage"),
                     ]
                         + (hasTesting ? [.target(name: "\(name)Testing")] : [])
                 )

--- a/Tuist/ProjectDescriptionHelpers/Target+Helpers.swift
+++ b/Tuist/ProjectDescriptionHelpers/Target+Helpers.swift
@@ -9,7 +9,13 @@ extension Target {
     public static func target(
         name: String,
         product: Product,
-        dependencies: [TargetDependency]
+        dependencies: [TargetDependency],
+        settings _: Settings = .settings(
+            configurations: [
+                .debug(name: "Debug", settings: [:], xcconfig: nil),
+                .release(name: "Release", settings: [:], xcconfig: nil),
+            ]
+        )
     ) -> Target {
         let rootFolder: String
         switch product {
@@ -26,13 +32,7 @@ extension Target {
             deploymentTarget: Constants.deploymentTarget,
             infoPlist: .default,
             sources: ["\(rootFolder)/\(name)/**/*.swift"],
-            dependencies: dependencies,
-            settings: .settings(
-                configurations: [
-                    .debug(name: "Debug", settings: [:], xcconfig: nil),
-                    .release(name: "Release", settings: [:], xcconfig: nil),
-                ]
-            )
+            dependencies: dependencies
         )
     }
 


### PR DESCRIPTION
### Short description 📝

This PR does two things:
- Fixes `tuist` project definition, so replacing individual binaries works correctly
- Sets up pipelines to run `cache warm` both for Sillicon and Intel machines
- `tuist test` should now reuse these binaries when available, making those tests faster

The only downside of these changes is that now we have lots of warnings that dependencies are imported by multiple targets. We should follow up on this PR and make it possible to selectively disable this warning for frameworks where you know duplicated symbols won't cause issues.

### How to test the changes locally 🧐

- CI should pass
- If you can connect to our `tuist` Tuist Cloud instance, run `tuist generate tuist` -> you should be able to run the CLI with the downloaded binaries.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
