### PR TITLE
Fix warnings with including `.stencil` files when running `tuist edit`. Fixes #5603

### DIFF
--- a/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
@@ -148,7 +148,7 @@ final class ProjectEditor: ProjectEditing {
         let templateSources = templatesDirectoryLocator.locateUserTemplates(at: editingPath).map {
             FileHandler.shared.glob($0, glob: "**/*.swift")
         } ?? []
-        
+
         let templateResources = templatesDirectoryLocator.locateUserTemplates(at: editingPath).map {
             FileHandler.shared.glob($0, glob: "**/*.stencil")
         } ?? []

--- a/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditor.swift
@@ -145,8 +145,12 @@ final class ProjectEditor: ProjectEditing {
             ].flatMap { $0 }
         } ?? []
 
-        let templates = templatesDirectoryLocator.locateUserTemplates(at: editingPath).map {
-            FileHandler.shared.glob($0, glob: "**/*.swift") + FileHandler.shared.glob($0, glob: "**/*.stencil")
+        let templateSources = templatesDirectoryLocator.locateUserTemplates(at: editingPath).map {
+            FileHandler.shared.glob($0, glob: "**/*.swift")
+        } ?? []
+        
+        let templateResources = templatesDirectoryLocator.locateUserTemplates(at: editingPath).map {
+            FileHandler.shared.glob($0, glob: "**/*.stencil")
         } ?? []
 
         let resourceSynthesizers = resourceSynthesizersDirectoryLocator.locate(at: editingPath).map {
@@ -171,7 +175,7 @@ final class ProjectEditor: ProjectEditing {
         )
 
         /// We error if the user tries to edit a project in a directory where there are no editable files.
-        if projectManifests.isEmpty, editablePluginManifests.isEmpty, helpers.isEmpty, templates.isEmpty,
+        if projectManifests.isEmpty, editablePluginManifests.isEmpty, helpers.isEmpty, templateSources.isEmpty,
            resourceSynthesizers.isEmpty, stencils.isEmpty
         {
             throw ProjectEditorError.noEditableFiles(editingPath)
@@ -192,7 +196,8 @@ final class ProjectEditor: ProjectEditing {
             editablePluginManifests: editablePluginManifests,
             pluginProjectDescriptionHelpersModule: builtPluginHelperModules,
             helpers: helpers,
-            templates: templates,
+            templateSources: templateSources,
+            templateResources: templateResources,
             resourceSynthesizers: resourceSynthesizers,
             stencils: stencils,
             projectDescriptionSearchPath: projectDescriptionPath.parentDirectory

--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -207,7 +207,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
                 dependencies: helpersTarget.flatMap { [TargetDependency.target(name: $0.name)] } ?? []
             )
         }()
-    
+
         let resourceSynthesizersTarget: Target? = {
             guard !resourceSynthesizers.isEmpty else { return nil }
             return editorHelperTarget(

--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -17,7 +17,8 @@ protocol ProjectEditorMapping: AnyObject {
         editablePluginManifests: [EditablePluginManifest],
         pluginProjectDescriptionHelpersModule: [ProjectDescriptionHelpersModule],
         helpers: [AbsolutePath],
-        templates: [AbsolutePath],
+        templateSources: [AbsolutePath],
+        templateResources: [AbsolutePath],
         resourceSynthesizers: [AbsolutePath],
         stencils: [AbsolutePath],
         projectDescriptionSearchPath: AbsolutePath
@@ -38,7 +39,8 @@ final class ProjectEditorMapper: ProjectEditorMapping {
         editablePluginManifests: [EditablePluginManifest],
         pluginProjectDescriptionHelpersModule: [ProjectDescriptionHelpersModule],
         helpers: [AbsolutePath],
-        templates: [AbsolutePath],
+        templateSources: [AbsolutePath],
+        templateResources: [AbsolutePath],
         resourceSynthesizers: [AbsolutePath],
         stencils: [AbsolutePath],
         projectDescriptionSearchPath: AbsolutePath
@@ -62,7 +64,8 @@ final class ProjectEditorMapper: ProjectEditorMapping {
             destinationDirectory: destinationDirectory,
             tuistPath: tuistPath,
             helpers: helpers,
-            templates: templates,
+            templateSources: templateSources,
+            templateResources: templateResources,
             resourceSynthesizers: resourceSynthesizers,
             stencils: stencils,
             configPath: configPath,
@@ -136,7 +139,8 @@ final class ProjectEditorMapper: ProjectEditorMapping {
         destinationDirectory: AbsolutePath,
         tuistPath: AbsolutePath,
         helpers: [AbsolutePath],
-        templates: [AbsolutePath],
+        templateSources: [AbsolutePath],
+        templateResources: [AbsolutePath],
         resourceSynthesizers: [AbsolutePath],
         stencils: [AbsolutePath],
         configPath: AbsolutePath?,
@@ -192,23 +196,26 @@ final class ProjectEditorMapper: ProjectEditorMapping {
         }()
 
         let templatesTarget: Target? = {
-            guard !templates.isEmpty else { return nil }
+            let generateTemplateTarget = !templateSources.isEmpty || !templateResources.isEmpty
+            guard generateTemplateTarget else { return nil }
             return editorHelperTarget(
                 name: Constants.templatesDirectoryName,
                 filesGroup: manifestsFilesGroup,
                 targetSettings: baseTargetSettings,
-                sourcePaths: templates,
+                sourcePaths: templateSources,
+                additionalFilePaths: templateResources,
                 dependencies: helpersTarget.flatMap { [TargetDependency.target(name: $0.name)] } ?? []
             )
         }()
-
+    
         let resourceSynthesizersTarget: Target? = {
             guard !resourceSynthesizers.isEmpty else { return nil }
             return editorHelperTarget(
                 name: Constants.resourceSynthesizersDirectoryName,
                 filesGroup: manifestsFilesGroup,
                 targetSettings: baseTargetSettings,
-                sourcePaths: resourceSynthesizers,
+                sourcePaths: [],
+                additionalFilePaths: resourceSynthesizers,
                 dependencies: helpersTarget.flatMap { [TargetDependency.target(name: $0.name)] } ?? []
             )
         }()
@@ -445,6 +452,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
         filesGroup: ProjectGroup,
         targetSettings: Settings,
         sourcePaths: [AbsolutePath],
+        additionalFilePaths: [AbsolutePath] = [],
         dependencies: [TargetDependency] = []
     ) -> Target {
         Target(
@@ -456,7 +464,8 @@ final class ProjectEditorMapper: ProjectEditorMapping {
             settings: targetSettings,
             sources: sourcePaths.map { SourceFile(path: $0, compilerFlags: nil) },
             filesGroup: filesGroup,
-            dependencies: dependencies
+            dependencies: dependencies,
+            additionalFiles: additionalFilePaths.map { .file(path: $0) }
         )
     }
 

--- a/Tests/TuistKitTests/ProjectEditor/Mocks/MockProjectEditorMapper.swift
+++ b/Tests/TuistKitTests/ProjectEditor/Mocks/MockProjectEditorMapper.swift
@@ -21,7 +21,8 @@ final class MockProjectEditorMapper: ProjectEditorMapping {
         editablePluginManifests: [EditablePluginManifest],
         pluginProjectDescriptionHelpersModule: [ProjectDescriptionHelpersModule],
         helpers: [AbsolutePath],
-        templates: [AbsolutePath],
+        templateSources: [AbsolutePath],
+        templateResources: [AbsolutePath],
         resourceSynthesizers: [AbsolutePath],
         stencils: [AbsolutePath],
         projectDescriptionPath: AbsolutePath
@@ -38,7 +39,8 @@ final class MockProjectEditorMapper: ProjectEditorMapping {
         editablePluginManifests: [EditablePluginManifest],
         pluginProjectDescriptionHelpersModule: [ProjectDescriptionHelpersModule],
         helpers: [AbsolutePath],
-        templates: [AbsolutePath],
+        templateSources: [AbsolutePath],
+        templateResources: [AbsolutePath],
         resourceSynthesizers: [AbsolutePath],
         stencils: [AbsolutePath],
         projectDescriptionSearchPath: AbsolutePath
@@ -54,7 +56,8 @@ final class MockProjectEditorMapper: ProjectEditorMapping {
             editablePluginManifests: editablePluginManifests,
             pluginProjectDescriptionHelpersModule: pluginProjectDescriptionHelpersModule,
             helpers: helpers,
-            templates: templates,
+            templateSources: templateSources,
+            templateResources: templateResources,
             resourceSynthesizers: resourceSynthesizers,
             stencils: stencils,
             projectDescriptionPath: projectDescriptionSearchPath

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
@@ -12,19 +12,19 @@ import XCTest
 
 final class ProjectEditorMapperTests: TuistUnitTestCase {
     var subject: ProjectEditorMapper!
-    
+
     override func setUp() {
         super.setUp()
         system.swiftVersionStub = { "5.2" }
         developerEnvironment.stubbedArchitecture = .arm64
         subject = ProjectEditorMapper()
     }
-    
+
     override func tearDown() {
         subject = nil
         super.tearDown()
     }
-    
+
     func test_edit_when_there_are_helpers_and_setup_and_config_and_dependencies_and_tasks_and_plugins() throws {
         // Given
         let sourceRootPath = try temporaryPath()
@@ -44,7 +44,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             sourceRootPath.appending(component: "PluginTwo"),
             sourceRootPath.appending(component: "PluginThree"),
         ].map { EditablePluginManifest(name: $0.basename, path: $0) }
-        
+
         // When
         let graph = try subject.map(
             name: "TestManifests",
@@ -63,22 +63,22 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             stencils: stencils,
             projectDescriptionSearchPath: projectDescriptionPath
         )
-        
+
         let project = try XCTUnwrap(graph.projects.values.first(where: { $0.name == projectName }))
-        
+
         let targets = graph.targets.values.lazy
             .flatMap(\.values)
             .sorted(by: { $0.name < $1.name })
-        
+
         // Then
         XCTAssertEqual(graph.name, "TestManifests")
-        
+
         XCTAssertEqual(targets.count, 9)
-        
+
         // Generated Manifests target
         let manifestsTarget = try XCTUnwrap(project.targets.first(where: { $0.name == sourceRootPath.basename + projectName }))
         XCTAssertEqual(targets.last, manifestsTarget)
-        
+
         XCTAssertEqual(manifestsTarget.destinations, .macOS)
         XCTAssertEqual(manifestsTarget.product, .staticFramework)
         XCTAssertEqual(
@@ -92,11 +92,11 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             .target(name: "PluginTwo"),
             .target(name: "PluginThree"),
         ]))
-        
+
         // Generated Helpers target
         let helpersTarget = try XCTUnwrap(project.targets.last(where: { $0.name == "ProjectDescriptionHelpers" }))
         XCTAssertTrue(targets.contains(helpersTarget))
-        
+
         XCTAssertEqual(helpersTarget.name, "ProjectDescriptionHelpers")
         XCTAssertEqual(helpersTarget.destinations, .macOS)
         XCTAssertEqual(helpersTarget.product, .staticFramework)
@@ -111,11 +111,11 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             .target(name: "PluginTwo"),
             .target(name: "PluginThree"),
         ]))
-        
+
         // Generated Templates target
         let templatesTarget = try XCTUnwrap(project.targets.last(where: { $0.name == "Templates" }))
         XCTAssertTrue(targets.contains(templatesTarget))
-        
+
         XCTAssertEqual(templatesTarget.name, "Templates")
         XCTAssertEqual(templatesTarget.destinations, .macOS)
         XCTAssertEqual(templatesTarget.product, .staticFramework)
@@ -129,11 +129,11 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(Set(templatesTarget.dependencies), Set([
             .target(name: "ProjectDescriptionHelpers"),
         ]))
-        
+
         // Generated ResourceSynthesizers target
         let resourceSynthesizersTarget = try XCTUnwrap(project.targets.last(where: { $0.name == "ResourceSynthesizers" }))
         XCTAssertTrue(targets.contains(resourceSynthesizersTarget))
-        
+
         XCTAssertEqual(resourceSynthesizersTarget.name, "ResourceSynthesizers")
         XCTAssertEqual(resourceSynthesizersTarget.destinations, .macOS)
         XCTAssertEqual(resourceSynthesizersTarget.product, .staticFramework)
@@ -146,11 +146,11 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(Set(resourceSynthesizersTarget.dependencies), Set([
             .target(name: "ProjectDescriptionHelpers"),
         ]))
-        
+
         // Generated Stencils target
         let stencilsTarget = try XCTUnwrap(project.targets.last(where: { $0.name == "Stencils" }))
         XCTAssertTrue(targets.contains(stencilsTarget))
-        
+
         XCTAssertEqual(stencilsTarget.name, "Stencils")
         XCTAssertEqual(stencilsTarget.destinations, .macOS)
         XCTAssertEqual(stencilsTarget.product, .staticFramework)
@@ -163,11 +163,11 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(Set(stencilsTarget.dependencies), Set([
             .target(name: "ProjectDescriptionHelpers"),
         ]))
-        
+
         // Generated Config target
         let configTarget = try XCTUnwrap(project.targets.last(where: { $0.name == "Config" }))
         XCTAssertTrue(targets.contains(configTarget))
-        
+
         XCTAssertEqual(configTarget.name, "Config")
         XCTAssertEqual(configTarget.destinations, .macOS)
         XCTAssertEqual(configTarget.product, .staticFramework)
@@ -178,11 +178,11 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(configTarget.sources.map(\.path), [configPath])
         XCTAssertEqual(configTarget.filesGroup, projectsGroup)
         XCTAssertEmpty(configTarget.dependencies)
-        
+
         // Generated Dependencies target
         let dependenciesTarget = try XCTUnwrap(project.targets.last(where: { $0.name == "Dependencies" }))
         XCTAssertTrue(targets.contains(dependenciesTarget))
-        
+
         XCTAssertEqual(dependenciesTarget.name, "Dependencies")
         XCTAssertEqual(dependenciesTarget.destinations, .macOS)
         XCTAssertEqual(dependenciesTarget.product, .staticFramework)
@@ -197,7 +197,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             .target(name: "PluginTwo"),
             .target(name: "PluginThree"),
         ]))
-        
+
         // Generated Project
         XCTAssertEqual(project.path, sourceRootPath.appending(component: projectName))
         XCTAssertEqual(project.name, projectName)
@@ -207,21 +207,21 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             defaultSettings: .recommended
         ))
         XCTAssertEqual(project.filesGroup, projectsGroup)
-        
+
         // Generated Scheme
         XCTAssertEqual(project.schemes.count, 1)
         let scheme = try XCTUnwrap(project.schemes.first)
         XCTAssertEqual(scheme.name, projectName)
-        
+
         let buildAction = try XCTUnwrap(scheme.buildAction)
         XCTAssertEqual(buildAction.targets.lazy.map(\.name).sorted(), project.targets.map(\.name).sorted())
-        
+
         let runAction = try XCTUnwrap(scheme.runAction)
         XCTAssertEqual(runAction.filePath, tuistPath)
         let generateArgument = "generate --path \(sourceRootPath)"
         XCTAssertEqual(runAction.arguments, Arguments(launchArguments: [LaunchArgument(name: generateArgument, isEnabled: true)]))
     }
-    
+
     func test_edit_when_there_are_no_helpers_and_no_setup_and_no_config_and_no_dependencies() throws {
         // Given
         let sourceRootPath = try temporaryPath()
@@ -234,7 +234,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         let tuistPath = try AbsolutePath(validating: "/usr/bin/foo/bar/tuist")
         let projectName = "Manifests"
         let projectsGroup = ProjectGroup.group(name: projectName)
-        
+
         // When
         let graph = try subject.map(
             name: "TestManifests",
@@ -253,20 +253,20 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             stencils: stencils,
             projectDescriptionSearchPath: projectDescriptionPath
         )
-        
+
         let project = try XCTUnwrap(graph.projects.values.first)
-        
+
         let targets = graph.targets.values.lazy
             .flatMap(\.values)
             .sorted(by: { $0.name < $1.name })
-        
+
         // Then
         XCTAssertEqual(targets.count, 1)
         XCTAssertEmpty(targets.flatMap(\.dependencies))
-        
+
         // Generated Manifests target
         let manifestsTarget = try XCTUnwrap(project.targets.last(where: { $0.name == sourceRootPath.basename + projectName }))
-        
+
         XCTAssertEqual(manifestsTarget.destinations, .macOS)
         XCTAssertEqual(manifestsTarget.product, .staticFramework)
         XCTAssertEqual(
@@ -276,7 +276,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(manifestsTarget.sources.map(\.path), projectManifestPaths)
         XCTAssertEqual(manifestsTarget.filesGroup, projectsGroup)
         XCTAssertEmpty(manifestsTarget.dependencies)
-        
+
         // Generated Project
         XCTAssertEqual(project.path, sourceRootPath.appending(component: projectName))
         XCTAssertEqual(project.name, projectName)
@@ -286,21 +286,21 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             defaultSettings: .recommended
         ))
         XCTAssertEqual(project.filesGroup, projectsGroup)
-        
+
         // Generated Scheme
         XCTAssertEqual(project.schemes.count, 1)
         let scheme = try XCTUnwrap(project.schemes.first)
         XCTAssertEqual(scheme.name, projectName)
-        
+
         let buildAction = try XCTUnwrap(scheme.buildAction)
         XCTAssertEqual(buildAction.targets.map(\.name), targets.map(\.name))
-        
+
         let runAction = try XCTUnwrap(scheme.runAction)
         XCTAssertEqual(runAction.filePath, tuistPath)
         let generateArgument = "generate --path \(sourceRootPath)"
         XCTAssertEqual(runAction.arguments, Arguments(launchArguments: [LaunchArgument(name: generateArgument, isEnabled: true)]))
     }
