### PR TITLE
Improve the error when users try to build or test multi-platform targets

### DIFF
--- a/Sources/TuistKit/Utils/Target+PlatformResolution.swift
+++ b/Sources/TuistKit/Utils/Target+PlatformResolution.swift
@@ -1,7 +1,10 @@
 import Foundation
 import TuistGraph
+import TuistSupport
 
-struct UnspecifiedPlatformError: Error, CustomStringConvertible {
+struct UnspecifiedPlatformError: FatalError, CustomStringConvertible {
+    var type: TuistSupport.ErrorType = .abort
+
     let target: Target
     var description: String {
         "Only single platform targets supported. The target \(target.name) specifies multiple supported platforms (\(target.supportedPlatforms.map(\.rawValue).joined(separator: ", ")))."


### PR DESCRIPTION
Related: https://github.com/tuist/tuist/issues/5918

### Short description 📝
Service commands like "run" or "test" don't support multi-platform targets yet. However, we currently throw a standard Swift Error that is presented very verbose. I'm adjusting it to conform to `FatalError` and have a better presentation.