### PR TITLE
Revert "Add back `SwiftPackageManagerDependencies` conformance to `ExpressibleByArrayLiteral` for backwards compatibility"

### DIFF
--- a/Sources/ProjectDescription/Dependencies/SwiftPackageManagerDependencies.swift
+++ b/Sources/ProjectDescription/Dependencies/SwiftPackageManagerDependencies.swift
@@ -70,17 +70,4 @@ public struct SwiftPackageManagerDependencies: Codable, Equatable {
         self.targetSettings = targetSettings
         self.projectOptions = projectOptions
     }
-
-    public static var manifest: SwiftPackageManagerDependencies {
-        // Needed to disambiguate `.init()` call sites
-        .init(productTypes: [:])
-    }
-}
-
-// MARK: - ExpressibleByArrayLiteral
-
-extension SwiftPackageManagerDependencies: ExpressibleByArrayLiteral {
-    public init(arrayLiteral elements: Package...) {
-        self.init(elements)
-    }
 }

--- a/Tests/ProjectDescriptionTests/Dependencies/DependenciesTests.swift
+++ b/Tests/ProjectDescriptionTests/Dependencies/DependenciesTests.swift
@@ -10,7 +10,7 @@ final class DependenciesTests: XCTestCase {
                 .github(path: "Dependency1/Dependency1", requirement: .branch("BranchName")),
                 .git(path: "Dependency2/Dependency2", requirement: .upToNext("1.2.3")),
             ],
-            swiftPackageManager: [],
+            swiftPackageManager: .init(),
             platforms: [.iOS, .macOS, .tvOS, .watchOS]
         )
         XCTAssertCodable(subject)

--- a/Tests/ProjectDescriptionTests/Dependencies/SwiftPackageManagerDependenciesTests.swift
+++ b/Tests/ProjectDescriptionTests/Dependencies/SwiftPackageManagerDependenciesTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class SwiftPackageManagerDependenciesTests: XCTestCase {
     func test_swiftPackageManagerDependencies_codable() {
-        let subject: SwiftPackageManagerDependencies = []
+        let subject: SwiftPackageManagerDependencies = .init()
         XCTAssertCodable(subject)
     }
 }

--- a/Tests/TuistLoaderTests/Loaders/DependenciesModelLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/DependenciesModelLoaderTests.swift
@@ -41,7 +41,7 @@ final class DependenciesModelLoaderTests: TuistUnitTestCase {
                     .github(path: "Dependency1", requirement: .exact("1.1.1")),
                     .git(path: "Dependency1", requirement: .exact("2.3.4")),
                 ],
-                swiftPackageManager: .manifest,
+                swiftPackageManager: .init(),
                 platforms: [.iOS, .macOS]
             )
         }

--- a/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
@@ -45,7 +45,7 @@ final class PackageSettingsLoaderTests: TuistUnitTestCase {
                     .github(path: "Dependency1", requirement: .exact("1.1.1")),
                     .git(path: "Dependency1", requirement: .exact("2.3.4")),
                 ],
-                swiftPackageManager: [],
+                swiftPackageManager: .init(),
                 platforms: [.iOS, .macOS]
             )
         }

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/DependenciesManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/DependenciesManifestMapperTests.swift
@@ -21,7 +21,7 @@ final class DependenciesManifestMapperTests: TuistUnitTestCase {
                 .git(path: "Dependency.git", requirement: .branch("BranchName")),
                 .binary(path: "DependencyXYZ", requirement: .atLeast("2.3.1")),
             ],
-            swiftPackageManager: .manifest,
+            swiftPackageManager: .init(),
             platforms: [.iOS, .macOS, .tvOS]
         )
 

--- a/fixtures/multiplatform_app_with_sdk/Tuist/Dependencies.swift
+++ b/fixtures/multiplatform_app_with_sdk/Tuist/Dependencies.swift
@@ -1,6 +1,6 @@
 import ProjectDescription
 
 let dependencies = Dependencies(
-    swiftPackageManager: .manifest,
+    swiftPackageManager: .init(),
     platforms: [.macOS, .iOS]
 )


### PR DESCRIPTION
Reverts tuist/tuist#5809

We decided to revert the change in PR #5809 , which adds yet another breaking change. We made the mistake and already reported it, apologizing to users, so it's better at this point to focus on adding the necessary measures so that it doesn't happen again and make sure that the users running into this are well-supported.