### PR TITLE
Fix failing unit tests due to not properly decoding module aliases

### DIFF
--- a/Sources/TuistSupportTesting/SwiftPackageManager/PackageInfo+TestData.swift
+++ b/Sources/TuistSupportTesting/SwiftPackageManager/PackageInfo+TestData.swift
@@ -111,6 +111,7 @@ extension PackageInfo {
                   "product" : [
                     "ALibrary",
                     "a-dependency",
+                    null,
                     {
                       "platformNames" : [
                         "ios"
@@ -225,6 +226,7 @@ extension PackageInfo {
                   "product" : [
                     "AnotherLibrary",
                     "another-dependency",
+                    null,
                     null
                   ]
                 }
@@ -378,6 +380,7 @@ extension PackageInfo {
                   "product" : [
                     "ALibrary",
                     "a-dependency",
+                    null,
                     {
                       "platformNames" : [
                         "ios"
@@ -504,6 +507,7 @@ extension PackageInfo {
                   "product" : [
                     "AnotherLibrary",
                     "another-dependency",
+                    null,
                     null
                   ]
                 }
@@ -1034,6 +1038,7 @@ extension PackageInfo {
                   "product" : [
                     "GULAppDelegateSwizzler",
                     "GoogleUtilities",
+                    null,
                     null
                   ]
                 },
@@ -1041,6 +1046,7 @@ extension PackageInfo {
                   "product" : [
                     "GULMethodSwizzler",
                     "GoogleUtilities",
+                    null,
                     null
                   ]
                 },
@@ -1048,6 +1054,7 @@ extension PackageInfo {
                   "product" : [
                     "GULNSData",
                     "GoogleUtilities",
+                    null,
                     null
                   ]
                 },
@@ -1055,6 +1062,7 @@ extension PackageInfo {
                   "product" : [
                     "GULNetwork",
                     "GoogleUtilities",
+                    null,
                     null
                   ]
                 },
@@ -1062,6 +1070,7 @@ extension PackageInfo {
                   "product" : [
                     "nanopb",
                     "nanopb",
+                    null,
                     null
                   ]
                 }
@@ -1136,6 +1145,7 @@ extension PackageInfo {
                   "product" : [
                     "GULAppDelegateSwizzler",
                     "GoogleUtilities",
+                    null,
                     null
                   ]
                 },
@@ -1143,6 +1153,7 @@ extension PackageInfo {
                   "product" : [
                     "GULMethodSwizzler",
                     "GoogleUtilities",
+                    null,
                     null
                   ]
                 },
@@ -1150,6 +1161,7 @@ extension PackageInfo {
                   "product" : [
                     "GULNSData",
                     "GoogleUtilities",
+                    null,
                     null
                   ]
                 },
@@ -1157,6 +1169,7 @@ extension PackageInfo {
                   "product" : [
                     "GULNetwork",
                     "GoogleUtilities",
+                    null,
                     null
                   ]
                 },
@@ -1164,6 +1177,7 @@ extension PackageInfo {
                   "product" : [
                     "nanopb",
                     "nanopb",
+                    null,
                     null
                   ]
                 }


### PR DESCRIPTION
### Short description 📝

[This](https://github.com/tuist/tuist/pull/5846) caused `main` to start failing due to a unit test where the decoding of `PackageInfo` was failing because of missing `moduleAliases`

### How to test the changes locally 🧐

CI should pass

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
