### PR TITLE
Macro support via Dependencies.swift

### DIFF
--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -246,8 +246,8 @@ public final class PackageInfoMapper: PackageInfoMapping {
         var visited: Set<String> = []
         var macroDependencies = Set<ResolvedDependency>()
 
-        while !macroTargetsNames.isEmpty {
-            guard let targetName = macroTargetsNames.popFirst(), !visited.contains(targetName) {
+        while !macroTargetsAndDescendants.isEmpty {
+            guard let targetName = macroTargetsAndDescendants.popFirst(), !visited.contains(targetName) else {
                 continue
             }
 
@@ -257,7 +257,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
                 macroDependencies.insert(dependency)
                 let dependencyTargetName = dependency.targetName
                 if let dependencyTargetName, !visited.contains(dependencyTargetName) {
-                    macroTargetsNames.insert(dependencyTargetName)
+                    macroTargetsAndDescendants.insert(dependencyTargetName)
                 }
             }
         }

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -241,8 +241,8 @@ public final class PackageInfoMapper: PackageInfoMapping {
                         )
                     }
             }
-        
-        var macroTargetsNames = Set(packageInfos.values.flatMap { $0.targets.filter({ $0.type == .macro}).map { $0.name } })
+
+        var macroTargetsNames = Set(packageInfos.values.flatMap { $0.targets.filter { $0.type == .macro }.map(\.name) })
 //        let macroDependencies = resolvedDependencies.filter { macroTargetsNames.contains($0.key) }.flatMap({ $0.value })
         var visited: Set<String> = []
         var macroDependencies = Set<ResolvedDependency>()
