### PR TITLE
Fix running tuist clean without a specific category

### DIFF
--- a/Sources/TuistKit/Commands/CleanCommand.swift
+++ b/Sources/TuistKit/Commands/CleanCommand.swift
@@ -13,7 +13,7 @@ public struct CleanCommand<T: CleanCategory>: ParsableCommand {
     }
 
     @Argument(help: "The cache and artifact categories to be cleaned. If no category is specified, everything is cleaned.")
-    var cleanCategories: [T]
+    var cleanCategories: [T] = T.allCases.map { $0 }
 
     @Option(
         name: .shortAndLong,


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/5867

### Short description 📝

Fixes running `tuist clean` without specifying a category.

### How to test the changes locally 🧐

Run `tuist clean`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
