### PR TITLE
Move local tuist test cache to tuist-cloud

### DIFF
--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -292,25 +292,6 @@ public final class TestService { // swiftlint:disable:this type_body_length
             }
         }
 
-        // Saving hashes from `testsCacheTemporaryDirectory` to `testsCacheDirectory` after all the tests have run successfully
-
-        if !FileHandler.shared.exists(
-            cacheDirectoriesProvider.cacheDirectory(for: .tests)
-        ) {
-            try FileHandler.shared.createFolder(cacheDirectoriesProvider.cacheDirectory(for: .tests))
-        }
-
-        try FileHandler.shared
-            .contentsOfDirectory(testsCacheTemporaryDirectory.path)
-            .forEach { hashPath in
-                let destination = cacheDirectoriesProvider.cacheDirectory(for: .tests).appending(component: hashPath.basename)
-                guard !FileHandler.shared.exists(destination) else { return }
-                try FileHandler.shared.move(
-                    from: hashPath,
-                    to: destination
-                )
-            }
-
         logger.log(level: .notice, "The project tests ran successfully", metadata: .success)
     }
 

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -294,12 +294,6 @@ final class TestServiceTests: TuistUnitTestCase {
                 "ProjectSchemeTwo",
             ]
         )
-        XCTAssertTrue(
-            fileHandler.exists(cacheDirectoriesProvider.cacheDirectory(for: .tests).appending(component: "A"))
-        )
-        XCTAssertTrue(
-            fileHandler.exists(cacheDirectoriesProvider.cacheDirectory(for: .tests).appending(component: "B"))
-        )
     }
 
     func test_run_tests_individual_scheme() async throws {
@@ -338,12 +332,6 @@ final class TestServiceTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(testedSchemes, ["ProjectSchemeOne"])
-        XCTAssertTrue(
-            fileHandler.exists(cacheDirectoriesProvider.cacheDirectory(for: .tests).appending(component: "A"))
-        )
-        XCTAssertTrue(
-            fileHandler.exists(cacheDirectoriesProvider.cacheDirectory(for: .tests).appending(component: "B"))
-        )
     }
 
     func test_run_tests_all_project_schemes_when_fails() async throws {


### PR DESCRIPTION
### Short description 📝

We're moving the `tuist test` caching to `tuist-cloud`.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x]  The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
