### PR TITLE
Improve the group hierarchy for cache binaries

### DIFF
--- a/Sources/TuistCore/Cache/CacheCategory.swift
+++ b/Sources/TuistCore/Cache/CacheCategory.swift
@@ -17,7 +17,7 @@ public enum CacheCategory: String, CaseIterable, RawRepresentable {
 
     /// The manifests cache
     case manifests
-    
+
     public var directoryName: String {
         switch self {
         case .plugins:

--- a/Sources/TuistCore/Cache/CacheCategory.swift
+++ b/Sources/TuistCore/Cache/CacheCategory.swift
@@ -17,4 +17,21 @@ public enum CacheCategory: String, CaseIterable, RawRepresentable {
 
     /// The manifests cache
     case manifests
+    
+    public var directoryName: String {
+        switch self {
+        case .plugins:
+            return "Plugins"
+        case .builds:
+            return "BuildCache"
+        case .tests:
+            return "TestsCache"
+        case .generatedAutomationProjects:
+            return "Projects"
+        case .projectDescriptionHelpers:
+            return "ProjectDescriptionHelpers"
+        case .manifests:
+            return "Manifests"
+        }
+    }
 }

--- a/Sources/TuistCore/Cache/CacheDirectoriesProvider.swift
+++ b/Sources/TuistCore/Cache/CacheDirectoriesProvider.swift
@@ -30,22 +30,3 @@ public final class CacheDirectoriesProvider: CacheDirectoriesProviding {
         (Self.forcedCacheDirectory ?? cacheDirectory).appending(component: category.directoryName)
     }
 }
-
-extension CacheCategory {
-    var directoryName: String {
-        switch self {
-        case .plugins:
-            return "Plugins"
-        case .builds:
-            return "BuildCache"
-        case .tests:
-            return "TestsCache"
-        case .generatedAutomationProjects:
-            return "Projects"
-        case .projectDescriptionHelpers:
-            return "ProjectDescriptionHelpers"
-        case .manifests:
-            return "Manifests"
-        }
-    }
-}

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -207,11 +207,9 @@ class ProjectFileElements {
         sourceRootPath: AbsolutePath,
         filesGroup: ProjectGroup
     ) throws {
-        let sortedDependencies = dependencyReferences.sorted()
-
-        try sortedDependencies.forEach { dependency in
+        try dependencyReferences.sorted().forEach { (dependency: GraphDependencyReference) in
             switch dependency {
-            case let .xcframework(path, _, _, _, _):
+            case let .xcframework(path, _, _, _, _, _):
                 try generatePrecompiledDependency(
                     path,
                     groups: groups,
@@ -219,7 +217,7 @@ class ProjectFileElements {
                     group: filesGroup,
                     sourceRootPath: sourceRootPath
                 )
-            case let .framework(path, _, _, _, _, _, _, _, _):
+            case let .framework(path, _, _, _, _, _, _, _, _, _):
                 try generatePrecompiledDependency(
                     path,
                     groups: groups,
@@ -227,7 +225,7 @@ class ProjectFileElements {
                     group: filesGroup,
                     sourceRootPath: sourceRootPath
                 )
-            case let .library(path, _, _, _):
+            case let .library(path, _, _, _, _):
                 try generatePrecompiledDependency(
                     path,
                     groups: groups,
@@ -235,7 +233,7 @@ class ProjectFileElements {
                     group: filesGroup,
                     sourceRootPath: sourceRootPath
                 )
-            case let .bundle(path):
+            case let .bundle(path, _):
                 try generatePrecompiledDependency(
                     path,
                     groups: groups,
@@ -243,7 +241,7 @@ class ProjectFileElements {
                     group: filesGroup,
                     sourceRootPath: sourceRootPath
                 )
-            case let .sdk(sdkNodePath, _, _):
+            case let .sdk(sdkNodePath, _, _, _):
                 generateSDKFileElement(
                     sdkNodePath: sdkNodePath,
                     toGroup: groups.compiled,

--- a/Sources/TuistGenerator/Generator/ProjectGroups.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGroups.swift
@@ -28,7 +28,7 @@ class ProjectGroups {
 
     @SortedPBXGroup var sortedMain: PBXGroup
     let products: PBXGroup
-    let frameworks: PBXGroup
+    let compiled: PBXGroup
 
     private let pbxproj: PBXProj
     private let projectGroups: [String: PBXGroup]
@@ -39,21 +39,21 @@ class ProjectGroups {
         main: PBXGroup,
         projectGroups: [(name: String, group: PBXGroup)],
         products: PBXGroup,
-        frameworks: PBXGroup,
+        compiled: PBXGroup,
         pbxproj: PBXProj
     ) {
         sortedMain = main
         self.projectGroups = Dictionary(uniqueKeysWithValues: projectGroups)
         self.products = products
-        self.frameworks = frameworks
+        self.compiled = compiled
         self.pbxproj = pbxproj
     }
 
     func targetFrameworks(target: String) throws -> PBXGroup {
-        if let group = frameworks.group(named: target) {
+        if let group = compiled.group(named: target) {
             return group
         } else {
-            return try frameworks.addGroup(named: target, options: .withoutFolder).last!
+            return try compiled.addGroup(named: target, options: .withoutFolder).last!
         }
     }
 
@@ -93,10 +93,10 @@ class ProjectGroups {
             projectGroups.append(($0, projectGroup))
         }
 
-        /// Frameworks
-        let frameworksGroup = PBXGroup(children: [], sourceTree: .group, name: "Frameworks")
-        pbxproj.add(object: frameworksGroup)
-        mainGroup.children.append(frameworksGroup)
+        /// Compiled
+        let compiledGroup = PBXGroup(children: [], sourceTree: .group, name: "Compiled")
+        pbxproj.add(object: compiledGroup)
+        mainGroup.children.append(compiledGroup)
 
         /// Products
         let productsGroup = PBXGroup(children: [], sourceTree: .group, name: "Products")
@@ -107,7 +107,7 @@ class ProjectGroups {
             main: mainGroup,
             projectGroups: projectGroups,
             products: productsGroup,
-            frameworks: frameworksGroup,
+            compiled: compiledGroup,
             pbxproj: pbxproj
         )
     }

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -751,8 +751,8 @@ final class LinkGeneratorTests: XCTestCase {
         let fileElements = ProjectFileElements()
         let requiredFile = PBXFileReference(name: "required")
         let optionalFile = PBXFileReference(name: "optional")
-        fileElements.sdks["/Strong/Foo.framework"] = requiredFile
-        fileElements.sdks["/Weak/Bar.framework"] = optionalFile
+        fileElements.compiled["/Strong/Foo.framework"] = requiredFile
+        fileElements.compiled["/Weak/Bar.framework"] = optionalFile
         let path = try AbsolutePath(validating: "/path/")
         let graphTraverser = MockGraphTraverser()
         graphTraverser.stubbedLinkableDependenciesResult = dependencies

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -653,7 +653,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         pbxproj.add(object: group)
 
         // When
-        subject.addFileElement(
+        subject.addFileElementRelativeToGroup(
             from: from,
             fileAbsolutePath: fileAbsolutePath,
             fileRelativePath: fileRelativePath,
@@ -704,7 +704,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         let group = PBXGroup()
         let pbxproj = PBXProj()
         pbxproj.add(object: group)
-        subject.addFileElement(
+        subject.addFileElementRelativeToGroup(
             from: from,
             fileAbsolutePath: fileAbsolutePath,
             fileRelativePath: fileRelativePath,
@@ -792,7 +792,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertEqual(groups.frameworks.flattenedChildren, [
+        XCTAssertEqual(groups.compiled.flattenedChildren, [
             "ARKit.framework",
         ])
 

--- a/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
@@ -74,10 +74,10 @@ final class ProjectGroupsTests: XCTestCase {
         XCTAssertNil(main.group(named: "Target")?.path)
         XCTAssertEqual(main.group(named: "Target")?.sourceTree, .group)
 
-        XCTAssertTrue(main.children.contains(subject.frameworks))
-        XCTAssertEqual(subject.frameworks.name, "Frameworks")
-        XCTAssertNil(subject.frameworks.path)
-        XCTAssertEqual(subject.frameworks.sourceTree, .group)
+        XCTAssertTrue(main.children.contains(subject.compiled))
+        XCTAssertEqual(subject.compiled.name, "Compiled")
+        XCTAssertNil(subject.compiled.path)
+        XCTAssertEqual(subject.compiled.sourceTree, .group)
 
         XCTAssertTrue(main.children.contains(subject.products))
         XCTAssertEqual(subject.products.name, "Products")
@@ -111,7 +111,7 @@ final class ProjectGroupsTests: XCTestCase {
             "B",
             "C",
             "A",
-            "Frameworks",
+            "Compiled",
             "Products",
         ])
     }
@@ -125,7 +125,7 @@ final class ProjectGroupsTests: XCTestCase {
         let got = try subject.targetFrameworks(target: "Test")
         XCTAssertEqual(got.name, "Test")
         XCTAssertEqual(got.sourceTree, .group)
-        XCTAssertTrue(subject.frameworks.children.contains(got))
+        XCTAssertTrue(subject.compiled.children.contains(got))
     }
 
     func test_projectGroup_unknownProjectGroups() throws {


### PR DESCRIPTION
### Short description 📝
Projects generated with cache binaries end up with references to the binaries very nested in a group hierarchy. I found that somewhat annoying, so I adjusted the logic a bit to flatten all the compiled artifacts into a group, `Compiled`, that contains both the cache binaries as well as any project-compiled binaries and system frameworks.

##### Alternative considered
I considered creating a new group, `Cache`, specifically for cache binaries, but then I realized that determining whether we should create it or not based on the existence of cache binaries would require and additional traversal of the graph, regardless of whether using or not the caching feature of Tuist, and I thought that performance penalty was not a good idea.


### How to test the changes locally 🧐
If you generate a project using cache binaries, you should see a `Compiled` group at the root of the project.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
