### PR TITLE
Optimize the graph traverser function to obtain the platforms for external dependencies

### DIFF
--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -802,6 +802,13 @@ public class GraphTraverser: GraphTraversing {
         var platforms: [GraphTarget: Set<Platform>] = [:]
 
         func traverse(target: GraphTarget, parentPlatforms: Set<Platform>) {
+            /**
+             If the parent platform sare not a strict superset of the target platforms, there's no need to traverse the branch again.
+             */
+            guard parentPlatforms.isStrictSuperset(of: platforms[target, default: Set()]) else {
+                return
+            }
+            
             let dependencies = directTargetDependenciesWithConditions(path: target.path, name: target.target.name)
 
             dependencies.forEach { dependencyTarget, dependencyCondition in

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -806,7 +806,7 @@ public class GraphTraverser: GraphTraversing {
 
             dependencies.forEach { dependencyTarget, dependencyCondition in
                 var platformsToInsert: Set<Platform>?
-                
+
                 if let dependencyCondition,
                    let platformIntersection = PlatformCondition.when(target.target.dependencyPlatformFilters)?
                    .intersection(dependencyCondition)
@@ -825,13 +825,13 @@ public class GraphTraverser: GraphTraversing {
                     let inheritedPlatforms = dependencyTarget.target.product == .macro ? Set<Platform>([.macOS]) : parentPlatforms
                     platformsToInsert = inheritedPlatforms.intersection(dependencyTarget.target.supportedPlatforms)
                 }
-                
-                if let platformsToInsert = platformsToInsert {
+
+                if let platformsToInsert {
                     var existingPlatforms = platforms[dependencyTarget, default: Set()]
                     let continueTraversing = !platformsToInsert.isSubset(of: existingPlatforms)
                     existingPlatforms.formUnion(platformsToInsert)
                     platforms[dependencyTarget] = existingPlatforms
-                    
+
                     if continueTraversing {
                         traverse(target: dependencyTarget, parentPlatforms: platforms[dependencyTarget, default: Set()])
                     }

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -802,16 +802,11 @@ public class GraphTraverser: GraphTraversing {
         var platforms: [GraphTarget: Set<Platform>] = [:]
 
         func traverse(target: GraphTarget, parentPlatforms: Set<Platform>) {
-            /**
-             If the parent platform sare not a strict superset of the target platforms, there's no need to traverse the branch again.
-             */
-            guard parentPlatforms.isStrictSuperset(of: platforms[target, default: Set()]) else {
-                return
-            }
-            
             let dependencies = directTargetDependenciesWithConditions(path: target.path, name: target.target.name)
 
             dependencies.forEach { dependencyTarget, dependencyCondition in
+                var platformsToInsert: Set<Platform>?
+                
                 if let dependencyCondition,
                    let platformIntersection = PlatformCondition.when(target.target.dependencyPlatformFilters)?
                    .intersection(dependencyCondition)
@@ -823,22 +818,24 @@ public class GraphTraverser: GraphTraversing {
                         if let condition {
                             let dependencyPlatforms: [Platform] = condition.platformFilters.map(\.platform).filter { $0 != nil }
                                 .map { $0! }
-                            var existingDependencyPlatforms = platforms[dependencyTarget, default: Set()]
-                            existingDependencyPlatforms.formUnion(dependencyPlatforms)
-                            platforms[dependencyTarget] = existingDependencyPlatforms
+                            platformsToInsert = Set(dependencyPlatforms)
                         }
                     }
                 } else {
-                    /**
-                     When there are no conditions, the platforms are inherited from the parent.
-                     */
-                    var dependencyPlatforms = platforms[dependencyTarget, default: Set()]
                     let inheritedPlatforms = dependencyTarget.target.product == .macro ? Set<Platform>([.macOS]) : parentPlatforms
-                    dependencyPlatforms.formUnion(inheritedPlatforms.intersection(dependencyTarget.target.supportedPlatforms))
-                    platforms[dependencyTarget] = dependencyPlatforms
+                    platformsToInsert = inheritedPlatforms.intersection(dependencyTarget.target.supportedPlatforms)
                 }
-
-                traverse(target: dependencyTarget, parentPlatforms: platforms[dependencyTarget, default: Set()])
+                
+                if let platformsToInsert = platformsToInsert {
+                    var existingPlatforms = platforms[dependencyTarget, default: Set()]
+                    let continueTraversing = !platformsToInsert.isSubset(of: existingPlatforms)
+                    existingPlatforms.formUnion(platformsToInsert)
+                    platforms[dependencyTarget] = existingPlatforms
+                    
+                    if continueTraversing {
+                        traverse(target: dependencyTarget, parentPlatforms: platforms[dependencyTarget, default: Set()])
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
### Short description 📝
Trendyol's project stopped generating after we added the logic for narrowing down the platforms for external target. It turns out that the logic in `GraphTraverser.externalTargetSupportedPlatforms` was unnecessarily slow and recursing indefinitely in some scenarios. This PR adds a check to stop traversals through an external target if the target has already been traversed with the same filtering platforms. 

### How to test the changes locally 🧐
Tests of `GraphTraverser` should pass, and running `tuist generate` against a project (e.g. Tuist) should output a valid project.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
