### PR TITLE
Fixed archival with swift macro

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -158,6 +158,14 @@ var targets: [Target] = [
         ]
     ),
     .target(
+        name: "TuistGeneratorTesting",
+        dependencies: [
+            "TuistGenerator",
+            swiftToolsSupportDependency,
+        ],
+        linkerSettings: [.linkedFramework("XCTest")]
+    ),
+    .target(
         name: "TuistScaffold",
         dependencies: [
             swiftToolsSupportDependency,

--- a/Project.swift
+++ b/Project.swift
@@ -267,11 +267,11 @@ func targets() -> [Target] {
             testDependencies: [
                 .target(name: "TuistSupportTesting"),
                 .target(name: "TuistCoreTesting"),
-                .target(name: "TuistGraphTesting")
+                .target(name: "TuistGraphTesting"),
             ],
             testingDependencies: [
                 .target(name: "TuistGraphTesting"),
-                .target(name: "TuistGraph")
+                .target(name: "TuistGraph"),
             ],
             integrationTestsDependencies: [
                 .target(name: "TuistSupportTesting"),
@@ -300,7 +300,7 @@ func targets() -> [Target] {
                 .target(name: "ProjectDescription"),
                 .target(name: "TuistSupportTesting"),
                 .target(name: "TuistGraphTesting"),
-                .target(name: "TuistGraph")
+                .target(name: "TuistGraph"),
             ],
             integrationTestsDependencies: [
                 .target(name: "TuistGraphTesting"),

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -534,7 +534,8 @@ final class LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_
             }
         }.map { ("$SYMROOT/$CONFIGURATION/\($0)", "$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/Macros/\($0)") }
 
-        copySwiftMacrosBuildPhase.shellScript = filesToCopy.map { "cp \"\($0.0)\" \"\($0.1)\"" }.joined(separator: "\n")        copySwiftMacrosBuildPhase.inputPaths = filesToCopy.map(\.0)
+        copySwiftMacrosBuildPhase.shellScript = filesToCopy.map { "cp \"\($0.0)\" \"\($0.1)\"" }.joined(separator: "\n")
+        copySwiftMacrosBuildPhase.inputPaths = filesToCopy.map(\.0)
         copySwiftMacrosBuildPhase.outputPaths = filesToCopy.map(\.1)
 
         pbxproj.add(object: copySwiftMacrosBuildPhase)

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -534,8 +534,7 @@ final class LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_
             }
         }.map { ("$SYMROOT/$CONFIGURATION/\($0)", "$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/Macros/\($0)") }
 
-        copySwiftMacrosBuildPhase.shellScript = filesToCopy.map { "cp \($0.0) \($0.1)" }.joined(separator: "\n")
-        copySwiftMacrosBuildPhase.inputPaths = filesToCopy.map(\.0)
+        copySwiftMacrosBuildPhase.shellScript = filesToCopy.map { "cp \"\($0.0)\" \"\($0.1)\"" }.joined(separator: "\n")        copySwiftMacrosBuildPhase.inputPaths = filesToCopy.map(\.0)
         copySwiftMacrosBuildPhase.outputPaths = filesToCopy.map(\.1)
 
         pbxproj.add(object: copySwiftMacrosBuildPhase)

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -1020,7 +1020,7 @@ final class LinkGeneratorTests: XCTestCase {
         XCTAssertNotNil(buildPhase)
 
         let expectedScript =
-            "cp $SYMROOT/$CONFIGURATION/\(macroExecutable.productName) $BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/Macros/\(macroExecutable.productName)"
+            "cp \"$SYMROOT/$CONFIGURATION/\(macroExecutable.productName)\" \"$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/Macros/\(macroExecutable.productName)\""
         XCTAssertTrue(buildPhase?.shellScript?.contains(expectedScript) == true)
         XCTAssertTrue(buildPhase?.inputPaths.contains("$SYMROOT/$CONFIGURATION/\(macroExecutable.productName)") == true)
         XCTAssertTrue(


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5652

### Short description 📝

Handle framework names with spaces in them while copying over macros for archival

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).
1. Update `fixtures/framework_with_native_swift_macro/Project.swift` to include a space e.g. `"My Framework"`
2. `tuist fetch` and `tuist generate` that fixture
3. In the opened project, choose the My Framework scheme and Product -> Archive

Before
<img width="668" alt="Before" src="https://github.com/tuist/tuist/assets/5884570/f4aa86c9-fc8c-489e-b617-043df034a8c9">

After
<img width="774" alt="After" src="https://github.com/tuist/tuist/assets/5884570/8e5770ea-5f4c-4eda-b6b5-78805053cd94">
r

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
