### PR TITLE
Bump to xcbeautify 2.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -212,8 +212,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/cpisciotta/xcbeautify",
       "state" : {
-        "revision" : "82bc54c25c78284555759277d4d92fef5627f95e",
-        "version" : "1.6.0"
+        "revision" : "3140aa2d58063dbe30426cce118f8ba8feb37e60",
+        "version" : "2.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -421,7 +421,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit", exact: "2.10.1"),
         .package(url: "https://github.com/SwiftGen/SwiftGen", exact: "6.6.2"),
         .package(url: "https://github.com/tuist/XcodeProj", exact: "8.19.0"),
-        .package(url: "https://github.com/cpisciotta/xcbeautify", from: "1.6.0"),
+        .package(url: "https://github.com/cpisciotta/xcbeautify", exact: "2.0.1"),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", from: "1.0.2"),
         .package(url: "https://github.com/Kolos65/Mockable.git", from: "0.0.2"),
     ],

--- a/Sources/TuistAutomation/Utilities/Formatter.swift
+++ b/Sources/TuistAutomation/Utilities/Formatter.swift
@@ -8,18 +8,19 @@ protocol Formatting {
 }
 
 final class Formatter: Formatting {
-    private let parser: Parser
+    private let formatter: XCBeautifier
 
     init() {
-        parser = Parser(
+        formatter = XCBeautifier(
             colored: Environment.shared.shouldOutputBeColoured,
             renderer: Self.renderer(),
+            preserveUnbeautifiedLines: false,
             additionalLines: { nil }
         )
     }
 
     func format(_ line: String) -> String? {
-        parser.parse(line: line)
+        formatter.format(line: line)
     }
 
     private static func renderer() -> Renderer {


### PR DESCRIPTION
### Short description 📝

Bump to latest, major xcbeautify release.

### How to test the changes locally 🧐

xcodebuild output formats as expect.

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
