### PR TITLE
Resolve Tuist-4 Compiler Errors

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -78,13 +78,7 @@ jobs:
       - name: Print hashes
         run: tuist cache print-hashes --xcframeworks
       - name: Cache warm
-        run: tuist cache warm --xcframeworks --raw-xcodebuild-logs-path /tmp/tuist/cache-warm-x86_64.xcodebuild.log
-      - uses: actions/upload-artifact@v4
-        if: ${{ always() }}
-        with:
-          name: cache-warm-x86_64.xcodebuild.log
-          path: |
-            /tmp/tuist/**
+        run: tuist cache warm --xcframeworks
 
   acceptance_tests:
     name: Run ${{ matrix.feature }}

--- a/Sources/TuistDependencies/DependenciesController.swift
+++ b/Sources/TuistDependencies/DependenciesController.swift
@@ -141,7 +141,6 @@ public final class DependenciesController: DependenciesControlling {
         try install(
             at: path,
             dependencies: TuistGraph.Dependencies(
-                carthage: nil,
                 swiftPackageManager: TuistGraph.SwiftPackageManagerDependencies(
                     .manifest,
                     productTypes: packageSettings.productTypes,
@@ -165,7 +164,6 @@ public final class DependenciesController: DependenciesControlling {
         try install(
             at: path,
             dependencies: TuistGraph.Dependencies(
-                carthage: nil,
                 swiftPackageManager: TuistGraph.SwiftPackageManagerDependencies(
                     .manifest,
                     productTypes: packageSettings.productTypes,

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -430,7 +430,7 @@ final class LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_
 
         for dependency in linkableDependencies {
             switch dependency {
-            case let .framework(path, _, _, _, _, _, _, _, status, condition):
+            case let .framework(path, _, _, _, _, _, _, status, condition):
                 try addBuildFile(path, condition: condition, status: status)
             case let .library(path, _, _, _, condition):
                 try addBuildFile(path, condition: condition)

--- a/Sources/TuistSupport/Utils/Environment.swift
+++ b/Sources/TuistSupport/Utils/Environment.swift
@@ -1,6 +1,7 @@
 import Darwin
 import Foundation
 import TSCBasic
+
 /// Protocol that defines the interface of a local environment controller.
 /// It manages the local directory where tuistenv stores the tuist versions and user settings.
 public protocol Environmenting: AnyObject {

--- a/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
@@ -41,10 +41,6 @@ final class PackageSettingsLoaderTests: TuistUnitTestCase {
         }
         manifestLoader.loadDependenciesStub = { _ in
             Dependencies(
-                carthage: [
-                    .github(path: "Dependency1", requirement: .exact("1.1.1")),
-                    .git(path: "Dependency1", requirement: .exact("2.3.4")),
-                ],
                 swiftPackageManager: .init(),
                 platforms: [.iOS, .macOS]
             )

--- a/Tuist/ProjectDescriptionHelpers/Target+Helpers.swift
+++ b/Tuist/ProjectDescriptionHelpers/Target+Helpers.swift
@@ -26,10 +26,10 @@ extension Target {
         }
         return Target(
             name: name,
-            destinations: [.mac],
+            platform: .macOS,
             product: product,
             bundleId: "io.tuist.\(name)",
-            deploymentTargets: .macOS("12.0"),
+            deploymentTarget: .macOS(targetVersion: "12.0"),
             infoPlist: .default,
             sources: ["\(rootFolder)/\(name)/**/*.swift"],
             dependencies: dependencies


### PR DESCRIPTION
### Short description 📝

- Resolve compiler errors when running `tuist generate` on a local machine.
- Resolve CI job failure, since `--raw-xcodebuild-logs-path` is no longer available.
- Resolve lint failure.

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
