### PR TITLE
Fixes non-deterministic condition resolution

### DIFF
--- a/Sources/TuistCore/Graph/ConditionCache.swift
+++ b/Sources/TuistCore/Graph/ConditionCache.swift
@@ -1,0 +1,47 @@
+import Foundation
+import TuistGraph
+import TuistSupport
+
+/// Cache designed to store `PlatformCondition.CombinationResult` for `GraphTraverser`
+final class ConditionCache {
+    private final class ConditionCacheValue {
+        let conditionResult: PlatformCondition.CombinationResult
+        init(conditionResult: PlatformCondition.CombinationResult) {
+            self.conditionResult = conditionResult
+        }
+    }
+    
+    private final class GraphEdgeCacheKey: NSObject {
+        let edge: GraphEdge
+        init(_ edge: GraphEdge) {
+            self.edge = edge
+        }
+        
+        override func isEqual(_ object: Any?) -> Bool {
+            guard let other = object as? Self else {
+                return false
+            }
+            
+            return edge == other.edge
+        }
+        
+        override var hash: Int {
+            edge.hashValue
+        }
+    }
+    
+    private let cache = NSCache<GraphEdgeCacheKey, ConditionCacheValue>()
+    
+    public subscript(_ edge: (GraphDependency, GraphDependency)) -> PlatformCondition.CombinationResult? {
+        get {
+            cache.object(forKey: GraphEdgeCacheKey(GraphEdge(from: edge.0, to: edge.1)))?.conditionResult
+        }
+        set {
+            if let newValue {
+                cache.setObject(ConditionCacheValue(conditionResult: newValue), forKey: GraphEdgeCacheKey(GraphEdge(from: edge.0, to: edge.1)))
+            } else {
+                cache.removeObject(forKey: GraphEdgeCacheKey(GraphEdge(from: edge.0, to: edge.1)))
+            }
+        }
+    }
+}

--- a/Sources/TuistCore/Graph/ConditionCache.swift
+++ b/Sources/TuistCore/Graph/ConditionCache.swift
@@ -10,35 +10,38 @@ final class ConditionCache {
             self.conditionResult = conditionResult
         }
     }
-    
+
     private final class GraphEdgeCacheKey: NSObject {
         let edge: GraphEdge
         init(_ edge: GraphEdge) {
             self.edge = edge
         }
-        
+
         override func isEqual(_ object: Any?) -> Bool {
             guard let other = object as? Self else {
                 return false
             }
-            
+
             return edge == other.edge
         }
-        
+
         override var hash: Int {
             edge.hashValue
         }
     }
-    
+
     private let cache = NSCache<GraphEdgeCacheKey, ConditionCacheValue>()
-    
+
     public subscript(_ edge: (GraphDependency, GraphDependency)) -> PlatformCondition.CombinationResult? {
         get {
             cache.object(forKey: GraphEdgeCacheKey(GraphEdge(from: edge.0, to: edge.1)))?.conditionResult
         }
         set {
             if let newValue {
-                cache.setObject(ConditionCacheValue(conditionResult: newValue), forKey: GraphEdgeCacheKey(GraphEdge(from: edge.0, to: edge.1)))
+                cache.setObject(
+                    ConditionCacheValue(conditionResult: newValue),
+                    forKey: GraphEdgeCacheKey(GraphEdge(from: edge.0, to: edge.1))
+                )
             } else {
                 cache.removeObject(forKey: GraphEdgeCacheKey(GraphEdge(from: edge.0, to: edge.1)))
             }

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -740,18 +740,17 @@ public class GraphTraverser: GraphTraversing {
     ) -> PlatformCondition
         .CombinationResult
     {
-
         if let cached = conditionCache[(rootDependency, transitiveDependency)] {
             return cached
         } else if graph.dependencyConditions.isEmpty {
             return .condition(nil)
         }
-        
+
         // if we're at a leaf dependency, there is nothing else to traverse.
         guard let dependencies = graph.dependencies[rootDependency] else { return .incompatible }
-        
+
         let result: PlatformCondition.CombinationResult
-        
+
         // We've reached our destination, return the filters or `.all` if none are set
         if dependencies.contains(transitiveDependency) {
             result = .condition(graph.dependencyConditions[(rootDependency, transitiveDependency)])
@@ -770,7 +769,7 @@ public class GraphTraverser: GraphTraversing {
                     return .condition(currentCondition)
                 }
             }
-            
+
             // Union our filters because multiple paths could lead to the same dependency (e.g. AVFoundation)
             //  A --> (.ios) B --> C
             //  A --> (.macos) D --> C
@@ -779,14 +778,13 @@ public class GraphTraverser: GraphTraversing {
                 .reduce(PlatformCondition.CombinationResult.incompatible) { result, condition in
                     result.combineWith(condition)
                 }
-            
+
             result = transitiveFilters
         }
-        
+
         conditionCache[(rootDependency, transitiveDependency)] = result
         return result
     }
-
 
     public func externalTargetSupportedPlatforms() -> [GraphTarget: Set<Platform>] {
         let targetsWithExternalDependencies = targetsWithExternalDependencies()

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -724,12 +724,11 @@ public class GraphTraverser: GraphTraversing {
                 }
             }
         }
-
         return references
     }
 
