### PR TITLE
Rename Compiled group to Frameworks

### DIFF
--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -244,7 +244,7 @@ class ProjectFileElements {
             case let .sdk(sdkNodePath, _, _, _):
                 generateSDKFileElement(
                     sdkNodePath: sdkNodePath,
-                    toGroup: groups.compiled,
+                    toGroup: groups.frameworks,
                     pbxproj: pbxproj
                 )
             case let .product(target: target, productName: productName, _):
@@ -274,7 +274,7 @@ class ProjectFileElements {
                 from: sourceRootPath,
                 fileAbsolutePath: path,
                 name: path.basename,
-                toGroup: groups.compiled,
+                toGroup: groups.frameworks,
                 pbxproj: pbxproj
             )
             compiled[path] = fileElement

--- a/Sources/TuistGenerator/Generator/ProjectGroups.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGroups.swift
@@ -28,7 +28,7 @@ class ProjectGroups {
 
     @SortedPBXGroup var sortedMain: PBXGroup
     let products: PBXGroup
-    let compiled: PBXGroup
+    let frameworks: PBXGroup
 
     private let pbxproj: PBXProj
     private let projectGroups: [String: PBXGroup]
@@ -39,21 +39,21 @@ class ProjectGroups {
         main: PBXGroup,
         projectGroups: [(name: String, group: PBXGroup)],
         products: PBXGroup,
-        compiled: PBXGroup,
+        frameworks: PBXGroup,
         pbxproj: PBXProj
     ) {
         sortedMain = main
         self.projectGroups = Dictionary(uniqueKeysWithValues: projectGroups)
         self.products = products
-        self.compiled = compiled
+        self.frameworks = frameworks
         self.pbxproj = pbxproj
     }
 
     func targetFrameworks(target: String) throws -> PBXGroup {
-        if let group = compiled.group(named: target) {
+        if let group = frameworks.group(named: target) {
             return group
         } else {
-            return try compiled.addGroup(named: target, options: .withoutFolder).last!
+            return try frameworks.addGroup(named: target, options: .withoutFolder).last!
         }
     }
 
@@ -93,10 +93,10 @@ class ProjectGroups {
             projectGroups.append((item, projectGroup))
         }
 
-        /// Compiled
-        let compiledGroup = PBXGroup(children: [], sourceTree: .group, name: "Compiled")
-        pbxproj.add(object: compiledGroup)
-        mainGroup.children.append(compiledGroup)
+        /// SDSKs & Pre-compiled frameworks
+        let frameworksGroup = PBXGroup(children: [], sourceTree: .group, name: "Frameworks")
+        pbxproj.add(object: frameworksGroup)
+        mainGroup.children.append(frameworksGroup)
 
         /// Products
         let productsGroup = PBXGroup(children: [], sourceTree: .group, name: "Products")
@@ -107,7 +107,7 @@ class ProjectGroups {
             main: mainGroup,
             projectGroups: projectGroups,
             products: productsGroup,
-            compiled: compiledGroup,
+            frameworks: frameworksGroup,
             pbxproj: pbxproj
         )
     }

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -792,7 +792,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertEqual(groups.compiled.flattenedChildren, [
+        XCTAssertEqual(groups.frameworks.flattenedChildren, [
             "ARKit.framework",
         ])
 
@@ -841,7 +841,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertEqual(groups.compiled.flattenedChildren, [
+        XCTAssertEqual(groups.frameworks.flattenedChildren, [
             "Test.framework",
         ])
 

--- a/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
@@ -74,10 +74,10 @@ final class ProjectGroupsTests: XCTestCase {
         XCTAssertNil(main.group(named: "Target")?.path)
         XCTAssertEqual(main.group(named: "Target")?.sourceTree, .group)
 
-        XCTAssertTrue(main.children.contains(subject.compiled))
-        XCTAssertEqual(subject.compiled.name, "Compiled")
-        XCTAssertNil(subject.compiled.path)
-        XCTAssertEqual(subject.compiled.sourceTree, .group)
+        XCTAssertTrue(main.children.contains(subject.frameworks))
+        XCTAssertEqual(subject.frameworks.name, "Frameworks")
+        XCTAssertNil(subject.frameworks.path)
+        XCTAssertEqual(subject.frameworks.sourceTree, .group)
 
         XCTAssertTrue(main.children.contains(subject.products))
         XCTAssertEqual(subject.products.name, "Products")
@@ -111,7 +111,7 @@ final class ProjectGroupsTests: XCTestCase {
             "B",
             "C",
             "A",
-            "Compiled",
+            "Frameworks",
             "Products",
         ])
     }
@@ -125,7 +125,7 @@ final class ProjectGroupsTests: XCTestCase {
         let got = try subject.targetFrameworks(target: "Test")
         XCTAssertEqual(got.name, "Test")
         XCTAssertEqual(got.sourceTree, .group)
-        XCTAssertTrue(subject.compiled.children.contains(got))
+        XCTAssertTrue(subject.frameworks.children.contains(got))
     }
 
     func test_projectGroup_unknownProjectGroups() throws {


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/5753

### Short description 📝

- https://github.com/tuist/tuist/pull/5617 introduced a change to clean up the project structure when cached binaries are used (via `tuist cache`) to flatten the hierarchy and place file references under a "Compiled" group
- The chanege also merged System frameworks into this new group (e.g. when linking against StoreKit or ARKit)
- This deviates from how Xcode organizes system frameworks and can cause inconsistent projects should a generated project be modified manually outside of Tuist (e.g. a `Frameworks` group would be created but existing `Compiled` would still contain older references)
- A simple solution is to re-name `Compiled` back to `Frameworks` while keeping the new logic intact to add cached binaries to that group

### How to test the changes locally 🧐

- Generate the fixture `ios_app_with_sdk`

```sh
swift build
swift run tuist generate --path fixtures/ios_app_with_sdk
```

- Verify the generated project has the System frameworks and libraries listed under a "Frameworks" group


![Screenshot 2024-01-23 at 08 35 49](https://github.com/tuist/tuist/assets/11914919/98281c95-a41c-49c9-9c4c-edaad4ad3dd2)


### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
