### PR TITLE
Fix --skip-test-targets with a test class

### DIFF
--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -194,7 +194,7 @@ public final class TestService { // swiftlint:disable:this type_body_length
                 testsCacheDirectory: testsCacheTemporaryDirectory.path,
                 testPlan: testPlanConfiguration?.testPlan,
                 includedTargets: Set(testTargets.map(\.target)),
-                excludedTargets: Set(skipTestTargets.map(\.target)),
+                excludedTargets: Set(skipTestTargets.filter { $0.class == nil }.map(\.target)),
                 skipUITests: skipUITests
             )
         }

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -346,6 +346,34 @@ final class TestServiceTests: TuistUnitTestCase {
         )
     }
 
+    func test_run_tests_with_skipped_targets() async throws {
+        // Given
+        buildGraphInspector.testableSchemesStub = { _ in
+            [
+                Scheme.test(name: "ProjectSchemeOneTests"),
+            ]
+        }
+        generator.generateWithGraphStub = { path in
+            (path, Graph.test())
+        }
+        var testedSchemes: [String] = []
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
+            testedSchemes.append(scheme)
+            return [.standardOutput(.init(raw: "success"))]
+        }
+
+        // When
+        try await subject.testRun(
+            schemeName: "ProjectSchemeOneTests",
+            path: try temporaryPath(),
+            skipTestTargets: [.init(target: "ProjectSchemeOnTests", class: "TestClass")]
+        )
+
+        // Then
+        XCTAssertEqual(testedSchemes, ["ProjectSchemeOneTests"])
+        XCTAssertEqual(generatorFactory.invokedTestParameters?.excludedTargets, [])
+    }
+
     func test_run_tests_all_project_schemes_when_fails() async throws {
         // Given
         buildGraphInspector.workspaceSchemesStub = { _ in


### PR DESCRIPTION
### Short description 📝

Running `tuist test MyScheme --skip-test-targets MyScheme/MyClass` would incorrectly remove the `MyScheme` even though we should skip only a specific test class and not the whole scheme.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
