### PR TITLE
Use the correct Swift tools version when loading the PackageSettings

### DIFF
--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -397,8 +397,8 @@ public class ManifestLoader: ManifestLoading {
                     "-L", manifestPath,
                     "-F", manifestPath,
                     "-lPackageDescription",
-                    "-D", "TUIST",
                     "-package-description-version", packageVersion.description,
+                    "-D", "TUIST",
                 ]
             } else {
                 return []

--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -111,6 +111,7 @@ public class ManifestLoader: ManifestLoading {
     private let cacheDirectoryProviderFactory: CacheDirectoriesProviderFactoring
     private let projectDescriptionHelpersBuilderFactory: ProjectDescriptionHelpersBuilderFactoring
     private let xcodeController: XcodeControlling
+    private let swiftPackageManagerController: SwiftPackageManagerControlling
 
     // MARK: - Init
 
@@ -121,7 +122,8 @@ public class ManifestLoader: ManifestLoading {
             cacheDirectoryProviderFactory: CacheDirectoriesProviderFactory(),
             projectDescriptionHelpersBuilderFactory: ProjectDescriptionHelpersBuilderFactory(),
             manifestFilesLocator: ManifestFilesLocator(),
-            xcodeController: XcodeController.shared
+            xcodeController: XcodeController.shared,
+            swiftPackageManagerController: SwiftPackageManagerController()
         )
     }
 
@@ -131,7 +133,8 @@ public class ManifestLoader: ManifestLoading {
         cacheDirectoryProviderFactory: CacheDirectoriesProviderFactoring,
         projectDescriptionHelpersBuilderFactory: ProjectDescriptionHelpersBuilderFactoring,
         manifestFilesLocator: ManifestFilesLocating,
-        xcodeController: XcodeControlling
+        xcodeController: XcodeControlling,
+        swiftPackageManagerController: SwiftPackageManagerControlling
     ) {
         self.environment = environment
         self.resourceLocator = resourceLocator
@@ -139,6 +142,7 @@ public class ManifestLoader: ManifestLoading {
         self.projectDescriptionHelpersBuilderFactory = projectDescriptionHelpersBuilderFactory
         self.manifestFilesLocator = manifestFilesLocator
         self.xcodeController = xcodeController
+        self.swiftPackageManagerController = swiftPackageManagerController
         decoder = JSONDecoder()
     }
 
@@ -383,6 +387,9 @@ public class ManifestLoader: ManifestLoading {
         let packageDescriptionArguments: [String] = try {
             if case .package = manifest {
                 guard let xcode = try xcodeController.selected() else { return [] }
+                let packageVersion = try swiftPackageManagerController.getToolsVersion(
+                    at: path.parentDirectory
+                )
                 let manifestPath =
                     "\(xcode.path.pathString)/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/ManifestAPI"
                 return [
@@ -391,6 +398,7 @@ public class ManifestLoader: ManifestLoading {
                     "-F", manifestPath,
                     "-lPackageDescription",
                     "-D", "TUIST",
+                    "-package-description-version", packageVersion.description,
                 ]
             } else {
                 return []

--- a/Tests/TuistLoaderIntegrationTests/Loaders/ManifestLoaderTests.swift
+++ b/Tests/TuistLoaderIntegrationTests/Loaders/ManifestLoaderTests.swift
@@ -93,7 +93,9 @@ final class ManifestLoaderTests: TuistTestCase {
 
         let package = Package(
             name: "PackageName",
-            dependencies: []
+            dependencies: [
+                .package(url: "https://github.com/Alamofire/Alamofire", exact: "5.8.0"),
+            ]
         )
 
         """

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Alamofire/Alamofire",
       "state" : {
-        "revision" : "3dc6a42c7727c49bf26508e29b0a0b35f9c7e1ad",
-        "version" : "5.8.1"
+        "revision" : "b2fa556e4e48cbf06cf8c63def138c98f4b811fa",
+        "version" : "5.8.0"
       }
     },
     {

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.swift
@@ -18,7 +18,7 @@ import PackageDescription
 let package = Package(
     name: "PackageName",
     dependencies: [
-        .package(url: "https://github.com/Alamofire/Alamofire", from: "5.8.0"),
+        .package(url: "https://github.com/Alamofire/Alamofire", exact: "5.8.0"),
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture", .upToNextMinor(from: "1.5.0")),
         .package(path: "../../../LocalSwiftPackage"),
         .package(path: "../../../StringifyMacro"),


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5819

### Short description 📝

We were not passing the Swift tools version when we were loading the `PackageSettings` which could lead to compiler issues (as described in the attached issue)

### How to test the changes locally 🧐

Run `tuist fetch` for the `app_with_spm_dependencies` fixture (also run via acceptance tests)

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
