### PR TITLE
Skip docc dry run on push to main

### DIFF
--- a/.github/workflows/deploy-tuist-docc-dry-run.yml
+++ b/.github/workflows/deploy-tuist-docc-dry-run.yml
@@ -1,9 +1,6 @@
 name: Deploy Tuist Docc dry-run
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - Package.swift


### PR DESCRIPTION
### Short description 📝

I've noticed we're running docc dry run on push to main – which doesn't make much sense as we also run the docc publish process which does the same.

Running docc dry run makes only sense for PRs.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
