### PR TITLE
Revert using `Workspace.swift` to detect the root directory

### DIFF
--- a/Sources/TuistCoreTesting/Utils/MockRootDirectoryLocator.swift
+++ b/Sources/TuistCoreTesting/Utils/MockRootDirectoryLocator.swift
@@ -5,11 +5,6 @@ import TSCBasic
 public final class MockRootDirectoryLocator: RootDirectoryLocating {
     public var locateArgs: [AbsolutePath] = []
     public var locateStub: AbsolutePath?
-    public var usingProjectManifest: Bool
-
-    public init(usingProjectManifest: Bool) {
-        self.usingProjectManifest = usingProjectManifest
-    }
 
     public func locate(from path: AbsolutePath) -> AbsolutePath? {
         locateArgs.append(path)

--- a/Sources/TuistLoader/Utils/ManifestFilesLocator.swift
+++ b/Sources/TuistLoader/Utils/ManifestFilesLocator.swift
@@ -43,7 +43,7 @@ public final class ManifestFilesLocator: ManifestFilesLocating {
     /// Utility to locate the root directory of the project
     let rootDirectoryLocator: RootDirectoryLocating
 
-    public init(rootDirectoryLocator: RootDirectoryLocating = RootDirectoryLocator(usingProjectManifest: true)) {
+    public init(rootDirectoryLocator: RootDirectoryLocating = RootDirectoryLocator()) {
         self.rootDirectoryLocator = rootDirectoryLocator
     }
 

--- a/Tests/TuistCoreIntegrationTests/RootDirectoryLocatorIntegrationTests.swift
+++ b/Tests/TuistCoreIntegrationTests/RootDirectoryLocatorIntegrationTests.swift
@@ -140,18 +140,4 @@ final class RootDirectoryLocatorIntegrationTests: TuistTestCase {
             "APlugin/",
         ].map { temporaryDirectory.appending(try RelativePath(validating: $0)) })
     }
-
-    func test_locate_when_only_workspace_manifest_exists() throws {
-        // Given
-        let temporaryDirectory = try temporaryPath()
-        try createFiles([
-            "Workspace.swift",
-        ])
-
-        // When
-        let got = subject.locate(from: temporaryDirectory.appending(component: "Workspace.swift"))
-
-        // Then
-        XCTAssertEqual(got, temporaryDirectory)
-    }
 }

--- a/Tests/TuistLoaderTests/Utils/ManifestFilesLocatorTests.swift
+++ b/Tests/TuistLoaderTests/Utils/ManifestFilesLocatorTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import TSCBasic
-import TuistCore
 import TuistSupport
 import XCTest
 
@@ -32,7 +31,7 @@ final class ManifestFilesLocatorTests: TuistUnitTestCase {
 
         // When
         let manifests = subject
-            .locateProjectManifests(at: paths[1], excluding: [], onlyCurrentDirectory: false)
+            .locateProjectManifests(at: paths.first!, excluding: [], onlyCurrentDirectory: false)
             .sorted(by: { $0.path < $1.path })
 
         // Then
@@ -46,78 +45,6 @@ final class ManifestFilesLocatorTests: TuistUnitTestCase {
                 ManifestFilesLocator.ProjectManifest(
                     manifest: .project,
                     path: paths[1]
-                ),
-            ]
-        )
-    }
-
-    func test_locateProjectManifests_returns_all_manifest_using_project_manifest_given_child_path() throws {
-        // Given
-        let tuistManifestSignature = "import ProjectDescription"
-        let paths = try createFiles([
-            "App/Project.swift",
-            "FrameworkA/Project.swift",
-            "FrameworkB/Project.swift",
-            "Project.swift",
-        ], content: tuistManifestSignature)
-        subject = ManifestFilesLocator(rootDirectoryLocator: RootDirectoryLocator(usingProjectManifest: true))
-
-        // When
-        let manifests = subject
-            .locateProjectManifests(at: paths[3], excluding: [], onlyCurrentDirectory: false)
-            .sorted(by: { $0.path < $1.path })
-
-        // Then
-        XCTAssertEqual(
-            manifests,
-            [
-                ManifestFilesLocator.ProjectManifest(
-                    manifest: .project,
-                    path: paths[0]
-                ),
-                ManifestFilesLocator.ProjectManifest(
-                    manifest: .project,
-                    path: paths[1]
-                ),
-                ManifestFilesLocator.ProjectManifest(
-                    manifest: .project,
-                    path: paths[2]
-                ),
-                ManifestFilesLocator.ProjectManifest(
-                    manifest: .project,
-                    path: paths[3]
-                ),
-            ]
-        )
-    }
-
-    func test_locateProjectManifests_returns_all_manifest_using_project_manifest_given_parent_path() throws {
-        // Given
-        let tuistManifestSignature = "import ProjectDescription"
-        let paths = try createFiles([
-            "App/Project.swift",
-            "App/FrameworkA/Project.swift",
-            "FrameworkB/Project.swift",
-            "Project.swift",
-        ], content: tuistManifestSignature)
-        subject = ManifestFilesLocator(rootDirectoryLocator: RootDirectoryLocator(usingProjectManifest: true))
-
-        // When
-        let manifests = subject
-            .locateProjectManifests(at: paths[0], excluding: [], onlyCurrentDirectory: false)
-            .sorted(by: { $0.path < $1.path })
-
-        // Then
-        XCTAssertEqual(
-            manifests,
-            [
-                ManifestFilesLocator.ProjectManifest(
-                    manifest: .project,
-                    path: paths[1]
-                ),
-                ManifestFilesLocator.ProjectManifest(
-                    manifest: .project,
-                    path: paths[0]
                 ),
             ]
         )
@@ -134,7 +61,7 @@ final class ManifestFilesLocatorTests: TuistUnitTestCase {
 
         // When
         let manifests = subject
-            .locateProjectManifests(at: paths[1], excluding: [], onlyCurrentDirectory: false)
+            .locateProjectManifests(at: paths.first!, excluding: [], onlyCurrentDirectory: false)
             .sorted(by: { $0.path < $1.path })
 
         // Then
@@ -148,59 +75,6 @@ final class ManifestFilesLocatorTests: TuistUnitTestCase {
                 ManifestFilesLocator.ProjectManifest(
                     manifest: .workspace,
                     path: paths[1]
-                ),
-            ]
-        )
-    }
-
-    func test_locateProjectManifests_returns_single_manifest_no_workspace_using_project_manifest_given_child_path() throws {
-        // Given
-        let tuistManifestSignature = "import ProjectDescription"
-        let paths = try createFiles([
-            "Module/Project.swift",
-            "Project.swift",
-            "Tuist/Config.swift",
-        ], content: tuistManifestSignature)
-        subject = ManifestFilesLocator(rootDirectoryLocator: RootDirectoryLocator(usingProjectManifest: true))
-        // When
-        let manifests = subject
-            .locateProjectManifests(at: paths.first!, excluding: [], onlyCurrentDirectory: false)
-            .sorted(by: { $0.path < $1.path })
-
-        // Then
-        XCTAssertEqual(
-            manifests,
-            [
-                ManifestFilesLocator.ProjectManifest(
-                    manifest: .project,
-                    path: paths[0]
-                ),
-            ]
-        )
-    }
-
-    func test_locateProjectManifests_returns_single_manifest_with_workspace_using_project_manifest_given_child_path() throws {
-        // Given
-        let tuistManifestSignature = "import ProjectDescription"
-        let paths = try createFiles([
-            "Module/Project.swift",
-            "Workspace.swift",
-            "Tuist/Config.swift",
-        ], content: tuistManifestSignature)
-        subject = ManifestFilesLocator(rootDirectoryLocator: RootDirectoryLocator(usingProjectManifest: true))
-
-        // When
-        let manifests = subject
-            .locateProjectManifests(at: paths.first!, excluding: [], onlyCurrentDirectory: false)
-            .sorted(by: { $0.path < $1.path })
-
-        // Then
-        XCTAssertEqual(
-            manifests,
-            [
-                ManifestFilesLocator.ProjectManifest(
-                    manifest: .project,
-                    path: paths[0]
                 ),
             ]
         )

--- a/features/edit.feature
+++ b/features/edit.feature
@@ -23,10 +23,3 @@ Feature: Edit an existing project using Tuist
     Then I should be able to build for macOS the scheme Manifests
     Then I should be able to build for macOS the scheme Plugins
     Then I should be able to build for macOS the scheme LocalPlugin
-
-  Scenario: The project is a workspace with multiple projects (workspace_with_multiple_projects)
-    Given that tuist is available
-    And I have a working directory
-    Then I copy the fixture workspace_with_multiple_projects into the working directory
-    Then tuist edits the project
-    Then I should be able to build for macOS the scheme Manifests


### PR DESCRIPTION
Reverts https://github.com/tuist/tuist/pull/5499

### Short description 📝

https://github.com/tuist/tuist/pull/5499 changed the logic that detects the root directory to treat the directory containing a workspace as the root directory. That broke logic in Tuist and the workflow for some users as reported [here](https://github.com/tuist/tuist/issues/5588). Back when we designed the directory convention, we agreed on making `Tuist/` the reference to determine whether a directory represents the root or not. If we want to change this, we need to carefully understand the implications of the change as well as the value of this for users.

Reading the original issue

> When I tried to create two projects and linked them through Workspace.swift, I found that tuist edit could not process the Tuist folder of each project

Tuist doesn't expect each project to have a `/Tuist` folder, and therefore we shouldn't have treated that as a problem in the first place. The example project in that issue should have hoisted `Tuist/` up to the root and share the helpers across all the projects.

### How to test the changes locally 🧐
You should be able to run any Tuist workflow, since all of them rely on detecting the root directory.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
