### PR TITLE
Fix external platform narrowing when there is a dependency platform condition

### DIFF
--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -827,8 +827,8 @@ public class GraphTraverser: GraphTraversing {
 
             for dependencyTargetReference in dependencies {
                 var platformsToInsert: Set<Platform>?
-
                 let dependencyTarget = dependencyTargetReference.graphTarget
+                let inheritedPlatforms = dependencyTarget.target.product == .macro ? Set<Platform>([.macOS]) : parentPlatforms
                 if let dependencyCondition = dependencyTargetReference.condition,
                    let platformIntersection = PlatformCondition.when(target.target.dependencyPlatformFilters)?
                    .intersection(dependencyCondition)
@@ -838,13 +838,16 @@ public class GraphTraverser: GraphTraversing {
                         break
                     case let .condition(condition):
                         if let condition {
-                            let dependencyPlatforms: [Platform] = condition.platformFilters.map(\.platform).filter { $0 != nil }
-                                .map { $0! }
-                            platformsToInsert = Set(dependencyPlatforms)
+                            let dependencyPlatforms = Set(
+                                condition.platformFilters.map(\.platform)
+                                    .filter { $0 != nil }
+                                    .map { $0! }
+                            )
+                            .intersection(inheritedPlatforms)
+                            platformsToInsert = dependencyPlatforms
                         }
                     }
                 } else {
-                    let inheritedPlatforms = dependencyTarget.target.product == .macro ? Set<Platform>([.macOS]) : parentPlatforms
                     platformsToInsert = inheritedPlatforms.intersection(dependencyTarget.target.supportedPlatforms)
                 }
 


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/5930

### Short description 📝

We were skipping intersecting with the `inheritedPlatforms` when there was a dependency condition. When running `tuist cache`, we would create schemes for platforms that are not necessary for the downstream internal targets.

### How to test the changes locally 🧐

Run `tuist cache` for the repro project: https://github.com/dogo/swdestiny-trades (for Tuist Cloud team only)

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
