### PR TITLE
Add flag to opt out from beautifying `xcodebuild` logs

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -90,6 +90,8 @@ jobs:
           restore-keys: spm-v1-${{ hashFiles('Package.resolved') }}
       - name: Fetch dependencies
         run: tuist fetch
+      - name: Print hashes
+        run: tuist cache print-hashes
       - name: Cache warm
         run: tuist cache warm
 
@@ -109,6 +111,8 @@ jobs:
           restore-keys: spm-v1-${{ hashFiles('Package.resolved') }}
       - name: Fetch dependencies
         run: tuist fetch
+      - name: Print hashes
+        run: tuist cache print-hashes
       - name: Cache warm
         run: tuist cache warm
 

--- a/Sources/TuistAutomation/Utilities/TargetBuilder.swift
+++ b/Sources/TuistAutomation/Utilities/TargetBuilder.swift
@@ -18,6 +18,7 @@ public protocol TargetBuilding {
     ///   - device: An optional device specifier to use when building the scheme.
     ///   - osVersion: An optional OS number to use when building the scheme.
     ///   - graphTraverser: The Graph traverser.
+    ///   - rawXcodebuildLogs: When true, it outputs the raw xcodebuild logs.
     func buildTarget(
         _ target: GraphTarget,
         platform: TuistGraph.Platform,
@@ -30,7 +31,8 @@ public protocol TargetBuilding {
         device: String?,
         osVersion: Version?,
         rosetta: Bool,
-        graphTraverser: GraphTraversing
+        graphTraverser: GraphTraversing,
+        rawXcodebuildLogs: Bool
     ) async throws
 }
 
@@ -87,7 +89,8 @@ public final class TargetBuilder: TargetBuilding {
         device: String?,
         osVersion: Version?,
         rosetta: Bool,
-        graphTraverser: GraphTraversing
+        graphTraverser: GraphTraversing,
+        rawXcodebuildLogs: Bool
     ) async throws {
         logger.log(level: .notice, "Building scheme \(scheme.name)", metadata: .section)
 
@@ -116,7 +119,8 @@ public final class TargetBuilder: TargetBuilding {
                 rosetta: rosetta,
                 derivedDataPath: derivedDataPath,
                 clean: clean,
-                arguments: buildArguments
+                arguments: buildArguments,
+                rawXcodebuildLogs: rawXcodebuildLogs
             )
             .printFormattedOutput()
 

--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -17,15 +17,18 @@ public final class XcodeBuildController: XcodeBuildControlling {
     )
 
     private let formatter: Formatting
-
+    private let environment: Environmenting
+    
     public convenience init() {
-        self.init(formatter: Formatter())
+        self.init(formatter: Formatter(), environment: Environment.shared)
     }
 
     init(
-        formatter: Formatting
+        formatter: Formatting,
+        environment: Environmenting
     ) {
         self.formatter = formatter
+        self.environment = environment
     }
 
     public func build(
@@ -292,14 +295,14 @@ public final class XcodeBuildController: XcodeBuildControlling {
                 switch event {
                 case let .standardError(errorData):
                     guard let line = String(data: errorData, encoding: .utf8) else { return nil }
-                    if rawXcodebuildLogs {
+                    if rawXcodebuildLogs || self?.environment.isVerbose == true {
                         return SystemEvent.standardError(XcodeBuildOutput(raw: line))
                     } else {
                         return SystemEvent.standardError(XcodeBuildOutput(raw: self?.formatter.format(line) ?? ""))
                     }
                 case let .standardOutput(outputData):
                     guard let line = String(data: outputData, encoding: .utf8) else { return nil }
-                    if rawXcodebuildLogs {
+                    if rawXcodebuildLogs || self?.environment.isVerbose == true {
                         return SystemEvent.standardOutput(XcodeBuildOutput(raw: line))
                     } else {
                         return SystemEvent.standardOutput(XcodeBuildOutput(raw: self?.formatter.format(line) ?? ""))

--- a/Sources/TuistAutomationTesting/Utilities/MockTargetBuilder.swift
+++ b/Sources/TuistAutomationTesting/Utilities/MockTargetBuilder.swift
@@ -18,7 +18,8 @@ public final class MockTargetBuilder: TargetBuilding {
         String?,
         Version?,
         Bool,
-        GraphTraversing
+        GraphTraversing,
+        Bool
     ) throws -> Void)?
 
     public func buildTarget(
@@ -33,7 +34,8 @@ public final class MockTargetBuilder: TargetBuilding {
         device: String?,
         osVersion: Version?,
         rosetta: Bool,
-        graphTraverser: GraphTraversing
+        graphTraverser: GraphTraversing,
+        rawXcodebuildLogs: Bool
     ) throws {
         try buildTargetStub?(
             target,
@@ -46,7 +48,8 @@ public final class MockTargetBuilder: TargetBuilding {
             device,
             osVersion,
             rosetta,
-            graphTraverser
+            graphTraverser,
+            rawXcodebuildLogs
         )
     }
 }

--- a/Sources/TuistCore/Automation/Extensions/AsyncThrowingStream+XcodeBuildOutput.swift
+++ b/Sources/TuistCore/Automation/Extensions/AsyncThrowingStream+XcodeBuildOutput.swift
@@ -13,7 +13,7 @@ extension AsyncThrowingStream where Element == SystemEvent<XcodeBuildOutput> {
             case let .standardOutput(output):
                 let lines = output.raw.split(separator: "\n")
                 for line in lines where !line.isEmpty {
-                    logger.notice("\(line)")
+                    logger.info("\(line)")
                 }
             }
         }

--- a/Sources/TuistCore/Automation/XcodeBuildControlling.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildControlling.swift
@@ -16,6 +16,7 @@ public protocol XcodeBuildControlling {
     ///   to determine the destination.
     ///   - clean: True if xcodebuild should clean the project before building.
     ///   - arguments: Extra xcodebuild arguments.
+    ///   - rawXcodebuildLogs: When true, it outputs the raw xcodebuild logs.
     func build(
         _ target: XcodeBuildTarget,
         scheme: String,
@@ -23,7 +24,8 @@ public protocol XcodeBuildControlling {
         rosetta: Bool,
         derivedDataPath: AbsolutePath?,
         clean: Bool,
-        arguments: [XcodeBuildArgument]
+        arguments: [XcodeBuildArgument],
+        rawXcodebuildLogs: Bool
     ) throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error>
 
     /// Returns an observable to test the given project using xcodebuild.
@@ -38,6 +40,7 @@ public protocol XcodeBuildControlling {
     ///   - testTargets: A list of test identifiers indicating which tests to run
     ///   - skipTestTargets: A list of test identifiers indicating which tests to skip
     ///   - testPlanConfiguration: A configuration object indicating which test plan to use and its configurations
+    ///   - rawXcodebuildLogs: When true, it outputs the raw xcodebuild logs.
     func test(
         _ target: XcodeBuildTarget,
         scheme: String,
@@ -50,7 +53,8 @@ public protocol XcodeBuildControlling {
         retryCount: Int,
         testTargets: [TestIdentifier],
         skipTestTargets: [TestIdentifier],
-        testPlanConfiguration: TestPlanConfiguration?
+        testPlanConfiguration: TestPlanConfiguration?,
+        rawXcodebuildLogs: Bool
     ) throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error>
 
     /// Returns an observable that archives the given project using xcodebuild.
@@ -60,19 +64,22 @@ public protocol XcodeBuildControlling {
     ///   - clean: True if xcodebuild should clean the project before archiving.
     ///   - archivePath: Path where the archive will be exported (with extension .xcarchive)
     ///   - arguments: Extra xcodebuild arguments.
+    ///   - rawXcodebuildLogs: When true, it outputs the raw xcodebuild logs.
     func archive(
         _ target: XcodeBuildTarget,
         scheme: String,
         clean: Bool,
         archivePath: AbsolutePath,
-        arguments: [XcodeBuildArgument]
+        arguments: [XcodeBuildArgument],
+        rawXcodebuildLogs: Bool
     ) throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error>
 
     /// Creates an .xcframework combining the list of given frameworks.
     /// - Parameters:
     ///   - frameworks: Frameworks to be combined.
     ///   - output: Path to the output .xcframework.
-    func createXCFramework(frameworks: [AbsolutePath], output: AbsolutePath)
+    ///   - rawXcodebuildLogs: When true, it outputs the raw xcodebuild logs.
+    func createXCFramework(frameworks: [AbsolutePath], output: AbsolutePath, rawXcodebuildLogs: Bool)
         throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error>
 
     /// Gets the build settings of a scheme targets.

--- a/Sources/TuistCoreTesting/Automation/MockXcodeBuildController.swift
+++ b/Sources/TuistCoreTesting/Automation/MockXcodeBuildController.swift
@@ -12,7 +12,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         Bool,
         AbsolutePath?,
         Bool,
-        [XcodeBuildArgument]
+        [XcodeBuildArgument],
+        Bool
     ) -> [SystemEvent<XcodeBuildOutput>])?
 
     func build(
@@ -22,7 +23,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         rosetta: Bool,
         derivedDataPath: AbsolutePath?,
         clean: Bool,
-        arguments: [XcodeBuildArgument]
+        arguments: [XcodeBuildArgument],
+        rawXcodebuildLogs: Bool
     ) -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         if let buildStub {
             return buildStub(
@@ -32,7 +34,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
                 rosetta,
                 derivedDataPath,
                 clean,
-                arguments
+                arguments,
+                rawXcodebuildLogs
             ).asAsyncThrowingStream()
         } else {
             return AsyncThrowingStream {
@@ -56,7 +59,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
             Int,
             [TestIdentifier],
             [TestIdentifier],
-            TestPlanConfiguration?
+            TestPlanConfiguration?,
+            Bool
         )
             -> [SystemEvent<XcodeBuildOutput>]
     )?
@@ -73,7 +77,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         retryCount: Int,
         testTargets: [TestIdentifier],
         skipTestTargets: [TestIdentifier],
-        testPlanConfiguration: TestPlanConfiguration?
+        testPlanConfiguration: TestPlanConfiguration?,
+        rawXcodebuildLogs: Bool
     ) -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         if let testStub {
             let results = testStub(
@@ -88,7 +93,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
                 retryCount,
                 testTargets,
                 skipTestTargets,
-                testPlanConfiguration
+                testPlanConfiguration,
+                rawXcodebuildLogs
             )
             if let testErrorStub {
                 return AsyncThrowingStream {
@@ -107,7 +113,7 @@ final class MockXcodeBuildController: XcodeBuildControlling {
     }
 
     var archiveStub: (
-        (XcodeBuildTarget, String, Bool, AbsolutePath, [XcodeBuildArgument])
+        (XcodeBuildTarget, String, Bool, AbsolutePath, [XcodeBuildArgument], Bool)
             -> [SystemEvent<XcodeBuildOutput>]
     )?
     func archive(
@@ -115,10 +121,11 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         scheme: String,
         clean: Bool,
         archivePath: AbsolutePath,
-        arguments: [XcodeBuildArgument]
+        arguments: [XcodeBuildArgument],
+        rawXcodebuildLogs: Bool
     ) -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         if let archiveStub {
-            return archiveStub(target, scheme, clean, archivePath, arguments).asAsyncThrowingStream()
+            return archiveStub(target, scheme, clean, archivePath, arguments, rawXcodebuildLogs).asAsyncThrowingStream()
         } else {
             return AsyncThrowingStream {
                 throw TestError(
@@ -128,13 +135,14 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         }
     }
 
-    var createXCFrameworkStub: (([AbsolutePath], AbsolutePath) -> [SystemEvent<XcodeBuildOutput>])?
+    var createXCFrameworkStub: (([AbsolutePath], AbsolutePath, Bool) -> [SystemEvent<XcodeBuildOutput>])?
     func createXCFramework(
         frameworks: [AbsolutePath],
-        output: AbsolutePath
+        output: AbsolutePath,
+        rawXcodebuildLogs: Bool
     ) -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         if let createXCFrameworkStub {
-            return createXCFrameworkStub(frameworks, output).asAsyncThrowingStream()
+            return createXCFrameworkStub(frameworks, output, rawXcodebuildLogs).asAsyncThrowingStream()
         } else {
             return AsyncThrowingStream {
                 throw TestError(

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -76,6 +76,12 @@ public struct BuildCommand: AsyncParsableCommand {
     )
     var derivedDataPath: String?
 
+    @Flag(
+        name: [.customLong("raw-xcodebuild-logs"), .customShort("P")],
+        help: "When passed, it outputs the raw xcodebuild logs without formatting them."
+    )
+    var rawXcodebuildLogs: Bool = false
+
     public func run() async throws {
         let absolutePath: AbsolutePath
         if let path {
@@ -95,7 +101,8 @@ public struct BuildCommand: AsyncParsableCommand {
             device: device,
             platform: platform,
             osVersion: os,
-            rosetta: rosetta
+            rosetta: rosetta,
+            rawXcodebuildLogs: rawXcodebuildLogs
         )
     }
 }

--- a/Sources/TuistKit/Commands/RunCommand.swift
+++ b/Sources/TuistKit/Commands/RunCommand.swift
@@ -64,6 +64,12 @@ struct RunCommand: AsyncParsableCommand {
     )
     var arguments: [String] = []
 
+    @Flag(
+        name: [.customLong("raw-xcodebuild-logs"), .customShort("P")],
+        help: "When passed, it outputs the raw xcodebuild logs without formatting them."
+    )
+    var rawXcodebuildLogs: Bool = false
+
     func run() async throws {
         try await RunService().run(
             path: path,
@@ -74,7 +80,8 @@ struct RunCommand: AsyncParsableCommand {
             device: device,
             version: os,
             rosetta: rosetta,
-            arguments: arguments
+            arguments: arguments,
+            rawXcodebuildLogs: rawXcodebuildLogs
         )
     }
 }

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -124,6 +124,12 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
     )
     var skipConfigurations: [String] = []
 
+    @Flag(
+        name: [.customLong("raw-xcodebuild-logs"), .customShort("P")],
+        help: "When passed, it outputs the raw xcodebuild logs without formatting them."
+    )
+    var rawXcodebuildLogs: Bool = false
+
     public func validate() throws {
         try TestService().validateParameters(
             testTargets: testTargets,
@@ -167,7 +173,8 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
                     skipConfigurations: skipConfigurations
                 )
             },
-            validateTestTargetsParameters: false
+            validateTestTargetsParameters: false,
+            rawXcodebuildLogs: rawXcodebuildLogs
         )
     }
 }

--- a/Sources/TuistKit/Services/BuildService.swift
+++ b/Sources/TuistKit/Services/BuildService.swift
@@ -60,7 +60,8 @@ final class BuildService {
         device: String?,
         platform: String?,
         osVersion: String?,
-        rosetta: Bool
+        rosetta: Bool,
+        rawXcodebuildLogs: Bool
     ) async throws {
         let graph: Graph
         let generator = generatorFactory.default()
@@ -118,7 +119,8 @@ final class BuildService {
                 device: device,
                 osVersion: osVersion?.version(),
                 rosetta: rosetta,
-                graphTraverser: graphTraverser
+                graphTraverser: graphTraverser,
+                rawXcodebuildLogs: rawXcodebuildLogs
             )
         } else {
             var cleaned = false
@@ -149,7 +151,8 @@ final class BuildService {
                     device: device,
                     osVersion: osVersion?.version(),
                     rosetta: rosetta,
-                    graphTraverser: graphTraverser
+                    graphTraverser: graphTraverser,
+                    rawXcodebuildLogs: rawXcodebuildLogs
                 )
                 cleaned = true
             }

--- a/Sources/TuistKit/Services/RunService.swift
+++ b/Sources/TuistKit/Services/RunService.swift
@@ -66,7 +66,8 @@ final class RunService {
         device: String?,
         version: String?,
         rosetta: Bool,
-        arguments: [String]
+        arguments: [String],
+        rawXcodebuildLogs: Bool
     ) async throws {
         let runPath: AbsolutePath
         if let path {
@@ -115,7 +116,8 @@ final class RunService {
             device: device,
             osVersion: version?.version(),
             rosetta: rosetta,
-            graphTraverser: graphTraverser
+            graphTraverser: graphTraverser,
+            rawXcodebuildLogs: rawXcodebuildLogs
         )
 
         let minVersion: Version?

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -169,7 +169,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
         skipTestTargets: [TestIdentifier],
         testPlanConfiguration: TestPlanConfiguration?,
         validateTestTargetsParameters: Bool = true,
-        generator: Generating? = nil
+        generator: Generating? = nil,
+        rawXcodebuildLogs: Bool
     ) async throws {
         if validateTestTargetsParameters {
             try validateParameters(
@@ -255,7 +256,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
                     retryCount: retryCount,
                     testTargets: testTargets,
                     skipTestTargets: skipTestTargets,
-                    testPlanConfiguration: testPlanConfiguration
+                    testPlanConfiguration: testPlanConfiguration,
+                    rawXcodebuildLogs: rawXcodebuildLogs
                 )
             }
         } else {
@@ -284,7 +286,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
                     retryCount: retryCount,
                     testTargets: testTargets,
                     skipTestTargets: skipTestTargets,
-                    testPlanConfiguration: testPlanConfiguration
+                    testPlanConfiguration: testPlanConfiguration,
+                    rawXcodebuildLogs: rawXcodebuildLogs
                 )
             }
         }
@@ -327,7 +330,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
         retryCount: Int,
         testTargets: [TestIdentifier],
         skipTestTargets: [TestIdentifier],
-        testPlanConfiguration: TestPlanConfiguration?
+        testPlanConfiguration: TestPlanConfiguration?,
+        rawXcodebuildLogs: Bool
     ) async throws {
         logger.log(level: .notice, "Testing scheme \(scheme.name)", metadata: .section)
         if let testPlan = testPlanConfiguration?.testPlan, let testPlans = scheme.testAction?.testPlans,
@@ -384,7 +388,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
             retryCount: retryCount,
             testTargets: testTargets,
             skipTestTargets: skipTestTargets,
-            testPlanConfiguration: testPlanConfiguration
+            testPlanConfiguration: testPlanConfiguration,
+            rawXcodebuildLogs: rawXcodebuildLogs
         )
         .printFormattedOutput()
     }

--- a/Tests/TuistAutomationTests/Utilities/TargetBuilderTests.swift
+++ b/Tests/TuistAutomationTests/Utilities/TargetBuilderTests.swift
@@ -82,7 +82,7 @@ final class TargetBuilderTests: TuistUnitTestCase {
             buildArguments
         }
 
-        xcodeBuildController.buildStub = { _workspace, _scheme, _destination, _rosetta, _, _clean, _buildArguments in
+        xcodeBuildController.buildStub = { _workspace, _scheme, _destination, _rosetta, _, _clean, _buildArguments, _ in
             XCTAssertEqual(_workspace.path, workspacePath)
             XCTAssertEqual(_scheme, scheme.name)
             XCTAssertEqual(_destination, destination)
@@ -105,7 +105,8 @@ final class TargetBuilderTests: TuistUnitTestCase {
             device: device,
             osVersion: version,
             rosetta: rosetta,
-            graphTraverser: MockGraphTraverser()
+            graphTraverser: MockGraphTraverser(),
+            rawXcodebuildLogs: false
         )
     }
 
@@ -117,7 +118,7 @@ final class TargetBuilderTests: TuistUnitTestCase {
         let workspacePath = try AbsolutePath(validating: "/path/to/project.xcworkspace")
         let graphTraverser = MockGraphTraverser()
 
-        xcodeBuildController.buildStub = { _, _, _, _, _, _, _ in
+        xcodeBuildController.buildStub = { _, _, _, _, _, _, _, _ in
             [.standardOutput(.init(raw: "success"))]
         }
 
@@ -141,7 +142,8 @@ final class TargetBuilderTests: TuistUnitTestCase {
             device: nil,
             osVersion: nil,
             rosetta: false,
-            graphTraverser: graphTraverser
+            graphTraverser: graphTraverser,
+            rawXcodebuildLogs: false
         )
 
         // Then
@@ -168,7 +170,7 @@ final class TargetBuilderTests: TuistUnitTestCase {
         let workspacePath = try AbsolutePath(validating: "/path/to/project.xcworkspace")
         let graphTraverser = MockGraphTraverser()
 
-        xcodeBuildController.buildStub = { _, _, _, _, _, _, _ in
+        xcodeBuildController.buildStub = { _, _, _, _, _, _, _, _ in
             [.standardOutput(.init(raw: "success"))]
         }
 
@@ -192,7 +194,8 @@ final class TargetBuilderTests: TuistUnitTestCase {
             device: nil,
             osVersion: nil,
             rosetta: false,
-            graphTraverser: graphTraverser
+            graphTraverser: graphTraverser,
+            rawXcodebuildLogs: false
         )
 
         // Then

--- a/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildControllerTests.swift
+++ b/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildControllerTests.swift
@@ -20,7 +20,7 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
     override func setUp() {
         super.setUp()
         formatter = MockFormatter()
-        subject = XcodeBuildController(formatter: formatter, environment: Environment.shared)
+        subject = XcodeBuildController(formatter: formatter)
     }
 
     override func tearDown() {
@@ -50,7 +50,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             rosetta: false,
             derivedDataPath: nil,
             clean: true,
-            arguments: []
+            arguments: [],
+            rawXcodebuildLogs: false
         )
 
         let result = try await events.toArray()
@@ -78,7 +79,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             rosetta: true,
             derivedDataPath: nil,
             clean: true,
-            arguments: []
+            arguments: [],
+            rawXcodebuildLogs: false
         )
 
         let result = try await events.toArray()
@@ -107,7 +109,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             rosetta: false,
             derivedDataPath: nil,
             clean: true,
-            arguments: []
+            arguments: [],
+            rawXcodebuildLogs: false
         )
 
         let result = try await events.toArray()
@@ -136,7 +139,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             rosetta: true,
             derivedDataPath: nil,
             clean: true,
-            arguments: []
+            arguments: [],
+            rawXcodebuildLogs: false
         )
 
         let result = try await events.toArray()
@@ -177,7 +181,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             retryCount: 0,
             testTargets: [],
             skipTestTargets: [],
-            testPlanConfiguration: nil
+            testPlanConfiguration: nil,
+            rawXcodebuildLogs: false
         )
 
         let result = try await events.toArray()
@@ -218,7 +223,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             retryCount: 0,
             testTargets: [],
             skipTestTargets: [],
-            testPlanConfiguration: nil
+            testPlanConfiguration: nil,
+            rawXcodebuildLogs: false
         )
 
         let result = try await events.toArray()
@@ -261,7 +267,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             retryCount: 0,
             testTargets: [],
             skipTestTargets: [],
-            testPlanConfiguration: nil
+            testPlanConfiguration: nil,
+            rawXcodebuildLogs: false
         )
 
         let result = try await events.toArray()
@@ -304,7 +311,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             retryCount: 0,
             testTargets: [],
             skipTestTargets: [],
-            testPlanConfiguration: nil
+            testPlanConfiguration: nil,
+            rawXcodebuildLogs: false
         )
 
         let result = try await events.toArray()
@@ -347,7 +355,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             retryCount: 0,
             testTargets: [],
             skipTestTargets: [],
-            testPlanConfiguration: nil
+            testPlanConfiguration: nil,
+            rawXcodebuildLogs: false
         )
 
         let result = try await events.toArray()

--- a/Tests/TuistKitTests/Services/BuildServiceTests.swift
+++ b/Tests/TuistKitTests/Services/BuildServiceTests.swift
@@ -97,7 +97,7 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_skipSigning, skipSigning)
             return buildArguments
         }
-        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _device, _osVersion, _, _ in
+        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _device, _osVersion, _, _, _ in
             XCTAssertEqual(_workspacePath, workspacePath)
             XCTAssertEqual(_scheme, scheme)
             XCTAssertTrue(_clean)
@@ -144,7 +144,7 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_skipSigning, skipSigning)
             return buildArguments
         }
-        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _, _, _, _ in
+        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _, _, _, _, _ in
             XCTAssertEqual(_workspacePath, workspacePath)
             XCTAssertEqual(_scheme, scheme)
             XCTAssertTrue(_clean)
@@ -190,7 +190,7 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_skipSigning, skipSigning)
             return buildArguments
         }
