### PR TITLE
Fix tuist cache warm job

### DIFF
--- a/.github/workflows/tuist.yml
+++ b/.github/workflows/tuist.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Print hashes
         run: tuist cache print-hashes --xcframeworks
       - name: Cache warm
-        run: tuist cache warm --xcframeworks --raw-xcodebuild-logs-path /tmp/tuist/cache-warm-x86_64.xcodebuild.log
+        run: tuist cache warm --xcframeworks
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:


### PR DESCRIPTION
### Short description 📝

We removed the `--raw-xcodebuild-log-path` from `cache warm` but we have not updated the CI suite.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
