### PR TITLE
Remove testing and test targets from Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,12 +34,13 @@ var targets: [Target] = [
     ),
     .target(
         name: "TuistGraphTesting",
-        dependencies: ["TuistGraph", "TuistSupportTesting"],
+        dependencies: [
+            "TuistGraph", 
+            "TuistSupportTesting",
+            swiftToolsSupportDependency,
+            "AnyCodable",
+        ],
         linkerSettings: [.linkedFramework("XCTest")]
-    ),
-    .testTarget(
-        name: "TuistGraphTests",
-        dependencies: ["TuistGraph", "TuistGraphTesting", "TuistSupportTesting", "TuistCoreTesting"]
     ),
     .target(
         name: "TuistCore",
@@ -53,16 +54,13 @@ var targets: [Target] = [
     ),
     .target(
         name: "TuistCoreTesting",
-        dependencies: ["TuistCore", "TuistSupportTesting", "TuistGraphTesting"],
+        dependencies: [
+            "TuistCore", 
+            "TuistSupportTesting", 
+            "TuistGraphTesting",
+            swiftToolsSupportDependency,
+        ],
         linkerSettings: [.linkedFramework("XCTest")]
-    ),
-    .testTarget(
-        name: "TuistCoreTests",
-        dependencies: ["TuistCore", "TuistCoreTesting", "TuistSupportTesting"]
-    ),
-    .testTarget(
-        name: "TuistCoreIntegrationTests",
-        dependencies: ["TuistCore", "TuistSupportTesting"]
     ),
     .target(
         name: "TuistKit",
@@ -87,40 +85,6 @@ var targets: [Target] = [
             "TuistGraph",
         ]
     ),
-    .testTarget(
-        name: "TuistKitTests",
-        dependencies: [
-            "TuistKit",
-            "TuistAutomation",
-            "TuistSupportTesting",
-            "TuistCoreTesting",
-            "ProjectDescription",
-            "ProjectAutomation",
-            "TuistLoaderTesting",
-            "TuistGeneratorTesting",
-            "TuistScaffoldTesting",
-            "TuistAutomationTesting",
-            "TuistSigningTesting",
-            "TuistDependenciesTesting",
-            "TuistMigrationTesting",
-            "TuistAsyncQueueTesting",
-            "TuistGraphTesting",
-            "TuistPlugin",
-            "TuistPluginTesting",
-        ]
-    ),
-    .testTarget(
-        name: "TuistKitIntegrationTests",
-        dependencies: [
-            "TuistKit",
-            "TuistCoreTesting",
-            "TuistSupportTesting",
-            "ProjectDescription",
-            "ProjectAutomation",
-            "TuistLoaderTesting",
-            "TuistGraphTesting",
-        ]
-    ),
     .executableTarget(
         name: "tuist",
         dependencies: [
@@ -137,13 +101,6 @@ var targets: [Target] = [
             "TuistSupport",
         ]
     ),
-    .testTarget(
-        name: "TuistEnvKitTests",
-        dependencies: [
-            "TuistEnvKit",
-            "TuistSupportTesting",
-        ]
-    ),
     .executableTarget(
         name: "tuistenv",
         dependencies: [
@@ -153,13 +110,6 @@ var targets: [Target] = [
     .target(
         name: "ProjectDescription",
         dependencies: []
-    ),
-    .testTarget(
-        name: "ProjectDescriptionTests",
-        dependencies: [
-            "ProjectDescription",
-            "TuistSupportTesting",
-        ]
     ),
     .target(
         name: "ProjectAutomation"
@@ -185,21 +135,6 @@ var targets: [Target] = [
         ],
         linkerSettings: [.linkedFramework("XCTest")]
     ),
-    .testTarget(
-        name: "TuistSupportTests",
-        dependencies: [
-            "TuistCore",
-            "TuistSupport",
-            "TuistSupportTesting",
-        ]
-    ),
-    .testTarget(
-        name: "TuistSupportIntegrationTests",
-        dependencies: [
-            "TuistSupport",
-            "TuistSupportTesting",
-        ]
-    ),
     .target(
         name: "TuistAcceptanceTesting",
         dependencies: [
@@ -223,37 +158,6 @@ var targets: [Target] = [
         ]
     ),
     .target(
-        name: "TuistGeneratorTesting",
-        dependencies: [
-            "TuistGenerator",
-            "TuistCoreTesting",
-            "TuistSupportTesting",
-            "TuistGraphTesting",
-        ],
-        linkerSettings: [.linkedFramework("XCTest")]
-    ),
-    .testTarget(
-        name: "TuistGeneratorTests",
-        dependencies: [
-            "TuistGenerator",
-            "TuistSupportTesting",
-            "TuistCoreTesting",
-            "TuistGeneratorTesting",
-            "TuistSigningTesting",
-            "TuistGraphTesting",
-        ]
-    ),
-    .testTarget(
-        name: "TuistGeneratorIntegrationTests",
-        dependencies: [
-            "TuistGenerator",
-            "TuistSupportTesting",
-            "TuistCoreTesting",
-            "TuistGeneratorTesting",
-            "TuistGraphTesting",
-        ]
-    ),
-    .target(
         name: "TuistScaffold",
         dependencies: [
             swiftToolsSupportDependency,
@@ -262,31 +166,6 @@ var targets: [Target] = [
             "TuistSupport",
             "StencilSwiftKit",
             "Stencil",
-        ]
-    ),
-    .target(
-        name: "TuistScaffoldTesting",
-        dependencies: [
-            "TuistScaffold",
-            "TuistGraphTesting",
-        ],
-        linkerSettings: [.linkedFramework("XCTest")]
-    ),
-    .testTarget(
-        name: "TuistScaffoldTests",
-        dependencies: [
-            "TuistScaffold",
-            "TuistSupportTesting",
-            "TuistCoreTesting",
-            "TuistGraphTesting",
-        ]
-    ),
-    .testTarget(
-        name: "TuistScaffoldIntegrationTests",
-        dependencies: [
-            "TuistScaffold",
-            "TuistSupportTesting",
-            "TuistGraphTesting",
         ]
     ),
     .target(
@@ -299,37 +178,6 @@ var targets: [Target] = [
             "TuistSupport",
         ]
     ),
-    .testTarget(
-        name: "TuistAutomationTests",
-        dependencies: [
-            "TuistAutomation",
-            "TuistAutomationTesting",
-            "TuistSupportTesting",
-            "TuistCoreTesting",
-            "TuistGraphTesting",
-        ]
-    ),
-    .target(
-        name: "TuistAutomationTesting",
-        dependencies: [
-            "TuistAutomation",
-            swiftToolsSupportDependency,
-            "TuistCore",
-            "TuistCoreTesting",
-            "ProjectDescription",
-            "TuistSupportTesting",
-            "TuistGraphTesting",
-        ],
-        linkerSettings: [.linkedFramework("XCTest")]
-    ),
-    .testTarget(
-        name: "TuistAutomationIntegrationTests",
-        dependencies: [
-            "TuistAutomation",
-            "TuistSupportTesting",
-            "TuistGraphTesting",
-        ]
-    ),
     .target(
         name: "TuistSigning",
         dependencies: [
@@ -337,24 +185,7 @@ var targets: [Target] = [
             "TuistGraph",
             "TuistSupport",
             "CryptoSwift",
-        ]
-    ),
-    .target(
-        name: "TuistSigningTesting",
-        dependencies: [
-            "TuistSigning",
-            "TuistGraphTesting",
-        ],
-        linkerSettings: [.linkedFramework("XCTest")]
-    ),
-    .testTarget(
-        name: "TuistSigningTests",
-        dependencies: [
-            "TuistSigning",
-            "TuistSupportTesting",
-            "TuistCoreTesting",
-            "TuistSigningTesting",
-            "TuistGraphTesting",
+            swiftToolsSupportDependency,
         ]
     ),
     .target(
@@ -365,26 +196,7 @@ var targets: [Target] = [
             "TuistGraph",
             "TuistSupport",
             "TuistPlugin",
-        ]
-    ),
-    .target(
-        name: "TuistDependenciesTesting",
-        dependencies: [
-            "TuistDependencies",
-            "TuistGraphTesting",
-        ],
-        linkerSettings: [.linkedFramework("XCTest")]
-    ),
-    .testTarget(
-        name: "TuistDependenciesTests",
-        dependencies: [
-            "TuistCoreTesting",
-            "TuistDependencies",
-            "TuistDependenciesTesting",
-            "TuistGraphTesting",
-            "TuistLoaderTesting",
-            "TuistSupportTesting",
-            "TuistPluginTesting",
+            swiftToolsSupportDependency,
         ]
     ),
     .target(
@@ -398,34 +210,6 @@ var targets: [Target] = [
         ]
     ),
     .target(
-        name: "TuistMigrationTesting",
-        dependencies: [
-            "TuistMigration",
-            "TuistGraphTesting",
-        ],
-        linkerSettings: [.linkedFramework("XCTest")]
-    ),
-    .testTarget(
-        name: "TuistMigrationTests",
-        dependencies: [
-            "TuistMigration",
-            "TuistSupportTesting",
-            "TuistCoreTesting",
-            "TuistMigrationTesting",
-            "TuistGraphTesting",
-        ]
-    ),
-    .testTarget(
-        name: "TuistMigrationIntegrationTests",
-        dependencies: [
-            "TuistMigration",
-            "TuistSupportTesting",
-            "TuistCoreTesting",
-            "TuistMigrationTesting",
-            "TuistGraphTesting",
-        ]
-    ),
-    .target(
         name: "TuistAsyncQueue",
         dependencies: [
             "TuistCore",
@@ -434,24 +218,6 @@ var targets: [Target] = [
             "XcodeProj",
             swiftToolsSupportDependency,
             "Queuer",
-        ]
-    ),
-    .target(
-        name: "TuistAsyncQueueTesting",
-        dependencies: [
-            "TuistAsyncQueue",
-            "TuistGraphTesting",
-        ],
-        linkerSettings: [.linkedFramework("XCTest")]
-    ),
-    .testTarget(
-        name: "TuistAsyncQueueTests",
-        dependencies: [
-            "TuistAsyncQueue",
-            "TuistSupportTesting",
-            "TuistCoreTesting",
-            "TuistAsyncQueueTesting",
-            "TuistGraphTesting",
         ]
     ),
     .target(
@@ -477,36 +243,6 @@ var targets: [Target] = [
         ],
         linkerSettings: [.linkedFramework("XCTest")]
     ),
-    .testTarget(
-        name: "TuistLoaderTests",
-        dependencies: [
-            "TuistLoader",
-            "TuistGraphTesting",
-            "TuistSupportTesting",
-            "TuistLoaderTesting",
-            "TuistCoreTesting",
-        ]
-    ),
-    .testTarget(
-        name: "TuistLoaderIntegrationTests",
-        dependencies: [
-            "TuistLoader",
-            "TuistGraphTesting",
-            "TuistSupportTesting",
-            "ProjectDescription",
-        ]
-    ),
-    .testTarget(
-        name: "TuistIntegrationTests",
-        dependencies: [
-            "TuistGenerator",
-            "TuistSupportTesting",
-            "TuistSupport",
-            "TuistCoreTesting",
-            "TuistGraphTesting",
-            "TuistLoaderTesting",
-        ]
-    ),
     .target(
         name: "TuistAnalytics",
         dependencies: [
@@ -515,6 +251,7 @@ var targets: [Target] = [
             "TuistCore",
             "TuistGraph",
             "TuistLoader",
+            swiftToolsSupportDependency,
         ]
     ),
     .target(
@@ -524,30 +261,6 @@ var targets: [Target] = [
             "TuistLoader",
             "TuistSupport",
             "TuistScaffold",
-            swiftToolsSupportDependency,
-        ]
-    ),
-    .target(
-        name: "TuistPluginTesting",
-        dependencies: [
-            "TuistGraph",
-            "TuistPlugin",
-            swiftToolsSupportDependency,
-        ],
-        linkerSettings: [.linkedFramework("XCTest")]
-    ),
-    .testTarget(
-        name: "TuistPluginTests",
-        dependencies: [
-            "ProjectDescription",
-            "TuistLoader",
-            "TuistLoaderTesting",
-            "TuistGraphTesting",
-            "TuistPlugin",
-            "TuistSupport",
-            "TuistSupportTesting",
-            "TuistScaffoldTesting",
-            "TuistCoreTesting",
             swiftToolsSupportDependency,
         ]
     ),


### PR DESCRIPTION
### Short description 📝

Maintaining test and testing targets is unnecessary since our go-to way to work on tuist is with tuist. The only reason we provide Package.swift is to create the binary CLI and allow other projects to integrate tuist products via SPM.
