### PR TITLE
Add support for transitive Swift Macros

### DIFF
--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -503,6 +503,13 @@ public class GraphTraverser: GraphTraversing {
         return Set(dependencies)
     }
 
+    public func allSwiftMacroFrameworkTargets(path: AbsolutePath, name: String) -> Set<GraphTarget> {
+        let dependencies = allTargetDependencies(path: path, name: name)
+            .filter { $0.target.product == .staticFramework }
+            .filter { self.directSwiftMacroExecutables(path: $0.path, name: $0.target.name).count != 0 }
+        return Set(dependencies)
+    }
+
     public func librariesPublicHeadersFolders(path: AbsolutePath, name: String) -> Set<AbsolutePath> {
         let dependencies = graph.dependencies[.target(name: name, path: path), default: []]
         let libraryPublicHeaders = dependencies.compactMap { dependency -> AbsolutePath? in

--- a/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
+++ b/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
@@ -251,6 +251,13 @@ public protocol GraphTraversing {
     ///   - name: Target name.
     func directSwiftMacroFrameworkTargets(path: AbsolutePath, name: String) -> Set<GraphTarget>
 
+    /// Given a project and a target name, it returns all the target dependencies that are a static framework representing
+    /// a Swift Macro
+    /// - Parameters:
+    ///   - path: Path to the directory that contains the project.
+    ///   - name: Target name.
+    func allSwiftMacroFrameworkTargets(path: AbsolutePath, name: String) -> Set<GraphTarget>
+
     /// It returns a set containing the external dependencies that are not referenced by the projects either directly nor
     /// transitively.
     /// - Returns: The list of dependencies.

--- a/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
+++ b/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
@@ -660,6 +660,20 @@ final class MockGraphTraverser: GraphTraversing {
         return stubbedDirectSwiftMacroFrameworkTargetsResult
     }
 
+    var invokedAllSwiftMacroFrameworkTargets = false
+    var invokedAllSwiftMacroFrameworkTargetsCount = 0
+    var invokedAllSwiftMacroFrameworkTargetsParameters: (path: AbsolutePath, name: String)?
+    var invokedAllSwiftMacroFrameworkTargetsParametersList =
+        [(path: AbsolutePath, name: String)]()
+    var stubbedAllSwiftMacroFrameworkTargetsResult: Set<GraphTarget>! = []
+    func allSwiftMacroFrameworkTargets(path: TSCBasic.AbsolutePath, name: String) -> Set<TuistGraph.GraphTarget> {
+        invokedAllSwiftMacroFrameworkTargets = true
+        invokedAllSwiftMacroFrameworkTargetsCount += 1
+        invokedAllSwiftMacroFrameworkTargetsParameters = (path, name)
+        invokedAllSwiftMacroFrameworkTargetsParametersList.append((path, name))
+        return stubbedAllSwiftMacroFrameworkTargetsResult
+    }
+
     var invokedAllOrphanExternalTargets = false
     var invokedAllOrphanExternalTargetsCount = 0
     var stubbedAllOrphanExternalTargetsResult: Set<GraphTarget>! = []

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -312,7 +312,7 @@ final class ConfigGenerator: ConfigGenerating {
         graphTraverser: GraphTraversing,
         projectPath: AbsolutePath
     ) -> SettingsDictionary {
-        let targets = graphTraverser.directSwiftMacroFrameworkTargets(path: projectPath, name: target.name)
+        let targets = graphTraverser.allSwiftMacroFrameworkTargets(path: projectPath, name: target.name)
         if targets.isEmpty { return [:] }
         var settings: SettingsDictionary = [:]
         settings["OTHER_SWIFT_FLAGS"] = .array(targets.flatMap { target in

--- a/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
+++ b/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
@@ -41,3 +41,28 @@ public enum AppKit {
         try? DatabasePool(path: NSTemporaryDirectory().appending("db.sqlite")).erase()
     }
 }
+
+@Reducer
+struct Counter {
+    struct State: Equatable {
+        var count = 0
+    }
+
+    enum Action {
+        case decrementButtonTapped
+        case incrementButtonTapped
+    }
+
+    var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            switch action {
+            case .decrementButtonTapped:
+                state.count -= 1
+                return .none
+            case .incrementButtonTapped:
+                state.count += 1
+                return .none
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5639

### Short description 📝
A Swift Macro can generate code referencing transitive Swift Macros like described [here](https://github.com/tuist/tuist/issues/5639). Tuis is unfortunately not handling that scenario, and that required some users to add those transitive dependencies as direct dependencies to workaround the issue.
This PR extends the logic to traverse the graph and include the transitive macros in the list of macros passed through the Swift compiler flag `-load-plugin-executable` ([code](https://github.com/tuist/tuist/blob/c2d3d1731074a303a8b4b563f5f47673f3f3f113/Sources/TuistGenerator/Generator/ConfigGenerator.swift#L315))

### How to test the changes locally 🧐
You should be able to generate the `app_with_spm_dependencies` project and compile it 

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
