### PR TITLE
Fix installation URL at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Install [mise](https://mise.jdx.dev/getting-started.html#quickstart) and then ru
 mise install tuist
 ```
 
-You can check out [the documentation](https://docs.next.tuist.io/documentation/tuist/installation) to learn more about the rationale behind our installation approach and alternative approaches.
+You can check out [the documentation](https://docs.tuist.io/documentation/tuist/installation/) to learn more about the rationale behind our installation approach and alternative approaches.
 
 ## Bootstrap your first project 🌀
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Install [mise](https://mise.jdx.dev/getting-started.html#quickstart) and then ru
 mise install tuist
 ```
 
-You can check out [the documentation](https://docs.tuist.io/documentation/tuist/installation/) to learn more about the rationale behind our installation approach and alternative approaches.
+You can check out [the documentation](https://docs.tuist.io/documentation/tuist/installation) to learn more about the rationale behind our installation approach and alternative approaches.
 
 ## Bootstrap your first project 🌀
 


### PR DESCRIPTION
### Short description 📝

> Describe here the purpose of your PR.

Fix installation URL at ReadMe.md

I can't access installation URL(https://docs.next.tuist.io/documentation/tuist/installation) at  README.md 

<img width="1370" alt="image" src="https://github.com/tuist/tuist/assets/10572119/ad37b3ee-9f08-4603-8e96-0d88c2529b60">

I'm guessing that there is an action missing from this [PR](https://github.com/tuist/tuist/pull/5775). 

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
