### PR TITLE
Make sourceRootPath public

### DIFF
--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
@@ -18,8 +18,8 @@ open class TuistAcceptanceTestCase: XCTestCase {
     public var fixturePath: AbsolutePath!
     public var derivedDataPath: AbsolutePath!
     public var environment: MockEnvironment!
+    public var sourceRootPath: AbsolutePath!
 
-    private var sourceRootPath: AbsolutePath!
     private var fixtureTemporaryDirectory: TemporaryDirectory!
 
     override open func setUp() {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY

### Short description 📝

In `tuist-cloud`, we need to be able to change the `sourceRootPath`.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
