### PR TITLE
Update xcbeautify URL and minimum version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
-        "version" : "1.2.3"
+        "revision" : "c8ed701b513cf5177118a175d85fbbbcd707ab41",
+        "version" : "1.3.0"
       }
     },
     {
@@ -218,10 +218,10 @@
     {
       "identity" : "xcbeautify",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tuist/xcbeautify",
+      "location" : "https://github.com/cpisciotta/xcbeautify",
       "state" : {
-        "revision" : "7dc31d4a9e9cc660f2de6ff6c6e0f0d5dfbb572b",
-        "version" : "1.0.1"
+        "revision" : "84d24a9854e6fdcd2c91122d50a3189b072e8136",
+        "version" : "1.4.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -385,7 +385,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit", exact: "2.10.1"),
         .package(url: "https://github.com/SwiftGen/SwiftGen", exact: "6.6.2"),
         .package(url: "https://github.com/tuist/XcodeProj", exact: "8.15.0"),
-        .package(url: "https://github.com/tuist/xcbeautify", from: "1.0.1"),
+        .package(url: "https://github.com/cpisciotta/xcbeautify", from: "1.4.0"),
     ],
     targets: targets
 )

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
-        "version" : "1.2.3"
+        "revision" : "c8ed701b513cf5177118a175d85fbbbcd707ab41",
+        "version" : "1.3.0"
       }
     },
     {
@@ -218,10 +218,10 @@
     {
       "identity" : "xcbeautify",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tuist/xcbeautify",
+      "location" : "https://github.com/cpisciotta/xcbeautify",
       "state" : {
-        "revision" : "7dc31d4a9e9cc660f2de6ff6c6e0f0d5dfbb572b",
-        "version" : "1.0.1"
+        "revision" : "84d24a9854e6fdcd2c91122d50a3189b072e8136",
+        "version" : "1.4.0"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -20,6 +20,6 @@ let package = Package(
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit", from: "2.10.1"),
         .package(url: "https://github.com/SwiftGen/SwiftGen", from: "6.6.2"),
         .package(url: "https://github.com/tuist/XcodeProj", from: "8.15.0"),
-        .package(url: "https://github.com/tuist/xcbeautify", from: "1.0.1"),
+        .package(url: "https://github.com/cpisciotta/xcbeautify", from: "1.4.0"),
     ]
 )


### PR DESCRIPTION
### Short description 📝

- Recently, xcbeautify moved locations on GitHub.
- There are several new xcbeautify releases, so ensure the latest is the minimum.

### How to test the changes locally 🧐

- SPM resolves all references to xcbeautify.

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
