### PR TITLE
Add back option to enforce explicit dependencies

### DIFF
--- a/Tuist/Config.swift
+++ b/Tuist/Config.swift
@@ -7,5 +7,5 @@ let config = Config(
         options: [.optional]
     ),
     swiftVersion: .init("5.8"),
-    generationOptions: .options()
+    generationOptions: .options(enforceExplicitDependencies: true)
 )


### PR DESCRIPTION
### Short description 📝

We removed the `enforceExplicitDependencies` as there was a bug when caching for `--xcframeworks`. That bug was fixed, so we can add this option back again.

### How to test the changes locally 🧐

CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
