### PR TITLE
Add support for `-debug-symbols` to `XcodeBuildControlling`'s interface for creating XCFrameworks

### DIFF
--- a/Sources/TuistCore/Automation/XcodeBuildControlling.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildControlling.swift
@@ -36,6 +36,11 @@ public enum XcodeBuildControllerCreateXCFrameworkArgument {
     case library(path: AbsolutePath, headers: AbsolutePath)
 
     /**
+     It passes the -debug-symbol argument when creating frameworks.
+     */
+    case debugSymbols(path: AbsolutePath)
+
+    /**
      Returns the arguments that represent his argument when invoking xcodebuild.
      */
     public var xcodebuildArguments: [String] {
@@ -51,6 +56,8 @@ public enum XcodeBuildControllerCreateXCFrameworkArgument {
             return ["-archive", sanitizedPath(archivePath), "-framework", framework]
         case let .library(libraryPath, headers):
             return ["-library", sanitizedPath(libraryPath), "-headers", sanitizedPath(headers)]
+        case let .debugSymbols(path):
+            return ["-debug-symbols", sanitizedPath(path)]
         }
     }
 }


### PR DESCRIPTION
### Short description 📝
The creation of XCFrameworks supports embedding debug symbols. This PR adjusts the `createFramework` arguments to support passing paths to debug symbols to include.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
