### PR TITLE
Adjust the `XcodeBuildController` interface for creating XCFrameworks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ Resolves https://github.com/tuist/tuist/issues/YYY
 
 ### Contributor checklist ✅
 
-- [ ] The code has been linted using run `make workspace/lint-fix`
+- [ ] The code has been linted using run `mise run lint:fix`
 - [ ] The change is tested via unit testing or acceptance testing, or both
 - [ ] The title of the PR is formulated in a way that is usable as a changelog entry
 - [ ] In case the PR introduces changes that affect users, the documentation has been updated

--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -197,22 +197,13 @@ public final class XcodeBuildController: XcodeBuildControlling {
     }
 
     public func createXCFramework(
-        frameworks: [AbsolutePath],
+        arguments: [XcodeBuildControllerCreateXCFrameworkArgument],
         output: AbsolutePath,
         rawXcodebuildLogs: Bool,
         rawXcodebuildLogsPath: AbsolutePath?
     ) throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         var command = ["/usr/bin/xcrun", "xcodebuild", "-create-xcframework"]
-        command.append(contentsOf: frameworks.flatMap {
-            let pathString = $0.pathString
-            return [
-                "-framework",
-                // It's workaround for Xcode 15 RC bug
-                // remove it since bug will be fixed
-                // more details here: https://github.com/tuist/tuist/issues/5354
-                pathString.hasPrefix("/var/") ? pathString.replacingOccurrences(of: "/var/", with: "/private/var/") : pathString
-            ]
-        })
+        command.append(contentsOf: arguments.flatMap(\.xcodebuildArguments))
         command.append(contentsOf: ["-output", output.pathString])
         command.append("-allow-internal-distribution")
         return try run(command: command, rawXcodebuildLogs: rawXcodebuildLogs, rawXcodebuildLogsPath: rawXcodebuildLogsPath)

--- a/Sources/TuistCoreTesting/Automation/MockXcodeBuildController.swift
+++ b/Sources/TuistCoreTesting/Automation/MockXcodeBuildController.swift
@@ -143,15 +143,18 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         }
     }
 
-    var createXCFrameworkStub: (([AbsolutePath], AbsolutePath, Bool, AbsolutePath?) -> [SystemEvent<XcodeBuildOutput>])?
+    var createXCFrameworkStub: (
+        ([XcodeBuildControllerCreateXCFrameworkArgument], AbsolutePath, Bool, AbsolutePath?)
+            -> [SystemEvent<XcodeBuildOutput>]
+    )?
     func createXCFramework(
-        frameworks: [AbsolutePath],
+        arguments: [XcodeBuildControllerCreateXCFrameworkArgument],
         output: AbsolutePath,
         rawXcodebuildLogs: Bool,
         rawXcodebuildLogsPath: AbsolutePath?
     ) -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         if let createXCFrameworkStub {
-            return createXCFrameworkStub(frameworks, output, rawXcodebuildLogs, rawXcodebuildLogsPath).asAsyncThrowingStream()
+            return createXCFrameworkStub(arguments, output, rawXcodebuildLogs, rawXcodebuildLogsPath).asAsyncThrowingStream()
         } else {
             return AsyncThrowingStream {
                 throw TestError(

--- a/Tests/TuistCoreTests/Automation/XcodeBuildControllingTests.swift
+++ b/Tests/TuistCoreTests/Automation/XcodeBuildControllingTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import TSCBasic
+import TuistSupport
+import XCTest
+@testable import TuistCore
+@testable import TuistSupportTesting
+
+final class XcodeBuildControllerCreateXCFrameworkArgumentTests: TuistUnitTestCase {
+    func test_xcodebuildArguments() throws {
+        // When: Framework
+        let archive = try AbsolutePath(validating: "/test.xcarchive")
+        let framework = "Test.framework"
+        XCTAssertEqual(
+            XcodeBuildControllerCreateXCFrameworkArgument.framework(archivePath: archive, framework: framework)
+                .xcodebuildArguments,
+            ["-archive", archive.pathString, "-framework", framework]
+        )
+
+        // When: Library
+        let library = try AbsolutePath(validating: "/library.a")
+        let headers = try AbsolutePath(validating: "/headers")
+        XCTAssertEqual(XcodeBuildControllerCreateXCFrameworkArgument.library(
+            path: library,
+            headers: headers
+        ).xcodebuildArguments, [
+            "-library",
+            library.pathString,
+            "-headers",
+            headers.pathString,
+        ])
+    }
+}


### PR DESCRIPTION
### Short description 📝
While working on adding support for caching multi-platform targets using XCFrameworks, I noticed that the [`xcodebuild` interface](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle) for creating XCFrameworks can accept the combo of arguments (`-archive`/`-framework`) & (`-library`/`-headers`). This PR adjusts the protocol `XcodeBuildControlling` and the implementation `XcodeBuildController` to reflect that CLI interface. 

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
