### PR TITLE
Prefer an exact match on `developmentRegion` when choosing localization strings files

### DIFF
--- a/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
@@ -166,12 +166,12 @@ public final class SynthesizedResourceInterfaceProjectMapper: ProjectMapping { /
                 return paths.sorted { lhs, rhs in
                     let lhsBasename = lhs.parentDirectory.basenameWithoutExt
                     let rhsBasename = rhs.parentDirectory.basenameWithoutExt
-                    
+
                     if lhsBasename == developmentRegion {
                         return true
                     } else if rhsBasename == developmentRegion {
                         return false
-                    } else if lhsBasename.contains(developmentRegion) && rhsBasename.contains(developmentRegion) {
+                    } else if lhsBasename.contains(developmentRegion), rhsBasename.contains(developmentRegion) {
                         return lhsBasename < rhsBasename
                     } else {
                         return lhsBasename < rhsBasename

--- a/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/SynthesizedResourceInterfaceProjectMapper.swift
@@ -161,23 +161,23 @@ public final class SynthesizedResourceInterfaceProjectMapper: ProjectMapping { /
         switch resourceSynthesizer.parser {
         case .strings:
             // This file kind is localizable, let's order files based on it
-            var regionPriorityQueue: [String] = []
-
-            if let developmentRegion {
-                regionPriorityQueue.insert(developmentRegion, at: 0)
-            }
-
-            // Let's sort paths moving the development region localization's one at first
-            let prioritizedPaths = paths.filter { path in
-                regionPriorityQueue.map { path.parentDirectory.basename.contains($0) }.contains(true)
-            }
-
-            let unprioritizedPaths = paths.filter { path in
-                !regionPriorityQueue.map { path.parentDirectory.basename.contains($0) }.contains(true)
-            }
-
-            paths = prioritizedPaths + unprioritizedPaths
-
+            paths = {
+                guard let developmentRegion else { return paths }
+                return paths.sorted { lhs, rhs in
+                    let lhsBasename = lhs.parentDirectory.basenameWithoutExt
+                    let rhsBasename = rhs.parentDirectory.basenameWithoutExt
+                    
+                    if lhsBasename == developmentRegion {
+                        return true
+                    } else if rhsBasename == developmentRegion {
+                        return false
+                    } else if lhsBasename.contains(developmentRegion) && rhsBasename.contains(developmentRegion) {
+                        return lhsBasename < rhsBasename
+                    } else {
+                        return lhsBasename < rhsBasename
+                    }
+                }
+            }()
         case .assets, .coreData, .fonts, .interfaceBuilder, .json, .plists, .yaml, .files:
             break
         }

--- a/Tests/TuistGenerateAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/Tests/TuistGenerateAcceptanceTests/GenerateAcceptanceTests.swift
@@ -140,6 +140,7 @@ final class GenerateAcceptanceTestIosAppWithCustomDevelopmentRegion: TuistAccept
         for resource in [
             "en.lproj/Greetings.strings",
             "fr.lproj/Greetings.strings",
+            "fr-CA.lproj/Greetings.strings",
         ] {
             try await XCTAssertProductWithDestinationContainsResource(
                 "App.app",

--- a/fixtures/ios_app_with_custom_development_region/App/Resources/fr-CA.lproj/Greetings.strings
+++ b/fixtures/ios_app_with_custom_development_region/App/Resources/fr-CA.lproj/Greetings.strings
@@ -1,0 +1,1 @@
+"morning" = "Bon matin";


### PR DESCRIPTION
### Short description 📝

When using resource synthesizers to generate `TuistStrings+Module`, the `developmentRegion` is used to prioritise which set of Strings files is used to generate the base set of keys. 

However, the current implementation prioritises language-region identifiers (eg: `en-GB`) over language only identifiers (eg: `en`), even if the `developmentRegion` is set to a language only identifier. (ie: `en-GB` would be preferred over `en`, even if `developmentRegion` is set to `en`.)

This updates the ordering to prioritise exact matches of the `developmentRegion` over other variations.

### How to test the changes locally 🧐

Tested via an update to the existing acceptance test: `TuistGenerateAcceptanceTests.GenerateAcceptanceTestIosAppWithCustomDevelopmentRegion.test_ios_app_with_custom_development_region`.

Running the test without the code change fails, since `fr-CA` is used to generate keys instead of `fr`. 
Running the test with the code change succeeds, since `fr` is prioritised over `fr-CA`.

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] N/A ~In case the PR introduces changes that affect users, the documentation has been updated~

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
