### PR TITLE
Add a `--generate-only` flag to the build command

### DIFF
--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -94,7 +94,7 @@ public struct BuildCommand: AsyncParsableCommand {
         name: .long,
         help: "When passed, it generates the project and skips building. This is useful for debugging purposes."
     )
-    var onlyGenerate: Bool = false
+    var generateOnly: Bool = false
 
     public func run() async throws {
         let absolutePath: AbsolutePath
@@ -122,7 +122,7 @@ public struct BuildCommand: AsyncParsableCommand {
             rosetta: rosetta,
             rawXcodebuildLogs: rawXcodebuildLogs,
             rawXcodebuildLogsPath: rawXcodebuildLogsPath,
-            onlyGenerate: onlyGenerate
+            generateOnly: generateOnly
         )
     }
 }

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -90,6 +90,12 @@ public struct BuildCommand: AsyncParsableCommand {
     )
     var rawXcodebuildLogsPath: String?
 
+    @Flag(
+        name: .long,
+        help: "When passed, it generates the project and skips building. This is useful for debugging purposes."
+    )
+    var onlyGenerate: Bool = false
+
     public func run() async throws {
         let absolutePath: AbsolutePath
         if let path {
@@ -115,7 +121,8 @@ public struct BuildCommand: AsyncParsableCommand {
             osVersion: os,
             rosetta: rosetta,
             rawXcodebuildLogs: rawXcodebuildLogs,
-            rawXcodebuildLogsPath: rawXcodebuildLogsPath
+            rawXcodebuildLogsPath: rawXcodebuildLogsPath,
+            onlyGenerate: onlyGenerate
         )
     }
 }

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -137,6 +137,12 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
     )
     var rawXcodebuildLogsPath: String?
 
+    @Flag(
+        name: .long,
+        help: "When passed, it generates the project and skips testing. This is useful for debugging purposes."
+    )
+    var generateOnly: Bool = false
+
     public func validate() throws {
         try TestService().validateParameters(
             testTargets: testTargets,
@@ -186,7 +192,8 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
             },
             validateTestTargetsParameters: false,
             rawXcodebuildLogs: rawXcodebuildLogs,
-            rawXcodebuildLogsPath: rawXcodebuildLogsPath
+            rawXcodebuildLogsPath: rawXcodebuildLogsPath,
+            generateOnly: generateOnly
         )
     }
 }

