### PR TITLE
Add SKIP_INSTALL=YES to build settings for macro targets

### DIFF
--- a/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
+++ b/Sources/TuistGenerator/Settings/DefaultSettingsProvider.swift
@@ -253,6 +253,10 @@ public final class DefaultSettingsProvider: DefaultSettingsProviding {
                     "@executable_path/Frameworks",
                 ],
             ]
+        } else if target.product == .macro {
+            return [
+                "SKIP_INSTALL": "YES",
+            ]
         } else {
             return [:]
         }

--- a/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
+++ b/Tests/TuistGeneratorTests/Settings/DefaultSettingsProviderTests.swift
@@ -860,6 +860,91 @@ final class DefaultSettingsProvider_iOSTests: TuistUnitTestCase {
     }
 }
 
+final class DefaultSettingsProvider_MacosTests: TuistUnitTestCase {
+    private var subject: DefaultSettingsProvider!
+
+    private let macroTargetEssentialDebugSettings: [String: SettingValue] = [
+        "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+        "SKIP_INSTALL": "YES",
+        "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+        "SWIFT_VERSION": "5.0",
+        "SDKROOT": "macosx",
+        "CODE_SIGN_IDENTITY": "-",
+    ]
+
+    private let macroTargetEssentialReleaseSettings: [String: SettingValue] = [
+        "SKIP_INSTALL": "YES",
+        "SWIFT_OPTIMIZATION_LEVEL": "-Owholemodule",
+        "SWIFT_VERSION": "5.0",
+        "SDKROOT": "macosx",
+        "CODE_SIGN_IDENTITY": "-",
+    ]
+
+    override func setUp() {
+        super.setUp()
+        subject = DefaultSettingsProvider(
+            xcodeController: xcodeController
+        )
+    }
+
+    override func tearDown() {
+        subject = nil
+        super.tearDown()
+    }
+
+    func testTargetSettings_whenEssentialDebug_Macro() throws {
+        // Given
+        let buildConfiguration: BuildConfiguration = .debug
+        let settings = Settings(
+            base: [:],
+            configurations: [buildConfiguration: nil],
+            defaultSettings: .essential
+        )
+        let project = Project.test()
+        let target = Target.test(
+            destinations: [.mac],
+            product: .macro,
+            settings: settings
+        )
+
+        // When
+        let got = try subject.targetSettings(
+            target: target,
+            project: project,
+            buildConfiguration: buildConfiguration
+        )
+
+        // Then
+        XCTAssertEqual(got, macroTargetEssentialDebugSettings)
+    }
+
+    func testTargetSettings_whenEssentialRelease_Macro() throws {
+        // Given
+        let buildConfiguration: BuildConfiguration = .release
+        let settings = Settings(
+            base: [:],
+            configurations: [buildConfiguration: nil],
+            defaultSettings: .essential
+        )
+        let project = Project.test()
+        let target = Target.test(
+            destinations: [.mac],
+            product: .macro,
+            settings: settings
+        )
+
+        // When
+        let got = try subject.targetSettings(
+            target: target,
+            project: project,
+            buildConfiguration: buildConfiguration
+        )
+
+        // Then
+        XCTAssertEqual(got, macroTargetEssentialReleaseSettings)
+    }
+}
+
 final class DictionaryStringAnyExtensionTests: XCTestCase {
     func testToSettings_whenOnlyStrings() throws {
         // Given


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY

### Short description 📝

iOS app archives included macro executable products under Products/usr/local which makes the archive invalid

### How to test the changes locally 🧐

- tuist fetch and generate the app_with_spm_dependencies fixture
- Check that the macro executables (ComposableArchitectureMacros, CasePathsMacros, DependenciesMacrosPlugin) all have `SKIP_INSTALL` set to `YES`.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
