### PR TITLE
Fix cache warm by temporarily removing external dependencies check

### DIFF
--- a/Tuist/Config.swift
+++ b/Tuist/Config.swift
@@ -7,5 +7,5 @@ let config = Config(
         options: [.optional]
     ),
     swiftVersion: .init("5.8"),
-    generationOptions: .options(enforceExplicitDependencies: true)
+    generationOptions: .options()
 )

--- a/Tuist/ProjectDescriptionHelpers/Target+Helpers.swift
+++ b/Tuist/ProjectDescriptionHelpers/Target+Helpers.swift
@@ -25,14 +25,14 @@ extension Target {
             rootFolder = "Sources"
         }
         return Target(
-          name: name,
-          destinations: [.mac],
-          product: product,
-          bundleId: "io.tuist.\(name)",
-          deploymentTargets: .macOS("12.0"),
-          infoPlist: .default,
-          sources: ["\(rootFolder)/\(name)/**/*.swift"],
-          dependencies: dependencies
+            name: name,
+            destinations: [.mac],
+            product: product,
+            bundleId: "io.tuist.\(name)",
+            deploymentTargets: .macOS("12.0"),
+            infoPlist: .default,
+            sources: ["\(rootFolder)/\(name)/**/*.swift"],
+            dependencies: dependencies
         )
     }
 


### PR DESCRIPTION
### Short description 📝

`cache warm` with the `enforceExplicitDependencies: true` generation option does not currently work and should be fixed in the next release. For now, we can remove this check.

### How to test the changes locally 🧐

CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
