### PR TITLE
Fix missing SPM platforms

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -267,11 +267,11 @@ func targets() -> [Target] {
             testDependencies: [
                 .target(name: "TuistSupportTesting"),
                 .target(name: "TuistCoreTesting"),
-                .target(name: "TuistGraphTesting")
+                .target(name: "TuistGraphTesting"),
             ],
             testingDependencies: [
                 .target(name: "TuistGraphTesting"),
-                .target(name: "TuistGraph")
+                .target(name: "TuistGraph"),
             ],
             integrationTestsDependencies: [
                 .target(name: "TuistSupportTesting"),
@@ -300,7 +300,7 @@ func targets() -> [Target] {
                 .target(name: "ProjectDescription"),
                 .target(name: "TuistSupportTesting"),
                 .target(name: "TuistGraphTesting"),
-                .target(name: "TuistGraph")
+                .target(name: "TuistGraph"),
             ],
             integrationTestsDependencies: [
                 .target(name: "TuistGraphTesting"),

--- a/fixtures/app_with_spm_dependencies/Features/FeatureOne/Project.swift
+++ b/fixtures/app_with_spm_dependencies/Features/FeatureOne/Project.swift
@@ -21,6 +21,7 @@ let project = Project(
             sources: ["Sources/**"],
             dependencies: [
                 .external(name: "Alamofire"),
+                .external(name: "Styles"),
             ],
             settings: .targetSettings
         ),


### PR DESCRIPTION
Only use `PackageInfo.Platforms` to resolve minimum versions
SPM packages implicitly support all platforms.

Reported via this [slack thread](https://tuistapp.slack.com/archives/C051W5ZTR8R/p1701820813372649)

### Short description 📝

Instead of `platforms` defining the set of supported platforms in SPM, it only defines minimum OS versions.  This PR adjusts our logic to include all platforms and intersect them with the platforms defined in `Dependencies.swift`

### How to test the changes locally 🧐

The `app_with_spm_dependencies` fixture was updated to replicate the bug.  Currently, running `tuist fetch && tuist generate` with the fixture results in a lint warning because the `LocalSwiftPackage` package does not explicitly declare a `watchOS` version.  

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
