### PR TITLE
Fix generation not including macros from XCFrameworks

### DIFF
--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -315,11 +315,8 @@ final class ConfigGenerator: ConfigGenerating {
         graphTraverser: GraphTraversing,
         projectPath: AbsolutePath
     ) -> SettingsDictionary {
-        let targets = graphTraverser.allSwiftMacroFrameworkTargets(path: projectPath, name: target.name)
-        if targets.isEmpty { return [:] }
-        var settings: SettingsDictionary = [:]
-
         let pluginExecutables = graphTraverser.allSwiftPluginExecutables(path: projectPath, name: target.name)
+        var settings: SettingsDictionary = [:]
         if pluginExecutables.isEmpty { return settings }
         let swiftCompilerFlags = pluginExecutables.flatMap { ["-load-plugin-executable", $0] }
         settings["OTHER_SWIFT_FLAGS"] = .array(swiftCompilerFlags)


### PR DESCRIPTION
### Short description 📝
A bug in a logic recently introduced to return all the plugin executables for Swift Macros, causes the targets to miss the logic executable Swift flags for pre-compiled Swift Macros in XCFrameworks

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
