### PR TITLE
Workflow for auto-release of Tuist and Tuistenv Homebrew formula 

### DIFF
--- a/.github/workflows/deploy-homebrew.yml
+++ b/.github/workflows/deploy-homebrew.yml
@@ -1,0 +1,18 @@
+name: Deployment
+on:
+  push:
+    tags:
+      - '*'
+env:
+  LOG_LEVEL: DEBUG
+  TARGET_REPO_NAME: tuist/homebrew-tuist
+  GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Dependencies
+        run: pip3 install -r requirements.txt
+      - name: Deploy new Homebrew formula
+        run: python3 -u make/tasks/homebrew/release-formulas.py

--- a/.github/workflows/deploy-homebrew.yml
+++ b/.github/workflows/deploy-homebrew.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Dependencies
-        run: pip3 install -r requirements.txt
+        run: pip3 install PyGithub==2.1.1
       - name: Deploy new Homebrew formula
         run: python3 -u make/tasks/homebrew/release-formulas.py

--- a/make/tasks/homebrew/release-formulas.py
+++ b/make/tasks/homebrew/release-formulas.py
@@ -25,8 +25,7 @@ tuist_package_repo_url = "https://github.com/tuist/tuist"
 
 def _set_logging():
     LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
-    print("LOG_LEVEL = {}".format(LOG_LEVEL))
-
+    print(f"LOG_LEVEL = {LOG_LEVEL}")
     if LOG_LEVEL == "DEBUG":
         logging.basicConfig(level=logging.DEBUG)
     else:

--- a/make/tasks/homebrew/release-formulas.py
+++ b/make/tasks/homebrew/release-formulas.py
@@ -1,0 +1,179 @@
+#!/usr/bin/python3
+
+import os, re, logging, subprocess
+from github import Github, Auth
+from sys import platform
+
+# Env vars
+target_repo_name = os.environ.get("TARGET_REPO_NAME", None)
+if target_repo_name is None:
+    raise Exception("No target repo name, please set `TARGET_REPO_NAME` env")
+
+access_token = os.environ.get("GITHUB_ACCESS_TOKEN", None)
+if access_token is None:
+    raise Exception("No access token, cannot authenticate with GitHub please set `GITHUB_ACCESS_TOKEN` env")
+
+branch_prefix = os.environ.get("RELEASE_BRANCH_PREFIX", 'release')
+git_email = os.environ.get("TUIST_GIT_EMAIL", "")
+git_user = os.environ.get("GITHUB_REPOSITORY_OWNER", "")
+
+# Constants
+target_repo_url = f'https://github.com/{target_repo_name}' # Supporting github for now
+tuist_package_repo_url = "https://github.com/tuist/tuist"
+
+# MARK: - Helpers
+
+def _set_logging():
+    LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
+    print("LOG_LEVEL = {}".format(LOG_LEVEL))
+
+    if LOG_LEVEL == "DEBUG":
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
+def _run_command(command):
+    logging.debug(f"Running command {command}")
+    return subprocess.run(command, shell=True, capture_output=True, text=True).stdout
+
+# MARK: - Formula builder
+
+def _create_new_formula(
+    template_name, 
+    new_formula_file_name, 
+    formula_placeholder,
+    sha_placeholder,
+    url_placeholder
+):
+    logging.debug(f'''
+        Creating formula from {template_name}
+        New formula file {new_formula_file_name}
+        Formula rb name {formula_placeholder}
+        Formula SHA {sha_placeholder}
+        Formula URL {url_placeholder}
+        ''')
+    
+    _run_command(f'cp {template_name} ./{new_formula_file_name}')
+
+    if platform == "linux" or platform == "linux2":
+        _run_command(f"sed -i 's|_FORMULA_|{formula_placeholder}|g' {new_formula_file_name}")
+        _run_command(f"sed -i 's|_SHA_|\"{sha_placeholder}\"|g' {new_formula_file_name}")
+        _run_command(f"sed -i 's|_URL_|\"{url_placeholder}\"|g' {new_formula_file_name}")
+    elif platform == "darwin":
+        _run_command(f"sed -i '' 's|_FORMULA_|{formula_placeholder}|g' {new_formula_file_name}")
+        _run_command(f"sed -i '' 's|_SHA_|\"{sha_placeholder}\"|g' {new_formula_file_name}")
+        _run_command(f"sed -i '' 's|_URL_|\"{url_placeholder}\"|g' {new_formula_file_name}")
+    else:
+        raise Exception(f"Not supported platform {platform}")
+
+    logging.debug(f'New Homebrew formula created successfully at {new_formula_file_name}')
+
+def _create_new_tuistenv_formula_by(tag, sha, url):
+    _create_new_formula(
+        template_name="../make/tasks/homebrew/tuistenv_template.rb",
+        new_formula_file_name=f"tuistenv@{tag}.rb",
+        formula_placeholder=f"TuistenvAt{tag}".replace(".", ""),
+        sha_placeholder=sha,
+        url_placeholder=url
+    )
+
+def _create_new_tuist_formula_by(tag, sha, url):
+    _create_new_formula(
+        template_name="../make/tasks/homebrew/tuist_template.rb",
+        new_formula_file_name=f"tuist@{tag}.rb",
+        formula_placeholder=f"TuistAt{tag}".replace(".", ""),
+        sha_placeholder=sha,
+        url_placeholder=url
+    )
+
+def _create_new_formulas_by(tag):
+    package_url = f"{tuist_package_repo_url}/archive/refs/tags/{tag}.tar.gz" # 
+    _run_command(f"curl {package_url} -o package.zip -s")
+    new_sha = _run_command("shasum -a 256 package.zip | cut -d ' ' -f 1").strip()
+
+    _create_new_tuist_formula_by(tag, new_sha, package_url)
+    _create_new_tuistenv_formula_by(tag, new_sha, package_url)
+
+# MARK: - Git operations
+
+def _get_tag():
+    # fetch all tags
+    tags = os.popen('git ls-remote --tags').read()
+    logging.debug('tags {}'.format(tags))
+
+    # parse tags and get the latest one
+    tag_list = re.findall(r'refs/tags/(\d+\.\d+\.\d+)', tags)
+    logging.debug('tag_list {}'.format(tag_list))
+
+    latest_tag = tag_list[-1] if tag_list else None
+    if latest_tag is None:
+        raise Exception("Could not find a tag")
+    return latest_tag
+
+def _prepare_repo_locally():
+    # clone the git repo
+    logging.debug('cloning {}'.format(target_repo_url))
+    _run_command(f'git clone {target_repo_url}')
+    # navigate into the cloned repo (given the default clone command, the folder name would be the repository name)
+    repo_name = target_repo_url.split('/')[-1].replace('.git', '')
+    os.chdir(repo_name)
+
+    _run_command(f"git config --local user.email {git_email}")
+    _run_command(f"git config --local user.name {git_user}")
+
+def _checkout_branch_by(tag):
+    # create branch name from the latest tag
+    branch = "{}_{}".format(branch_prefix, tag)
+    # create and checkout new branch
+    _run_command(f'git checkout -b {branch}')
+    logging.debug('new branch {}'.format(branch))
+    return branch
+
+def _commit_and_push(branch, message):
+    # Preparing for push
+    _run_command(f"git remote set-url origin https://{git_user}:{access_token}@github.com/{target_repo_name}")
+    # stage changes
+    _run_command('git add .')
+    # Unstage the package.zip
+    _run_command('git reset -- filename')
+    # commit changes
+    _run_command(f'git commit -m \"{message}\"')
+    # push changes
+    _run_command(f'git push --set-upstream origin {branch}')
+
+# MARK: - GitHub Operations
+
+def _github_auth():
+    logging.debug('Starting Authentication')
+    # using an access token
+    auth = Auth.Token(access_token)
+    # Public Web Github
+    g = Github(auth=auth)
+    logging.debug('Authentication Done')
+    return g
+
+def _create_pr_with(g, branch, title):
+    logging.debug(f'Creating PR from branch {branch}')
+    # get the repo by name
+    repo = g.get_repo(target_repo_name)
+    # create a GitHub pull request
+    pr = repo.create_pull(
+        title=title,
+        body='Created from automated script',
+        head=branch,
+        base='main'
+    )
+    logging.info(f"created new PR {pr}")
+
+###############
+# MAIN SCRIPT #
+###############
+
+_set_logging()
+tag = _get_tag()
+_prepare_repo_locally()
+branch = _checkout_branch_by(tag)
+_create_new_formulas_by(tag)
+_commit_and_push(branch=branch, message=f"New Release {tag}")
+g = _github_auth()
+_create_pr_with(g, branch=branch, title=f'Release {tag}')