-    
+
     func test_tuist_edit_with_more_than_one_manifest() throws {
         // Given
         let sourceRootPath = try temporaryPath()
@@ -318,7 +318,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         let projectDescriptionPath = sourceRootPath.appending(component: "ProjectDescription.framework")
         let tuistPath = try AbsolutePath(validating: "/usr/bin/foo/bar/tuist")
         let projectName = "Manifests"
-        
+
         // When
         let graph = try subject.map(
             name: "TestManifests",
@@ -337,21 +337,21 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             stencils: stencils,
             projectDescriptionSearchPath: projectDescriptionPath
         )
-        
+
         let project = try XCTUnwrap(graph.projects.values.first)
-        
+
         let targets = graph.targets.values.lazy
             .flatMap(\.values)
             .sorted(by: { $0.name < $1.name })
-        
+
         // Then
-        
+
         XCTAssertEqual(targets.count, 4)
         XCTAssertEmpty(targets.flatMap(\.dependencies))
-        
+
         // Generated Manifests target
         let manifestOneTarget = try XCTUnwrap(project.targets.last(where: { $0.name == "ModuleManifests" }))
-        
+
         XCTAssertEqual(manifestOneTarget.name, "ModuleManifests")
         XCTAssertEqual(manifestOneTarget.destinations, .macOS)
         XCTAssertEqual(manifestOneTarget.product, .staticFramework)
@@ -362,10 +362,10 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(manifestOneTarget.sources.map(\.path), [try XCTUnwrap(projectManifestPaths.last)])
         XCTAssertEqual(manifestOneTarget.filesGroup, .group(name: projectName))
         XCTAssertEmpty(manifestOneTarget.dependencies)
-        
+
         // Generated Manifests target
         let manifestTwoTarget = try XCTUnwrap(project.targets.last(where: { $0.name == "\(sourceRootPath.basename)Manifests" }))
-        
+
         XCTAssertEqual(manifestTwoTarget.destinations, .macOS)
         XCTAssertEqual(manifestTwoTarget.product, .staticFramework)
         XCTAssertEqual(
@@ -375,10 +375,10 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(manifestTwoTarget.sources.map(\.path), [try XCTUnwrap(projectManifestPaths.first)])
         XCTAssertEqual(manifestTwoTarget.filesGroup, .group(name: projectName))
         XCTAssertEmpty(manifestTwoTarget.dependencies)
-        
+
         // Generated Config target
         let configTarget = try XCTUnwrap(project.targets.last(where: { $0.name == "Config" }))
-        
+
         XCTAssertEqual(configTarget.name, "Config")
         XCTAssertEqual(configTarget.destinations, .macOS)
         XCTAssertEqual(configTarget.product, .staticFramework)
@@ -389,7 +389,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(configTarget.sources.map(\.path), [configPath])
         XCTAssertEqual(configTarget.filesGroup, .group(name: projectName))
         XCTAssertEmpty(configTarget.dependencies)
-        
+
         // Generated Project
         XCTAssertEqual(project.path, sourceRootPath.appending(component: projectName))
         XCTAssertEqual(project.name, projectName)
@@ -399,21 +399,21 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             defaultSettings: .recommended
         ))
         XCTAssertEqual(project.filesGroup, .group(name: projectName))
