### PR TITLE
Make CleanCommand public

### DIFF
--- a/Sources/TuistKit/Commands/CleanCommand.swift
+++ b/Sources/TuistKit/Commands/CleanCommand.swift
@@ -32,8 +32,10 @@ enum CleanCategory: ExpressibleByArgument {
     }
 }
 
-struct CleanCommand: ParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct CleanCommand: ParsableCommand {
+    public init() {}
+
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "clean",
             abstract: "Clean all the artifacts stored locally"
@@ -50,7 +52,7 @@ struct CleanCommand: ParsableCommand {
     )
     var path: String?
 
-    func run() throws {
+    public func run() throws {
         try CleanService().run(
             categories: cleanCategories,
             path: path


### PR DESCRIPTION
### Short description 📝

Make CleanCommand public

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
