### PR TITLE
Fix explicit dependencies for archive

### DIFF
--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -181,6 +181,9 @@ final class ConfigGenerator: ConfigGenerating {
         )
 
         settingsHelper.extend(buildSettings: &settings, with: target.settings?.base ?? [:])
+        if buildConfiguration.variant == .debug {
+            settingsHelper.extend(buildSettings: &settings, with: target.settings?.baseDebug ?? [:])
+        }
         settingsHelper.extend(buildSettings: &settings, with: configuration?.settings ?? [:])
 
         let variantBuildConfiguration = XCBuildConfiguration(

--- a/Sources/TuistGenerator/Mappers/ExplicitDependencyGraphMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ExplicitDependencyGraphMapper.swift
@@ -131,9 +131,16 @@ public struct ExplicitDependencyGraphMapper: GraphMapping {
         target = target.with(
             scripts: target.scripts + [
                 TargetScript(
-                    name: "Copy Built Products",
+                    name: "Copy Built Products for Explicit Dependencies",
                     order: .post,
-                    script: .embedded(copyBuiltProductsScript),
+                    script: .embedded(
+                        """
+                        # This script copies built products into the shared directory to be available for app and other targets that don't have scoped directories
+                        # If you try to archive any of the configurations seen in the output paths, the operation will fail due to `Multiple commands produce` error
+
+                        \(copyBuiltProductsScript)
+                        """
+                    ),
                     inputPaths: builtProductsScriptInputPaths,
                     outputPaths: builtProductsScriptOutputPaths
                 ),

--- a/Sources/TuistGraph/Models/Settings.swift
+++ b/Sources/TuistGraph/Models/Settings.swift
@@ -104,6 +104,8 @@ public struct Settings: Equatable, Codable {
     // MARK: - Attributes
 
     public let base: SettingsDictionary
+    /// Base settings applied only for configurations of `variant == .debug`
+    public let baseDebug: SettingsDictionary
     public let configurations: [BuildConfiguration: Configuration?]
     public let defaultSettings: DefaultSettings
 
@@ -111,10 +113,12 @@ public struct Settings: Equatable, Codable {
 
     public init(
         base: SettingsDictionary = [:],
+        baseDebug: SettingsDictionary = [:],
         configurations: [BuildConfiguration: Configuration?],
         defaultSettings: DefaultSettings = .recommended
     ) {
         self.base = base
+        self.baseDebug = baseDebug
         self.configurations = configurations
         self.defaultSettings = defaultSettings
     }

--- a/Sources/TuistGraphTesting/Models/Settings+TestData.swift
+++ b/Sources/TuistGraphTesting/Models/Settings+TestData.swift
@@ -13,11 +13,11 @@ extension Configuration {
 
 extension Settings {
     public static func test(
-        base: SettingsDictionary = [:],
+        base: SettingsDictionary,
         // swiftlint:disable:next force_try
-        debug: Configuration = Configuration(settings: [:], xcconfig: try! AbsolutePath(validating: "/Debug.xcconfig")),
+        debug: Configuration,
         // swiftlint:disable:next force_try
-        release: Configuration = Configuration(settings: [:], xcconfig: try! AbsolutePath(validating: "/Release.xcconfig"))
+        release: Configuration
     ) -> Settings {
         Settings(
             base: base,
@@ -27,9 +27,14 @@ extension Settings {
 
     public static func test(
         base: SettingsDictionary = [:],
+        baseDebug: SettingsDictionary = [:],
         configurations: [BuildConfiguration: Configuration?] = [:]
     ) -> Settings {
-        Settings(base: base, configurations: configurations)
+        Settings(
+            base: base,
+            baseDebug: baseDebug,
+            configurations: configurations
+        )
     }
 
     public static func test(defaultSettings: DefaultSettings) -> Settings {

--- a/Tests/TuistGeneratorTests/ProjectMappers/ExplicitDependencyGraphMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ExplicitDependencyGraphMapperTests.swift
@@ -137,9 +137,12 @@ final class ExplicitDependencyGraphMapperTests: TuistUnitTestCase {
             gotFrameworkA.scripts,
             [
                 TargetScript(
-                    name: "Copy Built Products",
+                    name: "Copy Built Products for Explicit Dependencies",
                     order: .post,
                     script: .embedded("""
+                    # This script copies built products into the shared directory to be available for app and other targets that don't have scoped directories
+                    # If you try to archive any of the configurations seen in the output paths, the operation will fail due to `Multiple commands produce` error
+
                     FILE="$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME$TARGET_BUILD_SUBPATH/$PRODUCT_NAME/$PRODUCT_NAME.framework"
                     DESTINATION_FILE="$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME$TARGET_BUILD_SUBPATH/$PRODUCT_NAME.framework"
                     \(copyScript)
@@ -173,9 +176,12 @@ final class ExplicitDependencyGraphMapperTests: TuistUnitTestCase {
                 ),
                 scripts: [
                     TargetScript(
-                        name: "Copy Built Products",
+                        name: "Copy Built Products for Explicit Dependencies",
                         order: .post,
                         script: .embedded("""
+                        # This script copies built products into the shared directory to be available for app and other targets that don't have scoped directories
+                        # If you try to archive any of the configurations seen in the output paths, the operation will fail due to `Multiple commands produce` error
+
                         FILE="$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME$TARGET_BUILD_SUBPATH/$PRODUCT_NAME/$PRODUCT_NAME.swiftmodule"
                         DESTINATION_FILE="$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME$TARGET_BUILD_SUBPATH/$PRODUCT_NAME.swiftmodule"
                         \(copyScript)
@@ -208,9 +214,12 @@ final class ExplicitDependencyGraphMapperTests: TuistUnitTestCase {
                     ),
                     scripts: [
                         TargetScript(
-                            name: "Copy Built Products",
+                            name: "Copy Built Products for Explicit Dependencies",
                             order: .post,
                             script: .embedded("""
+                            # This script copies built products into the shared directory to be available for app and other targets that don't have scoped directories
+                            # If you try to archive any of the configurations seen in the output paths, the operation will fail due to `Multiple commands produce` error
+
                             FILE="$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME$TARGET_BUILD_SUBPATH/$PRODUCT_NAME/$PRODUCT_NAME.framework"
                             DESTINATION_FILE="$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME$TARGET_BUILD_SUBPATH/$PRODUCT_NAME.framework"
                             \(copyScript)

--- a/Tests/TuistGeneratorTests/ProjectMappers/ExplicitDependencyGraphMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ExplicitDependencyGraphMapperTests.swift
@@ -112,14 +112,14 @@ final class ExplicitDependencyGraphMapperTests: TuistUnitTestCase {
             .framework
         )
         XCTAssertEqual(
-            gotFrameworkA.settings?.base["BUILT_PRODUCTS_DIR"],
+            gotFrameworkA.settings?.baseDebug["BUILT_PRODUCTS_DIR"],
             "$(CONFIGURATION_BUILD_DIR)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME)"
         )
         XCTAssertEqual(
-            gotFrameworkA.settings?.base["TARGET_BUILD_DIR"],
+            gotFrameworkA.settings?.baseDebug["TARGET_BUILD_DIR"],
             "$(CONFIGURATION_BUILD_DIR)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME)"
         )
-        switch gotFrameworkA.settings?.base["FRAMEWORK_SEARCH_PATHS"] {
+        switch gotFrameworkA.settings?.baseDebug["FRAMEWORK_SEARCH_PATHS"] {
         case let .array(array):
             XCTAssertEqual(
                 Set(array),
@@ -140,15 +140,15 @@ final class ExplicitDependencyGraphMapperTests: TuistUnitTestCase {
                     name: "Copy Built Products",
                     order: .post,
                     script: .embedded("""
-                    FILE="$CONFIGURATION_BUILD_DIR$TARGET_BUILD_SUBPATH/$PRODUCT_NAME/$PRODUCT_NAME.framework"
-                    DESTINATION_FILE="$CONFIGURATION_BUILD_DIR$TARGET_BUILD_SUBPATH/$PRODUCT_NAME.framework"
+                    FILE="$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME$TARGET_BUILD_SUBPATH/$PRODUCT_NAME/$PRODUCT_NAME.framework"
+                    DESTINATION_FILE="$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME$TARGET_BUILD_SUBPATH/$PRODUCT_NAME.framework"
                     \(copyScript)
                     """),
                     inputPaths: [
-                        "$(CONFIGURATION_BUILD_DIR)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME)/$(PRODUCT_NAME).framework",
+                        "$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME)/$(PRODUCT_NAME).framework",
                     ],
                     outputPaths: [
-                        "$(CONFIGURATION_BUILD_DIR)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME).framework",
+                        "$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME).framework",
                     ]
                 ),
             ]
@@ -166,7 +166,7 @@ final class ExplicitDependencyGraphMapperTests: TuistUnitTestCase {
                 name: "DynamicLibraryB",
                 product: .dynamicLibrary,
                 settings: .test(
-                    base: [
+                    baseDebug: [
                         "BUILT_PRODUCTS_DIR": "$(CONFIGURATION_BUILD_DIR)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME)",
                         "TARGET_BUILD_DIR": "$(CONFIGURATION_BUILD_DIR)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME)",
                     ]
@@ -176,15 +176,15 @@ final class ExplicitDependencyGraphMapperTests: TuistUnitTestCase {
                         name: "Copy Built Products",
                         order: .post,
                         script: .embedded("""
-                        FILE="$CONFIGURATION_BUILD_DIR$TARGET_BUILD_SUBPATH/$PRODUCT_NAME/$PRODUCT_NAME.swiftmodule"
-                        DESTINATION_FILE="$CONFIGURATION_BUILD_DIR$TARGET_BUILD_SUBPATH/$PRODUCT_NAME.swiftmodule"
+                        FILE="$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME$TARGET_BUILD_SUBPATH/$PRODUCT_NAME/$PRODUCT_NAME.swiftmodule"
+                        DESTINATION_FILE="$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME$TARGET_BUILD_SUBPATH/$PRODUCT_NAME.swiftmodule"
                         \(copyScript)
                         """),
                         inputPaths: [
-                            "$(CONFIGURATION_BUILD_DIR)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME)/$(PRODUCT_NAME).swiftmodule",
+                            "$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME)/$(PRODUCT_NAME).swiftmodule",
                         ],
                         outputPaths: [
-                            "$(CONFIGURATION_BUILD_DIR)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME).swiftmodule",
+                            "$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME).swiftmodule",
                         ]
                     ),
                 ]
@@ -198,7 +198,7 @@ final class ExplicitDependencyGraphMapperTests: TuistUnitTestCase {
                     product: .staticFramework,
                     productName: "ExternalFrameworkC",
                     settings: .test(
-                        base: [
+                        baseDebug: [
                             "BUILT_PRODUCTS_DIR": "$(CONFIGURATION_BUILD_DIR)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME)",
                             "TARGET_BUILD_DIR": "$(CONFIGURATION_BUILD_DIR)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME)",
                             "FRAMEWORK_SEARCH_PATHS": [
@@ -211,15 +211,15 @@ final class ExplicitDependencyGraphMapperTests: TuistUnitTestCase {
                             name: "Copy Built Products",
                             order: .post,
                             script: .embedded("""
-                            FILE="$CONFIGURATION_BUILD_DIR$TARGET_BUILD_SUBPATH/$PRODUCT_NAME/$PRODUCT_NAME.framework"
-                            DESTINATION_FILE="$CONFIGURATION_BUILD_DIR$TARGET_BUILD_SUBPATH/$PRODUCT_NAME.framework"
+                            FILE="$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME$TARGET_BUILD_SUBPATH/$PRODUCT_NAME/$PRODUCT_NAME.framework"
+                            DESTINATION_FILE="$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME$TARGET_BUILD_SUBPATH/$PRODUCT_NAME.framework"
                             \(copyScript)
                             """),
                             inputPaths: [
-                                "$(CONFIGURATION_BUILD_DIR)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME)/$(PRODUCT_NAME).framework",
+                                "$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME)/$(PRODUCT_NAME).framework",
                             ],
                             outputPaths: [
-                                "$(CONFIGURATION_BUILD_DIR)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME).framework",
+                                "$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME).framework",
                             ]
                         ),
                     ]


### PR DESCRIPTION
### Short description 📝

The `enforceExplicitDependencies` added in https://github.com/tuist/tuist/pull/5698 causes issues during archive.

This is because of a `Multiple commands produce` error:

```
Multiple commands produce '/Users/marekfort/Library/Developer/Xcode/DerivedData/App-ayjyvewfyfzdfdexjwdnsscucyjk/Build/Intermediates.noindex/ArchiveIntermediates/FrameworkC/BuildProductsPath/Release-iphoneos/FrameworkB.framework'

Target 'FrameworkB' (project 'App') has symlink command from '/Users/marekfort/Library/Developer/Xcode/DerivedData/App-ayjyvewfyfzdfdexjwdnsscucyjk/Build/Intermediates.noindex/ArchiveIntermediates/FrameworkC/BuildProductsPath/Release-iphoneos/FrameworkB.framework' to '../../IntermediateBuildFilesPath/UninstalledProducts/iphoneos/FrameworkB.framework'

That command depends on command in Target 'FrameworkB' (project 'App'): script phase “Copy Built Products”
```

The conflict happens because of the `Copy Built Products` phase that we added, more specifically the output file `$(CONFIGURATION_BUILD_DIR)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME).framework`. This is exactly the same output file that the archive process uses to copy products from `Build/Products` to the archive itself.

Solutions considered:
- Remove `Copy Built Products` phase and adjust _all_ targets to have a custom `BUILT_PRODUCTS_DIR`. This is something we tried and it turned out to be quite complex for some scenarios (like a unit test target with a host app) and a `Copy Built Products` phase of some sorts would still be needed for app targets
- Remove the output files list and uncheck the `Based on dependency analysis`. That way, Xcode does not know that the framework is produced by two commands. The command only adds a couple of symlinks and so it is extremely fast. Additionally, I've noticed that we run the `Copy Built Products` for each build regardless since the `XXX.framework` is updated on every incremental build.
- Adjust the `ExplicitDependencyGraphMapper` to only have effect on debug builds. We make the assumption that `Archive` is only run for release configurations. That is actually not true for `tuist cache warm --xcframeworks` but we can skip the `ExplicitDependencyGraphMapper` completely for that command.

From the solutions, I believe the last one is a good first step as we generally don't want the release build to have build phases meant for development.

If we find out that people need to archive debug configurations, we can also consider removing the input and output files in favor of unchecking the `Based on dependency analysis` option. This can be a follow-up. 

### How to test the changes locally 🧐

Run `generate` for an arbitrary project that has the `enforceExplicitDependencies` and ensure that both builds and archive operations succeed.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