-        
+
         // Generated Scheme
         XCTAssertEqual(project.schemes.count, 1)
         let scheme = try XCTUnwrap(project.schemes.first)
         XCTAssertEqual(scheme.name, projectName)
-        
+
         let buildAction = try XCTUnwrap(scheme.buildAction)
         XCTAssertEqual(buildAction.targets.map(\.name).sorted(), targets.map(\.name).sorted())
-        
+
         let runAction = try XCTUnwrap(scheme.runAction)
         XCTAssertEqual(runAction.filePath, tuistPath)
         let generateArgument = "generate --path \(sourceRootPath)"
         XCTAssertEqual(runAction.arguments, Arguments(launchArguments: [LaunchArgument(name: generateArgument, isEnabled: true)]))
     }
-    
+
     func test_tuist_edit_with_one_plugin_no_projects() throws {
         let sourceRootPath = try temporaryPath()
         let pluginManifestPaths = [sourceRootPath].map { $0.appending(component: "Plugin.swift") }
@@ -428,7 +428,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         let tuistPath = try AbsolutePath(validating: "/usr/bin/foo/bar/tuist")
         let projectName = "Plugins"
         let projectsGroup = ProjectGroup.group(name: projectName)
-        
+
         // When
         let graph = try subject.map(
             name: "TestManifests",
@@ -447,20 +447,20 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             stencils: stencils,
             projectDescriptionSearchPath: projectDescriptionPath
         )
-        
+
         let project = try XCTUnwrap(graph.projects.values.first)
-        
+
         let targets = graph.targets.values.lazy
             .flatMap(\.values)
             .sorted(by: { $0.name < $1.name })
-        
+
         // Then
         XCTAssertEqual(targets.count, 1)
         XCTAssertEmpty(targets.flatMap(\.dependencies))
-        
+
         // Generated Plugin target
         let pluginTarget = try XCTUnwrap(project.targets.last(where: { $0.name == sourceRootPath.basename }))
-        
+
         XCTAssertEqual(pluginTarget.destinations, .macOS)
         XCTAssertEqual(pluginTarget.product, .staticFramework)
         XCTAssertEqual(
@@ -470,7 +470,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(pluginTarget.sources.map(\.path), pluginManifestPaths)
         XCTAssertEqual(pluginTarget.filesGroup, projectsGroup)
         XCTAssertEmpty(pluginTarget.dependencies)
-        
+
         // Generated Project
         XCTAssertEqual(project.path, sourceRootPath.appending(component: projectName))
         XCTAssertEqual(project.name, projectName)
@@ -480,19 +480,19 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             defaultSettings: .recommended
         ))
         XCTAssertEqual(project.filesGroup, projectsGroup)
