### PR TITLE
Add missing `XcodeProj` dependency to `TuistAcceptanceTesting`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -141,6 +141,7 @@ var targets: [Target] = [
             "TuistKit",
             "TuistCore",
             "TuistSupportTesting",
+            "XcodeProj",
             swiftToolsSupportDependency,
         ],
         linkerSettings: [.linkedFramework("XCTest")]

--- a/Project.swift
+++ b/Project.swift
@@ -498,6 +498,7 @@ func targets() -> [Target] {
                 .target(name: "TuistCore"),
                 .external(name: "SwiftToolsSupport"),
                 .external(name: "SystemPackage"),
+                .external(name: "XcodeProj"),
                 .sdk(name: "XCTest", type: .framework, status: .optional),
             ]
         ),


### PR DESCRIPTION
### Short description 📝
The `XcodeProj` dependency was missing in the list of dependencies of `TuistAcceptanceTesting`. [`TuistAcceptanceTestCase+Extra.swift`](https://github.com/tuist/tuist/blob/main/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase%2BExtra.swift#L3) depends on it.