### PR TITLE
Fix install script

### DIFF
--- a/script/install
+++ b/script/install
@@ -20,8 +20,9 @@ warn() {
   printf "${tty_red}Warning${tty_reset}: %s\n" "$(chomp "$1")"
 }
 
-# The line below extracts the version from the list of tags in the Tuist repository.
-LATEST_VERSION=$(git ls-remote -t --sort=v:refname https://github.com/tuist/tuist.git | sed -ne '$s/.*tags\/\(.*\)/\1/p')
+# The line below extracts the latest 3.x version from the list of tags in the Tuist repository.
+# Tuist v3 is the last major to provide tuistenv.
+LATEST_VERSION=$(git ls-remote -t --sort=v:refname https://github.com/tuist/tuist.git | grep 'tags/3\.' | sed -ne '$s/.*tags\/\(.*\)/\1/p')
 ohai "Downloading tuistenv..."
 [ -f /tmp/tuistenv.zip ] && rm /tmp/tuistenv.zip
 [ -f /tmp/tuistenv ] && rm /tmp/tuistenv


### PR DESCRIPTION
### Short description 📝

Since tagging the first beta of Tuist 4.0.0 the install script is broken, because it always tries to install `tuistenv` from the latest git tag. However, `tuistenv` is only available in v3 tags.

This PR fixes the install script to only consider v3 tags.

### How to test the changes locally 🧐

1. Clone the repository.
1. Run `./script/install`.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
