### PR TITLE
Prevent duplicated warnings

### DIFF
--- a/Sources/TuistSupport/Utils/WarningController.swift
+++ b/Sources/TuistSupport/Utils/WarningController.swift
@@ -15,8 +15,8 @@ public protocol WarningControlling {
 
 public final class WarningController: WarningControlling {
     private let warningsQueue = DispatchQueue(label: "io.tuist.TuistSupport.WarningController")
-    private var _warnings: [String] = []
-    private var warnings: [String] {
+    private var _warnings: Set<String> = Set()
+    private var warnings: Set<String> {
         get {
             warningsQueue.sync { _warnings }
         }
@@ -31,7 +31,7 @@ public final class WarningController: WarningControlling {
 
     public func append(warning: String) {
         var warnings = warnings
-        warnings.append(warning)
+        warnings.insert(warning)
         self.warnings = warnings
     }
 

--- a/Sources/TuistSupport/Utils/WarningController.swift
+++ b/Sources/TuistSupport/Utils/WarningController.swift
@@ -27,7 +27,7 @@ public final class WarningController: WarningControlling {
 
     public static var shared: WarningControlling = WarningController()
 
-    private init() {}
+    init() {}
 
     public func append(warning: String) {
         var warnings = warnings


### PR DESCRIPTION
### Short description 📝
Stateless Tuist Cloud endpoints might return the same warning, and that'll lead to the same warning shown multiple times in the client. To solve that, I'm changing the data structure of `WarningController` from `Array<String>` to `Set<String>`.

### How to test the changes locally 🧐

You can either force a warning, or add one manually by editing one of the commands, and you should see them when running that command.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
