### PR TITLE
Fix `GenerateOneAcceptanceTestiOSAppWithSDK.test_ios_app_with_sdk()`

### DIFF
--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
@@ -81,6 +81,7 @@ open class TuistAcceptanceTestCase: XCTestCase {
     public func run(_ command: TestCommand.Type, _ arguments: [String] = []) async throws {
         let arguments = arguments + [
             "--derived-data-path", derivedDataPath.pathString,
+            "--raw-xcodebuild-logs",
             "--path", fixturePath.pathString,
         ]
 
@@ -91,6 +92,7 @@ open class TuistAcceptanceTestCase: XCTestCase {
     public func run(_ command: BuildCommand.Type, _ arguments: [String] = []) async throws {
         let arguments = arguments + [
             "--derived-data-path", derivedDataPath.pathString,
+            "--raw-xcodebuild-logs",
             "--path", fixturePath.pathString,
         ]
 


### PR DESCRIPTION
### Short description 📝

The `GenerateOneAcceptanceTestiOSAppWithSDK.test_ios_app_with_sdk()` acceptance test is [failing on CI](https://github.com/tuist/tuist/actions/runs/7160473513/job/19494883496). This PR attempts to fix it.
