### PR TITLE
Change cache warm from frameworks to xcframeworks

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Fetch dependencies
         run: tuist fetch
       - name: Test
-        run: tuist test --no-cache --skip-test-targets TuistBuildAcceptanceTests TuistGenerateAcceptanceTests TuistTestAcceptanceTests TuistAcceptanceTests
+        run: tuist test --xcframeworks --skip-test-targets TuistBuildAcceptanceTests TuistGenerateAcceptanceTests TuistTestAcceptanceTests TuistAcceptanceTests
 
   cache-warm:
     name: Cache warm with latest Tuist
@@ -70,7 +70,7 @@ jobs:
       - name: Fetch dependencies
         run: tuist fetch
       - name: Print hashes
-        run: tuist cache print-hashes
+        run: tuist cache print-hashes --xcframeworks
       - name: Cache warm
         run: tuist cache warm --xcframeworks
 
@@ -93,7 +93,7 @@ jobs:
       - name: Fetch dependencies
         run: tuist fetch
       - name: Print hashes
-        run: tuist cache print-hashes
+        run: tuist cache print-hashes --xcframeworks
       - name: Cache warm
         run: tuist cache warm --xcframeworks
 
@@ -132,7 +132,7 @@ jobs:
       - name: Fetch dependencies
         run: tuist fetch
       - name: Run acceptance tests
-        run: tuist test ${{ matrix.feature }}
+        run: tuist test ${{ matrix.feature }} --xcframeworks
   lint:
     name: Lint
     runs-on: macos-13

--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Print hashes
         run: tuist cache print-hashes
       - name: Cache warm
-        run: tuist cache warm
+        run: tuist cache warm --xcframeworks
 
   cache-warm-silicon:
     name: Cache warm with latest Tuist on Silicon
@@ -95,7 +95,7 @@ jobs:
       - name: Print hashes
         run: tuist cache print-hashes
       - name: Cache warm
-        run: tuist cache warm
+        run: tuist cache warm --xcframeworks
 
   acceptance_tests:
     name: Run ${{ matrix.feature }}


### PR DESCRIPTION
### Short description 📝

Based on the discussion [here](https://github.com/tuist/tuist/discussions/5738), we will most likely move to xcframeworks as the only type for caching. In the meantime, we can stress test xcframeworks by moving to them in the `tuist` repo.

### How to test the changes locally 🧐

CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
