### PR TITLE
Add option to enforce explicit dependencies

### DIFF
--- a/Tuist/Config.swift
+++ b/Tuist/Config.swift
@@ -6,5 +6,6 @@ let config = Config(
         url: "https://cloud.tuist.io",
         options: [.optional]
     ),
-    swiftVersion: .init("5.8")
+    swiftVersion: .init("5.8"),
+    generationOptions: .options(enforceExplicitDependencies: true)
 )


### PR DESCRIPTION
### Short description 📝

Add the `enforceExplicitDependencies` generation option to make the cache more reliable.

### How to test the changes locally 🧐

- Running `tuist` through Xcode should still work

### Contributor checklist ✅

- [x] The code has been linted using run `make workspace/lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
