### PR TITLE
Targets can override their colors and shapes when rendered in graphs

### DIFF
--- a/Sources/ProjectDescription/GraphDefinition.swift
+++ b/Sources/ProjectDescription/GraphDefinition.swift
@@ -1,0 +1,44 @@
+//
+//  GraphDefinition.swift
+//  TuistGraph
+//
+//  Created by Stefano Mondino on 08/02/24.
+//
+
+import Foundation
+
+public struct GraphDefinition: Hashable, Equatable, CustomStringConvertible, CustomDebugStringConvertible, Codable {
+    
+    public enum Shape: String, Hashable, Codable {
+        case box, rectangle, square, circle, ellipse, point, egg, triangle, plaintext, plain, diamond, trapezium, parallelogram, house, hexagon, octagon, doublecircle, doubleoctagon, invtriangle, invtrapezium, invhouse, Mdiamond, Msquare, Mcircle, polygon, oval, star, cylinder, note, tab, folder, box3d, component, cds, signature
+    }
+    
+    public struct Color: Codable, ExpressibleByStringInterpolation, CustomStringConvertible, Equatable, Hashable {
+        public let description: String
+        public init(stringLiteral: String) {
+            self.description = stringLiteral
+        }
+        public init(_ value: String) {
+            self.description = value
+        }
+    }
+    
+    public var description: String { "" }
+    
+    public var debugDescription: String { "" }
+    
+    public var fillColor: Color
+    public var textColor: Color?
+    public var shape: Shape
+    public var strokeWidth: Double?
+    internal init(fillColor: GraphDefinition.Color,
+                  textColor: GraphDefinition.Color? = nil,
+                  strokeWidth: Double? = nil,
+                  shape: GraphDefinition.Shape) {
+        self.fillColor = fillColor
+        self.textColor = textColor
+        self.shape = shape
+    }
+    
+    
+}

--- a/Sources/ProjectDescription/GraphDefinition.swift
+++ b/Sources/ProjectDescription/GraphDefinition.swift
@@ -1,44 +1,71 @@
-//
-//  GraphDefinition.swift
-//  TuistGraph
-//
-//  Created by Stefano Mondino on 08/02/24.
-//
-
 import Foundation
 
