### PR TITLE
Add missing TuistCore explicit dependency

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -495,6 +495,7 @@ func targets() -> [Target] {
             dependencies: [
                 .target(name: "TuistKit"),
                 .target(name: "TuistSupportTesting"),
+                .target(name: "TuistCore"),
                 .external(name: "SwiftToolsSupport"),
                 .external(name: "SystemPackage"),
                 .sdk(name: "XCTest", type: .framework, status: .optional),


### PR DESCRIPTION
### Short description 📝

I am adding a missing `TuistCore` dependency for `TuistAcceptanceTesting`.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
