### PR TITLE
Fix the wrong version of the cached project description helpers used when switching between debug and release

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -267,11 +267,11 @@ func targets() -> [Target] {
             testDependencies: [
                 .target(name: "TuistSupportTesting"),
                 .target(name: "TuistCoreTesting"),
-                .target(name: "TuistGraphTesting")
+                .target(name: "TuistGraphTesting"),
             ],
             testingDependencies: [
                 .target(name: "TuistGraphTesting"),
-                .target(name: "TuistGraph")
+                .target(name: "TuistGraph"),
             ],
             integrationTestsDependencies: [
                 .target(name: "TuistSupportTesting"),
@@ -300,7 +300,7 @@ func targets() -> [Target] {
                 .target(name: "ProjectDescription"),
                 .target(name: "TuistSupportTesting"),
                 .target(name: "TuistGraphTesting"),
-                .target(name: "TuistGraph")
+                .target(name: "TuistGraph"),
             ],
             integrationTestsDependencies: [
                 .target(name: "TuistGraphTesting"),

--- a/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasher.swift
+++ b/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasher.swift
@@ -32,8 +32,12 @@ public final class ProjectDescriptionHelpersHasher: ProjectDescriptionHelpersHas
             .compactMap { $0.compactMap { byte in String(format: "%02x", byte) }.joined() }
         let tuistEnvVariables = Environment.shared.manifestLoadingVariables.map { "\($0.key)=\($0.value)" }.sorted()
         let swiftVersion = try System.shared.swiftVersion()
+        var debug = false
+        #if DEBUG
+            debug = true
+        #endif
 
-        let identifiers = [swiftVersion, tuistVersion] + fileHashes + tuistEnvVariables
+        let identifiers = [swiftVersion, tuistVersion] + fileHashes + tuistEnvVariables + ["\(debug)"]
 
         return identifiers.joined(separator: "-").md5
     }

--- a/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasher.swift
+++ b/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasher.swift
@@ -32,9 +32,10 @@ public final class ProjectDescriptionHelpersHasher: ProjectDescriptionHelpersHas
             .compactMap { $0.compactMap { byte in String(format: "%02x", byte) }.joined() }
         let tuistEnvVariables = Environment.shared.manifestLoadingVariables.map { "\($0.key)=\($0.value)" }.sorted()
         let swiftVersion = try System.shared.swiftVersion()
-        var debug = false
         #if DEBUG
-            debug = true
+            let debug = true
+        #else
+            let debug = false
         #endif
 
         let identifiers = [swiftVersion, tuistVersion] + fileHashes + tuistEnvVariables + ["\(debug)"]


### PR DESCRIPTION
### Short description 📝
@waltflanagan reported an issue where Tuist dumps a bunch of symbols in the terminal:
```
Resolved cache profile 'Development' from Tuist's defaults
The 'swift' command exited with error code 255 and message:
JIT session error: Symbols not found: [ _$s25ProjectDescriptionHelpers12EtsyProjectsV7etsyAppSay0aB04PathVGyFZ, _$s25ProjectDescriptionHelpers12EtsyProjectsV7modulesSay0aB04PathVGyFZ, _$s25ProjectDescriptionHelpers12EtsyProjectsV8featuresSay0aB04PathVGyFZ, _$s25ProjectDescriptionHelpers12EtsyProjectsV5toolsSay0aB04PathVGyFZ,
```

It turns out that when switching from the release and the debug version of Tuist (development), the release version of Tuist might attempt to use a cached binary that links against the debug version of `ProjectDescription`, or the debug version of Tuist might attempt to use a cached binary that links against a release version of `ProjectDescription`. 

To solve it, I'm extending the hashing logic to include whether the version of Tuist used is the debug or release one.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