+/// A styling definition to be used when elements are rendered in graphs
 public struct GraphDefinition: Hashable, Equatable, CustomStringConvertible, CustomDebugStringConvertible, Codable {
-    
+    /// The shape of the object
     public enum Shape: String, Hashable, Codable {
-        case box, rectangle, square, circle, ellipse, point, egg, triangle, plaintext, plain, diamond, trapezium, parallelogram, house, hexagon, octagon, doublecircle, doubleoctagon, invtriangle, invtrapezium, invhouse, Mdiamond, Msquare, Mcircle, polygon, oval, star, cylinder, note, tab, folder, box3d, component, cds, signature
+        case box, rectangle, square, circle, ellipse, point, egg, triangle, plaintext, plain, diamond, trapezium, parallelogram,
+             house, hexagon, octagon, doublecircle, doubleoctagon, invtriangle, invtrapezium, invhouse, Mdiamond, Msquare,
+             Mcircle,
+             polygon, oval, star, cylinder, note, tab, folder, box3d, component, cds, signature
     }
-    
+
+    /// The color of the object. Can either be an hex string like "#FFCC00" or a color name like "black", "teal", etc.
     public struct Color: Codable, ExpressibleByStringInterpolation, CustomStringConvertible, Equatable, Hashable {
         public let description: String
         public init(stringLiteral: String) {
-            self.description = stringLiteral
+            description = stringLiteral
         }
+
         public init(_ value: String) {
-            self.description = value
+            description = value
         }
     }
-    
-    public var description: String { "" }
-    
-    public var debugDescription: String { "" }
-    
+
+    public var description: String { [
+        fillColor as CustomStringConvertible?,
+        textColor,
+        shape.rawValue,
+        strokeWidth,
+    ]
+    .compactMap { $0?.description }.joined(separator: " - ")
+    }
+
+    public var debugDescription: String { description }
+
     public var fillColor: Color
     public var textColor: Color?
     public var shape: Shape
     public var strokeWidth: Double?
-    internal init(fillColor: GraphDefinition.Color,
-                  textColor: GraphDefinition.Color? = nil,
-                  strokeWidth: Double? = nil,
-                  shape: GraphDefinition.Shape) {
+    init(
+        fillColor: GraphDefinition.Color,
+        textColor: GraphDefinition.Color? = nil,
+        strokeWidth _: Double? = nil,
+        shape: GraphDefinition.Shape
+    ) {
         self.fillColor = fillColor
         self.textColor = textColor
         self.shape = shape
     }
-    
-    
+
+    /// Returns a graph definition
+    /// - Parameters:
+    ///   - fillColor: The color used to fill the shape
+    ///   - textColor: The color used to write text over the shape. When nil, the graph rendering engine will use its internal
+    /// default value. Defaults to nil.
+    ///   - strokeWidth: The width of the stroke for borders. Defaults to nil.
+    ///   - shape: The shape used to draw the node in the graph.
+    public static func graph(
+        fillColor: GraphDefinition.Color,
+        textColor: GraphDefinition.Color? = nil,
+        strokeWidth: Double? = nil,
+        shape: GraphDefinition.Shape
+    ) -> GraphDefinition {
+        .init(
+            fillColor: fillColor,
+            textColor: textColor,
+            strokeWidth: strokeWidth,
+            shape: shape
+        )
+    }
 }

--- a/Sources/ProjectDescription/GraphDefinition.swift
+++ b/Sources/ProjectDescription/GraphDefinition.swift
@@ -55,7 +55,7 @@ public struct GraphDefinition: Hashable, Equatable, CustomStringConvertible, Cus
     /// default value. Defaults to nil.
     ///   - strokeWidth: The width of the stroke for borders. Defaults to nil.
     ///   - shape: The shape used to draw the node in the graph.
-    public static func graph(
+    public static func graphDefinition(
         fillColor: GraphDefinition.Color,
         textColor: GraphDefinition.Color? = nil,
         strokeWidth: Double? = nil,

--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -71,7 +71,7 @@ public struct Target: Codable, Equatable {
     public var mergeable: Bool
 
     public var graphDefinition: GraphDefinition?
-    
+
     public static func target(
         name: String,
         destinations: Destinations,
@@ -121,7 +121,6 @@ public struct Target: Codable, Equatable {
             mergedBinaryType: mergedBinaryType,
             mergeable: mergeable,
             graphDefinition: graphDefinition
-            
         )
     }
 }

--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -70,6 +70,8 @@ public struct Target: Codable, Equatable {
     /// Specifies whether if the target can be merged as part of another binary or not
     public var mergeable: Bool
 
+    public var graphDefinition: GraphDefinition?
+    
     public static func target(
         name: String,
         destinations: Destinations,
@@ -92,7 +94,8 @@ public struct Target: Codable, Equatable {
         additionalFiles: [FileElement] = [],
         buildRules: [BuildRule] = [],
         mergedBinaryType: MergedBinaryType = .disabled,
-        mergeable: Bool = false
+        mergeable: Bool = false,
+        graphDefinition: GraphDefinition? = nil
     ) -> Self {
         self.init(
             name: name,
@@ -116,7 +119,9 @@ public struct Target: Codable, Equatable {
             additionalFiles: additionalFiles,
             buildRules: buildRules,
             mergedBinaryType: mergedBinaryType,
-            mergeable: mergeable
+            mergeable: mergeable,
+            graphDefinition: graphDefinition
+            
         )
     }
 }

--- a/Sources/TuistGenerator/GraphViz/NodeStyling.swift
+++ b/Sources/TuistGenerator/GraphViz/NodeStyling.swift
@@ -16,6 +16,7 @@ extension GraphViz.Node {
 }
 
 struct NodeStyleAttributes {
+    
     let fillColor: GraphViz.Color?
     var textColor: GraphViz.Color?
     let strokeWidth: Double?
@@ -32,10 +33,30 @@ struct NodeStyleAttributes {
         self.strokeWidth = strokeWidth
         self.shape = shape
     }
+    
+    internal init(fillColor: Color? = nil, 
+                  textColor: Color? = nil,
+                  strokeWidth: Double? = nil,
+                  shape: Node.Shape? = nil) {
+        self.fillColor = fillColor
+        self.textColor = textColor
+        self.strokeWidth = strokeWidth
+        self.shape = shape
+    }
 }
 
 extension GraphTarget {
     var styleAttributes: NodeStyleAttributes {
+        let defaultAttributes = defaultStyleAttributes
+        guard let customAttributes = target.graphDefinition?.styleAttributes else {
+            return defaultAttributes
+        }
+        return .init(fillColor: customAttributes.fillColor ?? defaultAttributes.fillColor,
+                     textColor: customAttributes.textColor ?? defaultAttributes.textColor,
+                     strokeWidth: customAttributes.strokeWidth ?? defaultAttributes.strokeWidth,
+                     shape: customAttributes.shape ?? defaultAttributes.shape)
+    }
+    private var defaultStyleAttributes: NodeStyleAttributes {
         switch target.product {
         case .app, .watch2App, .commandLineTool, .macro, .appClip, .xpc, .systemExtension:
             return .init(fillColorName: .deepskyblue, strokeWidth: 1.5, shape: .box3d)
@@ -82,5 +103,24 @@ extension GraphDependency {
             return graphTraverser.target(path: path, name: name)
                 .map(\.styleAttributes)
         }
+    }
+}
+
+extension GraphDefinition {
+    var styleAttributes: NodeStyleAttributes {
+        .init(fillColor: fillColor.graphViz,
+              textColor: textColor?.graphViz,
+              strokeWidth: strokeWidth,
+              shape: shape.graphViz)
+    }
+}
+extension GraphDefinition.Color {
+    var graphViz: GraphViz.Color {
+        .custom(description)
+    }
+}
+extension GraphDefinition.Shape {
+    var graphViz: GraphViz.Node.Shape? {
+        .init(rawValue: description)
     }
 }

--- a/Sources/TuistGenerator/GraphViz/NodeStyling.swift
+++ b/Sources/TuistGenerator/GraphViz/NodeStyling.swift
@@ -16,7 +16,6 @@ extension GraphViz.Node {
 }
 
 struct NodeStyleAttributes {
-    
     let fillColor: GraphViz.Color?
     var textColor: GraphViz.Color?
     let strokeWidth: Double?
@@ -33,11 +32,14 @@ struct NodeStyleAttributes {
         self.strokeWidth = strokeWidth
         self.shape = shape
     }
-    
-    internal init(fillColor: Color? = nil, 
-                  textColor: Color? = nil,
-                  strokeWidth: Double? = nil,
-                  shape: Node.Shape? = nil) {
+
+    init(
+        fillColor: Color? = nil,
+
+        textColor: Color? = nil,
+        strokeWidth: Double? = nil,
+        shape: Node.Shape? = nil
+    ) {
         self.fillColor = fillColor
         self.textColor = textColor
         self.strokeWidth = strokeWidth
@@ -51,11 +53,14 @@ extension GraphTarget {
         guard let customAttributes = target.graphDefinition?.styleAttributes else {
             return defaultAttributes
         }
-        return .init(fillColor: customAttributes.fillColor ?? defaultAttributes.fillColor,
-                     textColor: customAttributes.textColor ?? defaultAttributes.textColor,
-                     strokeWidth: customAttributes.strokeWidth ?? defaultAttributes.strokeWidth,
-                     shape: customAttributes.shape ?? defaultAttributes.shape)
+        return .init(
+            fillColor: customAttributes.fillColor ?? defaultAttributes.fillColor,
+            textColor: customAttributes.textColor ?? defaultAttributes.textColor,
+            strokeWidth: customAttributes.strokeWidth ?? defaultAttributes.strokeWidth,
+            shape: customAttributes.shape ?? defaultAttributes.shape
+        )
     }
+
     private var defaultStyleAttributes: NodeStyleAttributes {
         switch target.product {
         case .app, .watch2App, .commandLineTool, .macro, .appClip, .xpc, .systemExtension:
@@ -108,17 +113,21 @@ extension GraphDependency {
 
 extension GraphDefinition {
     var styleAttributes: NodeStyleAttributes {
-        .init(fillColor: fillColor.graphViz,
-              textColor: textColor?.graphViz,
-              strokeWidth: strokeWidth,
-              shape: shape.graphViz)
+        .init(
+            fillColor: fillColor.graphViz,
+            textColor: textColor?.graphViz,
+            strokeWidth: strokeWidth,
+            shape: shape.graphViz
+        )
     }
 }
+
 extension GraphDefinition.Color {
     var graphViz: GraphViz.Color {
         .custom(description)
     }
 }
+
 extension GraphDefinition.Shape {
     var graphViz: GraphViz.Node.Shape? {
         .init(rawValue: description)

--- a/Sources/TuistGraph/Models/GraphDefinition.swift
+++ b/Sources/TuistGraph/Models/GraphDefinition.swift
@@ -1,0 +1,63 @@
+//
+//  GraphDefinition.swift
+//  TuistGraph
+//
+//  Created by Stefano Mondino on 08/02/24.
+//
+
+import Foundation
+
+public struct GraphDefinition: Hashable, Equatable, CustomStringConvertible, CustomDebugStringConvertible, Codable {
+
+    public struct Color: Codable, ExpressibleByStringInterpolation, CustomStringConvertible, Equatable, Hashable {
+        public let description: String
+        public init(stringLiteral: String) {
+            self.description = stringLiteral
+        }
+        public init(_ value: CustomStringConvertible) {
+            self.description = value.description
+        }
+    }
+    
+    public struct Shape: Codable, ExpressibleByStringInterpolation, CustomStringConvertible, Equatable, Hashable {
+        public let description: String
+        public init(stringLiteral: String) {
+            self.description = stringLiteral
+        }
+        public init(_ value: CustomStringConvertible) {
+            self.description = value.description
+        }
+    }
+    
+    public var description: String { [fillColor as CustomStringConvertible?,
+                                      textColor,
+                                      shape,
+                                      strokeWidth]
+        .compactMap { $0?.description }.joined(separator: " - ") }
+    
+    public var debugDescription: String { description }
+    
+    public var fillColor: Color
+    public var textColor: Color?
+    public var shape: Shape
+    public var strokeWidth: Double?
+    internal init(fillColor: GraphDefinition.Color,
+                  textColor: GraphDefinition.Color? = nil,
+                  strokeWidth: Double? = nil,
+                  shape: GraphDefinition.Shape) {
+        self.fillColor = fillColor
+        self.textColor = textColor
+        self.shape = shape
+    }
+    
+    public init(fillColor: GraphDefinition.Color,
+                textColor: GraphDefinition.Color? = nil,
+                shape: GraphDefinition.Shape,
+                strokeWidth: Double? = nil) {
+        self.fillColor = fillColor
+        self.textColor = textColor
+        self.shape = shape
+        self.strokeWidth = strokeWidth
+    }
+    
+}

--- a/Sources/TuistGraph/Models/GraphDefinition.swift
+++ b/Sources/TuistGraph/Models/GraphDefinition.swift
@@ -1,63 +1,63 @@
-//
-//  GraphDefinition.swift
-//  TuistGraph
-//
-//  Created by Stefano Mondino on 08/02/24.
-//
-
 import Foundation
 
 public struct GraphDefinition: Hashable, Equatable, CustomStringConvertible, CustomDebugStringConvertible, Codable {
-
     public struct Color: Codable, ExpressibleByStringInterpolation, CustomStringConvertible, Equatable, Hashable {
         public let description: String
         public init(stringLiteral: String) {
-            self.description = stringLiteral
+            description = stringLiteral
         }
+
         public init(_ value: CustomStringConvertible) {
-            self.description = value.description
+            description = value.description
         }
     }
-    
+
     public struct Shape: Codable, ExpressibleByStringInterpolation, CustomStringConvertible, Equatable, Hashable {
         public let description: String
         public init(stringLiteral: String) {
-            self.description = stringLiteral
+            description = stringLiteral
         }
+
         public init(_ value: CustomStringConvertible) {
-            self.description = value.description
+            description = value.description
         }
     }
-    
-    public var description: String { [fillColor as CustomStringConvertible?,
-                                      textColor,
-                                      shape,
-                                      strokeWidth]
-        .compactMap { $0?.description }.joined(separator: " - ") }
-    
+
+    public var description: String { [
+        fillColor as CustomStringConvertible?,
+        textColor,
+        shape,
+        strokeWidth,
+    ]
+    .compactMap { $0?.description }.joined(separator: " - ")
+    }
+
     public var debugDescription: String { description }
-    
+
     public var fillColor: Color
     public var textColor: Color?
     public var shape: Shape
     public var strokeWidth: Double?
-    internal init(fillColor: GraphDefinition.Color,
-                  textColor: GraphDefinition.Color? = nil,
-                  strokeWidth: Double? = nil,
-                  shape: GraphDefinition.Shape) {
+    init(
+        fillColor: GraphDefinition.Color,
+        textColor: GraphDefinition.Color? = nil,
+        strokeWidth _: Double? = nil,
+        shape: GraphDefinition.Shape
+    ) {
         self.fillColor = fillColor
         self.textColor = textColor
         self.shape = shape
     }
-    
-    public init(fillColor: GraphDefinition.Color,
-                textColor: GraphDefinition.Color? = nil,
-                shape: GraphDefinition.Shape,
-                strokeWidth: Double? = nil) {
+
+    public init(
+        fillColor: GraphDefinition.Color,
+        textColor: GraphDefinition.Color? = nil,
+        shape: GraphDefinition.Shape,
+        strokeWidth: Double? = nil
+    ) {
         self.fillColor = fillColor
         self.textColor = textColor
         self.shape = shape
         self.strokeWidth = strokeWidth
     }
-    
 }

--- a/Sources/TuistGraph/Models/Target.swift
+++ b/Sources/TuistGraph/Models/Target.swift
@@ -1,6 +1,5 @@
 import Foundation
 import TSCBasic
-
 // swiftlint:disable:next type_body_length
 public struct Target: Equatable, Hashable, Comparable, Codable {
     // MARK: - Static
@@ -46,7 +45,8 @@ public struct Target: Equatable, Hashable, Comparable, Codable {
     public var prune: Bool
     public let mergedBinaryType: MergedBinaryType
     public let mergeable: Bool
-
+    public let graphDefinition: GraphDefinition?
+    
     // MARK: - Init
 
     public init(
@@ -75,7 +75,8 @@ public struct Target: Equatable, Hashable, Comparable, Codable {
         buildRules: [BuildRule] = [],
         prune: Bool = false,
         mergedBinaryType: MergedBinaryType = .disabled,
-        mergeable: Bool = false
+        mergeable: Bool = false,
+        graphDefinition: GraphDefinition? = nil
     ) {
         self.name = name
         self.product = product
@@ -103,6 +104,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable {
         self.prune = prune
         self.mergedBinaryType = mergedBinaryType
         self.mergeable = mergeable
+        self.graphDefinition = graphDefinition
     }
 
     /// Target can be included in the link phase of other targets

--- a/Sources/TuistGraph/Models/Target.swift
+++ b/Sources/TuistGraph/Models/Target.swift
@@ -1,5 +1,6 @@
 import Foundation
 import TSCBasic
+
 // swiftlint:disable:next type_body_length
 public struct Target: Equatable, Hashable, Comparable, Codable {
     // MARK: - Static
@@ -46,7 +47,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable {
     public let mergedBinaryType: MergedBinaryType
     public let mergeable: Bool
     public let graphDefinition: GraphDefinition?
-    
+
     // MARK: - Init
 
     public init(

--- a/Sources/TuistGraphTesting/Models/Target+TestData.swift
+++ b/Sources/TuistGraphTesting/Models/Target+TestData.swift
@@ -30,7 +30,8 @@ extension Target {
         additionalFiles: [FileElement] = [],
         prune: Bool = false,
         mergedBinaryType: MergedBinaryType = .disabled,
-        mergeable: Bool = false
+        mergeable: Bool = false,
+        graphDefinition: GraphDefinition? = nil
     ) -> Target {
         Target(
             name: name,
@@ -57,7 +58,8 @@ extension Target {
             additionalFiles: additionalFiles,
             prune: prune,
             mergedBinaryType: mergedBinaryType,
-            mergeable: mergeable
+            mergeable: mergeable,
+            graphDefinition: graphDefinition
         )
     }
 

--- a/Sources/TuistLoader/Models+ManifestMappers/GraphDefinition+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/GraphDefinition+ManifestMapper.swift
@@ -1,0 +1,35 @@
+//
+//  GraphDefinition+ManifestMapper.swift
+//  TuistLoader
+//
+//  Created by Stefano Mondino on 08/02/24.
+//
+
+import Foundation
+import ProjectDescription
+import TuistGraph
+
+extension TuistGraph.GraphDefinition {
+    static func from(_ graph: ProjectDescription.GraphDefinition) -> TuistGraph.GraphDefinition {
+        .init(fillColor: graph.fillColor.graphValue,
+              textColor: graph.textColor?.graphValue,
+              shape: .init(graph.shape.rawValue),
+              strokeWidth: graph.strokeWidth)
+    }
+}
+extension TuistGraph.GraphDefinition.Color {
+    static func from(_ color: ProjectDescription.GraphDefinition.Color) -> TuistGraph.GraphDefinition.Color {
+        .init(color)
+    }
+}
+
+extension ProjectDescription.GraphDefinition.Color {
+    var graphValue: TuistGraph.GraphDefinition.Color {
+        .from(self)
+    }
+}
+extension ProjectDescription.GraphDefinition {
+    var graphValue: TuistGraph.GraphDefinition {
+        .from(self)
+    }
+}

--- a/Sources/TuistLoader/Models+ManifestMappers/GraphDefinition+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/GraphDefinition+ManifestMapper.swift
@@ -1,22 +1,18 @@
-//
-//  GraphDefinition+ManifestMapper.swift
-//  TuistLoader
-//
-//  Created by Stefano Mondino on 08/02/24.
-//
-
 import Foundation
 import ProjectDescription
 import TuistGraph
 
 extension TuistGraph.GraphDefinition {
     static func from(_ graph: ProjectDescription.GraphDefinition) -> TuistGraph.GraphDefinition {
-        .init(fillColor: graph.fillColor.graphValue,
-              textColor: graph.textColor?.graphValue,
-              shape: .init(graph.shape.rawValue),
-              strokeWidth: graph.strokeWidth)
+        .init(
+            fillColor: graph.fillColor.graphValue,
+            textColor: graph.textColor?.graphValue,
+            shape: .init(graph.shape.rawValue),
+            strokeWidth: graph.strokeWidth
+        )
     }
 }
+
 extension TuistGraph.GraphDefinition.Color {
     static func from(_ color: ProjectDescription.GraphDefinition.Color) -> TuistGraph.GraphDefinition.Color {
         .init(color)
@@ -28,6 +24,7 @@ extension ProjectDescription.GraphDefinition.Color {
         .from(self)
     }
 }
+
 extension ProjectDescription.GraphDefinition {
     var graphValue: TuistGraph.GraphDefinition {
         .from(self)

--- a/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
@@ -98,6 +98,8 @@ extension TuistGraph.Target {
         let buildRules = manifest.buildRules.map {
             TuistGraph.BuildRule.from(manifest: $0)
         }
+        
+        let graphDefinition = manifest.graphDefinition?.graphValue
 
         return TuistGraph.Target(
             name: name,
@@ -123,7 +125,8 @@ extension TuistGraph.Target {
             additionalFiles: additionalFiles,
             buildRules: buildRules,
             mergedBinaryType: mergedBinaryType,
-            mergeable: manifest.mergeable
+            mergeable: manifest.mergeable,
+            graphDefinition: graphDefinition
         )
     }
 

--- a/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
@@ -98,7 +98,7 @@ extension TuistGraph.Target {
         let buildRules = manifest.buildRules.map {
             TuistGraph.BuildRule.from(manifest: $0)
         }
-        
+
         let graphDefinition = manifest.graphDefinition?.graphValue
 
         return TuistGraph.Target(

--- a/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
+++ b/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
@@ -74,7 +74,8 @@ extension Target {
         dependencies: [TargetDependency] = [],
         settings: Settings? = nil,
         coreDataModels: [CoreDataModel] = [],
-        environment: [String: String] = [:]
+        environment: [String: String] = [:],
+        graphDefinition: GraphDefinition? = nil
     ) -> Target {
         .target(
             name: name,
@@ -91,7 +92,8 @@ extension Target {
             dependencies: dependencies,
             settings: settings,
             coreDataModels: coreDataModels,
-            environmentVariables: environment.mapValues { .init(stringLiteral: $0) }
+            environmentVariables: environment.mapValues { .init(stringLiteral: $0) },
+            graphDefinition: graphDefinition
         )
     }
 }

--- a/Tests/TuistGeneratorTests/GraphViz/GraphToGraphVizMapperTests.swift
+++ b/Tests/TuistGeneratorTests/GraphViz/GraphToGraphVizMapperTests.swift
@@ -208,14 +208,14 @@ final class GraphToGraphVizMapperTests: XCTestCase {
             path: coreProject.path,
             target: Target.test(name: "Core")
         )
-        
+
         let graphDefinition = GraphDefinition(fillColor: "#FFCC00", shape: "octagon")
-        
+
         let styled = GraphTarget.test(
             path: coreProject.path,
             target: Target.test(name: "Styled", graphDefinition: graphDefinition)
         )
-        
+
         let coreDependency = GraphDependency.target(name: core.target.name, path: core.path)
         let coreTests = GraphTarget.test(
             path: coreProject.path,

--- a/Tests/TuistGeneratorTests/GraphViz/GraphToGraphVizMapperTests.swift
+++ b/Tests/TuistGeneratorTests/GraphViz/GraphToGraphVizMapperTests.swift
@@ -157,11 +157,13 @@ final class GraphToGraphVizMapperTests: XCTestCase {
         let rxSwift = GraphViz.Node("RxSwift")
         let xcodeProj = GraphViz.Node("XcodeProj")
         let core = GraphViz.Node("Core")
+        let styled = GraphViz.Node("Styled")
         let coreTests = GraphViz.Node("CoreTests")
         let watchOS = GraphViz.Node("Tuist watchOS")
         let externalDependency = GraphViz.Node("External dependency")
 
-        graph.append(contentsOf: [tuist, core])
+        graph.append(contentsOf: [tuist, core, styled])
+        graph.append(GraphViz.Edge(from: styled, to: core))
         if !onlyiOS {
             graph.append(watchOS)
         }
@@ -206,6 +208,14 @@ final class GraphToGraphVizMapperTests: XCTestCase {
             path: coreProject.path,
             target: Target.test(name: "Core")
         )
+        
+        let graphDefinition = GraphDefinition(fillColor: "#FFCC00", shape: "octagon")
+        
+        let styled = GraphTarget.test(
+            path: coreProject.path,
+            target: Target.test(name: "Styled", graphDefinition: graphDefinition)
+        )
+        
         let coreDependency = GraphDependency.target(name: core.target.name, path: core.path)
         let coreTests = GraphTarget.test(
             path: coreProject.path,
@@ -238,6 +248,7 @@ final class GraphToGraphVizMapperTests: XCTestCase {
                 ],
                 coreProject.path: [
                     core.target.name: core.target,
+                    styled.target.name: styled.target,
                     coreTests.target.name: coreTests.target,
                 ],
                 externalProject.path: [
@@ -251,6 +262,7 @@ final class GraphToGraphVizMapperTests: XCTestCase {
                     sdk,
                     externalDependency,
                 ],
+                .target(name: styled.target.name, path: styled.path): [coreDependency],
                 .target(name: coreTests.target.name, path: coreTests.path): [coreDependency],
                 .target(name: iOSApp.target.name, path: iOSApp.path): [coreDependency],
                 .target(name: watchApp.target.name, path: watchApp.path): [coreDependency],

--- a/Tests/TuistLoaderTests/Extensions/TuistTestCase+ManifestMappers.swift
+++ b/Tests/TuistLoaderTests/Extensions/TuistTestCase+ManifestMappers.swift
@@ -64,13 +64,14 @@ extension TuistTestCase {
             file: file,
             line: line
         )
-        
+
         XCTAssertEqual(
             target.graphDefinition,
             manifest.graphDefinition.map(TuistGraph.GraphDefinition.from),
             file: file,
-            line: line)
-        
+            line: line
+        )
+
         try assert(
             coreDataModels: target.coreDataModels,
             matches: manifest.coreDataModels,

--- a/Tests/TuistLoaderTests/Extensions/TuistTestCase+ManifestMappers.swift
+++ b/Tests/TuistLoaderTests/Extensions/TuistTestCase+ManifestMappers.swift
@@ -64,6 +64,13 @@ extension TuistTestCase {
             file: file,
             line: line
         )
+        
+        XCTAssertEqual(
+            target.graphDefinition,
+            manifest.graphDefinition.map(TuistGraph.GraphDefinition.from),
+            file: file,
+            line: line)
+        
         try assert(
             coreDataModels: target.coreDataModels,
             matches: manifest.coreDataModels,

--- a/Tests/TuistLoaderTests/Loaders/ManifestModelConverterTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/ManifestModelConverterTests.swift
@@ -98,7 +98,7 @@ class ManifestModelConverterTests: TuistUnitTestCase {
             generatorPaths: generatorPaths
         )
     }
-    
+
     func test_loadProject_withStyledTargets() throws {
         // Given
         let temporaryPath = try temporaryPath()

--- a/Tests/TuistLoaderTests/Loaders/ManifestModelConverterTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/ManifestModelConverterTests.swift
@@ -98,6 +98,51 @@ class ManifestModelConverterTests: TuistUnitTestCase {
             generatorPaths: generatorPaths
         )
     }
+    
+    func test_loadProject_withStyledTargets() throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let generatorPaths = GeneratorPaths(manifestDirectory: temporaryPath)
+        let graphDefinitionA = GraphDefinition(fillColor: "#FFCC00", shape: .octagon)
+        let graphDefinitionB = GraphDefinition(fillColor: "#33CD40", shape: .square)
+        let targetA = TargetManifest.test(name: "A", sources: [], resources: [], graphDefinition: graphDefinitionA)
+        let targetB = TargetManifest.test(name: "B", sources: [], resources: [], graphDefinition: graphDefinitionB)
+        let manifest = ProjectManifest.test(
+            name: "Project",
+            targets: [
+                targetA,
+                targetB,
+            ]
+        )
+        let manifestLoader = makeManifestLoader(with: [
+            temporaryPath: manifest,
+        ])
+        let subject = makeSubject(with: manifestLoader)
+
+        // When
+        let model = try subject.convert(
+            manifest: manifest,
+            path: temporaryPath,
+            plugins: .none,
+            externalDependencies: [:],
+            isExternal: false
+        )
+
+        // Then
+        XCTAssertEqual(model.targets.count, 2)
+        try XCTAssertTargetMatchesManifest(
+            target: model.targets[0],
+            matches: targetA,
+            at: temporaryPath,
+            generatorPaths: generatorPaths
+        )
+        try XCTAssertTargetMatchesManifest(
+            target: model.targets[1],
+            matches: targetB,
+            at: temporaryPath,
+            generatorPaths: generatorPaths
+        )
+    }
 
     func test_loadProject_withAdditionalFiles() throws {
         // Given


### PR DESCRIPTION
Resolves #5900 

### Short description 📝

Provides `Target` static initializer with a new custom object that mimics what is needed by GraphViz layer to render shapes for target when printing out the workspace graph with `tuist graph`


### How to test the changes locally 🧐

I've added as much tests as I could understand in the current structure, in particular:
- Manifests are passing down the GraphDefinition object to TuistGraph properly
- GraphDefinition is getting to the NodeStyling object where they are "mixed" with the default values (example: if I only want to change the shape but retain the original color, this should be doable by setting nil for the fillColor so that the default - orange - one is used)

I have a doubt about colors - I've tried with hexadecimals values ("CSS Style" but I don't know how double check if they work). Apparently nothing is under Unit Test on NodeStyling file - colors and shapes are not checked and I don't know how to automate this. 

Trying to add a `graphDefinition` value on my custom target + run tuist graph from xcode properly applies colors and shape to the rendered graph.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