-        
+
         // Generated Schemes
         XCTAssertEqual(project.schemes.count, 2)
         let schemes = project.schemes
         XCTAssertEqual(schemes.map(\.name).sorted(), [pluginTarget.name, "Plugins"].sorted())
-        
+
         let pluginBuildAction = try XCTUnwrap(schemes.first?.buildAction)
         XCTAssertEqual(pluginBuildAction.targets.map(\.name), [pluginTarget.name])
-        
+
         let allPluginsBuildAction = try XCTUnwrap(schemes.last?.buildAction)
         XCTAssertEqual(allPluginsBuildAction.targets.map(\.name).sorted(), targets.map(\.name).sorted())
     }
-    
+
     func test_tuist_edit_with_more_than_one_plugin_no_projects() throws {
         let sourceRootPath = try temporaryPath()
         let pluginManifestPaths = [
@@ -510,7 +510,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         let tuistPath = try AbsolutePath(validating: "/usr/bin/foo/bar/tuist")
         let projectName = "Plugins"
         let projectsGroup = ProjectGroup.group(name: projectName)
-        
+
         // When
         let graph = try subject.map(
             name: "TestManifests",
@@ -529,20 +529,20 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             stencils: stencils,
             projectDescriptionSearchPath: projectDescriptionPath
         )
-        
+
         let project = try XCTUnwrap(graph.projects.values.first)
-        
+
         let targets = graph.targets.values.lazy
             .flatMap(\.values)
             .sorted(by: { $0.name < $1.name })
-        
+
         // Then
         XCTAssertEqual(targets.count, 2)
         XCTAssertEmpty(targets.flatMap(\.dependencies))
-        
+
         // Generated first plugin target
         let firstPluginTarget = try XCTUnwrap(project.targets.last(where: { $0.name == "A" }))
-        
+
         XCTAssertEqual(firstPluginTarget.destinations, .macOS)
         XCTAssertEqual(firstPluginTarget.product, .staticFramework)
         XCTAssertEqual(
@@ -552,10 +552,10 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(firstPluginTarget.sources.map(\.path), [pluginManifestPaths[0]])
         XCTAssertEqual(firstPluginTarget.filesGroup, projectsGroup)
         XCTAssertEmpty(firstPluginTarget.dependencies)
-        
+
         // Generated second plugin target
         let secondPluginTarget = try XCTUnwrap(project.targets.last(where: { $0.name == "B" }))
-        
+
         XCTAssertEqual(secondPluginTarget.destinations, .macOS)
         XCTAssertEqual(secondPluginTarget.product, .staticFramework)
         XCTAssertEqual(
@@ -565,7 +565,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(secondPluginTarget.sources.map(\.path), [pluginManifestPaths[1]])
         XCTAssertEqual(secondPluginTarget.filesGroup, projectsGroup)
         XCTAssertEmpty(secondPluginTarget.dependencies)
-        
+
         // Generated Project
         XCTAssertEqual(project.path, sourceRootPath.appending(component: projectName))
         XCTAssertEqual(project.name, projectName)
@@ -575,7 +575,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             defaultSettings: .recommended
         ))
         XCTAssertEqual(project.filesGroup, projectsGroup)
-        
+
         // Generated Schemes
         let schemes = project.schemes.sorted(by: { $0.name < $1.name })
         XCTAssertEqual(project.schemes.count, 3)
@@ -583,23 +583,23 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             schemes.map(\.name),
             [firstPluginTarget.name, secondPluginTarget.name, "Plugins"].sorted()
         )
-        
+
         let firstBuildAction = try XCTUnwrap(schemes[0].buildAction)
         XCTAssertEqual(
             firstBuildAction.targets.map(\.name),
             [firstPluginTarget].map(\.name)
         )
-        
+
         let secondBuildAction = try XCTUnwrap(schemes[1].buildAction)
         XCTAssertEqual(secondBuildAction.targets.map(\.name), [secondPluginTarget].map(\.name))
-        
+
         let pluginsBuildAction = try XCTUnwrap(schemes[2].buildAction)
         XCTAssertEqual(
             pluginsBuildAction.targets.map(\.name).sorted(),
             [firstPluginTarget, secondPluginTarget].map(\.name).sorted()
         )
     }
