### PR TITLE
Add back `SwiftPackageManagerDependencies` conformance to `ExpressibleByArrayLiteral` for backwards compatibility

### DIFF
--- a/Sources/ProjectDescription/Dependencies/SwiftPackageManagerDependencies.swift
+++ b/Sources/ProjectDescription/Dependencies/SwiftPackageManagerDependencies.swift
@@ -70,7 +70,7 @@ public struct SwiftPackageManagerDependencies: Codable, Equatable {
         self.targetSettings = targetSettings
         self.projectOptions = projectOptions
     }
-    
+
     public static var manifest: SwiftPackageManagerDependencies {
         // Needed to disambiguate `.init()` call sites
         .init(productTypes: [:])

--- a/Sources/ProjectDescription/Dependencies/SwiftPackageManagerDependencies.swift
+++ b/Sources/ProjectDescription/Dependencies/SwiftPackageManagerDependencies.swift
@@ -70,6 +70,11 @@ public struct SwiftPackageManagerDependencies: Codable, Equatable {
         self.targetSettings = targetSettings
         self.projectOptions = projectOptions
     }
+    
+    public static var manifest: SwiftPackageManagerDependencies {
+        // Needed to disambiguate `.init()` call sites
+        .init(productTypes: [:])
+    }
 }
 
 // MARK: - ExpressibleByArrayLiteral

--- a/Sources/ProjectDescription/Dependencies/SwiftPackageManagerDependencies.swift
+++ b/Sources/ProjectDescription/Dependencies/SwiftPackageManagerDependencies.swift
@@ -71,3 +71,11 @@ public struct SwiftPackageManagerDependencies: Codable, Equatable {
         self.projectOptions = projectOptions
     }
 }
+
+// MARK: - ExpressibleByArrayLiteral
+
+extension SwiftPackageManagerDependencies: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: Package...) {
+        self.init(elements)
+    }
+}

--- a/Tests/ProjectDescriptionTests/Dependencies/DependenciesTests.swift
+++ b/Tests/ProjectDescriptionTests/Dependencies/DependenciesTests.swift
@@ -10,7 +10,7 @@ final class DependenciesTests: XCTestCase {
                 .github(path: "Dependency1/Dependency1", requirement: .branch("BranchName")),
                 .git(path: "Dependency2/Dependency2", requirement: .upToNext("1.2.3")),
             ],
-            swiftPackageManager: .init(),
+            swiftPackageManager: [],
             platforms: [.iOS, .macOS, .tvOS, .watchOS]
         )
         XCTAssertCodable(subject)

--- a/Tests/ProjectDescriptionTests/Dependencies/SwiftPackageManagerDependenciesTests.swift
+++ b/Tests/ProjectDescriptionTests/Dependencies/SwiftPackageManagerDependenciesTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class SwiftPackageManagerDependenciesTests: XCTestCase {
     func test_swiftPackageManagerDependencies_codable() {
-        let subject: SwiftPackageManagerDependencies = .init()
+        let subject: SwiftPackageManagerDependencies = []
         XCTAssertCodable(subject)
     }
 }

--- a/Tests/TuistLoaderTests/Loaders/DependenciesModelLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/DependenciesModelLoaderTests.swift
@@ -41,7 +41,7 @@ final class DependenciesModelLoaderTests: TuistUnitTestCase {
                     .github(path: "Dependency1", requirement: .exact("1.1.1")),
                     .git(path: "Dependency1", requirement: .exact("2.3.4")),
                 ],
-                swiftPackageManager: .init(),
+                swiftPackageManager: .manifest,
                 platforms: [.iOS, .macOS]
             )
         }

--- a/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
@@ -45,7 +45,7 @@ final class PackageSettingsLoaderTests: TuistUnitTestCase {
                     .github(path: "Dependency1", requirement: .exact("1.1.1")),
                     .git(path: "Dependency1", requirement: .exact("2.3.4")),
                 ],
-                swiftPackageManager: .init(),
+                swiftPackageManager: [],
                 platforms: [.iOS, .macOS]
             )
         }

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/DependenciesManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/DependenciesManifestMapperTests.swift
@@ -21,7 +21,7 @@ final class DependenciesManifestMapperTests: TuistUnitTestCase {
                 .git(path: "Dependency.git", requirement: .branch("BranchName")),
                 .binary(path: "DependencyXYZ", requirement: .atLeast("2.3.1")),
             ],
-            swiftPackageManager: .init(),
+            swiftPackageManager: .manifest,
             platforms: [.iOS, .macOS, .tvOS]
         )
 

--- a/fixtures/multiplatform_app_with_sdk/Tuist/Dependencies.swift
+++ b/fixtures/multiplatform_app_with_sdk/Tuist/Dependencies.swift
@@ -1,6 +1,6 @@
 import ProjectDescription
 
 let dependencies = Dependencies(
-    swiftPackageManager: [],
+    swiftPackageManager: .manifest,
     platforms: [.macOS, .iOS]
 )

--- a/fixtures/multiplatform_app_with_sdk/Tuist/Dependencies.swift
+++ b/fixtures/multiplatform_app_with_sdk/Tuist/Dependencies.swift
@@ -1,6 +1,6 @@
 import ProjectDescription
 
 let dependencies = Dependencies(
-    swiftPackageManager: .init(),
+    swiftPackageManager: [],
     platforms: [.macOS, .iOS]
 )


### PR DESCRIPTION
Addresses #5792 and #5806 

### Short description 📝

The removal of `ExpressibleByArrayLiteral` introduced a source incompatible change with older versions of Tuist.  Restoring this despite tuist 4 moving towards `Package.swift` as the source of truth for dependencies.

### How to test the changes locally 🧐

Code like this should compile:
```
let dependencies = Dependencies(
swiftPackageManager: [
     .remote(url: "https://github.com/apple/swift-collections.git", requirement: .upToNextMajor(from: "1.0.0")),
])

```


### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
