### PR TITLE
Improve editing of PackageSettings in Package.swift

### DIFF
--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
@@ -217,22 +217,30 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
         XCTAssertEqual(packagesTarget.name, "Packages")
         XCTAssertEqual(packagesTarget.destinations, .macOS)
         XCTAssertEqual(packagesTarget.product, .staticFramework)
-        XCTAssertEqual(
-            packagesTarget.settings,
-            Settings(
-                base: [
+        var expectedPackagesSettings = expectedSettings(includePaths: [
+            projectDescriptionPath,
+            projectDescriptionPath.parentDirectory,
+        ])
+        expectedPackagesSettings = expectedPackagesSettings.with(
+            base: expectedPackagesSettings.base.merging(
+                [
                     "OTHER_SWIFT_FLAGS": .array([
                         "-package-description-version",
                         "5.5.0",
+                        "-D", "TUIST",
                     ]),
                     "SWIFT_INCLUDE_PATHS": .array([
                         "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/ManifestAPI",
                     ]),
                 ],
-                configurations: Settings.default.configurations,
-                defaultSettings: .recommended
+                uniquingKeysWith: { $1 }
             )
         )
+        XCTAssertEqual(
+            packagesTarget.settings,
+            expectedPackagesSettings
+        )
+        XCTAssertEqual(packagesTarget.dependencies, [.target(name: "ProjectDescriptionHelpers")])
         XCTAssertEqual(packagesTarget.sources.map(\.path), [packageManifestPath])
         XCTAssertEqual(packagesTarget.filesGroup, projectsGroup)
 


### PR DESCRIPTION
### Short description 📝

As shown in the below screenshot, we were not passing the `TUIST` debug flag, so the `PackageSettings` definition would be skipped from compilation.

For better DX, we will now add the `TUIST` flag. For the project to compile, we also need to add the dependency on the `ProjectDescriptionHelpers`.

Before:
![image](https://github.com/tuist/tuist/assets/9371695/80f39098-857c-4df2-849d-59a0f3f0ae4f)
After: 
![image](https://github.com/tuist/tuist/assets/9371695/50192a44-a7c2-4bea-bd82-3ef504cc4f17)

### How to test the changes locally 🧐

Run `tuist edit` in the `fixtures/app_with_spm_dependencies` -> the `PackageSettings` should compile in the generated project

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
