### PR TITLE
FIx uninstall script

### DIFF
--- a/script/uninstall
+++ b/script/uninstall
@@ -27,7 +27,7 @@ sudo_if_install_dir_not_writeable() {
   if [ -w $INSTALL_DIR ]; then
     bash -c "$command"
   else
-    bash -c "sudo \"$command\""
+    bash -c "sudo $command"
   fi
 }
 


### PR DESCRIPTION
### Short description 📝

This PR aims to resolve an issue running the uninstall script from [https://uninstall.tuist.io](https://uninstall.tuist.io) which, with the switch to mise, is more important now than ever ;)  
When I try to run the script, I get the following output: 
```shell
➜  ~ curl -Ls https://uninstall.tuist.io | bash                                                            
sudo: rm -rf /usr/local/bin/tuist: command not found
``` 
Using the provided fix tuist is successfully uninstalled:
```shell
➜  ~ curl -Ls https://raw.githubusercontent.com/Lilfaen/tuist/uninstall_script_fix/script/uninstall | bash 
==> Tuist uninstalled
```


### How to test the changes locally 🧐

Install tuist with the official (now deprecated) script, try to uninstall it with the official script, then try to uninstall it with the fixed script:
```shell
➜  ~ curl -Ls https://install.tuist.io | bash 
==> Downloading tuistenv...
==> Unzipping tuistenv...
==> Installing tuistenv...
==> tuistenv installed. Try running 'tuist'
==> Check out the documentation at https://docs.tuist.io/
➜  ~ which tuist # verify installation
/usr/local/bin/tuist
➜  ~ curl -Ls https://uninstall.tuist.io | bash # try uninstall using official script
sudo: rm -rf /usr/local/bin/tuist: command not found
➜  ~ which tuist
/usr/local/bin/tuist # uninstall unsuccessful 
➜  ~ curl -Ls https://raw.githubusercontent.com/Lilfaen/tuist/uninstall_script_fix/script/uninstall | bash
==> Tuist uninstalled
➜  ~ which tuist                                                                                          
tuist not found # uninstall successful
```

The commands to test: 
```shell
curl -Ls https://install.tuist.io | bash 
curl -Ls https://uninstall.tuist.io | bash
curl -Ls https://raw.githubusercontent.com/Lilfaen/tuist/uninstall_script_fix/script/uninstall | bash
which tuist
```

Please do test this locally on your machines, I could test this fix successfully on two machines.

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
