### PR TITLE
Fix PlistsTemplate to support multiline strings

### DIFF
--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
@@ -30,6 +30,7 @@ public enum TuistAcceptanceFixtures {
     case iosAppWithFrameworks
     case iosAppWithHeaders
     case iosAppWithHelpers
+    case iosAppWithInfoplist
     case iosAppWithImplicitDependencies
     case iosAppWithIncompatibleXcode
     case iosAppWithLocalBinarySwiftPackage
@@ -121,6 +122,8 @@ public enum TuistAcceptanceFixtures {
             return "ios_app_with_headers"
         case .iosAppWithHelpers:
             return "ios_app_with_helpers"
+        case .iosAppWithInfoplist:
+            return "ios_app_with_infoplist"
         case .iosAppWithImplicitDependencies:
             return "ios_app_with_implicit_dependencies"
         case .iosAppWithIncompatibleXcode:

--- a/Sources/TuistGenerator/Templates/PlistsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/PlistsTemplate.swift
@@ -44,7 +44,7 @@ extension SynthesizedResourceInterfaceTemplates {
     {% endmacro %}
     {% macro valueBlock value metadata %}
       {%- if metadata.type == "String" -%}
-        "{{ value|replace: "\n", "\\n", "regex" }}"
+        "{{ value|removeNewlines }}"
       {%- elif metadata.type == "Date" -%}
         Date(timeIntervalSinceReferenceDate: {{ value.timeIntervalSinceReferenceDate }})
       {%- elif metadata.type == "Optional" -%}

--- a/Sources/TuistGenerator/Templates/PlistsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/PlistsTemplate.swift
@@ -44,7 +44,7 @@ extension SynthesizedResourceInterfaceTemplates {
     {% endmacro %}
     {% macro valueBlock value metadata %}
       {%- if metadata.type == "String" -%}
-        "{{ value|removeNewlines: "leading" }}"
+        "{{ value|replace: "\\n", " ", "regex" }}"
       {%- elif metadata.type == "Date" -%}
         Date(timeIntervalSinceReferenceDate: {{ value.timeIntervalSinceReferenceDate }})
       {%- elif metadata.type == "Optional" -%}

--- a/Sources/TuistGenerator/Templates/PlistsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/PlistsTemplate.swift
@@ -44,7 +44,7 @@ extension SynthesizedResourceInterfaceTemplates {
     {% endmacro %}
     {% macro valueBlock value metadata %}
       {%- if metadata.type == "String" -%}
-        "{{ value|removeNewlines }}"
+        "{{ value|removeNewlines: "leading" }}"
       {%- elif metadata.type == "Date" -%}
         Date(timeIntervalSinceReferenceDate: {{ value.timeIntervalSinceReferenceDate }})
       {%- elif metadata.type == "Optional" -%}

--- a/Sources/TuistGenerator/Templates/PlistsTemplate.swift
+++ b/Sources/TuistGenerator/Templates/PlistsTemplate.swift
@@ -44,7 +44,7 @@ extension SynthesizedResourceInterfaceTemplates {
     {% endmacro %}
     {% macro valueBlock value metadata %}
       {%- if metadata.type == "String" -%}
-        "{{ value }}"
+        "{{ value|replace: "\n", "\\n", "regex" }}"
       {%- elif metadata.type == "Date" -%}
         Date(timeIntervalSinceReferenceDate: {{ value.timeIntervalSinceReferenceDate }})
       {%- elif metadata.type == "Optional" -%}

--- a/Tests/TuistGenerateAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/Tests/TuistGenerateAcceptanceTests/GenerateAcceptanceTests.swift
@@ -240,6 +240,15 @@ final class GenerateAcceptanceTestIosAppWithInfoPlist: TuistAcceptanceTestCase {
                 #"public static let items: [String] = ["D\n"]"#
             )
         )
+        
+        XCTAssertTrue(
+            try FileHandler.shared.readTextFile(
+                fixturePath.appending(components: "Derived", "Sources", "TuistPlists+App.swift")
+            )
+            .contains(
+                #"public static let items: [String] = ["E F"]"#
+            )
+        )
     }
 }
 

--- a/Tests/TuistGenerateAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/Tests/TuistGenerateAcceptanceTests/GenerateAcceptanceTests.swift
@@ -201,6 +201,48 @@ final class GenerateAcceptanceTestiOSAppWithCustomResourceParserOptions: TuistAc
     }
 }
 
+final class GenerateAcceptanceTestIosAppWithInfoPlist: TuistAcceptanceTestCase {
+    func test_ios_app_with_multiline_string_value_infoplist() async throws {
+        try setUpFixture(.iosAppWithInfoplist)
+        try await run(GenerateCommand.self)
+        try await run(BuildCommand.self)
+        for resource in ["Test1.plist", "Test2.plist", "Test3.plist"] {
+            try await XCTAssertProductWithDestinationContainsResource(
+                "App.app",
+                destination: "Debug-iphonesimulator",
+                resource: resource
+            )
+        }
+
+        XCTAssertTrue(
+            try FileHandler.shared.readTextFile(
+                fixturePath.appending(components: "Derived", "Sources", "TuistPlists+App.swift")
+            )
+            .contains(
+                #"public static let items: [String] = ["A\\n"]"#
+            )
+        )
+
+        XCTAssertTrue(
+            try FileHandler.shared.readTextFile(
+                fixturePath.appending(components: "Derived", "Sources", "TuistPlists+App.swift")
+            )
+            .contains(
+                #"public static let items: [String] = ["BC"]"#
+            )
+        )
+
+        XCTAssertTrue(
+            try FileHandler.shared.readTextFile(
+                fixturePath.appending(components: "Derived", "Sources", "TuistPlists+App.swift")
+            )
+            .contains(
+                #"public static let items: [String] = ["D\n"]"#
+            )
+        )
+    }
+}
+
 final class GenerateAcceptanceTestiOSAppWithFrameworkLinkingStaticFramework: TuistAcceptanceTestCase {
     func test_ios_app_with_framework_linking_static_framework() async throws {
         try setUpFixture(.iosAppWithFrameworkLinkingStaticFramework)

--- a/Tests/TuistGenerateAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/Tests/TuistGenerateAcceptanceTests/GenerateAcceptanceTests.swift
@@ -228,7 +228,7 @@ final class GenerateAcceptanceTestIosAppWithInfoPlist: TuistAcceptanceTestCase {
                 fixturePath.appending(components: "Derived", "Sources", "TuistPlists+App.swift")
             )
             .contains(
-                #"public static let items: [String] = ["BC"]"#
+                #"public static let items: [String] = ["B C"]"#
             )
         )
 
@@ -246,7 +246,7 @@ final class GenerateAcceptanceTestIosAppWithInfoPlist: TuistAcceptanceTestCase {
                 fixturePath.appending(components: "Derived", "Sources", "TuistPlists+App.swift")
             )
             .contains(
-                #"public static let items: [String] = ["E F"]"#
+                #"public static let items: [String] = ["E F   "]"#
             )
         )
     }

