### PR TITLE
Fix a bug that causes platform from being wrongly stripped

### DIFF
--- a/Sources/TuistDependencies/Mappers/ExternalProjectsPlatformNarrowerGraphMapper.swift
+++ b/Sources/TuistDependencies/Mappers/ExternalProjectsPlatformNarrowerGraphMapper.swift
@@ -30,7 +30,7 @@ public struct ExternalProjectsPlatformNarrowerGraphMapper: GraphMapping {
                 /**
                  We only include the destinations whose platform is included in the list of the target supported platforms.
                  */
-                if let targetFilteredPlatforms = externalTargetSupportedPlatforms[graphTarget] {
+                if project.isExternal, let targetFilteredPlatforms = externalTargetSupportedPlatforms[graphTarget] {
                     target.destinations = target.destinations.filter { destination in
                         targetFilteredPlatforms.contains(destination.platform)
                     }

--- a/Sources/TuistDependencies/Mappers/ExternalProjectsPlatformNarrowerGraphMapper.swift
+++ b/Sources/TuistDependencies/Mappers/ExternalProjectsPlatformNarrowerGraphMapper.swift
@@ -24,21 +24,45 @@ public struct ExternalProjectsPlatformNarrowerGraphMapper: GraphMapping {
         graph.targets = Dictionary(uniqueKeysWithValues: graph.targets.map { projectPath, projectTargets in
             let project = graph.projects[projectPath]!
             let projectTargets = Dictionary(uniqueKeysWithValues: projectTargets.map { targetName, target in
-                let graphTarget = GraphTarget(path: projectPath, target: target, project: project)
-                var target = target
-
-                /**
-                 We only include the destinations whose platform is included in the list of the target supported platforms.
-                 */
-                if project.isExternal, let targetFilteredPlatforms = externalTargetSupportedPlatforms[graphTarget] {
-                    target.destinations = target.destinations.filter { destination in
-                        targetFilteredPlatforms.contains(destination.platform)
-                    }
-                }
-                return (targetName, target)
+                (
+                    targetName,
+                    mapTarget(
+                        target: target,
+                        project: project,
+                        externalTargetSupportedPlatforms: externalTargetSupportedPlatforms
+                    )
+                )
             })
             return (projectPath, projectTargets)
         })
+        graph.projects = Dictionary(uniqueKeysWithValues: graph.projects.map { projectPath, project in
+            var project = project
+            project.targets = project.targets.map { mapTarget(
+                target: $0,
+                project: project,
+                externalTargetSupportedPlatforms: externalTargetSupportedPlatforms
+            ) }
+            return (projectPath, project)
+        })
+
         return (graph, [])
+    }
+
+    private func mapTarget(
+        target: Target,
+        project: Project,
+        externalTargetSupportedPlatforms: [GraphTarget: Set<Platform>]
+    ) -> Target {
+        /**
+         We only include the destinations whose platform is included in the list of the target supported platforms.
+         */
+        var target = target
+        let graphTarget = GraphTarget(path: project.path, target: target, project: project)
+        if project.isExternal, let targetFilteredPlatforms = externalTargetSupportedPlatforms[graphTarget] {
+            target.destinations = target.destinations.filter { destination in
+                targetFilteredPlatforms.contains(destination.platform)
+            }
+        }
+        return target
     }
 }

--- a/Tests/TuistDependenciesTests/Mappers/ExternalProjectsPlatformNarrowerGraphMapperTests.swift
+++ b/Tests/TuistDependenciesTests/Mappers/ExternalProjectsPlatformNarrowerGraphMapperTests.swift
@@ -67,6 +67,60 @@ final class ExternalProjectsPlatformNarrowerGraphMapperTests: TuistUnitTestCase 
         )
     }
 
+    func test_map_when_external_with_platform_filter() async throws {
+        // Given
+        let directory = try temporaryPath()
+        let packagesDirectory = directory.appending(component: "Dependencies")
+
+        let appTarget = Target.test(name: "App", destinations: [.iPad, .iPhone, .appleWatch, .appleTv, .mac])
+        let externalPackage = Target.test(
+            name: "Package",
+            destinations: [.iPhone, .iPad],
+            product: .framework
+        )
+
+        let project = Project.test(path: directory, targets: [appTarget])
+        let externalProject = Project.test(path: packagesDirectory, targets: [externalPackage], isExternal: true)
+
+        let appTargetDependency = GraphDependency.target(name: appTarget.name, path: project.path)
+        let externalPackageDependency = GraphDependency.target(name: externalPackage.name, path: externalProject.path)
+        let dependencyCondition = try XCTUnwrap(PlatformCondition.when([.ios]))
+
+        let graph = Graph.test(
+            projects: [
+                directory: project,
+                packagesDirectory: externalProject,
+            ],
+            targets: [
+                project.path: [
+                    appTarget.name: appTarget,
+                ],
+                externalProject.path: [
+                    externalPackage.name: externalPackage,
+                ],
+            ],
+            dependencies: [
+                appTargetDependency: Set([externalPackageDependency]),
+            ],
+            dependencyConditions: [
+                GraphEdge(from: appTargetDependency, to: externalPackageDependency): dependencyCondition,
+            ]
+        )
+
+        // When
+        let (mappedGraph, _) = try await subject.map(graph: graph)
+
+        // Then
+        XCTAssertEqual(
+            try XCTUnwrap(mappedGraph.targets[project.path]?[appTarget.name]?.supportedPlatforms),
+            Set([.iOS, .macOS, .tvOS, .watchOS])
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(mappedGraph.targets[externalProject.path]![externalPackage.name]?.supportedPlatforms),
+            Set([.iOS])
+        )
+    }
+
     func test_map_when_external_transitive_dependency_without_platform_filter() async throws {
         // Given
         let directory = try temporaryPath()


### PR DESCRIPTION
### Short description 📝
The logic that narrowed platforms for external dependencies wrongly deleted platforms for non-external targets as reported [on Slack](https://tuistapp.slack.com/archives/C051W5ZTR8R/p1703166223646419). This PR fixes it.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
