### PR TITLE
When available, use git rev-parse --show-toplevel to find root of project (#5588)

### DIFF
--- a/Sources/TuistCore/Utils/RootDirectoryLocator.swift
+++ b/Sources/TuistCore/Utils/RootDirectoryLocator.swift
@@ -26,7 +26,7 @@ extension RootDirectoryLocating {
 
 public final class RootDirectoryLocator: RootDirectoryLocating {
     private let fileHandler: FileHandling = FileHandler.shared
-    internal var gitHandler: GitHandling = GitHandler()
+    private let gitHandler: GitHandling = GitHandler()
     /// This cache avoids having to traverse the directories hierarchy every time the locate method is called.
     @Atomic private var cache: [AbsolutePath: AbsolutePath] = [:]
     private let usingProjectManifest: Bool

--- a/Sources/TuistCore/Utils/RootDirectoryLocator.swift
+++ b/Sources/TuistCore/Utils/RootDirectoryLocator.swift
@@ -26,6 +26,7 @@ extension RootDirectoryLocating {
 
 public final class RootDirectoryLocator: RootDirectoryLocating {
     private let fileHandler: FileHandling = FileHandler.shared
+    internal var gitHandler: GitHandling = GitHandler()
     /// This cache avoids having to traverse the directories hierarchy every time the locate method is called.
     @Atomic private var cache: [AbsolutePath: AbsolutePath] = [:]
     private let usingProjectManifest: Bool
@@ -41,6 +42,8 @@ public final class RootDirectoryLocator: RootDirectoryLocating {
     private func locate(from path: AbsolutePath, source: AbsolutePath) -> AbsolutePath? {
         if let cachedDirectory = cached(path: path) {
             return cachedDirectory
+        } else if let gitRoot = try? gitHandler.locateTopLevel(from: path) {
+            return gitRoot
         } else if (usingProjectManifest && fileHandler.exists(path.appending(component: "Project.swift"))) ||
             fileHandler.exists(path.appending(component: "Workspace.swift")) ||
             fileHandler.exists(path.appending(component: Constants.tuistDirectoryName)) ||

--- a/Sources/TuistSupport/Utils/GitHandler.swift
+++ b/Sources/TuistSupport/Utils/GitHandler.swift
@@ -36,6 +36,13 @@ public protocol GitHandling {
     /// - Parameters:
     ///   - url: The `url` of the git repository.
     func remoteTaggedVersions(url: String) throws -> [Version]
+
+    /// Given a path that may be within a local copy, return the root path of that local copy.
+    /// If the path is not within a local copy, return `nil`.
+    ///
+    /// - Parameters:
+    ///   - path: A local path that may be part of a local copy
+    func locateTopLevel(from path: AbsolutePath) throws -> AbsolutePath?
 }
 
 /// An implementation of `GitHandling`.
@@ -72,6 +79,12 @@ public final class GitHandler: GitHandling {
 
     public func remoteTaggedVersions(url: String) throws -> [Version] {
         try parseVersions(lsRemote(url: url))
+    }
+
+    public func locateTopLevel(from path: AbsolutePath) throws -> AbsolutePath? {
+        try (try? capture(command: "git", "-C", path.dirname, "rev-parse", "--show-toplevel")).flatMap {
+            try AbsolutePath(validating: $0.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
     }
 
     private func run(command: String...) throws {

--- a/Sources/TuistSupportTesting/Utils/MockGitHandler.swift
+++ b/Sources/TuistSupportTesting/Utils/MockGitHandler.swift
@@ -25,4 +25,9 @@ public final class MockGitHandler: GitHandling {
     public func remoteTaggedVersions(url _: String) -> [Version] {
         remoteTaggedVersionsStub?.compactMap { Version($0) } ?? []
     }
+
+    public var locateTopLevelStub: ((AbsolutePath) -> AbsolutePath?)?
+    public func locateTopLevel(from path: AbsolutePath) throws -> AbsolutePath? {
+        locateTopLevelStub?(path)
+    }
 }

--- a/Tests/TuistCoreIntegrationTests/RootDirectoryLocatorIntegrationTests.swift
+++ b/Tests/TuistCoreIntegrationTests/RootDirectoryLocatorIntegrationTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import TSCBasic
-@testable import TuistCore
+import TuistCore
 import TuistSupport
 import XCTest
 
@@ -157,7 +157,9 @@ final class RootDirectoryLocatorIntegrationTests: TuistTestCase {
 
     func test_locate_when_multiple_workspaces_exist_but_git_can_return_top_level() throws {
         // Given
-        let temporaryDirectory = try temporaryPath()
+        let temporaryDirectory = try AbsolutePath(validating: "/private")
+            .appending(temporaryPath().relative(to: "/"))
+        try System.shared.run(["git", "-C", temporaryDirectory.pathString, "init"])
         try createFolders([
             "Nested",
         ])
@@ -167,11 +169,7 @@ final class RootDirectoryLocatorIntegrationTests: TuistTestCase {
         ])
 
         // When
-        let source = temporaryDirectory.appending(components: ["Nested", "Workspace.swift"])
-        let gitHandler = MockGitHandler()
-        gitHandler.locateTopLevelStub = { _ in temporaryDirectory }
-        subject.gitHandler = gitHandler
-        let got = subject.locate(from: source)
+        let got = subject.locate(from: temporaryDirectory.appending(components: ["Nested", "Workspace.swift"]))
 
         // Then
         XCTAssertEqual(got, temporaryDirectory)

--- a/Tests/TuistCoreIntegrationTests/RootDirectoryLocatorIntegrationTests.swift
+++ b/Tests/TuistCoreIntegrationTests/RootDirectoryLocatorIntegrationTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import TSCBasic
-import TuistCore
+@testable import TuistCore
 import TuistSupport
 import XCTest
 
@@ -150,6 +150,28 @@ final class RootDirectoryLocatorIntegrationTests: TuistTestCase {
 
         // When
         let got = subject.locate(from: temporaryDirectory.appending(component: "Workspace.swift"))
+
+        // Then
+        XCTAssertEqual(got, temporaryDirectory)
+    }
+
+    func test_locate_when_multiple_workspaces_exist_but_git_can_return_top_level() throws {
+        // Given
+        let temporaryDirectory = try temporaryPath()
+        try createFolders([
+            "Nested",
+        ])
+        try createFiles([
+            "Workspace.swift",
+            "Nested/Workspace.swift",
+        ])
+
+        // When
+        let source = temporaryDirectory.appending(components: ["Nested", "Workspace.swift"])
+        let gitHandler = MockGitHandler()
+        gitHandler.locateTopLevelStub = { _ in temporaryDirectory }
+        subject.gitHandler = gitHandler
+        let got = subject.locate(from: source)
 
         // Then
         XCTAssertEqual(got, temporaryDirectory)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5588

### Short description 📝

* https://github.com/tuist/tuist/pull/5499 refactored `RootDirectoryLocating` to give precedence to `Workspace.swift` when locating the root of the project tree
* This breaks the ability to have nested workspaces, but also to shared code through ProjectDescriptionHelpers at the (true) root of the project
* The existing implementation relies entirely on inspecting the filesystem to work this out. However, it's possible to query Git directly to get the root of the local copy. In cases where this is possible (presence of Git doesn't need to be assumed), I can't think of any cases where this wouldn't be definitive

### How to test the changes locally 🧐

* An example project is provided in https://github.com/tuist/tuist/issues/5588
* Changes can be tested by running `tuist generate` for the nested workspace
* The "true" root of this project is then found and the shared ProjectDescriptionHelpers are compiled as expected

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
  - Apparently unrelated errors:

```
warning: Skipping correcting file because it produced Swift parser errors: /Users/jc/Developer/OpenSource/tuist/Sources/tuist/tuist.docc/Tutorials/Tuist Tutorial/Getting-Started/Add External Dependencies/Dependencies.swift
{
  "diagnostics" : [
    "expected value in function call"
  ]
}
```

- [x] The change is tested via unit testing or acceptance testing, or both
  - Apparently unrelated errors:
  
```
TuistGenerateOneAcceptanceTests.xctest
GenerateOneAcceptanceTestInvalidWorkspaceManifestName
❌ TuistAcceptanceTesting/TuistAcceptanceTestCase.swift:31: Unexpectedly found nil while unwrapping an Optional value
2023-11-20 13:21:32.928967+0000 xctest[30443:9409074] TuistAcceptanceTesting/TuistAcceptanceTestCase.swift:31: Fatal error: Unexpectedly found nil while unwrapping an Optional value
objc[30445]: Class _TtC7Stencil7Context is implemented in both /Users/jc/Library/Developer/Xcode/DerivedData/Tuist-eiecjmhtbqlnyxcmnvdxvyeixocs/Build/Products/Debug/TuistScaffold.framework/Versions/A/TuistScaffold (0x10476eee0) and /Users/jc/Library/Developer/Xcode/DerivedData/Tuist-eiecjmhtbqlnyxcmnvdxvyeixocs/Build/Products/Debug/TuistGenerator.framework/Versions/A/TuistGenerator (0x105e943b8). One of the two will be used. Which one is undefined.
    ✖ Restarting after unexpected exit, crash, or test timeout in GenerateOneAcceptanceTestInvalidWorkspaceManifestName.test_invalid_workspace_manifest_name(); summary will include totals from previous launches.
Selected tests
TuistGenerateOneAcceptanceTests.xctest
GenerateOneAcceptanceTestInvalidWorkspaceManifestName
GenerateOneAcceptanceTestiOSAppWithFrameworks
❌ TuistAcceptanceTesting/TuistAcceptanceTestCase.swift:31: Unexpectedly found nil while unwrapping an Optional value
2023-11-20 13:21:33.380714+0000 xctest[30445:9409096] TuistAcceptanceTesting/TuistAcceptanceTestCase.swift:31: Fatal error: Unexpectedly found nil while unwrapping an Optional value
objc[30446]: Class _T
tC7Stencil7Context is implemented in both /Users/jc/Library/Developer/Xcode/DerivedData/Tuist-eiecjmhtbqlnyxcmnvdxvyeixocs/Build/Products/Debug/TuistScaffold.framework/Versions/A/TuistScaffold (0x1123b2ee0) and /Users/jc/Library/Developer/Xcode/DerivedData/Tuist-eiecjmhtbqlnyxcmnvdxvyeixocs/Build/Products/Debug/TuistGenerator.framework/Versions/A/TuistGenerator (0x113c043b8). One of the two will be used. Which one is undefined.
    ✖ Restarting after unexpected exit, crash, or test timeout in GenerateOneAcceptanceTestiOSAppWithFrameworks.test_ios_app_with_frameworks(); summary will include totals from previous launches.
Selected tests
TuistGenerateOneAcceptanceTests.xctest
GenerateOneAcceptanceTestiOSAppWithFrameworks
GenerateOneAcceptanceTestiOSAppWithHeaders
❌ TuistAcceptanceTesting/TuistAcceptanceTestCase.swift:31: Unexpectedly found nil while unwrapping an Optional value
2023-11-20 13:21:33.838657+0000 xctest[30446:9409120] TuistAcceptanceTesting/TuistAcceptanceTestCase.swift:31: Fatal error: Unexpectedly found nil while unwrapping an Optional value
objc[30448]: Class _TtC7Stencil7Context is implemented in both /Users/jc/Library/Developer/Xcode/DerivedData/Tuist-eiecjmhtbqlnyxcmnvdxvyeixocs/Build/Products/Debug/TuistScaffold.framework/Versions/A/TuistScaffold (0x1092beee0) and /Users/jc/Library/Developer/Xcode/DerivedData/Tuist-eiecjmhtbqlnyxcmnvdxvyeixocs/Build/Products/Debug/TuistGenerator.framework/Versions/A/TuistGenerator (0x10a9e43b8). One of the two will be used. Which one is undefined.
    ✖ Restarting after unexpected exit, crash, or test timeout in GenerateOneAcceptanceTestiOSAppWithHeaders.test_ios_app_with_headers(); summary will include totals from previous launches.
Selected tests
TuistGenerateOneAcceptanceTests.xctest
GenerateOneAcceptanceTestiOSAppWithHeaders
GenerateOneAcceptanceTestiOSAppWithTests
❌ TuistAcceptanceTesting/TuistAcceptanceTestCase.swift:31: Unexpectedly found nil while unwrapping an Optional value
2023-11-20 13:21:34.286731+0000 xctest[30448:9409130] TuistAcceptanceTesting/TuistAcceptanceTestCase.swift:31: Fatal error: Unexpectedly found nil while unwrapping an Optional value
objc[30449]: Class _TtC7Stencil7Context is implemented in both /Users/jc/Library/Developer/Xcode/DerivedData/Tuist-eiecjmhtbqlnyxcmnvdxvyeixocs/Build/Products/Debug/TuistScaffold.framework/Versions/A/TuistScaffold (0x104e76ee0) and /Users/jc/Library/Developer/Xcode/DerivedData/Tuist-eiecjmhtbqlnyxcmnvdxvyeixocs/Build/Products/Debug/TuistGenerator.framework/Versions/A/TuistGenerator (0x10659c3b8). One of the two will be used. Which one is undefined.
    ✖ Restarting after unexpected exit, crash, or test timeout in GenerateOneAcceptanceTestiOSAppWithTests.test_ios_app_with_tests(); summary will include totals from previous launches.
```
  
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated
  - It seems like a good idea to document that nested workspaces are currently only supported as part of a Git repository

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
