### PR TITLE
Add GraphTraverser API to get all the Swift Plugin executables

### DIFF
--- a/Sources/TuistCore/Graph/GraphDependencyReference.swift
+++ b/Sources/TuistCore/Graph/GraphDependencyReference.swift
@@ -69,13 +69,13 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
                 product: (linking == .static) ? .staticLibrary : .dynamicLibrary,
                 condition: condition
             )
-        case let .xcframework(path, infoPlist, primaryBinaryPath, _, _, status, _):
+        case let .xcframework(xcframework):
             self = .xcframework(
-                path: path,
-                infoPlist: infoPlist,
-                primaryBinaryPath: primaryBinaryPath,
-                binaryPath: primaryBinaryPath,
-                status: status,
+                path: xcframework.path,
+                infoPlist: xcframework.infoPlist,
+                primaryBinaryPath: xcframework.primaryBinaryPath,
+                binaryPath: xcframework.primaryBinaryPath,
+                status: xcframework.status,
                 condition: condition
             )
         default:

--- a/Sources/TuistCore/Graph/GraphDependencyReference.swift
+++ b/Sources/TuistCore/Graph/GraphDependencyReference.swift
@@ -69,7 +69,7 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
                 product: (linking == .static) ? .staticLibrary : .dynamicLibrary,
                 condition: condition
             )
