### PR TITLE
Fix deployment targets on tree shake

### DIFF
--- a/Sources/TuistDependencies/Mappers/ExternalProjectsPlatformNarrowerGraphMapper.swift
+++ b/Sources/TuistDependencies/Mappers/ExternalProjectsPlatformNarrowerGraphMapper.swift
@@ -62,6 +62,16 @@ public struct ExternalProjectsPlatformNarrowerGraphMapper: GraphMapping {
             target.destinations = target.destinations.filter { destination in
                 targetFilteredPlatforms.contains(destination.platform)
             }
+
+            // By changing the destinations we also need to adapt the deployment targets accordingly to account for possibly
+            // removed destinations
+            target.deploymentTargets = .init(
+                iOS: targetFilteredPlatforms.contains(.iOS) ? target.deploymentTargets.iOS : nil,
+                macOS: targetFilteredPlatforms.contains(.macOS) ? target.deploymentTargets.macOS : nil,
+                watchOS: targetFilteredPlatforms.contains(.watchOS) ? target.deploymentTargets.watchOS : nil,
+                tvOS: targetFilteredPlatforms.contains(.tvOS) ? target.deploymentTargets.tvOS : nil,
+                visionOS: targetFilteredPlatforms.contains(.visionOS) ? target.deploymentTargets.visionOS : nil
+            )
         }
         return target
     }

--- a/Tests/TuistDependenciesTests/Mappers/ExternalProjectsPlatformNarrowerGraphMapperTests.swift
+++ b/Tests/TuistDependenciesTests/Mappers/ExternalProjectsPlatformNarrowerGraphMapperTests.swift
@@ -75,8 +75,9 @@ final class ExternalProjectsPlatformNarrowerGraphMapperTests: TuistUnitTestCase 
         let appTarget = Target.test(name: "App", destinations: [.iPad, .iPhone, .appleWatch, .appleTv, .mac])
         let externalPackage = Target.test(
             name: "Package",
-            destinations: [.iPhone, .iPad],
-            product: .framework
+            destinations: [.iPhone, .iPad, .appleWatch],
+            product: .framework,
+            deploymentTargets: .init(iOS: "16.0", macOS: nil, watchOS: "9.0", tvOS: nil, visionOS: nil)
         )
 
         let project = Project.test(path: directory, targets: [appTarget])
@@ -84,6 +85,8 @@ final class ExternalProjectsPlatformNarrowerGraphMapperTests: TuistUnitTestCase 
 
         let appTargetDependency = GraphDependency.target(name: appTarget.name, path: project.path)
         let externalPackageDependency = GraphDependency.target(name: externalPackage.name, path: externalProject.path)
+
+        // Only use the external target on iOS
         let dependencyCondition = try XCTUnwrap(PlatformCondition.when([.ios]))
 
         let graph = Graph.test(
@@ -118,6 +121,10 @@ final class ExternalProjectsPlatformNarrowerGraphMapperTests: TuistUnitTestCase 
         XCTAssertEqual(
             try XCTUnwrap(mappedGraph.targets[externalProject.path]![externalPackage.name]?.supportedPlatforms),
             Set([.iOS])
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(mappedGraph.targets[externalProject.path]![externalPackage.name]?.deploymentTargets),
+            .iOS("16.0")
         )
     }
 


### PR DESCRIPTION
### Short description 📝

This PR tries to fix an issue that on tree shaking external dependencies the deployment targets also needs to account for possibly removed destinations. 

Also reported [on Slack](https://tuistapp.slack.com/archives/C018QG7U7SN/p1703183601286719)

An example error that could be seen when this issue arises:

```
Found an inconsistency between target destinations `[TuistGraph.Destination.iPad, TuistGraph.Destination.iPhone, TuistGraph.Destination.macWithiPadDesign]` and deployment target `watchOS`
```

### How to test the changes locally 🧐

Unit tests should succeed

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
