### PR TITLE
Fix building zstd library

### DIFF
--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -1038,7 +1038,7 @@ extension ProjectDescription.Settings {
 
         if let moduleMap {
             switch moduleMap {
-            case .directory, .custom(_, umbrellaHeaderPath: nil):
+            case .directory:
                 settingsDictionary["DEFINES_MODULE"] = "NO"
             case .header, .nestedHeader, .none, .custom:
                 break

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -1025,7 +1025,6 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         basePath: basePath,
                         customSettings: [
                             "HEADER_SEARCH_PATHS": ["$(SRCROOT)/Sources/Target1/include"],
-                            "DEFINES_MODULE": "NO",
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Target1/include/module.modulemap"
                     ),
@@ -1073,9 +1072,6 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         "Target1",
                         basePath: basePath,
                         customSources: .custom(nil),
-                        customSettings: [
-                            "DEFINES_MODULE": "NO",
-                        ],
                         moduleMap: "$(SRCROOT)/Sources/Target1/module.modulemap"
                     ),
                 ]
@@ -1222,7 +1218,6 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                 "$(SRCROOT)/Sources/Dependency1/include",
                                 "$(SRCROOT)/Sources/Dependency2/include",
                             ],
-                            "DEFINES_MODULE": "NO",
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Target1/include/module.modulemap"
                     ),
@@ -1235,7 +1230,6 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                 "$(SRCROOT)/Sources/Dependency1/include",
                                 "$(SRCROOT)/Sources/Dependency2/include",
                             ],
-                            "DEFINES_MODULE": "NO",
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Dependency1/include/module.modulemap"
                     ),
@@ -1244,7 +1238,6 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         basePath: basePath,
                         customSettings: [
                             "HEADER_SEARCH_PATHS": ["$(SRCROOT)/Sources/Dependency2/include"],
-                            "DEFINES_MODULE": "NO",
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Dependency2/include/module.modulemap"
                     ),
@@ -1333,7 +1326,6 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                 "$(SRCROOT)/../Package2/Sources/Dependency1/include",
                                 "$(SRCROOT)/../Package3/Sources/Dependency2/include",
                             ],
-                            "DEFINES_MODULE": "NO",
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Target1/include/module.modulemap"
                     ),
@@ -1405,7 +1397,6 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         ],
                         customSettings: [
                             "HEADER_SEARCH_PATHS": ["$(SRCROOT)/Custom/Headers"],
-                            "DEFINES_MODULE": "NO",
                         ],
                         moduleMap: "$(SRCROOT)/Custom/Headers/module.modulemap"
                     ),

--- a/fixtures/app_with_spm_dependencies/LocalSwiftPackageB/Sources/LibraryA/MyStruct.swift
+++ b/fixtures/app_with_spm_dependencies/LocalSwiftPackageB/Sources/LibraryA/MyStruct.swift
@@ -1,3 +1,1 @@
-import AppKit
-
 public struct MyStruct {}

--- a/fixtures/app_with_spm_dependencies/Package.resolved
+++ b/fixtures/app_with_spm_dependencies/Package.resolved
@@ -215,6 +215,15 @@
         "revision" : "79d4dc9729096c6ad83dd3cee2b9f354d1b4ab7b",
         "version" : "2.5.5"
       }
+    },
+    {
+      "identity" : "zstd",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/facebook/zstd",
+      "state" : {
+        "revision" : "63779c798237346c2b245c546c40b72a5a5913fe",
+        "version" : "1.5.5"
+      }
     }
   ],
   "version" : 2

--- a/fixtures/app_with_spm_dependencies/Package.swift
+++ b/fixtures/app_with_spm_dependencies/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
         .package(url: "https://github.com/getsentry/sentry-cocoa", .upToNextMajor(from: "8.20.0")),
         .package(url: "https://github.com/realm/realm-swift", .upToNextMajor(from: "10.46.0")),
         .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack", .upToNextMajor(from: "3.8.4")),
+        .package(url: "https://github.com/facebook/zstd", exact: "1.5.5"),
         .package(path: "LocalSwiftPackage"),
         .package(path: "StringifyMacro"),
     ]


### PR DESCRIPTION
### Short description 📝

`zstd` library does have an [umbrella header](https://github.com/facebook/zstd/blob/dev/lib/zstd.h) but the name does not correspond to the name of the module which is `libzstd`. 

However, Xcode still somehow recognizes the header as an umbrella header even though I couldn't find how [here](https://github.com/apple/swift-package-manager/blob/6bcbf11476c5be39fb308ab50db72cc75a5cb103/Sources/PackageLoading/ModuleMapGenerator.swift#L91).

The library builds again if we set `DEFINES_MODULE` back to `YES`.

This causes [this warning](https://github.com/tuist/tuist/issues/5513) to pop up for `RealmCore` that actually has a modulemap with no public header. As a temporary fix, we can be less eager at setting `DEFINES_MODULE` to `NO` and we can investigate how to find the public header later.

### How to test the changes locally 🧐

Building `app_with_spm_dependencies` should work.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
