### PR TITLE
Fix tuist clean dependencies

### DIFF
--- a/Sources/TuistKit/Services/CleanService.swift
+++ b/Sources/TuistKit/Services/CleanService.swift
@@ -42,10 +42,9 @@ public enum TuistCleanCategory: CleanCategory {
         case let .global(category):
             return CacheDirectoriesProvider.tuistCacheDirectory(for: category, cacheDirectory: cacheDirectory)
         case .dependencies:
-            return rootDirectory?.appending(components: [
-                Constants.tuistDirectoryName,
-                Constants.SwiftPackageManager.packageBuildDirectoryName,
-            ])
+            return rootDirectory?.appending(
+                component: Constants.SwiftPackageManager.packageBuildDirectoryName
+            )
         }
     }
 }

--- a/Tests/TuistKitTests/Services/CleanServiceTests.swift
+++ b/Tests/TuistKitTests/Services/CleanServiceTests.swift
@@ -48,6 +48,20 @@ final class CleanServiceTests: TuistUnitTestCase {
         XCTAssertTrue(FileHandler.shared.exists(cachePaths[1]))
     }
 
+    func test_run_with_dependencies_cleans_dependencies() throws {
+        // Given
+        let localPaths = try createFolders([".build", "Tuist/ProjectDescriptionHelpers"])
+
+        rootDirectoryLocator.locateStub = localPaths[0].parentDirectory
+
+        // When
+        try subject.run(categories: [TuistCleanCategory.dependencies], path: nil)
+
+        // Then
+        XCTAssertFalse(FileHandler.shared.exists(localPaths[0]))
+        XCTAssertTrue(FileHandler.shared.exists(localPaths[1]))
+    }
+
     func test_run_without_category_cleans_all() throws {
         // Given
         let cachePaths = try createFolders(["tuist/Manifests"])

--- a/Tests/TuistKitTests/Services/CleanServiceTests.swift
+++ b/Tests/TuistKitTests/Services/CleanServiceTests.swift
@@ -72,7 +72,7 @@ final class CleanServiceTests: TuistUnitTestCase {
         let projectPath = try temporaryPath()
         rootDirectoryLocator.locateStub = projectPath
         let swiftPackageManagerBuildPath = projectPath.appending(
-            components: Constants.tuistDirectoryName, Constants.SwiftPackageManager.packageBuildDirectoryName
+            components: Constants.SwiftPackageManager.packageBuildDirectoryName
         )
         try fileHandler.createFolder(swiftPackageManagerBuildPath)
 


### PR DESCRIPTION
### Short description 📝

`tuist clean dependencies` was cleaning the `path-to-root/Tuist/.build` directory instead of `path-to-root/.build`

### How to test the changes locally 🧐

`tuist clean dependencies` should clean the `.build` directory.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x]  The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