--- a/fixtures/ios_app_with_infoplist/App/Resources/Test1.plist
+++ b/fixtures/ios_app_with_infoplist/App/Resources/Test1.plist
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<string>A\\n</string>
+</array>
+</plist>

--- a/fixtures/ios_app_with_infoplist/App/Resources/Test2.plist
+++ b/fixtures/ios_app_with_infoplist/App/Resources/Test2.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<string>B
+C</string>
+</array>
+</plist>

--- a/fixtures/ios_app_with_infoplist/App/Resources/Test3.plist
+++ b/fixtures/ios_app_with_infoplist/App/Resources/Test3.plist
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<string>D\n</string>
+</array>
+</plist>

--- a/fixtures/ios_app_with_infoplist/App/Resources/Test4.plist
+++ b/fixtures/ios_app_with_infoplist/App/Resources/Test4.plist
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<string>E F   </string>
+</array>
+</plist>

--- a/fixtures/ios_app_with_infoplist/App/Sources/AppDelegate.swift
+++ b/fixtures/ios_app_with_infoplist/App/Sources/AppDelegate.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(
+        _: UIApplication,
+        didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        let viewController = UIViewController()
+        viewController.view.backgroundColor = .white
+        window?.rootViewController = viewController
+        window?.makeKeyAndVisible()
+        return true
+    }
+}

--- a/fixtures/ios_app_with_infoplist/Project.swift
+++ b/fixtures/ios_app_with_infoplist/Project.swift
@@ -1,0 +1,16 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "io.tuist.app",
+            infoPlist: .default,
+            sources: ["App/Sources/**"],
+            resources: ["App/Resources/**"]
+        ),
+    ]
+)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5442

### Short description 📝

I have modified PlistsTemplate to support multiline string values. 
While adding this feature, I utilized the `removeNewLines`  provided by StencilSwiftKit. 


### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
