### PR TITLE
Removed TargetDependency's .packagePlugin API in favor of using PackageType

### DIFF
--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -103,14 +103,6 @@ public enum TargetDependency: Codable, Hashable {
     ///   - condition: condition under which to use this dependency, `nil` if this should always be used
     case package(product: String, type: PackageType = .runtime, condition: PlatformCondition? = nil)
 
-    /// Dependency on a swift package manager plugin product using Xcode native integration.
-    ///
-    /// - Parameters:
-    ///   - product: The name of the output product. ${PRODUCT_NAME} inside Xcode.
-    ///              e.g. RxSwift
-    ///   - condition: condition under which to use this dependency, `nil` if this should always be used
-    case packagePlugin(product: String, condition: PlatformCondition? = nil)
-
     /// Dependency on system library or framework
     ///
     /// - Parameters:
@@ -171,8 +163,6 @@ public enum TargetDependency: Codable, Hashable {
             return "library"
         case .package:
             return "package"
-        case .packagePlugin:
-            return "packagePlugin"
         case .sdk:
             return "sdk"
         case .xcframework:

--- a/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TargetDependency+ManifestMapper.swift
@@ -66,9 +66,6 @@ extension TuistGraph.TargetDependency {
             case .plugin:
                 return [.package(product: product, type: .plugin, condition: condition?.asGraphCondition)]
             }
-        case let .packagePlugin(product, condition):
-            logger.warning(".packagePlugin is deprecated. Use .package(product:, type: .plugin) instead.")
-            return [.package(product: product, type: .plugin, condition: condition?.asGraphCondition)]
         case let .sdk(name, type, status, condition):
             return [
                 .sdk(

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/TargetDependency+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/TargetDependency+ManifestMapperTests.swift
@@ -88,6 +88,72 @@ final class DependencyManifestMapperTests: TuistUnitTestCase {
         XCTAssertEqual(path, "/Project")
     }
 
+    func test_from_when_package_runtime() throws {
+        // Given
+        let dependency = ProjectDescription.TargetDependency.package(product: "RuntimePackageProduct", type: .runtime)
+        let generatorPaths = GeneratorPaths(manifestDirectory: try AbsolutePath(validating: "/"))
+        
+        // When
+        let got = try TuistGraph.TargetDependency.from(
+            manifest: dependency,
+            generatorPaths: generatorPaths,
+            externalDependencies: [:]
+        )
+        
+        // Then
+        XCTAssertEqual(got.count, 1)
+        guard case let .package(product, type, _) = got[0] else {
+            XCTFail("Dependency should be package")
+            return
+        }
+        XCTAssertEqual(product, "RuntimePackageProduct")
+        XCTAssertEqual(type, .runtime)
+    }
+    
+    func test_from_when_package_macro() throws {
+        // Given
+        let dependency = ProjectDescription.TargetDependency.package(product: "MacroPackageProduct", type: .macro)
+        let generatorPaths = GeneratorPaths(manifestDirectory: try AbsolutePath(validating: "/"))
+        
+        // When
+        let got = try TuistGraph.TargetDependency.from(
+            manifest: dependency,
+            generatorPaths: generatorPaths,
+            externalDependencies: [:]
+        )
+        
+        // Then
+        XCTAssertEqual(got.count, 1)
+        guard case let .package(product, type, _) = got[0] else {
+            XCTFail("Dependency should be package")
+            return
+        }
+        XCTAssertEqual(product, "MacroPackageProduct")
+        XCTAssertEqual(type, .macro)
+    }
+    
+    func test_from_when_package_plugin() throws {
+        // Given
+        let dependency = ProjectDescription.TargetDependency.package(product: "PluginPackageProduct", type: .plugin)
+        let generatorPaths = GeneratorPaths(manifestDirectory: try AbsolutePath(validating: "/"))
+        
+        // When
+        let got = try TuistGraph.TargetDependency.from(
+            manifest: dependency,
+            generatorPaths: generatorPaths,
+            externalDependencies: [:]
+        )
+        
+        // Then
+        XCTAssertEqual(got.count, 1)
+        guard case let .package(product, type, _) = got[0] else {
+            XCTFail("Dependency should be package")
+            return
+        }
+        XCTAssertEqual(product, "PluginPackageProduct")
+        XCTAssertEqual(type, .plugin)
+    }
+    
     func test_from_when_sdkLibrary() throws {
         // Given
         let dependency = ProjectDescription.TargetDependency.sdk(name: "c++", type: .library, status: .required)

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/TargetDependency+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/TargetDependency+ManifestMapperTests.swift
@@ -92,14 +92,14 @@ final class DependencyManifestMapperTests: TuistUnitTestCase {
         // Given
         let dependency = ProjectDescription.TargetDependency.package(product: "RuntimePackageProduct", type: .runtime)
         let generatorPaths = GeneratorPaths(manifestDirectory: try AbsolutePath(validating: "/"))
-        
+
         // When
         let got = try TuistGraph.TargetDependency.from(
             manifest: dependency,
             generatorPaths: generatorPaths,
             externalDependencies: [:]
         )
-        
+
         // Then
         XCTAssertEqual(got.count, 1)
         guard case let .package(product, type, _) = got[0] else {
@@ -109,19 +109,19 @@ final class DependencyManifestMapperTests: TuistUnitTestCase {
         XCTAssertEqual(product, "RuntimePackageProduct")
         XCTAssertEqual(type, .runtime)
     }
-    
+
     func test_from_when_package_macro() throws {
         // Given
         let dependency = ProjectDescription.TargetDependency.package(product: "MacroPackageProduct", type: .macro)
         let generatorPaths = GeneratorPaths(manifestDirectory: try AbsolutePath(validating: "/"))
-        
+
         // When
         let got = try TuistGraph.TargetDependency.from(
             manifest: dependency,
             generatorPaths: generatorPaths,
             externalDependencies: [:]
         )
-        
+
         // Then
         XCTAssertEqual(got.count, 1)
         guard case let .package(product, type, _) = got[0] else {
@@ -131,19 +131,19 @@ final class DependencyManifestMapperTests: TuistUnitTestCase {
         XCTAssertEqual(product, "MacroPackageProduct")
         XCTAssertEqual(type, .macro)
     }
-    
+
     func test_from_when_package_plugin() throws {
         // Given
         let dependency = ProjectDescription.TargetDependency.package(product: "PluginPackageProduct", type: .plugin)
         let generatorPaths = GeneratorPaths(manifestDirectory: try AbsolutePath(validating: "/"))
-        
+
         // When
         let got = try TuistGraph.TargetDependency.from(
             manifest: dependency,
             generatorPaths: generatorPaths,
             externalDependencies: [:]
         )
-        
+
         // Then
         XCTAssertEqual(got.count, 1)
         guard case let .package(product, type, _) = got[0] else {
@@ -153,7 +153,7 @@ final class DependencyManifestMapperTests: TuistUnitTestCase {
         XCTAssertEqual(product, "PluginPackageProduct")
         XCTAssertEqual(type, .plugin)
     }
-    
+
     func test_from_when_sdkLibrary() throws {
         // Given
         let dependency = ProjectDescription.TargetDependency.sdk(name: "c++", type: .library, status: .required)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5713

### Short description 📝

As `TargetDependency.swift` accepts attribute to select [type of package](https://github.com/tuist/tuist/blob/main/Sources/ProjectDescription/TargetDependency.swift#L33), Tuist 4 no longer need `.packagePlugin` API. 

### How to test the changes locally 🧐

Follow next steps:
1. Run `make/tasks/tuist/edit.sh -p fixtures/ios_app_with_frameworks`
2. Edit `Project.swift` add new line at 29
3. Try to add `.packagePlugin` instance
4. Get `Type 'Array<TargetDependency>.ArrayLiteralElement' (aka 'TargetDependency') has no member 'packagePlugin'` error

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
