### PR TITLE
Add option to export raw xcodebuild logs to a given file

### DIFF
--- a/Sources/TuistAutomation/Utilities/TargetBuilder.swift
+++ b/Sources/TuistAutomation/Utilities/TargetBuilder.swift
@@ -19,6 +19,7 @@ public protocol TargetBuilding {
     ///   - osVersion: An optional OS number to use when building the scheme.
     ///   - graphTraverser: The Graph traverser.
     ///   - rawXcodebuildLogs: When true, it outputs the raw xcodebuild logs.
+    ///   - rawXcodebuildLogsPath: When passed, it outputs the raw xcodebuild logs to that file.
     func buildTarget(
         _ target: GraphTarget,
         platform: TuistGraph.Platform,
@@ -32,7 +33,8 @@ public protocol TargetBuilding {
         osVersion: Version?,
         rosetta: Bool,
         graphTraverser: GraphTraversing,
-        rawXcodebuildLogs: Bool
+        rawXcodebuildLogs: Bool,
+        rawXcodebuildLogsPath: AbsolutePath?
     ) async throws
 }
 
@@ -90,7 +92,8 @@ public final class TargetBuilder: TargetBuilding {
         osVersion: Version?,
         rosetta: Bool,
         graphTraverser: GraphTraversing,
-        rawXcodebuildLogs: Bool
+        rawXcodebuildLogs: Bool,
+        rawXcodebuildLogsPath: AbsolutePath?
     ) async throws {
         logger.log(level: .notice, "Building scheme \(scheme.name)", metadata: .section)
 
@@ -120,7 +123,8 @@ public final class TargetBuilder: TargetBuilding {
                 derivedDataPath: derivedDataPath,
                 clean: clean,
                 arguments: buildArguments,
-                rawXcodebuildLogs: rawXcodebuildLogs
+                rawXcodebuildLogs: rawXcodebuildLogs,
+                rawXcodebuildLogsPath: rawXcodebuildLogsPath
             )
             .printFormattedOutput()
 

--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -5,6 +5,7 @@ import TuistCore
 import TuistSupport
 
 public final class XcodeBuildController: XcodeBuildControlling {
+
     // MARK: - Attributes
 
     /// Matches lines of the forms:
@@ -39,7 +40,8 @@ public final class XcodeBuildController: XcodeBuildControlling {
         derivedDataPath: AbsolutePath?,
         clean: Bool = false,
         arguments: [XcodeBuildArgument],
-        rawXcodebuildLogs: Bool
+        rawXcodebuildLogs: Bool,
+        rawXcodebuildLogsPath: AbsolutePath?
     ) throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         var command = ["/usr/bin/xcrun", "xcodebuild"]
 
@@ -77,7 +79,7 @@ public final class XcodeBuildController: XcodeBuildControlling {
             command.append(contentsOf: ["-derivedDataPath", derivedDataPath.pathString])
         }
 
-        return try run(command: command, rawXcodebuildLogs: rawXcodebuildLogs)
+        return try run(command: command, rawXcodebuildLogs: rawXcodebuildLogs, rawXcodebuildLogsPath: rawXcodebuildLogsPath)
     }
 
     public func test(
@@ -93,7 +95,8 @@ public final class XcodeBuildController: XcodeBuildControlling {
         testTargets: [TestIdentifier],
         skipTestTargets: [TestIdentifier],
         testPlanConfiguration: TestPlanConfiguration?,
-        rawXcodebuildLogs: Bool
+        rawXcodebuildLogs: Bool,
+        rawXcodebuildLogsPath: AbsolutePath?
     ) throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         var command = ["/usr/bin/xcrun", "xcodebuild"]
 
@@ -158,7 +161,7 @@ public final class XcodeBuildController: XcodeBuildControlling {
             }
         }
 
-        return try run(command: command, rawXcodebuildLogs: rawXcodebuildLogs)
+        return try run(command: command, rawXcodebuildLogs: rawXcodebuildLogs, rawXcodebuildLogsPath: rawXcodebuildLogsPath)
     }
 
     public func archive(
@@ -167,7 +170,8 @@ public final class XcodeBuildController: XcodeBuildControlling {
         clean: Bool,
         archivePath: AbsolutePath,
         arguments: [XcodeBuildArgument],
-        rawXcodebuildLogs: Bool
+        rawXcodebuildLogs: Bool,
+        rawXcodebuildLogsPath: AbsolutePath?
     ) throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         var command = ["/usr/bin/xcrun", "xcodebuild"]
 
@@ -189,13 +193,14 @@ public final class XcodeBuildController: XcodeBuildControlling {
         // Arguments
         command.append(contentsOf: arguments.flatMap(\.arguments))
 
-        return try run(command: command, rawXcodebuildLogs: rawXcodebuildLogs)
+        return try run(command: command, rawXcodebuildLogs: rawXcodebuildLogs, rawXcodebuildLogsPath: rawXcodebuildLogsPath)
     }
 
     public func createXCFramework(
         frameworks: [AbsolutePath],
         output: AbsolutePath,
-        rawXcodebuildLogs: Bool
+        rawXcodebuildLogs: Bool,
+        rawXcodebuildLogsPath: AbsolutePath?
     ) throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         var command = ["/usr/bin/xcrun", "xcodebuild", "-create-xcframework"]
         command.append(contentsOf: frameworks.flatMap {
@@ -210,7 +215,7 @@ public final class XcodeBuildController: XcodeBuildControlling {
         })
         command.append(contentsOf: ["-output", output.pathString])
         command.append("-allow-internal-distribution")
-        return try run(command: command, rawXcodebuildLogs: rawXcodebuildLogs)
+        return try run(command: command, rawXcodebuildLogs: rawXcodebuildLogs, rawXcodebuildLogsPath: rawXcodebuildLogsPath)
     }
 
     enum ShowBuildSettingsError: Error {
@@ -289,7 +294,7 @@ public final class XcodeBuildController: XcodeBuildControlling {
         return buildSettingsByTargetName
     }
 
-    fileprivate func run(command: [String], rawXcodebuildLogs: Bool) throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
+    fileprivate func run(command: [String], rawXcodebuildLogs: Bool, rawXcodebuildLogsPath: AbsolutePath?) throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         System.shared.publisher(command)
             .compactMap { [weak self] event -> SystemEvent<XcodeBuildOutput>? in
                 switch event {

--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -298,7 +298,7 @@ public final class XcodeBuildController: XcodeBuildControlling {
                          rawXcodebuildLogs: Bool,
                          rawXcodebuildLogsPath: AbsolutePath?) throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         
-        var rawXcodebuildFileLogger: FileLogger? = if let rawXcodebuildLogsPath = rawXcodebuildLogsPath {
+        let rawXcodebuildFileLogger: FileLogger? = if let rawXcodebuildLogsPath = rawXcodebuildLogsPath {
             try FileLogger(path: rawXcodebuildLogsPath)
         } else {
             nil

--- a/Sources/TuistAutomationTesting/Utilities/MockTargetBuilder.swift
+++ b/Sources/TuistAutomationTesting/Utilities/MockTargetBuilder.swift
@@ -19,7 +19,8 @@ public final class MockTargetBuilder: TargetBuilding {
         Version?,
         Bool,
         GraphTraversing,
-        Bool
+        Bool,
+        AbsolutePath?
     ) throws -> Void)?
 
     public func buildTarget(
@@ -35,7 +36,8 @@ public final class MockTargetBuilder: TargetBuilding {
         osVersion: Version?,
         rosetta: Bool,
         graphTraverser: GraphTraversing,
-        rawXcodebuildLogs: Bool
+        rawXcodebuildLogs: Bool,
+        rawXcodebuildLogsPath: AbsolutePath?
     ) throws {
         try buildTargetStub?(
             target,
@@ -49,7 +51,8 @@ public final class MockTargetBuilder: TargetBuilding {
             osVersion,
             rosetta,
             graphTraverser,
-            rawXcodebuildLogs
+            rawXcodebuildLogs,
+            rawXcodebuildLogsPath
         )
     }
 }

--- a/Sources/TuistCore/Automation/XcodeBuildControlling.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildControlling.swift
@@ -17,6 +17,7 @@ public protocol XcodeBuildControlling {
     ///   - clean: True if xcodebuild should clean the project before building.
     ///   - arguments: Extra xcodebuild arguments.
     ///   - rawXcodebuildLogs: When true, it outputs the raw xcodebuild logs.
+    ///   - rawXcodebuildLogsPath: When passed, it outputs the raw xcodebuildlogs in that file.
     func build(
         _ target: XcodeBuildTarget,
         scheme: String,
@@ -25,7 +26,8 @@ public protocol XcodeBuildControlling {
         derivedDataPath: AbsolutePath?,
         clean: Bool,
         arguments: [XcodeBuildArgument],
-        rawXcodebuildLogs: Bool
+        rawXcodebuildLogs: Bool,
+        rawXcodebuildLogsPath: AbsolutePath?
     ) throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error>
 
     /// Returns an observable to test the given project using xcodebuild.
@@ -41,6 +43,7 @@ public protocol XcodeBuildControlling {
     ///   - skipTestTargets: A list of test identifiers indicating which tests to skip
     ///   - testPlanConfiguration: A configuration object indicating which test plan to use and its configurations
     ///   - rawXcodebuildLogs: When true, it outputs the raw xcodebuild logs.
+    ///   - rawXcodebuildLogsPath: When passed, it outputs the raw xcodebuildlogs in that file.
     func test(
         _ target: XcodeBuildTarget,
         scheme: String,
@@ -54,7 +57,8 @@ public protocol XcodeBuildControlling {
         testTargets: [TestIdentifier],
         skipTestTargets: [TestIdentifier],
         testPlanConfiguration: TestPlanConfiguration?,
-        rawXcodebuildLogs: Bool
+        rawXcodebuildLogs: Bool,
+        rawXcodebuildLogsPath: AbsolutePath?
     ) throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error>
 
     /// Returns an observable that archives the given project using xcodebuild.
@@ -65,13 +69,15 @@ public protocol XcodeBuildControlling {
     ///   - archivePath: Path where the archive will be exported (with extension .xcarchive)
     ///   - arguments: Extra xcodebuild arguments.
     ///   - rawXcodebuildLogs: When true, it outputs the raw xcodebuild logs.
+    ///   - rawXcodebuildLogsPath: When passed, it outputs the raw xcodebuildlogs in that file.
     func archive(
         _ target: XcodeBuildTarget,
         scheme: String,
         clean: Bool,
         archivePath: AbsolutePath,
         arguments: [XcodeBuildArgument],
-        rawXcodebuildLogs: Bool
+        rawXcodebuildLogs: Bool,
+        rawXcodebuildLogsPath: AbsolutePath?
     ) throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error>
 
     /// Creates an .xcframework combining the list of given frameworks.
@@ -79,7 +85,13 @@ public protocol XcodeBuildControlling {
     ///   - frameworks: Frameworks to be combined.
     ///   - output: Path to the output .xcframework.
     ///   - rawXcodebuildLogs: When true, it outputs the raw xcodebuild logs.
-    func createXCFramework(frameworks: [AbsolutePath], output: AbsolutePath, rawXcodebuildLogs: Bool)
+    ///   - rawXcodebuildLogsPath: When passed, it outputs the raw xcodebuildlogs in that file.
+    func createXCFramework(
+        frameworks: [AbsolutePath],
+        output: AbsolutePath,
+        rawXcodebuildLogs: Bool,
+        rawXcodebuildLogsPath: AbsolutePath?
+    )
         throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error>
 
     /// Gets the build settings of a scheme targets.

--- a/Sources/TuistCoreTesting/Automation/MockXcodeBuildController.swift
+++ b/Sources/TuistCoreTesting/Automation/MockXcodeBuildController.swift
@@ -13,7 +13,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         AbsolutePath?,
         Bool,
         [XcodeBuildArgument],
-        Bool
+        Bool,
+        AbsolutePath?
     ) -> [SystemEvent<XcodeBuildOutput>])?
 
     func build(
@@ -24,7 +25,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         derivedDataPath: AbsolutePath?,
         clean: Bool,
         arguments: [XcodeBuildArgument],
-        rawXcodebuildLogs: Bool
+        rawXcodebuildLogs: Bool,
+        rawXcodebuildLogsPath: AbsolutePath?
     ) -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         if let buildStub {
             return buildStub(
@@ -35,7 +37,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
                 derivedDataPath,
                 clean,
                 arguments,
-                rawXcodebuildLogs
+                rawXcodebuildLogs,
+                rawXcodebuildLogsPath
             ).asAsyncThrowingStream()
         } else {
             return AsyncThrowingStream {
@@ -60,7 +63,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
             [TestIdentifier],
             [TestIdentifier],
             TestPlanConfiguration?,
-            Bool
+            Bool,
+            AbsolutePath?
         )
             -> [SystemEvent<XcodeBuildOutput>]
     )?
@@ -78,7 +82,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         testTargets: [TestIdentifier],
         skipTestTargets: [TestIdentifier],
         testPlanConfiguration: TestPlanConfiguration?,
-        rawXcodebuildLogs: Bool
+        rawXcodebuildLogs: Bool,
+        rawXcodebuildLogsPath: AbsolutePath?
     ) -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         if let testStub {
             let results = testStub(
@@ -94,7 +99,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
                 testTargets,
                 skipTestTargets,
                 testPlanConfiguration,
-                rawXcodebuildLogs
+                rawXcodebuildLogs,
+                rawXcodebuildLogsPath
             )
             if let testErrorStub {
                 return AsyncThrowingStream {
@@ -113,7 +119,7 @@ final class MockXcodeBuildController: XcodeBuildControlling {
     }
 
     var archiveStub: (
-        (XcodeBuildTarget, String, Bool, AbsolutePath, [XcodeBuildArgument], Bool)
+        (XcodeBuildTarget, String, Bool, AbsolutePath, [XcodeBuildArgument], Bool, AbsolutePath?)
             -> [SystemEvent<XcodeBuildOutput>]
     )?
     func archive(
@@ -122,10 +128,12 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         clean: Bool,
         archivePath: AbsolutePath,
         arguments: [XcodeBuildArgument],
-        rawXcodebuildLogs: Bool
+        rawXcodebuildLogs: Bool,
+        rawXcodebuildLogsPath: AbsolutePath?
     ) -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         if let archiveStub {
-            return archiveStub(target, scheme, clean, archivePath, arguments, rawXcodebuildLogs).asAsyncThrowingStream()
+            return archiveStub(target, scheme, clean, archivePath, arguments, rawXcodebuildLogs, rawXcodebuildLogsPath)
+                .asAsyncThrowingStream()
         } else {
             return AsyncThrowingStream {
                 throw TestError(
@@ -135,14 +143,15 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         }
     }
 
-    var createXCFrameworkStub: (([AbsolutePath], AbsolutePath, Bool) -> [SystemEvent<XcodeBuildOutput>])?
+    var createXCFrameworkStub: (([AbsolutePath], AbsolutePath, Bool, AbsolutePath?) -> [SystemEvent<XcodeBuildOutput>])?
     func createXCFramework(
         frameworks: [AbsolutePath],
         output: AbsolutePath,
-        rawXcodebuildLogs: Bool
+        rawXcodebuildLogs: Bool,
+        rawXcodebuildLogsPath: AbsolutePath?
     ) -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         if let createXCFrameworkStub {
-            return createXCFrameworkStub(frameworks, output, rawXcodebuildLogs).asAsyncThrowingStream()
+            return createXCFrameworkStub(frameworks, output, rawXcodebuildLogs, rawXcodebuildLogsPath).asAsyncThrowingStream()
         } else {
             return AsyncThrowingStream {
                 throw TestError(

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import TSCBasic
+import TSCUtility
 import TuistSupport
 
 /// Command that builds a target from the project in the current directory.
@@ -82,6 +83,13 @@ public struct BuildCommand: AsyncParsableCommand {
     )
     var rawXcodebuildLogs: Bool = false
 
+    @Option(
+        name: [.customLong("raw-xcodebuild-logs-path")],
+        help: "When passed, it writes the raw xcodebuild logs to the file at the given path.",
+        completion: .file()
+    )
+    var rawXcodebuildLogsPath: String?
+
     public func run() async throws {
         let absolutePath: AbsolutePath
         if let path {
@@ -89,6 +97,10 @@ public struct BuildCommand: AsyncParsableCommand {
         } else {
             absolutePath = FileHandler.shared.currentPath
         }
+        let rawXcodebuildLogsPath = rawXcodebuildLogsPath.map { try? AbsolutePath(
+            validating: $0,
+            relativeTo: FileHandler.shared.currentPath
+        ) } ?? nil
 
         try await BuildService().run(
             schemeName: scheme,
@@ -102,7 +114,8 @@ public struct BuildCommand: AsyncParsableCommand {
             platform: platform,
             osVersion: os,
             rosetta: rosetta,
-            rawXcodebuildLogs: rawXcodebuildLogs
+            rawXcodebuildLogs: rawXcodebuildLogs,
+            rawXcodebuildLogsPath: rawXcodebuildLogsPath
         )
     }
 }

--- a/Sources/TuistKit/Commands/RunCommand.swift
+++ b/Sources/TuistKit/Commands/RunCommand.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import TSCBasic
+import TSCUtility
 import TuistSupport
 
 public struct RunCommand: AsyncParsableCommand {
@@ -72,7 +73,18 @@ public struct RunCommand: AsyncParsableCommand {
     )
     var rawXcodebuildLogs: Bool = false
 
+    @Option(
+        name: [.customLong("raw-xcodebuild-logs-path")],
+        help: "When passed, it writes the raw xcodebuild logs to the file at the given path.",
+        completion: .file()
+    )
+    var rawXcodebuildLogsPath: String?
+
     public func run() async throws {
+        let rawXcodebuildLogsPath = rawXcodebuildLogsPath.map { try? AbsolutePath(
+            validating: $0,
+            relativeTo: FileHandler.shared.currentPath
+        ) } ?? nil
         try await RunService().run(
             path: path,
             schemeName: scheme,
@@ -83,7 +95,8 @@ public struct RunCommand: AsyncParsableCommand {
             version: os,
             rosetta: rosetta,
             arguments: arguments,
-            rawXcodebuildLogs: rawXcodebuildLogs
+            rawXcodebuildLogs: rawXcodebuildLogs,
+            rawXcodebuildLogsPath: rawXcodebuildLogsPath
         )
     }
 }

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -130,6 +130,13 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
     )
     var rawXcodebuildLogs: Bool = false
 
+    @Option(
+        name: [.customLong("raw-xcodebuild-logs-path")],
+        help: "When passed, it writes the raw xcodebuild logs to the file at the given path.",
+        completion: .file()
+    )
+    var rawXcodebuildLogsPath: String?
+
     public func validate() throws {
         try TestService().validateParameters(
             testTargets: testTargets,
@@ -145,6 +152,10 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
         } else {
             absolutePath = FileHandler.shared.currentPath
         }
+        let rawXcodebuildLogsPath = rawXcodebuildLogsPath.map { try? AbsolutePath(
+            validating: $0,
+            relativeTo: FileHandler.shared.currentPath
+        ) } ?? nil
 
         try await TestService().run(
             schemeName: scheme,
@@ -174,7 +185,8 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
                 )
             },
             validateTestTargetsParameters: false,
-            rawXcodebuildLogs: rawXcodebuildLogs
+            rawXcodebuildLogs: rawXcodebuildLogs,
+            rawXcodebuildLogsPath: rawXcodebuildLogsPath
         )
     }
 }

--- a/Sources/TuistKit/Services/BuildService.swift
+++ b/Sources/TuistKit/Services/BuildService.swift
@@ -61,7 +61,8 @@ final class BuildService {
         platform: String?,
         osVersion: String?,
         rosetta: Bool,
-        rawXcodebuildLogs: Bool
+        rawXcodebuildLogs: Bool,
+        rawXcodebuildLogsPath: AbsolutePath?
     ) async throws {
         let graph: Graph
         let generator = generatorFactory.default()
@@ -120,7 +121,8 @@ final class BuildService {
                 osVersion: osVersion?.version(),
                 rosetta: rosetta,
                 graphTraverser: graphTraverser,
-                rawXcodebuildLogs: rawXcodebuildLogs
+                rawXcodebuildLogs: rawXcodebuildLogs,
+                rawXcodebuildLogsPath: rawXcodebuildLogsPath
             )
         } else {
             var cleaned = false
@@ -152,7 +154,8 @@ final class BuildService {
                     osVersion: osVersion?.version(),
                     rosetta: rosetta,
                     graphTraverser: graphTraverser,
-                    rawXcodebuildLogs: rawXcodebuildLogs
+                    rawXcodebuildLogs: rawXcodebuildLogs,
+                    rawXcodebuildLogsPath: rawXcodebuildLogsPath
                 )
                 cleaned = true
             }

--- a/Sources/TuistKit/Services/RunService.swift
+++ b/Sources/TuistKit/Services/RunService.swift
@@ -67,7 +67,8 @@ final class RunService {
         version: String?,
         rosetta: Bool,
         arguments: [String],
-        rawXcodebuildLogs: Bool
+        rawXcodebuildLogs: Bool,
+        rawXcodebuildLogsPath: AbsolutePath?
     ) async throws {
         let runPath: AbsolutePath
         if let path {
@@ -117,7 +118,8 @@ final class RunService {
             osVersion: version?.version(),
             rosetta: rosetta,
             graphTraverser: graphTraverser,
-            rawXcodebuildLogs: rawXcodebuildLogs
+            rawXcodebuildLogs: rawXcodebuildLogs,
+            rawXcodebuildLogsPath: rawXcodebuildLogsPath
         )
 
         let minVersion: Version?

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -170,7 +170,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
         testPlanConfiguration: TestPlanConfiguration?,
         validateTestTargetsParameters: Bool = true,
         generator: Generating? = nil,
-        rawXcodebuildLogs: Bool
+        rawXcodebuildLogs: Bool,
+        rawXcodebuildLogsPath: AbsolutePath?
     ) async throws {
         if validateTestTargetsParameters {
             try validateParameters(
@@ -257,7 +258,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
                     testTargets: testTargets,
                     skipTestTargets: skipTestTargets,
                     testPlanConfiguration: testPlanConfiguration,
-                    rawXcodebuildLogs: rawXcodebuildLogs
+                    rawXcodebuildLogs: rawXcodebuildLogs,
+                    rawXcodebuildLogsPath: rawXcodebuildLogsPath
                 )
             }
         } else {
@@ -287,7 +289,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
                     testTargets: testTargets,
                     skipTestTargets: skipTestTargets,
                     testPlanConfiguration: testPlanConfiguration,
-                    rawXcodebuildLogs: rawXcodebuildLogs
+                    rawXcodebuildLogs: rawXcodebuildLogs,
+                    rawXcodebuildLogsPath: rawXcodebuildLogsPath
                 )
             }
         }
@@ -312,7 +315,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
         testTargets: [TestIdentifier],
         skipTestTargets: [TestIdentifier],
         testPlanConfiguration: TestPlanConfiguration?,
-        rawXcodebuildLogs: Bool
+        rawXcodebuildLogs: Bool,
+        rawXcodebuildLogsPath: AbsolutePath?
     ) async throws {
         logger.log(level: .notice, "Testing scheme \(scheme.name)", metadata: .section)
         if let testPlan = testPlanConfiguration?.testPlan, let testPlans = scheme.testAction?.testPlans,
@@ -370,7 +374,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
             testTargets: testTargets,
             skipTestTargets: skipTestTargets,
             testPlanConfiguration: testPlanConfiguration,
-            rawXcodebuildLogs: rawXcodebuildLogs
+            rawXcodebuildLogs: rawXcodebuildLogs,
+            rawXcodebuildLogsPath: rawXcodebuildLogsPath
         )
         .printFormattedOutput()
     }

--- a/Sources/TuistSupport/Logging/FileLogger.swift
+++ b/Sources/TuistSupport/Logging/FileLogger.swift
@@ -1,0 +1,31 @@
+import FileLogging
+import Foundation
+import TSCBasic
+
+public struct FileLogger: TextOutputStream {
+    enum FileHandlerOutputStream: Error {
+        case couldNotCreateFile
+    }
+
+    private let fileHandle: FileHandle
+    let encoding: String.Encoding
+
+    public init(path: AbsolutePath, encoding: String.Encoding = .utf8) throws {
+        if !FileManager.default.fileExists(atPath: path.url.path) {
+            guard FileManager.default.createFile(atPath: path.url.path, contents: nil, attributes: nil) else {
+                throw FileHandlerOutputStream.couldNotCreateFile
+            }
+        }
+
+        let fileHandle = try FileHandle(forWritingTo: path.url)
+        fileHandle.seekToEndOfFile()
+        self.fileHandle = fileHandle
+        self.encoding = encoding
+    }
+
+    public mutating func write(_ string: String) {
+        if let data = string.data(using: encoding) {
+            fileHandle.write(data)
+        }
+    }
+}

--- a/Sources/TuistSupport/Logging/FileLogger.swift
+++ b/Sources/TuistSupport/Logging/FileLogger.swift
@@ -1,4 +1,3 @@
-import FileLogging
 import Foundation
 import TSCBasic
 

--- a/Sources/TuistSupport/Logging/FileLogger.swift
+++ b/Sources/TuistSupport/Logging/FileLogger.swift
@@ -10,10 +10,11 @@ public struct FileLogger: TextOutputStream {
     let encoding: String.Encoding
 
     public init(path: AbsolutePath, encoding: String.Encoding = .utf8) throws {
-        if !FileManager.default.fileExists(atPath: path.url.path) {
-            guard FileManager.default.createFile(atPath: path.url.path, contents: nil, attributes: nil) else {
-                throw FileHandlerOutputStream.couldNotCreateFile
+        if !FileHandler.shared.exists(path) {
+            if !FileHandler.shared.exists(path.parentDirectory) {
+                try FileHandler.shared.createFolder(path.parentDirectory)
             }
+            try FileHandler.shared.touch(path)
         }
 
         let fileHandle = try FileHandle(forWritingTo: path.url)
@@ -22,7 +23,7 @@ public struct FileLogger: TextOutputStream {
         self.encoding = encoding
     }
 
-    public mutating func write(_ string: String) {
+    public func write(_ string: String) {
         if let data = string.data(using: encoding) {
             fileHandle.write(data)
         }

--- a/Tests/TuistAutomationTests/Utilities/TargetBuilderTests.swift
+++ b/Tests/TuistAutomationTests/Utilities/TargetBuilderTests.swift
@@ -61,6 +61,7 @@ final class TargetBuilderTests: TuistUnitTestCase {
         // Given
         let scheme = Scheme.test(name: "A")
         let workspacePath = try AbsolutePath(validating: "/path/to/project.xcworkspace")
+        let logsPath = try AbsolutePath(validating: "/tmp/logs.path")
         let configuration = "TestRelease"
         let clean = false
         let buildArguments: [XcodeBuildArgument] = [
@@ -82,15 +83,17 @@ final class TargetBuilderTests: TuistUnitTestCase {
             buildArguments
         }
 
-        xcodeBuildController.buildStub = { _workspace, _scheme, _destination, _rosetta, _, _clean, _buildArguments, _ in
-            XCTAssertEqual(_workspace.path, workspacePath)
-            XCTAssertEqual(_scheme, scheme.name)
-            XCTAssertEqual(_destination, destination)
-            XCTAssertEqual(_rosetta, rosetta)
-            XCTAssertEqual(_clean, clean)
-            XCTAssertEqual(_buildArguments, buildArguments)
-            return [.standardOutput(.init(raw: "success"))]
-        }
+        xcodeBuildController
+            .buildStub = { _workspace, _scheme, _destination, _rosetta, _, _clean, _buildArguments, _, _logsPath in
+                XCTAssertEqual(_workspace.path, workspacePath)
+                XCTAssertEqual(_scheme, scheme.name)
+                XCTAssertEqual(_destination, destination)
+                XCTAssertEqual(_rosetta, rosetta)
+                XCTAssertEqual(_clean, clean)
+                XCTAssertEqual(_buildArguments, buildArguments)
+                XCTAssertEqual(_logsPath, logsPath)
+                return [.standardOutput(.init(raw: "success"))]
+            }
 
         // When
         try await subject.buildTarget(
@@ -106,7 +109,8 @@ final class TargetBuilderTests: TuistUnitTestCase {
             osVersion: version,
             rosetta: rosetta,
             graphTraverser: MockGraphTraverser(),
-            rawXcodebuildLogs: false
+            rawXcodebuildLogs: false,
+            rawXcodebuildLogsPath: logsPath
         )
     }
 
@@ -118,7 +122,7 @@ final class TargetBuilderTests: TuistUnitTestCase {
         let workspacePath = try AbsolutePath(validating: "/path/to/project.xcworkspace")
         let graphTraverser = MockGraphTraverser()
 
-        xcodeBuildController.buildStub = { _, _, _, _, _, _, _, _ in
+        xcodeBuildController.buildStub = { _, _, _, _, _, _, _, _, _ in
             [.standardOutput(.init(raw: "success"))]
         }
 
@@ -143,7 +147,8 @@ final class TargetBuilderTests: TuistUnitTestCase {
             osVersion: nil,
             rosetta: false,
             graphTraverser: graphTraverser,
-            rawXcodebuildLogs: false
+            rawXcodebuildLogs: false,
+            rawXcodebuildLogsPath: nil
         )
 
         // Then
@@ -170,7 +175,7 @@ final class TargetBuilderTests: TuistUnitTestCase {
         let workspacePath = try AbsolutePath(validating: "/path/to/project.xcworkspace")
         let graphTraverser = MockGraphTraverser()
 
-        xcodeBuildController.buildStub = { _, _, _, _, _, _, _, _ in
+        xcodeBuildController.buildStub = { _, _, _, _, _, _, _, _, _ in
             [.standardOutput(.init(raw: "success"))]
         }
 
@@ -195,7 +200,8 @@ final class TargetBuilderTests: TuistUnitTestCase {
             osVersion: nil,
             rosetta: false,
             graphTraverser: graphTraverser,
-            rawXcodebuildLogs: false
+            rawXcodebuildLogs: false,
+            rawXcodebuildLogsPath: nil
         )
 
         // Then

--- a/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildControllerTests.swift
+++ b/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildControllerTests.swift
@@ -51,7 +51,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             derivedDataPath: nil,
             clean: true,
             arguments: [],
-            rawXcodebuildLogs: false
+            rawXcodebuildLogs: false,
+            rawXcodebuildLogsPath: nil
         )
 
         let result = try await events.toArray()
@@ -80,7 +81,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             derivedDataPath: nil,
             clean: true,
             arguments: [],
-            rawXcodebuildLogs: false
+            rawXcodebuildLogs: false,
+            rawXcodebuildLogsPath: nil
         )
 
         let result = try await events.toArray()
@@ -110,7 +112,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             derivedDataPath: nil,
             clean: true,
             arguments: [],
-            rawXcodebuildLogs: false
+            rawXcodebuildLogs: false,
+            rawXcodebuildLogsPath: nil
         )
 
         let result = try await events.toArray()
@@ -140,7 +143,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             derivedDataPath: nil,
             clean: true,
             arguments: [],
-            rawXcodebuildLogs: false
+            rawXcodebuildLogs: false,
+            rawXcodebuildLogsPath: nil
         )
 
         let result = try await events.toArray()
@@ -182,7 +186,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             testTargets: [],
             skipTestTargets: [],
             testPlanConfiguration: nil,
-            rawXcodebuildLogs: false
+            rawXcodebuildLogs: false,
+            rawXcodebuildLogsPath: nil
         )
 
         let result = try await events.toArray()
@@ -224,7 +229,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             testTargets: [],
             skipTestTargets: [],
             testPlanConfiguration: nil,
-            rawXcodebuildLogs: false
+            rawXcodebuildLogs: false,
+            rawXcodebuildLogsPath: nil
         )
 
         let result = try await events.toArray()
@@ -268,7 +274,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             testTargets: [],
             skipTestTargets: [],
             testPlanConfiguration: nil,
-            rawXcodebuildLogs: false
+            rawXcodebuildLogs: false,
+            rawXcodebuildLogsPath: nil
         )
 
         let result = try await events.toArray()
@@ -312,7 +319,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             testTargets: [],
             skipTestTargets: [],
             testPlanConfiguration: nil,
-            rawXcodebuildLogs: false
+            rawXcodebuildLogs: false,
+            rawXcodebuildLogsPath: nil
         )
 
         let result = try await events.toArray()
@@ -356,7 +364,8 @@ final class XcodeBuildControllerTests: TuistUnitTestCase {
             testTargets: [],
             skipTestTargets: [],
             testPlanConfiguration: nil,
-            rawXcodebuildLogs: false
+            rawXcodebuildLogs: false,
+            rawXcodebuildLogsPath: nil
         )
 
         let result = try await events.toArray()

--- a/Tests/TuistKitTests/Services/BuildServiceTests.swift
+++ b/Tests/TuistKitTests/Services/BuildServiceTests.swift
@@ -69,6 +69,7 @@ final class BuildServiceTests: TuistUnitTestCase {
         // Given
         let path = try temporaryPath()
         let workspacePath = path.appending(component: "App.xcworkspace")
+        let rawXcodebuildLogsPath = try AbsolutePath(validating: "/tmp/xcodebuild.log")
         let graph = Graph.test()
         let scheme = Scheme.test()
         let project = Project.test()
@@ -97,18 +98,22 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_skipSigning, skipSigning)
             return buildArguments
         }
-        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _device, _osVersion, _, _, _ in
-            XCTAssertEqual(_workspacePath, workspacePath)
-            XCTAssertEqual(_scheme, scheme)
-            XCTAssertTrue(_clean)
-            XCTAssertNil(_device)
-            XCTAssertNil(_osVersion)
-        }
+        targetBuilder
+            .buildTargetStub =
+            { _, _workspacePath, _scheme, _clean, _, _, _, _device, _osVersion, _, _, _, _rawXcodebuildLogsPath in
+                XCTAssertEqual(_workspacePath, workspacePath)
+                XCTAssertEqual(_scheme, scheme)
+                XCTAssertTrue(_clean)
+                XCTAssertNil(_device)
+                XCTAssertNil(_osVersion)
+                XCTAssertEqual(_rawXcodebuildLogsPath, rawXcodebuildLogsPath)
+            }
 
         // Then
         try await subject.testRun(
             schemeName: scheme.name,
-            path: path
+            path: path,
+            rawXcodebuildLogsPath: rawXcodebuildLogsPath
         )
     }
 
@@ -122,6 +127,7 @@ final class BuildServiceTests: TuistUnitTestCase {
         let target = Target.test()
         let buildArguments: [XcodeBuildArgument] = [.sdk("iphoneos")]
         let skipSigning = false
+        let rawXcodebuildLogsPath = try AbsolutePath(validating: "/tmp/xcodebuild.log")
 
         generator.loadStub = { _path in
             XCTAssertEqual(_path, path)
@@ -144,16 +150,18 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_skipSigning, skipSigning)
             return buildArguments
         }
-        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _, _, _, _, _ in
+        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _, _, _, _, _, _rawXcodebuildLogsPath in
             XCTAssertEqual(_workspacePath, workspacePath)
             XCTAssertEqual(_scheme, scheme)
             XCTAssertTrue(_clean)
+            XCTAssertEqual(_rawXcodebuildLogsPath, rawXcodebuildLogsPath)
         }
 
         // Then
         try await subject.testRun(
             schemeName: scheme.name,
-            path: path
+            path: path,
+            rawXcodebuildLogsPath: rawXcodebuildLogsPath
         )
     }
 
@@ -169,6 +177,7 @@ final class BuildServiceTests: TuistUnitTestCase {
         let targetB = Target.test(name: "B")
         let buildArguments: [XcodeBuildArgument] = [.sdk("iphoneos")]
         let skipSigning = false
+        let rawXcodebuildLogsPath = try AbsolutePath(validating: "/tmp/xcodebuild.log")
 
         generator.loadStub = { _path in
             XCTAssertEqual(_path, path)
@@ -190,26 +199,30 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_skipSigning, skipSigning)
             return buildArguments
         }
-        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _device, _osVersion, _, _, _ in
-            XCTAssertEqual(_workspacePath, workspacePath)
-            XCTAssertNil(_device)
-            XCTAssertNil(_osVersion)
+        targetBuilder
+            .buildTargetStub =
+            { _, _workspacePath, _scheme, _clean, _, _, _, _device, _osVersion, _, _, _, _rawXcodebuildLogsPath in
+                XCTAssertEqual(_workspacePath, workspacePath)
+                XCTAssertNil(_device)
+                XCTAssertNil(_osVersion)
+                XCTAssertEqual(_rawXcodebuildLogsPath, rawXcodebuildLogsPath)
 
-            if _scheme.name == "A" {
-                XCTAssertEqual(_scheme, schemeA)
-                XCTAssertTrue(_clean)
-            } else if _scheme.name == "B" {
-                // When running the second scheme clean should be false
-                XCTAssertEqual(_scheme, schemeB)
-                XCTAssertFalse(_clean)
-            } else {
-                XCTFail("unexpected scheme \(_scheme.name)")
+                if _scheme.name == "A" {
+                    XCTAssertEqual(_scheme, schemeA)
+                    XCTAssertTrue(_clean)
+                } else if _scheme.name == "B" {
+                    // When running the second scheme clean should be false
+                    XCTAssertEqual(_scheme, schemeB)
+                    XCTAssertFalse(_clean)
+                } else {
+                    XCTFail("unexpected scheme \(_scheme.name)")
+                }
             }
-        }
 
         // Then
         try await subject.testRun(
-            path: path
+            path: path,
+            rawXcodebuildLogsPath: rawXcodebuildLogsPath
         )
     }
 
@@ -225,6 +238,7 @@ final class BuildServiceTests: TuistUnitTestCase {
         let targetB = Target.test(name: "B")
         let buildArguments: [XcodeBuildArgument] = [.sdk("iphoneos")]
         let skipSigning = false
+        let rawXcodebuildLogsPath = try AbsolutePath(validating: "/tmp/xcodebuild.log")
 
         generator.loadStub = { _path in
             XCTAssertEqual(_path, path)
@@ -246,9 +260,9 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_skipSigning, skipSigning)
             return buildArguments
         }
-        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _, _, _, _, _ in
+        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _, _, _, _, _, _rawXcodebuildLogsPath in
             XCTAssertEqual(_workspacePath, workspacePath)
-
+            XCTAssertEqual(_rawXcodebuildLogsPath, rawXcodebuildLogsPath)
             if _scheme.name == "A" {
                 XCTAssertEqual(_scheme, schemeA)
                 XCTAssertTrue(_clean)
@@ -260,7 +274,8 @@ final class BuildServiceTests: TuistUnitTestCase {
         // Then
         try await subject.testRun(
             schemeName: "A",
-            path: path
+            path: path,
+            rawXcodebuildLogsPath: rawXcodebuildLogsPath
         )
     }
 
@@ -310,7 +325,8 @@ extension BuildService {
         device: String? = nil,
         platform: String? = nil,
         osVersion: String? = nil,
-        rosetta: Bool = false
+        rosetta: Bool = false,
+        rawXcodebuildLogsPath: AbsolutePath? = nil
     ) async throws {
         try await run(
             schemeName: schemeName,
@@ -324,7 +340,8 @@ extension BuildService {
             platform: platform,
             osVersion: osVersion,
             rosetta: rosetta,
-            rawXcodebuildLogs: false
+            rawXcodebuildLogs: false,
+            rawXcodebuildLogsPath: rawXcodebuildLogsPath
         )
     }
 }

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -203,7 +203,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedRosetta: Bool?
-        xcodebuildController.testStub = { _, _, _, _, rosetta, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, rosetta, _, _, _, _, _, _, _, _, _ in
             testedRosetta = rosetta
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -238,7 +238,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -270,7 +270,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -313,7 +313,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -345,7 +345,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -374,7 +374,7 @@ final class TestServiceTests: TuistUnitTestCase {
         }
         var testedSchemes: [String] = []
         xcodebuildController.testErrorStub = NSError.test()
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return []
         }
@@ -409,7 +409,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -429,7 +429,7 @@ final class TestServiceTests: TuistUnitTestCase {
         let expectedResourceBundlePath = try AbsolutePath(validating: "/test")
         var resourceBundlePath: AbsolutePath?
 
-        xcodebuildController.testStub = { _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _, _, _ in
             resourceBundlePath = gotResourceBundlePath
             return []
         }
@@ -460,7 +460,7 @@ final class TestServiceTests: TuistUnitTestCase {
         let expectedResourceBundlePath = try AbsolutePath(validating: "/test")
         var resourceBundlePath: AbsolutePath?
 
-        xcodebuildController.testStub = { _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _, _, _ in
             resourceBundlePath = gotResourceBundlePath
             return []
         }
@@ -505,7 +505,7 @@ final class TestServiceTests: TuistUnitTestCase {
         }
 
         var passedRetryCount = 0
-        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, retryCount, _, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, retryCount, _, _, _, _, _ in
             passedRetryCount = retryCount
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -538,7 +538,7 @@ final class TestServiceTests: TuistUnitTestCase {
         }
 
         var passedRetryCount = -1
-        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, retryCount, _, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, retryCount, _, _, _, _, _ in
             passedRetryCount = retryCount
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -581,7 +581,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -621,7 +621,7 @@ final class TestServiceTests: TuistUnitTestCase {
         generator.generateWithGraphStub = { path in
             (path, Graph.test())
         }
-        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, _, _, _, _, _, _ in
             [.standardOutput(.init(raw: "success"))]
         }
 
@@ -679,7 +679,8 @@ extension TestService {
             testTargets: testTargets,
             skipTestTargets: skipTestTargets,
             testPlanConfiguration: testPlanConfiguration,
-            rawXcodebuildLogs: false
+            rawXcodebuildLogs: false,
+            rawXcodebuildLogsPath: nil
         )
     }
 }


### PR DESCRIPTION
### Short description 📝
When running acceptance tests via `xcodebuild > XCTest`, logs are not forwarded through `xcodebuild`'s standard output. This motivated me to add a new option to commands, `--raw-xcodebuild-logs-path`, for Tuist to output the raw logs to a given path. In a follow-up PR I plan to use that flag from acceptance tests to output the logs as artifacts of the GitHub Actions workflows. This will improve the experience of debugging failing acceptance tests.

### How to test the changes locally 🧐
You can run `build` against a project passing that option. A file should get created and the raw logs should be dumped there.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
