### PR TITLE
Change ProjectDescription model constructors to static functions

### DIFF
--- a/Sources/ProjectDescription/Arguments.swift
+++ b/Sources/ProjectDescription/Arguments.swift
@@ -4,7 +4,7 @@ import Foundation
 public struct Arguments: Equatable, Codable {
     public var environmentVariables: [String: EnvironmentVariable]
     public var launchArguments: [LaunchArgument]
-    
+
     public static func arguments(
         environmentVariables: [String: EnvironmentVariable] = [:],
         launchArguments: [LaunchArgument] = []

--- a/Sources/ProjectDescription/Arguments.swift
+++ b/Sources/ProjectDescription/Arguments.swift
@@ -4,17 +4,11 @@ import Foundation
 public struct Arguments: Equatable, Codable {
     public var environmentVariables: [String: EnvironmentVariable]
     public var launchArguments: [LaunchArgument]
-
-    public init(
+    
+    public static func arguments(
         environmentVariables: [String: EnvironmentVariable] = [:],
         launchArguments: [LaunchArgument] = []
-    ) {
-        self.environmentVariables = environmentVariables
-        self.launchArguments = launchArguments
-    }
-
-    public init(launchArguments: [LaunchArgument]) {
-        environmentVariables = [:]
-        self.launchArguments = launchArguments
+    ) -> Self {
+        self.init(environmentVariables: environmentVariables, launchArguments: launchArguments)
     }
 }

--- a/Sources/ProjectDescription/BuildAction.swift
+++ b/Sources/ProjectDescription/BuildAction.swift
@@ -13,18 +13,6 @@ public struct BuildAction: Equatable, Codable {
     /// Whether the post actions should be run in the case of a failure
     public var runPostActionsOnFailure: Bool
 
-    public init(
-        targets: [TargetReference],
-        preActions: [ExecutionAction] = [],
-        postActions: [ExecutionAction] = [],
-        runPostActionsOnFailure: Bool = false
-    ) {
-        self.targets = targets
-        self.preActions = preActions
-        self.postActions = postActions
-        self.runPostActionsOnFailure = runPostActionsOnFailure
-    }
-
     /// Returns a build action.
     /// - Parameters:
     ///   - targets: A list of targets to build, which are defined in the project.

--- a/Sources/ProjectDescription/BuildRule.swift
+++ b/Sources/ProjectDescription/BuildRule.swift
@@ -29,7 +29,7 @@ public struct BuildRule: Codable, Equatable {
     /// Build rule run once per architecture.
     public var runOncePerArchitecture: Bool?
 
-    public init(
+    public static func buildRule(
         name: String? = nil,
         fileType: FileType,
         filePatterns: String? = nil,
@@ -39,15 +39,17 @@ public struct BuildRule: Codable, Equatable {
         outputFilesCompilerFlags: [String] = [],
         script: String? = nil,
         runOncePerArchitecture: Bool = false
-    ) {
-        self.name = name
-        self.fileType = fileType
-        self.filePatterns = filePatterns
-        self.compilerSpec = compilerSpec
-        self.inputFiles = inputFiles
-        self.outputFiles = outputFiles
-        self.outputFilesCompilerFlags = outputFilesCompilerFlags
-        self.script = script
-        self.runOncePerArchitecture = runOncePerArchitecture
+    ) -> Self {
+        self.init(
+            compilerSpec: compilerSpec,
+            filePatterns: filePatterns,
+            fileType: fileType,
+            name: name,
+            outputFiles: outputFiles,
+            inputFiles: inputFiles,
+            outputFilesCompilerFlags: outputFilesCompilerFlags,
+            script: script,
+            runOncePerArchitecture: runOncePerArchitecture
+        )
     }
 }

--- a/Sources/ProjectDescription/CoreDataModel.swift
+++ b/Sources/ProjectDescription/CoreDataModel.swift
@@ -14,11 +14,13 @@ public struct CoreDataModel: Codable, Equatable {
     ///   - path: relative path to the Core Data model.
     ///   - currentVersion: optional current version name (with or without the extension)
     ///   By providing nil, it will try to read it from the .xccurrentversion file.
-    public init(
+    public static func coreDataModel(
         _ path: Path,
         currentVersion: String? = nil
-    ) {
-        self.path = path
-        self.currentVersion = currentVersion
+    ) -> Self {
+        self.init(
+            path: path,
+            currentVersion: currentVersion
+        )
     }
 }

--- a/Sources/ProjectDescription/DeploymentTargets.swift
+++ b/Sources/ProjectDescription/DeploymentTargets.swift
@@ -15,12 +15,20 @@ public struct DeploymentTargets: Hashable, Codable {
     /// Minimum deployment version for visionOS
     public var visionOS: String?
 
-    public init(iOS: String? = nil, macOS: String? = nil, watchOS: String? = nil, tvOS: String? = nil, visionOS: String? = nil) {
-        self.iOS = iOS
-        self.macOS = macOS
-        self.watchOS = watchOS
-        self.tvOS = tvOS
-        self.visionOS = visionOS
+    public static func deploymentTargets(
+        iOS: String? = nil,
+        macOS: String? = nil,
+        watchOS: String? = nil,
+        tvOS: String? = nil,
+        visionOS: String? = nil
+    ) -> Self {
+        self.init(
+            iOS: iOS,
+            macOS: macOS,
+            watchOS: watchOS,
+            tvOS: tvOS,
+            visionOS: visionOS
+        )
     }
 
     /// Convenience accessor to retreive a minimum version given a `Platform`

--- a/Sources/ProjectDescription/Entitlements.swift
+++ b/Sources/ProjectDescription/Entitlements.swift
@@ -31,6 +31,6 @@ public enum Entitlements: Codable, Equatable {
 
 extension Entitlements: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
-        self = .file(path: Path(value))
+        self = .file(path: .path(value))
     }
 }

--- a/Sources/ProjectDescription/EnvironmentVariable.swift
+++ b/Sources/ProjectDescription/EnvironmentVariable.swift
@@ -10,10 +10,14 @@ public struct EnvironmentVariable: Equatable, Codable, Hashable, ExpressibleBySt
     public var isEnabled: Bool
 
     // MARK: - Init
-
-    public init(value: String, isEnabled: Bool) {
+    
+    init(value: String, isEnabled: Bool) {
         self.value = value
         self.isEnabled = isEnabled
+    }
+
+    public static func environmentVariable(value: String, isEnabled: Bool) -> Self {
+        self.init(value: value, isEnabled: isEnabled)
     }
 
     public init(stringLiteral value: String) {

--- a/Sources/ProjectDescription/EnvironmentVariable.swift
+++ b/Sources/ProjectDescription/EnvironmentVariable.swift
@@ -10,7 +10,7 @@ public struct EnvironmentVariable: Equatable, Codable, Hashable, ExpressibleBySt
     public var isEnabled: Bool
 
     // MARK: - Init
-    
+
     init(value: String, isEnabled: Bool) {
         self.value = value
         self.isEnabled = isEnabled

--- a/Sources/ProjectDescription/ExecuteAction.swift
+++ b/Sources/ProjectDescription/ExecuteAction.swift
@@ -9,10 +9,17 @@ public struct ExecutionAction: Equatable, Codable {
     /// The path to the shell which shall execute this script. if it is nil, Xcode will use default value.
     public var shellPath: String?
 
-    public init(title: String = "Run Script", scriptText: String, target: TargetReference? = nil, shellPath: String? = nil) {
-        self.title = title
-        self.scriptText = scriptText
-        self.target = target
-        self.shellPath = shellPath
+    public static func executionAction(
+        title: String = "Run Script",
+        scriptText: String,
+        target: TargetReference? = nil,
+        shellPath: String? = nil
+    ) -> Self {
+        self.init(
+            title: title,
+            scriptText: scriptText,
+            target: target,
+            shellPath: shellPath
+        )
     }
 }

--- a/Sources/ProjectDescription/FileElement.swift
+++ b/Sources/ProjectDescription/FileElement.swift
@@ -32,7 +32,7 @@ public enum FileElement: Codable, Equatable {
 
 extension FileElement: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
-        self = .glob(pattern: Path(value))
+        self = .glob(pattern: .path(value))
     }
 }
 
@@ -48,6 +48,6 @@ extension [FileElement]: ExpressibleByStringLiteral {
     public typealias StringLiteralType = String
 
     public init(stringLiteral value: String) {
-        self = [.glob(pattern: Path(value))]
+        self = [.glob(pattern: .path(value))]
     }
 }

--- a/Sources/ProjectDescription/FileListGlob.swift
+++ b/Sources/ProjectDescription/FileListGlob.swift
@@ -33,6 +33,6 @@ public struct FileListGlob: Codable, Equatable {
 
 extension FileListGlob: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
-        self.init(glob: Path(value), excluding: [])
+        self.init(glob: .path(value), excluding: [])
     }
 }

--- a/Sources/ProjectDescription/InfoPlist.swift
+++ b/Sources/ProjectDescription/InfoPlist.swift
@@ -41,6 +41,6 @@ public enum InfoPlist: Codable, Equatable {
 
 extension InfoPlist: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
-        self = .file(path: Path(value))
+        self = .file(path: .path(value))
     }
 }

--- a/Sources/ProjectDescription/LaunchArgument.swift
+++ b/Sources/ProjectDescription/LaunchArgument.swift
@@ -15,9 +15,8 @@ public struct LaunchArgument: Equatable, Codable {
     /// - Parameters:
     ///     - name: Name of argument
     ///     - isEnabled: If enabled then argument is marked as active
-    public init(name: String, isEnabled: Bool) {
-        self.name = name
-        self.isEnabled = isEnabled
+    public static func launchArgument(name: String, isEnabled: Bool) -> Self {
+        self.init(name: name, isEnabled: isEnabled)
     }
 }
 

--- a/Sources/ProjectDescription/Path.swift
+++ b/Sources/ProjectDescription/Path.swift
@@ -16,7 +16,7 @@ public struct Path: ExpressibleByStringInterpolation, Codable, Hashable {
     public var callerPath: String?
 
     /// Default PathType is `.relativeToManifest`
-    public init(_ path: String) {
+    public static func path(_ path: String) -> Self {
         self.init(path, type: .relativeToManifest)
     }
 

--- a/Sources/ProjectDescription/ResourceFileElement.swift
+++ b/Sources/ProjectDescription/ResourceFileElement.swift
@@ -31,6 +31,6 @@ public enum ResourceFileElement: Codable, Equatable {
 
 extension ResourceFileElement: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
-        self = .glob(pattern: Path(value))
+        self = .glob(pattern: .path(value))
     }
 }

--- a/Sources/ProjectDescription/ResourceFileElements.swift
+++ b/Sources/ProjectDescription/ResourceFileElements.swift
@@ -5,14 +5,14 @@ public struct ResourceFileElements: Codable, Equatable {
     /// List of resource file elements
     public var resources: [ResourceFileElement]
 
-    public init(resources: [ResourceFileElement]) {
-        self.resources = resources
+    public static func resources(_ resources: [ResourceFileElement]) -> Self {
+        self.init(resources: resources)
     }
 }
 
 extension ResourceFileElements: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
-        self.init(resources: [.glob(pattern: Path(value))])
+        self.init(resources: [.glob(pattern: .path(value))])
     }
 }
 

--- a/Sources/ProjectDescription/Scheme.swift
+++ b/Sources/ProjectDescription/Scheme.swift
@@ -35,7 +35,7 @@ public struct Scheme: Equatable, Codable {
     ///   - archiveAction: Action that runs the project archive.
     ///   - profileAction: Action that profiles the project.
     ///   - analyzeAction: Action that analyze the project.
-    public init(
+    public static func scheme(
         name: String,
         shared: Bool = true,
         hidden: Bool = false,
@@ -45,15 +45,17 @@ public struct Scheme: Equatable, Codable {
         archiveAction: ArchiveAction? = nil,
         profileAction: ProfileAction? = nil,
         analyzeAction: AnalyzeAction? = nil
-    ) {
-        self.name = name
-        self.shared = shared
-        self.hidden = hidden
-        self.buildAction = buildAction
-        self.testAction = testAction
-        self.runAction = runAction
-        self.archiveAction = archiveAction
-        self.profileAction = profileAction
-        self.analyzeAction = analyzeAction
+    ) -> Self {
+        self.init(
+            name: name,
+            shared: shared,
+            hidden: hidden,
+            buildAction: buildAction,
+            testAction: testAction,
+            runAction: runAction,
+            archiveAction: archiveAction,
+            profileAction: profileAction,
+            analyzeAction: analyzeAction
+        )
     }
 }

--- a/Sources/ProjectDescription/SourceFilesList.swift
+++ b/Sources/ProjectDescription/SourceFilesList.swift
@@ -81,7 +81,7 @@ public struct SourceFilesList: Codable, Equatable {
     ///
     /// - Parameter globs: Glob patterns.
     public static func sourceFilesList(globs: [String]) -> Self {
-        self.init(globs: globs.map(SourceFileGlob.init))
+        self.sourceFilesList(globs: globs.map(SourceFileGlob.init))
     }
 
     /// Returns a sources list from a list of paths.

--- a/Sources/ProjectDescription/SourceFilesList.swift
+++ b/Sources/ProjectDescription/SourceFilesList.swift
@@ -61,7 +61,7 @@ public struct SourceFileGlob: Codable, Equatable {
 
 extension SourceFileGlob: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
-        self.init(glob: Path(value), excluding: [], compilerFlags: nil, codeGen: nil, compilationCondition: nil)
+        self.init(glob: .path(value), excluding: [], compilerFlags: nil, codeGen: nil, compilationCondition: nil)
     }
 }
 
@@ -73,15 +73,15 @@ public struct SourceFilesList: Codable, Equatable {
     /// Creates the source files list with the glob patterns.
     ///
     /// - Parameter globs: Glob patterns.
-    public init(globs: [SourceFileGlob]) {
-        self.globs = globs
+    public static func sourceFilesList(globs: [SourceFileGlob]) -> Self {
+        self.init(globs: globs)
     }
 
     /// Creates the source files list with the glob patterns as strings.
     ///
     /// - Parameter globs: Glob patterns.
-    public init(globs: [String]) {
-        self.globs = globs.map(SourceFileGlob.init)
+    public static func sourceFilesList(globs: [String]) -> Self {
+        self.init(globs: globs.map(SourceFileGlob.init))
     }
 
     /// Returns a sources list from a list of paths.
@@ -94,7 +94,7 @@ public struct SourceFilesList: Codable, Equatable {
 /// Support file as single string
 extension SourceFilesList: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
-        self.init(globs: [value])
+        self = .sourceFilesList(globs: [value])
     }
 }
 

--- a/Sources/ProjectDescription/SourceFilesList.swift
+++ b/Sources/ProjectDescription/SourceFilesList.swift
@@ -81,7 +81,7 @@ public struct SourceFilesList: Codable, Equatable {
     ///
     /// - Parameter globs: Glob patterns.
     public static func sourceFilesList(globs: [String]) -> Self {
-        self.sourceFilesList(globs: globs.map(SourceFileGlob.init))
+        sourceFilesList(globs: globs.map(SourceFileGlob.init))
     }
 
     /// Returns a sources list from a list of paths.

--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -70,7 +70,7 @@ public struct Target: Codable, Equatable {
     /// Specifies whether if the target can be merged as part of another binary or not
     public var mergeable: Bool
 
-    public init(
+    public static func target(
         name: String,
         destinations: Destinations,
         product: Product,
@@ -93,28 +93,30 @@ public struct Target: Codable, Equatable {
         buildRules: [BuildRule] = [],
         mergedBinaryType: MergedBinaryType = .disabled,
         mergeable: Bool = false
-    ) {
-        self.name = name
-        self.destinations = destinations
-        self.bundleId = bundleId
-        self.productName = productName
-        self.product = product
-        self.infoPlist = infoPlist
-        self.entitlements = entitlements
-        self.dependencies = dependencies
-        self.settings = settings
-        self.sources = sources
-        self.resources = resources
-        self.copyFiles = copyFiles
-        self.headers = headers
-        self.scripts = scripts
-        self.coreDataModels = coreDataModels
-        self.environmentVariables = environmentVariables
-        self.launchArguments = launchArguments
-        self.deploymentTargets = deploymentTargets
-        self.additionalFiles = additionalFiles
-        self.buildRules = buildRules
-        self.mergedBinaryType = mergedBinaryType
-        self.mergeable = mergeable
+    ) -> Self {
+        self.init(
+            name: name,
+            destinations: destinations,
+            product: product,
+            productName: productName,
+            bundleId: bundleId,
+            deploymentTargets: deploymentTargets,
+            infoPlist: infoPlist,
+            sources: sources,
+            resources: resources,
+            copyFiles: copyFiles,
+            headers: headers,
+            entitlements: entitlements,
+            scripts: scripts,
+            dependencies: dependencies,
+            settings: settings,
+            coreDataModels: coreDataModels,
+            environmentVariables: environmentVariables,
+            launchArguments: launchArguments,
+            additionalFiles: additionalFiles,
+            buildRules: buildRules,
+            mergedBinaryType: mergedBinaryType,
+            mergeable: mergeable
+        )
     }
 }

--- a/Sources/ProjectDescription/TargetReference.swift
+++ b/Sources/ProjectDescription/TargetReference.swift
@@ -21,7 +21,7 @@ public struct TargetReference: Hashable, Codable, ExpressibleByStringInterpolati
     public static func project(path: Path, target: String) -> TargetReference {
         .init(projectPath: path, target: target)
     }
-    
+
     public static func target(_ name: String) -> TargetReference {
         .init(projectPath: nil, target: name)
     }

--- a/Sources/ProjectDescription/TargetReference.swift
+++ b/Sources/ProjectDescription/TargetReference.swift
@@ -9,7 +9,7 @@ public struct TargetReference: Hashable, Codable, ExpressibleByStringInterpolati
     /// Name of the target.
     public var targetName: String
 
-    public init(projectPath: Path?, target: String) {
+    init(projectPath: Path?, target: String) {
         self.projectPath = projectPath
         targetName = target
     }
@@ -20,5 +20,9 @@ public struct TargetReference: Hashable, Codable, ExpressibleByStringInterpolati
 
     public static func project(path: Path, target: String) -> TargetReference {
         .init(projectPath: path, target: target)
+    }
+    
+    public static func target(_ name: String) -> TargetReference {
+        .init(projectPath: nil, target: name)
     }
 }

--- a/Sources/ProjectDescription/Template/Template.swift
+++ b/Sources/ProjectDescription/Template/Template.swift
@@ -38,9 +38,8 @@ public struct Template: Codable, Equatable {
         public let path: String
         public let contents: Contents
 
-        public init(path: String, contents: Contents) {
-            self.path = path
-            self.contents = contents
+        public static func item(path: String, contents: Contents) -> Self {
+            self.init(path: path, contents: contents)
         }
     }
 

--- a/Sources/ProjectDescription/TestableTarget.swift
+++ b/Sources/ProjectDescription/TestableTarget.swift
@@ -6,19 +6,38 @@ public struct TestableTarget: Equatable, Codable, ExpressibleByStringInterpolati
     public var isParallelizable: Bool
     public var isRandomExecutionOrdering: Bool
 
-    public init(
+    init(
         target: TargetReference,
-        skipped: Bool = false,
-        parallelizable: Bool = false,
-        randomExecutionOrdering: Bool = false
+        isSkipped: Bool,
+        isParallelizable: Bool,
+        isRandomExecutionOrdering: Bool
     ) {
         self.target = target
-        isSkipped = skipped
-        isParallelizable = parallelizable
-        isRandomExecutionOrdering = randomExecutionOrdering
+        self.isSkipped = isSkipped
+        self.isParallelizable = isParallelizable
+        self.isRandomExecutionOrdering = isRandomExecutionOrdering
+    }
+    
+    public static func testableTarget(
+        target: TargetReference,
+        isSkipped: Bool = false,
+        isParallelizable: Bool = false,
+        isRandomExecutionOrdering: Bool = false
+    ) -> Self {
+        self.init(
+            target: target,
+            isSkipped: isSkipped,
+            isParallelizable: isParallelizable,
+            isRandomExecutionOrdering: isRandomExecutionOrdering
+        )
     }
 
     public init(stringLiteral value: String) {
-        self.init(target: .init(projectPath: nil, target: value))
+        self.init(
+            target: TargetReference(projectPath: nil, target: value),
+            isSkipped: false,
+            isParallelizable: false,
+            isRandomExecutionOrdering: false
+        )
     }
 }

--- a/Sources/ProjectDescription/TestableTarget.swift
+++ b/Sources/ProjectDescription/TestableTarget.swift
@@ -17,7 +17,7 @@ public struct TestableTarget: Equatable, Codable, ExpressibleByStringInterpolati
         self.isParallelizable = isParallelizable
         self.isRandomExecutionOrdering = isRandomExecutionOrdering
     }
-    
+
     public static func testableTarget(
         target: TargetReference,
         isSkipped: Bool = false,

--- a/Sources/TuistCoreTesting/Graph/DependenciesGraph+TestData.swift
+++ b/Sources/TuistCoreTesting/Graph/DependenciesGraph+TestData.swift
@@ -733,7 +733,7 @@ extension DependenciesGraph {
         let platforms = destinations.platforms
         let applicableVersions = PLATFORM_TEST_VERSION.filter { platforms.contains($0.key) }
 
-        return DeploymentTargets(
+        return .deploymentTargets(
             iOS: applicableVersions[Platform.iOS],
             macOS: applicableVersions[Platform.macOS],
             watchOS: applicableVersions[Platform.watchOS],

--- a/Sources/TuistCoreTesting/Graph/DependenciesGraph+TestData.swift
+++ b/Sources/TuistCoreTesting/Graph/DependenciesGraph+TestData.swift
@@ -33,7 +33,7 @@ extension TuistCore.DependenciesGraph {
     public static func testXCFramework(
         name: String = "Test",
         // swiftlint:disable:next force_try
-        path: Path = Path(AbsolutePath.root.appending(try! RelativePath(validating: "Test.xcframework")).pathString)
+        path: Path = .path(AbsolutePath.root.appending(try! RelativePath(validating: "Test.xcframework")).pathString)
     ) -> Self {
         let externalDependencies = [name: [TargetDependency.xcframework(path: path)]]
 
@@ -62,7 +62,7 @@ extension TuistCore.DependenciesGraph {
         ]
 
         let targets: [Target] = [
-            .init(
+            .target(
                 name: "Tuist",
                 destinations: destinations,
                 product: .staticFramework,
@@ -105,7 +105,7 @@ extension TuistCore.DependenciesGraph {
                     "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "SWIFT_DEFINE",
                 ])
             ),
-            .init(
+            .target(
                 name: "TuistKit",
                 destinations: destinations,
                 product: .staticFramework,
@@ -174,7 +174,7 @@ extension TuistCore.DependenciesGraph {
         ]
 
         let targets: [Target] = [
-            .init(
+            .target(
                 name: "ALibrary",
                 destinations: destinations,
                 product: .staticFramework,
@@ -192,7 +192,7 @@ extension TuistCore.DependenciesGraph {
                 ],
                 settings: Self.spmSettings()
             ),
-            .init(
+            .target(
                 name: "ALibraryUtils",
                 destinations: destinations,
                 product: .staticFramework,
@@ -247,7 +247,7 @@ extension TuistCore.DependenciesGraph {
         ]
 
         let targets: [Target] = [
-            .init(
+            .target(
                 name: "AnotherLibrary",
                 destinations: destinations,
                 product: .staticFramework,
@@ -302,7 +302,7 @@ extension TuistCore.DependenciesGraph {
         ]
 
         let targets: [Target] = [
-            .init(
+            .target(
                 name: "Alamofire",
                 destinations: destinations,
                 product: .staticFramework,
@@ -368,7 +368,7 @@ extension TuistCore.DependenciesGraph {
         ]
 
         let targets: [Target] = [
-            .init(
+            .target(
                 name: "GoogleAppMeasurementTarget",
                 destinations: destinations,
                 product: .staticFramework,
@@ -408,7 +408,7 @@ extension TuistCore.DependenciesGraph {
                 ],
                 settings: Self.spmSettings()
             ),
-            .init(
+            .target(
                 name: "GoogleAppMeasurementWithoutAdIdSupportTarget",
                 destinations: destinations,
                 product: .staticFramework,
@@ -516,7 +516,7 @@ extension TuistCore.DependenciesGraph {
         ]
 
         let targets: [Target] = [
-            .init(
+            .target(
                 name: "GULAppDelegateSwizzler",
                 destinations: destinations,
                 product: customProductTypes["GULAppDelegateSwizzler"] ?? .staticFramework,
@@ -529,7 +529,7 @@ extension TuistCore.DependenciesGraph {
                 ],
                 settings: Self.spmSettings()
             ),
-            .init(
+            .target(
                 name: "GULMethodSwizzler",
                 destinations: destinations,
                 product: customProductTypes["GULMethodSwizzler"] ?? .staticFramework,
@@ -543,7 +543,7 @@ extension TuistCore.DependenciesGraph {
                 settings: Self.spmSettings()
             ),
 
-            .init(
+            .target(
                 name: "GULNSData",
                 destinations: destinations,
                 product: customProductTypes["GULNSData"] ?? .staticFramework,
@@ -556,7 +556,7 @@ extension TuistCore.DependenciesGraph {
                 ],
                 settings: Self.spmSettings()
             ),
-            .init(
+            .target(
                 name: "GULNetwork",
                 destinations: destinations,
                 product: customProductTypes["GULNetwork"] ?? .staticFramework,
@@ -611,7 +611,7 @@ extension TuistCore.DependenciesGraph {
         ]
 
         let targets: [Target] = [
-            .init(
+            .target(
                 name: "nanopb",
                 destinations: destinations,
                 product: .staticFramework,

--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -265,7 +265,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
                         "\(xcode.path.pathString)/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/ManifestAPI",
                     ]),
                 ],
-                uniquingKeysWith: { 
+                uniquingKeysWith: {
                     switch ($0, $1) {
                     case let (.array(leftArray), .array(rightArray)):
                         return SettingValue.array(leftArray + rightArray)

--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -265,7 +265,14 @@ final class ProjectEditorMapper: ProjectEditorMapping {
                         "\(xcode.path.pathString)/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/ManifestAPI",
                     ]),
                 ],
-                uniquingKeysWith: { $1 }
+                uniquingKeysWith: { 
+                    switch ($0, $1) {
+                    case let (.array(leftArray), .array(rightArray)):
+                        return SettingValue.array(leftArray + rightArray)
+                    default:
+                        return $1
+                    }
+                }
             )
 
             let dependencies: [TargetDependency] = helpersTarget == nil ? [] : [

--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -304,7 +304,7 @@ public class ManifestLoader: ManifestLoading {
         ) + ["--tuist-dump"]
 
         do {
-            let string = try System.shared.capture(arguments, verbose: false, environment: environment.manifestLoadingVariables)
+            let string = try! System.shared.capture(arguments, verbose: false, environment: environment.manifestLoadingVariables)
 
             guard let startTokenRange = string.range(of: ManifestLoader.startManifestToken),
                   let endTokenRange = string.range(of: ManifestLoader.endManifestToken)

--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -304,7 +304,7 @@ public class ManifestLoader: ManifestLoading {
         ) + ["--tuist-dump"]
 
         do {
-            let string = try! System.shared.capture(arguments, verbose: false, environment: environment.manifestLoadingVariables)
+            let string = try System.shared.capture(arguments, verbose: false, environment: environment.manifestLoadingVariables)
 
             guard let startTokenRange = string.range(of: ManifestLoader.startManifestToken),
                   let endTokenRange = string.range(of: ManifestLoader.endManifestToken)

--- a/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -190,7 +190,7 @@ public final class SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoadi
                 packageToProject: packageToProject,
                 swiftToolsVersion: packageSettings.swiftToolsVersion
             )
-            result[Path(packageInfo.folder.pathString)] = manifest
+            result[.path(packageInfo.folder.pathString)] = manifest
         }
 
         return DependenciesGraph(

--- a/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
+++ b/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
@@ -119,7 +119,7 @@ public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBu
             if let sourceRoot = ProcessEnv.vars["TUIST_CONFIG_SRCROOT"],
                tuistHelpersDirectory.isDescendant(
                    // swiftlint:disable:next force_try
-                   of: try! AbsolutePath(validating: sourceRoot)
+                of: try! AbsolutePath(validating: sourceRoot).appending(component: Constants.tuistDirectoryName)
                )
             {
                 return nil

--- a/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
+++ b/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
@@ -115,6 +115,15 @@ public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBu
         customProjectDescriptionHelperModules: [ProjectDescriptionHelpersModule]
     ) throws -> ProjectDescriptionHelpersModule? {
         guard let tuistHelpersDirectory = helpersDirectoryLocator.locate(at: path) else { return nil }
+        #if DEBUG
+            if let sourceRoot = ProcessEnv.vars["TUIST_CONFIG_SRCROOT"],
+               tuistHelpersDirectory.isDescendant(
+                   of: try! AbsolutePath(validating: sourceRoot)
+               )
+            {
+                return nil
+            }
+        #endif
         return try buildHelpers(
             name: Self.defaultHelpersName,
             in: tuistHelpersDirectory,

--- a/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
+++ b/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
@@ -119,7 +119,7 @@ public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBu
             if let sourceRoot = ProcessEnv.vars["TUIST_CONFIG_SRCROOT"],
                tuistHelpersDirectory.isDescendant(
                    // swiftlint:disable:next force_try
-                of: try! AbsolutePath(validating: sourceRoot).appending(component: Constants.tuistDirectoryName)
+                   of: try! AbsolutePath(validating: sourceRoot).appending(component: Constants.tuistDirectoryName)
                )
             {
                 return nil

--- a/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
+++ b/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersBuilder.swift
@@ -118,6 +118,7 @@ public final class ProjectDescriptionHelpersBuilder: ProjectDescriptionHelpersBu
         #if DEBUG
             if let sourceRoot = ProcessEnv.vars["TUIST_CONFIG_SRCROOT"],
                tuistHelpersDirectory.isDescendant(
+                   // swiftlint:disable:next force_try
                    of: try! AbsolutePath(validating: sourceRoot)
                )
             {

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -635,7 +635,7 @@ extension ProjectDescription.DeploymentTargets {
     /// A dictionary that contains the oldest supported version of each platform
     public static func oldestVersions(for swiftVersion: TSCUtility.Version) -> ProjectDescription.DeploymentTargets {
         if swiftVersion < Version(5, 7, 0) {
-            return DeploymentTargets(
+            return .deploymentTargets(
                 iOS: "9.0",
                 macOS: "10.10",
                 watchOS: "2.0",
@@ -643,7 +643,7 @@ extension ProjectDescription.DeploymentTargets {
                 visionOS: "1.0"
             )
         } else if swiftVersion < Version(5, 9, 0) {
-            return DeploymentTargets(
+            return .deploymentTargets(
                 iOS: "11.0",
                 macOS: "10.13",
                 watchOS: "4.0",
@@ -651,7 +651,7 @@ extension ProjectDescription.DeploymentTargets {
                 visionOS: "1.0"
             )
         } else {
-            return DeploymentTargets(
+            return .deploymentTargets(
                 iOS: "12.0",
                 macOS: "10.13",
                 watchOS: "4.0",
@@ -680,7 +680,7 @@ extension ProjectDescription.DeploymentTargets {
             return try max(minDeploymentTargets[platform], platformInfos[platform])
         }
 
-        return .init(
+        return .deploymentTargets(
             iOS: try versionFor(platform: .iOS),
             macOS: try versionFor(platform: .macOS),
             watchOS: try versionFor(platform: .watchOS),

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -184,7 +184,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
                 guard target.type == .binary else { return }
                 if let path = target.path {
                     // local binary
-                    result[target.name] = Path(
+                    result[target.name] = .path(
                         packageToFolder[packageInfo.key]!.appending(try RelativePath(validating: path))
                             .pathString
                     )
@@ -194,7 +194,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
                     guard let artifactPath = packageToTargetsToArtifactPaths[packageInfo.key]?[target.name] else {
                         throw PackageInfoMapperError.missingBinaryArtifact(package: packageInfo.key, target: target.name)
                     }
-                    result[target.name] = Path(artifactPath.pathString)
+                    result[target.name] = .path(artifactPath.pathString)
                 }
             }
         }
@@ -279,7 +279,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
                             case let .target(name, condition):
                                 return .project(
                                     target: name,
-                                    path: Path(packageToFolder[packageInfo.key]!.pathString),
+                                    path: .path(packageToFolder[packageInfo.key]!.pathString),
                                     condition: condition
                                 )
                             case .externalTarget:
@@ -611,7 +611,7 @@ extension ProjectDescription.Target {
             targetSettings: targetSettings
         )
 
-        return ProjectDescription.Target(
+        return .target(
             name: PackageInfoMapper.sanitize(targetName: target.name),
             destinations: destinations,
             product: product,
@@ -764,14 +764,14 @@ extension SourceFilesList {
             sourcesPaths = [path.appending(component: "**")]
         }
         guard !sourcesPaths.isEmpty else { return nil }
-        return .init(
+        return .sourceFilesList(
             globs: try sourcesPaths.map { absolutePath -> ProjectDescription.SourceFileGlob in
                 .glob(
-                    Path(absolutePath.pathString),
+                    .path(absolutePath.pathString),
                     excluding: try excluding.map {
                         let excludePath = path.appending(try RelativePath(validating: $0))
                         let excludeGlob = excludePath.extension != nil ? excludePath : excludePath.appending(component: "**")
-                        return Path(excludeGlob.pathString)
+                        return .path(excludeGlob.pathString)
                     }
                 )
             }
@@ -792,7 +792,7 @@ extension ResourceFileElements {
         ///   - resourceAbsolutePath: The absolute path of that resource
         /// - Returns: A ProjectDescription.ResourceFileElement mapped from a `.copy` resource rule of SPM
         func handleCopyResource(resourceAbsolutePath: AbsolutePath) -> ProjectDescription.ResourceFileElement {
-            .folderReference(path: Path(resourceAbsolutePath.pathString))
+            .folderReference(path: .path(resourceAbsolutePath.pathString))
         }
 
         /// Handles the conversion of a `.process` resource rule of SPM
@@ -804,11 +804,11 @@ extension ResourceFileElements {
             let absolutePathGlob = resourceAbsolutePath.extension != nil ? resourceAbsolutePath : resourceAbsolutePath
                 .appending(component: "**")
             return .glob(
-                pattern: Path(absolutePathGlob.pathString),
+                pattern: .path(absolutePathGlob.pathString),
                 excluding: try excluding.map {
                     let excludePath = path.appending(try RelativePath(validating: $0))
                     let excludeGlob = excludePath.extension != nil ? excludePath : excludePath.appending(component: "**")
-                    return Path(excludeGlob.pathString)
+                    return .path(excludeGlob.pathString)
                 }
             )
         }
@@ -839,7 +839,7 @@ extension ResourceFileElements {
         // Check for empty resource files
         guard !resourceFileElements.isEmpty else { return nil }
 
-        return .init(resources: resourceFileElements)
+        return .resources(resourceFileElements)
     }
 
     // These files are automatically added as resource if they are inside targets directory.
@@ -875,7 +875,7 @@ extension ProjectDescription.TargetDependency {
             case let .externalTarget(project, target, condition):
                 return .project(
                     target: target,
-                    path: Path(packageToProject[project]!.pathString),
+                    path: .path(packageToProject[project]!.pathString),
                     condition: condition
                 )
             }
@@ -915,7 +915,7 @@ extension ProjectDescription.Headers {
         case .header, .nestedHeader:
             let publicHeaders = try FileHandler.shared.filesAndDirectoriesContained(in: publicHeadersPath)!
                 .filter { $0.extension == "h" }
-            let list: [FileListGlob] = publicHeaders.map { .glob(Path($0.pathString)) }
+            let list: [FileListGlob] = publicHeaders.map { .glob(.path($0.pathString)) }
             return .headers(public: .list(list))
         case .none, .custom, .directory:
             return nil
@@ -1161,7 +1161,7 @@ extension ProjectDescription.Configuration {
     ) -> Self {
         let name = ConfigurationName(stringLiteral: buildConfiguration.name)
         let settings = ProjectDescription.SettingsDictionary.from(settingsDictionary: configuration?.settings ?? [:])
-        let xcconfig = configuration?.xcconfig.map { Path($0.relative(to: packageFolder).pathString) }
+        let xcconfig = configuration?.xcconfig.map { Path.path($0.relative(to: packageFolder).pathString) }
         switch buildConfiguration.variant {
         case .debug:
             return .debug(name: name, settings: settings, xcconfig: xcconfig)

--- a/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
+++ b/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
@@ -76,7 +76,7 @@ extension Target {
         coreDataModels: [CoreDataModel] = [],
         environment: [String: String] = [:]
     ) -> Target {
-        Target(
+        .target(
             name: name,
             destinations: destinations,
             product: product,
@@ -129,7 +129,7 @@ extension Scheme {
         testAction: TestAction? = nil,
         runAction: RunAction? = nil
     ) -> Scheme {
-        Scheme(
+        .scheme(
             name: name,
             shared: shared,
             buildAction: buildAction,
@@ -141,7 +141,7 @@ extension Scheme {
 
 extension BuildAction {
     public static func test(targets: [TargetReference] = []) -> BuildAction {
-        BuildAction(
+        .buildAction(
             targets: targets,
             preActions: [ExecutionAction.test()],
             postActions: [ExecutionAction.test()]
@@ -185,7 +185,7 @@ extension ExecutionAction {
     public static func test(
         title: String = "Test Script",
         scriptText: String = "echo Test",
-        target: TargetReference? = TargetReference(projectPath: nil, target: "Target")
+        target: TargetReference? = .target("Target")
     ) -> ExecutionAction {
         ExecutionAction(
             title: title,

--- a/Sources/tuistfixturegenerator/Templates/ManifestTemplate.swift
+++ b/Sources/tuistfixturegenerator/Templates/ManifestTemplate.swift
@@ -27,7 +27,7 @@ class ManifestTemplate {
     """
 
     private let targetTemplate = """
-            Target(
+            .target(
                 name: "{TargetName}",
                 destinations: .iOS,
                 product: .framework,

--- a/Templates/Project+Templates.stencil
+++ b/Templates/Project+Templates.stencil
@@ -21,7 +21,7 @@ extension Project {
 
     /// Helper function to create a framework target and an associated unit test target
     private static func makeFrameworkTargets(name: String, destinations: Destinations) -> [Target] {
-        let sources = Target(name: name,
+        let sources: Target = .target(name: name,
                 destinations: destinations,
                 product: .framework,
                 bundleId: "io.tuist.\(name)",
@@ -29,7 +29,7 @@ extension Project {
                 sources: ["Targets/\(name)/Sources/**"],
                 resources: [],
                 dependencies: [])
-        let tests = Target(name: "\(name)Tests",
+        let tests: Target = .target(name: "\(name)Tests",
                 destinations: destinations,
                 product: .unitTests,
                 bundleId: "io.tuist.\(name)Tests",
@@ -48,7 +48,7 @@ extension Project {
             "UILaunchStoryboardName": "LaunchScreen"
             ]
 
-        let mainTarget = Target(
+        let mainTarget: Target = .target(
             name: name,
             destinations: destinations,
             product: .app,
@@ -59,7 +59,7 @@ extension Project {
             dependencies: dependencies
         )
 
-        let testTarget = Target(
+        let testTarget: Target = .target(
             name: "\(name)Tests",
             destinations: destinations,
             product: .unitTests,

--- a/Tests/Fixtures/WorkspaceWithPlugins/LocalPlugin/ProjectDescriptionHelpers/Project+Template.swift
+++ b/Tests/Fixtures/WorkspaceWithPlugins/LocalPlugin/ProjectDescriptionHelpers/Project+Template.swift
@@ -2,7 +2,7 @@ import ProjectDescription
 
 extension Target {
     public static func app(name: String, dependencies: [TargetDependency] = []) -> Target {
-        Target(
+        .target(
             name: name,
             destinations: [.iPhone, .iPad],
             product: .app,
@@ -15,7 +15,7 @@ extension Target {
     }
 
     public static func framework(name: String, dependencies: [TargetDependency] = []) -> Target {
-        Target(
+        .target(
             name: name,
             destinations: [.iPhone, .iPad],
             product: .framework,

--- a/Tests/ProjectDescriptionTests/CoreDataModelTests.swift
+++ b/Tests/ProjectDescriptionTests/CoreDataModelTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 final class CoreDataModelTests: XCTestCase {
     func test_toJSON() {
-        let subject = CoreDataModel("path", currentVersion: "current")
+        let subject: CoreDataModel = .coreDataModel("path", currentVersion: "current")
         XCTAssertCodable(subject)
     }
 }

--- a/Tests/ProjectDescriptionTests/PluginLocationTests.swift
+++ b/Tests/ProjectDescriptionTests/PluginLocationTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class PluginLocationTests: XCTestCase {
     func test_codable_local() throws {
-        let subject = PluginLocation.local(path: .init("/some/path"))
+        let subject = PluginLocation.local(path: .path("/some/path"))
         XCTAssertCodable(subject)
     }
 

--- a/Tests/ProjectDescriptionTests/SchemeTests.swift
+++ b/Tests/ProjectDescriptionTests/SchemeTests.swift
@@ -10,16 +10,16 @@ final class SchemeTests: XCTestCase {
 
     func test_codable() throws {
         // Given
-        let subject = Scheme(
+        let subject: Scheme = .scheme(
             name: "scheme",
             shared: true,
-            buildAction: BuildAction(
+            buildAction: .buildAction(
                 targets: [.init(projectPath: nil, target: "target")],
                 preActions: mockExecutionAction("build_action"),
                 postActions: mockExecutionAction("build_action")
             ),
             testAction: TestAction.targets(
-                [TestableTarget(target: .init(projectPath: nil, target: "target"))],
+                [.testableTarget(target: .init(projectPath: nil, target: "target"))],
                 arguments: Arguments(
                     environmentVariables: ["test": "b"],
                     launchArguments: [LaunchArgument(name: "test", isEnabled: true)]
@@ -52,16 +52,16 @@ final class SchemeTests: XCTestCase {
 
     func test_defaultConfigurationNames() throws {
         // Given / When
-        let subject = Scheme(
+        let subject: Scheme = .scheme(
             name: "scheme",
             shared: true,
-            buildAction: BuildAction(
-                targets: [.init(projectPath: nil, target: "target")],
+            buildAction: .buildAction(
+                targets: [.target("target")],
                 preActions: mockExecutionAction("build_action"),
                 postActions: mockExecutionAction("build_action")
             ),
             testAction: TestAction.targets(
-                [.init(target: .init(projectPath: nil, target: "target"))],
+                [.testableTarget(target: .init(projectPath: nil, target: "target"))],
                 arguments: Arguments(
                     environmentVariables: ["test": "b"],
                     launchArguments: [LaunchArgument(name: "test", isEnabled: true)]
@@ -93,7 +93,7 @@ final class SchemeTests: XCTestCase {
 
     private func mockExecutionAction(_ actionName: String) -> [ExecutionAction] {
         [
-            ExecutionAction(
+            .executionAction(
                 title: "Run Script",
                 scriptText: "echo \(actionName)",
                 target: TargetReference(

--- a/Tests/ProjectDescriptionTests/TargetDependencyTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetDependencyTests.swift
@@ -54,7 +54,7 @@ final class TargetDependencyTests: XCTestCase {
     }
 
     func test_instanceTarget() {
-        let target = Target(name: "Target", destinations: .iOS, product: .framework, bundleId: "bundleId")
+        let target: Target = .target(name: "Target", destinations: .iOS, product: .framework, bundleId: "bundleId")
         let subject = TargetDependency.target(target)
         XCTAssertEqual(subject, TargetDependency.target(name: "Target"))
     }

--- a/Tests/ProjectDescriptionTests/TargetTests.swift
+++ b/Tests/ProjectDescriptionTests/TargetTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 final class TargetTests: XCTestCase {
     func test_toJSON() {
-        let subject = Target(
+        let subject: Target = .target(
             name: "name",
             destinations: [.iPhone, .iPad],
             product: .app,
@@ -36,14 +36,14 @@ final class TargetTests: XCTestCase {
                 debug: ["a": .string("b")],
                 release: ["a": .string("b")]
             ),
-            coreDataModels: [CoreDataModel("pat", currentVersion: "version")],
+            coreDataModels: [.coreDataModel("pat", currentVersion: "version")],
             environmentVariables: ["a": "b"]
         )
         XCTAssertCodable(subject)
     }
 
     func test_toJSON_withFileList() {
-        let subject = Target(
+        let subject: Target = .target(
             name: "name",
             destinations: [.iPhone, .iPad, .macWithiPadDesign],
             product: .app,
@@ -85,7 +85,7 @@ final class TargetTests: XCTestCase {
                     .debug(name: .release, settings: ["a": .string("release")], xcconfig: "debug.xcconfig"),
                 ]
             ),
-            coreDataModels: [CoreDataModel("pat", currentVersion: "version")],
+            coreDataModels: [.coreDataModel("pat", currentVersion: "version")],
             environmentVariables: ["a": "b"]
         )
         XCTAssertCodable(subject)

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -586,7 +586,7 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
 
     func test_generateSourcesBuildPhase_whenCoreDataModel() throws {
         // Given
-        let coreDataModel = CoreDataModel(
+        let coreDataModel = .coreDataModel(
             path: try AbsolutePath(validating: "/Model.xcdatamodeld"),
             versions: [try AbsolutePath(validating: "/Model.xcdatamodeld/1.xcdatamodel")],
             currentVersion: "1"
@@ -1480,7 +1480,7 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
     func test_generateBuildPhases_whenStaticFrameworkWithCoreDataModels() throws {
         // Given
         let path = try AbsolutePath(validating: "/path/to/project")
-        let coreDataModel = CoreDataModel(
+        let coreDataModel = .coreDataModel(
             path: path.appending(component: "Model.xcdatamodeld"),
             versions: [
                 path.appending(components: "Model.xcdatamodeld", "1.xcdatamodel"),
@@ -1522,7 +1522,7 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
     func test_generateBuildPhases_whenBundleWithCoreDataModels() throws {
         // Given
         let path = try AbsolutePath(validating: "/path/to/project")
-        let coreDataModel = CoreDataModel(
+        let coreDataModel = .coreDataModel(
             path: path.appending(component: "Model.xcdatamodeld"),
             versions: [
                 path.appending(components: "Model.xcdatamodeld", "1.xcdatamodel"),

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -750,7 +750,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             targetSettingsResult,
             .array([
                 "-load-plugin-executable",
-                "$BUILT_PRODUCTS_DIR/\(macroFramework.productNameWithExtension)/Macros/\(macroExecutable.productName)#\(macroExecutable.productName)",
+                "$BUILT_PRODUCTS_DIR/\(macroExecutable.productName)#\(macroExecutable.productName)",
             ])
         )
     }

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -405,7 +405,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
                     ]
                 ),
             ],
-            coreDataModels: [CoreDataModel(
+            coreDataModels: [.coreDataModel(
                 path: try AbsolutePath(validating: "/project/model.xcdatamodeld"),
                 versions: [try AbsolutePath(validating: "/project/model.xcdatamodeld/1.xcdatamodel")],
                 currentVersion: "1"

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -359,7 +359,7 @@ final class TargetLinterTests: TuistUnitTestCase {
         let path = try temporaryPath()
         let dataModelPath = path.appending(component: "Model.xcdatamodeld")
         let target = Target.test(coreDataModels: [
-            CoreDataModel(path: dataModelPath, versions: [], currentVersion: "1.0.0"),
+            .coreDataModel(path: dataModelPath, versions: [], currentVersion: "1.0.0"),
         ])
 
         // When
@@ -379,7 +379,7 @@ final class TargetLinterTests: TuistUnitTestCase {
         try FileHandler.shared.createFolder(dataModelPath)
 
         let target = Target.test(coreDataModels: [
-            CoreDataModel(path: dataModelPath, versions: [], currentVersion: "1.0.0"),
+            .coreDataModel(path: dataModelPath, versions: [], currentVersion: "1.0.0"),
         ])
 
         // When

--- a/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -106,7 +106,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         // Given
 
         let coreDataModels: [CoreDataModel] =
-            [CoreDataModel(path: "/data.xcdatamodeld", versions: ["/data.xcdatamodeld"], currentVersion: "1")]
+            [.coreDataModel(path: "/data.xcdatamodeld", versions: ["/data.xcdatamodeld"], currentVersion: "1")]
         let target = Target.test(product: .staticLibrary, coreDataModels: coreDataModels)
         project = Project.test(targets: [target])
 
@@ -194,7 +194,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
     func test_map_when_a_target_that_has_core_data_models_and_supports_them() throws {
         // Given
         let coreDataModels: [CoreDataModel] =
-            [CoreDataModel(path: "/data.xcdatamodeld", versions: ["/data.xcdatamodeld"], currentVersion: "1")]
+            [.coreDataModel(path: "/data.xcdatamodeld", versions: ["/data.xcdatamodeld"], currentVersion: "1")]
         let target = Target.test(product: .framework, coreDataModels: coreDataModels)
         project = Project.test(targets: [target])
 

--- a/Tests/TuistGraphTests/Models/CoreDataModelTests.swift
+++ b/Tests/TuistGraphTests/Models/CoreDataModelTests.swift
@@ -7,7 +7,7 @@ import XCTest
 final class CoreDataModelTests: TuistUnitTestCase {
     func test_codable() {
         // Given
-        let subject = CoreDataModel(
+        let subject = .coreDataModel(
             path: "/path/to/model",
             versions: [
                 "/path/to/version",

--- a/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
+++ b/Tests/TuistKitTests/ProjectEditor/ProjectEditorMapperTests.swift
@@ -212,7 +212,14 @@ final class ProjectEditorMapperTests: TuistUnitTestCase {
                         "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/ManifestAPI",
                     ]),
                 ],
-                uniquingKeysWith: { $1 }
+                uniquingKeysWith: {
+                    switch ($0, $1) {
+                    case let (.array(leftArray), .array(rightArray)):
+                        return SettingValue.array(leftArray + rightArray)
+                    default:
+                        return $1
+                    }
+                }
             )
         )
         XCTAssertEqual(

--- a/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
@@ -266,7 +266,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
                 ".",
             ],
             schemes: [
-                Scheme(name: "CustomWorkspaceScheme"),
+                .scheme(name: "CustomWorkspaceScheme"),
             ]
         )
 

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/CodeCoverageMode+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/CodeCoverageMode+ManifestMapperTests.swift
@@ -44,7 +44,7 @@ final class CodeCoverageManifestMapperTests: TuistUnitTestCase {
         // Given
         let temporaryPath = try temporaryPath()
         let generatorPaths = GeneratorPaths(manifestDirectory: temporaryPath)
-        let targetRef = ProjectDescription.TargetReference(projectPath: nil, target: "Target")
+        let targetRef = ProjectDescription.TargetReference.target("Target")
         let manifest = Manifest.targets([targetRef])
 
         // When

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/Configuration+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/Configuration+ManifestMapperTests.swift
@@ -31,7 +31,7 @@ final class ConfigurationManifestMapperTests: TuistUnitTestCase {
         let manifest: ProjectDescription.Configuration = .debug(
             name: .debug,
             settings: settings,
-            xcconfig: Path(xcconfigPath.pathString)
+            xcconfig: .path(xcconfigPath.pathString)
         )
 
         // When

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/CoreDataModel+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/CoreDataModel+ManifestMapperTests.swift
@@ -43,7 +43,10 @@ final class CoreDataModelManifestMapperTests: TuistUnitTestCase {
         // When
         let model = try TuistGraph.CoreDataModel.from(manifest: manifestWithoutCurrentVersion, generatorPaths: generatorPaths)
 
-        let manifestWithCurrentVersionExplicitly = ProjectDescription.CoreDataModel.coreDataModel("model.xcdatamodeld", currentVersion: "83")
+        let manifestWithCurrentVersionExplicitly = ProjectDescription.CoreDataModel.coreDataModel(
+            "model.xcdatamodeld",
+            currentVersion: "83"
+        )
 
         // Then
         XCTAssertTrue(try coreDataModel(

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/CoreDataModel+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/CoreDataModel+ManifestMapperTests.swift
@@ -93,7 +93,7 @@ final class CoreDataModelManifestMapperTests: TuistUnitTestCase {
                 manifest: manifestWithoutCurrentVersion,
                 generatorPaths: generatorPaths
             ),
-            TuistGraph.CoreDataModel(
+            TuistGraph .. coreDataModel(
                 path: temporaryPath.appending(component: "model.xcdatamodeld"),
                 versions: [],
                 currentVersion: "model"

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/CoreDataModel+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/CoreDataModel+ManifestMapperTests.swift
@@ -15,7 +15,7 @@ final class CoreDataModelManifestMapperTests: TuistUnitTestCase {
         let temporaryPath = try temporaryPath()
         let generatorPaths = GeneratorPaths(manifestDirectory: temporaryPath)
         try FileHandler.shared.touch(temporaryPath.appending(component: "model.xcdatamodeld"))
-        let manifest = ProjectDescription.CoreDataModel(
+        let manifest = ProjectDescription.CoreDataModel.coreDataModel(
             "model.xcdatamodeld",
             currentVersion: "1"
         )
@@ -38,12 +38,12 @@ final class CoreDataModelManifestMapperTests: TuistUnitTestCase {
         )
         try createVersionFile(xcVersion: xcVersionDataString(), temporaryPath: temporaryPath)
 
-        let manifestWithoutCurrentVersion = ProjectDescription.CoreDataModel("model.xcdatamodeld")
+        let manifestWithoutCurrentVersion = ProjectDescription.CoreDataModel.coreDataModel("model.xcdatamodeld")
 
         // When
         let model = try TuistGraph.CoreDataModel.from(manifest: manifestWithoutCurrentVersion, generatorPaths: generatorPaths)
 
-        let manifestWithCurrentVersionExplicitly = ProjectDescription.CoreDataModel("model.xcdatamodeld", currentVersion: "83")
+        let manifestWithCurrentVersionExplicitly = ProjectDescription.CoreDataModel.coreDataModel("model.xcdatamodeld", currentVersion: "83")
 
         // Then
         XCTAssertTrue(try coreDataModel(
@@ -69,7 +69,7 @@ final class CoreDataModelManifestMapperTests: TuistUnitTestCase {
         )
 
         // When
-        let manifestWithoutCurrentVersion = ProjectDescription.CoreDataModel("model.xcdatamodeld")
+        let manifestWithoutCurrentVersion = ProjectDescription.CoreDataModel.coreDataModel("model.xcdatamodeld")
 
         // Then
         XCTAssertThrowsError(
@@ -83,7 +83,7 @@ final class CoreDataModelManifestMapperTests: TuistUnitTestCase {
         let generatorPaths = GeneratorPaths(manifestDirectory: temporaryPath)
 
         // When
-        let manifestWithoutCurrentVersion = ProjectDescription.CoreDataModel("model.xcdatamodeld")
+        let manifestWithoutCurrentVersion = ProjectDescription.CoreDataModel.coreDataModel("model.xcdatamodeld")
 
         XCTAssertEqual(
             try TuistGraph.CoreDataModel.from(

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/Scheme+ManifestMapper.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/Scheme+ManifestMapper.swift
@@ -31,8 +31,8 @@ final class SchemeManifestMapperTests: TuistUnitTestCase {
         let arguments = ProjectDescription.Arguments.test(
             environment: ["FOO": "BAR", "FIZ": "BUZZ"],
             launchArguments: [
-                LaunchArgument(name: "--help", isEnabled: true),
-                LaunchArgument(name: "subcommand", isEnabled: false),
+                .launchArgument(name: "--help", isEnabled: true),
+                .launchArgument(name: "subcommand", isEnabled: false),
             ]
         )
 

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -455,7 +455,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         .test(
                             "Target1",
                             basePath: basePath,
-                            customSources: .custom(.init(
+                            customSources: .custom(.sourceFilesList(
                                 globs: [
                                     basePath
                                         .appending(try RelativePath(validating: "Package/\(alternativeDefaultSource)/Target1/**"))
@@ -621,7 +621,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         basePath: basePath,
                         customProductName: "com_example_target_1",
                         customBundleID: "com.example.target-1",
-                        customSources: .custom(.init(globs: [
+                        customSources: .custom(.sourceFilesList(globs: [
                             basePath
                                 .appending(try RelativePath(validating: "Package/Sources/com.example.target-1/**")).pathString,
                         ]))
@@ -851,11 +851,11 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     .test(
                         "Target1",
                         basePath: basePath,
-                        customSources: .custom(.init(globs: [
+                        customSources: .custom(.sourceFilesList(globs: [
                             .glob(
-                                Path(basePath.appending(try RelativePath(validating: "Package/Sources/Target1/**")).pathString),
+                                .path(basePath.appending(try RelativePath(validating: "Package/Sources/Target1/**")).pathString),
                                 excluding: [
-                                    Path(
+                                    .path(
                                         basePath
                                             .appending(
                                                 try RelativePath(validating: "Package/Sources/Target1/AnotherOne/Resource/**")
@@ -867,14 +867,14 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         ])),
                         resources: [
                             .folderReference(
-                                path: Path(
+                                path: .path(
                                     basePath.appending(try RelativePath(validating: "Package/Sources/Target1/Resource/Folder"))
                                         .pathString
                                 ),
                                 tags: []
                             ),
                             .glob(
-                                pattern: Path(
+                                pattern: .path(
                                     basePath
                                         .appending(
                                             try RelativePath(validating: "Package/Sources/Target1/Another/Resource/Folder/**")
@@ -882,7 +882,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                         .pathString
                                 ),
                                 excluding: [
-                                    Path(
+                                    .path(
                                         basePath
                                             .appending(
                                                 try RelativePath(validating: "Package/Sources/Target1/AnotherOne/Resource/**")
@@ -893,7 +893,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                 tags: []
                             ),
                             .glob(
-                                pattern: Path(
+                                pattern: .path(
                                     basePath
                                         .appending(
                                             try RelativePath(validating: "Package/Sources/Target1/AnotherOne/Resource/Folder/**")
@@ -901,7 +901,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                         .pathString
                                 ),
                                 excluding: [
-                                    Path(
+                                    .path(
                                         basePath
                                             .appending(
                                                 try RelativePath(validating: "Package/Sources/Target1/AnotherOne/Resource/**")
@@ -960,7 +960,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         basePath: basePath,
                         resources: [
                             .glob(
-                                pattern: Path(defaultResourcePath.pathString),
+                                pattern: .path(defaultResourcePath.pathString),
                                 excluding: [],
                                 tags: []
                             ),
@@ -1305,7 +1305,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     .test(
                         "Target1",
                         basePath: basePath,
-                        dependencies: [.project(target: "Dependency1", path: Path("\(basePath.pathString)/Package2"))],
+                        dependencies: [.project(target: "Dependency1", path: .path("\(basePath.pathString)/Package2"))],
                         customSettings: [
                             "HEADER_SEARCH_PATHS": [
                                 "$(SRCROOT)/Sources/Target1/include",
@@ -1368,13 +1368,13 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     .test(
                         "Target1",
                         basePath: basePath,
-                        customSources: .custom(.init(globs: [
+                        customSources: .custom(.sourceFilesList(globs: [
                             basePath
                                 .appending(try RelativePath(validating: "Package/Custom/Sources/Folder/**")).pathString,
                         ])),
                         resources: [
                             .folderReference(
-                                path: Path(
+                                path: .path(
                                     basePath.appending(try RelativePath(validating: "Package/Custom/Resource/Folder"))
                                         .pathString
                                 ),
@@ -1483,7 +1483,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     customProductName: "Target1",
                     customBundleID: "Target1",
                     deploymentTargets: .init(iOS: "11.0", tvOS: "11.0"),
-                    customSources: .custom(.init(globs: [
+                    customSources: .custom(.sourceFilesList(globs: [
                         basePath.appending(try RelativePath(validating: "Package/Sources/Target1/**"))
                             .pathString,
                     ]))
@@ -2370,7 +2370,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         "Target1",
                         basePath: basePath,
                         dependencies: [
-                            .xcframework(path: Path(
+                            .xcframework(path: .path(
                                 basePath.appending(try RelativePath(validating: "artifacts/Package/Dependency1.xcframework"))
                                     .pathString
                             )),
@@ -2460,7 +2460,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         "Target1",
                         basePath: basePath,
                         dependencies: [
-                            .xcframework(path: Path(
+                            .xcframework(path: .path(
                                 basePath.appending(try RelativePath(validating: "artifacts/Package/Dependency1.xcframework"))
                                     .pathString
                             )),
@@ -2508,7 +2508,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     .test(
                         "Target1",
                         basePath: basePath,
-                        dependencies: [.xcframework(path: Path(
+                        dependencies: [.xcframework(path: .path(
                             basePath
                                 .appending(try RelativePath(validating: "Package/Dependency1/Dependency1.xcframework")).pathString
                         ))]
@@ -2573,11 +2573,11 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         dependencies: [
                             .project(
                                 target: "Target2",
-                                path: Path(basePath.appending(try RelativePath(validating: "Package2")).pathString)
+                                path: .path(basePath.appending(try RelativePath(validating: "Package2")).pathString)
                             ),
                             .project(
                                 target: "Target3",
-                                path: Path(basePath.appending(try RelativePath(validating: "Package2")).pathString)
+                                path: .path(basePath.appending(try RelativePath(validating: "Package2")).pathString)
                             ),
                         ]
                     ),
@@ -2641,11 +2641,11 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         dependencies: [
                             .project(
                                 target: "Target2",
-                                path: Path(basePath.appending(try RelativePath(validating: "Package2")).pathString)
+                                path: .path(basePath.appending(try RelativePath(validating: "Package2")).pathString)
                             ),
                             .project(
                                 target: "Target3",
-                                path: Path(basePath.appending(try RelativePath(validating: "Package2")).pathString)
+                                path: .path(basePath.appending(try RelativePath(validating: "Package2")).pathString)
                             ),
                         ]
                     ),
@@ -2978,7 +2978,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     customProductName: "Target1",
                     customBundleID: "Target1",
                     deploymentTargets: .init(iOS: "11.0", tvOS: "11.0"),
-                    customSources: .custom(.init(globs: [
+                    customSources: .custom(.sourceFilesList(globs: [
                         basePath.appending(try RelativePath(validating: "Package/Sources/Target1/**")).pathString,
                     ])),
                     dependencies: [
@@ -2993,7 +2993,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     customProductName: "Dependency1",
                     customBundleID: "Dependency1",
                     deploymentTargets: .init(iOS: "11.0", tvOS: "11.0"),
-                    customSources: .custom(.init(globs: [
+                    customSources: .custom(.sourceFilesList(globs: [
                         basePath.appending(try RelativePath(validating: "Package/Sources/Dependency1/**")).pathString,
                     ]))
                 ),
@@ -3004,7 +3004,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     customProductName: "Dependency2",
                     customBundleID: "Dependency2",
                     deploymentTargets: .init(iOS: "11.0", tvOS: "11.0"),
-                    customSources: .custom(.init(globs: [
+                    customSources: .custom(.sourceFilesList(globs: [
                         basePath.appending(try RelativePath(validating: "Package/Sources/Dependency2/**")).pathString,
                     ]))
                 ),
@@ -3075,18 +3075,18 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     customProductName: "Target1",
                     customBundleID: "Target1",
                     deploymentTargets: .init(iOS: "11.0", tvOS: "11.0"),
-                    customSources: .custom(.init(globs: [
+                    customSources: .custom(.sourceFilesList(globs: [
                         basePath.appending(try RelativePath(validating: "Package/Sources/Target1/**")).pathString,
                     ])),
                     dependencies: [
                         .project(
                             target: "Target2",
-                            path: Path(basePath.appending(try RelativePath(validating: "Package2")).pathString),
+                            path: .path(basePath.appending(try RelativePath(validating: "Package2")).pathString),
                             condition: .when([.ios])
                         ),
                         .project(
                             target: "Target3",
-                            path: Path(basePath.appending(try RelativePath(validating: "Package2")).pathString),
+                            path: .path(basePath.appending(try RelativePath(validating: "Package2")).pathString),
                             condition: .when([.ios])
                         ),
                     ]
@@ -3291,10 +3291,10 @@ extension ProjectDescription.Target {
             sources = list
         case .default:
             // swiftlint:disable:next force_try
-            sources = .init(globs: [basePath.appending(try! RelativePath(validating: "Package/Sources/\(name)/**")).pathString])
+            sources = .sourceFilesList(globs: [basePath.appending(try! RelativePath(validating: "Package/Sources/\(name)/**")).pathString])
         }
 
-        return ProjectDescription.Target(
+        return ProjectDescription.Target.target(
             name: name,
             destinations: destinations,
             product: product,
@@ -3303,7 +3303,7 @@ extension ProjectDescription.Target {
             deploymentTargets: deploymentTargets,
             infoPlist: .default,
             sources: sources,
-            resources: resources.isEmpty ? nil : ResourceFileElements(resources: resources),
+            resources: resources.isEmpty ? nil : .resources(resources),
             headers: headers,
             dependencies: dependencies,
             settings: DependenciesGraph.spmSettings(baseSettings: baseSettings, with: customSettings, moduleMap: moduleMap)
@@ -3319,7 +3319,7 @@ extension [ProjectDescription.ResourceFileElement] {
         ["xib", "storyboard", "xcdatamodeld", "xcmappingmodel", "xcassets", "lproj"]
             .map { file -> ProjectDescription.ResourceFileElement in
                 ResourceFileElement.glob(
-                    pattern: Path("\(path.appending(component: "**").pathString)/*.\(file)"),
+                    pattern: .path("\(path.appending(component: "**").pathString)/*.\(file)"),
                     excluding: excluding
                 )
             }

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -1482,7 +1482,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     destinations: [.iPad, .iPhone, .macWithiPadDesign, .appleVisionWithiPadDesign, .appleTv],
                     customProductName: "Target1",
                     customBundleID: "Target1",
-                    deploymentTargets: .init(iOS: "11.0", tvOS: "11.0"),
+                    deploymentTargets: .deploymentTargets(iOS: "11.0", tvOS: "11.0"),
                     customSources: .custom(.sourceFilesList(globs: [
                         basePath.appending(try RelativePath(validating: "Package/Sources/Target1/**"))
                             .pathString,
@@ -2977,7 +2977,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     destinations: [.iPhone, .iPad, .macWithiPadDesign, .appleVisionWithiPadDesign, .appleTv],
                     customProductName: "Target1",
                     customBundleID: "Target1",
-                    deploymentTargets: .init(iOS: "11.0", tvOS: "11.0"),
+                    deploymentTargets: .deploymentTargets(iOS: "11.0", tvOS: "11.0"),
                     customSources: .custom(.sourceFilesList(globs: [
                         basePath.appending(try RelativePath(validating: "Package/Sources/Target1/**")).pathString,
                     ])),
@@ -2992,7 +2992,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     destinations: [.iPhone, .iPad, .macWithiPadDesign, .appleVisionWithiPadDesign, .appleTv],
                     customProductName: "Dependency1",
                     customBundleID: "Dependency1",
-                    deploymentTargets: .init(iOS: "11.0", tvOS: "11.0"),
+                    deploymentTargets: .deploymentTargets(iOS: "11.0", tvOS: "11.0"),
                     customSources: .custom(.sourceFilesList(globs: [
                         basePath.appending(try RelativePath(validating: "Package/Sources/Dependency1/**")).pathString,
                     ]))
@@ -3003,7 +3003,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     destinations: [.iPhone, .iPad, .macWithiPadDesign, .appleVisionWithiPadDesign, .appleTv],
                     customProductName: "Dependency2",
                     customBundleID: "Dependency2",
-                    deploymentTargets: .init(iOS: "11.0", tvOS: "11.0"),
+                    deploymentTargets: .deploymentTargets(iOS: "11.0", tvOS: "11.0"),
                     customSources: .custom(.sourceFilesList(globs: [
                         basePath.appending(try RelativePath(validating: "Package/Sources/Dependency2/**")).pathString,
                     ]))
@@ -3074,7 +3074,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     destinations: [.iPhone, .iPad, .macWithiPadDesign, .appleVisionWithiPadDesign, .appleTv],
                     customProductName: "Target1",
                     customBundleID: "Target1",
-                    deploymentTargets: .init(iOS: "11.0", tvOS: "11.0"),
+                    deploymentTargets: .deploymentTargets(iOS: "11.0", tvOS: "11.0"),
                     customSources: .custom(.sourceFilesList(globs: [
                         basePath.appending(try RelativePath(validating: "Package/Sources/Target1/**")).pathString,
                     ])),
@@ -3275,7 +3275,7 @@ extension ProjectDescription.Target {
         product: ProjectDescription.Product = .staticFramework,
         customProductName: String? = nil,
         customBundleID: String? = nil,
-        deploymentTargets: ProjectDescription.DeploymentTargets = DeploymentTargets(iOS: "11.0"),
+        deploymentTargets: ProjectDescription.DeploymentTargets = .deploymentTargets(iOS: "11.0"),
         customSources: SourceFilesListType = .default,
         resources: [ProjectDescription.ResourceFileElement] = [],
         headers: ProjectDescription.Headers? = nil,

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -3291,7 +3291,11 @@ extension ProjectDescription.Target {
             sources = list
         case .default:
             // swiftlint:disable:next force_try
-            sources = .sourceFilesList(globs: [basePath.appending(try! RelativePath(validating: "Package/Sources/\(name)/**")).pathString])
+            sources =
+                .sourceFilesList(globs: [
+                    basePath.appending(try! RelativePath(validating: "Package/Sources/\(name)/**"))
+                        .pathString,
+                ])
         }
 
         return ProjectDescription.Target.target(

--- a/docs/Sources/tuist/tuist.docc/Articles/Tuist/Manifests/project.md
+++ b/docs/Sources/tuist/tuist.docc/Articles/Tuist/Manifests/project.md
@@ -10,7 +10,7 @@ import ProjectDescription
 let project = Project(
     name: "MyProject",
     targets: [
-        Target(
+        .target(
             name: "App",
             platform: .iOS,
             product: .app,

--- a/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Add External Dependencies/Project.swift
+++ b/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Add External Dependencies/Project.swift
@@ -4,7 +4,7 @@ let project = Project(
     name: "App",
     organizationName: "tuist.io",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: [.iPhone],
             product: .app,

--- a/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Create Project/inital-project-templates.swift
+++ b/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Create Project/inital-project-templates.swift
@@ -27,7 +27,7 @@ extension Project {
 
     /// Helper function to create a framework target and an associated unit test target
     private static func makeFrameworkTargets(name: String, destinations: Destinations) -> [Target] {
-        let sources = Target(
+        let sources = .target(
             name: name,
             destinations: destinations,
             product: .framework,
@@ -37,7 +37,7 @@ extension Project {
             resources: [],
             dependencies: []
         )
-        let tests = Target(
+        let tests = .target(
             name: "\(name)Tests",
             destinations: destinations,
             product: .unitTests,
@@ -60,7 +60,7 @@ extension Project {
             "UILaunchStoryboardName": "LaunchScreen",
         ]
 
-        let mainTarget = Target(
+        let mainTarget = .target(
             name: name,
             destinations: destinations,
             product: .app,
@@ -71,7 +71,7 @@ extension Project {
             dependencies: dependencies
         )
 
-        let testTarget = Target(
+        let testTarget = .target(
             name: "\(name)Tests",
             destinations: destinations,
             product: .unitTests,

--- a/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/dependencies.md
+++ b/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/dependencies.md
@@ -85,7 +85,7 @@ let project = Project(name: "MyProject", packages: [
 And then reference them from your targets:
 
 ```swift
-let target = Target(name: "MyTarget", dependencies: [
+let target = .target(name: "MyTarget", dependencies: [
     .package(product: "CryptoSwift", type: .runtime)
 ])
 ```

--- a/fixtures/app_with_build_rules/Project.swift
+++ b/fixtures/app_with_build_rules/Project.swift
@@ -4,14 +4,14 @@ let project = Project(
     name: "App",
     organizationName: "Tuist",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
             bundleId: "io.tuist.App",
             sources: ["App/*"],
             buildRules: [
-                .init(
+                .buildRule(
                     name: "Process_InfoPlist.strings",
                     fileType: .sourceFilesWithNamesMatching,
                     filePatterns: "*/InfoPlist.strings",

--- a/fixtures/app_with_framework_and_tests/Project.swift
+++ b/fixtures/app_with_framework_and_tests/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -14,7 +14,7 @@ let project = Project(
                 .target(name: "Framework"),
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,
@@ -25,7 +25,7 @@ let project = Project(
                 .target(name: "App"),
             ]
         ),
-        Target(
+        .target(
             name: "Framework",
             destinations: .iOS,
             product: .framework,
@@ -35,7 +35,7 @@ let project = Project(
             dependencies: [
             ]
         ),
-        Target(
+        .target(
             name: "FrameworkTests",
             destinations: .iOS,
             product: .unitTests,
@@ -48,7 +48,7 @@ let project = Project(
         ),
     ],
     schemes: [
-        Scheme(
+        .scheme(
             name: "AppCustomScheme",
             buildAction: .buildAction(targets: [TargetReference("App")])
         ),

--- a/fixtures/app_with_organization_name_project/Project.swift
+++ b/fixtures/app_with_organization_name_project/Project.swift
@@ -4,7 +4,7 @@ let project = Project(
     name: "App",
     organizationName: "Tuist",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,

--- a/fixtures/app_with_plugins/Tuist/Package.swift
+++ b/fixtures/app_with_plugins/Tuist/Package.swift
@@ -2,7 +2,6 @@
 import PackageDescription
 
 #if TUIST
-
     import ExampleTuistPlugin
     import LocalPlugin
     import ProjectDescription

--- a/fixtures/app_with_plugins/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/fixtures/app_with_plugins/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -9,7 +9,7 @@ extension Project {
         _ = LocalHelper(name: "local")
         _ = RemoteHelper(name: "remote")
 
-        let mainTarget = Target(
+        let mainTarget: Target = .target(
             name: name,
             destinations: destinations,
             product: .app,

--- a/fixtures/app_with_spm_dependencies/App/Project.swift
+++ b/fixtures/app_with_spm_dependencies/App/Project.swift
@@ -5,7 +5,7 @@ let project = Project(
     name: "App",
     settings: .projectSettings,
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -19,7 +19,7 @@ let project = Project(
             ],
             settings: .targetSettings
         ),
-        Target(
+        .target(
             name: "AppKit",
             destinations: .iOS,
             product: .staticFramework,
@@ -33,7 +33,7 @@ let project = Project(
             ],
             settings: .targetSettings
         ),
-        Target(
+        .target(
             name: "WatchApp",
             destinations: [.appleWatch],
             product: .watch2App,
@@ -48,7 +48,7 @@ let project = Project(
                 .target(name: "WatchExtension"),
             ]
         ),
-        Target(
+        .target(
             name: "WatchExtension",
             destinations: [.appleWatch],
             product: .watch2Extension,

--- a/fixtures/app_with_spm_dependencies/Features/FeatureOne/Project.swift
+++ b/fixtures/app_with_spm_dependencies/Features/FeatureOne/Project.swift
@@ -5,7 +5,7 @@ let project = Project(
     name: "FeatureOne",
     settings: .projectSettings,
     targets: [
-        Target(
+        .target(
             name: "FeatureOneFramework_iOS",
             destinations: .iOS,
             product: .framework,
@@ -16,7 +16,7 @@ let project = Project(
             ],
             settings: .targetSettings
         ),
-        Target(
+        .target(
             name: "FeatureOneFramework_watchOS",
             destinations: [.appleWatch],
             product: .framework,

--- a/fixtures/app_with_spm_dependencies/Tuist/ProjectDescriptionHelpers/Scheme+Templates.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/ProjectDescriptionHelpers/Scheme+Templates.swift
@@ -52,28 +52,4 @@ extension Scheme {
                 .map { scheme(for: $0, target: target, executable: executable) }
         }
     }
-
-    public static func scheme(
-        name: String,
-        shared: Bool = true,
-        hidden: Bool = false,
-        buildAction: ProjectDescription.BuildAction? = nil,
-        testAction: ProjectDescription.TestAction? = nil,
-        runAction: ProjectDescription.RunAction? = nil,
-        archiveAction: ProjectDescription.ArchiveAction? = nil,
-        profileAction: ProjectDescription.ProfileAction? = nil,
-        analyzeAction: ProjectDescription.AnalyzeAction? = nil
-    ) -> Scheme {
-        .scheme(
-            name: name,
-            shared: shared,
-            hidden: hidden,
-            buildAction: buildAction,
-            testAction: testAction,
-            runAction: runAction,
-            archiveAction: archiveAction,
-            profileAction: profileAction,
-            analyzeAction: analyzeAction
-        )
-    }
 }

--- a/fixtures/app_with_spm_dependencies/Tuist/ProjectDescriptionHelpers/Scheme+Templates.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/ProjectDescriptionHelpers/Scheme+Templates.swift
@@ -64,7 +64,7 @@ extension Scheme {
         profileAction: ProjectDescription.ProfileAction? = nil,
         analyzeAction: ProjectDescription.AnalyzeAction? = nil
     ) -> Scheme {
-        Scheme(
+        .scheme(
             name: name,
             shared: shared,
             hidden: hidden,

--- a/fixtures/app_with_tasks/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/fixtures/app_with_tasks/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -25,7 +25,7 @@ extension Project {
 
     /// Helper function to create a framework target and an associated unit test target
     private static func makeFrameworkTargets(name: String, platform: Platform) -> [Target] {
-        let sources = Target(
+        let sources = .target(
             name: name,
             platform: platform,
             product: .framework,
@@ -35,7 +35,7 @@ extension Project {
             resources: [],
             dependencies: []
         )
-        let tests = Target(
+        let tests = .target(
             name: "\(name)Tests",
             platform: platform,
             product: .unitTests,
@@ -62,7 +62,7 @@ extension Project {
             "aps-environment": "development",
         ]
 
-        let mainTarget = Target(
+        let mainTarget: Target = .target(
             name: name,
             platform: platform,
             product: .app,
@@ -74,7 +74,7 @@ extension Project {
             dependencies: dependencies
         )
 
-        let testTarget = Target(
+        let testTarget: Target = .target(
             name: "\(name)Tests",
             platform: platform,
             product: .unitTests,

--- a/fixtures/app_with_test_plan/Project.swift
+++ b/fixtures/app_with_test_plan/Project.swift
@@ -4,7 +4,7 @@ let project = Project(
     name: "App",
     organizationName: "tuist.io",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: [.iPhone],
             product: .app,
@@ -13,7 +13,7 @@ let project = Project(
             infoPlist: .default,
             sources: ["Targets/App/Sources/**"]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,
@@ -24,7 +24,7 @@ let project = Project(
                 .target(name: "App"),
             ]
         ),
-        Target(
+        .target(
             name: "MacFramework",
             destinations: [.mac],
             product: .framework,
@@ -39,7 +39,7 @@ let project = Project(
                 ]
             )
         ),
-        Target(
+        .target(
             name: "MacFrameworkTests",
             destinations: [.mac],
             product: .unitTests,
@@ -59,7 +59,7 @@ let project = Project(
         ),
     ],
     schemes: [
-        Scheme(
+        .scheme(
             name: "App",
             buildAction: BuildAction(targets: ["App"]),
             testAction: .testPlans([.relativeToManifest("All.xctestplan")]),

--- a/fixtures/app_with_test_plan/Project.swift
+++ b/fixtures/app_with_test_plan/Project.swift
@@ -61,7 +61,7 @@ let project = Project(
     schemes: [
         .scheme(
             name: "App",
-            buildAction: BuildAction(targets: ["App"]),
+            buildAction: .buildAction(targets: ["App"]),
             testAction: .testPlans([.relativeToManifest("All.xctestplan")]),
             runAction: .runAction(
                 configuration: .debug,

--- a/fixtures/app_with_tests/Project.swift
+++ b/fixtures/app_with_tests/Project.swift
@@ -4,7 +4,7 @@ let project = Project(
     name: "App",
     organizationName: "tuist.io",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: [.iPhone],
             product: .app,
@@ -13,7 +13,7 @@ let project = Project(
             infoPlist: .default,
             sources: ["Targets/App/Sources/**"]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,
@@ -24,7 +24,7 @@ let project = Project(
                 .target(name: "App"),
             ]
         ),
-        Target(
+        .target(
             name: "tvOSFramework",
             destinations: [.appleTv],
             product: .framework,
@@ -32,7 +32,7 @@ let project = Project(
             infoPlist: .default,
             sources: "Targets/tvOSFramework/Sources/**"
         ),
-        Target(
+        .target(
             name: "tvOSFrameworkTests",
             destinations: [.appleTv],
             product: .unitTests,
@@ -43,7 +43,7 @@ let project = Project(
                 .target(name: "tvOSFramework"),
             ]
         ),
-        Target(
+        .target(
             name: "MacFramework",
             destinations: [.mac],
             product: .framework,
@@ -58,7 +58,7 @@ let project = Project(
                 ]
             )
         ),
-        Target(
+        .target(
             name: "MacFrameworkTests",
             destinations: [.mac],
             product: .unitTests,

--- a/fixtures/command_line_tool_basic/Project.swift
+++ b/fixtures/command_line_tool_basic/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "CommandLineTool",
     targets: [
-        Target(
+        .target(
             name: "CommandLineTool",
             destinations: [.mac],
             product: .commandLineTool,

--- a/fixtures/command_line_tool_with_dynamic_framework/Project.swift
+++ b/fixtures/command_line_tool_with_dynamic_framework/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "CommandLineTool",
     targets: [
-        Target(
+        .target(
             name: "CommandLineTool",
             destinations: [.mac],
             product: .commandLineTool,
@@ -14,7 +14,7 @@ let project = Project(
                 .target(name: "DynamicFramework"),
             ]
         ),
-        Target(
+        .target(
             name: "DynamicFramework",
             destinations: [.mac],
             product: .framework,

--- a/fixtures/command_line_tool_with_dynamic_library/Project.swift
+++ b/fixtures/command_line_tool_with_dynamic_library/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "CommandLineTool",
     targets: [
-        Target(
+        .target(
             name: "CommandLineTool",
             destinations: [.mac],
             product: .commandLineTool,
@@ -14,7 +14,7 @@ let project = Project(
                 .target(name: "DynamicLib"),
             ]
         ),
-        Target(
+        .target(
             name: "DynamicLib",
             destinations: [.mac],
             product: .dynamicLibrary,

--- a/fixtures/command_line_tool_with_static_library/Project.swift
+++ b/fixtures/command_line_tool_with_static_library/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "CommandLineTool",
     targets: [
-        Target(
+        .target(
             name: "CommandLineTool",
             destinations: [.mac],
             product: .commandLineTool,
@@ -14,7 +14,7 @@ let project = Project(
                 .target(name: "StaticLib"),
             ]
         ),
-        Target(
+        .target(
             name: "StaticLib",
             destinations: [.mac],
             product: .staticLibrary,

--- a/fixtures/framework_with_environment_variables/Project.swift
+++ b/fixtures/framework_with_environment_variables/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework",
     targets: [
-        Target(
+        .target(
             name: Environment.frameworkName.getString(default: "Framework"),
             destinations: [.mac],
             product: .framework,

--- a/fixtures/framework_with_native_swift_macro/Project.swift
+++ b/fixtures/framework_with_native_swift_macro/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "FrameworkWithSwiftMacro",
     targets: [
-        Target(
+        .target(
             name: "Framework",
             destinations: [.iPhone, .mac],
             product: .staticLibrary,

--- a/fixtures/framework_with_swift_macro/Project.swift
+++ b/fixtures/framework_with_swift_macro/Project.swift
@@ -7,7 +7,7 @@ let project = Project(
         .remote(url: "https://github.com/pointfreeco/swift-composable-architecture", requirement: .exact("1.4.0")),
     ],
     targets: [
-        Target(
+        .target(
             name: "Framework",
             destinations: .iOS,
             product: .framework,

--- a/fixtures/ios_app_large/Project.swift
+++ b/fixtures/ios_app_large/Project.swift
@@ -1,7 +1,7 @@
 import ProjectDescription
 
 func target(name: String) -> Target {
-    Target(
+    .target(
         name: name,
         destinations: .iOS,
         product: .app,

--- a/fixtures/ios_app_with_actions/App With Space/Project.swift
+++ b/fixtures/ios_app_with_actions/App With Space/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "AppWithSpace",
     targets: [
-        Target(
+        .target(
             name: "AppWithSpace",
             destinations: .iOS,
             product: .app,

--- a/fixtures/ios_app_with_actions/App/Project.swift
+++ b/fixtures/ios_app_with_actions/App/Project.swift
@@ -6,7 +6,7 @@ let project = Project(
         .remote(url: "https://github.com/realm/SwiftLint", requirement: .exact("0.52.4")),
     ],
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,

--- a/fixtures/ios_app_with_appclip/Project.swift
+++ b/fixtures/ios_app_with_appclip/Project.swift
@@ -4,7 +4,7 @@ let project = Project(
     name: "App",
     organizationName: "Tuist",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -15,7 +15,7 @@ let project = Project(
                 .target(name: "AppClip1"),
             ]
         ),
-        Target(
+        .target(
             name: "Framework",
             destinations: .iOS,
             product: .framework,
@@ -24,7 +24,7 @@ let project = Project(
             sources: ["Framework/Sources/**"],
             dependencies: []
         ),
-        Target(
+        .target(
             name: "StaticFramework",
             destinations: .iOS,
             product: .staticFramework,
@@ -33,7 +33,7 @@ let project = Project(
             sources: ["StaticFramework/Sources/**"],
             dependencies: []
         ),
-        Target(
+        .target(
             name: "AppClip1",
             destinations: .iOS,
             product: .appClip,
@@ -46,7 +46,7 @@ let project = Project(
                 .target(name: "StaticFramework"),
             ]
         ),
-        Target(
+        .target(
             name: "AppClip1Tests",
             destinations: .iOS,
             product: .unitTests,
@@ -58,7 +58,7 @@ let project = Project(
                 .target(name: "StaticFramework"),
             ]
         ),
-        Target(
+        .target(
             name: "AppClip1UITests",
             destinations: .iOS,
             product: .uiTests,

--- a/fixtures/ios_app_with_build_variables/App/Project.swift
+++ b/fixtures/ios_app_with_build_variables/App/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,

--- a/fixtures/ios_app_with_coredata/Project.swift
+++ b/fixtures/ios_app_with_coredata/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,

--- a/fixtures/ios_app_with_coredata/Project.swift
+++ b/fixtures/ios_app_with_coredata/Project.swift
@@ -11,9 +11,9 @@ let project = Project(
             infoPlist: "Info.plist",
             sources: ["Sources/**"],
             coreDataModels: [
-                CoreDataModel("CoreData/Users.xcdatamodeld", currentVersion: "1"),
-                CoreDataModel("CoreData/UsersAutoDetect.xcdatamodeld"),
-                CoreDataModel("CoreData/Unversioned.xcdatamodeld"),
+                .coreDataModel("CoreData/Users.xcdatamodeld", currentVersion: "1"),
+                .coreDataModel("CoreData/UsersAutoDetect.xcdatamodeld"),
+                .coreDataModel("CoreData/Unversioned.xcdatamodeld"),
             ]
         ),
     ]

--- a/fixtures/ios_app_with_coredata_in_static_framework/App/Project.swift
+++ b/fixtures/ios_app_with_coredata_in_static_framework/App/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,

--- a/fixtures/ios_app_with_coredata_in_static_framework/Framework/Project.swift
+++ b/fixtures/ios_app_with_coredata_in_static_framework/Framework/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework",
     targets: [
-        Target(
+        .target(
             name: "Framework",
             destinations: .iOS,
             product: .staticFramework,

--- a/fixtures/ios_app_with_coredata_in_static_framework/Framework/Project.swift
+++ b/fixtures/ios_app_with_coredata_in_static_framework/Framework/Project.swift
@@ -11,7 +11,7 @@ let project = Project(
             infoPlist: .default,
             sources: ["Sources/**"],
             coreDataModels: [
-                CoreDataModel("CoreData/Users.xcdatamodeld"),
+                .coreDataModel("CoreData/Users.xcdatamodeld"),
             ]
         ),
     ]

--- a/fixtures/ios_app_with_custom_configuration/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/fixtures/ios_app_with_custom_configuration/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -62,7 +62,7 @@ extension Target {
         dependencies: [TargetDependency],
         resources: ResourceFileElements? = nil
     ) -> Target {
-        Target(
+        .target(
             name: name,
             destinations: [.iPhone],
             product: product,
@@ -78,7 +78,7 @@ extension Target {
     public static func test(
         name: String
     ) -> Target {
-        Target(
+        .target(
             name: "\(name)Tests",
             destinations: .iOS,
             product: .unitTests,
@@ -96,16 +96,14 @@ extension Scheme {
         mainTargetName: String,
         testTargetName: String
     ) -> Scheme {
-        let main = TargetReference(
-            projectPath: nil,
-            target: mainTargetName
+        let main: TargetReference = .target(
+            mainTargetName
         )
-        let test = TargetReference(
-            projectPath: nil,
-            target: testTargetName
+        let test: TargetReference = .target(
+            testTargetName
         )
 
-        return Scheme(
+        return .scheme(
             name: name,
             shared: true,
             buildAction: .buildAction(targets: [
@@ -113,7 +111,7 @@ extension Scheme {
             ]),
             testAction: .targets(
                 [
-                    TestableTarget(target: test),
+                    .testableTarget(target: test),
                 ],
                 configuration: "debug"
             ),

--- a/fixtures/ios_app_with_custom_development_region/Project.swift
+++ b/fixtures/ios_app_with_custom_development_region/Project.swift
@@ -6,7 +6,7 @@ let project = Project(
         developmentRegion: "fr"
     ),
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,

--- a/fixtures/ios_app_with_custom_regions/Project.swift
+++ b/fixtures/ios_app_with_custom_regions/Project.swift
@@ -7,7 +7,7 @@ let project = Project(
         developmentRegion: "en-GB"
     ),
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,

--- a/fixtures/ios_app_with_custom_resource_parser_options/Project.swift
+++ b/fixtures/ios_app_with_custom_resource_parser_options/Project.swift
@@ -6,7 +6,7 @@ let project = Project(
         developmentRegion: "fr"
     ),
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,

--- a/fixtures/ios_app_with_custom_scheme/App/Project.swift
+++ b/fixtures/ios_app_with_custom_scheme/App/Project.swift
@@ -1,7 +1,7 @@
 import ProjectDescription
 
-let debugAction = ExecutionAction(scriptText: "echo Debug", target: "App")
-let debugScheme = .scheme(
+let debugAction: ExecutionAction = .executionAction(scriptText: "echo Debug", target: "App")
+let debugScheme: Scheme = .scheme(
     name: "App-Debug",
     shared: true,
     buildAction: .buildAction(
@@ -22,8 +22,8 @@ let debugScheme = .scheme(
     )
 )
 
-let releaseAction = ExecutionAction(scriptText: "echo Release", target: "App")
-let releaseScheme = .scheme(
+let releaseAction: ExecutionAction = .executionAction(scriptText: "echo Release", target: "App")
+let releaseScheme: Scheme = .scheme(
     name: "App-Release",
     shared: true,
     buildAction: .buildAction(targets: ["App"], preActions: [releaseAction]),
@@ -38,7 +38,7 @@ let releaseScheme = .scheme(
     )
 )
 
-let userScheme = .scheme(
+let userScheme: Scheme = .scheme(
     name: "App-Local",
     shared: false,
     buildAction: .buildAction(targets: ["App"], preActions: [debugAction]),

--- a/fixtures/ios_app_with_custom_scheme/App/Project.swift
+++ b/fixtures/ios_app_with_custom_scheme/App/Project.swift
@@ -1,7 +1,7 @@
 import ProjectDescription
 
 let debugAction = ExecutionAction(scriptText: "echo Debug", target: "App")
-let debugScheme = Scheme(
+let debugScheme = .scheme(
     name: "App-Debug",
     shared: true,
     buildAction: .buildAction(
@@ -23,7 +23,7 @@ let debugScheme = Scheme(
 )
 
 let releaseAction = ExecutionAction(scriptText: "echo Release", target: "App")
-let releaseScheme = Scheme(
+let releaseScheme = .scheme(
     name: "App-Release",
     shared: true,
     buildAction: .buildAction(targets: ["App"], preActions: [releaseAction]),
@@ -38,7 +38,7 @@ let releaseScheme = Scheme(
     )
 )
 
-let userScheme = Scheme(
+let userScheme = .scheme(
     name: "App-Local",
     shared: false,
     buildAction: .buildAction(targets: ["App"], preActions: [debugAction]),
@@ -49,7 +49,7 @@ let userScheme = Scheme(
 let project = Project(
     name: "MainApp",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -61,7 +61,7 @@ let project = Project(
                 .project(target: "Framework2", path: "../Frameworks/Framework2"),
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_custom_scheme/Frameworks/Framework1/Project.swift
+++ b/fixtures/ios_app_with_custom_scheme/Frameworks/Framework1/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework1",
     targets: [
-        Target(
+        .target(
             name: "Framework1",
             destinations: .iOS,
             product: .framework,
@@ -15,7 +15,7 @@ let project = Project(
             ]
         ),
 
-        Target(
+        .target(
             name: "Framework1Tests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_custom_scheme/Frameworks/Framework2/Project.swift
+++ b/fixtures/ios_app_with_custom_scheme/Frameworks/Framework2/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework2",
     targets: [
-        Target(
+        .target(
             name: "Framework2",
             destinations: .iOS,
             product: .framework,
@@ -13,7 +13,7 @@ let project = Project(
             dependencies: []
         ),
 
-        Target(
+        .target(
             name: "Framework2Tests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_custom_scheme/Workspace.swift
+++ b/fixtures/ios_app_with_custom_scheme/Workspace.swift
@@ -1,6 +1,6 @@
 import ProjectDescription
 
-let customAppScheme = Scheme(
+let customAppScheme = .scheme(
     name: "Workspace-App",
     shared: true,
     buildAction: .buildAction(
@@ -48,7 +48,7 @@ let customAppScheme = Scheme(
     archiveAction: .archiveAction(configuration: "Debug", customArchiveName: "Something2")
 )
 
-let customAppSchemeWithTestPlans = Scheme(
+let customAppSchemeWithTestPlans = .scheme(
     name: "Workspace-App-With-TestPlans",
     shared: true,
     buildAction: .buildAction(
@@ -66,7 +66,7 @@ let customAppSchemeWithTestPlans = Scheme(
     archiveAction: .archiveAction(configuration: "Debug", customArchiveName: "Something2")
 )
 
-let customFrameworkScheme = Scheme(
+let customFrameworkScheme = .scheme(
     name: "Workspace-Framework",
     shared: true,
     buildAction: .buildAction(

--- a/fixtures/ios_app_with_custom_scheme/Workspace.swift
+++ b/fixtures/ios_app_with_custom_scheme/Workspace.swift
@@ -1,6 +1,6 @@
 import ProjectDescription
 
-let customAppScheme = .scheme(
+let customAppScheme: Scheme = .scheme(
     name: "Workspace-App",
     shared: true,
     buildAction: .buildAction(
@@ -9,14 +9,14 @@ let customAppScheme = .scheme(
             .project(path: "Frameworks/Framework1", target: "Framework1"),
         ],
         preActions: [
-            ExecutionAction(
+            .executionAction(
                 scriptText: "echo \"pre-action in $SHELL\"",
                 target: .project(path: "App", target: "App"),
                 shellPath: "/bin/zsh"
             ),
         ],
         postActions: [
-            ExecutionAction(
+            .executionAction(
                 scriptText: "echo \"post-action in $SHELL\"",
                 target: .project(path: "Frameworks/Framework1", target: "Framework1"),
                 shellPath: "/bin/zsh"
@@ -25,12 +25,12 @@ let customAppScheme = .scheme(
     ),
     testAction: TestAction.targets(
         [
-            TestableTarget(target: .project(path: "App", target: "AppTests")),
-            TestableTarget(target: .project(
+            .testableTarget(target: .project(path: "App", target: "AppTests")),
+            .testableTarget(target: .project(
                 path: "Frameworks/Framework1",
                 target: "Framework1Tests"
             )),
-            TestableTarget(target: .project(
+            .testableTarget(target: .project(
                 path: "Frameworks/Framework2",
                 target: "Framework2Tests"
             )),
@@ -39,7 +39,7 @@ let customAppScheme = .scheme(
     ),
     runAction: .runAction(
         executable: .project(path: "App", target: "App"),
-        arguments: .init(environmentVariables: ["path": "$(SRCROOT)"], launchArguments: []),
+        arguments: .arguments(environmentVariables: ["path": "$(SRCROOT)"], launchArguments: []),
         options: .options(
             storeKitConfigurationPath: "App/Config/ProjectStoreKitConfig.storekit"
         ),
@@ -48,7 +48,7 @@ let customAppScheme = .scheme(
     archiveAction: .archiveAction(configuration: "Debug", customArchiveName: "Something2")
 )
 
-let customAppSchemeWithTestPlans = .scheme(
+let customAppSchemeWithTestPlans: Scheme = .scheme(
     name: "Workspace-App-With-TestPlans",
     shared: true,
     buildAction: .buildAction(
@@ -66,7 +66,7 @@ let customAppSchemeWithTestPlans = .scheme(
     archiveAction: .archiveAction(configuration: "Debug", customArchiveName: "Something2")
 )
 
-let customFrameworkScheme = .scheme(
+let customFrameworkScheme: Scheme = .scheme(
     name: "Workspace-Framework",
     shared: true,
     buildAction: .buildAction(
@@ -74,7 +74,7 @@ let customFrameworkScheme = .scheme(
         preActions: []
     ),
     testAction: TestAction
-        .targets([TestableTarget(target: .project(
+        .targets([.testableTarget(target: .project(
             path: "Frameworks/Framework1",
             target: "Framework1Tests"
         ))]),

--- a/fixtures/ios_app_with_custom_workspace/App/Project.swift
+++ b/fixtures/ios_app_with_custom_workspace/App/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "MainApp",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -15,7 +15,7 @@ let project = Project(
                 .project(target: "Framework2", path: "../Frameworks/Framework2"),
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_custom_workspace/Frameworks/Framework1/Project.swift
+++ b/fixtures/ios_app_with_custom_workspace/Frameworks/Framework1/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework1",
     targets: [
-        Target(
+        .target(
             name: "Framework1",
             destinations: .iOS,
             product: .framework,
@@ -15,7 +15,7 @@ let project = Project(
             ]
         ),
 
-        Target(
+        .target(
             name: "Framework1Tests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_custom_workspace/Frameworks/Framework2/Project.swift
+++ b/fixtures/ios_app_with_custom_workspace/Frameworks/Framework2/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework2",
     targets: [
-        Target(
+        .target(
             name: "Framework2",
             destinations: .iOS,
             product: .framework,
@@ -13,7 +13,7 @@ let project = Project(
             dependencies: []
         ),
 
-        Target(
+        .target(
             name: "Framework2Tests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_env_suppressed/App With Space/Project.swift
+++ b/fixtures/ios_app_with_env_suppressed/App With Space/Project.swift
@@ -4,7 +4,7 @@ let project = Project(
     name: "AppWithSpace",
     options: .options(disableShowEnvironmentVarsInScriptPhases: true),
     targets: [
-        Target(
+        .target(
             name: "AppWithSpace",
             destinations: .iOS,
             product: .app,

--- a/fixtures/ios_app_with_env_suppressed/App/Project.swift
+++ b/fixtures/ios_app_with_env_suppressed/App/Project.swift
@@ -4,7 +4,7 @@ let project = Project(
     name: "App",
     options: .options(disableShowEnvironmentVarsInScriptPhases: true),
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,

--- a/fixtures/ios_app_with_extensions/Project.swift
+++ b/fixtures/ios_app_with_extensions/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -20,7 +20,7 @@ let project = Project(
         // We need a separate app to test out Message Extensions
         // as having both stickers pack and message extensions in one app
         // doesn't seem to be supported.
-        Target(
+        .target(
             name: "AppWithMessagesExtension",
             destinations: .iOS,
             product: .app,
@@ -32,7 +32,7 @@ let project = Project(
                 .target(name: "NotificationServiceExtension"),
             ]
         ),
-        Target(
+        .target(
             name: "StickersPackExtension",
             destinations: .iOS,
             product: .stickerPackExtension,
@@ -49,7 +49,7 @@ let project = Project(
             dependencies: [
             ]
         ),
-        Target(
+        .target(
             name: "NotificationServiceExtension",
             destinations: .iOS,
             product: .appExtension,
@@ -65,7 +65,7 @@ let project = Project(
             dependencies: [
             ]
         ),
-        Target(
+        .target(
             name: "MessageExtension",
             destinations: .iOS,
             product: .messagesExtension,
@@ -82,7 +82,7 @@ let project = Project(
             dependencies: [
             ]
         ),
-        Target(
+        .target(
             name: "WidgetExtension",
             destinations: .iOS,
             product: .appExtension,
@@ -99,7 +99,7 @@ let project = Project(
                 .target(name: "StaticFramework"),
             ]
         ),
-        Target(
+        .target(
             name: "StaticFramework",
             destinations: .iOS,
             product: .staticFramework,
@@ -107,7 +107,7 @@ let project = Project(
             infoPlist: .default,
             sources: "StaticFramework/Sources/**"
         ),
-        Target(
+        .target(
             name: "AppIntentExtension",
             destinations: .iOS,
             product: .extensionKitExtension,

--- a/fixtures/ios_app_with_framework_and_disabled_resources/App/Project.swift
+++ b/fixtures/ios_app_with_framework_and_disabled_resources/App/Project.swift
@@ -7,7 +7,7 @@ let project = Project(
         disableSynthesizedResourceAccessors: true
     ),
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,

--- a/fixtures/ios_app_with_framework_and_disabled_resources/Framework1/Project.swift
+++ b/fixtures/ios_app_with_framework_and_disabled_resources/Framework1/Project.swift
@@ -15,7 +15,7 @@ let project = Project(
         disableSynthesizedResourceAccessors: true
     ),
     targets: [
-        Target(
+        .target(
             name: "Framework1",
             destinations: .iOS,
             product: .framework,

--- a/fixtures/ios_app_with_framework_and_disabled_resources/Framework1/Project.swift
+++ b/fixtures/ios_app_with_framework_and_disabled_resources/Framework1/Project.swift
@@ -22,7 +22,7 @@ let project = Project(
             bundleId: "io.tuist.Framework1",
             infoPlist: "Config/Framework1-Info.plist",
             sources: "Sources/**",
-            resources: ResourceFileElements(resources: resources)
+            resources: .resources(resources)
         ),
     ]
 )

--- a/fixtures/ios_app_with_framework_and_disabled_resources/StaticFramework/Project.swift
+++ b/fixtures/ios_app_with_framework_and_disabled_resources/StaticFramework/Project.swift
@@ -7,7 +7,7 @@ let project = Project(
         disableSynthesizedResourceAccessors: true
     ),
     targets: [
-        Target(
+        .target(
             name: "StaticFramework",
             destinations: .iOS,
             product: .staticFramework,
@@ -16,7 +16,7 @@ let project = Project(
             sources: "Sources/**",
             dependencies: []
         ),
-        Target(
+        .target(
             name: "StaticFrameworkResources",
             destinations: .iOS,
             product: .bundle,

--- a/fixtures/ios_app_with_framework_and_resources/App/Project.swift
+++ b/fixtures/ios_app_with_framework_and_resources/App/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "MainApp",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -34,7 +34,7 @@ let project = Project(
                 .project(target: "StaticFramework5", path: "../StaticFramework5"),
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_framework_and_resources/Framework1/Project.swift
+++ b/fixtures/ios_app_with_framework_and_resources/Framework1/Project.swift
@@ -12,7 +12,7 @@ let resources: [ResourceFileElement] = [
 let project = Project(
     name: "Framework1",
     targets: [
-        Target(
+        .target(
             name: "Framework1",
             destinations: .iOS,
             product: .framework,

--- a/fixtures/ios_app_with_framework_and_resources/Framework1/Project.swift
+++ b/fixtures/ios_app_with_framework_and_resources/Framework1/Project.swift
@@ -19,7 +19,7 @@ let project = Project(
             bundleId: "io.tuist.Framework1",
             infoPlist: "Config/Framework1-Info.plist",
             sources: "Sources/**",
-            resources: ResourceFileElements(resources: resources)
+            resources: .resources(resources)
         ),
     ]
 )

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework/Project.swift
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "StaticFramework",
     targets: [
-        Target(
+        .target(
             name: "StaticFramework",
             destinations: .iOS,
             product: .staticFramework,
@@ -12,7 +12,7 @@ let project = Project(
             sources: "Sources/**",
             dependencies: []
         ),
-        Target(
+        .target(
             name: "StaticFrameworkResources",
             destinations: .iOS,
             product: .bundle,

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework2/Project.swift
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework2/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "StaticFramework2",
     targets: [
-        Target(
+        .target(
             name: "StaticFramework2",
             destinations: .iOS,
             product: .staticFramework,
@@ -14,7 +14,7 @@ let project = Project(
                 .target(name: "StaticFramework2Resources"),
             ]
         ),
-        Target(
+        .target(
             name: "StaticFramework2Resources",
             destinations: .iOS,
             product: .bundle,

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework3/Project.swift
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework3/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "StaticFramework3",
     targets: [
-        Target(
+        .target(
             name: "StaticFramework3",
             destinations: .iOS,
             product: .staticFramework,

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework4/Project.swift
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework4/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "StaticFramework4",
     targets: [
-        Target(
+        .target(
             name: "StaticFramework4",
             destinations: .iOS,
             product: .staticFramework,

--- a/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Project.swift
+++ b/fixtures/ios_app_with_framework_and_resources/StaticFramework5/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "StaticFramework5",
     targets: [
-        Target(
+        .target(
             name: "StaticFramework5",
             destinations: .iOS,
             product: .staticFramework,

--- a/fixtures/ios_app_with_framework_linking_static_framework/App/Project.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/App/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "MainApp",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -14,7 +14,7 @@ let project = Project(
                 .project(target: "Framework1", path: "../Framework1"),
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework1/Project.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework1/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework1",
     targets: [
-        Target(
+        .target(
             name: "Framework1",
             destinations: .iOS,
             product: .framework,
@@ -17,7 +17,7 @@ let project = Project(
             ]
         ),
 
-        Target(
+        .target(
             name: "Framework1Tests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework2/Project.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework2/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework2",
     targets: [
-        Target(
+        .target(
             name: "Framework2",
             destinations: .iOS,
             product: .staticFramework,
@@ -13,7 +13,7 @@ let project = Project(
             dependencies: []
         ),
 
-        Target(
+        .target(
             name: "Framework2Tests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework3/Project.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework3/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework3",
     targets: [
-        Target(
+        .target(
             name: "Framework3",
             destinations: .iOS,
             product: .staticFramework,
@@ -15,7 +15,7 @@ let project = Project(
             ]
         ),
 
-        Target(
+        .target(
             name: "Framework3Tests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_framework_linking_static_framework/Framework4/Project.swift
+++ b/fixtures/ios_app_with_framework_linking_static_framework/Framework4/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework4",
     targets: [
-        Target(
+        .target(
             name: "Framework4",
             destinations: .iOS,
             product: .staticFramework,
@@ -13,7 +13,7 @@ let project = Project(
             dependencies: []
         ),
 
-        Target(
+        .target(
             name: "Framework4Tests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_frameworks/App/Project.swift
+++ b/fixtures/ios_app_with_frameworks/App/Project.swift
@@ -8,7 +8,7 @@ let project = Project(
     name: "MainApp",
     settings: settings,
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -21,7 +21,7 @@ let project = Project(
                 .project(target: "Framework2-iOS", path: "../Framework2"),
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_frameworks/Framework1/Project.swift
+++ b/fixtures/ios_app_with_frameworks/Framework1/Project.swift
@@ -17,7 +17,7 @@ let infoPlist: [String: Plist.Value] = [
 let project = Project(
     name: "Framework1",
     targets: [
-        Target(
+        .target(
             name: "Framework1",
             destinations: .iOS,
             product: .framework,
@@ -29,7 +29,7 @@ let project = Project(
                 .project(target: "Framework2-iOS", path: "../Framework2"),
             ]
         ),
-        Target(
+        .target(
             name: "Framework1Tests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_frameworks/Framework2/Project.swift
+++ b/fixtures/ios_app_with_frameworks/Framework2/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework2",
     targets: [
-        Target(
+        .target(
             name: "Framework2-iOS",
             destinations: .iOS,
             product: .framework,
@@ -20,7 +20,7 @@ let project = Project(
                 .project(target: "Framework3", path: "../Framework3"),
             ]
         ),
-        Target(
+        .target(
             name: "Framework2-macOS",
             destinations: [.mac],
             product: .framework,
@@ -35,7 +35,7 @@ let project = Project(
             ),
             dependencies: []
         ),
-        Target(
+        .target(
             name: "Framework2Tests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_frameworks/Framework3/Project.swift
+++ b/fixtures/ios_app_with_frameworks/Framework3/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework3",
     targets: [
-        Target(
+        .target(
             name: "Framework3",
             destinations: .iOS,
             product: .framework,

--- a/fixtures/ios_app_with_frameworks/Framework4/Project.swift
+++ b/fixtures/ios_app_with_frameworks/Framework4/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework4",
     targets: [
-        Target(
+        .target(
             name: "Framework4",
             destinations: .iOS,
             product: .framework,

--- a/fixtures/ios_app_with_frameworks/Framework5/Project.swift
+++ b/fixtures/ios_app_with_frameworks/Framework5/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework5",
     targets: [
-        Target(
+        .target(
             name: "Framework5",
             destinations: .iOS,
             product: .framework,

--- a/fixtures/ios_app_with_headers/App/Project.swift
+++ b/fixtures/ios_app_with_headers/App/Project.swift
@@ -7,7 +7,7 @@ let project = Project(
     name: "MainApp",
     settings: settings,
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -18,7 +18,7 @@ let project = Project(
                 .project(target: "Framework1-iOS", path: "../Framework1"),
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_headers/Framework1/Project.swift
+++ b/fixtures/ios_app_with_headers/Framework1/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework1",
     targets: [
-        Target(
+        .target(
             name: "Framework1-iOS",
             destinations: .iOS,
             product: .framework,
@@ -18,7 +18,7 @@ let project = Project(
             ),
             dependencies: []
         ),
-        Target(
+        .target(
             name: "Framework1-macOS",
             destinations: [.mac],
             product: .framework,
@@ -33,7 +33,7 @@ let project = Project(
             ),
             dependencies: []
         ),
-        Target(
+        .target(
             name: "Framework1Tests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_headers_in_one_dir/App/Project.swift
+++ b/fixtures/ios_app_with_headers_in_one_dir/App/Project.swift
@@ -7,7 +7,7 @@ let project = Project(
     name: "MainApp",
     settings: settings,
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -18,7 +18,7 @@ let project = Project(
                 .project(target: "Framework1-iOS", path: "../Framework1"),
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_headers_in_one_dir/Framework1/Project.swift
+++ b/fixtures/ios_app_with_headers_in_one_dir/Framework1/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework1",
     targets: [
-        Target(
+        .target(
             name: "Framework1-iOS",
             destinations: .iOS,
             product: .framework,
@@ -18,7 +18,7 @@ let project = Project(
             ),
             dependencies: []
         ),
-        Target(
+        .target(
             name: "Framework1-macOS",
             destinations: [.mac],
             product: .framework,
@@ -33,7 +33,7 @@ let project = Project(
             ),
             dependencies: []
         ),
-        Target(
+        .target(
             name: "Framework1Tests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_helpers/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/fixtures/ios_app_with_helpers/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -22,7 +22,7 @@ extension Project {
         Project(
             name: name,
             targets: [
-                Target(
+                .target(
                     name: name,
                     destinations: destinations,
                     product: product,
@@ -32,7 +32,7 @@ extension Project {
                     resources: [],
                     dependencies: dependencies
                 ),
-                Target(
+                .target(
                     name: "\(name)Tests",
                     destinations: destinations,
                     product: .unitTests,

--- a/fixtures/ios_app_with_implicit_dependencies/Project.swift
+++ b/fixtures/ios_app_with_implicit_dependencies/Project.swift
@@ -4,7 +4,7 @@ let project = Project(
     name: "App",
     organizationName: "tuist.io",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -15,21 +15,21 @@ let project = Project(
                 .target(name: "FrameworkB"),
             ]
         ),
-        Target(
+        .target(
             name: "FrameworkA",
             destinations: .iOS,
             product: .framework,
             bundleId: "io.tuist.FrameworkA",
             sources: ["Targets/FrameworkA/Sources/**"]
         ),
-        Target(
+        .target(
             name: "FrameworkB",
             destinations: .iOS,
             product: .framework,
             bundleId: "io.tuist.FrameworkB",
             sources: ["Targets/FrameworkB/Sources/**"]
         ),
-        Target(
+        .target(
             name: "FrameworkC",
             destinations: .iOS,
             product: .framework,

--- a/fixtures/ios_app_with_incompatible_dependencies/Project.swift
+++ b/fixtures/ios_app_with_incompatible_dependencies/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: [.mac],
             product: .app,
@@ -18,7 +18,7 @@ let project = Project(
                 "CODE_SIGNING_REQUIRED": "NO",
             ])
         ),
-        Target(
+        .target(
             name: "Framework",
             destinations: .iOS,
             product: .framework,

--- a/fixtures/ios_app_with_incompatible_xcode/Project.swift
+++ b/fixtures/ios_app_with_incompatible_xcode/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,

--- a/fixtures/ios_app_with_intents/Project.swift
+++ b/fixtures/ios_app_with_intents/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,

--- a/fixtures/ios_app_with_local_binary_swift_package/Packages/LocalPackage/MyFramework/Project.swift
+++ b/fixtures/ios_app_with_local_binary_swift_package/Packages/LocalPackage/MyFramework/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "MyFramework",
     targets: [
-        Target(
+        .target(
             name: "MyFramework",
             destinations: .iOS,
             product: .framework,

--- a/fixtures/ios_app_with_local_binary_swift_package/Project.swift
+++ b/fixtures/ios_app_with_local_binary_swift_package/Project.swift
@@ -6,7 +6,7 @@ let project = Project(
         .package(path: "Packages/LocalPackage"),
     ],
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -19,7 +19,7 @@ let project = Project(
                 .package(product: "MyFramework"),
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_local_swift_package/Frameworks/FrameworkA/Project.swift
+++ b/fixtures/ios_app_with_local_swift_package/Frameworks/FrameworkA/Project.swift
@@ -6,7 +6,7 @@ let project = Project(
         .package(path: "../../Packages/PackageA"),
     ],
     targets: [
-        Target(
+        .target(
             name: "FrameworkA",
             destinations: .iOS,
             product: .staticFramework,

--- a/fixtures/ios_app_with_local_swift_package/Project.swift
+++ b/fixtures/ios_app_with_local_swift_package/Project.swift
@@ -6,7 +6,7 @@ let project = Project(
         .package(path: "Packages/PackageA"),
     ],
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -23,7 +23,7 @@ let project = Project(
                 .package(product: "LibraryB"),
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_multi_configs/App/Project.swift
+++ b/fixtures/ios_app_with_multi_configs/App/Project.swift
@@ -11,7 +11,7 @@ let settings: Settings = .settings(
     ]
 )
 
-let betaScheme = .scheme(
+let betaScheme: Scheme = .scheme(
     name: "App-Beta",
     shared: true,
     buildAction: .buildAction(targets: ["App"]),

--- a/fixtures/ios_app_with_multi_configs/App/Project.swift
+++ b/fixtures/ios_app_with_multi_configs/App/Project.swift
@@ -11,7 +11,7 @@ let settings: Settings = .settings(
     ]
 )
 
-let betaScheme = Scheme(
+let betaScheme = .scheme(
     name: "App-Beta",
     shared: true,
     buildAction: .buildAction(targets: ["App"]),
@@ -25,7 +25,7 @@ let project = Project(
     name: "MainApp",
     settings: settings,
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -37,7 +37,7 @@ let project = Project(
                 .project(target: "Framework2", path: "../Framework2"),
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_multi_configs/Framework1/Project.swift
+++ b/fixtures/ios_app_with_multi_configs/Framework1/Project.swift
@@ -15,7 +15,7 @@ let project = Project(
     name: "Framework1",
     settings: settings,
     targets: [
-        Target(
+        .target(
             name: "Framework1",
             destinations: .iOS,
             product: .framework,
@@ -27,7 +27,7 @@ let project = Project(
                 .project(target: "Framework2", path: "../Framework2"),
             ]
         ),
-        Target(
+        .target(
             name: "Framework1Tests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_multi_configs/Framework2/Project.swift
+++ b/fixtures/ios_app_with_multi_configs/Framework2/Project.swift
@@ -22,7 +22,7 @@ let project = Project(
     name: "Framework2",
     settings: settings,
     targets: [
-        Target(
+        .target(
             name: "Framework2",
             destinations: .iOS,
             product: .framework,
@@ -32,7 +32,7 @@ let project = Project(
             dependencies: [],
             settings: targetSettings
         ),
-        Target(
+        .target(
             name: "Framework2Tests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_remote_swift_package/Project.swift
+++ b/fixtures/ios_app_with_remote_swift_package/Project.swift
@@ -6,7 +6,7 @@ let project = Project(
         .package(url: "https://github.com/ReactiveX/RxSwift", .upToNextMajor(from: "5.0.0")),
     ],
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -22,7 +22,7 @@ let project = Project(
                 .package(product: "RxBlocking"),
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_sdk/Modules/StaticFramework/Project.swift
+++ b/fixtures/ios_app_with_sdk/Modules/StaticFramework/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "StaticFramework",
     targets: [
-        Target(
+        .target(
             name: "StaticFramework",
             destinations: .iOS,
             product: .staticFramework,
@@ -15,7 +15,7 @@ let project = Project(
                 .sdk(name: "c++", type: .library),
             ]
         ),
-        Target(
+        .target(
             name: "StaticFrameworkTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_sdk/Project.swift
+++ b/fixtures/ios_app_with_sdk/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Project",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -18,7 +18,7 @@ let project = Project(
                 .project(target: "StaticFramework", path: "Modules/StaticFramework"),
             ]
         ),
-        Target(
+        .target(
             name: "MyTestFramework",
             destinations: .iOS,
             product: .framework,
@@ -29,7 +29,7 @@ let project = Project(
                 .xctest,
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,
@@ -41,7 +41,7 @@ let project = Project(
                 .target(name: "MyTestFramework"),
             ]
         ),
-        Target(
+        .target(
             name: "MacFramework",
             destinations: [.mac],
             product: .framework,
@@ -53,7 +53,7 @@ let project = Project(
                 .sdk(name: "sqlite3", type: .library),
             ]
         ),
-        Target(
+        .target(
             name: "TVFramework",
             destinations: [.appleTv],
             product: .framework,

--- a/fixtures/ios_app_with_signing/Project.swift
+++ b/fixtures/ios_app_with_signing/Project.swift
@@ -8,7 +8,7 @@ let project = Project(
     name: "SignApp",
     settings: settings,
     targets: [
-        Target(
+        .target(
             name: "SignApp",
             destinations: .iOS,
             product: .app,
@@ -21,7 +21,7 @@ let project = Project(
                 .release(name: "Release", xcconfig: "ConfigurationFiles/Release.xcconfig"),
             ])
         ),
-        Target(
+        .target(
             name: "AppA",
             destinations: .iOS,
             product: .app,
@@ -33,7 +33,7 @@ let project = Project(
                 .debug(name: "Debug", settings: ["PRODUCT_BUNDLE_IDENTIFIER": .string("io.tuist.test.appA")]),
             ])
         ),
-        Target(
+        .target(
             name: "AppB",
             destinations: .iOS,
             product: .app,

--- a/fixtures/ios_app_with_static_frameworks/Modules/A/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks/Modules/A/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "A",
     targets: [
-        Target(
+        .target(
             name: "A",
             destinations: .iOS,
             product: .staticFramework,
@@ -16,7 +16,7 @@ let project = Project(
                 .framework(path: "../../Prebuilt/prebuilt/PrebuiltStaticFramework.framework"),
             ]
         ),
-        Target(
+        .target(
             name: "ATests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_static_frameworks/Modules/AppTestsSupport/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks/Modules/AppTestsSupport/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "AppTestsSupport",
     targets: [
-        Target(
+        .target(
             name: "AppTestsSupport",
             destinations: .iOS,
             product: .staticFramework,

--- a/fixtures/ios_app_with_static_frameworks/Modules/B/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks/Modules/B/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "B",
     targets: [
-        Target(
+        .target(
             name: "B",
             destinations: .iOS,
             product: .staticFramework,
@@ -15,7 +15,7 @@ let project = Project(
                 /* .framework(path: "framework") */
             ]
         ),
-        Target(
+        .target(
             name: "BTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_static_frameworks/Modules/C/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks/Modules/C/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "C",
     targets: [
-        Target(
+        .target(
             name: "C",
             destinations: .iOS,
             product: .staticFramework,
@@ -16,7 +16,7 @@ let project = Project(
                 .project(target: "D", path: "../D"),
             ]
         ),
-        Target(
+        .target(
             name: "CTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_static_frameworks/Modules/D/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks/Modules/D/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "D",
     targets: [
-        Target(
+        .target(
             name: "D",
             destinations: .iOS,
             product: .framework,

--- a/fixtures/ios_app_with_static_frameworks/Prebuilt/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks/Prebuilt/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Prebuilt",
     targets: [
-        Target(
+        .target(
             name: "PrebuiltStaticFramework",
             destinations: .iOS,
             product: .staticFramework,

--- a/fixtures/ios_app_with_static_frameworks/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -16,7 +16,7 @@ let project = Project(
                 .framework(path: "Prebuilt/prebuilt/PrebuiltStaticFramework.framework"),
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_static_frameworks_with_resources/Modules/A/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks_with_resources/Modules/A/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "A",
     targets: [
-        Target(
+        .target(
             name: "A",
             destinations: .iOS,
             product: .staticFramework,
@@ -16,7 +16,7 @@ let project = Project(
                 .project(target: "C", path: "../C"),
             ]
         ),
-        Target(
+        .target(
             name: "ATests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_static_frameworks_with_resources/Modules/B/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks_with_resources/Modules/B/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "B",
     targets: [
-        Target(
+        .target(
             name: "B",
             destinations: .iOS,
             product: .staticFramework,
@@ -16,7 +16,7 @@ let project = Project(
                 /* .framework(path: "framework") */
             ]
         ),
-        Target(
+        .target(
             name: "BTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_static_frameworks_with_resources/Modules/C/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks_with_resources/Modules/C/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "C",
     targets: [
-        Target(
+        .target(
             name: "C",
             destinations: .iOS,
             product: .staticFramework,
@@ -17,7 +17,7 @@ let project = Project(
                 .project(target: "D", path: "../D"),
             ]
         ),
-        Target(
+        .target(
             name: "CTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_static_frameworks_with_resources/Modules/D/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks_with_resources/Modules/D/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "D",
     targets: [
-        Target(
+        .target(
             name: "D",
             destinations: .iOS,
             product: .framework,

--- a/fixtures/ios_app_with_static_frameworks_with_resources/Prebuilt/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks_with_resources/Prebuilt/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Prebuilt",
     targets: [
-        Target(
+        .target(
             name: "PrebuiltStaticFramework",
             destinations: .iOS,
             product: .staticFramework,

--- a/fixtures/ios_app_with_static_frameworks_with_resources/Project.swift
+++ b/fixtures/ios_app_with_static_frameworks_with_resources/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -21,7 +21,7 @@ let project = Project(
                 ]
             )
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_static_libraries/Modules/A/Project.swift
+++ b/fixtures/ios_app_with_static_libraries/Modules/A/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "A",
     targets: [
-        Target(
+        .target(
             name: "A",
             destinations: .iOS,
             product: .staticLibrary,
@@ -21,7 +21,7 @@ let project = Project(
 
             settings: .settings(base: ["HEADER_SEARCH_PATHS": "$(SRCROOT)/CustomHeaders"])
         ),
-        Target(
+        .target(
             name: "ATests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_static_libraries/Modules/B/Project.swift
+++ b/fixtures/ios_app_with_static_libraries/Modules/B/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "B",
     targets: [
-        Target(
+        .target(
             name: "B",
             destinations: .iOS,
             product: .staticLibrary,
@@ -15,7 +15,7 @@ let project = Project(
                 /* .framework(path: "framework") */
             ]
         ),
-        Target(
+        .target(
             name: "BTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_static_libraries/Modules/C/Project.swift
+++ b/fixtures/ios_app_with_static_libraries/Modules/C/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "C",
     targets: [
-        Target(
+        .target(
             name: "C",
             destinations: .iOS,
             product: .staticLibrary,
@@ -16,7 +16,7 @@ let project = Project(
             ],
             settings: .settings(base: ["BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"])
         ),
-        Target(
+        .target(
             name: "CTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_static_libraries/Project.swift
+++ b/fixtures/ios_app_with_static_libraries/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "iOSAppWithTransistiveStaticLibraries",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -14,7 +14,7 @@ let project = Project(
                 .project(target: "A", path: "Modules/A"),
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_static_library_and_package/Prebuilt/Project.swift
+++ b/fixtures/ios_app_with_static_library_and_package/Prebuilt/Project.swift
@@ -6,7 +6,7 @@ let project = Project(
         .package(path: "../Packages/PackageA"),
     ],
     targets: [
-        Target(
+        .target(
             name: "PrebuiltStaticFramework",
             destinations: .iOS,
             product: .staticFramework,

--- a/fixtures/ios_app_with_static_library_and_package/Project.swift
+++ b/fixtures/ios_app_with_static_library_and_package/Project.swift
@@ -6,7 +6,7 @@ let project = Project(
         .package(path: "Packages/PackageA"),
     ],
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -22,7 +22,7 @@ let project = Project(
                 .package(product: "LibraryA"),
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_templates/Project.swift
+++ b/fixtures/ios_app_with_templates/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -15,7 +15,7 @@ let project = Project(
                 // "Resources/**"
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_tests/Project.swift
+++ b/fixtures/ios_app_with_tests/Project.swift
@@ -11,7 +11,7 @@ let project = Project(
         )
     ),
     targets: [
-        Target(
+        .target(
             name: "AppCore",
             destinations: [.iPhone],
             product: .framework,
@@ -20,7 +20,7 @@ let project = Project(
             infoPlist: .default,
             sources: .paths([.relativeToManifest("AppCore/Sources/**")])
         ),
-        Target(
+        .target(
             name: "AppCoreTests",
             destinations: [.iPhone],
             product: .unitTests,
@@ -32,7 +32,7 @@ let project = Project(
                 .target(name: "AppCore"),
             ]
         ),
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -47,7 +47,7 @@ let project = Project(
                 "CODE_SIGNING_REQUIRED": "NO",
             ])
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,
@@ -62,7 +62,7 @@ let project = Project(
                 "CODE_SIGNING_REQUIRED": "NO",
             ])
         ),
-        Target(
+        .target(
             name: "MacFramework",
             destinations: [.mac],
             product: .framework,
@@ -75,7 +75,7 @@ let project = Project(
                 "CODE_SIGNING_REQUIRED": "NO",
             ])
         ),
-        Target(
+        .target(
             name: "MacFrameworkTests",
             destinations: [.mac],
             product: .unitTests,
@@ -91,7 +91,7 @@ let project = Project(
                 "CODE_SIGNING_REQUIRED": "NO",
             ])
         ),
-        Target(
+        .target(
             name: "AppUITests",
             destinations: .iOS,
             product: .uiTests,
@@ -102,7 +102,7 @@ let project = Project(
                 .target(name: "App"),
             ]
         ),
-        Target(
+        .target(
             name: "App-dash",
             destinations: .iOS,
             product: .app,
@@ -118,7 +118,7 @@ let project = Project(
                 "CODE_SIGNING_REQUIRED": "NO",
             ])
         ),
-        Target(
+        .target(
             name: "App-dashUITests",
             destinations: .iOS,
             product: .uiTests,

--- a/fixtures/ios_app_with_transitive_framework/App/Project.swift
+++ b/fixtures/ios_app_with_transitive_framework/App/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "MainApp",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -14,7 +14,7 @@ let project = Project(
                 .project(target: "Framework1-iOS", path: "../Framework1"),
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,
@@ -25,7 +25,7 @@ let project = Project(
                 .target(name: "App"),
             ]
         ),
-        Target(
+        .target(
             name: "AppUITests",
             destinations: .iOS,
             product: .uiTests,

--- a/fixtures/ios_app_with_transitive_framework/Framework1/Project.swift
+++ b/fixtures/ios_app_with_transitive_framework/Framework1/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework1",
     targets: [
-        Target(
+        .target(
             name: "Framework1-iOS",
             destinations: .iOS,
             product: .framework,
@@ -15,7 +15,7 @@ let project = Project(
                 .framework(path: "../Framework2/prebuilt/iOS/Framework2.framework"),
             ]
         ),
-        Target(
+        .target(
             name: "Framework1-macOS",
             destinations: [.mac],
             product: .framework,
@@ -27,7 +27,7 @@ let project = Project(
                 .framework(path: "../Framework2/prebuilt/Mac/Framework2.framework"),
             ]
         ),
-        Target(
+        .target(
             name: "Framework1Tests-iOS",
             destinations: .iOS,
             product: .unitTests,
@@ -38,7 +38,7 @@ let project = Project(
                 .target(name: "Framework1-iOS"),
             ]
         ),
-        Target(
+        .target(
             name: "Framework1Tests-macOS",
             destinations: [.mac],
             product: .unitTests,

--- a/fixtures/ios_app_with_transitive_framework/Framework2/Project.swift
+++ b/fixtures/ios_app_with_transitive_framework/Framework2/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework2",
     targets: [
-        Target(
+        .target(
             name: "Framework2-iOS",
             destinations: .iOS,
             product: .framework,
@@ -15,7 +15,7 @@ let project = Project(
             ],
             settings: .settings(base: ["BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"])
         ),
-        Target(
+        .target(
             name: "Framework2-macOS",
             destinations: [.mac],
             product: .framework,

--- a/fixtures/ios_app_with_transitive_framework/StaticFramework1/Project.swift
+++ b/fixtures/ios_app_with_transitive_framework/StaticFramework1/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "StaticFramework1",
     targets: [
-        Target(
+        .target(
             name: "StaticFramework1",
             destinations: .iOS,
             product: .staticFramework,
@@ -14,7 +14,7 @@ let project = Project(
                 .framework(path: "../Framework2/prebuilt/iOS/Framework2.framework"),
             ]
         ),
-        Target(
+        .target(
             name: "StaticFramework1Tests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_transitive_project/App/Project.swift
+++ b/fixtures/ios_app_with_transitive_project/App/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "MainApp",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -15,7 +15,7 @@ let project = Project(
                 .project(target: "FrameworkA-iOS", path: "../FrameworkA"),
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,
@@ -26,7 +26,7 @@ let project = Project(
                 .target(name: "App"),
             ]
         ),
-        Target(
+        .target(
             name: "AppUITests",
             destinations: .iOS,
             product: .uiTests,

--- a/fixtures/ios_app_with_transitive_project/Framework1/Project.swift
+++ b/fixtures/ios_app_with_transitive_project/Framework1/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework1",
     targets: [
-        Target(
+        .target(
             name: "Framework1-iOS",
             destinations: .iOS,
             product: .staticFramework,
@@ -15,7 +15,7 @@ let project = Project(
                 .project(target: "Framework2-iOS", path: "../Framework2"),
             ]
         ),
-        Target(
+        .target(
             name: "Framework1-macOS",
             destinations: [.mac],
             product: .framework,
@@ -27,7 +27,7 @@ let project = Project(
                 .project(target: "Framework2-macOS", path: "../Framework2"),
             ]
         ),
-        Target(
+        .target(
             name: "Framework1Tests-iOS",
             destinations: .iOS,
             product: .unitTests,
@@ -38,7 +38,7 @@ let project = Project(
                 .target(name: "Framework1-iOS"),
             ]
         ),
-        Target(
+        .target(
             name: "Framework1Tests-macOS",
             destinations: [.mac],
             product: .unitTests,

--- a/fixtures/ios_app_with_transitive_project/Framework2/Project.swift
+++ b/fixtures/ios_app_with_transitive_project/Framework2/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Framework2",
     targets: [
-        Target(
+        .target(
             name: "Framework2-iOS",
             destinations: .iOS,
             product: .staticFramework,
@@ -14,7 +14,7 @@ let project = Project(
             dependencies: [
             ]
         ),
-        Target(
+        .target(
             name: "Framework2-macOS",
             destinations: [.mac],
             product: .framework,

--- a/fixtures/ios_app_with_transitive_project/FrameworkA/Project.swift
+++ b/fixtures/ios_app_with_transitive_project/FrameworkA/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "FrameworkA",
     targets: [
-        Target(
+        .target(
             name: "FrameworkA-iOS",
             destinations: .iOS,
             product: .staticFramework,
@@ -15,7 +15,7 @@ let project = Project(
                 .project(target: "FrameworkB-iOS", path: "../FrameworkB"),
             ]
         ),
-        Target(
+        .target(
             name: "FrameworkA-macOS",
             destinations: [.mac],
             product: .framework,

--- a/fixtures/ios_app_with_transitive_project/FrameworkB/Project.swift
+++ b/fixtures/ios_app_with_transitive_project/FrameworkB/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "FrameworkB",
     targets: [
-        Target(
+        .target(
             name: "FrameworkB-iOS",
             destinations: .iOS,
             product: .staticFramework,
@@ -15,7 +15,7 @@ let project = Project(
                 .project(target: "FrameworkC-iOS", path: "../FrameworkC"),
             ]
         ),
-        Target(
+        .target(
             name: "FrameworkB-macOS",
             destinations: [.mac],
             product: .framework,

--- a/fixtures/ios_app_with_transitive_project/FrameworkC/Project.swift
+++ b/fixtures/ios_app_with_transitive_project/FrameworkC/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "FrameworkC",
     targets: [
-        Target(
+        .target(
             name: "FrameworkC-iOS",
             destinations: .iOS,
             product: .staticFramework,
@@ -13,7 +13,7 @@ let project = Project(
             sources: "Sources/**",
             dependencies: []
         ),
-        Target(
+        .target(
             name: "FrameworkC-macOS",
             destinations: [.mac],
             product: .framework,

--- a/fixtures/ios_app_with_watch_application/Project.swift
+++ b/fixtures/ios_app_with_watch_application/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "AppWithWatchApp",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -20,14 +20,14 @@ let project = Project(
                 .target(name: "Framework_a_ios"),
             ]
         ),
-        Target(
+        .target(
             name: "Framework_a_ios",
             destinations: .iOS,
             product: .framework,
             productName: "FrameworkA",
             bundleId: "io.tuist.framework.a"
         ),
-        Target(
+        .target(
             name: "Framework_a_watchos",
             destinations: [.appleWatch],
             product: .framework,
@@ -36,7 +36,7 @@ let project = Project(
         ),
         // In Xcode 14, watch application can now leverage the `.app` product type
         // rather than the previous `.watch2App` type
-        Target(
+        .target(
             name: "WatchApp",
             destinations: [.appleWatch],
             product: .app,
@@ -62,7 +62,7 @@ let project = Project(
                 ]
             )
         ),
-        Target(
+        .target(
             name: "WatchWidgetExtension",
             destinations: [.appleWatch],
             product: .appExtension,
@@ -79,7 +79,7 @@ let project = Project(
                 .target(name: "Framework_a_watchos"),
             ]
         ),
-        Target(
+        .target(
             name: "WatchAppTests",
             destinations: [.appleWatch],
             product: .unitTests,

--- a/fixtures/ios_app_with_watchapp2/Project.swift
+++ b/fixtures/ios_app_with_watchapp2/Project.swift
@@ -6,7 +6,7 @@ let project = Project(
         .package(path: "Packages/LibraryA"),
     ],
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -24,7 +24,7 @@ let project = Project(
                 .package(product: "LibraryA"),
             ]
         ),
-        Target(
+        .target(
             name: "WatchApp",
             destinations: [.appleWatch],
             product: .watch2App,
@@ -35,7 +35,7 @@ let project = Project(
                 .target(name: "WatchAppExtension"),
             ]
         ),
-        Target(
+        .target(
             name: "WatchAppExtension",
             destinations: [.appleWatch],
             product: .watch2Extension,
@@ -49,7 +49,7 @@ let project = Project(
                 .package(product: "LibraryA"),
             ]
         ),
-        Target(
+        .target(
             name: "WatchAppUITests",
             destinations: [.appleWatch],
             product: .uiTests,

--- a/fixtures/ios_app_with_watchapp2_xcode14/Project.swift
+++ b/fixtures/ios_app_with_watchapp2_xcode14/Project.swift
@@ -6,7 +6,7 @@ let project = Project(
         .package(path: "Packages/LibraryA"),
     ],
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -24,7 +24,7 @@ let project = Project(
                 .package(product: "LibraryA"),
             ]
         ),
-        Target(
+        .target(
             name: "WatchApp",
             platform: .watchOS,
             product: .watch2App,
@@ -35,7 +35,7 @@ let project = Project(
                 .target(name: "WatchAppExtension"),
             ]
         ),
-        Target(
+        .target(
             name: "WatchAppExtension",
             platform: .watchOS,
             product: .watch2Extension,
@@ -50,7 +50,7 @@ let project = Project(
                 .target(name: "WatchAppWidgetExtension"),
             ]
         ),
-        Target(
+        .target(
             name: "WatchAppWidgetExtension",
             platform: .watchOS,
             product: .appExtension,
@@ -67,7 +67,7 @@ let project = Project(
                 .sdk(name: "SwiftUI", type: .framework, status: .required),
             ]
         ),
-        Target(
+        .target(
             name: "WatchAppUITests",
             platform: .watchOS,
             product: .uiTests,

--- a/fixtures/ios_app_with_xcframeworks/Modules/StaticFrameworkA/Project.swift
+++ b/fixtures/ios_app_with_xcframeworks/Modules/StaticFrameworkA/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "StaticFrameworkA",
     targets: [
-        Target(
+        .target(
             name: "StaticFrameworkA",
             destinations: .iOS,
             product: .staticFramework,

--- a/fixtures/ios_app_with_xcframeworks/Modules/StaticFrameworkB/Project.swift
+++ b/fixtures/ios_app_with_xcframeworks/Modules/StaticFrameworkB/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "StaticFrameworkB",
     targets: [
-        Target(
+        .target(
             name: "StaticFrameworkB",
             destinations: .iOS,
             product: .staticFramework,

--- a/fixtures/ios_app_with_xcframeworks/Project.swift
+++ b/fixtures/ios_app_with_xcframeworks/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -22,7 +22,7 @@ let project = Project(
                 "BITCODE_ENABLED": "NO",
             ])
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_xcframeworks/XCFrameworks/MyFramework/Project.swift
+++ b/fixtures/ios_app_with_xcframeworks/XCFrameworks/MyFramework/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "MyFramework",
     targets: [
-        Target(
+        .target(
             name: "MyFramework",
             destinations: .iOS,
             product: .framework,
@@ -22,7 +22,7 @@ let project = Project(
                 "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES",
             ])
         ),
-        Target(
+        .target(
             name: "MyFrameworkTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_app_with_xcframeworks/XCFrameworks/MyStaticFramework/Project.swift
+++ b/fixtures/ios_app_with_xcframeworks/XCFrameworks/MyStaticFramework/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "MyStaticFramework",
     targets: [
-        Target(
+        .target(
             name: "MyStaticFramework",
             destinations: .iOS,
             product: .staticFramework,

--- a/fixtures/ios_app_with_xcframeworks/XCFrameworks/MyStaticLibrary/Project.swift
+++ b/fixtures/ios_app_with_xcframeworks/XCFrameworks/MyStaticLibrary/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "MyStaticLibrary",
     targets: [
-        Target(
+        .target(
             name: "MyStaticLibrary",
             destinations: .iOS,
             product: .staticLibrary,

--- a/fixtures/ios_workspace_with_dependency_cycle/App/Project.swift
+++ b/fixtures/ios_workspace_with_dependency_cycle/App/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -20,7 +20,7 @@ let project = Project(
                 .project(target: "FrameworkA", path: "../Frameworks/FrameworkA"),
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkA/Project.swift
+++ b/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkA/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "FrameworkA",
     targets: [
-        Target(
+        .target(
             name: "FrameworkA",
             destinations: .iOS,
             product: .framework,
@@ -20,7 +20,7 @@ let project = Project(
                 .project(target: "FrameworkB", path: "../FrameworkB"),
             ]
         ),
-        Target(
+        .target(
             name: "FrameworkATests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkB/Project.swift
+++ b/fixtures/ios_workspace_with_dependency_cycle/Frameworks/FrameworkB/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "FrameworkB",
     targets: [
-        Target(
+        .target(
             name: "FrameworkB",
             destinations: .iOS,
             product: .framework,
@@ -20,7 +20,7 @@ let project = Project(
                 .project(target: "FrameworkA", path: "../FrameworkA"),
             ]
         ),
-        Target(
+        .target(
             name: "FrameworkBTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/CoreFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/CoreFramework/Project.swift
@@ -4,7 +4,7 @@ import ProjectDescription
 let project = Project(
     name: "Core",
     targets: [
-        Target(
+        .target(
             name: "Core",
             destinations: .iOS,
             product: .framework,
@@ -16,7 +16,7 @@ let project = Project(
                 // "Resources/**"
             ]
         ),
-        Target(
+        .target(
             name: "CoreTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/DataFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/DataFramework/Project.swift
@@ -4,7 +4,7 @@ import ProjectDescription
 let project = Project(
     name: "Data",
     targets: [
-        Target(
+        .target(
             name: "Data",
             destinations: .iOS,
             product: .framework,
@@ -21,7 +21,7 @@ let project = Project(
                 .project(target: "Core", path: "../CoreFramework"),
             ]
         ),
-        Target(
+        .target(
             name: "DataTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureAFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureAFramework/Project.swift
@@ -4,7 +4,7 @@ import ProjectDescription
 let project = Project(
     name: "FrameworkA",
     targets: [
-        Target(
+        .target(
             name: "FrameworkA",
             destinations: .iOS,
             product: .framework,
@@ -24,7 +24,7 @@ let project = Project(
                 .project(target: "UIComponents", path: "../UIComponentsFramework"),
             ]
         ),
-        Target(
+        .target(
             name: "FrameworkATests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureContracts/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/FeatureContracts/Project.swift
@@ -4,7 +4,7 @@ import ProjectDescription
 let project = Project(
     name: "FeatureContracts",
     targets: [
-        Target(
+        .target(
             name: "FeatureContracts",
             destinations: .iOS,
             product: .framework,
@@ -22,7 +22,7 @@ let project = Project(
                 .project(target: "Core", path: "../CoreFramework"),
             ]
         ),
-        Target(
+        .target(
             name: "FeatureContractsTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/UIComponentsFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Frameworks/UIComponentsFramework/Project.swift
@@ -4,7 +4,7 @@ import ProjectDescription
 let project = Project(
     name: "UIComponents",
     targets: [
-        Target(
+        .target(
             name: "UIComponents",
             destinations: .iOS,
             product: .framework,
@@ -21,7 +21,7 @@ let project = Project(
                 .project(target: "FeatureContracts", path: "../FeatureContracts"),
             ]
         ),
-        Target(
+        .target(
             name: "UIComponentsTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_workspace_with_microfeature_architecture/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture/Project.swift
@@ -4,7 +4,7 @@ import ProjectDescription
 let project = Project(
     name: "App",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -21,7 +21,7 @@ let project = Project(
                 .project(target: "FrameworkA", path: "Frameworks/FeatureAFramework"),
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/CoreFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/CoreFramework/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Core",
     targets: [
-        Target(
+        .target(
             name: "Core",
             destinations: .iOS,
             product: .staticFramework,
@@ -15,7 +15,7 @@ let project = Project(
                 // "Resources/**"
             ]
         ),
-        Target(
+        .target(
             name: "CoreTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/DataFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/DataFramework/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Data",
     targets: [
-        Target(
+        .target(
             name: "Data",
             destinations: .iOS,
             product: .staticFramework,
@@ -20,7 +20,7 @@ let project = Project(
                 .project(target: "Core", path: "../CoreFramework"),
             ]
         ),
-        Target(
+        .target(
             name: "DataTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/FeatureAFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/FeatureAFramework/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "FrameworkA",
     targets: [
-        Target(
+        .target(
             name: "FrameworkA",
             destinations: .iOS,
             product: .staticFramework,
@@ -23,7 +23,7 @@ let project = Project(
                 .project(target: "UIComponents", path: "../UIComponentsFramework"),
             ]
         ),
-        Target(
+        .target(
             name: "FrameworkATests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/FeatureContracts/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/FeatureContracts/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "FeatureContracts",
     targets: [
-        Target(
+        .target(
             name: "FeatureContracts",
             destinations: .iOS,
             product: .staticFramework,
@@ -21,7 +21,7 @@ let project = Project(
                 .project(target: "Core", path: "../CoreFramework"),
             ]
         ),
-        Target(
+        .target(
             name: "FeatureContractsTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/UIComponentsFramework/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture_static_linking/Frameworks/UIComponentsFramework/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "UIComponents",
     targets: [
-        Target(
+        .target(
             name: "UIComponents",
             destinations: .iOS,
             product: .staticFramework,
@@ -20,7 +20,7 @@ let project = Project(
                 .project(target: "FeatureContracts", path: "../FeatureContracts"),
             ]
         ),
-        Target(
+        .target(
             name: "UIComponentsTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/ios_workspace_with_microfeature_architecture_static_linking/StaticApp/Project.swift
+++ b/fixtures/ios_workspace_with_microfeature_architecture_static_linking/StaticApp/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "StaticApp",
     targets: [
-        Target(
+        .target(
             name: "StaticApp",
             destinations: .iOS,
             product: .app,
@@ -20,7 +20,7 @@ let project = Project(
                 .project(target: "FrameworkA", path: "../Frameworks/FeatureAFramework"),
             ]
         ),
-        Target(
+        .target(
             name: "StaticAppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/macos_app_with_app_inside/Project.swift
+++ b/fixtures/macos_app_with_app_inside/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Embedded App",
     targets: [
-        Target(
+        .target(
             name: "MainApp",
             destinations: [.mac],
             product: .app,
@@ -18,7 +18,7 @@ let project = Project(
                 .target(name: "InnerCLI"),
             ]
         ),
-        Target(
+        .target(
             name: "InnerApp",
             destinations: [.mac],
             product: .app,
@@ -26,7 +26,7 @@ let project = Project(
             infoPlist: "InnerApp/Info.plist",
             sources: ["InnerApp/Sources/**"]
         ),
-        Target(
+        .target(
             name: "InnerCLI",
             destinations: [.mac],
             product: .commandLineTool,

--- a/fixtures/macos_app_with_copy_files/Project.swift
+++ b/fixtures/macos_app_with_copy_files/Project.swift
@@ -1,7 +1,7 @@
 import ProjectDescription
 
 func target(name: String) -> Target {
-    Target(
+    .target(
         name: name,
         destinations: [.mac],
         product: .app,

--- a/fixtures/macos_app_with_extensions/Project.swift
+++ b/fixtures/macos_app_with_extensions/Project.swift
@@ -15,7 +15,7 @@ let workflowExtensionSettings: SettingsDictionary = [
 let project = Project(
     name: "App",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: [.mac],
             product: .app,
@@ -24,7 +24,7 @@ let project = Project(
             sources: "App/**",
             dependencies: [.target(name: "Workflow")]
         ),
-        Target(
+        .target(
             name: "Workflow",
             destinations: [.mac],
             product: .appExtension,

--- a/fixtures/macos_app_with_system_extension/Project.swift
+++ b/fixtures/macos_app_with_system_extension/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App with SystemExtension",
     targets: [
-        Target(
+        .target(
             name: "MainApp",
             destinations: [.mac],
             product: .app,
@@ -14,7 +14,7 @@ let project = Project(
                 .target(name: "SystemExtension"),
             ]
         ),
-        Target(
+        .target(
             name: "SystemExtension",
             destinations: [.mac],
             product: .systemExtension,

--- a/fixtures/macos_app_with_xpc/Project.swift
+++ b/fixtures/macos_app_with_xpc/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App with XPC",
     targets: [
-        Target(
+        .target(
             name: "MainApp",
             destinations: [.mac],
             product: .app,
@@ -14,7 +14,7 @@ let project = Project(
                 .target(name: "XPCApp"),
             ]
         ),
-        Target(
+        .target(
             name: "XPCApp",
             destinations: [.mac],
             product: .xpc,
@@ -25,14 +25,14 @@ let project = Project(
                 .target(name: "StaticFramework"),
             ]
         ),
-        Target(
+        .target(
             name: "DynamicFramework",
             destinations: [.mac],
             product: .framework,
             bundleId: "io.tuist.DynamicFramework",
             sources: ["DynamicFramework/Sources/**"]
         ),
-        Target(
+        .target(
             name: "StaticFramework",
             destinations: [.mac],
             product: .staticFramework,

--- a/fixtures/manifest_with_logs/Project.swift
+++ b/fixtures/manifest_with_logs/Project.swift
@@ -2,7 +2,7 @@ import ProjectDescription
 
 func target(name: String) -> Target {
     print("Target name - \(name)")
-    return Target(
+    return .target(
         name: name,
         destinations: [.mac],
         product: .app,

--- a/fixtures/multiplatform_app_with_extension/Project.swift
+++ b/fixtures/multiplatform_app_with_extension/Project.swift
@@ -1,6 +1,6 @@
 import ProjectDescription
 
-let appTarget = Target(
+let appTarget: Target = .target(
     name: "App",
     destinations: [.iPhone, .iPad, .appleVision],
     product: .app,
@@ -13,7 +13,7 @@ let appTarget = Target(
     ]
 )
 
-let widgetExtensionTarget = Target(
+let widgetExtensionTarget: Target = .target(
     name: "WidgetExtension",
     destinations: [.iPhone, .iPad],
     product: .appExtension,
@@ -28,7 +28,7 @@ let widgetExtensionTarget = Target(
     resources: "Extensions/WidgetExtension/Resources/**"
 )
 
-let watchApp = Target(
+let watchApp: Target = .target(
     name: "WatchApp",
     destinations: [.appleWatch],
     product: .app,

--- a/fixtures/multiplatform_app_with_sdk/Modules/StaticFramework/Project.swift
+++ b/fixtures/multiplatform_app_with_sdk/Modules/StaticFramework/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "StaticFramework",
     targets: [
-        Target(
+        .target(
             name: "StaticFramework",
             destinations: .iOS,
             product: .staticFramework,
@@ -15,7 +15,7 @@ let project = Project(
                 .sdk(name: "c++", type: .library),
             ]
         ),
-        Target(
+        .target(
             name: "StaticFrameworkTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/multiplatform_app_with_sdk/Project.swift
+++ b/fixtures/multiplatform_app_with_sdk/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "Project",
     targets: [
-        Target(
+        .target(
             name: "MyTestFramework",
             destinations: .iOS,
             product: .framework,
@@ -14,7 +14,7 @@ let project = Project(
                 .xctest,
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,
@@ -26,7 +26,7 @@ let project = Project(
                 .target(name: "MyTestFramework"),
             ]
         ),
-        Target(
+        .target(
             name: "App",
             destinations: [.iPhone, .iPad, .mac],
             product: .app,
@@ -41,7 +41,7 @@ let project = Project(
                 .sdk(name: "MobileCoreServices", type: .framework, status: .required, condition: .when([.ios])),
             ]
         ),
-        Target(
+        .target(
             name: "MultiPlatformFramework",
             destinations: [.iPad, .iPhone, .mac, .appleTv],
             product: .framework,

--- a/fixtures/tvos_app_with_extensions/Project.swift
+++ b/fixtures/tvos_app_with_extensions/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: [.appleTv],
             product: .app,
@@ -14,7 +14,7 @@ let project = Project(
                 .target(name: "TopShelfExtension"),
             ]
         ),
-        Target(
+        .target(
             name: "TopShelfExtension",
             destinations: [.appleTv],
             product: .tvTopShelfExtension,
@@ -30,7 +30,7 @@ let project = Project(
             dependencies: [
             ]
         ),
-        Target(
+        .target(
             name: "StaticFramework",
             destinations: .iOS,
             product: .staticFramework,

--- a/fixtures/tvos_app_with_uitest/Project.swift
+++ b/fixtures/tvos_app_with_uitest/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: [.appleTv],
             product: .app,
@@ -12,7 +12,7 @@ let project = Project(
             infoPlist: .default,
             sources: .paths([.relativeToManifest("App/Sources/**")])
         ),
-        Target(
+        .target(
             name: "AppUITests",
             destinations: [.appleTv],
             product: .uiTests,

--- a/fixtures/visionos_app/Project.swift
+++ b/fixtures/visionos_app/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "App",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: [.appleVision],
             product: .app,
@@ -15,7 +15,7 @@ let project = Project(
                 // "Resources/**"
             ]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: [.appleVision],
             product: .unitTests,

--- a/fixtures/workspace_with_multiple_projects/ProjectA/Project.swift
+++ b/fixtures/workspace_with_multiple_projects/ProjectA/Project.swift
@@ -4,7 +4,7 @@ let project = Project(
     name: "ProjectA",
     organizationName: "tuist.io",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: .iOS,
             product: .app,
@@ -13,7 +13,7 @@ let project = Project(
             infoPlist: .default,
             sources: ["Targets/App/Sources/**"]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,

--- a/fixtures/workspace_with_multiple_projects/ProjectB/Project.swift
+++ b/fixtures/workspace_with_multiple_projects/ProjectB/Project.swift
@@ -4,7 +4,7 @@ let project = Project(
     name: "ProjectB",
     organizationName: "tuist.io",
     targets: [
-        Target(
+        .target(
             name: "App",
             destinations: [.iPhone],
             product: .app,
@@ -13,7 +13,7 @@ let project = Project(
             infoPlist: .default,
             sources: ["Targets/App/Sources/**"]
         ),
-        Target(
+        .target(
             name: "AppTests",
             destinations: .iOS,
             product: .unitTests,


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5714

### Short description 📝

We're making all constructors of `ProjectDescription` models internal in favor of public static constructors with the exception of:
- Top-level models like `Project` (any that needs to run `dumpIfNeeded`) -> this convention is inline with `PackageDescription` and imho makes sense

### How to test the changes locally 🧐

CI should pass

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
