### PR TITLE
Fix integration of Objective C dependencies with resources

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -31,6 +31,7 @@ public class ResourcesProjectMapper: ProjectMapping {
 
     public func mapTarget(_ target: Target, project: Project) throws -> ([Target], [SideEffectDescriptor]) {
         if target.resources.isEmpty, target.coreDataModels.isEmpty { return ([target], []) }
+        
         var additionalTargets: [Target] = []
         var sideEffects: [SideEffectDescriptor] = []
 
@@ -63,7 +64,7 @@ public class ResourcesProjectMapper: ProjectMapping {
             additionalTargets.append(resourcesTarget)
         }
 
-        if target.supportsSources {
+        if target.supportsSources, target.sources.contains(where: { $0.path.extension == "swift" }) {
             let (filePath, data) = synthesizedFile(bundleName: bundleName, target: target, project: project)
 
             let hash = try data.map(contentHasher.hash)

--- a/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
@@ -78,27 +78,7 @@ public final class SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerMod
             // User defined modulemap exists, use it
             return .custom(customModuleMapPath, umbrellaHeaderPath: nil)
         } else if FileHandler.shared.exists(publicHeadersPath) {
-            // We move the umbrella headers directory to a different location for CocoaLumberjack. Somehow, the one used by
-            // default is not properly recognized even if the path in the `modulemap` is correct.
-            // If the directory is copied to a different location, it works.
-            if sanitizedModuleName == "CocoaLumberjack" {
-                let copiedPublicHeadersPath = publicHeadersPath.parentDirectory.appending(component: "tuist-public-headers")
-                if !FileHandler.shared.exists(copiedPublicHeadersPath) {
-                    try FileHandler.shared.copy(from: publicHeadersPath, to: copiedPublicHeadersPath)
-                }
-                let generatedModuleMapContent =
-                    """
-                    module \(sanitizedModuleName) {
-                        umbrella "\(copiedPublicHeadersPath.pathString)"
-                        export *
-                    }
-                    """
-                let generatedModuleMapPath = publicHeadersPath.appending(component: "\(moduleName).modulemap")
-                try FileHandler.shared.write(generatedModuleMapContent, path: generatedModuleMapPath, atomically: true)
-                return .directory(moduleMapPath: generatedModuleMapPath, umbrellaDirectory: copiedPublicHeadersPath)
-            }
-
-            // Otherwise, consider the public headers folder as umbrella directory
+            // Consider the public headers folder as umbrella directory
             let generatedModuleMapContent =
                 """
                 module \(sanitizedModuleName) {

--- a/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -33,7 +33,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
     func test_map_when_a_target_that_has_resources_and_doesnt_supports_them() throws {
         // Given
         let resources: [ResourceFileElement] = [.file(path: "/image.png")]
-        let target = Target.test(product: .staticLibrary, resources: resources)
+        let target = Target.test(product: .staticLibrary, sources: ["/Absolute/File.swift"], resources: resources)
         project = Project.test(targets: [target])
 
         // Got
@@ -61,9 +61,9 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(gotTarget.name, target.name)
         XCTAssertEqual(gotTarget.product, target.product)
         XCTAssertEqual(gotTarget.resources.count, 0)
-        XCTAssertEqual(gotTarget.sources.count, 1)
-        XCTAssertEqual(gotTarget.sources.first?.path, expectedPath)
-        XCTAssertNotNil(gotTarget.sources.first?.contentHash)
+        XCTAssertEqual(gotTarget.sources.count, 2)
+        XCTAssertEqual(gotTarget.sources.last?.path, expectedPath)
+        XCTAssertNotNil(gotTarget.sources.last?.contentHash)
         XCTAssertEqual(gotTarget.dependencies.count, 1)
         XCTAssertEqual(
             gotTarget.dependencies.first,
@@ -101,13 +101,50 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(project, gotProject)
         XCTAssertEqual(gotSideEffects, [])
     }
+    
+    func testMap_whenNoSwiftSources() throws {
+        // Given
+        let resources: [ResourceFileElement] = [.file(path: "/image.png")]
+        let target = Target.test(product: .staticLibrary, sources: ["/Absolute/File.m"], resources: resources)
+        project = Project.test(
+            targets: [target]
+        )
+
+        // Got
+        let (gotProject, gotSideEffects) = try subject.map(project: project)
+
+        // Then: Side effects
+        XCTAssertEqual(gotSideEffects, [])
+        XCTAssertEqual(gotProject.targets.count, 2)
+        
+        let gotTarget = try XCTUnwrap(gotProject.targets.first)
+        XCTAssertEqual(gotTarget.name, target.name)
+        XCTAssertEqual(gotTarget.product, target.product)
+        XCTAssertEqual(gotTarget.resources.count, 0)
+        XCTAssertEqual(gotTarget.sources.count, 1)
+        XCTAssertEqual(gotTarget.dependencies.count, 1)
+        XCTAssertEqual(
+            gotTarget.dependencies.first,
+            TargetDependency.target(name: "\(project.name)_\(target.name)", condition: .when([.ios]))
+        )
+
+        
+        let resourcesTarget = try XCTUnwrap(gotProject.targets.last)
+        XCTAssertEqual(resourcesTarget.name, "\(project.name)_\(target.name)")
+        XCTAssertEqual(resourcesTarget.product, .bundle)
+        XCTAssertEqual(resourcesTarget.destinations, target.destinations)
+        XCTAssertEqual(resourcesTarget.bundleId, "\(target.bundleId).resources")
+        XCTAssertEqual(resourcesTarget.deploymentTargets, target.deploymentTargets)
+        XCTAssertEqual(resourcesTarget.filesGroup, target.filesGroup)
+        XCTAssertEqual(resourcesTarget.resources, resources)
+    }
 
     func test_map_when_a_target_that_has_core_data_models_and_doesnt_supports_them() throws {
         // Given
 
         let coreDataModels: [CoreDataModel] =
             [CoreDataModel(path: "/data.xcdatamodeld", versions: ["/data.xcdatamodeld"], currentVersion: "1")]
-        let target = Target.test(product: .staticLibrary, coreDataModels: coreDataModels)
+        let target = Target.test(product: .staticLibrary, sources: ["/Absolute/File.swift"], coreDataModels: coreDataModels)
         project = Project.test(targets: [target])
 
         // Got
@@ -135,9 +172,9 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(gotTarget.name, target.name)
         XCTAssertEqual(gotTarget.product, target.product)
         XCTAssertEqual(gotTarget.resources.count, 0)
-        XCTAssertEqual(gotTarget.sources.count, 1)
-        XCTAssertEqual(gotTarget.sources.first?.path, expectedPath)
-        XCTAssertNotNil(gotTarget.sources.first?.contentHash)
+        XCTAssertEqual(gotTarget.sources.count, 2)
+        XCTAssertEqual(gotTarget.sources.last?.path, expectedPath)
+        XCTAssertNotNil(gotTarget.sources.last?.contentHash)
         XCTAssertEqual(gotTarget.dependencies.count, 1)
         XCTAssertEqual(
             gotTarget.dependencies.first,
@@ -157,7 +194,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
     func test_map_when_a_target_that_has_resources_and_supports_them() throws {
         // Given
         let resources: [ResourceFileElement] = [.file(path: "/image.png")]
-        let target = Target.test(product: .framework, resources: resources)
+        let target = Target.test(product: .framework, sources: ["/Absolute/File.swift"], resources: resources)
         project = Project.test(targets: [target])
 
         // Got
@@ -185,9 +222,9 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(gotTarget.name, target.name)
         XCTAssertEqual(gotTarget.product, target.product)
         XCTAssertEqual(gotTarget.resources, resources)
-        XCTAssertEqual(gotTarget.sources.count, 1)
-        XCTAssertEqual(gotTarget.sources.first?.path, expectedPath)
-        XCTAssertNotNil(gotTarget.sources.first?.contentHash)
+        XCTAssertEqual(gotTarget.sources.count, 2)
+        XCTAssertEqual(gotTarget.sources.last?.path, expectedPath)
+        XCTAssertNotNil(gotTarget.sources.last?.contentHash)
         XCTAssertEqual(gotTarget.dependencies.count, 0)
     }
 
@@ -195,7 +232,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         // Given
         let coreDataModels: [CoreDataModel] =
             [CoreDataModel(path: "/data.xcdatamodeld", versions: ["/data.xcdatamodeld"], currentVersion: "1")]
-        let target = Target.test(product: .framework, coreDataModels: coreDataModels)
+        let target = Target.test(product: .framework, sources: ["/Absolute/File.swift"], coreDataModels: coreDataModels)
         project = Project.test(targets: [target])
 
         // Got
@@ -223,9 +260,9 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(gotTarget.name, target.name)
         XCTAssertEqual(gotTarget.product, target.product)
         XCTAssertEqual(gotTarget.coreDataModels, coreDataModels)
-        XCTAssertEqual(gotTarget.sources.count, 1)
-        XCTAssertEqual(gotTarget.sources.first?.path, expectedPath)
-        XCTAssertNotNil(gotTarget.sources.first?.contentHash)
+        XCTAssertEqual(gotTarget.sources.count, 2)
+        XCTAssertEqual(gotTarget.sources.last?.path, expectedPath)
+        XCTAssertNotNil(gotTarget.sources.last?.contentHash)
         XCTAssertEqual(gotTarget.dependencies.count, 0)
     }
 
@@ -263,7 +300,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
     func test_map_when_a_target_that_has_name_with_hyphen() throws {
         // Given
         let resources: [ResourceFileElement] = [.file(path: "/image.png")]
-        let target = Target.test(name: "test-tuist", product: .staticLibrary, resources: resources)
+        let target = Target.test(name: "test-tuist", product: .staticLibrary, sources: ["/Absolute/File.swift"], resources: resources)
         project = Project.test(targets: [target])
 
         // Got

--- a/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
+++ b/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
@@ -29,7 +29,7 @@ public enum AppKit {
         SentrySDK.startSession()
 
         // Use CocoaLumberjack
-        _ = CocoaLumberjackSwift.DDLogInfo("Log")
+        _ = DDOSLogger.sharedInstance
 
         // Use Realm
         _ = Realm.Configuration()


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5915

### Short description 📝

It turns out the hacks we needed for `CocoaLumberjack` were necessary because we were adding a Swift file with generated bundle accessors into a pure Objective C target. That screws up some logic Xcode does. Ideally, our bundle accessors would generate a file that would be purely in Objective C, but I believe that is not necessary for now. We can do that down the line.

Thanks a lot to @amarcadet for the initial idea.

### How to test the changes locally 🧐

You should be able to build the `app_with_spm_dependencies` fixture.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
