### PR TITLE
Export the `TuistDependencies` product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -343,6 +343,10 @@ let package = Package(
             targets: ["TuistSigning"]
         ),
         .library(
+            name: "TuistDependencies",
+            targets: ["TuistDependencies"]
+        ),
+        .library(
             name: "TuistAcceptanceTesting",
             targets: ["TuistAcceptanceTesting"]
         ),


### PR DESCRIPTION
### Short description 📝
In order to address [this comment](https://github.com/tuist/tuist/pull/5674/files#r1426407334), and be able to use the new graph mappers beyond this repository, I need to export the `TuistDependencies` product. In the future we can iterate on the code pattern to avoid some duplications.