### PR TITLE
Adding automatic release for the ProjectDescription swift package

### DIFF
--- a/.github/workflows/deploy-project-description.yml
+++ b/.github/workflows/deploy-project-description.yml
@@ -1,0 +1,16 @@
+name: Project Description Deployment
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  GITHUB_ACCESS_TOKEN: ${{ secrets.DEPLOY_GITHUB_ACCESS_TOKEN }}
+  TARGET_REPO_NAME: tuist/ProjectDescription
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy Project Description
+        run: ./make/tasks/tuist/release-project-description.sh

--- a/make/tasks/tuist/release-project-description.sh
+++ b/make/tasks/tuist/release-project-description.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Env vars
+access_token="$GITHUB_ACCESS_TOKEN"
+if [ -z "$access_token" ]; then
+    echo "No access token, cannot authenticate with GitHub. Please set GITHUB_ACCESS_TOKEN environment variable"
+    exit 1
+fi
+
+target_repo_name="$TARGET_REPO_NAME"
+if [ -z "$target_repo_name" ]; then
+    echo "No target repo name, please set TARGET_REPO_NAME environment variable"
+    exit 1
+fi
+
+# Constants
+git_email="${TUIST_GIT_EMAIL:-}"
+git_user="${GITHUB_REPOSITORY_OWNER:-}"
+
+_get_tag() {
+    # Fetch all tags from the repository
+    git fetch --tags >/dev/null 2>&1
+
+    # Get the last tag using git describe
+    last_tag=$(git describe --tags --abbrev=0 2>/dev/null)
+
+    if [ -z "$last_tag" ]; then
+        echo "Could not find a tag"
+        exit 1
+    fi
+    echo "$last_tag"
+}
+
+tag=$(_get_tag)
+echo "Releasing with tag $tag"
+
+# Cloning ProjectDescription project
+target_repo_url="https://github.com/$target_repo_name"
+echo "Cloning $target_repo_url"
+git clone $target_repo_url
+repo_name=$(echo "$target_repo_url" | awk -F'/' '{print $(NF-0)}' | sed 's/.git$//')
+cd "$repo_name" || exit
+
+# git remote set-url origin target_repo_url
+git remote set-url origin https://$git_user:$access_token@github.com/$target_repo_name
+git config --local user.email $git_email
+git config --local user.name $git_user
+
+echo "Releasing new version of Project Descriptin with tag=$tag"
+ls -l
+./release.sh "$tag"


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY

### Short description 📝

Creating a new release for the ProjectDescription repo when a new release tag is tagged to the main
Notes:
- Depends on settings a git hub access token to push to another repo
- based the ProjectDescription repo tagging on the `release.sh` script in the repo

### How to test the changes locally 🧐

- Clone the repo and checkout to the relevant branch
- Run `chmod +x make/tasks/tuist/release-project-description.sh`
- Run `./make/tasks/tuist/release-project-description.sh`

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
