### PR TITLE
Improve performance by replacing globing with FileManager when finding resource files

### DIFF
--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -846,19 +846,17 @@ extension ResourceFileElements {
 
     // These files are automatically added as resource if they are inside targets directory.
     // Check https://developer.apple.com/documentation/swift_packages/bundling_resources_with_a_swift_package
-    private static let defaultSpmResourceFileExtensions = [
+    private static let defaultSpmResourceFileExtensions = Set([
         "xib",
         "storyboard",
         "xcdatamodeld",
         "xcmappingmodel",
         "xcassets",
         "strings",
-    ]
+    ])
 
     private static func defaultResourcePaths(from path: AbsolutePath) -> [AbsolutePath] {
-        ResourceFileElements.defaultSpmResourceFileExtensions.flatMap {
-            FileHandler.shared.glob(path, glob: "**/*.\($0)")
-        }
+        Array(FileHandler.shared.files(in: path, nameFilter: nil, extensionFilter: defaultSpmResourceFileExtensions))
     }
 }
 

--- a/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
+++ b/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
@@ -91,6 +91,14 @@ public final class MockFileHandler: FileHandler {
         try closure(temporaryDirectory())
     }
 
+    public var stubFiles: ((AbsolutePath, Set<String>?, Set<String>?) -> Set<AbsolutePath>)?
+    override public func files(in path: AbsolutePath, nameFilter: Set<String>?, extensionFilter: Set<String>?) -> Set<AbsolutePath> {
+        guard let stubFiles else {
+            return super.files(in: path, nameFilter: nameFilter, extensionFilter: extensionFilter)
+        }
+        return stubFiles(path, nameFilter, extensionFilter)
+    }
+
     public var stubGlob: ((AbsolutePath, String) -> [AbsolutePath])?
     override public func glob(_ path: AbsolutePath, glob: String) -> [AbsolutePath] {
         guard let stubGlob else {

--- a/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
+++ b/Sources/TuistSupportTesting/TestCase/TuistTestCase.swift
@@ -92,7 +92,11 @@ public final class MockFileHandler: FileHandler {
     }
 
     public var stubFiles: ((AbsolutePath, Set<String>?, Set<String>?) -> Set<AbsolutePath>)?
-    override public func files(in path: AbsolutePath, nameFilter: Set<String>?, extensionFilter: Set<String>?) -> Set<AbsolutePath> {
+    override public func files(
+        in path: AbsolutePath,
+        nameFilter: Set<String>?,
+        extensionFilter: Set<String>?
+    ) -> Set<AbsolutePath> {
         guard let stubFiles else {
             return super.files(in: path, nameFilter: nameFilter, extensionFilter: extensionFilter)
         }

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
@@ -389,6 +389,10 @@ final class WorkspaceStructureGeneratorTests: XCTestCase {
 
         func inTemporaryDirectory(_: @escaping (AbsolutePath) async throws -> Void) async throws {}
 
+        func files(in path: AbsolutePath, nameFilter: Set<String>?, extensionFilter: Set<String>?) -> Set<AbsolutePath> {
+            []
+        }
+        
         func glob(_: AbsolutePath, glob _: String) -> [AbsolutePath] {
             []
         }

--- a/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/WorkspaceStructureGeneratorTests.swift
@@ -389,10 +389,10 @@ final class WorkspaceStructureGeneratorTests: XCTestCase {
 
         func inTemporaryDirectory(_: @escaping (AbsolutePath) async throws -> Void) async throws {}
 
-        func files(in path: AbsolutePath, nameFilter: Set<String>?, extensionFilter: Set<String>?) -> Set<AbsolutePath> {
+        func files(in _: AbsolutePath, nameFilter _: Set<String>?, extensionFilter _: Set<String>?) -> Set<AbsolutePath> {
             []
         }
-        
+
         func glob(_: AbsolutePath, glob _: String) -> [AbsolutePath] {
             []
         }

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -936,13 +936,8 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))
         let defaultResourcePath = sourcesPath.appending(try RelativePath(validating: "Resources/file.xib"))
         try fileHandler.createFolder(sourcesPath)
-        fileHandler.stubGlob = { path, glob in
-            XCTAssertEqual(path, sourcesPath)
-            if glob == "**/*.xib" {
-                return [defaultResourcePath]
-            } else {
-                return []
-            }
+        fileHandler.stubFiles = { _, _, _ in
+            return [defaultResourcePath]
         }
 
         let project = try subject.map(


### PR DESCRIPTION
### Short description 📝

This shaves off some 700ms (in our project on a M2 Max, your mileage may vary) when running `tuist generate` by replacing globing operation with `FileManager` in `defaultResourcePaths`. I tried to keep the changes to a minimum and not duplicate any code.

### How to test the changes locally 🧐

Either run with Time Profiler or use some other benchmarking tool like hyperfine.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
