### PR TITLE
Fix caching package manifests

### DIFF
--- a/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -63,11 +63,12 @@ public final class SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoadi
         manifestLoader: ManifestLoading
     ) {
         self.init(
+            manifestLoader: manifestLoader,
             packageSettingsLoader: PackageSettingsLoader(manifestLoader: manifestLoader)
         )
     }
 
-    public init(
+    init(
         swiftPackageManagerController: SwiftPackageManagerControlling = SwiftPackageManagerController(),
         packageInfoMapper: PackageInfoMapping = PackageInfoMapper(),
         manifestLoader: ManifestLoading = ManifestLoader(),

--- a/Sources/TuistSupport/SwiftPackageManager/PackageInfo.swift
+++ b/Sources/TuistSupport/SwiftPackageManager/PackageInfo.swift
@@ -553,12 +553,8 @@ extension PackageInfo.Target.Dependency: Codable {
             var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .product)
             try unkeyedContainer.encode(name)
             try unkeyedContainer.encode(package)
-            if let moduleAliases {
-                try unkeyedContainer.encode(moduleAliases)
-            }
-            if let condition {
-                try unkeyedContainer.encode(condition)
-            }
+            try unkeyedContainer.encode(moduleAliases)
+            try unkeyedContainer.encode(condition)
         case let .target(name: name, condition: condition):
             var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .target)
             try unkeyedContainer.encode(name)

--- a/Tests/TuistSupportTests/SwiftPackageManager/PackageInfoTests.swift
+++ b/Tests/TuistSupportTests/SwiftPackageManager/PackageInfoTests.swift
@@ -29,6 +29,12 @@ final class PackageInfoTests: XCTestCase {
                                 moduleAliases: ["TuistSupport": "InternalTuistSupport"],
                                 condition: nil
                             ),
+                            .product(
+                                name: "ArgumentParser",
+                                package: "argument-parser",
+                                moduleAliases: nil,
+                                condition: PackageInfo.PackageConditionDescription(platformNames: ["macOS"], config: nil)
+                            ),
                         ],
                         publicHeadersPath: nil,
                         type: .executable,


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5911

### Short description 📝

We were not properly caching `Package.swift` manifests. The issue was that we were not passing the `CachedManifestLoader` but would create a new `ManifestLoader` in one of the inits. 

I also fixed an issue that caused always an encoding failure when a package dependency had a `condition` but not `moduleAliases` set.

### How to test the changes locally 🧐

Run `tuist generate --verbose` twice in the `app_with_spm_dependencies` fixture. The second run, you should see no invocations of `swift package dump-package`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