-        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _device, _osVersion, _, _ in
+        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _device, _osVersion, _, _, _ in
             XCTAssertEqual(_workspacePath, workspacePath)
             XCTAssertNil(_device)
             XCTAssertNil(_osVersion)
@@ -246,7 +246,7 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_skipSigning, skipSigning)
             return buildArguments
         }
-        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _, _, _, _ in
+        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _, _, _, _, _ in
             XCTAssertEqual(_workspacePath, workspacePath)
 
             if _scheme.name == "A" {
@@ -323,7 +323,8 @@ extension BuildService {
             device: device,
             platform: platform,
             osVersion: osVersion,
-            rosetta: rosetta
+            rosetta: rosetta,
+            rawXcodebuildLogs: false
         )
     }
 }

--- a/Tests/TuistKitTests/Services/RunServiceTests.swift
+++ b/Tests/TuistKitTests/Services/RunServiceTests.swift
@@ -112,7 +112,7 @@ final class RunServiceTests: TuistUnitTestCase {
         let schemeName = "AScheme"
         let clean = true
         let configuration = "Test"
-        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _configuration, _, _, _, _, _, _ in
+        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _configuration, _, _, _, _, _, _, _ in
             // Then
             XCTAssertEqual(_workspacePath, workspacePath)
             XCTAssertEqual(_scheme.name, schemeName)
@@ -184,7 +184,7 @@ final class RunServiceTests: TuistUnitTestCase {
         buildGraphInspector.workspacePathStub = { _ in workspacePath }
         buildGraphInspector.runnableSchemesStub = { _ in [.test()] }
         buildGraphInspector.runnableTargetStub = { _, _ in .test() }
-        targetBuilder.buildTargetStub = { _, _, _, _, _, _, _, _, _, _, _ in expectation.fulfill() }
+        targetBuilder.buildTargetStub = { _, _, _, _, _, _, _, _, _, _, _, _ in expectation.fulfill() }
         targetRunner.assertCanRunTargetStub = { _ in throw TestError() }
 
         // Then
@@ -217,7 +217,8 @@ extension RunService {
             device: device,
             version: version,
             rosetta: rosetta,
-            arguments: arguments
+            arguments: arguments,
+            rawXcodebuildLogs: false
         )
     }
 }

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -203,7 +203,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedRosetta: Bool?
-        xcodebuildController.testStub = { _, _, _, _, rosetta, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, rosetta, _, _, _, _, _, _, _, _ in
             testedRosetta = rosetta
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -238,7 +238,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -270,7 +270,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -319,7 +319,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -358,7 +358,7 @@ final class TestServiceTests: TuistUnitTestCase {
         }
         var testedSchemes: [String] = []
         xcodebuildController.testErrorStub = NSError.test()
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return []
         }