-    
+
     func test_tuist_edit_plugin_only_takes_required_sources() throws {
         // Given
         let sourceRootPath = try temporaryPath()
@@ -645,17 +645,17 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             stencils: stencils,
             projectDescriptionSearchPath: projectDescriptionPath
         )
-        
+
         // Then
         let project = try XCTUnwrap(graph.projects.values.first)
         let pluginTarget = try XCTUnwrap(project.targets.first)
-        
+
         XCTAssertEqual(
             pluginTarget.sources,
             ([pluginManifestPath] + helperSources + templateSources).map { SourceFile(path: $0) }
         )
     }
-    
+
     func test_tuist_edit_project_with_plugin() throws {
         // Given
         let sourceRootPath = try temporaryPath()
@@ -672,7 +672,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         let pluginsGroup = ProjectGroup.group(name: pluginsProjectName)
         let localPlugin = EditablePluginManifest(name: "ALocalPlugin", path: sourceRootPath.appending(component: "ALocalPlugin"))
         let remotePlugin = ProjectDescriptionHelpersModule(name: "RemotePlugin", path: "/path/to/remote/plugin")
-        
+
         // When
         let graph = try subject.map(
             name: "TestManifests",
@@ -691,20 +691,20 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             stencils: stencils,
             projectDescriptionSearchPath: projectDescriptionPath
         )
-        
+
         let pluginsProject = try XCTUnwrap(graph.projects.values.first(where: { $0.name == pluginsProjectName }))
         let manifestsProject = try XCTUnwrap(graph.projects.values.first(where: { $0.name == manifestsProjectName }))
-        
+
         let targets = graph.targets.values.lazy
             .flatMap(\.values)
             .sorted(by: { $0.name < $1.name })
         let localPluginTarget = try XCTUnwrap(targets.first(where: { $0.name == "ALocalPlugin" }))
         let helpersTarget = try XCTUnwrap(targets.first(where: { $0.name == "ProjectDescriptionHelpers" }))
         let manifestsTarget = try XCTUnwrap(targets.first(where: { $0 != localPluginTarget && $0 != helpersTarget }))
-        
+
         // Then
         XCTAssertEqual(targets.count, 3)
-        
+
         // Local plugin target
         XCTAssertEqual(localPluginTarget.destinations, .macOS)
         XCTAssertEqual(localPluginTarget.product, .staticFramework)
@@ -718,7 +718,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
                 projectDescriptionPath.parentDirectory,
             ])
         )
