### PR TITLE
Add exclude targets that contain strings from the graph rendering.

### DIFF
--- a/Sources/TuistGenerator/Extensions/Graph+Extras.swift
+++ b/Sources/TuistGenerator/Extensions/Graph+Extras.swift
@@ -36,23 +36,24 @@ extension TuistGraph.Graph {
                     return false
                 }
             }
-            
+
             return true
         }
 
         let filteredTargetsAndDependencies: Set<GraphTarget> = filteredTargets.union(
             transitiveClosure(Array(filteredTargets)) { target in
-                Array(graphTraverser.directTargetDependencies(path: target.path, name: target.target.name)
-                    .compactMap { dependency in
-                        let dependencyTarget = dependency.graphTarget
-                        
-                        for excludeTargetString in excludeTargetsContaining {
-                            if dependencyTarget.target.name.lowercased().contains(excludeTargetString.lowercased()) {
-                                return nil
+                Array(
+                    graphTraverser.directTargetDependencies(path: target.path, name: target.target.name)
+                        .compactMap { dependency in
+                            let dependencyTarget = dependency.graphTarget
+
+                            for excludeTargetString in excludeTargetsContaining {
+                                if dependencyTarget.target.name.lowercased().contains(excludeTargetString.lowercased()) {
+                                    return nil
+                                }
                             }
+                            return dependencyTarget
                         }
-                        return dependencyTarget
-                    }
                 )
             }
         )
@@ -70,7 +71,7 @@ extension TuistGraph.Graph {
                             return false
                         }
                     }
-                    
+
                     if skipExternalDependencies, dependency.isExternal(projects) { return false }
                     return true
                 }

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -31,7 +31,7 @@ public class ResourcesProjectMapper: ProjectMapping {
 
     public func mapTarget(_ target: Target, project: Project) throws -> ([Target], [SideEffectDescriptor]) {
         if target.resources.isEmpty, target.coreDataModels.isEmpty { return ([target], []) }
-        
+
         var additionalTargets: [Target] = []
         var sideEffects: [SideEffectDescriptor] = []
 

--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -21,6 +21,12 @@ public struct GraphCommand: AsyncParsableCommand, HasTrackableParameters {
         )
     }
 
+    @Option(
+        name: [.customShort("x"), .customLong("exclude-targets-containing")],
+        help: "Exclude targets that contain the specified string from the graph rendering."
+    )
+    var excludeTargetsContaining: [String]
+    
     @Flag(
         name: [.customShort("t"), .long],
         help: "Skip Test targets during graph rendering."
@@ -80,6 +86,7 @@ public struct GraphCommand: AsyncParsableCommand, HasTrackableParameters {
                 "algorithm": AnyCodable(layoutAlgorithm.rawValue),
                 "skip_external_dependencies": AnyCodable(skipExternalDependencies),
                 "skip_test_targets": AnyCodable(skipExternalDependencies),
+                "exclude_string": AnyCodable(excludeTargetsContaining)
             ]
         )
         try await GraphService().run(
@@ -90,6 +97,7 @@ public struct GraphCommand: AsyncParsableCommand, HasTrackableParameters {
             open: !noOpen,
             platformToFilter: platform,
             targetsToFilter: targets,
+            excludeTargetsContaining: excludeTargetsContaining,
             path: path.map { try AbsolutePath(validating: $0) } ?? FileHandler.shared.currentPath,
             outputPath: outputPath
                 .map { try AbsolutePath(validating: $0, relativeTo: FileHandler.shared.currentPath) } ?? FileHandler.shared

--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -26,7 +26,7 @@ public struct GraphCommand: AsyncParsableCommand, HasTrackableParameters {
         help: "Exclude targets that contain the specified string from the graph rendering."
     )
     var excludeTargetsContaining: [String]
-    
+
     @Flag(
         name: [.customShort("t"), .long],
         help: "Skip Test targets during graph rendering."
@@ -86,7 +86,7 @@ public struct GraphCommand: AsyncParsableCommand, HasTrackableParameters {
                 "algorithm": AnyCodable(layoutAlgorithm.rawValue),
                 "skip_external_dependencies": AnyCodable(skipExternalDependencies),
                 "skip_test_targets": AnyCodable(skipExternalDependencies),
-                "exclude_string": AnyCodable(excludeTargetsContaining)
+                "exclude_string": AnyCodable(excludeTargetsContaining),
             ]
         )
         try await GraphService().run(

--- a/Sources/TuistKit/Services/GraphService.swift
+++ b/Sources/TuistKit/Services/GraphService.swift
@@ -46,6 +46,7 @@ final class GraphService {
         open: Bool,
         platformToFilter: Platform?,
         targetsToFilter: [String],
+        excludeTargetsContaining: [String],
         path: AbsolutePath,
         outputPath: AbsolutePath
     ) async throws {
@@ -61,7 +62,8 @@ final class GraphService {
             skipTestTargets: skipTestTargets,
             skipExternalDependencies: skipExternalDependencies,
             platformToFilter: platformToFilter,
-            targetsToFilter: targetsToFilter
+            targetsToFilter: targetsToFilter,
+            excludeTargetsContaining: excludeTargetsContaining
         )
 
         switch format {

--- a/Tests/TuistGeneratorTests/GraphViz/GraphToGraphVizMapperTests.swift
+++ b/Tests/TuistGeneratorTests/GraphViz/GraphToGraphVizMapperTests.swift
@@ -44,12 +44,12 @@ final class GraphToGraphVizMapperTests: XCTestCase {
         XCTAssertEqual(gotNodeIds, expectedNodeIds)
         XCTAssertEqual(gotEdgeIds, expectedEdgeIds)
     }
-    
+
     func test_map_excluding_targets_containing_strings() throws {
         // Given
         let graph = try makeGivenGraph()
         let excludeTargetsContaining = ["External", "rx"]
-        
+
         // When
         let got = subject.map(
             graph: graph,
@@ -61,18 +61,18 @@ final class GraphToGraphVizMapperTests: XCTestCase {
                 excludeTargetsContaining: excludeTargetsContaining
             )
         )
-        
+
         // Then
         let expected = makeExpectedGraphViz(excludeTargetsContaining: excludeTargetsContaining)
         let gotNodeIds = got.nodes.map(\.id).sorted()
         let expectedNodeIds = expected.nodes.map(\.id).sorted()
         let gotEdgeIds = got.edges.map { "\($0.from) -> \($0.to)" }.sorted()
         let expectedEdgeIds = expected.edges.map { "\($0.from) -> \($0.to)" }.sorted()
-        
+
         XCTAssertEqual(gotNodeIds, expectedNodeIds)
         XCTAssertEqual(gotEdgeIds, expectedEdgeIds)
     }
-    
+
     func test_map_skipping_external_dependencies() throws {
         // Given
         let graph = try makeGivenGraph()
@@ -173,7 +173,7 @@ final class GraphToGraphVizMapperTests: XCTestCase {
         let expectedNodeIds = expected.nodes.map(\.id).sorted()
         let gotEdgeIds = got.edges.map { $0.from + " -> " + $0.to }.sorted()
         let expectedEdgeIds = expected.edges.map { $0.from + " -> " + $0.to }.sorted()
-        
+
         XCTAssertEqual(gotNodeIds, expectedNodeIds)
         XCTAssertEqual(gotEdgeIds, expectedEdgeIds)
     }
@@ -225,7 +225,11 @@ final class GraphToGraphVizMapperTests: XCTestCase {
             !excludeTargetsContaining.contains(where: { node.id.lowercased().contains($0.lowercased()) })
         }
         edges = edges.filter { edge in
-            !(excludeTargetsContaining.contains(where: { edge.from.lowercased().contains($0.lowercased()) }) || excludeTargetsContaining.contains(where: { edge.to.lowercased().contains($0.lowercased()) }))
+            !(
+                excludeTargetsContaining
+                    .contains(where: { edge.from.lowercased().contains($0.lowercased()) }) || excludeTargetsContaining
+                    .contains(where: { edge.to.lowercased().contains($0.lowercased()) })
+            )
         }
 
         var graph = GraphViz.Graph(directed: true)
@@ -233,7 +237,7 @@ final class GraphToGraphVizMapperTests: XCTestCase {
         for edge in edges {
             graph.append(edge)
         }
-        
+
         return graph
     }
 

--- a/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -101,7 +101,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         XCTAssertEqual(project, gotProject)
         XCTAssertEqual(gotSideEffects, [])
     }
-    
+
     func testMap_whenNoSwiftSources() throws {
         // Given
         let resources: [ResourceFileElement] = [.file(path: "/image.png")]
@@ -116,7 +116,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         // Then: Side effects
         XCTAssertEqual(gotSideEffects, [])
         XCTAssertEqual(gotProject.targets.count, 2)
-        
+
         let gotTarget = try XCTUnwrap(gotProject.targets.first)
         XCTAssertEqual(gotTarget.name, target.name)
         XCTAssertEqual(gotTarget.product, target.product)
@@ -128,7 +128,6 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
             TargetDependency.target(name: "\(project.name)_\(target.name)", condition: .when([.ios]))
         )
 
-        
         let resourcesTarget = try XCTUnwrap(gotProject.targets.last)
         XCTAssertEqual(resourcesTarget.name, "\(project.name)_\(target.name)")
         XCTAssertEqual(resourcesTarget.product, .bundle)
@@ -300,7 +299,12 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
     func test_map_when_a_target_that_has_name_with_hyphen() throws {
         // Given
         let resources: [ResourceFileElement] = [.file(path: "/image.png")]
-        let target = Target.test(name: "test-tuist", product: .staticLibrary, sources: ["/Absolute/File.swift"], resources: resources)
+        let target = Target.test(
+            name: "test-tuist",
+            product: .staticLibrary,
+            sources: ["/Absolute/File.swift"],
+            resources: resources
+        )
         project = Project.test(targets: [target])
 
         // Got

--- a/Tests/TuistKitTests/Services/GraphServiceTests.swift
+++ b/Tests/TuistKitTests/Services/GraphServiceTests.swift
@@ -56,6 +56,7 @@ final class GraphServiceTests: TuistUnitTestCase {
             open: false,
             platformToFilter: nil,
             targetsToFilter: [],
+            excludeTargetsContaining: [],
             path: temporaryPath,
             outputPath: temporaryPath
         )
@@ -87,6 +88,7 @@ final class GraphServiceTests: TuistUnitTestCase {
             open: false,
             platformToFilter: nil,
             targetsToFilter: [],
+            excludeTargetsContaining: [],
             path: temporaryPath,
             outputPath: temporaryPath
         )


### PR DESCRIPTION
### Short description 📝

> When rendering a graph, there may be cases where you do not want to include dependencies that contain certain words. For example, if you do not want to see example projects, you can use `tuist graph -x "example"`.

### How to test the changes locally 🧐

> Use` tuist graph -x "string"` to check whether modules with the corresponding string have been removed from the graph.

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
