### PR TITLE
Fix caching regression with Firebase

### DIFF
--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -138,6 +138,19 @@ public class GraphTraverser: GraphTraversing {
             return [GraphTarget(path: path, target: dependencyTarget, project: project)]
         })
     }
+    
+    public func directLocalTargetDependenciesWithConditions(path: AbsolutePath, name: String) -> [(GraphTarget, TargetDependency.Condition?)] {
+        let sorted = directLocalTargetDependencies(path: path, name: name).sorted()
+        let from = GraphDependency.target(name: name, path: path)
+        
+        return sorted.map { dependency in
+            let condition = graph.dependencyConditions[GraphEdge(
+                from: from,
+                to: GraphDependency.target(name: dependency.target.name, path: dependency.path)
+            )]
+            return (dependency, condition)
+        }
+    }
 
     public func resourceBundleDependencies(path: AbsolutePath, name: String) -> Set<GraphDependencyReference> {
         guard let target = graph.targets[path]?[name] else { return [] }
@@ -628,7 +641,7 @@ public class GraphTraverser: GraphTraversing {
     ///   - rootDependency: dependency whose platform filters we need when depending on `transitiveDependency`
     ///   - transitiveDependency: target dependency
     /// - Returns: CombinationResult which represents a resolved condition or `.invalid` based on traversing
-    public func combinedCondition(to transitiveDependency: GraphDependency, from rootDependency: GraphDependency) -> TargetDependency
+    func combinedCondition(to transitiveDependency: GraphDependency, from rootDependency: GraphDependency) -> TargetDependency
         .Condition.CombinationResult
     {
         var visited: Set<GraphDependency> = []

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -138,11 +138,14 @@ public class GraphTraverser: GraphTraversing {
             return [GraphTarget(path: path, target: dependencyTarget, project: project)]
         })
     }
-    
-    public func directLocalTargetDependenciesWithConditions(path: AbsolutePath, name: String) -> [(GraphTarget, TargetDependency.Condition?)] {
+
+    public func directLocalTargetDependenciesWithConditions(path: AbsolutePath, name: String) -> [(
+        GraphTarget,
+        TargetDependency.Condition?
+    )] {
         let sorted = directLocalTargetDependencies(path: path, name: name).sorted()
         let from = GraphDependency.target(name: name, path: path)
-        
+
         return sorted.map { dependency in
             let condition = graph.dependencyConditions[GraphEdge(
                 from: from,

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -628,7 +628,7 @@ public class GraphTraverser: GraphTraversing {
     ///   - rootDependency: dependency whose platform filters we need when depending on `transitiveDependency`
     ///   - transitiveDependency: target dependency
     /// - Returns: CombinationResult which represents a resolved condition or `.invalid` based on traversing
-    func combinedCondition(to transitiveDependency: GraphDependency, from rootDependency: GraphDependency) -> TargetDependency
+    public func combinedCondition(to transitiveDependency: GraphDependency, from rootDependency: GraphDependency) -> TargetDependency
         .Condition.CombinationResult
     {
         var visited: Set<GraphDependency> = []

--- a/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
+++ b/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
@@ -90,7 +90,10 @@ public protocol GraphTraversing {
     /// - Parameters:
     ///   - path: Path to the directory that contains the project.
     ///   - name: Target name.
-    func directLocalTargetDependenciesWithConditions(path: AbsolutePath, name: String) -> [(GraphTarget, TargetDependency.Condition?)]
+    func directLocalTargetDependenciesWithConditions(path: AbsolutePath, name: String) -> [(
+        GraphTarget,
+        TargetDependency.Condition?
+    )]
 
     /// Given a project directory and a target name, it returns all the dependencies that are extensions.
     /// - Parameters:

--- a/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
+++ b/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
@@ -86,6 +86,8 @@ public protocol GraphTraversing {
     ///   - name: Target name.
     func directLocalTargetDependencies(path: AbsolutePath, name: String) -> Set<GraphTarget>
 
+    func combinedCondition(to transitiveDependency: GraphDependency, from rootDependency: GraphDependency) -> TargetDependency.Condition.CombinationResult
+
     /// Given a project directory and a target name, it returns all the dependencies that are extensions.
     /// - Parameters:
     ///   - path: Path to the directory that contains the project.

--- a/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
+++ b/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
@@ -86,7 +86,11 @@ public protocol GraphTraversing {
     ///   - name: Target name.
     func directLocalTargetDependencies(path: AbsolutePath, name: String) -> Set<GraphTarget>
 
-    func combinedCondition(to transitiveDependency: GraphDependency, from rootDependency: GraphDependency) -> TargetDependency.Condition.CombinationResult
+    /// Given a project directory and a target name, it returns all direct dependencies with their conditions
+    /// - Parameters:
+    ///   - path: Path to the directory that contains the project.
+    ///   - name: Target name.
+    func directLocalTargetDependenciesWithConditions(path: AbsolutePath, name: String) -> [(GraphTarget, TargetDependency.Condition?)]
 
     /// Given a project directory and a target name, it returns all the dependencies that are extensions.
     /// - Parameters:

--- a/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
+++ b/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
@@ -254,6 +254,25 @@ final class MockGraphTraverser: GraphTraversing {
         return stubbedDirectLocalTargetDependenciesResult
     }
 
+    var invokedDirectLocalTargetDependenciesWithConditions = false
+
+    var invokedDirectLocalTargetDependenciesWithConditionsCount = 0
+    var invokedDirectLocalTargetDependenciesWithConditionsParameters: (
+        path: AbsolutePath,
+        name: String
+    )?
+    var invokedDirectLocalTargetDependenciesWithConditionsParametersList =
+        [(path: AbsolutePath, name: String)]()
+    var stubbedDirectLocalTargetDependenciesWithConditionsResult: [(GraphTarget, TargetDependency.Condition?)]! = []
+
+    func directLocalTargetDependenciesWithConditions(path: TSCBasic.AbsolutePath, name: String) -> [(TuistGraph.GraphTarget, TuistGraph.TargetDependency.Condition?)] {
+        invokedDirectLocalTargetDependenciesWithConditions = true
+        invokedDirectLocalTargetDependenciesWithConditionsCount += 1
+        invokedDirectLocalTargetDependenciesWithConditionsParameters = (path, name)
+        invokedDirectLocalTargetDependenciesWithConditionsParametersList.append((path, name))
+        return stubbedDirectLocalTargetDependenciesWithConditionsResult
+    }
+
     var invokedDirectTargetDependencies = false
     var invokedDirectTargetDependenciesCount = 0
     var invokedDirectTargetDependenciesParameters: (path: AbsolutePath, name: String)?

--- a/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
+++ b/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
@@ -265,7 +265,10 @@ final class MockGraphTraverser: GraphTraversing {
         [(path: AbsolutePath, name: String)]()
     var stubbedDirectLocalTargetDependenciesWithConditionsResult: [(GraphTarget, TargetDependency.Condition?)]! = []
 
-    func directLocalTargetDependenciesWithConditions(path: TSCBasic.AbsolutePath, name: String) -> [(TuistGraph.GraphTarget, TuistGraph.TargetDependency.Condition?)] {
+    func directLocalTargetDependenciesWithConditions(path: TSCBasic.AbsolutePath, name: String) -> [(
+        TuistGraph.GraphTarget,
+        TuistGraph.TargetDependency.Condition?
+    )] {
         invokedDirectLocalTargetDependenciesWithConditions = true
         invokedDirectLocalTargetDependenciesWithConditionsCount += 1
         invokedDirectLocalTargetDependenciesWithConditionsParameters = (path, name)

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -536,11 +536,16 @@ extension ProjectDescription.Target {
 
         // Use the intersection of destations from `Dependencies.swift` and the destinations supported by the package.
 
-        var destinations = if target.type == .macro {
-            Set<ProjectDescription.Destination>([.mac])
+        var destinations: ProjectDescription.Destinations
+
+        if target.type == .macro {
+            destinations = Set<ProjectDescription.Destination>([.mac])
+        } else if packageName == "Firebase" {
+            var supportedPlatforms = try ProjectDescription.Destinations.fromFirebase(platforms: packageInfo.platforms, forTargetNamed: target.name)
+            destinations = packageDestinations.intersection(supportedPlatforms)
         } else {
-            packageDestinations
-                .intersection(try ProjectDescription.Destinations.from(platforms: packageInfo.platforms))
+            var supportedPlatforms = try ProjectDescription.Destinations.from(platforms: packageInfo.platforms)
+            destinations = packageDestinations.intersection(supportedPlatforms)
         }
 
         if macroDependencies.contains(where: { dependency in
@@ -861,9 +866,35 @@ extension ResourceFileElements {
 }
 
 extension ProjectDescription.Destinations {
-    fileprivate static func from(platforms: [PackageInfo.Platform]) throws -> Self {
+    fileprivate static func fromFirebase(platforms: [PackageInfo.Platform], forTargetNamed name: String) throws -> Self {
         guard !platforms.isEmpty else { return Set(Destination.allCases) }
 
+        return Set(try platforms.filter({ platform in
+            switch name {
+            case "FirebaseAnalyticsWrapper",
+                "FirebaseAnalyticsSwift",
+                "FirebaseAnalyticsWithoutAdIdSupportWrapper",
+                "FirebaseFirestoreSwift",
+                "FirebaseFirestore": // These dont support watchOS
+                platform.platform != .watchOS
+            case "FirebaseAppDistribution",
+                "FirebaseDynamicLinks": // iOS only
+                platform.platform == .iOS
+            case "FirebaseInAppMessaging":
+                platform.platform == .iOS ||
+                platform.platform == .tvOS ||
+                platform.platform == .visionOS
+            case "FirebasePerformance":
+                platform.platform != .macOS &&
+                platform.platform != .watchOS
+            default: true
+            }
+        })
+            .flatMap { try $0.destinations() })
+    }
+
+    fileprivate static func from(platforms: [PackageInfo.Platform]) throws -> Self {
+        guard !platforms.isEmpty else { return Set(Destination.allCases) }
         return Set(try platforms.flatMap { try $0.destinations() })
     }
 }

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -541,10 +541,10 @@ extension ProjectDescription.Target {
         if target.type == .macro {
             destinations = Set<ProjectDescription.Destination>([.mac])
         } else if packageName == "Firebase" {
-            var supportedPlatforms = try ProjectDescription.Destinations.fromFirebase(platforms: packageInfo.platforms, forTargetNamed: target.name)
+            let supportedPlatforms = try ProjectDescription.Destinations.fromFirebase(platforms: packageInfo.platforms, forTargetNamed: target.name)
             destinations = packageDestinations.intersection(supportedPlatforms)
         } else {
-            var supportedPlatforms = try ProjectDescription.Destinations.from(platforms: packageInfo.platforms)
+            let supportedPlatforms = try ProjectDescription.Destinations.from(platforms: packageInfo.platforms)
             destinations = packageDestinations.intersection(supportedPlatforms)
         }
 

--- a/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
+++ b/Sources/TuistDependencies/SwiftPackageManager/Utils/PackageInfoMapper.swift
@@ -541,7 +541,10 @@ extension ProjectDescription.Target {
         if target.type == .macro {
             destinations = Set<ProjectDescription.Destination>([.mac])
         } else if packageName == "Firebase" {
-            let supportedPlatforms = try ProjectDescription.Destinations.fromFirebase(platforms: packageInfo.platforms, forTargetNamed: target.name)
+            let supportedPlatforms = try ProjectDescription.Destinations.fromFirebase(
+                platforms: packageInfo.platforms,
+                forTargetNamed: target.name
+            )
             destinations = packageDestinations.intersection(supportedPlatforms)
         } else {
             let supportedPlatforms = try ProjectDescription.Destinations.from(platforms: packageInfo.platforms)
@@ -869,28 +872,30 @@ extension ProjectDescription.Destinations {
     fileprivate static func fromFirebase(platforms: [PackageInfo.Platform], forTargetNamed name: String) throws -> Self {
         guard !platforms.isEmpty else { return Set(Destination.allCases) }
 
-        return Set(try platforms.filter({ platform in
-            switch name {
-            case "FirebaseAnalyticsWrapper",
-                "FirebaseAnalyticsSwift",
-                "FirebaseAnalyticsWithoutAdIdSupportWrapper",
-                "FirebaseFirestoreSwift",
-                "FirebaseFirestore": // These dont support watchOS
-                platform.platform != .watchOS
-            case "FirebaseAppDistribution",
-                "FirebaseDynamicLinks": // iOS only
-                platform.platform == .iOS
-            case "FirebaseInAppMessaging":
-                platform.platform == .iOS ||
-                platform.platform == .tvOS ||
-                platform.platform == .visionOS
-            case "FirebasePerformance":
-                platform.platform != .macOS &&
-                platform.platform != .watchOS
-            default: true
+        return Set(
+            try platforms.filter { platform in
+                switch name {
+                case "FirebaseAnalyticsWrapper",
+                     "FirebaseAnalyticsSwift",
+                     "FirebaseAnalyticsWithoutAdIdSupportWrapper",
+                     "FirebaseFirestoreSwift",
+                     "FirebaseFirestore": // These dont support watchOS
+                    platform.platform != .watchOS
+                case "FirebaseAppDistribution",
+                     "FirebaseDynamicLinks": // iOS only
+                    platform.platform == .iOS
+                case "FirebaseInAppMessaging":
+                    platform.platform == .iOS ||
+                        platform.platform == .tvOS ||
+                        platform.platform == .visionOS
+                case "FirebasePerformance":
+                    platform.platform != .macOS &&
+                        platform.platform != .watchOS
+                default: true
+                }
             }
-        })
-            .flatMap { try $0.destinations() })
+            .flatMap { try $0.destinations() }
+        )
     }
 
     fileprivate static func from(platforms: [PackageInfo.Platform]) throws -> Self {

--- a/Sources/TuistGenerator/Extensions/Xcodeproj+Extras.swift
+++ b/Sources/TuistGenerator/Extensions/Xcodeproj+Extras.swift
@@ -27,7 +27,15 @@ extension PBXFileElement {
     }
 }
 
-extension PBXBuildFile {
+extension PBXBuildFile: PlatformFilterable {}
+extension PBXTargetDependency: PlatformFilterable {}
+
+protocol PlatformFilterable: AnyObject {
+    var platformFilters: [String]? {get set}
+    var platformFilter: String? {get set}
+}
+
+extension PlatformFilterable {
     /// Apply platform filters either `platformFilter` or `platformFilters` depending on count
     /// With Xcode 15, we're seeing `platformFilter` not have the effects we expect
     public func applyCondition(_ condition: TargetDependency.Condition?, applicableTo target: Target) {
@@ -76,3 +84,4 @@ extension PBXBuildFile {
         }
     }
 }
+

--- a/Sources/TuistGenerator/Extensions/Xcodeproj+Extras.swift
+++ b/Sources/TuistGenerator/Extensions/Xcodeproj+Extras.swift
@@ -31,8 +31,8 @@ extension PBXBuildFile: PlatformFilterable {}
 extension PBXTargetDependency: PlatformFilterable {}
 
 protocol PlatformFilterable: AnyObject {
-    var platformFilters: [String]? {get set}
-    var platformFilter: String? {get set}
+    var platformFilters: [String]? { get set }
+    var platformFilter: String? { get set }
 }
 
 extension PlatformFilterable {
@@ -84,4 +84,3 @@ extension PlatformFilterable {
         }
     }
 }
-

--- a/Sources/TuistGenerator/Generator/TargetGenerator.swift
+++ b/Sources/TuistGenerator/Generator/TargetGenerator.swift
@@ -153,10 +153,7 @@ final class TargetGenerator: TargetGenerating {
                 let nativeTarget = nativeTargets[targetSpec.name]!
                 let nativeDependency = nativeTargets[dependency.target.name]!
                 let pbxTargetDependency = try nativeTarget.addDependency(target: nativeDependency)
-
-                if let condition {
-                    pbxTargetDependency?.platformFilters = condition.platformFilters.xcodeprojValue
-                }
+                pbxTargetDependency?.applyCondition(condition, applicableTo: dependency.target)
             }
         }
     }

--- a/Sources/TuistGenerator/Generator/TargetGenerator.swift
+++ b/Sources/TuistGenerator/Generator/TargetGenerator.swift
@@ -147,7 +147,10 @@ final class TargetGenerator: TargetGenerating {
     ) throws {
         try targets.forEach { targetSpec in
 
-            let dependenciesAndConditions = graphTraverser.directLocalTargetDependenciesWithConditions(path: path, name: targetSpec.name)
+            let dependenciesAndConditions = graphTraverser.directLocalTargetDependenciesWithConditions(
+                path: path,
+                name: targetSpec.name
+            )
 
             try dependenciesAndConditions.forEach { dependency, condition in
                 let nativeTarget = nativeTargets[targetSpec.name]!

--- a/Sources/TuistGenerator/Generator/TargetGenerator.swift
+++ b/Sources/TuistGenerator/Generator/TargetGenerator.swift
@@ -147,18 +147,15 @@ final class TargetGenerator: TargetGenerating {
     ) throws {
         try targets.forEach { targetSpec in
 
-            let dependencies = graphTraverser.directLocalTargetDependencies(path: path, name: targetSpec.name).sorted()
+            let dependenciesAndConditions = graphTraverser.directLocalTargetDependenciesWithConditions(path: path, name: targetSpec.name)
 
-            let target = GraphDependency.target(name: targetSpec.name, path: path)
-
-            try dependencies.forEach { dependency in
+            try dependenciesAndConditions.forEach { dependency, condition in
                 let nativeTarget = nativeTargets[targetSpec.name]!
                 let nativeDependency = nativeTargets[dependency.target.name]!
                 let pbxTargetDependency = try nativeTarget.addDependency(target: nativeDependency)
-                let path = dependency.path 
-                if case let .condition(condition) = graphTraverser.combinedCondition(to: .target(name: dependency.target.name, path: dependency.path), from: target),
-                   let filters = condition?.platformFilters {
-                    pbxTargetDependency?.platformFilters = filters.xcodeprojValue
+
+                if let condition {
+                    pbxTargetDependency?.platformFilters = condition.platformFilters.xcodeprojValue
                 }
             }
         }

--- a/Sources/TuistGraph/Graph/Graph.swift
+++ b/Sources/TuistGraph/Graph/Graph.swift
@@ -2,6 +2,7 @@ import Foundation
 import TSCBasic
 
 /// A directed edge linking representing a dependent relationship
+/// e.g. `from` (MainApp) depends on `to` (UIKit)
 public struct GraphEdge: Hashable, Codable {
     public let from: GraphDependency
     public let to: GraphDependency

--- a/Sources/TuistSupport/SwiftPackageManager/PackageInfo.swift
+++ b/Sources/TuistSupport/SwiftPackageManager/PackageInfo.swift
@@ -79,6 +79,10 @@ extension PackageInfo {
             self.version = version
             self.options = options
         }
+
+        public var platform: PackagePlatform? {
+            PackagePlatform(rawValue: platformName)
+        }
     }
 }
 

--- a/fixtures/multiplatform_app_with_sdk/Project.swift
+++ b/fixtures/multiplatform_app_with_sdk/Project.swift
@@ -37,6 +37,7 @@ let project = Project(
                 .sdk(name: "CloudKit", type: .framework, status: .required),
                 .sdk(name: "ARKit", type: .framework, status: .required, condition: .when([.ios])),
                 .external(name: "FirebaseAnalytics"),
+                .external(name: "FirebasePerformance", condition: .when([.ios])),
                 .sdk(name: "MobileCoreServices", type: .framework, status: .required, condition: .when([.ios])),
             ]
         ),


### PR DESCRIPTION
Resolves #5622

### Short description 📝

1) Strip unsupported platforms from known firebase targets that need them removed.  These are defined in the Firebase `Package.swift` file as well as here: https://github.com/firebase/firebase-ios-sdk/tree/master/SwiftPM-PlatformExclude

2) Fix an issue where we did not add conditions to the dependencies for a given target. this meant dependent targets would attempt to be build when building another platform they may not be compatible with.

### How to test the changes locally 🧐

Run `cache warm` against `fixtures/multiplatform_app_with_sdk`

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
