### PR TITLE
Handle the graph scenario with pre-compiled Swift Macros

### DIFF
--- a/Sources/TuistGraph/Graph/GraphDependency.swift
+++ b/Sources/TuistGraph/Graph/GraphDependency.swift
@@ -181,6 +181,19 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
         }
     }
 
+    public var isLinkable: Bool {
+        switch self {
+        case .macro: return false
+        case .xcframework: return true
+        case .framework: return true
+        case .library: return true
+        case .bundle: return false
+        case .packageProduct: return true
+        case .target: return true
+        case .sdk: return true
+        }
+    }
+
     public var isPrecompiledDynamicAndLinkable: Bool {
         switch self {
         case .macro: return false

--- a/Sources/TuistGraphTesting/Graph/GraphDependency+TestData.swift
+++ b/Sources/TuistGraphTesting/Graph/GraphDependency+TestData.swift
@@ -96,6 +96,10 @@ extension GraphDependency {
         )
     }
 
+    public static func testBundle(path: AbsolutePath = .root.appending(component: "test.bundle")) -> GraphDependency {
+        .bundle(path: path)
+    }
+
     public static func testPackageProduct(
         path: AbsolutePath = .root,
         product: String = "Tuist"

--- a/Tests/TuistGraphTests/Graph/GraphDependencyTests.swift
+++ b/Tests/TuistGraphTests/Graph/GraphDependencyTests.swift
@@ -20,4 +20,15 @@ final class GraphDependencyTests: TuistUnitTestCase {
         // Then
         XCTAssertCodable(subject)
     }
+
+    func test_isLinkable() {
+        XCTAssertFalse(GraphDependency.testMacro().isLinkable)
+        XCTAssertTrue(GraphDependency.testXCFramework().isLinkable)
+        XCTAssertTrue(GraphDependency.testFramework().isLinkable)
+        XCTAssertTrue(GraphDependency.testLibrary().isLinkable)
+        XCTAssertFalse(GraphDependency.testBundle().isLinkable)
+        XCTAssertTrue(GraphDependency.testPackageProduct().isLinkable)
+        XCTAssertTrue(GraphDependency.testTarget().isLinkable)
+        XCTAssertTrue(GraphDependency.testSDK().isLinkable)
+    }
 }


### PR DESCRIPTION
### Short description 📝
Tuist Cloud will soon support caching Swift Macros. The graphs that we end up after the mutation look like this:

```bash
Target > Macro XCFramework > Macro Executable > Macro dependencies
```

Note that when obtaining the linkable elements from target, we need to ensure we don't traverse the graph through the `Macro Executable` node. The current logic does; therefore, we end up with wrong links in the `Target` target. 
This PR adjusts the traversing to skip traversing through those nodes if they exist in the graph.


### How to test the changes locally 🧐
`GraphTraverserTests` should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
