### PR TITLE
Export the raw xcodebuild logs from CI workflows

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -49,7 +49,13 @@ jobs:
       - name: Fetch dependencies
         run: tuist fetch
       - name: Test
-        run: tuist test --xcframeworks --skip-test-targets TuistBuildAcceptanceTests TuistGenerateAcceptanceTests TuistTestAcceptanceTests TuistAcceptanceTests
+        run: tuist test --xcframeworks --skip-test-targets --raw-xcodebuild-logs-path /tmp/tuist/test.xcodebuild.log TuistBuildAcceptanceTests TuistGenerateAcceptanceTests TuistTestAcceptanceTests TuistAcceptanceTests
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: test.xcodebuild.log
+          path: |
+            /tmp/tuist/**
 
   cache-warm:
     name: Cache warm with latest Tuist
@@ -72,7 +78,13 @@ jobs:
       - name: Print hashes
         run: tuist cache print-hashes --xcframeworks
       - name: Cache warm
-        run: tuist cache warm --xcframeworks
+        run: tuist cache warm --xcframeworks --raw-xcodebuild-logs-path /tmp/tuist/cache-warm-x86_64.xcodebuild.log
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: cache-warm-x86_64.xcodebuild.log
+          path: |
+            /tmp/tuist/**
 
   cache-warm-silicon:
     name: Cache warm with latest Tuist on Silicon
@@ -95,7 +107,13 @@ jobs:
       - name: Print hashes
         run: tuist cache print-hashes --xcframeworks
       - name: Cache warm
-        run: tuist cache warm --xcframeworks
+        run: tuist cache warm --xcframeworks --raw-xcodebuild-logs-path /tmp/tuist/cache-warm-arm64.xcodebuild.log
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: cache-warm-arm64.xcodebuild.log
+          path: |
+            /tmp/tuist/**
 
   acceptance_tests:
     name: Run ${{ matrix.feature }}
@@ -132,7 +150,13 @@ jobs:
       - name: Fetch dependencies
         run: tuist fetch
       - name: Run acceptance tests
-        run: tuist test ${{ matrix.feature }} --xcframeworks
+        run: tuist test --xcframeworks --raw-xcodebuild-logs-path /tmp/tuist/test-${{ matrix.feature }}.xcodebuild.log ${{ matrix.feature }}
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: test-${{ matrix.feature }}.xcodebuild.log
+          path: |
+            /tmp/tuist/**
   lint:
     name: Lint
     runs-on: macos-13

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Fetch dependencies
         run: tuist fetch
       - name: Run acceptance tests
-        run: tuist test --xcframeworks --raw-xcodebuild-logs-path /tmp/tuist/test-${{ matrix.feature }}.xcodebuild.log ${{ matrix.feature }}
+        run: tuist test --xcframeworks --raw-xcodebuild-logs-path /tmp/tuist/test.${{ matrix.feature }}.xcodebuild.log ${{ matrix.feature }}
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Fetch dependencies
         run: tuist fetch
       - name: Test
-        run: tuist test --xcframeworks --skip-test-targets --raw-xcodebuild-logs-path /tmp/tuist/test.xcodebuild.log TuistBuildAcceptanceTests TuistGenerateAcceptanceTests TuistTestAcceptanceTests TuistAcceptanceTests
+        run: tuist test --xcframeworks --skip-test-targets TuistBuildAcceptanceTests TuistGenerateAcceptanceTests TuistTestAcceptanceTests TuistAcceptanceTests --raw-xcodebuild-logs-path /tmp/tuist/test.xcodebuild.log
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:


### PR DESCRIPTION
### Short description 📝
Tuist commands that use `xcodebuild` under the hood support exporting the `xcodebuild` raw logs to a given file. Having the raw logs is handy for debugging issues because the formatted `xcbeautify` might have swallowed the actual cause of the issue. This PR adjusts our CI pipelines to export the logs as artifacts. They should be accessible via the GitHub UI.

### How to test the changes 🧐
The test and cache warm workflows should have the artifacts exported.

### Contributor checklist ✅

- [ ] The code has been linted using run `make workspace/lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
