### PR TITLE
Fix runtime crash when using Obj-C dependencies

### DIFF
--- a/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -95,6 +95,7 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
                     "-fmodule-map-file=$(SRCROOT)/../B/B2/B2.module",
                 ]),
                 "HEADER_SEARCH_PATHS": .array(["$(inherited)", "$(SRCROOT)/../B/B1", "$(SRCROOT)/../B/B2"]),
+                "OTHER_LDFLAGS": .array(["$(inherited)", "-ObjC"]),
             ]),
             dependencies: [
                 .project(target: "B1", path: projectBPath),
@@ -114,6 +115,7 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
                 "OTHER_CFLAGS": .array(["$(inherited)", "-fmodule-map-file=$(SRCROOT)/B2/B2.module"]),
                 "OTHER_SWIFT_FLAGS": .array(["$(inherited)", "-Xcc", "-fmodule-map-file=$(SRCROOT)/B2/B2.module"]),
                 "HEADER_SEARCH_PATHS": .array(["$(inherited)", "$(SRCROOT)/B2"]),
+                "OTHER_LDFLAGS": .array(["$(inherited)", "-ObjC"]),
             ]),
             dependencies: [
                 .target(name: "B2"),
@@ -205,6 +207,7 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
                         "-fmodule-map-file=$(SRCROOT)/../B/B/B.module",
                     ]),
                     "HEADER_SEARCH_PATHS": .array(["$(inherited)", "$(SRCROOT)/../B/B"]),
+                    "OTHER_LDFLAGS": .array(["$(inherited)", "-ObjC"]),
                 ],
                 configurations: [:],
                 defaultSettings: .recommended

--- a/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
+++ b/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
@@ -23,7 +23,7 @@ public enum AppKit {
         _ = YAMLEncoder()
 
         // Use GoogleSignIn
-        _ = GIDSignIn.sharedInstance.configuration
+        _ = GIDSignIn.sharedInstance.hasPreviousSignIn()
 
         // Use Sentry
         SentrySDK.startSession()


### PR DESCRIPTION
### Short description 📝

As reported by @freak4pc, the current fix for ObjC dependencies is missing the addition of the `-ObjC` linker flag. When accessing ObjC code without this flag, the app crashes with an `unrecognized selector sent to instance ...`.

We can add the flag whenever there's a `modulemap` as that's a good way to tell if a target has an objc dependency.

### How to test the changes locally 🧐

Run `app_with_spm_dependencies` app. Before this PR and with the current changes in `AppKit`, the app would crash in runtime.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