--- a/make/tasks/homebrew/tuist_template.rb
+++ b/make/tasks/homebrew/tuist_template.rb
@@ -1,0 +1,40 @@
+class _FORMULA_ < Formula
+  desc "Create, maintain, and interact with Xcode projects at scale"
+  homepage "https://tuist.io"
+  url _URL_
+  sha256 _SHA_
+  license "MIT"
+  head "https://github.com/tuist/tuist.git", branch: "main"
+
+  # https://github.com/tuist/tuist/blob/3.33.4/.xcode-version#L1
+  depends_on xcode: ["14.3", :build]
+
+  # https://github.com/tuist/tuist/blob/3.33.4/Package.swift#L14
+  depends_on macos: :monterey
+
+  def install
+    # https://github.com/tuist/tuist/blob/3.33.4/.github/workflows/tuist.yml#L81
+    system "swift", "build",
+      "--configuration", "release",
+      "--product", "tuist",
+      "--disable-sandbox"
+
+    # https://github.com/tuist/tuist/blob/3.33.4/.github/workflows/tuist.yml#L85
+    system "swift", "build",
+      "--configuration", "release",
+      "--product", "ProjectDescription",
+      "--disable-sandbox"
+
+    # https://github.com/tuist/tuist/blob/3.33.4/Sources/TuistEnvKit/Installer/BuildCopier.swift#L13
+    bin.install ".build/release/tuist"
+    bin.install "Templates"
+    bin.install "projects/tuist/vendor"
+    bin.install ".build/release/ProjectDescription.swiftmodule"
+    bin.install ".build/release/ProjectDescription.swiftdoc"
+    bin.install ".build/release/libProjectDescription.dylib"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/tuist version")
+  end
+end

--- a/make/tasks/homebrew/tuistenv_template.rb
+++ b/make/tasks/homebrew/tuistenv_template.rb
@@ -1,0 +1,25 @@
+class _FORMULA_ < Formula
+    desc "Managing Tuist versions"
+    homepage "https://tuist.io"
+    url _URL_
+    sha256 _SHA_
+    license "MIT"
+    head "https://github.com/tuist/tuist.git", branch: "main"
+  
+    # https://github.com/tuist/tuist/blob/3.33.4/.xcode-version#L1
+    depends_on xcode: ["14.3", :build]
+  
+    # https://github.com/tuist/tuist/blob/3.33.4/Package.swift#L14
+    depends_on macos: :monterey
+  
+    def install
+      # https://github.com/tuist/tuist/blob/3.33.4/.github/workflows/tuist.yml#L83
+      system "swift", "build",
+        "--configuration", "release",
+        "--product", "tuistenv",
+        "--disable-sandbox"
+  
+      bin.install ".build/release/tuistenv"
+    end
+  end
+  


### PR DESCRIPTION

### Short description 📝
Workflow for auto-release of Tuist and Tuistenv Homebrew formula 

Adding new workflow triggered on tags
Adding python script for deploy
Adding templates of formulas

For the workflow to actually work within Tuist repos one needs to set the GITHUB_ACCESS_TOKEN secret

### How to test the changes locally 🧐

TL;DR look at the `.github/workflow/deploy-homebrew` job and run it

1.  Clone the repo
2. Make sure you have python3 is installed
3. Run `pip3 install PyGithub==2.1.1`
4. Setup relevant env variables (most important is the `GITHUB_ACCESS_TOKEN`)
5. Run `python3 -u make/tasks/homebrew/release-formulas.py`

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
