### PR TITLE
Remove the comment about the tuist-cloud CLI

### DIFF
--- a/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/installation.md
+++ b/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/installation.md
@@ -100,8 +100,6 @@ jobs:
 
 > Tip: We recommend using `mise use --pin` in your Tuist projects to pin the version of Tuist across environments. The command will create a `.tool-versions` file containing the version of Tuist.
 
-> Important: **Tuist Cloud** (<doc:tuist-cloud>), a closed-source extension of Tuist with optimizations such as binary caching and selective testing, is distributed as a different asdf plugin, tuist-cloud. Note that by using it, you agree to the [Tuist Cloud Terms of Service](https://tuist.io/terms/).
-
 ### Alternative: Homebrew
 
 If version pinning across environments is not a concern for you,


### PR DESCRIPTION
### Short description 📝
We won't distribute `tuist-cloud` as a different CLI and therefore I'm removing that piece from the documentation.
