### PR TITLE
[Feature] - Adds support for loading environment variables via a .env file

### DIFF
--- a/Tests/TuistSupportTests/Utils/EnvironmentFileTests.swift
+++ b/Tests/TuistSupportTests/Utils/EnvironmentFileTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import TSCBasic
+import XCTest
+@testable import TuistSupport
+@testable import TuistSupportTesting
+
+final class EnvironmentFileTests: TuistUnitTestCase {
+    private var subject: TuistSupport.Environment!
+    private let fileManager = FileManager.default
+    
+    override func setUp() {
+        super.setUp()
+        subject = Environment()
+    }
+    
+    override func tearDown() {
+        subject = nil
+        super.tearDown()
+    }
+    
+    // MARK: - Tests
+    
+    func test_loading_env_values_from_file() {
+        let path = try temporaryPath()
+        let file = path.appending(".env")
+        """
+        API_KEY=some-value
+        BUILD_NUMBER=5
+        IDENTIFIER="com.app.example"
+        MAIL_TEMPLATE="The "Quoted" Title"
+        DB_PASSPHRASE="1qaz?#@"' wsx$"
+        """.write(to: file.asURL, atomically: true, encoding: .utf8)
+        
+        XCTAssertEqual(subject.tuistVariables["API_KEY"], "some-value")
+        XCTAssertEqual(subject.tuistVariables["BUILD_NUMBER"], "5")
+        XCTAssertEqual(subject.tuistVariables["IDENTIFIER"], "com.app.example")
+        XCTAssertEqual(subject.tuistVariables["MAIL_TEMPLATE"], "The \"Quoted\" Title")
+        XCTAssertEqual(subject.tuistVariables["DB_PASSPHRASE"], "1qaz?#@\"' wsx$")
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/4139

Original PR: #4750 

### Short description 📝

This PR addresses a pain point with loading environment variables. Using `.env` files is a pretty common practice and saves users from having to type `TUIST_DEVELOPMENT_TEAM=XXX twist generate` every time.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

- create a template tuist project (any template)
- create a `.env` file in the `Tuist` folder of your project directory
- put a key value pair in the file such as `TUIST_BUILD_SECRET=SECRET-KEY`
- run `tuist edit` and inside `Project.swift`, print out the env var
- run `tuist generate` and verify the value is printed as expected

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
