### PR TITLE
Verbose-log the `xcodebuild` command that's being executed

### DIFF
--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -289,6 +289,7 @@ public final class XcodeBuildController: XcodeBuildControlling {
                          rawXcodebuildLogs: Bool,
                          rawXcodebuildLogsPath: AbsolutePath?) throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         
+        logger.debug("Running xcodebuild command: \(command.joined(separator: " "))")
         let rawXcodebuildFileLogger: FileLogger? = if let rawXcodebuildLogsPath = rawXcodebuildLogsPath {
             try FileLogger(path: rawXcodebuildLogsPath)
         } else {


### PR DESCRIPTION
### Short description 📝
When running commands like `tuist test` or `tuist cache warm`, which use `xcodebuild` internally, it's useful to see the command that's being executed for debugging purposes. This PR adds an additional log that will show up when invoking those Tuist commands with the `--verbose` flag.

### How to test the changes locally 🧐
You can run `tuist build --verbose` against Tuist itself, and you should see the xcodebuild command being executed.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
