### PR TITLE
Increase the depth of changelog categories by one level

### DIFF
--- a/.github/workflows/changelog-configuration.json
+++ b/.github/workflows/changelog-configuration.json
@@ -1,15 +1,15 @@
 {
   "categories": [
     {
-      "title": "### Changed",
+      "title": "#### Changed",
       "labels": ["changelog:changed"]
     },
     {
-      "title": "### Added",
+      "title": "#### Added",
       "labels": ["changelog:added"]
     },
     {
-      "title": "### Fixed",
+      "title": "#### Fixed",
       "labels": ["changelog:fixed"]
     }
   ],


### PR DESCRIPTION
### Short description 📝
We are extending the release workflow to include release notes of both, the Tuist and the Tuist Cloud CLIs. This requires adding markdown heading level, so I'm adjusting the template to move the categories to one level deeper.
