### PR TITLE
Fix DEFINES_MODULE warning

### DIFF
--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -1036,6 +1036,15 @@ extension ProjectDescription.Settings {
             settingsDictionary["MODULEMAP_FILE"] = .string("$(SRCROOT)/\(moduleMapPath.relative(to: packageFolder))")
         }
 
+        if let moduleMap {
+            switch moduleMap {
+            case .directory, .custom(_, umbrellaHeaderPath: nil):
+                settingsDictionary["DEFINES_MODULE"] = "NO"
+            case .header, .nestedHeader, .none, .custom:
+                break
+            }
+        }
+
         var mappedSettingsDictionary = ProjectDescription.SettingsDictionary.from(settingsDictionary: settingsDictionary)
 
         if let settingsToOverride = targetSettings[target.name] {

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -460,23 +460,6 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 ]
             )
 
-            let test = Project.testWithDefaultConfigs(
-                name: "Package",
-                targets: [
-                    .test(
-                        "Target1",
-                        basePath: basePath,
-                        customSources: .custom(.sourceFilesList(
-                            globs: [
-                                basePath
-                                    .appending(try RelativePath(validating: "Package/\(alternativeDefaultSource)/Target1/**"))
-                                    .pathString,
-                            ]
-                        ))
-                    ),
-                ]
-            )
-
             XCTAssertBetterEqual(
                 project,
                 .testWithDefaultConfigs(
@@ -1042,6 +1025,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         basePath: basePath,
                         customSettings: [
                             "HEADER_SEARCH_PATHS": ["$(SRCROOT)/Sources/Target1/include"],
+                            "DEFINES_MODULE": "NO",
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Target1/include/module.modulemap"
                     ),
@@ -1080,7 +1064,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             platforms: [.iOS]
         )
 
-        XCTAssertEqual(
+        XCTAssertBetterEqual(
             project,
             .testWithDefaultConfigs(
                 name: "Package",
@@ -1089,6 +1073,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         "Target1",
                         basePath: basePath,
                         customSources: .custom(nil),
+                        customSettings: [
+                            "DEFINES_MODULE": "NO",
+                        ],
                         moduleMap: "$(SRCROOT)/Sources/Target1/module.modulemap"
                     ),
                 ]
@@ -1235,6 +1222,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                 "$(SRCROOT)/Sources/Dependency1/include",
                                 "$(SRCROOT)/Sources/Dependency2/include",
                             ],
+                            "DEFINES_MODULE": "NO",
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Target1/include/module.modulemap"
                     ),
@@ -1247,6 +1235,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                 "$(SRCROOT)/Sources/Dependency1/include",
                                 "$(SRCROOT)/Sources/Dependency2/include",
                             ],
+                            "DEFINES_MODULE": "NO",
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Dependency1/include/module.modulemap"
                     ),
@@ -1255,6 +1244,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         basePath: basePath,
                         customSettings: [
                             "HEADER_SEARCH_PATHS": ["$(SRCROOT)/Sources/Dependency2/include"],
+                            "DEFINES_MODULE": "NO",
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Dependency2/include/module.modulemap"
                     ),
@@ -1343,6 +1333,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                 "$(SRCROOT)/../Package2/Sources/Dependency1/include",
                                 "$(SRCROOT)/../Package3/Sources/Dependency2/include",
                             ],
+                            "DEFINES_MODULE": "NO",
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Target1/include/module.modulemap"
                     ),
@@ -1414,6 +1405,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         ],
                         customSettings: [
                             "HEADER_SEARCH_PATHS": ["$(SRCROOT)/Custom/Headers"],
+                            "DEFINES_MODULE": "NO",
                         ],
                         moduleMap: "$(SRCROOT)/Custom/Headers/module.modulemap"
                     ),
@@ -1473,6 +1465,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         ),
                         customSettings: [
                             "HEADER_SEARCH_PATHS": ["$(SRCROOT)/Sources/Dependency1/include"],
+                            "DEFINES_MODULE": "NO",
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Dependency1/include/Dependency1.modulemap"
                     ),


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5513

### Short description 📝

This PR fixes a long-standing issue where we set `DEFINES_MODULE` for all targets ([in Xcodeproj](https://github.com/tuist/XcodeProj/blob/41d52ce7424906980fd1b133454b444f5bb5f21b/Sources/XcodeProj/Utils/BuildSettingsProvider.swift#L211)) but external objc dependencies without an umbrella header should have this set to `NO`.

### How to test the changes locally 🧐

Generate `app_with_spm_dependencies` fixture. You should see no warnings related to `DEFINES_MODULE`.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x]  Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