@@ -393,7 +393,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -413,7 +413,7 @@ final class TestServiceTests: TuistUnitTestCase {
         let expectedResourceBundlePath = try AbsolutePath(validating: "/test")
         var resourceBundlePath: AbsolutePath?
 
-        xcodebuildController.testStub = { _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _, _ in
             resourceBundlePath = gotResourceBundlePath
             return []
         }
@@ -444,7 +444,7 @@ final class TestServiceTests: TuistUnitTestCase {
         let expectedResourceBundlePath = try AbsolutePath(validating: "/test")
         var resourceBundlePath: AbsolutePath?
 
-        xcodebuildController.testStub = { _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _, _ in
             resourceBundlePath = gotResourceBundlePath
             return []
         }
@@ -489,7 +489,7 @@ final class TestServiceTests: TuistUnitTestCase {
         }
 
         var passedRetryCount = 0
-        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, retryCount, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, retryCount, _, _, _, _ in
             passedRetryCount = retryCount
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -522,7 +522,7 @@ final class TestServiceTests: TuistUnitTestCase {
         }
 
         var passedRetryCount = -1
-        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, retryCount, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, retryCount, _, _, _, _ in
             passedRetryCount = retryCount
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -565,7 +565,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -605,7 +605,7 @@ final class TestServiceTests: TuistUnitTestCase {
         generator.generateWithGraphStub = { path in
             (path, Graph.test())
         }
-        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, _, _, _, _, _ in
             [.standardOutput(.init(raw: "success"))]
         }
 
@@ -662,7 +662,8 @@ extension TestService {
             retryCount: retryCount,
             testTargets: testTargets,
             skipTestTargets: skipTestTargets,
-            testPlanConfiguration: testPlanConfiguration
+            testPlanConfiguration: testPlanConfiguration,
+            rawXcodebuildLogs: false
         )
     }
 }


### PR DESCRIPTION
### Short description 📝
Tuist defaults to beautifying the xcodebuild logs using [xcbeautify](https://github.com/tuist/xcbeautify) without giving the users the option to opt-out from that. I'm adding a new flag, `--raw-xcodebuild-logs` to give users control, and I'm adjusting our acceptance tests to use it for the inner `xcodebuild` processes. As described [here](https://github.com/tuist/xcbeautify/issues/165), that results in xcodebuild logs beautified and mixed together, which complicates the debugging a bit, but hopefully that's something we'll be able to address soon once we tackle that PR. After this change is merge, we should be able to debug our acceptance tests in production using logs.

### How to test the changes locally 🧐
You can run a command like `build` against Tuist passing the `--raw-xcodebuild-logs` flag and you should see the raw `xcodebuild` logs.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
