### PR TITLE
Remove Mockable from the list of targets that depend on XCTest

### DIFF
--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -433,7 +433,6 @@ public final class PackageInfoMapper: PackageInfoMapping {
                     "TSCTestSupport", // https://github.com/apple/swift-tools-support-core
                     "ViewInspector", // https://github.com/nalexn/ViewInspector
                     "XCTVapor", // https://github.com/vapor/vapor
-                    "Mockable", // https://github.com/Kolos65/Mockable.git
                     "MockableTest", // https://github.com/Kolos65/Mockable.git
                 ].map {
                     ($0, ["ENABLE_TESTING_SEARCH_PATHS": "YES"])


### PR DESCRIPTION
### Short description 📝
We added `Mockable` to the list of package products that depend on XCTest, but this is inaccurate because the product that depends on XCTest is `MockableTest`.

This PR removes it from the list.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
