### PR TITLE
Support visionOS from the default templates to synthesize resources

### DIFF
--- a/Sources/TuistGenerator/Templates/FontsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/FontsTemplate.swift
@@ -10,7 +10,7 @@ extension SynthesizedResourceInterfaceTemplates {
     {% set fontType %}{{param.name}}FontConvertible{% endset %}
     #if os(macOS)
       import AppKit.NSFont
-    #elseif os(iOS) || os(tvOS) || os(watchOS) || vision(OS)
+    #elseif os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
       import UIKit.UIFont
     #endif
     #if canImport(SwiftUI)
@@ -55,7 +55,7 @@ extension SynthesizedResourceInterfaceTemplates {
 
       #if os(macOS)
       {{accessModifier}} typealias Font = NSFont
-      #elseif os(iOS) || os(tvOS) || os(watchOS) || vision(OS)
+      #elseif os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
       {{accessModifier}} typealias Font = UIFont
       #endif
 
@@ -74,7 +74,7 @@ extension SynthesizedResourceInterfaceTemplates {
         }
         #if os(macOS)
         return SwiftUI.Font.custom(font.fontName, size: font.pointSize)
-        #elseif os(iOS) || os(tvOS) || os(watchOS) || vision(OS)
+        #elseif os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
         return SwiftUI.Font(font)
         #endif
       }
@@ -98,7 +98,7 @@ extension SynthesizedResourceInterfaceTemplates {
 
     {{accessModifier}} extension {{fontType}}.Font {
       convenience init?(font: {{fontType}}, size: CGFloat) {
-        #if os(iOS) || os(tvOS) || os(watchOS) || vision(OS)
+        #if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
         if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
           font.register()
         }

--- a/Sources/TuistGenerator/Templates/FontsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/FontsTemplate.swift
@@ -10,7 +10,7 @@ extension SynthesizedResourceInterfaceTemplates {
     {% set fontType %}{{param.name}}FontConvertible{% endset %}
     #if os(macOS)
       import AppKit.NSFont
-    #elseif os(iOS) || os(tvOS) || os(watchOS)
+    #elseif os(iOS) || os(tvOS) || os(watchOS) || vision(OS)
       import UIKit.UIFont
     #endif
     #if canImport(SwiftUI)
@@ -55,7 +55,7 @@ extension SynthesizedResourceInterfaceTemplates {
 
       #if os(macOS)
       {{accessModifier}} typealias Font = NSFont
-      #elseif os(iOS) || os(tvOS) || os(watchOS)
+      #elseif os(iOS) || os(tvOS) || os(watchOS) || vision(OS)
       {{accessModifier}} typealias Font = UIFont
       #endif
 
@@ -74,7 +74,7 @@ extension SynthesizedResourceInterfaceTemplates {
         }
         #if os(macOS)
         return SwiftUI.Font.custom(font.fontName, size: font.pointSize)
-        #elseif os(iOS) || os(tvOS) || os(watchOS)
+        #elseif os(iOS) || os(tvOS) || os(watchOS) || vision(OS)
         return SwiftUI.Font(font)
         #endif
       }
@@ -98,7 +98,7 @@ extension SynthesizedResourceInterfaceTemplates {
 
     {{accessModifier}} extension {{fontType}}.Font {
       convenience init?(font: {{fontType}}, size: CGFloat) {
-        #if os(iOS) || os(tvOS) || os(watchOS)
+        #if os(iOS) || os(tvOS) || os(watchOS) || vision(OS)
         if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
           font.register()
         }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5891

### Short description 📝

Add check for VisionOS in the Font template

### How to test the changes locally 🧐

### Contributor checklist ✅

- [X] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [X] The title of the PR is formulated in a way that is usable as a changelog entry
- [X] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
