### PR TITLE
Fix false static side effect positives when the project contains Swift Macros

### DIFF
--- a/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/StaticProductsGraphLinter.swift
@@ -228,6 +228,10 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
             // System Extension can safely link the same static products as apps
             // as they are an independent product
             return false
+        case (_, .macro):
+            // Macro executables can safely link the same static products as the targets
+            // depending on the executable's parent target (e.g. framework or library).
+            return false
         default:
             return true
         }


### PR DESCRIPTION
### Short description 📝
The logic to detect potential side effects when using static artifacts was not accounting for Swift Macros causing false positives. I adjusted the logic to skip the edge `Any product (to) Any macro product`.

### How to test the changes locally 🧐
You can run `generate` against the fixture `framework_with_native_swift_macro` and get no warnings.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
