### PR TITLE
Fix cache warming

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -267,10 +267,11 @@ func targets() -> [Target] {
             testDependencies: [
                 .target(name: "TuistSupportTesting"),
                 .target(name: "TuistCoreTesting"),
-                .target(name: "TuistGraphTesting"),
+                .target(name: "TuistGraphTesting")
             ],
             testingDependencies: [
                 .target(name: "TuistGraphTesting"),
+                .target(name: "TuistGraph")
             ],
             integrationTestsDependencies: [
                 .target(name: "TuistSupportTesting"),
@@ -299,6 +300,7 @@ func targets() -> [Target] {
                 .target(name: "ProjectDescription"),
                 .target(name: "TuistSupportTesting"),
                 .target(name: "TuistGraphTesting"),
+                .target(name: "TuistGraph")
             ],
             integrationTestsDependencies: [
                 .target(name: "TuistGraphTesting"),


### PR DESCRIPTION
### Short description 📝
Xcode's build system can transitively import dependencies even if they are not declared explicitly. This is a terrible design that leads to issues like the one we experienced here, where CI was green, but later on, some workflows that rely on explicitness like `cache warm` don't work. 

I hope to introduce something in Tuist in the future to prevent this from happening. Until then, we'll have to rely on PR reviews to prevent the issues. For people having to debug this issue in the future, you'll have to pull he changes, run `tuist clean builds`, delete derived data, and run `tuist cache warm`. When it fails, open the generated Xcode project and compile it through the GUI to see what the actual issue is.