--- a/Sources/TuistKit/Services/BuildService.swift
+++ b/Sources/TuistKit/Services/BuildService.swift
@@ -62,7 +62,8 @@ final class BuildService {
         osVersion: String?,
         rosetta: Bool,
         rawXcodebuildLogs: Bool,
-        rawXcodebuildLogsPath: AbsolutePath?
+        rawXcodebuildLogsPath: AbsolutePath?,
+        onlyGenerate: Bool
     ) async throws {
         let graph: Graph
         let generator = generatorFactory.default()
@@ -70,6 +71,10 @@ final class BuildService {
             graph = try await generator.generateWithGraph(path: path).1
         } else {
             graph = try await generator.load(path: path)
+        }
+
+        if onlyGenerate {
+            return
         }
 
         guard let workspacePath = try buildGraphInspector.workspacePath(directory: path) else {

--- a/Sources/TuistKit/Services/BuildService.swift
+++ b/Sources/TuistKit/Services/BuildService.swift
@@ -63,7 +63,7 @@ final class BuildService {
         rosetta: Bool,
         rawXcodebuildLogs: Bool,
         rawXcodebuildLogsPath: AbsolutePath?,
-        onlyGenerate: Bool
+        generateOnly: Bool
     ) async throws {
         let graph: Graph
         let generator = generatorFactory.default()
@@ -73,7 +73,7 @@ final class BuildService {
             graph = try await generator.load(path: path)
         }
 
-        if onlyGenerate {
+        if generateOnly {
             return
         }
 

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -171,7 +171,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
         validateTestTargetsParameters: Bool = true,
         generator: Generating? = nil,
         rawXcodebuildLogs: Bool,
-        rawXcodebuildLogsPath: AbsolutePath?
+        rawXcodebuildLogsPath: AbsolutePath?,
+        generateOnly: Bool
     ) async throws {
         if validateTestTargetsParameters {
             try validateParameters(
@@ -203,6 +204,11 @@ public final class TestService { // swiftlint:disable:this type_body_length
         let graph = try await testGenerator.generateWithGraph(
             path: path
         ).1
+
+        if generateOnly {
+            return
+        }
+
         let graphTraverser = GraphTraverser(graph: graph)
         let version = osVersion?.version()
         let testableSchemes = buildGraphInspector.testableSchemes(graphTraverser: graphTraverser) +

--- a/Tests/TuistKitTests/Services/BuildServiceTests.swift
+++ b/Tests/TuistKitTests/Services/BuildServiceTests.swift
@@ -327,7 +327,7 @@ extension BuildService {
         osVersion: String? = nil,
         rosetta: Bool = false,
         rawXcodebuildLogsPath: AbsolutePath? = nil,
-        onlyGenerate: Bool = false
+        generateOnly: Bool = false
     ) async throws {
         try await run(
             schemeName: schemeName,
@@ -343,7 +343,7 @@ extension BuildService {
             rosetta: rosetta,
             rawXcodebuildLogs: false,
             rawXcodebuildLogsPath: rawXcodebuildLogsPath,
-            onlyGenerate: onlyGenerate
+            generateOnly: generateOnly
         )
     }
 }

--- a/Tests/TuistKitTests/Services/BuildServiceTests.swift
+++ b/Tests/TuistKitTests/Services/BuildServiceTests.swift
@@ -326,7 +326,8 @@ extension BuildService {
         platform: String? = nil,
         osVersion: String? = nil,
         rosetta: Bool = false,
-        rawXcodebuildLogsPath: AbsolutePath? = nil
+        rawXcodebuildLogsPath: AbsolutePath? = nil,
+        onlyGenerate: Bool = false
     ) async throws {
         try await run(
             schemeName: schemeName,
@@ -341,7 +342,8 @@ extension BuildService {
             osVersion: osVersion,
             rosetta: rosetta,
             rawXcodebuildLogs: false,
-            rawXcodebuildLogsPath: rawXcodebuildLogsPath
+            rawXcodebuildLogsPath: rawXcodebuildLogsPath,
+            onlyGenerate: onlyGenerate
         )
     }
 }

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -661,7 +661,10 @@ extension TestService {
         retryCount: Int = 0,
         testTargets: [TestIdentifier] = [],
         skipTestTargets: [TestIdentifier] = [],
-        testPlanConfiguration: TestPlanConfiguration? = nil
+        testPlanConfiguration: TestPlanConfiguration? = nil,
+        rawXcodebuildLogs: Bool = false,
+        rawXcodebuildLogsPath: AbsolutePath? = nil,
+        generateOnly: Bool = false
     ) async throws {
         try await run(
             schemeName: schemeName,
@@ -679,8 +682,9 @@ extension TestService {
             testTargets: testTargets,
             skipTestTargets: skipTestTargets,
             testPlanConfiguration: testPlanConfiguration,
-            rawXcodebuildLogs: false,
-            rawXcodebuildLogsPath: nil
+            rawXcodebuildLogs: rawXcodebuildLogs,
+            rawXcodebuildLogsPath: rawXcodebuildLogsPath,
+            generateOnly: generateOnly
         )
     }
 }


### PR DESCRIPTION
### Short description 📝

`cache warm`, `test`, and `build`, generate the project before interacting with it through `xcodebuild` project. When those commands fail, we recommend users open the generated Xcode project to check if it is valid and can be built or tested. Currently, users don't have a way to say, "Generate the project that you'd use for warming the cache". This PR addresses that for the `build` command by adding a `--generate-only` option. I'll do the same for `test` and `cache warm`.


### How to test the changes locally 🧐
You should be able to run `tuist build --only-generate` against a project and only get the project generated.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
