### PR TITLE
Include a CLI overview in the documentation

### DIFF
--- a/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Install Tuist/install.tutorial
+++ b/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Install Tuist/install.tutorial
@@ -1,5 +1,5 @@
 @Tutorial(time: 2) {
-    @Intro(title: "Install/Uninstall Tuist") {
+    @Intro(title: "Install Tuist") {
         Learn how to install tuist and manage it.
         
         @Image(source: "Logo-Blurred.png", alt: "Blurred Tuist Logo.")

--- a/Sources/tuist/tuist.docc/Articles/Tuist/Users/command-line-interface.md
+++ b/Sources/tuist/tuist.docc/Articles/Tuist/Users/command-line-interface.md
@@ -1,0 +1,81 @@
+# Command line interface (CLI)
+
+This page contains an overview of the command line interface (CLI) of Tuist.
+
+## Overview
+
+`tuist` is the command line interface (CLI) that you use to interact with Tuist. It's a binary that you can install (<doc:installation>) in your system and use to generate, build, test, and more your Xcode projects. In the following sections, you'll learn about the different commands that you can use to interact with Tuist.
+If you want to learn more about the commands, you can run `tuist help` to get a list of all the available commands and `tuist help <command>` to get more information about a specific command.
+
+### Init
+
+`tuist init` is the command that you use to initialise a new project from a template.
+
+### Generate
+
+`tuist generate` is the command that you use to generate an Xcode workspace from a project manifest. It's the most common command that you'll use when working with Tuist.
+
+### Edit
+
+`tuist edit` is the command that you use to edit manifests using Xcode. It generates an Xcode project with the manifest files and opens it in Xcode. The lifecycle of the Xcode project is tied to the lifecycle of the command execution. Once the command is aborted, the Xcode project is deleted. When you're done editing the manifest, you can run `tuist generate` to generate the Xcode project.
+
+**We recommend editing the manifest files using Xcode** because it provides a better experience than editing them using a text editor. For instance, Xcode provides syntax highlighting, code completion, and more.
+
+
+### Fetch
+
+`tuist fetch` is the command that you use to fetch the Package dependencies (<doc:dependencies>) in the `Package.swift` file. It resolves the dependencies using the Swift Package Manager and generates the `Package.resolved` file. When your Xcode projects are generated, Tuist generates Xcode projects for the dependencies and links them to the Xcode projects of your project.
+
+### Build
+
+`tuist build` is the command that you use to build your project. It generates the Xcode project and builds it using the `xcodebuild` command line tool. It builds all the buildable targets in the project or the schemes that you pass as arguments to the command.
+
+> Tip: Although you can generate the project and build it with `xcodebuild` or any automation tool that wraps it, we recommend using `tuist build` because it can leverage the graph information to build the project faster (<doc:binary-caching>).
+
+### Test
+
+`tuist test` is the command that you use to test your project. It generates the Xcode project and tests it using the `xcodebuild` command line tool. It tests all the testable targets in the project or the schemes that you pass as arguments to the command.
+
+> Tip: `tuist test` leverages the graph information to speed up the test execution by skipping compilation steps (<doc:binary-caching>) and selectively running the tests impacted by the changes.
+
+### Run
+
+`tuist run` is the command that you use to run your project. It generates the Xcode project and runs it using the `xcodebuild` command line tool. It runs the runnable scheme passed as an argument to the command.
+
+> Important: Only iOS apps are currently supported. We plan to support other product types and platforms.
+
+### Cache
+
+`tuist cache` contains a set of commands that you can use to interact with the cache. The most common command is `tuist cache warm` which warms up the cache with binary artifacts that Tuist uses to generate more optimized Xcode projects and provide faster builds and tests (<doc:binary-caching>).
+
+### Dump
+
+`tuist dump` outputs a manifest as a JSON. It's useful when you want to inspect through a serialised representation of the manifest.
+
+### Scaffold
+
+`tuist scaffold` is the command that you use to scaffold new files in your project from templates (<doc:extensions>). It's useful when you want to add new files to your project and you don't want to do it manually. 
+
+### Migration
+
+`tuist migration` contains a set of commands that you can use to migrate your Xcode project (<doc:migration-guidelines>) to a Tuist. For example, you can use `tuist migration settings-to-xcconfig` to extract build settings into `.xcconfig` files or `tuist migration check-empty-settings` to check a target or project for empty build settings.
+
+### Graph
+
+`tuist graph` is the command that you use to visualise the dependency graph of your project. You can output it in different formats such as `.dot`, `.png`, or `.svg` and use it to understand the dependencies between the targets in your project. 
+
+### Clean
+
+`tuist clean` contains a set of commands that you can use to clean artifacts stored globally in your system. For example, `tuist clean manifests` cleans the cache that Tuist users to speed up the compilation of the manifest files.
+
+### Signing
+
+`tuist signing` contains a set of commands that allows you to keep certificates and provisioning profiles encrypted in your repository (<doc:signing>). Tuist can decrypt them, install certificates in the Keychain, and configure the generated Xcode projects accordingly.
+
+### Cloud
+
+`tuist cloud` contains a set of commands that you can use to interact with the Tuist Cloud service (<doc:tuist-cloud>). You can authenticate and manage organizations and projects.
+
+### Plugin
+
+`tuist plugin` contains a set of commands to build, run, test, and archive plugins, which are Swift packages that extend Tuist's functionality (<doc:extensions>).

--- a/Sources/tuist/tuist.docc/Articles/Tuist/Users/dependencies.md
+++ b/Sources/tuist/tuist.docc/Articles/Tuist/Users/dependencies.md
@@ -1,0 +1,14 @@
+# Dependencies
+
+Learn how to declare internal and external dependencies in your project.
+
+## Overview
+
+<!--TODO-->
+
+
+## External dependencies
+
+### Swift Packages
+
+

--- a/Sources/tuist/tuist.docc/Articles/Tuist/Users/extensions.md
+++ b/Sources/tuist/tuist.docc/Articles/Tuist/Users/extensions.md
@@ -1,0 +1,11 @@
+# Extensions
+
+Learn about how you can extend Tuist's functionality.
+
+## Overview
+
+<!-- TODO -->
+
+### Section header
+
+<!-- TODO -->

--- a/Sources/tuist/tuist.docc/Articles/Tuist/Users/migration-guidelines.md
+++ b/Sources/tuist/tuist.docc/Articles/Tuist/Users/migration-guidelines.md
@@ -1,0 +1,11 @@
+# Migration guidelines
+
+These guidelines help you migrate your Xcode project to Tuist.
+
+## Overview
+
+<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+
+### Section header
+
+<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->

--- a/Sources/tuist/tuist.docc/Articles/Tuist/Users/signing.md
+++ b/Sources/tuist/tuist.docc/Articles/Tuist/Users/signing.md
@@ -1,0 +1,11 @@
+# Signing
+
+Store encrypted certificates and provisioning profiles in your repository. Tuist can decrypt them, install certificates in the Keychain, and configure the generated Xcode projects accordingly.
+
+## Overview
+
+<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+
+### Section header
+
+<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->

--- a/Sources/tuist/tuist.docc/Tuist.md
+++ b/Sources/tuist/tuist.docc/Tuist.md
@@ -69,6 +69,11 @@ The choice is yours. By adding .xcodeproj and .xcworkspace files to your .gitign
 
 - <doc:installation>
 - <doc:project-structure>
+- <doc:command-line-interface>
+- <doc:dependencies>
+- <doc:signing>
+- <doc:extensions>
+- <doc:migration-guidelines>
 - <doc:tuist-tutorials>
 
 ### For Tuist Cloud Users


### PR DESCRIPTION
I'm adding a CLI overview to the documentation. Note that I point developers to using `help` if they want to know in detail what arguments and flags are supported, and also include references to other documentation pages where I plan to go into detail about the feature (for example pointing people to the page explaining binary caching). 