-    @Atomic var conditionCache = [GraphEdge: PlatformCondition.CombinationResult]()
-    
+    let conditionCache = ConditionCache()
+
     /// Recursively find platform filters within transitive dependencies
     /// - Parameters:
     ///   - rootDependency: dependency whose platform filters we need when depending on `transitiveDependency`
@@ -742,8 +741,10 @@ public class GraphTraverser: GraphTraversing {
         .CombinationResult
     {
 
-        if let cached = conditionCache[GraphEdge(from: rootDependency, to: transitiveDependency)] {
+        if let cached = conditionCache[(rootDependency, transitiveDependency)] {
             return cached
+        } else if graph.dependencyConditions.isEmpty {
+            return .condition(nil)
         }
         
         // if we're at a leaf dependency, there is nothing else to traverse.
@@ -782,7 +783,7 @@ public class GraphTraverser: GraphTraversing {
             result = transitiveFilters
         }
         
-        conditionCache[GraphEdge(from: rootDependency, to: transitiveDependency)] = result
+        conditionCache[(rootDependency, transitiveDependency)] = result
         return result
     }
 

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -751,7 +751,7 @@ public class GraphTraverser: GraphTraversing {
 
         let result: PlatformCondition.CombinationResult
 
-        // We've reached our destination, return the filters or `.all` if none are set
+        // We've reached our destination, return a condition for the leaf relationship (`nil` or a `PlatformFilters` set)
         if dependencies.contains(transitiveDependency) {
             result = .condition(graph.dependencyConditions[(rootDependency, transitiveDependency)])
         } else {

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -14,6 +14,7 @@ public class GraphTraverser: GraphTraversing {
     public var dependencies: [GraphDependency: Set<GraphDependency>] { graph.dependencies }
 
     private let graph: Graph
+    private let conditionCache = ConditionCache()
     private let systemFrameworkMetadataProvider: SystemFrameworkMetadataProviding = SystemFrameworkMetadataProvider()
 
     public required init(graph: Graph) {
@@ -726,8 +727,6 @@ public class GraphTraverser: GraphTraversing {
         }
         return references
     }
-
-    let conditionCache = ConditionCache()
 
     /// Recursively find platform filters within transitive dependencies
     /// - Parameters:

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -4600,6 +4600,68 @@ final class GraphTraverserTests: TuistUnitTestCase {
         XCTAssertEqual(result.0, GraphTarget(path: project.path, target: framework, project: project))
         XCTAssertEqual(result.1, platformCondition)
     }
+    
+    // https://github.com/tuist/tuist/issues/5746
+    func test_transitiveTargetDependenciesWhenIntermediateDependenciesHaveConditions() throws {
+        // Given
+        let app = Target.test(name: "App", destinations: [.iPhone, .mac], product: .app)
+        let frameworkA = Target.test(name: "FrameworkA", destinations: [.iPhone, .mac], product: .framework)
+        let frameworkB = Target.test(name: "FrameworkB", destinations: [.iPhone], product: .framework)
+        let frameworkC = Target.test(name: "FrameworkC", destinations: [.iPhone, .mac], product: .framework)
+        let frameworkD = Target.test(name: "FrameworkD", destinations: [.iPhone, .mac], product: .framework)
+
+        let project = Project.test(targets: [app, frameworkA, frameworkB, frameworkC, frameworkD])
+        let appDependency = GraphDependency.target(name: app.name, path: project.path)
+        let frameworkADependency = GraphDependency.target(name: frameworkA.name, path: project.path)
+        let frameworkBDependency = GraphDependency.target(name: frameworkB.name, path: project.path)
+        let frameworkCDependency = GraphDependency.target(name: frameworkC.name, path: project.path)
+        let frameworkDDependency = GraphDependency.target(name: frameworkD.name, path: project.path)
+        
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            appDependency: Set([
+                frameworkADependency,
+                frameworkBDependency
+            ]),
+            frameworkADependency: Set([frameworkCDependency]),
+            frameworkBDependency: Set([frameworkCDependency]),
+            frameworkCDependency: Set([frameworkDDependency]),
+        ]
+        let platformCondition = try PlatformCondition.test([.ios])
+
+        // Given: Value Graph
+        let graph = Graph.test(
+            path: project.path,
+            projects: [project.path: project],
+            targets: [project.path: [
+                app.name: app,
+                frameworkA.name: frameworkA,
+                frameworkB.name: frameworkB,
+                frameworkC.name: frameworkC,
+                frameworkD.name: frameworkD,
+            ]],
+            dependencies: dependencies,
+            dependencyConditions: [
+                GraphEdge(from: frameworkBDependency, to: frameworkCDependency): platformCondition,
+            ]
+        )
+        let subject = GraphTraverser(graph: graph)
+
+        // When
+        let appToFrameworkC = subject.combinedCondition(
+            to: frameworkCDependency,
+            from: appDependency
+        )
+
+        let appToFrameworkD = subject.combinedCondition(
+            to: frameworkDDependency,
+            from: appDependency
+        )
+
+        // Then
+        XCTAssertEqual(appToFrameworkC, .condition(nil))
+        XCTAssertEqual(appToFrameworkD, .condition(nil))
+    }
+
 
     func test_orphanExternalDependencies() throws {
         // Given

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -4644,22 +4644,25 @@ final class GraphTraverserTests: TuistUnitTestCase {
                 GraphEdge(from: frameworkBDependency, to: frameworkCDependency): platformCondition,
             ]
         )
-        let subject = GraphTraverser(graph: graph)
+        
+        for _ in 0..<50 {
+            let subject = GraphTraverser(graph: graph)
 
-        // When
-        let appToFrameworkC = subject.combinedCondition(
-            to: frameworkCDependency,
-            from: appDependency
-        )
+            // When
+            let appToFrameworkC = subject.combinedCondition(
+                to: frameworkCDependency,
+                from: appDependency
+            )
 
-        let appToFrameworkD = subject.combinedCondition(
-            to: frameworkDDependency,
-            from: appDependency
-        )
+            let appToFrameworkD = subject.combinedCondition(
+                to: frameworkDDependency,
+                from: appDependency
+            )
 
-        // Then
-        XCTAssertEqual(appToFrameworkC, .condition(nil))
-        XCTAssertEqual(appToFrameworkD, .condition(nil))
+            // Then
+            XCTAssertEqual(appToFrameworkC, .condition(nil))
+            XCTAssertEqual(appToFrameworkD, .condition(nil))
+        }
     }
 
     func test_orphanExternalDependencies() throws {

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -4644,8 +4644,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
                 GraphEdge(from: frameworkBDependency, to: frameworkCDependency): platformCondition,
             ]
         )
-        
-        for _ in 0..<50 {
+
+        for _ in 0 ..< 50 {
             let subject = GraphTraverser(graph: graph)
 
             // When

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -4600,7 +4600,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         XCTAssertEqual(result.0, GraphTarget(path: project.path, target: framework, project: project))
         XCTAssertEqual(result.1, platformCondition)
     }
-    
+
     // https://github.com/tuist/tuist/issues/5746
     func test_transitiveTargetDependenciesWhenIntermediateDependenciesHaveConditions() throws {
         // Given
@@ -4616,11 +4616,11 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let frameworkBDependency = GraphDependency.target(name: frameworkB.name, path: project.path)
         let frameworkCDependency = GraphDependency.target(name: frameworkC.name, path: project.path)
         let frameworkDDependency = GraphDependency.target(name: frameworkD.name, path: project.path)
-        
+
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
             appDependency: Set([
                 frameworkADependency,
-                frameworkBDependency
+                frameworkBDependency,
             ]),
             frameworkADependency: Set([frameworkCDependency]),
             frameworkBDependency: Set([frameworkCDependency]),
@@ -4661,7 +4661,6 @@ final class GraphTraverserTests: TuistUnitTestCase {
         XCTAssertEqual(appToFrameworkC, .condition(nil))
         XCTAssertEqual(appToFrameworkD, .condition(nil))
     }
-
 
     func test_orphanExternalDependencies() throws {
         // Given


### PR DESCRIPTION
Fixes #5746

The optimization that was used elsewhere in the GraphTraverser to skip nodes actually introduced a logic error in the case where different dependency paths lead to the same transitive dependency with different conditions.  Depending on the ordering of traversal we would end up with different nodes being skipped which would lead to different results. 

### How to test the changes locally 🧐

Run against test project in #5746.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