@@ -251,13 +251,13 @@ public final class PackageInfoMapper: PackageInfoMapping {
             guard let targetName = macroTargetsNames.popFirst() else {
                 continue
             }
-            
+
             if visited.contains(targetName) {
                 continue
             }
-            
+
             visited.insert(targetName)
-            
+
             for dependency in resolvedDependencies[targetName] ?? [] {
                 macroDependencies.insert(dependency)
                 let dependencyTargetName = dependency.targetName
@@ -540,17 +540,17 @@ extension ProjectDescription.Target {
         let moduleMap = targetToModuleMap[target.name]
 
         // Use the intersection of destations from `Dependencies.swift` and the destinations supported by the package.
-        
+
         var destinations = if target.type == .macro {
             Set<ProjectDescription.Destination>([.mac])
         } else {
             packageDestinations
                 .intersection(try ProjectDescription.Destinations.from(platforms: packageInfo.platforms))
         }
-        
-        if macroDependencies.contains (where: { dependency in
+
+        if macroDependencies.contains(where: { dependency in
             switch dependency {
-            case .externalTarget(_, let targetName, _), .target(let targetName, platformFilters: _):
+            case let .externalTarget(_, targetName, _), .target(let targetName, platformFilters: _):
                 return target.name == targetName
             default:
                 return false
@@ -1336,7 +1336,7 @@ extension PackageInfoMapper {
                 return condition
             }
         }
-        
+
         fileprivate var targetName: String? {
             switch self {
             case let .target(targetName, _), let .externalTarget(_, targetName, _):

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -550,7 +550,7 @@ extension ProjectDescription.Target {
 
         if macroDependencies.contains(where: { dependency in
             switch dependency {
-            case let .externalTarget(_, targetName, _), .target(let targetName, platformFilters: _):
+            case let .externalTarget(_, targetName, _), .target(let targetName, condition: _):
                 return target.name == targetName
             default:
                 return false

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -242,17 +242,12 @@ public final class PackageInfoMapper: PackageInfoMapping {
                     }
             }
 
-        var macroTargetsNames = Set(packageInfos.values.flatMap { $0.targets.filter { $0.type == .macro }.map(\.name) })
-//        let macroDependencies = resolvedDependencies.filter { macroTargetsNames.contains($0.key) }.flatMap({ $0.value })
+        var macroTargetsAndDescendants = Set(packageInfos.values.flatMap { $0.targets.filter { $0.type == .macro }.map(\.name) })
         var visited: Set<String> = []
         var macroDependencies = Set<ResolvedDependency>()
 
         while !macroTargetsNames.isEmpty {
-            guard let targetName = macroTargetsNames.popFirst() else {
-                continue
-            }
-
-            if visited.contains(targetName) {
+            guard let targetName = macroTargetsNames.popFirst(), !visited.contains(targetName) {
                 continue
             }
 

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerGraphGenerator.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerGraphGenerator.swift
@@ -154,7 +154,7 @@ public final class SwiftPackageManagerGraphGenerator: SwiftPackageManagerGraphGe
                 [.appleVision]
             }
         })
-
+        
         let externalProjects: [Path: ProjectDescription.Project] = try packageInfos.reduce(into: [:]) { result, packageInfo in
             let manifest = try packageInfoMapper.map(
                 packageInfo: packageInfo.info,
@@ -169,6 +169,7 @@ public final class SwiftPackageManagerGraphGenerator: SwiftPackageManagerGraphGe
                 destinations: destinations,
                 targetToProducts: preprocessInfo.targetToProducts,
                 targetToResolvedDependencies: preprocessInfo.targetToResolvedDependencies,
+                macroDependencies: preprocessInfo.macroDependencies,
                 targetToModuleMap: preprocessInfo.targetToModuleMap,
                 packageToProject: packageToProject,
                 swiftToolsVersion: swiftToolsVersion

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerGraphGenerator.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/SwiftPackageManagerGraphGenerator.swift
@@ -154,7 +154,7 @@ public final class SwiftPackageManagerGraphGenerator: SwiftPackageManagerGraphGe
                 [.appleVision]
             }
         })
-        
+
         let externalProjects: [Path: ProjectDescription.Project] = try packageInfos.reduce(into: [:]) { result, packageInfo in
             let manifest = try packageInfoMapper.map(
                 packageInfo: packageInfo.info,

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -322,7 +322,7 @@ final class ConfigGenerator: ConfigGenerating {
                 case let .product(_, productName, _):
                     return [
                         "-load-plugin-executable",
-                        "$BUILT_PRODUCTS_DIR/\(target.target.productNameWithExtension)/Macros/\(productName)/#\(productName)",
+                        "$BUILT_PRODUCTS_DIR/\(target.target.productNameWithExtension)/Macros/\(productName)#\(productName)",
                     ]
                 default:
                     return []

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -532,7 +532,7 @@ final class LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_
             default:
                 return nil
             }
-        }.map { ("$BUILT_PRODUCTS_DIR/\($0)", "$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/Macros/\($0)") }
+        }.map { ("$SYMROOT/$CONFIGURATION/\($0)", "$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/Macros/\($0)") }
 
         copySwiftMacrosBuildPhase.shellScript = filesToCopy.map { "cp \($0.0) \($0.1)" }.joined(separator: "\n")
         copySwiftMacrosBuildPhase.inputPaths = filesToCopy.map(\.0)

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -38,13 +38,13 @@ public class GraphLinter: GraphLinting {
 
     public func lint(graphTraverser: GraphTraversing) -> [LintingIssue] {
         var issues: [LintingIssue] = []
-//        issues.append(contentsOf: graphTraverser.projects.flatMap { project -> [LintingIssue] in
-//            projectLinter.lint(project.value)
-//        })
-//        issues.append(contentsOf: lintDependencies(graphTraverser: graphTraverser))
-//        issues.append(contentsOf: lintMismatchingConfigurations(graphTraverser: graphTraverser))
-//        issues.append(contentsOf: lintWatchBundleIndentifiers(graphTraverser: graphTraverser))
-//        issues.append(contentsOf: lintCodeCoverageMode(graphTraverser: graphTraverser))
+        issues.append(contentsOf: graphTraverser.projects.flatMap { project -> [LintingIssue] in
+            projectLinter.lint(project.value)
+        })
+        issues.append(contentsOf: lintDependencies(graphTraverser: graphTraverser))
+        issues.append(contentsOf: lintMismatchingConfigurations(graphTraverser: graphTraverser))
+        issues.append(contentsOf: lintWatchBundleIndentifiers(graphTraverser: graphTraverser))
+        issues.append(contentsOf: lintCodeCoverageMode(graphTraverser: graphTraverser))
         return issues
     }
 
@@ -89,57 +89,56 @@ public class GraphLinter: GraphLinting {
 
     private func lintDependencies(graphTraverser: GraphTraversing) -> [LintingIssue] {
         var issues: [LintingIssue] = []
-//        let dependencyIssues = graphTraverser.dependencies.flatMap { fromDependency, toDependencies -> [LintingIssue] in
-//            toDependencies.flatMap { toDependency -> [LintingIssue] in
-//                guard case let GraphDependency.target(fromTargetName, fromTargetPath) = fromDependency else { return [] }
-//                guard case let GraphDependency.target(toTargetName, toTargetPath) = toDependency else { return [] }
-//                guard let fromTarget = graphTraverser.target(path: fromTargetPath, name: fromTargetName) else { return [] }
-//                guard let toTarget = graphTraverser.target(path: toTargetPath, name: toTargetName) else { return [] }
-//                return lintDependency(from: fromTarget, to: toTarget)
-//            }
-//        }
-//
-//        issues.append(contentsOf: dependencyIssues)
-//        issues.append(contentsOf: staticProductsLinter.lint(graphTraverser: graphTraverser))
-//        issues.append(contentsOf: lintPrecompiledFrameworkDependencies(graphTraverser: graphTraverser))
-//        issues.append(contentsOf: lintPackageDependencies(graphTraverser: graphTraverser))
-//        issues.append(contentsOf: lintAppClip(graphTraverser: graphTraverser))
+        let dependencyIssues = graphTraverser.dependencies.flatMap { fromDependency, toDependencies -> [LintingIssue] in
+            toDependencies.flatMap { toDependency -> [LintingIssue] in
+                guard case let GraphDependency.target(fromTargetName, fromTargetPath) = fromDependency else { return [] }
+                guard case let GraphDependency.target(toTargetName, toTargetPath) = toDependency else { return [] }
+                guard let fromTarget = graphTraverser.target(path: fromTargetPath, name: fromTargetName) else { return [] }
+                guard let toTarget = graphTraverser.target(path: toTargetPath, name: toTargetName) else { return [] }
+                return lintDependency(from: fromTarget, to: toTarget)
+            }
+        }
+
+        issues.append(contentsOf: dependencyIssues)
+        issues.append(contentsOf: staticProductsLinter.lint(graphTraverser: graphTraverser))
+        issues.append(contentsOf: lintPrecompiledFrameworkDependencies(graphTraverser: graphTraverser))
+        issues.append(contentsOf: lintPackageDependencies(graphTraverser: graphTraverser))
+        issues.append(contentsOf: lintAppClip(graphTraverser: graphTraverser))
 
         return issues
     }
 
     private func lintDependency(from: GraphTarget, to: GraphTarget) -> [LintingIssue] {
-//        return []
-//        let fromPlatforms = from.target.supportedPlatforms
-//        let toPlatforms = to.target.supportedPlatforms
-//
-//        var validLinksCount = 0
-//        for fromPlatform in fromPlatforms {
-//            let fromTarget = LintableTarget(
-//                platform: fromPlatform,
-//                product: from.target.product
-//            )
-//
-//            guard let supportedTargets = GraphLinter.validLinks[fromTarget] else {
-//                let reason =
-//                    "Target \(from.target.name) has platform '\(fromPlatform)' and product '\(from.target.product)' which is an invalid or not yet supported combination."
-//                return [LintingIssue(reason: reason, severity: .error)]
-//            }
-//
-//            let toLintTargets = toPlatforms.map {
-//                LintableTarget(platform: $0, product: to.target.product)
-//            }
-//
-//            let validLinks = Set(toLintTargets).intersection(supportedTargets)
-//            validLinksCount += validLinks.count
-//        }
-//
-//        // Need to have at least one valid link based on common platforms
-//        guard validLinksCount > 0 else {
-//            let reason =
-//                "Target \(from.target.name) has platforms '\(fromPlatforms.map(\.caseValue).listed())' and product '\(from.target.product)' and depends on target \(to.target.name) of type '\(to.target.product)' and platforms '\(toPlatforms.map(\.caseValue).listed())' which is an invalid or not yet supported combination."
-//            return [LintingIssue(reason: reason, severity: .error)]
-//        }
+        let fromPlatforms = from.target.supportedPlatforms
+        let toPlatforms = to.target.supportedPlatforms
+
+        var validLinksCount = 0
+        for fromPlatform in fromPlatforms {
+            let fromTarget = LintableTarget(
+                platform: fromPlatform,
+                product: from.target.product
+            )
+
+            guard let supportedTargets = GraphLinter.validLinks[fromTarget] else {
+                let reason =
+                    "Target \(from.target.name) has platform '\(fromPlatform)' and product '\(from.target.product)' which is an invalid or not yet supported combination."
+                return [LintingIssue(reason: reason, severity: .error)]
+            }
+
+            let toLintTargets = toPlatforms.map {
+                LintableTarget(platform: $0, product: to.target.product)
+            }
+
+            let validLinks = Set(toLintTargets).intersection(supportedTargets)
+            validLinksCount += validLinks.count
+        }
+
+        // Need to have at least one valid link based on common platforms
+        guard validLinksCount > 0 else {
+            let reason =
+                "Target \(from.target.name) has platforms '\(fromPlatforms.map(\.caseValue).listed())' and product '\(from.target.product)' and depends on target \(to.target.name) of type '\(to.target.product)' and platforms '\(toPlatforms.map(\.caseValue).listed())' which is an invalid or not yet supported combination."
+            return [LintingIssue(reason: reason, severity: .error)]
+        }
 
         return []
     }

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -38,13 +38,13 @@ public class GraphLinter: GraphLinting {
 
     public func lint(graphTraverser: GraphTraversing) -> [LintingIssue] {
         var issues: [LintingIssue] = []
-        issues.append(contentsOf: graphTraverser.projects.flatMap { project -> [LintingIssue] in
-            projectLinter.lint(project.value)
-        })
-        issues.append(contentsOf: lintDependencies(graphTraverser: graphTraverser))
-        issues.append(contentsOf: lintMismatchingConfigurations(graphTraverser: graphTraverser))
-        issues.append(contentsOf: lintWatchBundleIndentifiers(graphTraverser: graphTraverser))
-        issues.append(contentsOf: lintCodeCoverageMode(graphTraverser: graphTraverser))
+//        issues.append(contentsOf: graphTraverser.projects.flatMap { project -> [LintingIssue] in
+//            projectLinter.lint(project.value)
+//        })
+//        issues.append(contentsOf: lintDependencies(graphTraverser: graphTraverser))
+//        issues.append(contentsOf: lintMismatchingConfigurations(graphTraverser: graphTraverser))
+//        issues.append(contentsOf: lintWatchBundleIndentifiers(graphTraverser: graphTraverser))
+//        issues.append(contentsOf: lintCodeCoverageMode(graphTraverser: graphTraverser))
         return issues
     }
 
@@ -89,56 +89,57 @@ public class GraphLinter: GraphLinting {
 
     private func lintDependencies(graphTraverser: GraphTraversing) -> [LintingIssue] {
         var issues: [LintingIssue] = []
-        let dependencyIssues = graphTraverser.dependencies.flatMap { fromDependency, toDependencies -> [LintingIssue] in
-            toDependencies.flatMap { toDependency -> [LintingIssue] in
-                guard case let GraphDependency.target(fromTargetName, fromTargetPath) = fromDependency else { return [] }
-                guard case let GraphDependency.target(toTargetName, toTargetPath) = toDependency else { return [] }
-                guard let fromTarget = graphTraverser.target(path: fromTargetPath, name: fromTargetName) else { return [] }
-                guard let toTarget = graphTraverser.target(path: toTargetPath, name: toTargetName) else { return [] }
-                return lintDependency(from: fromTarget, to: toTarget)
-            }
-        }
-
-        issues.append(contentsOf: dependencyIssues)
-        issues.append(contentsOf: staticProductsLinter.lint(graphTraverser: graphTraverser))
-        issues.append(contentsOf: lintPrecompiledFrameworkDependencies(graphTraverser: graphTraverser))
-        issues.append(contentsOf: lintPackageDependencies(graphTraverser: graphTraverser))
-        issues.append(contentsOf: lintAppClip(graphTraverser: graphTraverser))
+//        let dependencyIssues = graphTraverser.dependencies.flatMap { fromDependency, toDependencies -> [LintingIssue] in
+//            toDependencies.flatMap { toDependency -> [LintingIssue] in
+//                guard case let GraphDependency.target(fromTargetName, fromTargetPath) = fromDependency else { return [] }
+//                guard case let GraphDependency.target(toTargetName, toTargetPath) = toDependency else { return [] }
+//                guard let fromTarget = graphTraverser.target(path: fromTargetPath, name: fromTargetName) else { return [] }
+//                guard let toTarget = graphTraverser.target(path: toTargetPath, name: toTargetName) else { return [] }
+//                return lintDependency(from: fromTarget, to: toTarget)
+//            }
+//        }
+//
+//        issues.append(contentsOf: dependencyIssues)
+//        issues.append(contentsOf: staticProductsLinter.lint(graphTraverser: graphTraverser))
+//        issues.append(contentsOf: lintPrecompiledFrameworkDependencies(graphTraverser: graphTraverser))
+//        issues.append(contentsOf: lintPackageDependencies(graphTraverser: graphTraverser))
+//        issues.append(contentsOf: lintAppClip(graphTraverser: graphTraverser))
 
         return issues
     }
 
     private func lintDependency(from: GraphTarget, to: GraphTarget) -> [LintingIssue] {
-        let fromPlatforms = from.target.supportedPlatforms
-        let toPlatforms = to.target.supportedPlatforms
-
-        var validLinksCount = 0
-        for fromPlatform in fromPlatforms {
-            let fromTarget = LintableTarget(
-                platform: fromPlatform,
-                product: from.target.product
-            )
-
-            guard let supportedTargets = GraphLinter.validLinks[fromTarget] else {
-                let reason =
-                    "Target \(from.target.name) has platform '\(fromPlatform)' and product '\(from.target.product)' which is an invalid or not yet supported combination."
-                return [LintingIssue(reason: reason, severity: .error)]
-            }
-
-            let toLintTargets = toPlatforms.map {
-                LintableTarget(platform: $0, product: to.target.product)
-            }
-
-            let validLinks = Set(toLintTargets).intersection(supportedTargets)
-            validLinksCount += validLinks.count
-        }
-
-        // Need to have at least one valid link based on common platforms
-        guard validLinksCount > 0 else {
-            let reason =
-                "Target \(from.target.name) has platforms '\(fromPlatforms.map(\.caseValue).listed())' and product '\(from.target.product)' and depends on target \(to.target.name) of type '\(to.target.product)' and platforms '\(toPlatforms.map(\.caseValue).listed())' which is an invalid or not yet supported combination."
-            return [LintingIssue(reason: reason, severity: .error)]
-        }
+//        return []
+//        let fromPlatforms = from.target.supportedPlatforms
+//        let toPlatforms = to.target.supportedPlatforms
+//
+//        var validLinksCount = 0
+//        for fromPlatform in fromPlatforms {
+//            let fromTarget = LintableTarget(
+//                platform: fromPlatform,
+//                product: from.target.product
+//            )
+//
+//            guard let supportedTargets = GraphLinter.validLinks[fromTarget] else {
+//                let reason =
+//                    "Target \(from.target.name) has platform '\(fromPlatform)' and product '\(from.target.product)' which is an invalid or not yet supported combination."
+//                return [LintingIssue(reason: reason, severity: .error)]
+//            }
+//
+//            let toLintTargets = toPlatforms.map {
+//                LintableTarget(platform: $0, product: to.target.product)
+//            }
+//
+//            let validLinks = Set(toLintTargets).intersection(supportedTargets)
+//            validLinksCount += validLinks.count
+//        }
+//
+//        // Need to have at least one valid link based on common platforms
+//        guard validLinksCount > 0 else {
+//            let reason =
+//                "Target \(from.target.name) has platforms '\(fromPlatforms.map(\.caseValue).listed())' and product '\(from.target.product)' and depends on target \(to.target.name) of type '\(to.target.product)' and platforms '\(toPlatforms.map(\.caseValue).listed())' which is an invalid or not yet supported combination."
+//            return [LintingIssue(reason: reason, severity: .error)]
+//        }
 
         return []
     }

--- a/Tests/TuistBuildAcceptanceTests/BuildAcceptanceTests.swift
+++ b/Tests/TuistBuildAcceptanceTests/BuildAcceptanceTests.swift
@@ -91,7 +91,8 @@ final class BuildAcceptanceTestFrameworkWithSwiftMacroIntegratedWithXcodeProjPri
     func test_framework_with_swift_macro_integrated_with_xcode_proj_primitives() async throws {
         try setUpFixture("framework_with_native_swift_macro")
         try await run(FetchCommand.self)
-        try await run(BuildCommand.self, "Framework")
+        try await run(BuildCommand.self, "Framework", "--platform", "macos")
+        try await run(BuildCommand.self, "Framework", "--platform", "ios")
     }
 }
 

--- a/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
+++ b/Tests/TuistDependenciesTests/SwiftPackageManager/Utils/PackageInfoMapperTests.swift
@@ -3187,6 +3187,7 @@ extension PackageInfoMapping {
             destinations: destinations,
             targetToProducts: preprocessInfo.targetToProducts,
             targetToResolvedDependencies: preprocessInfo.targetToResolvedDependencies,
+            macroDependencies: preprocessInfo.macroDependencies,
             targetToModuleMap: preprocessInfo.targetToModuleMap,
             packageToProject: Dictionary(uniqueKeysWithValues: packageInfos.keys.map {
                 ($0, basePath.appending(component: $0))

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -750,7 +750,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             targetSettingsResult,
             .array([
                 "-load-plugin-executable",
-                "$BUILT_PRODUCTS_DIR/\(macroFramework.productNameWithExtension)/Macros/\(macroExecutable.productName)/#\(macroExecutable.productName)",
+                "$SYMROOT/$CONFIGURATION/\(macroFramework.productNameWithExtension)/Macros/\(macroExecutable.productName)/#\(macroExecutable.productName)",
             ])
         )
     }

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -750,7 +750,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             targetSettingsResult,
             .array([
                 "-load-plugin-executable",
-                "$SYMROOT/$CONFIGURATION/\(macroFramework.productNameWithExtension)/Macros/\(macroExecutable.productName)/#\(macroExecutable.productName)",
+                "$BUILT_PRODUCTS_DIR/\(macroFramework.productNameWithExtension)/Macros/\(macroExecutable.productName)#\(macroExecutable.productName)",
             ])
         )
     }

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -1020,9 +1020,9 @@ final class LinkGeneratorTests: XCTestCase {
         XCTAssertNotNil(buildPhase)
 
         let expectedScript =
-            "cp $BUILT_PRODUCTS_DIR/\(macroExecutable.productName) $BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/Macros/\(macroExecutable.productName)"
+            "cp $SYMROOT/$CONFIGURATION/\(macroExecutable.productName) $BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/Macros/\(macroExecutable.productName)"
         XCTAssertTrue(buildPhase?.shellScript?.contains(expectedScript) == true)
-        XCTAssertTrue(buildPhase?.inputPaths.contains("$BUILT_PRODUCTS_DIR/\(macroExecutable.productName)") == true)
+        XCTAssertTrue(buildPhase?.inputPaths.contains("$SYMROOT/$CONFIGURATION/\(macroExecutable.productName)") == true)
         XCTAssertTrue(
             buildPhase?.outputPaths
                 .contains("$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/Macros/\(macroExecutable.productName)") == true

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .package(url: "https://github.com/Alamofire/Alamofire", from: "5.8.0"),
         .package(url: "https://github.com/facebook/facebook-ios-sdk", from: "16.1.3"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.15.0"),
-        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", .upToNextMinor(from: "1.0.0")),
+        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", .upToNextMinor(from: "1.5.0")),
         .package(url: "https://github.com/iterable/swift-sdk", from: "6.4.15"),
         .package(url: "https://github.com/Trendyol/ios-components", revision: "c9260bfe203a16a278eca5542c98455eece98aa4"),
         .package(url: "https://github.com/stripe/stripe-ios", from: "23.12.0"),

--- a/fixtures/framework_with_native_swift_macro/Project.swift
+++ b/fixtures/framework_with_native_swift_macro/Project.swift
@@ -5,7 +5,7 @@ let project = Project(
     targets: [
         Target(
             name: "Framework",
-            platform: .macOS,
+            destinations: [.iPhone, .mac],
             product: .staticLibrary,
             bundleId: "io.tuist.FrameworkWithSwiftMacro",
             sources: ["Sources/**/*"],

--- a/fixtures/framework_with_native_swift_macro/Tuist/Dependencies.swift
+++ b/fixtures/framework_with_native_swift_macro/Tuist/Dependencies.swift
@@ -4,5 +4,5 @@ let dependencies = Dependencies(
     swiftPackageManager: .init(
         targetSettings: [:]
     ),
-    platforms: [.macOS]
+    platforms: [.macOS, .iOS]
 )


### PR DESCRIPTION
Resolves #5488 

### Short description 📝

This allows non-macos targets to depend on packages that provide macros.

### How to test the changes locally 🧐

Run `fetch` and `generate` against the fixture `framework_with_swift_macro`.  Framework should build when depending on packages that provide macros via `Dependencies.swift`

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
