### PR TITLE
Add SkippedTests for TestAction

### DIFF
--- a/Sources/ProjectDescription/TestAction.swift
+++ b/Sources/ProjectDescription/TestAction.swift
@@ -35,6 +35,9 @@ public struct TestAction: Equatable, Codable {
     /// List of diagnostics options to set to the action.
     public var diagnosticsOptions: [SchemeDiagnosticsOption]
 
+    /// List of testIdentifiers to skip to the test
+    public var skippedTestIdentifiers: [String]?
+
     private init(
         testPlans: [Path]?,
         targets: [TestableTarget],
@@ -45,7 +48,8 @@ public struct TestAction: Equatable, Codable {
         preActions: [ExecutionAction],
         postActions: [ExecutionAction],
         options: TestActionOptions,
-        diagnosticsOptions: [SchemeDiagnosticsOption]
+        diagnosticsOptions: [SchemeDiagnosticsOption],
+        skippedTestIdentifiers: [String]?
     ) {
         self.testPlans = testPlans
         self.targets = targets
@@ -57,6 +61,7 @@ public struct TestAction: Equatable, Codable {
         self.expandVariableFromTarget = expandVariableFromTarget
         self.options = options
         self.diagnosticsOptions = diagnosticsOptions
+        self.skippedTestIdentifiers = skippedTestIdentifiers
     }
 
     /// Returns a test action from a list of targets to be tested.
@@ -81,7 +86,8 @@ public struct TestAction: Equatable, Codable {
         preActions: [ExecutionAction] = [],
         postActions: [ExecutionAction] = [],
         options: TestActionOptions = .options(),
-        diagnosticsOptions: [SchemeDiagnosticsOption] = [.mainThreadChecker]
+        diagnosticsOptions: [SchemeDiagnosticsOption] = [.mainThreadChecker],
+        skippedTestIdentifiers: [String] = []
     ) -> Self {
         Self(
             testPlans: nil,
@@ -93,7 +99,8 @@ public struct TestAction: Equatable, Codable {
             preActions: preActions,
             postActions: postActions,
             options: options,
-            diagnosticsOptions: diagnosticsOptions
+            diagnosticsOptions: diagnosticsOptions,
+            skippedTestIdentifiers: skippedTestIdentifiers
         )
     }
 
@@ -122,7 +129,8 @@ public struct TestAction: Equatable, Codable {
             preActions: preActions,
             postActions: postActions,
             options: .options(),
-            diagnosticsOptions: []
+            diagnosticsOptions: [],
+            skippedTestIdentifiers: nil
         )
     }
 }

--- a/Sources/ProjectDescription/TestAction.swift
+++ b/Sources/ProjectDescription/TestAction.swift
@@ -36,7 +36,7 @@ public struct TestAction: Equatable, Codable {
     public var diagnosticsOptions: [SchemeDiagnosticsOption]
 
     /// List of testIdentifiers to skip to the test
-    public var skippedTestIdentifiers: [String]?
+    public var skippedTests: [String]?
 
     private init(
         testPlans: [Path]?,
@@ -49,7 +49,7 @@ public struct TestAction: Equatable, Codable {
         postActions: [ExecutionAction],
         options: TestActionOptions,
         diagnosticsOptions: [SchemeDiagnosticsOption],
-        skippedTestIdentifiers: [String]?
+        skippedTests: [String]?
     ) {
         self.testPlans = testPlans
         self.targets = targets
@@ -61,7 +61,7 @@ public struct TestAction: Equatable, Codable {
         self.expandVariableFromTarget = expandVariableFromTarget
         self.options = options
         self.diagnosticsOptions = diagnosticsOptions
-        self.skippedTestIdentifiers = skippedTestIdentifiers
+        self.skippedTests = skippedTests
     }
 
     /// Returns a test action from a list of targets to be tested.
@@ -87,7 +87,7 @@ public struct TestAction: Equatable, Codable {
         postActions: [ExecutionAction] = [],
         options: TestActionOptions = .options(),
         diagnosticsOptions: [SchemeDiagnosticsOption] = [.mainThreadChecker],
-        skippedTestIdentifiers: [String] = []
+        skippedTests: [String] = []
     ) -> Self {
         Self(
             testPlans: nil,
@@ -100,7 +100,7 @@ public struct TestAction: Equatable, Codable {
             postActions: postActions,
             options: options,
             diagnosticsOptions: diagnosticsOptions,
-            skippedTestIdentifiers: skippedTestIdentifiers
+            skippedTests: skippedTests
         )
     }
 
@@ -130,7 +130,7 @@ public struct TestAction: Equatable, Codable {
             postActions: postActions,
             options: .options(),
             diagnosticsOptions: [],
-            skippedTestIdentifiers: nil
+            skippedTests: nil
         )
     }
 }

--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -294,7 +294,7 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
             )
         }
 
-        let skippedTests = testAction.skippedTestIdentifiers?.map { value in
+        let skippedTests = testAction.skippedTests?.map { value in
             XCScheme.TestItem(identifier: value)
         } ?? []
 

--- a/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -294,6 +294,10 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
             )
         }
 
+        let skippedTests = testAction.skippedTestIdentifiers?.map { value in
+            XCScheme.TestItem(identifier: value)
+        } ?? []
+
         try testAction.targets.forEach { testableTarget in
             guard let testableGraphTarget = graphTraverser.target(
                 path: testableTarget.target.projectPath,
@@ -312,7 +316,8 @@ final class SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
                 skipped: testableTarget.isSkipped,
                 parallelizable: testableTarget.isParallelizable,
                 randomExecutionOrdering: testableTarget.isRandomExecutionOrdering,
-                buildableReference: reference
+                buildableReference: reference,
+                skippedTests: skippedTests
             )
             testables.append(testable)
         }

--- a/Sources/TuistGraph/Models/TestAction.swift
+++ b/Sources/TuistGraph/Models/TestAction.swift
@@ -18,7 +18,7 @@ public struct TestAction: Equatable, Codable {
     public var language: String?
     public var region: String?
     public var preferredScreenCaptureFormat: ScreenCaptureFormat?
-    public var skippedTestIdentifiers: [String]?
+    public var skippedTests: [String]?
 
     // MARK: - Init
 
@@ -37,7 +37,7 @@ public struct TestAction: Equatable, Codable {
         region: String? = nil,
         preferredScreenCaptureFormat: ScreenCaptureFormat? = nil,
         testPlans: [TestPlan]? = nil,
-        skippedTestIdentifiers: [String]? = nil
+        skippedTests: [String]? = nil
     ) {
         self.testPlans = testPlans
         self.targets = targets
@@ -53,6 +53,6 @@ public struct TestAction: Equatable, Codable {
         self.language = language
         self.region = region
         self.preferredScreenCaptureFormat = preferredScreenCaptureFormat
-        self.skippedTestIdentifiers = skippedTestIdentifiers
+        self.skippedTests = skippedTests
     }
 }

--- a/Sources/TuistGraph/Models/TestAction.swift
+++ b/Sources/TuistGraph/Models/TestAction.swift
@@ -18,6 +18,7 @@ public struct TestAction: Equatable, Codable {
     public var language: String?
     public var region: String?
     public var preferredScreenCaptureFormat: ScreenCaptureFormat?
+    public var skippedTestIdentifiers: [String]?
 
     // MARK: - Init
 
@@ -35,7 +36,8 @@ public struct TestAction: Equatable, Codable {
         language: String? = nil,
         region: String? = nil,
         preferredScreenCaptureFormat: ScreenCaptureFormat? = nil,
-        testPlans: [TestPlan]? = nil
+        testPlans: [TestPlan]? = nil,
+        skippedTestIdentifiers: [String]? = nil
     ) {
         self.testPlans = testPlans
         self.targets = targets
@@ -51,5 +53,6 @@ public struct TestAction: Equatable, Codable {
         self.language = language
         self.region = region
         self.preferredScreenCaptureFormat = preferredScreenCaptureFormat
+        self.skippedTestIdentifiers = skippedTestIdentifiers
     }
 }

--- a/Sources/TuistGraphTesting/Models/TestAction+TestData.swift
+++ b/Sources/TuistGraphTesting/Models/TestAction+TestData.swift
@@ -19,7 +19,7 @@ extension TestAction {
         region: String? = nil,
         preferredScreenCaptureFormat: ScreenCaptureFormat? = nil,
         testPlans: [TestPlan]? = nil,
-        skippedTestIdentifiers: [String]? = nil
+        skippedTests: [String]? = nil
     ) -> TestAction {
         TestAction(
             targets: targets,
@@ -36,7 +36,7 @@ extension TestAction {
             region: region,
             preferredScreenCaptureFormat: preferredScreenCaptureFormat,
             testPlans: testPlans,
-            skippedTestIdentifiers: skippedTestIdentifiers
+            skippedTests: skippedTests
         )
     }
 }

--- a/Sources/TuistGraphTesting/Models/TestAction+TestData.swift
+++ b/Sources/TuistGraphTesting/Models/TestAction+TestData.swift
@@ -18,7 +18,8 @@ extension TestAction {
         language: String? = nil,
         region: String? = nil,
         preferredScreenCaptureFormat: ScreenCaptureFormat? = nil,
-        testPlans: [TestPlan]? = nil
+        testPlans: [TestPlan]? = nil,
+        skippedTestIdentifiers: [String]? = nil
     ) -> TestAction {
         TestAction(
             targets: targets,
@@ -34,7 +35,8 @@ extension TestAction {
             language: language,
             region: region,
             preferredScreenCaptureFormat: preferredScreenCaptureFormat,
-            testPlans: testPlans
+            testPlans: testPlans,
+            skippedTestIdentifiers: skippedTestIdentifiers
         )
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
@@ -23,6 +23,7 @@ extension TuistGraph.TestAction {
         let language: SchemeLanguage?
         let region: String?
         let preferredScreenCaptureFormat: TuistGraph.ScreenCaptureFormat?
+        let skippedTestIdentifiers: [String]?
 
         if let plans = manifest.testPlans {
             testPlans = try plans.enumerated().compactMap { index, path in
@@ -41,6 +42,7 @@ extension TuistGraph.TestAction {
             language = nil
             region = nil
             preferredScreenCaptureFormat = nil
+            skippedTestIdentifiers = nil
         } else {
             targets = try manifest.targets
                 .map { try TuistGraph.TestableTarget.from(manifest: $0, generatorPaths: generatorPaths) }
@@ -67,6 +69,7 @@ extension TuistGraph.TestAction {
 
             // not used when using targets
             testPlans = nil
+            skippedTestIdentifiers = manifest.skippedTestIdentifiers
         }
 
         let configurationName = manifest.configuration.rawValue
@@ -93,7 +96,8 @@ extension TuistGraph.TestAction {
             language: language?.identifier,
             region: region,
             preferredScreenCaptureFormat: preferredScreenCaptureFormat,
-            testPlans: testPlans
+            testPlans: testPlans,
+            skippedTestIdentifiers: skippedTestIdentifiers
         )
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/TestAction+ManifestMapper.swift
@@ -23,7 +23,7 @@ extension TuistGraph.TestAction {
         let language: SchemeLanguage?
         let region: String?
         let preferredScreenCaptureFormat: TuistGraph.ScreenCaptureFormat?
-        let skippedTestIdentifiers: [String]?
+        let skippedTests: [String]?
 
         if let plans = manifest.testPlans {
             testPlans = try plans.enumerated().compactMap { index, path in
@@ -42,7 +42,7 @@ extension TuistGraph.TestAction {
             language = nil
             region = nil
             preferredScreenCaptureFormat = nil
-            skippedTestIdentifiers = nil
+            skippedTests = nil
         } else {
             targets = try manifest.targets
                 .map { try TuistGraph.TestableTarget.from(manifest: $0, generatorPaths: generatorPaths) }
@@ -69,7 +69,7 @@ extension TuistGraph.TestAction {
 
             // not used when using targets
             testPlans = nil
-            skippedTestIdentifiers = manifest.skippedTestIdentifiers
+            skippedTests = manifest.skippedTests
         }
 
         let configurationName = manifest.configuration.rawValue
@@ -97,7 +97,7 @@ extension TuistGraph.TestAction {
             region: region,
             preferredScreenCaptureFormat: preferredScreenCaptureFormat,
             testPlans: testPlans,
-            skippedTestIdentifiers: skippedTestIdentifiers
+            skippedTests: skippedTests
         )
     }
 }

--- a/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -1002,7 +1002,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         XCTAssertEqual(postBuildableReference.buildableIdentifier, "primary")
     }
 
-    func test_schemeTestAction_when_testsTarget_with_skskippedTestIdentifiers() throws {
+    func test_schemeTestAction_when_testsTarget_with_skippedTests() throws {
         // Given
         let target = Target.test(name: "App", product: .app)
         let testTarget = Target.test(name: "AppTests", product: .unitTests)
@@ -1011,7 +1011,7 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         let testAction = TestAction.test(
             targets: [TestableTarget(target: TargetReference(projectPath: project.path, name: "AppTests"))],
             arguments: nil,
-            skippedTestIdentifiers: ["AppTests/test_twoPlusTwo_isFour"]
+            skippedTests: ["AppTests/test_twoPlusTwo_isFour"]
         )
 
         let scheme = Scheme.test(name: "AppTests", testAction: testAction)

--- a/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -1002,6 +1002,63 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         XCTAssertEqual(postBuildableReference.buildableIdentifier, "primary")
     }
 
+    func test_schemeTestAction_when_testsTarget_with_skskippedTestIdentifiers() throws {
+        // Given
+        let target = Target.test(name: "App", product: .app)
+        let testTarget = Target.test(name: "AppTests", product: .unitTests)
+        let project = Project.test(targets: [target, testTarget])
+
+        let testAction = TestAction.test(
+            targets: [TestableTarget(target: TargetReference(projectPath: project.path, name: "AppTests"))],
+            arguments: nil,
+            skippedTestIdentifiers: ["AppTests/test_twoPlusTwo_isFour"]
+        )
+
+        let scheme = Scheme.test(name: "AppTests", testAction: testAction)
+        let generatedProjects = createGeneratedProjects(projects: [project])
+
+        let graph = Graph.test(
+            projects: [project.path: project],
+            targets: [
+                project.path: [
+                    target.name: target,
+                    testTarget.name: testTarget,
+                ],
+            ],
+            dependencies: [
+                .target(name: testTarget.name, path: project.path): [
+                    .target(name: target.name, path: project.path),
+                ],
+            ]
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let got = try subject.schemeTestAction(
+            scheme: scheme,
+            graphTraverser: graphTraverser,
+            rootPath: project.path,
+            generatedProjects: generatedProjects
+        )
+
+        // Then
+        let result = try XCTUnwrap(got)
+        XCTAssertEqual(result.buildConfiguration, "Debug")
+        XCTAssertEqual(result.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
+        XCTAssertEqual(result.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
+        XCTAssertEqual(result.shouldUseLaunchSchemeArgsEnv, true)
+        XCTAssertNil(result.macroExpansion)
+        let testable = try XCTUnwrap(result.testables.first)
+        let buildableReference = testable.buildableReference
+
+        XCTAssertEqual(testable.skipped, false)
+        XCTAssertEqual(buildableReference.referencedContainer, "container:Project.xcodeproj")
+        XCTAssertEqual(buildableReference.buildableName, "AppTests.xctest")
+        XCTAssertEqual(buildableReference.blueprintName, "AppTests")
+        XCTAssertEqual(buildableReference.buildableIdentifier, "primary")
+        XCTAssertEqual(testable.skippedTests, [XCScheme.TestItem(identifier: "AppTests/test_twoPlusTwo_isFour")])
+    }
+
     // MARK: - Launch Action Tests
 
     func test_schemeLaunchAction() throws {


### PR DESCRIPTION
[Dicussions > Q&A](https://github.com/tuist/tuist/discussions/5703)

### Short description 📝

> Describe here the purpose of your PR.

When create a TestAction in Scheme, it receives TestIdentifiers that skip specific XCTestCases.
In Xcode, To implement the same role as the one pictured below.
<img width="567" alt="image" src="https://github.com/tuist/tuist/assets/10572119/5a2bcebd-5b85-482e-bd1e-4df1453851b6">


### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

When creating Scheme, pass in the skippedTestIdentifiers as shown in the photo below.
<img width="703" alt="image" src="https://github.com/tuist/tuist/assets/10572119/2aa856b6-89ff-4039-a52c-ea8042272b28">

and, next tuist generate.
and if you look at the test list of that Scheme, you will see that it is disabled, as shown in the photo below.
<img width="273" alt="image" src="https://github.com/tuist/tuist/assets/10572119/f692f04e-e326-4498-857c-d2befe040fcb">

Finally, when we actually run the test, that test case will not be executed.
<img width="288" alt="image" src="https://github.com/tuist/tuist/assets/10572119/1140a65d-8a99-4907-9001-c995114c6db3">

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
