### PR TITLE
Fix logic when applying `platformFilters` for the dependencies build phase.

### DIFF
--- a/Sources/TuistGenerator/Generator/TargetGenerator.swift
+++ b/Sources/TuistGenerator/Generator/TargetGenerator.swift
@@ -156,7 +156,7 @@ final class TargetGenerator: TargetGenerating {
                 let nativeTarget = nativeTargets[targetSpec.name]!
                 let nativeDependency = nativeTargets[dependency.target.name]!
                 let pbxTargetDependency = try nativeTarget.addDependency(target: nativeDependency)
-                pbxTargetDependency?.applyCondition(condition, applicableTo: dependency.target)
+                pbxTargetDependency?.applyCondition(condition, applicableTo: targetSpec)
             }
         }
     }

--- a/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/TargetGeneratorTests.swift
@@ -107,10 +107,14 @@ final class TargetGeneratorTests: XCTestCase {
 
     func test_generateTargetDependencies() throws {
         // Given
-        let targetA = Target.test(name: "TargetA",
-                                  destinations: [.mac, .iPhone])
-        let targetB = Target.test(name: "TargetB",
-                                  destinations: [.mac, .iPhone])
+        let targetA = Target.test(
+            name: "TargetA",
+            destinations: [.mac, .iPhone]
+        )
+        let targetB = Target.test(
+            name: "TargetB",
+            destinations: [.mac, .iPhone]
+        )
         let targetC = Target.test(name: "TargetC")
         let nativeTargetA = createNativeTarget(for: targetA)
         let nativeTargetB = createNativeTarget(for: targetB)
@@ -127,13 +131,15 @@ final class TargetGeneratorTests: XCTestCase {
             dependencies: [
                 .target(name: targetA.name, path: path): [
                     .target(name: targetB.name, path: path),
-                    .target(name: targetC.name, path: path)
+                    .target(name: targetC.name, path: path),
                 ],
             ],
             dependencyConditions: [
-            GraphEdge(from: .target(name: targetA.name, path: path),
-                      to: .target(name: targetC.name, path: path)) :
-                    try XCTUnwrap(.when([.ios]))
+                GraphEdge(
+                    from: .target(name: targetA.name, path: path),
+                    to: .target(name: targetC.name, path: path)
+                ):
+                    try XCTUnwrap(.when([.ios])),
             ]
         )
         let graphTraverser = GraphTraverser(graph: graph)


### PR DESCRIPTION

Related to #5689

### Short description 📝

We we using the wrong target for our filter application logic.  Using the dependency target we would end up not applying filters because the filter set matched the supported platforms of the dependency.  We need to always use the "from" target when applying filters.

### How to test the changes locally 🧐

Run `tuist generate` against the sample project in 5689.

### Contributor checklist ✅

- [ ] The code has been linted using run `make workspace/lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
