### PR TITLE
Fix error message on missing dependencies

### DIFF
--- a/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -13,3 +13,19 @@ final class DependenciesAcceptanceTestAppWithSPMDependencies: TuistAcceptanceTes
         try await run(BuildCommand.self, "App")
     }
 }
+
+final class DependenciesAcceptanceTestAppWithSPMDependenciesWithoutInstall: TuistAcceptanceTestCase {
+    func test() async throws {
+        try setUpFixture(.appWithSpmDependencies)
+        do {
+            try await run(GenerateCommand.self)
+        } catch {
+            XCTAssertEqual(
+                (error as? FatalError)?.description,
+                "We could not find external dependencies. Run `tuist install` before you continue."
+            )
+            return
+        }
+        XCTFail("Generate should have failed.")
+    }
+}


### PR DESCRIPTION
### Short description 📝

If you run `tuist generate` and you have not installed your dependencies via `tuist install`, you will get a cryptic error that occurs when we try to read the `workspace-state.json` file:
```
We received an error that we couldn't handle:
    - Localized description: The file “workspace-state.json” couldn’t be opened because there is no such file.
    - Error: Error Domain=NSCocoaErrorDomain Code=260 "The file “workspace-state.json” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Users/marekfort/Developer/tuist/fixtures/app_with_spm_dependencies/.build/workspace-state.json, NSUnderlyingError=0x1294060f0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}

If you think it's a legit issue, please file an issue including the reproducible steps: https://github.com/tuist/tuist/issues/new/choose
Consider creating an issue using the following link: https://github.com/tuist/tuist/issues/new/choose
```

Instead, we should make sure the file exists and if not, we now throw the following message:
```
We could not find external dependencies. Run `tuist install` before you continue.
```

### How to test the changes locally 🧐

Run `tuist generate` with a project that has `Package.swift` but the dependencies have not been installed, yet.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
