### PR TITLE
Adjust the logic to obtain the plugin executables to account for the `.macro` extension in pre-compiled executables

### DIFF
--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -719,7 +719,7 @@ public class GraphTraverser: GraphTraversing {
         })
         .lazy
         .flatMap(precompiledMacroDependencies)
-        .map { "\($0.pathString)/#\($0.basename)" }
+        .map { "\($0.pathString)/#\($0.basename.replacingOccurrences(of: ".macro", with: ""))" }
 
         let sourceMacroPluginExecutables = allSwiftMacroTargets(path: path, name: name)
             .flatMap { target in

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -5198,7 +5198,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let project = Project.test(path: directory, targets: [appTarget])
         let appTargetDependency = GraphDependency.target(name: appTarget.name, path: project.path)
         let precompiledMacroXCFramework = GraphDependency.testXCFramework()
-        let macroPath = AbsolutePath.root.appending(components: ["macros", "macro"])
+        let macroPath = AbsolutePath.root.appending(components: ["macros", "macro.macro"])
         let precompiledMacroExecutable = GraphDependency.testMacro(path: macroPath)
 
         let graph = Graph.test(
@@ -5220,7 +5220,7 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let got = GraphTraverser(graph: graph).allSwiftPluginExecutables(path: project.path, name: appTarget.name)
 
         XCTAssertEqual(got.sorted(), [
-            "\(macroPath.pathString)/#\(macroPath.basename)",
+            "\(macroPath.pathString)/#\(macroPath.basename.replacingOccurrences(of: ".macro", with: ""))",
         ])
     }
 


### PR DESCRIPTION
### Short description 📝

When storing macro executables in the cache, we will use the `.macro` executable to disambiguate from other files in the directory. This PR adjusts the logic that returns the plugin executables to account for that.

### How to test the changes locally 🧐
Tests should pass. Unfortunately, the integration test can only be done from the Tuist Cloud side.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