-        case let .xcframework(path, infoPlist, primaryBinaryPath, _, _, status):
+        case let .xcframework(path, infoPlist, primaryBinaryPath, _, _, status, _):
             self = .xcframework(
                 path: path,
                 infoPlist: infoPlist,

--- a/Sources/TuistCore/Graph/GraphLoader.swift
+++ b/Sources/TuistCore/Graph/GraphLoader.swift
@@ -260,7 +260,7 @@ public final class GraphLoader: GraphLoading {
             at: path,
             status: status
         )
-        let xcframework: GraphDependency = .xcframework(
+        let xcframework: GraphDependency = .xcframework(GraphDependency.XCFramework(
             path: metadata.path,
             infoPlist: metadata.infoPlist,
             primaryBinaryPath: metadata.primaryBinaryPath,
@@ -268,7 +268,7 @@ public final class GraphLoader: GraphLoading {
             mergeable: metadata.mergeable,
             status: metadata.status,
             macroPath: metadata.macroPath
-        )
+        ))
         cache.add(xcframework: xcframework, at: path)
         return xcframework
     }

--- a/Sources/TuistCore/Graph/GraphLoader.swift
+++ b/Sources/TuistCore/Graph/GraphLoader.swift
@@ -266,7 +266,8 @@ public final class GraphLoader: GraphLoading {
             primaryBinaryPath: metadata.primaryBinaryPath,
             linking: metadata.linking,
             mergeable: metadata.mergeable,
-            status: metadata.status
+            status: metadata.status,
+            macroPath: metadata.macroPath
         )
         cache.add(xcframework: xcframework, at: path)
         return xcframework

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -301,7 +301,7 @@ public class GraphTraverser: GraphTraversing {
         /// Precompiled frameworks
         var precompiledFrameworks = filterDependencies(
             from: .target(name: name, path: path),
-            test: isDependencyPrecompiledDynamicAndLinkable,
+            test: { $0.isPrecompiledDynamicAndLinkable },
             skip: canDependencyEmbedProducts
         )
         // Skip merged precompiled libraries from merging into the runnable binary
@@ -409,7 +409,7 @@ public class GraphTraverser: GraphTraversing {
             .flatMap { filterDependencies(from: $0) }
 
         let precompiledLibrariesAndFrameworks = Set(precompiled + precompiledDependencies)
-            .filter(isDependencyPrecompiledDynamicAndLinkable)
+            .filter(\.isPrecompiledDynamicAndLinkable)
             .compactMap { dependencyReference(to: $0, from: targetGraphDependency) }
 
         references.formUnion(precompiledLibrariesAndFrameworks)
@@ -567,13 +567,13 @@ public class GraphTraverser: GraphTraversing {
         let from = GraphDependency.target(name: name, path: path)
         let precompiledFrameworksPaths = filterDependencies(
             from: from,
-            test: isDependencyPrecompiledDynamicAndLinkable,
+            test: { $0.isPrecompiledDynamicAndLinkable },
             skip: canDependencyEmbedProducts
         )
         .lazy
         .compactMap { (dependency: GraphDependency) -> AbsolutePath? in
             switch dependency {
-            case let .xcframework(path, _, _, _, _, _, _): return path
+            case let .xcframework(xcframework): return xcframework.path
             case let .framework(path, _, _, _, _, _, _, _): return path
             case .library: return nil
             case .bundle: return nil
@@ -688,16 +688,16 @@ public class GraphTraverser: GraphTraversing {
     public func allSwiftPluginExecutables(path: TSCBasic.AbsolutePath, name: String) -> Set<String> {
         let precompiledMacroPluginExecutables = filterDependencies(from: .target(name: name, path: path), test: { dependency in
             switch dependency {
-            case let .xcframework(_, _, _, _, _, _, macroPath):
-                return macroPath != nil
+            case let .xcframework(xcframework):
+                return xcframework.macroPath != nil
             case .bundle, .library, .framework, .sdk, .target, .packageProduct:
                 return false
             }
         })
         .lazy.compactMap { dependency in
             switch dependency {
-            case let .xcframework(_, _, _, _, _, _, macroPath):
-                return macroPath!
+            case let .xcframework(xcframework):
+                return xcframework.macroPath!
             case .bundle, .library, .framework, .sdk, .target, .packageProduct:
                 return nil
             }
@@ -928,16 +928,16 @@ public class GraphTraverser: GraphTraversing {
     }
 
     func isXCFrameworkMerged(dependency: GraphDependency, expectedMergedBinaries: Set<String>) -> Bool {
-        guard case let .xcframework(_, infoPlist, _, _, mergeable, _, _) = dependency,
-              let binaryName = infoPlist.libraries.first?.binaryName,
+        guard case let .xcframework(xcframework) = dependency,
+              let binaryName = xcframework.infoPlist.libraries.first?.binaryName,
               expectedMergedBinaries.contains(binaryName)
         else {
             return false
         }
-        if !mergeable {
+        if !xcframework.mergeable {
             fatalError("XCFramework \(binaryName) must be compiled with  -make_mergeable option enabled")
         }
-        return mergeable
+        return xcframework.mergeable
     }
 
     func isDependencyDynamicNonMergeableTarget(dependency: GraphDependency) -> Bool {
@@ -954,8 +954,9 @@ public class GraphTraverser: GraphTraversing {
 
     func isDependencyStatic(dependency: GraphDependency) -> Bool {
         switch dependency {
-        case let .xcframework(_, _, _, linking, _, _, _),
-             let .framework(_, _, _, _, linking, _, _, _),
+        case let .xcframework(xcframework):
+            return xcframework.linking == .static
+        case let .framework(_, _, _, _, linking, _, _, _),
              let .library(_, _, linking, _, _):
             return linking == .static
         case .bundle: return false
@@ -989,19 +990,6 @@ public class GraphTraverser: GraphTraversing {
         case let .target(name, path):
             guard let target = target(path: path, name: name) else { return false }
             return target.target.product.isDynamic
-        case .sdk: return false
-        }
-    }
-
-    func isDependencyPrecompiledDynamicAndLinkable(dependency: GraphDependency) -> Bool {
-        switch dependency {
-        case let .xcframework(_, _, _, linking, _, _, _),
-             let .framework(_, _, _, _, linking, _, _, _),
-             let .library(path: _, publicHeaders: _, linking: linking, architectures: _, swiftModuleMap: _):
-            return linking == .dynamic
-        case .bundle: return false
-        case .packageProduct: return false
-        case .target: return false
         case .sdk: return false
         }
     }
@@ -1085,13 +1073,13 @@ public class GraphTraverser: GraphTraversing {
                 productName: target.target.productNameWithExtension,
                 condition: condition
             )
-        case let .xcframework(path, infoPlist, primaryBinaryPath, _, _, status, _):
+        case let .xcframework(xcframework):
             return .xcframework(
-                path: path,
-                infoPlist: infoPlist,
-                primaryBinaryPath: primaryBinaryPath,
-                binaryPath: primaryBinaryPath,
-                status: status,
+                path: xcframework.path,
+                infoPlist: xcframework.infoPlist,
+                primaryBinaryPath: xcframework.primaryBinaryPath,
+                binaryPath: xcframework.primaryBinaryPath,
+                status: xcframework.status,
                 condition: condition
             )
         }
@@ -1148,8 +1136,8 @@ public class GraphTraverser: GraphTraversing {
             from: .target(name: name, path: path),
             test: { dependency in
                 switch dependency {
-                case let .xcframework(_, _, _, linking: linking, _, _, _):
-                    return linking == .static
+                case let .xcframework(xcframework):
+                    return xcframework.linking == .static
                 case .framework, .library, .bundle, .packageProduct, .target, .sdk:
                     return false
                 }

--- a/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
+++ b/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
@@ -286,6 +286,17 @@ public protocol GraphTraversing {
     ///   - name: Target name.
     /// - Returns: A set containing all the direct target dependencies that are external.
     func directTargetExternalDependencies(path: AbsolutePath, name: String) -> Set<GraphTarget>
+
+    /// It returns all the plugin executables to use for a given target. A plugin executable can represent a Swift Macro
+    /// executable to resolve macros.
+    ///
+    /// Executables are passed through the build setting "OTHER_SWIFT_FLAGS" and the flag "-load-plugin-executable {value}"
+    ///
+    ///
+    /// - Parameters:
+    ///   - path: Path to the directory that contains the project.
+    ///   - name: Target name.
+    func allSwiftPluginExecutables(path: AbsolutePath, name: String) -> Set<String>
 }
 
 extension GraphTraversing {

--- a/Sources/TuistCore/MetadataProviders/XCFrameworkMetadataProvider.swift
+++ b/Sources/TuistCore/MetadataProviders/XCFrameworkMetadataProvider.swift
@@ -88,9 +88,9 @@ public final class XCFrameworkMetadataProvider: PrecompiledMetadataProvider, XCF
      x86_64 and arm64.
      */
     public func macroPath(xcframeworkPath: AbsolutePath) throws -> AbsolutePath? {
-        guard let frameworkPath = fileHandler.glob(xcframeworkPath, glob: "*/*.framework").first else { return nil }
+        guard let frameworkPath = fileHandler.glob(xcframeworkPath, glob: "*/*.framework").sorted().first else { return nil }
         guard let macroPath = fileHandler.glob(frameworkPath, glob: "Macros/*").first else { return nil }
-        return try AbsolutePath(validating: "\(macroPath.pathString)/#\(macroPath.basename)")
+        return try AbsolutePath(validating: macroPath.pathString)
     }
 
     public func infoPlist(xcframeworkPath: AbsolutePath) throws -> XCFrameworkInfoPlist {

--- a/Sources/TuistCore/NodeLoaders/XCFrameworkLoader.swift
+++ b/Sources/TuistCore/NodeLoaders/XCFrameworkLoader.swift
@@ -52,7 +52,7 @@ public final class XCFrameworkLoader: XCFrameworkLoading {
             at: path,
             status: status
         )
-        return .xcframework(
+        let xcframework = GraphDependency.XCFramework(
             path: path,
             infoPlist: metadata.infoPlist,
             primaryBinaryPath: metadata.primaryBinaryPath,
@@ -61,5 +61,6 @@ public final class XCFrameworkLoader: XCFrameworkLoading {
             status: metadata.status,
             macroPath: metadata.macroPath
         )
+        return .xcframework(xcframework)
     }
 }

--- a/Sources/TuistCore/NodeLoaders/XCFrameworkLoader.swift
+++ b/Sources/TuistCore/NodeLoaders/XCFrameworkLoader.swift
@@ -58,7 +58,8 @@ public final class XCFrameworkLoader: XCFrameworkLoading {
             primaryBinaryPath: metadata.primaryBinaryPath,
             linking: metadata.linking,
             mergeable: metadata.mergeable,
-            status: metadata.status
+            status: metadata.status,
+            macroPath: metadata.macroPath
         )
     }
 }

--- a/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
+++ b/Sources/TuistCoreTesting/GraphTraverser/MockGraphTraverser.swift
@@ -723,4 +723,18 @@ final class MockGraphTraverser: GraphTraversing {
         invokedDirectTargetExternalDependenciesParametersList.append((path, name))
         return stubbedDirectTargetExternalDependenciesResult
     }
+
+    var invokedAllSwiftPluginExecutables = false
+    var invokedAllSwiftPluginExecutablesCount = 0
+    var invokedAllSwiftPluginExecutablesParameters: (path: AbsolutePath, name: String)?
+    var invokedAllSwiftPluginExecutablesParametersList =
+        [(path: AbsolutePath, name: String)]()
+    var stubbedAllSwiftPluginExecutablesResult: Set<String>! = []
+    func allSwiftPluginExecutables(path: TSCBasic.AbsolutePath, name: String) -> Set<String> {
+        invokedAllSwiftPluginExecutables = true
+        invokedAllSwiftPluginExecutablesCount += 1
+        invokedAllSwiftPluginExecutablesParameters = (path, name)
+        invokedAllSwiftPluginExecutablesParametersList.append((path, name))
+        return stubbedAllSwiftPluginExecutablesResult
+    }
 }

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -318,20 +318,11 @@ final class ConfigGenerator: ConfigGenerating {
         let targets = graphTraverser.allSwiftMacroFrameworkTargets(path: projectPath, name: target.name)
         if targets.isEmpty { return [:] }
         var settings: SettingsDictionary = [:]
-        settings["OTHER_SWIFT_FLAGS"] = .array(targets.flatMap { target in
-            let macroExecutables = graphTraverser.directSwiftMacroExecutables(path: target.path, name: target.target.name)
-            return macroExecutables.flatMap { macroExecutable in
-                switch macroExecutable {
-                case let .product(_, productName, _):
-                    return [
-                        "-load-plugin-executable",
-                        "$BUILT_PRODUCTS_DIR/\(target.target.productNameWithExtension)/Macros/\(productName)#\(productName)",
-                    ]
-                default:
-                    return []
-                }
-            }
-        })
+
+        let pluginExecutables = graphTraverser.allSwiftPluginExecutables(path: projectPath, name: target.name)
+        if pluginExecutables.isEmpty { return settings }
+        let swiftCompilerFlags = pluginExecutables.flatMap { ["-load-plugin-executable", $0] }
+        settings["OTHER_SWIFT_FLAGS"] = .array(swiftCompilerFlags)
         return settings
     }
 

--- a/Sources/TuistGenerator/GraphViz/GraphToGraphVizMapper.swift
+++ b/Sources/TuistGenerator/GraphViz/GraphToGraphVizMapper.swift
@@ -81,16 +81,8 @@ extension GraphDependency {
             status: _
         ):
             return path.basenameWithoutExt
-        case let .xcframework(
-            path: path,
-            infoPlist: _,
-            primaryBinaryPath: _,
-            linking: _,
-            mergeable: _,
-            status: _,
-            macroPath: _
-        ):
-            return path.basenameWithoutExt
+        case let .xcframework(xcframework):
+            return xcframework.path.basenameWithoutExt
         case let .library(
             path: path,
             publicHeaders: _,

--- a/Sources/TuistGenerator/GraphViz/GraphToGraphVizMapper.swift
+++ b/Sources/TuistGenerator/GraphViz/GraphToGraphVizMapper.swift
@@ -87,7 +87,8 @@ extension GraphDependency {
             primaryBinaryPath: _,
             linking: _,
             mergeable: _,
-            status: _
+            status: _,
+            macroPath: _
         ):
             return path.basenameWithoutExt
         case let .library(

--- a/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -158,8 +158,8 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
 
     private func isStaticProduct(_ dependency: GraphDependency, graphTraverser: GraphTraversing) -> Bool {
         switch dependency {
-        case let .xcframework(_, _, _, linking, _, _, _):
-            return linking == .static
+        case let .xcframework(xcframework):
+            return xcframework.linking == .static
         case let .framework(_, _, _, _, linking, _, _, _):
             return linking == .static
         case let .library(_, _, linking, _, _):

--- a/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -158,7 +158,7 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
 
     private func isStaticProduct(_ dependency: GraphDependency, graphTraverser: GraphTraversing) -> Bool {
         switch dependency {
-        case let .xcframework(_, _, _, linking, _, _):
+        case let .xcframework(_, _, _, linking, _, _, _):
             return linking == .static
         case let .framework(_, _, _, _, linking, _, _, _):
             return linking == .static

--- a/Sources/TuistGraph/Graph/GraphDependency.swift
+++ b/Sources/TuistGraph/Graph/GraphDependency.swift
@@ -23,7 +23,8 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         primaryBinaryPath: AbsolutePath,
         linking: BinaryLinking,
         mergeable: Bool,
-        status: FrameworkStatus
+        status: FrameworkStatus,
+        macroPath: AbsolutePath?
     )
 
     /// A dependency that represents a pre-compiled framework.
@@ -61,7 +62,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
 
     public func hash(into hasher: inout Hasher) {
         switch self {
-        case let .xcframework(path, _, _, _, _, _):
+        case let .xcframework(path, _, _, _, _, _, _):
             hasher.combine("xcframework")
             hasher.combine(path)
         case let .framework(path, _, _, _, _, _, _, _):
@@ -108,7 +109,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
      */
     public var isStaticPrecompiled: Bool {
         switch self {
-        case let .xcframework(_, _, _, linking, _, _),
+        case let .xcframework(_, _, _, linking, _, _, _),
              let .framework(_, _, _, _, linking, _, _, _),
              let .library(_, _, linking, _, _): return linking == .static
         case .bundle: return false
@@ -123,7 +124,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
      */
     public var isDynamicPrecompiled: Bool {
         switch self {
-        case let .xcframework(_, _, _, linking, _, _),
+        case let .xcframework(_, _, _, linking, _, _, _),
              let .framework(_, _, _, _, linking, _, _, _),
              let .library(_, _, linking, _, _): return linking == .dynamic
         case .bundle: return false
@@ -179,7 +180,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
 
     public var name: String {
         switch self {
-        case let .xcframework(path, _, _, _, _, _):
+        case let .xcframework(path, _, _, _, _, _, _):
             return path.basename
         case let .framework(path, _, _, _, _, _, _, _):
             return path.basename

--- a/Sources/TuistGraph/Graph/GraphDependency.swift
+++ b/Sources/TuistGraph/Graph/GraphDependency.swift
@@ -2,6 +2,42 @@ import Foundation
 import TSCBasic
 
 public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Codable {
+    public struct XCFramework: Hashable, CustomStringConvertible, Comparable, Codable {
+        public let path: AbsolutePath
+        public let infoPlist: XCFrameworkInfoPlist
+        public let primaryBinaryPath: AbsolutePath
+        public let linking: BinaryLinking
+        public let mergeable: Bool
+        public let status: FrameworkStatus
+        public let macroPath: AbsolutePath?
+
+        public init(
+            path: AbsolutePath,
+            infoPlist: XCFrameworkInfoPlist,
+            primaryBinaryPath: AbsolutePath,
+            linking: BinaryLinking,
+            mergeable: Bool,
+            status: FrameworkStatus,
+            macroPath: AbsolutePath?
+        ) {
+            self.path = path
+            self.infoPlist = infoPlist
+            self.primaryBinaryPath = primaryBinaryPath
+            self.linking = linking
+            self.mergeable = mergeable
+            self.status = status
+            self.macroPath = macroPath
+        }
+
+        public var description: String {
+            "xcframework '\(path.basename)'"
+        }
+
+        public static func < (lhs: GraphDependency.XCFramework, rhs: GraphDependency.XCFramework) -> Bool {
+            lhs.description < rhs.description
+        }
+    }
+
     public enum PackageProductType: String, Hashable, CustomStringConvertible, Comparable, Codable {
         public var description: String {
             rawValue
@@ -16,16 +52,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         }
     }
 
-    /// A dependency that represents a pre-compiled .xcframework.
-    case xcframework(
-        path: AbsolutePath,
-        infoPlist: XCFrameworkInfoPlist,
-        primaryBinaryPath: AbsolutePath,
-        linking: BinaryLinking,
-        mergeable: Bool,
-        status: FrameworkStatus,
-        macroPath: AbsolutePath?
-    )
+    case xcframework(GraphDependency.XCFramework)
 
     /// A dependency that represents a pre-compiled framework.
     case framework(
@@ -62,9 +89,8 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
 
     public func hash(into hasher: inout Hasher) {
         switch self {
-        case let .xcframework(path, _, _, _, _, _, _):
-            hasher.combine("xcframework")
-            hasher.combine(path)
+        case let .xcframework(xcframework):
+            hasher.combine(xcframework)
         case let .framework(path, _, _, _, _, _, _, _):
             hasher.combine("framework")
             hasher.combine(path)
@@ -109,8 +135,9 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
      */
     public var isStaticPrecompiled: Bool {
         switch self {
-        case let .xcframework(_, _, _, linking, _, _, _),
-             let .framework(_, _, _, _, linking, _, _, _),
+        case let .xcframework(xcframework):
+            return xcframework.linking == .static
+        case let .framework(_, _, _, _, linking, _, _, _),
              let .library(_, _, linking, _, _): return linking == .static
         case .bundle: return false
         case .packageProduct: return false
@@ -124,8 +151,9 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
      */
     public var isDynamicPrecompiled: Bool {
         switch self {
-        case let .xcframework(_, _, _, linking, _, _, _),
-             let .framework(_, _, _, _, linking, _, _, _),
+        case let .xcframework(xcframework):
+            return xcframework.linking == .dynamic
+        case let .framework(_, _, _, _, linking, _, _, _),
              let .library(_, _, linking, _, _): return linking == .dynamic
         case .bundle: return false
         case .packageProduct: return false
@@ -140,6 +168,20 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         case .framework: return true
         case .library: return true
         case .bundle: return true
+        case .packageProduct: return false
+        case .target: return false
+        case .sdk: return false
+        }
+    }
+
+    public var isPrecompiledDynamicAndLinkable: Bool {
+        switch self {
+        case let .xcframework(xcframework):
+            return xcframework.linking == .dynamic
+        case let .framework(_, _, _, _, linking, _, _, _),
+             let .library(path: _, publicHeaders: _, linking: linking, architectures: _, swiftModuleMap: _):
+            return linking == .dynamic
+        case .bundle: return false
         case .packageProduct: return false
         case .target: return false
         case .sdk: return false
@@ -180,8 +222,8 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
 
     public var name: String {
         switch self {
-        case let .xcframework(path, _, _, _, _, _, _):
-            return path.basename
+        case let .xcframework(xcframework):
+            return xcframework.path.basename
         case let .framework(path, _, _, _, _, _, _, _):
             return path.basename
         case let .library(path, _, _, _, _):

--- a/Sources/TuistGraph/Models/BinaryArchitecture.swift
+++ b/Sources/TuistGraph/Models/BinaryArchitecture.swift
@@ -11,7 +11,7 @@ public enum BinaryArchitecture: String, Codable {
     case arm64e
 }
 
-public enum BinaryLinking: String, Codable {
+public enum BinaryLinking: String, Hashable, Codable {
     case `static`, dynamic
 }
 

--- a/Sources/TuistGraph/Models/Metadata/XCFrameworkMetadata.swift
+++ b/Sources/TuistGraph/Models/Metadata/XCFrameworkMetadata.swift
@@ -9,6 +9,7 @@ public struct XCFrameworkMetadata: Equatable {
     public var linking: BinaryLinking
     public var mergeable: Bool
     public var status: FrameworkStatus
+    public var macroPath: AbsolutePath?
 
     public init(
         path: AbsolutePath,
@@ -16,7 +17,8 @@ public struct XCFrameworkMetadata: Equatable {
         primaryBinaryPath: AbsolutePath,
         linking: BinaryLinking,
         mergeable: Bool,
-        status: FrameworkStatus
+        status: FrameworkStatus,
+        macroPath: AbsolutePath?
     ) {
         self.path = path
         self.infoPlist = infoPlist
@@ -24,5 +26,6 @@ public struct XCFrameworkMetadata: Equatable {
         self.linking = linking
         self.mergeable = mergeable
         self.status = status
+        self.macroPath = macroPath
     }
 }

--- a/Sources/TuistGraph/Models/TargetDependency.swift
+++ b/Sources/TuistGraph/Models/TargetDependency.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TSCBasic
 
-public enum FrameworkStatus: String, Codable {
+public enum FrameworkStatus: String, Hashable, Codable {
     case required
     case optional
 }

--- a/Sources/TuistGraph/Models/XCFrameworkInfoPlist.swift
+++ b/Sources/TuistGraph/Models/XCFrameworkInfoPlist.swift
@@ -2,13 +2,13 @@ import Foundation
 import TSCBasic
 
 /// It represents th Info.plist contained in an .xcframework bundle.
-public struct XCFrameworkInfoPlist: Codable, Equatable {
+public struct XCFrameworkInfoPlist: Codable, Hashable, Equatable {
     private enum CodingKeys: String, CodingKey {
         case libraries = "AvailableLibraries"
     }
 
     /// It represents a library inside an .xcframework
-    public struct Library: Codable, Equatable {
+    public struct Library: Codable, Hashable, Equatable {
         private enum CodingKeys: String, CodingKey {
             case identifier = "LibraryIdentifier"
             case path = "LibraryPath"
@@ -17,7 +17,7 @@ public struct XCFrameworkInfoPlist: Codable, Equatable {
         }
 
         /// It represents the library's platform.
-        public enum Platform: String, Codable {
+        public enum Platform: String, Hashable, Codable {
             case ios
         }
 

--- a/Sources/TuistGraphTesting/Graph/GraphDependency+TestData.swift
+++ b/Sources/TuistGraphTesting/Graph/GraphDependency+TestData.swift
@@ -38,13 +38,15 @@ extension GraphDependency {
         macroPath: AbsolutePath? = nil
     ) -> GraphDependency {
         .xcframework(
-            GraphDependency.XCFramework(path: path,
-                                        infoPlist: infoPlist,
-                                        primaryBinaryPath: primaryBinaryPath,
-                                        linking: linking,
-                                        mergeable: false,
-                                        status: status,
-                                        macroPath: macroPath)
+            GraphDependency.XCFramework(
+                path: path,
+                infoPlist: infoPlist,
+                primaryBinaryPath: primaryBinaryPath,
+                linking: linking,
+                mergeable: false,
+                status: status,
+                macroPath: macroPath
+            )
         )
     }
 

--- a/Sources/TuistGraphTesting/Graph/GraphDependency+TestData.swift
+++ b/Sources/TuistGraphTesting/Graph/GraphDependency+TestData.swift
@@ -34,7 +34,8 @@ extension GraphDependency {
         primaryBinaryPath: AbsolutePath = AbsolutePath.root
             .appending(try! RelativePath(validating: "Test.xcframework/Test")),
         linking: BinaryLinking = .dynamic,
-        status: FrameworkStatus = .required
+        status: FrameworkStatus = .required,
+        macroPath: AbsolutePath? = nil
     ) -> GraphDependency {
         .xcframework(
             path: path,
@@ -42,7 +43,8 @@ extension GraphDependency {
             primaryBinaryPath: primaryBinaryPath,
             linking: linking,
             mergeable: false,
-            status: status
+            status: status,
+            macroPath: macroPath
         )
     }
 

--- a/Sources/TuistGraphTesting/Graph/GraphDependency+TestData.swift
+++ b/Sources/TuistGraphTesting/Graph/GraphDependency+TestData.swift
@@ -38,13 +38,13 @@ extension GraphDependency {
         macroPath: AbsolutePath? = nil
     ) -> GraphDependency {
         .xcframework(
-            path: path,
-            infoPlist: infoPlist,
-            primaryBinaryPath: primaryBinaryPath,
-            linking: linking,
-            mergeable: false,
-            status: status,
-            macroPath: macroPath
+            GraphDependency.XCFramework(path: path,
+                                        infoPlist: infoPlist,
+                                        primaryBinaryPath: primaryBinaryPath,
+                                        linking: linking,
+                                        mergeable: false,
+                                        status: status,
+                                        macroPath: macroPath)
         )
     }
 

--- a/Sources/TuistGraphTesting/Models/Metadata/XCFrameworkMetadata+TestData.swift
+++ b/Sources/TuistGraphTesting/Models/Metadata/XCFrameworkMetadata+TestData.swift
@@ -10,7 +10,8 @@ extension XCFrameworkMetadata {
         primaryBinaryPath: AbsolutePath = "/XCFrameworks/XCFramework.xcframework/ios-arm64/XCFramework",
         linking: BinaryLinking = .dynamic,
         mergeable: Bool = false,
-        status: FrameworkStatus = .required
+        status: FrameworkStatus = .required,
+        macroPath: AbsolutePath? = nil
     ) -> XCFrameworkMetadata {
         XCFrameworkMetadata(
             path: path,
@@ -18,7 +19,8 @@ extension XCFrameworkMetadata {
             primaryBinaryPath: primaryBinaryPath,
             linking: linking,
             mergeable: mergeable,
-            status: status
+            status: status,
+            macroPath: macroPath
         )
     }
 }

--- a/Tests/TuistCoreTests/Graph/GraphLoaderTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphLoaderTests.swift
@@ -387,13 +387,15 @@ final class GraphLoaderTests: TuistUnitTestCase {
         XCTAssertEqual(graph.dependencies, [
             .target(name: "A", path: "/A"): Set([
                 .xcframework(
-                    path: "/XCFrameworks/XF1.xcframework",
-                    infoPlist: .test(),
-                    primaryBinaryPath: "/XCFrameworks/XF1.xcframework/ios-arm64/XF1",
-                    linking: .dynamic,
-                    mergeable: false,
-                    status: .required,
-                    macroPath: nil
+                    GraphDependency.XCFramework(
+                        path: "/XCFrameworks/XF1.xcframework",
+                        infoPlist: .test(),
+                        primaryBinaryPath: "/XCFrameworks/XF1.xcframework/ios-arm64/XF1",
+                        linking: .dynamic,
+                        mergeable: false,
+                        status: .required,
+                        macroPath: nil
+                    )
                 ),
             ]),
         ])
@@ -434,13 +436,15 @@ final class GraphLoaderTests: TuistUnitTestCase {
         XCTAssertEqual(graph.dependencies, [
             .target(name: "A", path: "/A"): Set([
                 .xcframework(
-                    path: "/XCFrameworks/XF1.xcframework",
-                    infoPlist: .test(),
-                    primaryBinaryPath: "/XCFrameworks/XF1.xcframework/ios-arm64/XF1",
-                    linking: .dynamic,
-                    mergeable: true,
-                    status: .required,
-                    macroPath: nil
+                    GraphDependency.XCFramework(
+                        path: "/XCFrameworks/XF1.xcframework",
+                        infoPlist: .test(),
+                        primaryBinaryPath: "/XCFrameworks/XF1.xcframework/ios-arm64/XF1",
+                        linking: .dynamic,
+                        mergeable: true,
+                        status: .required,
+                        macroPath: nil
+                    )
                 ),
             ]),
         ])

--- a/Tests/TuistCoreTests/Graph/GraphLoaderTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphLoaderTests.swift
@@ -368,7 +368,8 @@ final class GraphLoaderTests: TuistUnitTestCase {
                 primaryBinaryPath: "/XCFrameworks/XF1.xcframework/ios-arm64/XF1",
                 linking: .dynamic,
                 mergeable: false,
-                status: .required
+                status: .required,
+                macroPath: nil
             )
         )
 
@@ -391,7 +392,8 @@ final class GraphLoaderTests: TuistUnitTestCase {
                     primaryBinaryPath: "/XCFrameworks/XF1.xcframework/ios-arm64/XF1",
                     linking: .dynamic,
                     mergeable: false,
-                    status: .required
+                    status: .required,
+                    macroPath: nil
                 ),
             ]),
         ])
@@ -413,7 +415,8 @@ final class GraphLoaderTests: TuistUnitTestCase {
                 primaryBinaryPath: "/XCFrameworks/XF1.xcframework/ios-arm64/XF1",
                 linking: .dynamic,
                 mergeable: true,
-                status: .required
+                status: .required,
+                macroPath: nil
             )
         )
 
@@ -436,7 +439,8 @@ final class GraphLoaderTests: TuistUnitTestCase {
                     primaryBinaryPath: "/XCFrameworks/XF1.xcframework/ios-arm64/XF1",
                     linking: .dynamic,
                     mergeable: true,
-                    status: .required
+                    status: .required,
+                    macroPath: nil
                 ),
             ]),
         ])

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -1317,7 +1317,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
             primaryBinaryPath: "/xcframeworks/c.xcframework/c",
             linking: .dynamic,
             mergeable: false,
-            status: .required
+            status: .required,
+            macroPath: nil
         )
         let dDependency = GraphDependency.xcframework(
             path: "/xcframeworks/d.xcframework",
@@ -1329,7 +1330,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
             primaryBinaryPath: "/xcframeworks/d.xcframework/d",
             linking: .dynamic,
             mergeable: false,
-            status: .required
+            status: .required,
+            macroPath: nil
         )
         let eDependency = GraphDependency.xcframework(
             path: "/xcframeworks/e.xcframework",
@@ -1342,7 +1344,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
             primaryBinaryPath: "/xcframeworks/e.xcframework/e",
             linking: .dynamic,
             mergeable: true,
-            status: .required
+            status: .required,
+            macroPath: nil
         )
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
             .target(name: app.name, path: project.path): Set(arrayLiteral: cDependency, eDependency),
@@ -1389,7 +1392,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
             primaryBinaryPath: "/xcframeworks/c.xcframework/c",
             linking: .dynamic,
             mergeable: false,
-            status: .required
+            status: .required,
+            macroPath: nil
         )
         let dDependency = GraphDependency.xcframework(
             path: "/xcframeworks/d.xcframework",
@@ -1401,7 +1405,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
             primaryBinaryPath: "/xcframeworks/d.xcframework/d",
             linking: .dynamic,
             mergeable: false,
-            status: .required
+            status: .required,
+            macroPath: nil
         )
         let eDependency = GraphDependency.xcframework(
             path: "/xcframeworks/e.xcframework",
@@ -1414,7 +1419,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
             primaryBinaryPath: "/xcframeworks/e.xcframework/e",
             linking: .dynamic,
             mergeable: true,
-            status: .required
+            status: .required,
+            macroPath: nil
         )
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
             .target(name: app.name, path: project.path): Set(arrayLiteral: cDependency, eDependency),
@@ -3988,7 +3994,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
             primaryBinaryPath: "/xcframeworks/direct.xcframework/direct",
             linking: .static,
             mergeable: false,
-            status: .required
+            status: .required,
+            macroPath: nil
         )
         let directFramework = GraphDependency.framework(
             path: "/frameworks/direct.framework",
@@ -4011,7 +4018,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
             primaryBinaryPath: "/xcframeworks/transitive-framework-target-xcframework.xcframework/transitive",
             linking: .static,
             mergeable: false,
-            status: .required
+            status: .required,
+            macroPath: nil
         )
         let transitiveXCFramework = GraphDependency.xcframework(
             path: "/xcframeworks/transitive.xcframework",
@@ -4023,7 +4031,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
             primaryBinaryPath: "/xcframeworks/transitive.xcframework/transitive",
             linking: .static,
             mergeable: false,
-            status: .required
+            status: .required,
+            macroPath: nil
         )
         let frameworkTransitiveXCFramework = GraphDependency.xcframework(
             path: "/xcframeworks/framework-transitive.xcframework",
@@ -4035,7 +4044,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
             primaryBinaryPath: "/xcframeworks/framework-transitive.xcframework/framework-transitive",
             linking: .static,
             mergeable: false,
-            status: .required
+            status: .required,
+            macroPath: nil
         )
 
         let dependencies: [GraphDependency: Set<GraphDependency>] = [

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -1308,44 +1308,50 @@ final class GraphTraverserTests: TuistUnitTestCase {
 
         // Given: Value Graph
         let cDependency = GraphDependency.xcframework(
-            path: "/xcframeworks/c.xcframework",
-            infoPlist: .test(libraries: [.test(
-                identifier: "id",
-                path: try RelativePath(validating: "path"),
-                architectures: [.arm64]
-            )]),
-            primaryBinaryPath: "/xcframeworks/c.xcframework/c",
-            linking: .dynamic,
-            mergeable: false,
-            status: .required,
-            macroPath: nil
+            GraphDependency.XCFramework(
+                path: "/xcframeworks/c.xcframework",
+                infoPlist: .test(libraries: [.test(
+                    identifier: "id",
+                    path: try RelativePath(validating: "path"),
+                    architectures: [.arm64]
+                )]),
+                primaryBinaryPath: "/xcframeworks/c.xcframework/c",
+                linking: .dynamic,
+                mergeable: false,
+                status: .required,
+                macroPath: nil
+            )
         )
         let dDependency = GraphDependency.xcframework(
-            path: "/xcframeworks/d.xcframework",
-            infoPlist: .test(libraries: [.test(
-                identifier: "id",
-                path: try RelativePath(validating: "path"),
-                architectures: [.arm64]
-            )]),
-            primaryBinaryPath: "/xcframeworks/d.xcframework/d",
-            linking: .dynamic,
-            mergeable: false,
-            status: .required,
-            macroPath: nil
+            GraphDependency.XCFramework(
+                path: "/xcframeworks/d.xcframework",
+                infoPlist: .test(libraries: [.test(
+                    identifier: "id",
+                    path: try RelativePath(validating: "path"),
+                    architectures: [.arm64]
+                )]),
+                primaryBinaryPath: "/xcframeworks/d.xcframework/d",
+                linking: .dynamic,
+                mergeable: false,
+                status: .required,
+                macroPath: nil
+            )
         )
         let eDependency = GraphDependency.xcframework(
-            path: "/xcframeworks/e.xcframework",
-            infoPlist: .test(libraries: [.test(
-                identifier: "id",
-                path: try RelativePath(validating: "path"),
+            GraphDependency.XCFramework(
+                path: "/xcframeworks/e.xcframework",
+                infoPlist: .test(libraries: [.test(
+                    identifier: "id",
+                    path: try RelativePath(validating: "path"),
+                    mergeable: true,
+                    architectures: [.arm64]
+                )]),
+                primaryBinaryPath: "/xcframeworks/e.xcframework/e",
+                linking: .dynamic,
                 mergeable: true,
-                architectures: [.arm64]
-            )]),
-            primaryBinaryPath: "/xcframeworks/e.xcframework/e",
-            linking: .dynamic,
-            mergeable: true,
-            status: .required,
-            macroPath: nil
+                status: .required,
+                macroPath: nil
+            )
         )
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
             .target(name: app.name, path: project.path): Set(arrayLiteral: cDependency, eDependency),
@@ -1383,44 +1389,50 @@ final class GraphTraverserTests: TuistUnitTestCase {
 
         // Given: Value Graph
         let cDependency = GraphDependency.xcframework(
-            path: "/xcframeworks/c.xcframework",
-            infoPlist: .test(libraries: [.test(
-                identifier: "id",
-                path: try RelativePath(validating: "c.framework"),
-                architectures: [.arm64]
-            )]),
-            primaryBinaryPath: "/xcframeworks/c.xcframework/c",
-            linking: .dynamic,
-            mergeable: false,
-            status: .required,
-            macroPath: nil
+            GraphDependency.XCFramework(
+                path: "/xcframeworks/c.xcframework",
+                infoPlist: .test(libraries: [.test(
+                    identifier: "id",
+                    path: try RelativePath(validating: "c.framework"),
+                    architectures: [.arm64]
+                )]),
+                primaryBinaryPath: "/xcframeworks/c.xcframework/c",
+                linking: .dynamic,
+                mergeable: false,
+                status: .required,
+                macroPath: nil
+            )
         )
         let dDependency = GraphDependency.xcframework(
-            path: "/xcframeworks/d.xcframework",
-            infoPlist: .test(libraries: [.test(
-                identifier: "id",
-                path: try RelativePath(validating: "d.framework"),
-                architectures: [.arm64]
-            )]),
-            primaryBinaryPath: "/xcframeworks/d.xcframework/d",
-            linking: .dynamic,
-            mergeable: false,
-            status: .required,
-            macroPath: nil
+            GraphDependency.XCFramework(
+                path: "/xcframeworks/d.xcframework",
+                infoPlist: .test(libraries: [.test(
+                    identifier: "id",
+                    path: try RelativePath(validating: "d.framework"),
+                    architectures: [.arm64]
+                )]),
+                primaryBinaryPath: "/xcframeworks/d.xcframework/d",
+                linking: .dynamic,
+                mergeable: false,
+                status: .required,
+                macroPath: nil
+            )
         )
         let eDependency = GraphDependency.xcframework(
-            path: "/xcframeworks/e.xcframework",
-            infoPlist: .test(libraries: [.test(
-                identifier: "id",
-                path: try RelativePath(validating: "e.framework"),
+            GraphDependency.XCFramework(
+                path: "/xcframeworks/e.xcframework",
+                infoPlist: .test(libraries: [.test(
+                    identifier: "id",
+                    path: try RelativePath(validating: "e.framework"),
+                    mergeable: true,
+                    architectures: [.arm64]
+                )]),
+                primaryBinaryPath: "/xcframeworks/e.xcframework/e",
+                linking: .dynamic,
                 mergeable: true,
-                architectures: [.arm64]
-            )]),
-            primaryBinaryPath: "/xcframeworks/e.xcframework/e",
-            linking: .dynamic,
-            mergeable: true,
-            status: .required,
-            macroPath: nil
+                status: .required,
+                macroPath: nil
+            )
         )
         let dependencies: [GraphDependency: Set<GraphDependency>] = [
             .target(name: app.name, path: project.path): Set(arrayLiteral: cDependency, eDependency),
@@ -3985,17 +3997,19 @@ final class GraphTraverserTests: TuistUnitTestCase {
 
         let project = Project.test(targets: [staticLibrary])
         let directXCFramework = GraphDependency.xcframework(
-            path: "/xcframeworks/direct.xcframework",
-            infoPlist: .test(libraries: [.test(
-                identifier: "id",
-                path: try RelativePath(validating: "path"),
-                architectures: [.arm64]
-            )]),
-            primaryBinaryPath: "/xcframeworks/direct.xcframework/direct",
-            linking: .static,
-            mergeable: false,
-            status: .required,
-            macroPath: nil
+            GraphDependency.XCFramework(
+                path: "/xcframeworks/direct.xcframework",
+                infoPlist: .test(libraries: [.test(
+                    identifier: "id",
+                    path: try RelativePath(validating: "path"),
+                    architectures: [.arm64]
+                )]),
+                primaryBinaryPath: "/xcframeworks/direct.xcframework/direct",
+                linking: .static,
+                mergeable: false,
+                status: .required,
+                macroPath: nil
+            )
         )
         let directFramework = GraphDependency.framework(
             path: "/frameworks/direct.framework",
@@ -4009,43 +4023,49 @@ final class GraphTraverserTests: TuistUnitTestCase {
         )
         let directFrameworkTarget = GraphDependency.target(name: staticFramework.name, path: project.path)
         let transitiveFrameworkTargetXCFramework = GraphDependency.xcframework(
-            path: "/xcframeworks/transitive-framework-target-xcframework.xcframework",
-            infoPlist: .test(libraries: [.test(
-                identifier: "id",
-                path: try RelativePath(validating: "path"),
-                architectures: [.arm64]
-            )]),
-            primaryBinaryPath: "/xcframeworks/transitive-framework-target-xcframework.xcframework/transitive",
-            linking: .static,
-            mergeable: false,
-            status: .required,
-            macroPath: nil
+            GraphDependency.XCFramework(
+                path: "/xcframeworks/transitive-framework-target-xcframework.xcframework",
+                infoPlist: .test(libraries: [.test(
+                    identifier: "id",
+                    path: try RelativePath(validating: "path"),
+                    architectures: [.arm64]
+                )]),
+                primaryBinaryPath: "/xcframeworks/transitive-framework-target-xcframework.xcframework/transitive",
+                linking: .static,
+                mergeable: false,
+                status: .required,
+                macroPath: nil
+            )
         )
         let transitiveXCFramework = GraphDependency.xcframework(
-            path: "/xcframeworks/transitive.xcframework",
-            infoPlist: .test(libraries: [.test(
-                identifier: "id",
-                path: try RelativePath(validating: "path"),
-                architectures: [.arm64]
-            )]),
-            primaryBinaryPath: "/xcframeworks/transitive.xcframework/transitive",
-            linking: .static,
-            mergeable: false,
-            status: .required,
-            macroPath: nil
+            GraphDependency.XCFramework(
+                path: "/xcframeworks/transitive.xcframework",
+                infoPlist: .test(libraries: [.test(
+                    identifier: "id",
+                    path: try RelativePath(validating: "path"),
+                    architectures: [.arm64]
+                )]),
+                primaryBinaryPath: "/xcframeworks/transitive.xcframework/transitive",
+                linking: .static,
+                mergeable: false,
+                status: .required,
+                macroPath: nil
+            )
         )
         let frameworkTransitiveXCFramework = GraphDependency.xcframework(
-            path: "/xcframeworks/framework-transitive.xcframework",
-            infoPlist: .test(libraries: [.test(
-                identifier: "id",
-                path: try RelativePath(validating: "path"),
-                architectures: [.arm64]
-            )]),
-            primaryBinaryPath: "/xcframeworks/framework-transitive.xcframework/framework-transitive",
-            linking: .static,
-            mergeable: false,
-            status: .required,
-            macroPath: nil
+            GraphDependency.XCFramework(
+                path: "/xcframeworks/framework-transitive.xcframework",
+                infoPlist: .test(libraries: [.test(
+                    identifier: "id",
+                    path: try RelativePath(validating: "path"),
+                    architectures: [.arm64]
+                )]),
+                primaryBinaryPath: "/xcframeworks/framework-transitive.xcframework/framework-transitive",
+                linking: .static,
+                mergeable: false,
+                status: .required,
+                macroPath: nil
+            )
         )
 
         let dependencies: [GraphDependency: Set<GraphDependency>] = [

--- a/Tests/TuistCoreTests/MetadataProviders/XCFrameworkMetadataProviderTests.swift
+++ b/Tests/TuistCoreTests/MetadataProviders/XCFrameworkMetadataProviderTests.swift
@@ -135,7 +135,8 @@ final class XCFrameworkMetadataProviderTests: TuistTestCase {
             primaryBinaryPath: expectedBinaryPath,
             linking: .dynamic,
             mergeable: false,
-            status: .required
+            status: .required,
+            macroPath: nil
         ))
     }
 
@@ -170,7 +171,8 @@ final class XCFrameworkMetadataProviderTests: TuistTestCase {
             primaryBinaryPath: expectedBinaryPath,
             linking: .dynamic,
             mergeable: true,
-            status: .required
+            status: .required,
+            macroPath: nil
         ))
     }
 
@@ -204,7 +206,8 @@ final class XCFrameworkMetadataProviderTests: TuistTestCase {
             primaryBinaryPath: expectedBinaryPath,
             linking: .static,
             mergeable: false,
-            status: .required
+            status: .required,
+            macroPath: nil
         ))
     }
 
@@ -238,7 +241,8 @@ final class XCFrameworkMetadataProviderTests: TuistTestCase {
             primaryBinaryPath: expectedBinaryPath,
             linking: .dynamic,
             mergeable: false,
-            status: .required
+            status: .required,
+            macroPath: nil
         ))
 
         XCTAssertPrinterOutputContains("""

--- a/Tests/TuistCoreTests/MetadataProviders/XCFrameworkMetadataProviderTests.swift
+++ b/Tests/TuistCoreTests/MetadataProviders/XCFrameworkMetadataProviderTests.swift
@@ -249,4 +249,27 @@ final class XCFrameworkMetadataProviderTests: TuistTestCase {
         MyFrameworkMissingArch.xcframework is missing architecture ios-x86_64-simulator/MyFrameworkMissingArch.framework/MyFrameworkMissingArch defined in the Info.plist
         """)
     }
+
+    func test_loadMetadata_when_containsMacros() throws {
+        // Given
+        let temporaryDirectory = try temporaryPath()
+        let xcframeworkPath = temporaryDirectory.appending(component: "MyFramework.xcframework")
+        try fileHandler.copy(
+            from: fixturePath(path: try RelativePath(validating: "MyFramework.xcframework")),
+            to: xcframeworkPath
+        )
+        var macroPaths: [AbsolutePath] = []
+        try fileHandler.glob(xcframeworkPath, glob: "*/*.framework").sorted().forEach { frameworkPath in
+            try fileHandler.createFolder(frameworkPath.appending(component: "Macros"))
+            let macroPath = frameworkPath.appending(components: ["Macros", "MyFramework"])
+            try fileHandler.touch(macroPath)
+            macroPaths.append(macroPath)
+        }
+
+        // When
+        let metadata = try subject.loadMetadata(at: xcframeworkPath, status: .required)
+
+        // Then
+        XCTAssertEqual(metadata.macroPath, macroPaths.sorted().first)
+    }
 }

--- a/Tests/TuistCoreTests/NodeLoaders/XCFrameworkLoaderTests.swift
+++ b/Tests/TuistCoreTests/NodeLoaders/XCFrameworkLoaderTests.swift
@@ -70,7 +70,8 @@ final class XCFrameworkLoaderTests: TuistUnitTestCase {
                 primaryBinaryPath: binaryPath,
                 linking: linking,
                 mergeable: false,
-                status: .required
+                status: .required,
+                macroPath: nil
             )
         }
 
@@ -86,7 +87,8 @@ final class XCFrameworkLoaderTests: TuistUnitTestCase {
                 primaryBinaryPath: binaryPath,
                 linking: linking,
                 mergeable: false,
-                status: .required
+                status: .required,
+                macroPath: nil
             )
         )
     }

--- a/Tests/TuistCoreTests/NodeLoaders/XCFrameworkLoaderTests.swift
+++ b/Tests/TuistCoreTests/NodeLoaders/XCFrameworkLoaderTests.swift
@@ -82,13 +82,15 @@ final class XCFrameworkLoaderTests: TuistUnitTestCase {
         XCTAssertEqual(
             got,
             .xcframework(
-                path: xcframeworkPath,
-                infoPlist: infoPlist,
-                primaryBinaryPath: binaryPath,
-                linking: linking,
-                mergeable: false,
-                status: .required,
-                macroPath: nil
+                GraphDependency.XCFramework(
+                    path: xcframeworkPath,
+                    infoPlist: infoPlist,
+                    primaryBinaryPath: binaryPath,
+                    linking: linking,
+                    mergeable: false,
+                    status: .required,
+                    macroPath: nil
+                )
             )
         )
     }

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -1073,7 +1073,7 @@ final class LinkGeneratorTests: XCTestCase {
         let projectFileElements = ProjectFileElements()
         dependencies.forEach { dependency in
             switch dependency {
-            case .xcframework(path: let path, infoPlist: _, primaryBinaryPath: _, linking: _, mergeable: _, _):
+            case .xcframework(path: let path, infoPlist: _, primaryBinaryPath: _, linking: _, mergeable: _, _, _):
                 projectFileElements.elements[path] = PBXFileReference(
                     path: path.relative(to: projectPath).pathString
                 )

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -1073,9 +1073,9 @@ final class LinkGeneratorTests: XCTestCase {
         let projectFileElements = ProjectFileElements()
         dependencies.forEach { dependency in
             switch dependency {
-            case .xcframework(path: let path, infoPlist: _, primaryBinaryPath: _, linking: _, mergeable: _, _, _):
-                projectFileElements.elements[path] = PBXFileReference(
-                    path: path.relative(to: projectPath).pathString
+            case let .xcframework(xcframework):
+                projectFileElements.elements[xcframework.path] = PBXFileReference(
+                    path: xcframework.path.relative(to: projectPath).pathString
                 )
             default:
                 fatalError("Scenarios not handled in this test stub")


### PR DESCRIPTION
### Short description 📝
I'm adding an API to the `GraphTraversing` protocol, to return all the Swift Plugin executables that should be used when compiling a target. The executables are passed through the Swift compiler flag `-load-plugin-executable`. The API is `allSwiftPluginExecutables`.

The logic includes:
- Executables that are direct and transitive target dependencies of product type `.macro`.
- Macro executables are contained in the pre-compiled XCFramework method.

The latter is required for the upcoming binary-caching of Swift Macros. The convention we've established is that XCFrameworks contain the Swift Macro static frameworks, which contain a `Macros` directory with the executable in it. We assume that the executable is a fat binary for `x86_64` and `arm64` architectures

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