-        
+
         // ProjectDescriptionHelpers target
         XCTAssertEqual(helpersTarget.destinations, .macOS)
         XCTAssertEqual(helpersTarget.product, .staticFramework)
@@ -737,7 +737,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
                 remotePlugin.path.parentDirectory,
             ])
         )
-        
+
         // Generated Manifests target
         XCTAssertEqual(manifestsTarget.destinations, .macOS)
         XCTAssertEqual(manifestsTarget.product, .staticFramework)
@@ -759,7 +759,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
                 remotePlugin.path.parentDirectory,
             ])
         )
-        
+
         // Generated manifests Project
         let manifestsScheme = try XCTUnwrap(manifestsProject.schemes.first)
         let manifestsBuildAction = try XCTUnwrap(manifestsScheme.buildAction)
@@ -783,7 +783,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
             manifestsRunAction.arguments,
             Arguments(launchArguments: [LaunchArgument(name: "generate --path \(sourceRootPath)", isEnabled: true)])
         )
-        
+
         // Generated plugins project for local plugins
         let schemes = pluginsProject.schemes
         let aLocalPluginScheme = try XCTUnwrap(schemes.first(where: { $0.name == "ALocalPlugin" }))
@@ -800,7 +800,7 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(aLocalPluginScheme.buildAction?.targets.map(\.name).sorted(), [localPlugin.name])
         XCTAssertEqual(pluginsScheme.buildAction?.targets.map(\.name).sorted(), [localPlugin.name])
     }
-    
+
     fileprivate func expectedSettings(includePaths: [AbsolutePath]) -> Settings {
         let paths = includePaths
             .map(\.pathString)


### PR DESCRIPTION
Fixes #5603 

### Short description 📝

Add `.stencil` files as additional files instead of source files to avoid warnings during `tuist edit`

### How to test the changes locally 🧐

Run Tests. 

Run `tuist edit` on a fixture with custom resource synthesizers or scaffold templates that include stencil files.  Build the manifest project and no warnings should occur related to the stencil files.  See #5603 for more details.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
