### PR TITLE
Fix incremental test execution when migrating from Tuist versions older than 3.36.0

### DIFF
--- a/Sources/TuistCore/Cache/CacheCategory.swift
+++ b/Sources/TuistCore/Cache/CacheCategory.swift
@@ -25,7 +25,7 @@ public enum CacheCategory: String, CaseIterable, RawRepresentable {
         case .builds:
             return "BuildCache"
         case .tests:
-            return "TestsCache"
+            return "incremental-tests"
         case .generatedAutomationProjects:
             return "Projects"
         case .projectDescriptionHelpers:

--- a/Tests/TuistKitTests/Services/CleanServiceTests.swift
+++ b/Tests/TuistKitTests/Services/CleanServiceTests.swift
@@ -28,7 +28,7 @@ final class CleanServiceTests: TuistUnitTestCase {
 
     func test_run_with_category_cleans_category() throws {
         // Given
-        let cachePaths = try createFolders(["Cache", "Cache/BuildCache", "Cache/Manifests", "Cache/TestsCache"])
+        let cachePaths = try createFolders(["Cache", "Cache/BuildCache", "Cache/Manifests", "Cache/incremental-tests"])
         let cachePath = cachePaths[0]
         for path in cachePaths {
             let correctlyCreated = FileManager.default.fileExists(atPath: path.pathString)
@@ -53,7 +53,7 @@ final class CleanServiceTests: TuistUnitTestCase {
 
     func test_run_without_category_cleans_all() throws {
         // Given
-        let cachePaths = try createFolders(["Cache", "Cache/BuildCache", "Cache/Manifests", "Cache/TestsCache"])
+        let cachePaths = try createFolders(["Cache", "Cache/BuildCache", "Cache/Manifests", "Cache/incremental-tests"])
         let cachePath = cachePaths[0]
         for path in cachePaths {
             let correctlyCreated = FileManager.default.fileExists(atPath: path.pathString)


### PR DESCRIPTION
Fixes https://github.com/tuist/tuist/issues/5786

### Short description 📝
Tuist 3.36.0 introduced a breaking change in the local directory that Tuist Cloud uses to persist state to provide incremental build functionality, and it's causing an error for users that have state persisted following the previous convention (when migrating from versions older than 3.36.0).
As a solution, I would suggest to rename the directory. This has the caveat that we'll invalidate any existing data, so the test execution after updating Tuist will run all the tests, which is fair. The incremental test execution isn't widely used since we haven't promoted it much, so I think it's sensible. The alternative would have consisted of adding some migration logic, but the overhead in the codebase is not worth it.


### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
