### PR TITLE
Fix loading PackageSettings when not specified in Package.swift

### DIFF
--- a/Tests/TuistLoaderTests/Loaders/ManifestLoaderErrorTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/ManifestLoaderErrorTests.swift
@@ -25,8 +25,12 @@ final class ManifestLoaderErrorTests: TuistUnitTestCase {
             "Manifest not found at path /test"
         )
         XCTAssertEqual(
-            ManifestLoaderError.manifestLoadingFailed(path: try AbsolutePath(validating: "/test/"), context: "Context")
-                .description,
+            ManifestLoaderError.manifestLoadingFailed(
+                path: try AbsolutePath(validating: "/test/"),
+                data: Data(),
+                context: "Context"
+            )
+            .description,
             """
             Unable to load manifest at \("/test".bold())
             Context
@@ -39,7 +43,11 @@ final class ManifestLoaderErrorTests: TuistUnitTestCase {
         XCTAssertEqual(ManifestLoaderError.unexpectedOutput(try AbsolutePath(validating: "/test/")).type, .bug)
         XCTAssertEqual(ManifestLoaderError.manifestNotFound(.project, try AbsolutePath(validating: "/test/")).type, .abort)
         XCTAssertEqual(
-            ManifestLoaderError.manifestLoadingFailed(path: try AbsolutePath(validating: "/test/"), context: "Context").type,
+            ManifestLoaderError.manifestLoadingFailed(
+                path: try AbsolutePath(validating: "/test/"),
+                data: Data(),
+                context: "Context"
+            ).type,
             .abort
         )
     }


### PR DESCRIPTION
### Short description 📝

I made a mistake in https://github.com/tuist/tuist/pull/5802 where `tuist fetch` would fail if a `Package.swift` would not contain `let packageSettings`. This PR fixes that.

### How to test the changes locally 🧐

Run `tuist fetch` for a project with `Package.swift` that doesn't have `Dependencies.swift` or `packageSettings` inside `Package.swift`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
