### PR TITLE
Remove custom short name for raw xcodebuild logs

### DIFF
--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -77,7 +77,7 @@ public struct BuildCommand: AsyncParsableCommand {
     var derivedDataPath: String?
 
     @Flag(
-        name: [.customLong("raw-xcodebuild-logs"), .customShort("P")],
+        name: [.customLong("raw-xcodebuild-logs")],
         help: "When passed, it outputs the raw xcodebuild logs without formatting them."
     )
     var rawXcodebuildLogs: Bool = false

--- a/Sources/TuistKit/Commands/RunCommand.swift
+++ b/Sources/TuistKit/Commands/RunCommand.swift
@@ -65,7 +65,7 @@ struct RunCommand: AsyncParsableCommand {
     var arguments: [String] = []
 
     @Flag(
-        name: [.customLong("raw-xcodebuild-logs"), .customShort("P")],
+        name: [.customLong("raw-xcodebuild-logs")],
         help: "When passed, it outputs the raw xcodebuild logs without formatting them."
     )
     var rawXcodebuildLogs: Bool = false

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -125,7 +125,7 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
     var skipConfigurations: [String] = []
 
     @Flag(
-        name: [.customLong("raw-xcodebuild-logs"), .customShort("P")],
+        name: [.customLong("raw-xcodebuild-logs")],
         help: "When passed, it outputs the raw xcodebuild logs without formatting them."
     )
     var rawXcodebuildLogs: Bool = false


### PR DESCRIPTION
### Short description 📝

The short name for `raw-xcodebuild-logs` as `P`:
- doesn't really make sense (why P?)
- I don't think the shorthand form is useful for this one

Therefore, I am removing it completely. The command is still really new, so I believe it's fine to make this, technically-speaking, breaking change.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
