### PR TITLE
Fix apps not exporting due to dynamic frameworks with a `/Macros` directory in them.

### DIFF
--- a/Sources/TuistCore/Graph/GraphDependencyReference.swift
+++ b/Sources/TuistCore/Graph/GraphDependencyReference.swift
@@ -12,9 +12,12 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
              let .product(_, _, condition),
              let .sdk(_, _, _, condition):
             return condition
+        case .macro:
+            return nil
         }
     }
 
+    case macro(path: AbsolutePath)
     case xcframework(
         path: AbsolutePath,
         infoPlist: XCFrameworkInfoPlist,
@@ -109,6 +112,7 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
     // Private helper type to auto-synthesize the hashable & comparable implementations
     // where only the required subset of properties are used.
     private enum Synthesized: Comparable, Hashable {
+        case macro(path: AbsolutePath)
         case sdk(path: AbsolutePath, condition: PlatformCondition?)
         case product(target: String, productName: String, condition: PlatformCondition?)
         case library(path: AbsolutePath, condition: PlatformCondition?)
@@ -118,6 +122,8 @@ public enum GraphDependencyReference: Equatable, Comparable, Hashable {
 
         init(dependencyReference: GraphDependencyReference) {
             switch dependencyReference {
+            case let .macro(path):
+                self = .macro(path: path)
             case .xcframework(
                 path: let path,
                 infoPlist: _,

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -707,10 +707,10 @@ public class GraphTraverser: GraphTraversing {
             .flatMap { target in
                 directSwiftMacroExecutables(path: target.project.path, name: target.target.name).map { (target, $0) }
             }
-            .compactMap { target, dependencyReference in
+            .compactMap { _, dependencyReference in
                 switch dependencyReference {
                 case let .product(_, productName, _):
-                    return "$BUILT_PRODUCTS_DIR/\(target.target.productNameWithExtension)/Macros/\(productName)#\(productName)"
+                    return "$BUILT_PRODUCTS_DIR/\(productName)#\(productName)"
                 default:
                     return nil
                 }

--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -575,6 +575,7 @@ public class GraphTraverser: GraphTraversing {
             switch dependency {
             case let .xcframework(xcframework): return xcframework.path
             case let .framework(path, _, _, _, _, _, _, _): return path
+            case .macro: return nil
             case .library: return nil
             case .bundle: return nil
             case .packageProduct: return nil
@@ -686,22 +687,31 @@ public class GraphTraverser: GraphTraversing {
     }
 
     public func allSwiftPluginExecutables(path: TSCBasic.AbsolutePath, name: String) -> Set<String> {
+        func precompiledMacroDependencies(_ graphDependency: GraphDependency) -> Set<AbsolutePath> {
+            Set(
+                dependencies[graphDependency, default: Set()]
+                    .lazy
+                    .compactMap {
+                        if case let GraphDependency.macro(path) = $0 {
+                            return path
+                        } else {
+                            return nil
+                        }
+                    }
+            )
+        }
+
         let precompiledMacroPluginExecutables = filterDependencies(from: .target(name: name, path: path), test: { dependency in
             switch dependency {
-            case let .xcframework(xcframework):
-                return xcframework.macroPath != nil
-            case .bundle, .library, .framework, .sdk, .target, .packageProduct:
+            case .xcframework:
+                return !precompiledMacroDependencies(dependency).isEmpty
+            case .bundle, .library, .framework, .sdk, .target, .packageProduct, .macro:
                 return false
             }
         })
-        .lazy.compactMap { dependency in
-            switch dependency {
-            case let .xcframework(xcframework):
-                return xcframework.macroPath!
-            case .bundle, .library, .framework, .sdk, .target, .packageProduct:
-                return nil
-            }
-        }.map { "\($0.pathString)/#\($0.basename)" }
+        .lazy
+        .flatMap(precompiledMacroDependencies)
+        .map { "\($0.pathString)/#\($0.basename)" }
 
         let sourceMacroPluginExecutables = allSwiftMacroFrameworkTargets(path: path, name: name)
             .flatMap { target in
@@ -905,6 +915,7 @@ public class GraphTraverser: GraphTraversing {
 
     func isDependencyPrecompiledLibrary(dependency: GraphDependency) -> Bool {
         switch dependency {
+        case .macro: return false
         case .xcframework: return true
         case .framework: return true
         case .library: return true
@@ -917,6 +928,7 @@ public class GraphTraverser: GraphTraversing {
 
     func isDependencyPrecompiledFramework(dependency: GraphDependency) -> Bool {
         switch dependency {
+        case .macro: return false
         case .xcframework: return true
         case .framework: return true
         case .library: return false
@@ -954,6 +966,8 @@ public class GraphTraverser: GraphTraversing {
 
     func isDependencyStatic(dependency: GraphDependency) -> Bool {
         switch dependency {
+        case .macro:
+            return false
         case let .xcframework(xcframework):
             return xcframework.linking == .static
         case let .framework(_, _, _, _, linking, _, _, _),
@@ -982,6 +996,7 @@ public class GraphTraverser: GraphTraversing {
 
     func isDependencyDynamicTarget(dependency: GraphDependency) -> Bool {
         switch dependency {
+        case .macro: return false
         case .xcframework: return false
         case .framework: return false
         case .library: return false
@@ -1034,6 +1049,8 @@ public class GraphTraverser: GraphTraversing {
         }
 
         switch toDependency {
+        case let .macro(path):
+            return .macro(path: path)
         case let .framework(path, binaryPath, dsymPath, bcsymbolmapPaths, linking, architectures, isCarthage, status):
             return .framework(
                 path: path,
@@ -1116,7 +1133,7 @@ public class GraphTraverser: GraphTraversing {
                 switch dependency {
                 case let .framework(_, _, _, _, linking: linking, _, _, _):
                     return linking == .static
-                case .xcframework, .library, .bundle, .packageProduct, .target, .sdk:
+                case .xcframework, .library, .bundle, .packageProduct, .target, .sdk, .macro:
                     return false
                 }
             }
@@ -1138,7 +1155,7 @@ public class GraphTraverser: GraphTraversing {
                 switch dependency {
                 case let .xcframework(xcframework):
                     return xcframework.linking == .static
-                case .framework, .library, .bundle, .packageProduct, .target, .sdk:
+                case .framework, .library, .bundle, .packageProduct, .target, .sdk, .macro:
                     return false
                 }
             },

--- a/Sources/TuistCoreTesting/Graph/GraphDependencyReference+TestData.swift
+++ b/Sources/TuistCoreTesting/Graph/GraphDependencyReference+TestData.swift
@@ -32,6 +32,12 @@ extension GraphDependencyReference {
         )
     }
 
+    public static func testMacro(
+        path: AbsolutePath = "/macros/tuist"
+    ) -> GraphDependencyReference {
+        GraphDependencyReference.macro(path: path)
+    }
+
     public static func testXCFramework(
         path: AbsolutePath = "/frameworks/tuist.xcframework",
         infoPlist: XCFrameworkInfoPlist = .test(),

--- a/Sources/TuistGenerator/Extensions/Graph+Extras.swift
+++ b/Sources/TuistGenerator/Extensions/Graph+Extras.swift
@@ -59,7 +59,7 @@ extension GraphDependency {
         switch self {
         case let .target(_, path):
             return projects[path]?.isExternal ?? false
-        case .framework, .xcframework, .library, .bundle, .packageProduct, .sdk:
+        case .framework, .xcframework, .library, .bundle, .packageProduct, .sdk, .macro:
             return true
         }
     }

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -255,7 +255,7 @@ final class LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_
                 buildFile.applyCondition(condition, applicableTo: target)
                 pbxproj.add(object: buildFile)
                 embedPhase.files?.append(buildFile)
-            case .library, .bundle, .sdk:
+            case .library, .bundle, .sdk, .macro:
                 // Do nothing
                 break
             }
@@ -436,7 +436,7 @@ final class LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_
                 try addBuildFile(path, condition: condition)
             case let .xcframework(path, _, _, _, status, condition):
                 try addBuildFile(path, condition: condition, status: status)
-            case .bundle:
+            case .bundle, .macro:
                 break
             case let .product(dependencyTarget, _, condition):
                 guard let fileRef = fileElements.product(target: dependencyTarget) else {

--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -209,6 +209,14 @@ class ProjectFileElements {
     ) throws {
         for dependency in dependencyReferences.sorted() {
             switch dependency {
+            case let .macro(path):
+                try generatePrecompiledDependency(
+                    path,
+                    groups: groups,
+                    pbxproj: pbxproj,
+                    group: filesGroup,
+                    sourceRootPath: sourceRootPath
+                )
             case let .xcframework(path, _, _, _, _, _):
                 try generatePrecompiledDependency(
                     path,

--- a/Sources/TuistGenerator/GraphViz/GraphToGraphVizMapper.swift
+++ b/Sources/TuistGenerator/GraphViz/GraphToGraphVizMapper.swift
@@ -101,6 +101,8 @@ extension GraphDependency {
             source: _
         ):
             return String(name.split(separator: ".").first ?? "")
+        case let .macro(path):
+            return path.basename
         }
     }
 }

--- a/Sources/TuistGenerator/GraphViz/NodeStyling.swift
+++ b/Sources/TuistGenerator/GraphViz/NodeStyling.swift
@@ -64,6 +64,8 @@ extension GraphDependency {
         graphTraverser: GraphTraversing
     ) -> NodeStyleAttributes? {
         switch self {
+        case .macro:
+            return .init(fillColorName: .gray, shape: .diamond)
         case .sdk:
             return .init(fillColorName: .violet, shape: .rectangle)
         case .framework:

--- a/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -176,7 +176,7 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
         case let .target(name, path):
             guard let target = graphTraverser.target(path: path, name: name) else { return false }
             return target.target.product.isStatic
-        case .sdk:
+        case .sdk, .macro:
             return false
         }
     }

--- a/Sources/TuistGraph/Graph/GraphDependency.swift
+++ b/Sources/TuistGraph/Graph/GraphDependency.swift
@@ -9,7 +9,6 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         public let linking: BinaryLinking
         public let mergeable: Bool
         public let status: FrameworkStatus
-        public let macroPath: AbsolutePath?
 
         public init(
             path: AbsolutePath,
@@ -18,7 +17,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
             linking: BinaryLinking,
             mergeable: Bool,
             status: FrameworkStatus,
-            macroPath: AbsolutePath?
+            macroPath _: AbsolutePath?
         ) {
             self.path = path
             self.infoPlist = infoPlist
@@ -26,7 +25,6 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
             self.linking = linking
             self.mergeable = mergeable
             self.status = status
-            self.macroPath = macroPath
         }
 
         public var description: String {
@@ -75,6 +73,9 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         swiftModuleMap: AbsolutePath?
     )
 
+    /// A macOS executable that represents a macro
+    case macro(path: AbsolutePath)
+
     /// A dependency that represents a pre-compiled bundle.
     case bundle(path: AbsolutePath)
 
@@ -89,6 +90,8 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
 
     public func hash(into hasher: inout Hasher) {
         switch self {
+        case let .macro(path):
+            hasher.combine(path)
         case let .xcframework(xcframework):
             hasher.combine(xcframework)
         case let .framework(path, _, _, _, _, _, _, _):
@@ -120,6 +123,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
 
     public var isTarget: Bool {
         switch self {
+        case .macro: return false
         case .xcframework: return false
         case .framework: return false
         case .library: return false
@@ -135,6 +139,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
      */
     public var isStaticPrecompiled: Bool {
         switch self {
+        case .macro: return false
         case let .xcframework(xcframework):
             return xcframework.linking == .static
         case let .framework(_, _, _, _, linking, _, _, _),
@@ -151,6 +156,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
      */
     public var isDynamicPrecompiled: Bool {
         switch self {
+        case .macro: return false
         case let .xcframework(xcframework):
             return xcframework.linking == .dynamic
         case let .framework(_, _, _, _, linking, _, _, _),
@@ -164,6 +170,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
 
     public var isPrecompiled: Bool {
         switch self {
+        case .macro: return true
         case .xcframework: return true
         case .framework: return true
         case .library: return true
@@ -176,6 +183,7 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
 
     public var isPrecompiledDynamicAndLinkable: Bool {
         switch self {
+        case .macro: return false
         case let .xcframework(xcframework):
             return xcframework.linking == .dynamic
         case let .framework(_, _, _, _, linking, _, _, _),
@@ -203,6 +211,8 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
 
     public var description: String {
         switch self {
+        case .macro:
+            return "macro '\(name)'"
         case .xcframework:
             return "xcframework '\(name)'"
         case .framework:
@@ -222,6 +232,8 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
 
     public var name: String {
         switch self {
+        case let .macro(path):
+            return path.basename
         case let .xcframework(xcframework):
             return xcframework.path.basename
         case let .framework(path, _, _, _, _, _, _, _):

--- a/Sources/TuistGraphTesting/Graph/GraphDependency+TestData.swift
+++ b/Sources/TuistGraphTesting/Graph/GraphDependency+TestData.swift
@@ -28,6 +28,12 @@ extension GraphDependency {
         )
     }
 
+    public static func testMacro(
+        path: AbsolutePath = AbsolutePath.root.appending(try! RelativePath(validating: "macro"))
+    ) -> GraphDependency {
+        .macro(path: path)
+    }
+
     public static func testXCFramework(
         path: AbsolutePath = AbsolutePath.root.appending(try! RelativePath(validating: "Test.xcframework")),
         infoPlist: XCFrameworkInfoPlist = .test(),

--- a/Tests/TuistCoreTests/Graph/GraphDependencyReferenceTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphDependencyReferenceTests.swift
@@ -76,9 +76,12 @@ private enum KnownGraphDependencyReference: CaseIterable {
     case library
     case product
     case sdk
+    case macro
 
     func sampleReferences(name: String) -> [GraphDependencyReference] {
         switch self {
+        case .macro:
+            return [.testMacro(path: try! AbsolutePath(validating: "/macros/\(name)"))]
         case .xcframework:
             return [.testXCFramework(path: try! AbsolutePath(validating: "/dependencies/\(name).xcframework"))]
         case .framework:
@@ -131,6 +134,8 @@ extension GraphDependencyReference {
             return .product
         case .sdk:
             return .sdk
+        case .macro:
+            return .macro
         }
     }
 }

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -5202,8 +5202,8 @@ final class GraphTraverserTests: TuistUnitTestCase {
         print(got)
 
         XCTAssertEqual(got.sorted(), [
-            "$BUILT_PRODUCTS_DIR/\(directMacroStaticFrameworkTarget.productNameWithExtension)/Macros/DirectMacro#DirectMacro",
-            "$BUILT_PRODUCTS_DIR/\(transitiveMacroStaticFrameworkTarget.productNameWithExtension)/Macros/TransitiveMacro#TransitiveMacro",
+            "$BUILT_PRODUCTS_DIR/DirectMacro#DirectMacro",
+            "$BUILT_PRODUCTS_DIR/TransitiveMacro#TransitiveMacro",
         ])
     }
 

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -1015,17 +1015,17 @@ final class LinkGeneratorTests: XCTestCase {
             .pbxTarget
             .buildPhases
             .compactMap { $0 as? PBXShellScriptBuildPhase }
-            .first(where: { $0.name() == "Copy Swift Macro executable into /Macros" })
+            .first(where: { $0.name() == "Copy Swift Macro executable into $BUILT_PRODUCT_DIR" })
 
         XCTAssertNotNil(buildPhase)
 
         let expectedScript =
-            "cp \"$SYMROOT/$CONFIGURATION/\(macroExecutable.productName)\" \"$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/Macros/\(macroExecutable.productName)\""
+            "cp \"$SYMROOT/$CONFIGURATION/\(macroExecutable.productName)\" \"$BUILT_PRODUCTS_DIR/\(macroExecutable.productName)\""
         XCTAssertTrue(buildPhase?.shellScript?.contains(expectedScript) == true)
         XCTAssertTrue(buildPhase?.inputPaths.contains("$SYMROOT/$CONFIGURATION/\(macroExecutable.productName)") == true)
         XCTAssertTrue(
             buildPhase?.outputPaths
-                .contains("$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/Macros/\(macroExecutable.productName)") == true
+                .contains("$BUILT_PRODUCTS_DIR/\(macroExecutable.productName)") == true
         )
     }
 


### PR DESCRIPTION
### Short description 📝
When implementing support for Swift Macros using native XcodeProj primitives, I leaned on using the target that depends on the Swift Macro executable as a container for the executable. Thus, I added a script build phase to the parent target to copy the Swift Macro in the `/Macros` directory. This was a bad idea for two reasons:

1. It doesn't work when the Swift Macro product is a library, not a framework.
2. Exporting fails when the Swift Macro product is a dynamic framework because it contains the `Macros` directory when it's embedded.

I tried to solve 2 with an additional build phase that deletes the `Macros` directory for the embedded frameworks. However, I quickly realized it was a bad idea because the deletion of the directory causes any framework signature to be invalid and the archiving to fail. Therefore, it is not a sensible path forward.

I ended up revisiting the decision to use the framework as a container instead of just copying the executable into the built products directory of the parent target. This copy is necessary, otherwise, Xcode build system might not compile the Swift Macro executable target if the destination is not macOS (e.g. `A (iOS) > Macro framework (iOS) > Macro Executable (macOS)`). 

It required few changes in the end. I verified that it works with various configurations and also builds and archives. This work will also simplify the binary caching logic since the resulting graph is the same as the input one but with nodes replaced. 

### How to test the changes locally 🧐
You can run `tuist generate --path fixtures/framework_with_native_swift_macro` and generate a project that compiles. 

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
