### PR TITLE
Allow specifying Xcodebuild arch argument

### DIFF
--- a/Sources/TuistCore/Automation/XcodeBuildArgument.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildArgument.swift
@@ -19,6 +19,9 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
     /// Specifies number of retry attempts on failure for testing
     case retryCount(Int)
 
+    /// Specifies architecture for which to build
+    case arch(String)
+
     /// To pass additional arguments
     case xcarg(String, String)
 
@@ -35,6 +38,8 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
             return ["-derivedDataPath", path.pathString]
         case let .retryCount(count):
             return ["-retry-tests-on-failure", "-test-iterations", "\(count + 1)"]
+        case let .arch(architecture):
+            return ["-arch", architecture]
         case let .xcarg(key, value):
             return ["\(key)=\(value.spm_shellEscaped())"]
         }
@@ -53,6 +58,8 @@ public enum XcodeBuildArgument: Equatable, CustomStringConvertible {
             return "Xcodebuild's derivedDataPath argument: \(path.pathString)"
         case let .retryCount(count):
             return "Xcodebuild's retry-tests-on-failure argument combined with test-iterations: \(count + 1)"
+        case let .arch(architecture):
+            return "Xcodebuild's arch argument: \(architecture)"
         case let .xcarg(key, value):
             return "Xcodebuild's additional argument: \(key)=\(value)"
         }


### PR DESCRIPTION
### Short description 📝

Allow specifying `arch` in `XcodeBuildArgument`

### How to test the changes locally 🧐

CI should succeed.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
