### PR TITLE
Remove mentions of tuist-cloud

### DIFF
--- a/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/installation.md
+++ b/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/installation.md
@@ -19,7 +19,6 @@ Once installed, you can install Tuist through any of the following commands:
 
 
 ```bash
-# Tuist
 mise install tuist            # Install the current version specified in .tool-versions/.mise.toml
 mise install tuist@x.y.z      # Install a specific version number
 mise install tuist@3          # Install a fuzzy version number
@@ -27,16 +26,6 @@ mise use tuist@x.y.z          # Use tuist-x.y.z in the current project
 mise use -g tuist@x.y.z       # Use tuist-x.y.z as the global default
 mise use tuist@latest         # Use the latest tuist in the current directory
 mise use -g tuist@system      # Use the system's tuist as the global default
-
-# Tuist Cloud (For users of Tuist Cloud)
-# Note: You need to install one OR the other, not both
-mise install tuist-cloud            # Install the current version specified in .tool-versions/.mise.toml
-mise install tuist-cloud@x.y.z
-mise install tuist-cloud@3
-mise use tuist-cloud@x.y.z   
-mise use -g tuist-cloud@x.y.z       # Use tuist-cloud-x.y.z as the global default
-mise use tuist-cloud@latest         # Use the latest tuist-cloud in the current directory
-mise use -g tuist-cloud@system      # Use the system's tuist-cloud as the global default
 ```
 
 #### Continuous integration
@@ -109,7 +98,6 @@ you can install Tuist using [Homebrew](https://brew.sh) and [our formulas](https
 brew tap tuist/tuist
 brew install tuist
 brew install tuist@x.y.z
-brew install tuist-cloud # If you are a Tuist Cloud user
 ```
 
 ### Shell completions


### PR DESCRIPTION
### Short description 📝

We only have one version of the CLI, `tuist`. Removing mentions of `tuist-cloud`.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x]  The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
