### PR TITLE
Change the approach to control the colouring of the output to embrace a more widespread convention

### DIFF
--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -64,7 +64,6 @@ public enum Constants {
     /// But only eg. for acceptance tests and other cases needed internally
     public enum EnvironmentVariables {
         public static let verbose = "TUIST_CONFIG_VERBOSE"
-        public static let colouredOutput = "TUIST_CONFIG_COLOURED_OUTPUT"
         public static let versionsDirectory = "TUIST_CONFIG_VERSIONS_DIRECTORY"
         public static let forceConfigCacheDirectory = "TUIST_CONFIG_FORCE_CONFIG_CACHE_DIRECTORY"
         public static let automationPath = "TUIST_CONFIG_AUTOMATION_PATH"

--- a/Sources/TuistSupport/Utils/Environment.swift
+++ b/Sources/TuistSupport/Utils/Environment.swift
@@ -1,7 +1,6 @@
-import Darwin.C
+import Darwin
 import Foundation
 import TSCBasic
-
 /// Protocol that defines the interface of a local environment controller.
 /// It manages the local directory where tuistenv stores the tuist versions and user settings.
 public protocol Environmenting: AnyObject {
@@ -91,10 +90,23 @@ public class Environment: Environmenting {
 
     /// Returns true if the output of Tuist should be coloured.
     public var shouldOutputBeColoured: Bool {
-        if let coloredOutput = ProcessInfo.processInfo.environment[Constants.EnvironmentVariables.colouredOutput] {
-            return Constants.trueValues.contains(coloredOutput)
+        let noColor = if let noColorEnvVariable = ProcessInfo.processInfo.environment["NO_COLOR"] {
+            Constants.trueValues.contains(noColorEnvVariable)
         } else {
-            return isStandardOutputInteractive
+            false
+        }
+        let ciColorForce = if let ciColorForceEnvVariable = ProcessInfo.processInfo.environment["CLICOLOR_FORCE"] {
+            Constants.trueValues.contains(ciColorForceEnvVariable)
+        } else {
+            false
+        }
+        if noColor {
+            return false
+        } else if ciColorForce {
+            return true
+        } else {
+            let isPiped = isatty(fileno(stdout)) == 0
+            return !isPiped
         }
     }
 


### PR DESCRIPTION
### Short description 📝
As noted [here](https://bixense.com/clicolors/), there isn't a standard to control the coloring behavior of CLI applications. However, that website is trying to establish a convention, which some CLI applications have already adopted, so I propose to adopt the same one for Tuist.

**Note** that I'm making this a breaking change and merging it into the `tuist-4` branch.

### How to test the changes locally 🧐
If you run it against a Tuist project with `NO_COLOR=1` you should not see a colored output.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
