### PR TITLE
Add an option to the `Config.swift` to disable static side effect warnings

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -489,7 +489,7 @@ func targets() -> [Target] {
     return executableTargets + moduleTargets + acceptanceTests.map(\.target) + [
         .target(
             name: "TuistAcceptanceTesting",
-            product: .framework,
+            product: .staticFramework,
             dependencies: [
                 .target(name: "TuistKit"),
                 .target(name: "TuistSupportTesting"),

--- a/Sources/ProjectDescription/ConfigGenerationOptions.swift
+++ b/Sources/ProjectDescription/ConfigGenerationOptions.swift
@@ -1,6 +1,16 @@
 extension Config {
     /// Options for project generation.
     public struct GenerationOptions: Codable, Equatable {
+        /**
+         This enum represents the targets against which Tuist will run the check for potential side effects
+         caused by static transitive dependencies.
+         */
+        public enum StaticSideEffectsWarningTargets: Codable, Equatable {
+            case all
+            case none
+            case only([String])
+        }
+        
         /// When passed, Xcode will resolve its Package Manager dependencies using the system-defined
         /// accounts (for example, git) instead of the Xcode-defined accounts
         public let resolveDependenciesWithSystemScm: Bool
@@ -12,16 +22,22 @@ extension Config {
         /// Allows setting a custom directory to be used when resolving package dependencies
         /// This path is passed to `xcodebuild` via the `-clonedSourcePackagesDirPath` argument
         public let clonedSourcePackagesDirPath: Path?
+        
+        /// Allows configuring which targets Tuist checks for potential side effects due multiple branches of the graph
+        /// including the same static library of framework as a transitive dependency.
+        public let staticSideEffectsWarningTargets: StaticSideEffectsWarningTargets
 
         public static func options(
             resolveDependenciesWithSystemScm: Bool = false,
             disablePackageVersionLocking: Bool = false,
-            clonedSourcePackagesDirPath: Path? = nil
+            clonedSourcePackagesDirPath: Path? = nil,
+            staticSideEffectsWarningTargets: StaticSideEffectsWarningTargets = .all
         ) -> Self {
             self.init(
                 resolveDependenciesWithSystemScm: resolveDependenciesWithSystemScm,
                 disablePackageVersionLocking: disablePackageVersionLocking,
-                clonedSourcePackagesDirPath: clonedSourcePackagesDirPath
+                clonedSourcePackagesDirPath: clonedSourcePackagesDirPath,
+                staticSideEffectsWarningTargets: staticSideEffectsWarningTargets
             )
         }
     }

--- a/Sources/ProjectDescription/ConfigGenerationOptions.swift
+++ b/Sources/ProjectDescription/ConfigGenerationOptions.swift
@@ -8,7 +8,7 @@ extension Config {
         public enum StaticSideEffectsWarningTargets: Codable, Equatable {
             case all
             case none
-            case only([String])
+            case excluding([String])
         }
 
         /// When passed, Xcode will resolve its Package Manager dependencies using the system-defined

--- a/Sources/ProjectDescription/ConfigGenerationOptions.swift
+++ b/Sources/ProjectDescription/ConfigGenerationOptions.swift
@@ -10,7 +10,7 @@ extension Config {
             case none
             case only([String])
         }
-        
+
         /// When passed, Xcode will resolve its Package Manager dependencies using the system-defined
         /// accounts (for example, git) instead of the Xcode-defined accounts
         public let resolveDependenciesWithSystemScm: Bool
@@ -22,7 +22,7 @@ extension Config {
         /// Allows setting a custom directory to be used when resolving package dependencies
         /// This path is passed to `xcodebuild` via the `-clonedSourcePackagesDirPath` argument
         public let clonedSourcePackagesDirPath: Path?
-        
+
         /// Allows configuring which targets Tuist checks for potential side effects due multiple branches of the graph
         /// including the same static library of framework as a transitive dependency.
         public let staticSideEffectsWarningTargets: StaticSideEffectsWarningTargets

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -5,7 +5,7 @@ import TuistGraph
 import TuistSupport
 
 public protocol GraphLinting: AnyObject {
-    func lint(graphTraverser: GraphTraversing) -> [LintingIssue]
+    func lint(graphTraverser: GraphTraversing, config: Config) -> [LintingIssue]
 }
 
 // swiftlint:disable type_body_length
@@ -36,12 +36,12 @@ public class GraphLinter: GraphLinting {
 
     // MARK: - GraphLinting
 
-    public func lint(graphTraverser: GraphTraversing) -> [LintingIssue] {
+    public func lint(graphTraverser: GraphTraversing, config: Config) -> [LintingIssue] {
         var issues: [LintingIssue] = []
         issues.append(contentsOf: graphTraverser.projects.flatMap { project -> [LintingIssue] in
             projectLinter.lint(project.value)
         })
-        issues.append(contentsOf: lintDependencies(graphTraverser: graphTraverser))
+        issues.append(contentsOf: lintDependencies(graphTraverser: graphTraverser, config: config))
         issues.append(contentsOf: lintMismatchingConfigurations(graphTraverser: graphTraverser))
         issues.append(contentsOf: lintWatchBundleIndentifiers(graphTraverser: graphTraverser))
         issues.append(contentsOf: lintCodeCoverageMode(graphTraverser: graphTraverser))
@@ -87,7 +87,7 @@ public class GraphLinter: GraphLinting {
         }
     }
 
-    private func lintDependencies(graphTraverser: GraphTraversing) -> [LintingIssue] {
+    private func lintDependencies(graphTraverser: GraphTraversing, config: Config) -> [LintingIssue] {
         var issues: [LintingIssue] = []
         let dependencyIssues = graphTraverser.dependencies.flatMap { fromDependency, toDependencies -> [LintingIssue] in
             toDependencies.flatMap { toDependency -> [LintingIssue] in
@@ -100,7 +100,7 @@ public class GraphLinter: GraphLinting {
         }
 
         issues.append(contentsOf: dependencyIssues)
-        issues.append(contentsOf: staticProductsLinter.lint(graphTraverser: graphTraverser))
+        issues.append(contentsOf: staticProductsLinter.lint(graphTraverser: graphTraverser, config: config))
         issues.append(contentsOf: lintPrecompiledFrameworkDependencies(graphTraverser: graphTraverser))
         issues.append(contentsOf: lintPackageDependencies(graphTraverser: graphTraverser))
         issues.append(contentsOf: lintAppClip(graphTraverser: graphTraverser))

--- a/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -150,9 +150,9 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
 
     private func shouldSkipDependency(_ dependency: GraphDependency, config: Config) -> Bool {
         switch config.generationOptions.staticSideEffectsWarningTargets {
-        case .all: return true
-        case .none: return false
-        case let .only(names): return names.contains(dependency.name)
+        case .all: return false
+        case .none: return true
+        case let .excluding(names): return names.contains(dependency.name)
         }
     }
 

--- a/Sources/TuistGeneratorTesting/Linter/MockGraphLinter.swift
+++ b/Sources/TuistGeneratorTesting/Linter/MockGraphLinter.swift
@@ -7,15 +7,15 @@ import TuistSupport
 public class MockGraphLinter: GraphLinting {
     var invokedLint = false
     var invokedLintCount = 0
-    var invokedLintParameters: (graphTraverser: GraphTraversing, Void)?
-    var invokedLintParametersList = [(graphTraverser: GraphTraversing, Void)]()
+    var invokedLintParameters: (graphTraverser: GraphTraversing, config: Config)?
+    var invokedLintParametersList = [(graphTraverser: GraphTraversing, config: Config)]()
     var stubbedLintResult: [LintingIssue]! = []
 
-    public func lint(graphTraverser: GraphTraversing) -> [LintingIssue] {
+    public func lint(graphTraverser: GraphTraversing, config: Config) -> [LintingIssue] {
         invokedLint = true
         invokedLintCount += 1
-        invokedLintParameters = (graphTraverser, ())
-        invokedLintParametersList.append((graphTraverser, ()))
+        invokedLintParameters = (graphTraverser, config)
+        invokedLintParametersList.append((graphTraverser, config))
         return stubbedLintResult
     }
 }

--- a/Sources/TuistGraph/Graph/GraphDependency.swift
+++ b/Sources/TuistGraph/Graph/GraphDependency.swift
@@ -160,20 +160,39 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
 
     public var description: String {
         switch self {
-        case let .xcframework(path, _, _, _, _, _):
-            return "xcframework '\(path.basename)'"
-        case let .framework(path, _, _, _, _, _, _, _):
-            return "framework '\(path.basename)'"
-        case let .library(path, _, _, _, _):
-            return "library '\(path.basename)'"
-        case let .bundle(path):
-            return "bundle '\(path.basename)'"
-        case let .packageProduct(_, product, _):
-            return "package '\(product)'"
-        case let .target(name, _):
+        case .xcframework:
+            return "xcframework '\(name)'"
+        case .framework:
+            return "framework '\(name)'"
+        case .library:
+            return "library '\(name)'"
+        case .bundle:
+            return "bundle '\(name)'"
+        case .packageProduct:
+            return "package '\(name)'"
+        case .target:
             return "target '\(name)'"
-        case let .sdk(name, _, _, _):
+        case .sdk:
             return "sdk '\(name)'"
+        }
+    }
+
+    public var name: String {
+        switch self {
+        case let .xcframework(path, _, _, _, _, _):
+            return path.basename
+        case let .framework(path, _, _, _, _, _, _, _):
+            return path.basename
+        case let .library(path, _, _, _, _):
+            return path.basename
+        case let .bundle(path):
+            return path.basename
+        case let .packageProduct(_, product, _):
+            return product
+        case let .target(name, _):
+            return name
+        case let .sdk(name, _, _, _):
+            return name
         }
     }
 

--- a/Sources/TuistGraph/Models/Config.swift
+++ b/Sources/TuistGraph/Models/Config.swift
@@ -36,7 +36,8 @@ public struct Config: Equatable, Hashable {
             plugins: [],
             generationOptions: .init(
                 resolveDependenciesWithSystemScm: false,
-                disablePackageVersionLocking: false
+                disablePackageVersionLocking: false,
+                staticSideEffectsWarningTargets: .all
             ),
             path: nil
         )

--- a/Sources/TuistGraph/Models/ConfigGenerationOptions.swift
+++ b/Sources/TuistGraph/Models/ConfigGenerationOptions.swift
@@ -8,7 +8,7 @@ extension Config {
             case none
             case only([String])
         }
-        
+
         public let resolveDependenciesWithSystemScm: Bool
         public let disablePackageVersionLocking: Bool
         public let clonedSourcePackagesDirPath: AbsolutePath?

--- a/Sources/TuistGraph/Models/ConfigGenerationOptions.swift
+++ b/Sources/TuistGraph/Models/ConfigGenerationOptions.swift
@@ -6,7 +6,7 @@ extension Config {
         public enum StaticSideEffectsWarningTargets: Codable, Hashable, Equatable {
             case all
             case none
-            case only([String])
+            case excluding([String])
         }
 
         public let resolveDependenciesWithSystemScm: Bool

--- a/Sources/TuistGraph/Models/ConfigGenerationOptions.swift
+++ b/Sources/TuistGraph/Models/ConfigGenerationOptions.swift
@@ -2,28 +2,28 @@ import TSCBasic
 import TSCUtility
 
 extension Config {
-    /// Contains options related to the project generation.
     public struct GenerationOptions: Codable, Hashable {
-        /// When passed, Xcode will resolve its Package Manager dependencies using the system-defined
-        /// accounts (for example, git) instead of the Xcode-defined accounts
+        public enum StaticSideEffectsWarningTargets: Codable, Hashable, Equatable {
+            case all
+            case none
+            case only([String])
+        }
+        
         public let resolveDependenciesWithSystemScm: Bool
-
-        /// Disables locking Swift packages. This can speed up generation but does increase risk if packages are not locked
-        /// in their declarations.
         public let disablePackageVersionLocking: Bool
-
-        /// Allows setting a custom directory to be used when resolving package dependencies
-        /// This path is passed to `xcodebuild` via the `-clonedSourcePackagesDirPath` argument
         public let clonedSourcePackagesDirPath: AbsolutePath?
+        public let staticSideEffectsWarningTargets: StaticSideEffectsWarningTargets
 
         public init(
             resolveDependenciesWithSystemScm: Bool,
             disablePackageVersionLocking: Bool,
-            clonedSourcePackagesDirPath: AbsolutePath? = nil
+            clonedSourcePackagesDirPath: AbsolutePath? = nil,
+            staticSideEffectsWarningTargets: StaticSideEffectsWarningTargets = .all
         ) {
             self.resolveDependenciesWithSystemScm = resolveDependenciesWithSystemScm
             self.disablePackageVersionLocking = disablePackageVersionLocking
             self.clonedSourcePackagesDirPath = clonedSourcePackagesDirPath
+            self.staticSideEffectsWarningTargets = staticSideEffectsWarningTargets
         }
     }
 }

--- a/Sources/TuistGraphTesting/Models/Config+TestData.swift
+++ b/Sources/TuistGraphTesting/Models/Config+TestData.swift
@@ -29,12 +29,14 @@ extension Config.GenerationOptions {
     public static func test(
         resolveDependenciesWithSystemScm: Bool = false,
         disablePackageVersionLocking: Bool = false,
-        clonedSourcePackagesDirPath: AbsolutePath? = nil
+        clonedSourcePackagesDirPath: AbsolutePath? = nil,
+        staticSideEffectsWarningTargets: TuistGraph.Config.GenerationOptions.StaticSideEffectsWarningTargets = .all
     ) -> Self {
         .init(
             resolveDependenciesWithSystemScm: resolveDependenciesWithSystemScm,
             disablePackageVersionLocking: disablePackageVersionLocking,
-            clonedSourcePackagesDirPath: clonedSourcePackagesDirPath
+            clonedSourcePackagesDirPath: clonedSourcePackagesDirPath,
+            staticSideEffectsWarningTargets: staticSideEffectsWarningTargets
         )
     }
 }

--- a/Sources/TuistKit/Generator/Generator.swift
+++ b/Sources/TuistKit/Generator/Generator.swift
@@ -94,7 +94,7 @@ public class Generator: Generating {
         try environmentIssues.printAndThrowErrorsIfNeeded()
         lintingIssues.append(contentsOf: environmentIssues)
 
-        let graphIssues = graphLinter.lint(graphTraverser: graphTraverser)
+        let graphIssues = graphLinter.lint(graphTraverser: graphTraverser, config: config)
         try graphIssues.printAndThrowErrorsIfNeeded()
         lintingIssues.append(contentsOf: graphIssues)
     }

--- a/Sources/TuistLoader/Models+ManifestMappers/Config+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Config+ManifestMapper.swift
@@ -67,7 +67,25 @@ extension TuistGraph.Config.GenerationOptions {
         return .init(
             resolveDependenciesWithSystemScm: manifest.resolveDependenciesWithSystemScm,
             disablePackageVersionLocking: manifest.disablePackageVersionLocking,
-            clonedSourcePackagesDirPath: clonedSourcePackagesDirPath
+            clonedSourcePackagesDirPath: clonedSourcePackagesDirPath,
+            staticSideEffectsWarningTargets: TuistGraph.Config.GenerationOptions.StaticSideEffectsWarningTargets
+                .from(manifest: manifest.staticSideEffectsWarningTargets)
         )
+    }
+}
+
+extension TuistGraph.Config.GenerationOptions.StaticSideEffectsWarningTargets {
+    /// Maps a ProjectDescription.Config.GenerationOptions.StaticSideEffectsWarningTargets instance into a
+    /// TuistGraph.Config.GenerationOptions.StaticSideEffectsWarningTargets model.
+    /// - Parameters:
+    ///   - manifest: Manifest representation of Tuist config static side effects warning targets option
+    static func from(
+        manifest: ProjectDescription.Config.GenerationOptions.StaticSideEffectsWarningTargets
+    ) -> TuistGraph.Config.GenerationOptions.StaticSideEffectsWarningTargets {
+        switch manifest {
+        case .all: return .all
+        case .none: return .none
+        case let .excluding(excludedTargets): return .excluding(excludedTargets)
+        }
     }
 }

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -40,10 +40,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             GraphDependency.testFramework(path: frameworkAPath): Set(),
             GraphDependency.testFramework(path: frameworkBPath): Set(),
         ])
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let result = subject.lint(graphTraverser: graphTraverser)
+        let result = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(
@@ -59,10 +60,11 @@ final class GraphLinterTests: TuistUnitTestCase {
         let versionStub = Version(10, 0, 0)
         xcodeController.selectedVersionStub = .success(versionStub)
         let graph = Graph.test(packages: [path: ["package": package]])
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let result = subject.lint(graphTraverser: graphTraverser)
+        let result = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         let reason =
@@ -77,10 +79,11 @@ final class GraphLinterTests: TuistUnitTestCase {
         let versionStub = Version(11, 0, 0)
         xcodeController.selectedVersionStub = .success(versionStub)
         let graph = Graph.test(packages: [path: ["package": package]])
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let result = subject.lint(graphTraverser: graphTraverser)
+        let result = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         let reason =
@@ -95,10 +98,11 @@ final class GraphLinterTests: TuistUnitTestCase {
         let error = NSError.test()
         xcodeController.selectedVersionStub = .failure(error)
         let graph = Graph.test(packages: [path: ["package": package]])
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let result = subject.lint(graphTraverser: graphTraverser)
+        let result = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(result.contains(LintingIssue(reason: "Could not determine Xcode version", severity: .error)))
@@ -141,10 +145,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let result = subject.lint(graphTraverser: graphTraverser)
+        let result = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(result.isEmpty)
@@ -187,10 +192,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let result = subject.lint(graphTraverser: graphTraverser)
+        let result = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(result.isEmpty)
@@ -236,10 +242,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let result = subject.lint(graphTraverser: graphTraverser)
+        let result = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(result.isEmpty)
@@ -266,10 +273,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let result = subject.lint(graphTraverser: graphTraverser)
+        let result = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(result.isEmpty)
@@ -296,10 +304,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let result = subject.lint(graphTraverser: graphTraverser)
+        let result = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(result.isEmpty)
@@ -341,10 +350,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let result = subject.lint(graphTraverser: graphTraverser)
+        let result = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(result, [])
@@ -374,10 +384,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let result = subject.lint(graphTraverser: graphTraverser)
+        let result = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(result.isEmpty)
@@ -407,10 +418,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let result = subject.lint(graphTraverser: graphTraverser)
+        let result = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(result.isEmpty)
@@ -446,10 +458,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let result = subject.lint(graphTraverser: graphTraverser)
+        let result = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertFalse(result.isEmpty)
@@ -476,10 +489,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let result = subject.lint(graphTraverser: graphTraverser)
+        let result = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(result.isEmpty)
@@ -506,10 +520,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let result = subject.lint(graphTraverser: graphTraverser)
+        let result = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertFalse(result.isEmpty)
@@ -543,10 +558,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             targets: [path: [watchApp.name: watchApp, watchAppTests.name: watchAppTests]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(got.isEmpty)
@@ -580,10 +596,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             targets: [path: [staticLibrary.name: staticLibrary, watchAppTests.name: watchAppTests]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(got.isEmpty)
@@ -617,10 +634,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             targets: [path: [framework.name: framework, watchAppTests.name: watchAppTests]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(got.isEmpty)
@@ -654,10 +672,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             targets: [path: [staticFramework.name: staticFramework, watchAppTests.name: watchAppTests]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(got.isEmpty)
@@ -712,10 +731,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             ],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(got.isEmpty)
@@ -761,10 +781,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             ],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(got.isEmpty)
@@ -807,10 +828,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             ],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(got.isEmpty)
@@ -865,10 +887,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             ],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let result = subject.lint(graphTraverser: graphTraverser)
+        let result = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(result, [
@@ -939,10 +962,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             ],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let result = subject.lint(graphTraverser: graphTraverser)
+        let result = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(result, [
@@ -1015,10 +1039,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             ],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let result = subject.lint(graphTraverser: graphTraverser)
+        let result = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(result, [])
@@ -1059,10 +1084,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             targets: [path: [app.name: app, watchApp.name: watchApp, watchExtension.name: watchExtension]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(got.isEmpty)
@@ -1103,10 +1129,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             targets: [path: [app.name: app, watchApp.name: watchApp, watchExtension.name: watchExtension]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(got, [
@@ -1156,10 +1183,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             targets: [temporaryPath: [app.name: app, appClip.name: appClip]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(got.isEmpty)
@@ -1201,10 +1229,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             targets: [temporaryPath: [app.name: app, appClip.name: appClip]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(got, [
@@ -1243,10 +1272,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             targets: [path: [app.name: app, appClip.name: appClip]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(got, [
@@ -1286,10 +1316,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             targets: [path: [app.name: app, appClip.name: appClip]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(got, [
@@ -1352,10 +1383,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             targets: [temporaryPath: [app.name: app, appClip1.name: appClip1, appClip2.name: appClip2]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(got, [
@@ -1405,10 +1437,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             targets: [temporaryPath: [app.name: app, appClip.name: appClip, framework.name: framework]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEmpty(got)
@@ -1444,10 +1477,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             targets: [path: [tool.name: tool, dynamic.name: dynamic]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEmpty(got)
@@ -1483,10 +1517,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             targets: [path: [tool.name: tool, dynamic.name: dynamic]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEmpty(got)
@@ -1533,10 +1568,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             targets: [path: [tool.name: tool, staticFmwk.name: staticFmwk, staticLib.name: staticLib]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEmpty(got)
@@ -1575,10 +1611,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             ],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEmpty(got)
@@ -1620,10 +1657,11 @@ final class GraphLinterTests: TuistUnitTestCase {
             ],
             dependencies: [:]
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEmpty(got)
@@ -1631,10 +1669,11 @@ final class GraphLinterTests: TuistUnitTestCase {
 
     func test_lintCodeCoverage_none() {
         // Given
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: .test())
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEmpty(got)
@@ -1642,6 +1681,7 @@ final class GraphLinterTests: TuistUnitTestCase {
 
     func test_lintCodeCoverage_all() {
         // Given
+        let config = Config.test()
         let graphTraverser = GraphTraverser(
             graph: .test(
                 workspace: .test(
@@ -1653,7 +1693,7 @@ final class GraphLinterTests: TuistUnitTestCase {
         )
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEmpty(got)
@@ -1694,10 +1734,11 @@ final class GraphLinterTests: TuistUnitTestCase {
                 ],
             ]
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEmpty(got)
@@ -1705,6 +1746,7 @@ final class GraphLinterTests: TuistUnitTestCase {
 
     func test_lintCodeCoverage_relevant_notConfigured() {
         // Given
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: .test(
             workspace: .test(
                 generationOptions: .test(
@@ -1714,7 +1756,7 @@ final class GraphLinterTests: TuistUnitTestCase {
         ))
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(
@@ -1755,10 +1797,11 @@ final class GraphLinterTests: TuistUnitTestCase {
                 ],
             ]
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEmpty(got)
@@ -1766,6 +1809,7 @@ final class GraphLinterTests: TuistUnitTestCase {
 
     func test_lintCodeCoverage_targets_empty() {
         // Given
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: .test(
             workspace: .test(
                 generationOptions: .test(
@@ -1775,7 +1819,7 @@ final class GraphLinterTests: TuistUnitTestCase {
         ))
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(
@@ -1816,10 +1860,11 @@ final class GraphLinterTests: TuistUnitTestCase {
                 ],
             ]
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let got = subject.lint(graphTraverser: graphTraverser)
+        let got = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(
@@ -1861,10 +1906,11 @@ final class GraphLinterTests: TuistUnitTestCase {
                 .target(name: macOnlyTarget.name, path: path): [],
             ]
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(results.isEmpty)
@@ -1898,10 +1944,11 @@ final class GraphLinterTests: TuistUnitTestCase {
                 .target(name: watchOnlyTarget.name, path: path): [],
             ]
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertFalse(results.isEmpty)

--- a/Tests/TuistGeneratorTests/Linter/Mocks/MockStaticProductsGraphLinter.swift
+++ b/Tests/TuistGeneratorTests/Linter/Mocks/MockStaticProductsGraphLinter.swift
@@ -1,19 +1,20 @@
 import Foundation
 import TuistCore
+import TuistGraph
 @testable import TuistGenerator
 
 class MockStaticProductsGraphLinter: StaticProductsGraphLinting {
     var invokedLint = false
     var invokedLintCount = 0
-    var invokedLintParameters: (graphTraverser: GraphTraversing, Void)?
-    var invokedLintParametersList = [(graphTraverser: GraphTraversing, Void)]()
+    var invokedLintParameters: (graphTraverser: GraphTraversing, config: Config)?
+    var invokedLintParametersList = [(graphTraverser: GraphTraversing, config: Config)]()
     var stubbedLintResult: [LintingIssue]! = []
 
-    func lint(graphTraverser: GraphTraversing) -> [LintingIssue] {
+    func lint(graphTraverser: GraphTraversing, config: Config) -> [LintingIssue] {
         invokedLint = true
         invokedLintCount += 1
-        invokedLintParameters = (graphTraverser, ())
-        invokedLintParametersList.append((graphTraverser, ()))
+        invokedLintParameters = (graphTraverser, config)
+        invokedLintParametersList.append((graphTraverser, config))
         return stubbedLintResult
     }
 }

--- a/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
@@ -46,10 +46,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(results, [
@@ -83,10 +84,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(results.isEmpty)
@@ -120,10 +122,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(results, [
@@ -158,10 +161,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(results, [
@@ -213,10 +217,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(results, [
@@ -268,10 +273,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(results, [
@@ -318,10 +324,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(results, [
@@ -357,10 +364,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertFalse(results.isEmpty)
@@ -410,10 +418,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(results.isEmpty)
@@ -446,10 +455,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(results.isEmpty)
@@ -486,10 +496,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(results, [
@@ -524,10 +535,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(results.isEmpty)
@@ -618,10 +630,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(results.isEmpty)
@@ -654,10 +667,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(results.isEmpty)
@@ -728,10 +742,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(results, [
@@ -776,10 +791,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(results, [
@@ -819,10 +835,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
 
@@ -864,10 +881,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(results, [
@@ -908,10 +926,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(results, [
@@ -948,10 +967,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(results.isEmpty)
@@ -989,10 +1009,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(results, [
@@ -1028,10 +1049,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(results.isEmpty)
@@ -1069,10 +1091,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(results, [
@@ -1110,10 +1133,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertTrue(results.isEmpty)
@@ -1153,10 +1177,11 @@ class StaticProductsGraphLinterTests: XCTestCase {
             ]],
             dependencies: dependencies
         )
+        let config = Config.test()
         let graphTraverser = GraphTraverser(graph: graph)
 
         // When
-        let results = subject.lint(graphTraverser: graphTraverser)
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
         XCTAssertEqual(results, [

--- a/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
+++ b/Tests/TuistIntegrationTests/Generator/MultipleConfigurationsIntegrationTests.swift
@@ -337,10 +337,11 @@ final class MultipleConfigurationsIntegrationTests: TuistUnitTestCase {
         let writer = XcodeProjWriter()
         let linter = GraphLinter()
         let graphLoader = GraphLoader()
+        let config = Config.test()
 
         let graph = try graphLoader.loadWorkspace(workspace: models.workspace, projects: models.projects)
         let graphTraverser = GraphTraverser(graph: graph)
-        try linter.lint(graphTraverser: graphTraverser).printAndThrowErrorsIfNeeded()
+        try linter.lint(graphTraverser: graphTraverser, config: config).printAndThrowErrorsIfNeeded()
         let descriptor = try subject.generateWorkspace(graphTraverser: graphTraverser)
         try writer.write(workspace: descriptor)
     }

--- a/Tests/TuistKitIntegrationTests/Commands/DumpServiceIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Commands/DumpServiceIntegrationTests.swift
@@ -171,7 +171,12 @@ final class DumpServiceTests: TuistTestCase {
           },
           "generationOptions": {
             "disablePackageVersionLocking": false,
-            "resolveDependenciesWithSystemScm": false
+            "resolveDependenciesWithSystemScm": false,
+            "staticSideEffectsWarningTargets": {
+              "all": {
+
+              }
+            }
           },
           "plugins": [
 

--- a/Tuist/Config.swift
+++ b/Tuist/Config.swift
@@ -6,6 +6,7 @@ let config = Config(
         url: "https://cloud.tuist.io",
         options: [.optional]
     ),
-    swiftVersion: .init("5.8"),
-    generationOptions: .options(staticSideEffectsWarningTargets: .none)
+    swiftVersion: .init("5.8")
+    // TODO: Enable after https://github.com/tuist/tuist/pull/5632 is merged
+    // generationOptions: .options(staticSideEffectsWarningTargets: .none)
 )

--- a/Tuist/Config.swift
+++ b/Tuist/Config.swift
@@ -6,5 +6,6 @@ let config = Config(
         url: "https://cloud.tuist.io",
         options: [.optional]
     ),
-    swiftVersion: .init("5.8")
+    swiftVersion: .init("5.8"),
+    generationOptions: .options(staticSideEffectsWarningTargets: .none)
 )

--- a/Tuist/Config.swift
+++ b/Tuist/Config.swift
@@ -7,6 +7,4 @@ let config = Config(
         options: [.optional]
     ),
     swiftVersion: .init("5.8")
-    // TODO: Enable after https://github.com/tuist/tuist/pull/5632 is merged
-    // generationOptions: .options(staticSideEffectsWarningTargets: .none)
 )


### PR DESCRIPTION
### Short description 📝
Tuist outputs a warning when there are transitive static dependencies that might lead to side effects like an increase in bundle size. When the team using Tuist knows what they are doing, like it's the case with the Tuist project itself, those warnings become too noisy and therefore it becomes necessary for an API configure the behaviour.

This PR adds a new generation option to configure it:

```swift
let config = Config(generationOptions: .options(staticSideEffectsWarningTargets: .none))
```

### How to test the changes locally 🧐

You'll have to bundle a new version of Tuist and the companion dynamic frameworks, and run it against Tuist.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
