### PR TITLE
Fix `main` unit tests failing due to missing fixtures

### DIFF
--- a/Sources/TuistCore/Automation/Extensions/AsyncThrowingStream+XcodeBuildOutput.swift
+++ b/Sources/TuistCore/Automation/Extensions/AsyncThrowingStream+XcodeBuildOutput.swift
@@ -13,7 +13,7 @@ extension AsyncThrowingStream where Element == SystemEvent<XcodeBuildOutput> {
             case let .standardOutput(output):
                 let lines = output.raw.split(separator: "\n")
                 for line in lines where !line.isEmpty {
-                    logger.info("\(line)")
+                    logger.notice("\(line)")
                 }
             }
         }

--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -91,7 +91,7 @@ public struct TuistCommand: AsyncParsableCommand {
     private static func handleParseError(_ error: Error) -> Never {
         let exitCode = exitCode(for: error).rawValue
         if exitCode == 0 {
-            logger.info("\(fullMessage(for: error))")
+            logger.notice("\(fullMessage(for: error))")
         } else {
             logger.error("\(fullMessage(for: error))")
         }

--- a/Sources/TuistKit/Generator/Generator.swift
+++ b/Sources/TuistKit/Generator/Generator.swift
@@ -80,7 +80,11 @@ public class Generator: Generating {
     }
 
     func load(path: AbsolutePath) async throws -> (Graph, [SideEffectDescriptor]) {
+        logger.notice("Loading and constructing the graph", metadata: .section)
+        logger.notice("It might take a while if the cache is empty")
+
         let (graph, sideEffectDescriptors, issues) = try await manifestGraphLoader.load(path: path)
+
         lintingIssues.append(contentsOf: issues)
         return (graph, sideEffectDescriptors)
     }

--- a/Sources/TuistKit/Mappers/Workspace/TuistWorkspaceRenderMarkdownMapper.swift
+++ b/Sources/TuistKit/Mappers/Workspace/TuistWorkspaceRenderMarkdownMapper.swift
@@ -10,7 +10,6 @@ final class TuistWorkspaceRenderMarkdownReadmeMapper: WorkspaceMapping {
     func map(workspace: WorkspaceWithProjects) throws -> (WorkspaceWithProjects, [SideEffectDescriptor]) {
         logger.debug("Transforming workspace \(workspace.workspace.name): Including .xcodesample.plist")
 
-        logger.info("")
         let tuistGeneratedFileDescriptor = FileDescriptor(
             path: workspace
                 .workspace

--- a/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
+++ b/Sources/TuistKit/ProjectEditor/ProjectEditorMapper.swift
@@ -53,7 +53,7 @@ final class ProjectEditorMapper: ProjectEditorMapping {
         stencils: [AbsolutePath],
         projectDescriptionSearchPath: AbsolutePath
     ) throws -> Graph {
-        logger.info("Building the editable project graph")
+        logger.notice("Building the editable project graph")
         let swiftVersion = try System.shared.swiftVersion()
 
         let pluginsProject = mapPluginsProject(

--- a/Sources/TuistKit/Services/CleanService.swift
+++ b/Sources/TuistKit/Services/CleanService.swift
@@ -89,9 +89,9 @@ final class CleanService {
                fileHandler.exists(directory)
             {
                 try FileHandler.shared.delete(directory)
-                logger.info("Successfully cleaned artifacts at path \(directory.pathString)", metadata: .success)
+                logger.notice("Successfully cleaned artifacts at path \(directory.pathString)", metadata: .success)
             } else {
-                logger.info("There's nothing to clean for \(category.defaultValueDescription)")
+                logger.notice("There's nothing to clean for \(category.defaultValueDescription)")
             }
         }
     }

--- a/Sources/TuistKit/Services/GenerateService.swift
+++ b/Sources/TuistKit/Services/GenerateService.swift
@@ -42,6 +42,7 @@ final class GenerateService {
         let path = try self.path(path)
         let config = try configLoader.loadConfig(path: path)
         let generator = generatorFactory.default(config: config)
+
         let workspacePath = try await generator.generate(path: path)
         if !noOpen {
             try opener.open(path: workspacePath)

--- a/Sources/TuistKit/Services/InstallService.swift
+++ b/Sources/TuistKit/Services/InstallService.swift
@@ -46,12 +46,12 @@ final class InstallService {
     }
 
     private func fetchPlugins(path: AbsolutePath) async throws {
-        logger.info("Resolving and fetching plugins.", metadata: .section)
+        logger.notice("Resolving and fetching plugins.", metadata: .section)
 
         let config = try configLoader.loadConfig(path: path)
         _ = try await pluginService.loadPlugins(using: config)
 
-        logger.info("Plugins resolved and fetched successfully.", metadata: .success)
+        logger.notice("Plugins resolved and fetched successfully.", metadata: .success)
     }
 
     private func fetchDependencies(path: AbsolutePath, update: Bool) throws {
@@ -64,11 +64,11 @@ final class InstallService {
         }
 
         if update {
-            logger.info("Updating dependencies.", metadata: .section)
+            logger.notice("Updating dependencies.", metadata: .section)
 
             try swiftPackageManagerController.update(at: path, printOutput: true)
         } else {
-            logger.info("Resolving and fetching dependencies.", metadata: .section)
+            logger.notice("Resolving and fetching dependencies.", metadata: .section)
 
             try swiftPackageManagerController.resolve(at: path, printOutput: true)
         }

--- a/Sources/TuistKit/Services/ListService.swift
+++ b/Sources/TuistKit/Services/ListService.swift
@@ -42,7 +42,7 @@ class ListService {
         }
 
         let output = try string(for: templates, in: format)
-        logger.info("\(output)")
+        logger.notice("\(output)")
     }
 
     // MARK: - Helpers

--- a/Sources/TuistKit/Services/Migration/MigrationTargetsByDependenciesService.swift
+++ b/Sources/TuistKit/Services/Migration/MigrationTargetsByDependenciesService.swift
@@ -19,7 +19,7 @@ final class MigrationTargetsByDependenciesService {
     func run(xcodeprojPath: AbsolutePath) throws {
         let sortedTargets = try targetsExtractor.targetsSortedByDependencies(xcodeprojPath: xcodeprojPath)
         let sortedTargetsJson = try makeJson(from: sortedTargets)
-        logger.info("\(sortedTargetsJson)")
+        logger.notice("\(sortedTargetsJson)")
     }
 
     private func makeJson(from sortedTargets: [TargetDependencyCount]) throws -> String {

--- a/Sources/TuistLoader/Loaders/ManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/ManifestLoader.swift
@@ -314,8 +314,8 @@ public class ManifestLoader: ManifestLoading {
             let preManifestLogs = String(string[string.startIndex ..< startTokenRange.lowerBound]).chomp()
             let postManifestLogs = String(string[endTokenRange.upperBound ..< string.endIndex]).chomp()
 
-            if !preManifestLogs.isEmpty { logger.info("\(path.pathString): \(preManifestLogs)") }
-            if !postManifestLogs.isEmpty { logger.info("\(path.pathString):\(postManifestLogs)") }
+            if !preManifestLogs.isEmpty { logger.notice("\(path.pathString): \(preManifestLogs)") }
+            if !postManifestLogs.isEmpty { logger.notice("\(path.pathString):\(postManifestLogs)") }
 
             let manifest = string[startTokenRange.upperBound ..< endTokenRange.lowerBound]
             return manifest.data(using: .utf8)!
@@ -420,7 +420,7 @@ public class ManifestLoader: ManifestLoading {
 
         if errorMessage.contains(defaultHelpersName) {
             logger.error("Cannot import \(defaultHelpersName) in \(manifest.fileName(path))")
-            logger.info("Project description helpers that depend on plugins are not allowed in \(manifest.fileName(path))")
+            logger.notice("Project description helpers that depend on plugins are not allowed in \(manifest.fileName(path))")
         } else if errorMessage.contains("import") {
             logger.error("Helper plugins are not allowed in \(manifest.fileName(path))")
         }

--- a/Sources/TuistMigration/Utilities/EmptyBuildSettingsChecker.swift
+++ b/Sources/TuistMigration/Utilities/EmptyBuildSettingsChecker.swift
@@ -58,7 +58,7 @@ public class EmptyBuildSettingsChecker: EmptyBuildSettingsChecking {
         let nonEmptyBuildSettings = buildConfigurations.compactMap { config -> String? in
             if config.buildSettings.isEmpty { return nil }
             for (key, _) in config.buildSettings {
-                logger.info("The build setting '\(key)' of build configuration '\(config.name)' is not empty.")
+                logger.notice("The build setting '\(key)' of build configuration '\(config.name)' is not empty.")
             }
             return config.name
         }

--- a/Sources/TuistMigration/Utilities/SettingsToXCConfigExtractor.swift
+++ b/Sources/TuistMigration/Utilities/SettingsToXCConfigExtractor.swift
@@ -50,7 +50,7 @@ public class SettingsToXCConfigExtractor: SettingsToXCConfigExtracting {
         let buildConfigurations = try buildConfigurations(pbxproj: pbxproj, targetName: targetName)
 
         if buildConfigurations.isEmpty {
-            logger.info("The list of configurations is empty. Exiting...")
+            logger.notice("The list of configurations is empty. Exiting...")
             return
         }
 
@@ -92,7 +92,7 @@ public class SettingsToXCConfigExtractor: SettingsToXCConfigExtracting {
             buildSettingsLines.sorted().joined(separator: "\n"),
         ].joined(separator: "\n\n")
         try FileHandler.shared.write(buildSettingsContent, path: xcconfigPath, atomically: true)
-        logger.info("Build settings successfully extracted into \(xcconfigPath.pathString)", metadata: .success)
+        logger.notice("Build settings successfully extracted into \(xcconfigPath.pathString)", metadata: .success)
     }
 
     private func buildConfigurations(pbxproj: PBXProj, targetName: String?) throws -> [XCBuildConfiguration] {

--- a/Sources/TuistSupport/System/Publisher+System.swift
+++ b/Sources/TuistSupport/System/Publisher+System.swift
@@ -16,7 +16,7 @@ extension Publisher where Output == SystemEvent<String>, Failure == Error {
             case let .standardError(error):
                 logger.error("\(error)")
             case let .standardOutput(output):
-                logger.info("\(output)")
+                logger.notice("\(output)")
             }
         })
         .eraseToAnyPublisher()

--- a/Tests/TuistKitTests/Services/ListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/ListServiceTests.swift
@@ -58,7 +58,7 @@ final class ListServiceTests: TuistUnitTestCase {
         try await subject.run(path: nil, outputFormat: .table)
 
         // Then
-        XCTAssertPrinterContains(expectedOutput, at: .info, ==)
+        XCTAssertPrinterContains(expectedOutput, at: .notice, ==)
     }
 
     func test_lists_available_templates_json_format() async throws {
@@ -120,6 +120,6 @@ final class ListServiceTests: TuistUnitTestCase {
         try await subject.run(path: nil, outputFormat: .table)
 
         // Then
-        XCTAssertPrinterContains(expectedOutput, at: .info, ==)
+        XCTAssertPrinterContains(expectedOutput, at: .notice, ==)
     }
 }

--- a/Tests/TuistKitTests/Services/ListServiceTests.swift
+++ b/Tests/TuistKitTests/Services/ListServiceTests.swift
@@ -89,7 +89,7 @@ final class ListServiceTests: TuistUnitTestCase {
         try await subject.run(path: nil, outputFormat: .json)
 
         // Then
-        XCTAssertPrinterContains(expectedOutput, at: .info, ==)
+        XCTAssertPrinterContains(expectedOutput, at: .notice, ==)
     }
 
     func test_lists_available_templates_with_plugins() async throws {

--- a/Tests/TuistSupportTests/Utils/FileHandlerTests.swift
+++ b/Tests/TuistSupportTests/Utils/FileHandlerTests.swift
@@ -87,8 +87,10 @@ final class FileHandlerTests: TuistUnitTestCase {
 
     func test_changeExtension() throws {
         // Given
-        let testZippedFrameworkPath = fixturePath(path: try RelativePath(validating: "uUI.xcframework.zip"))
-
+        let temporaryDirectory = try temporaryPath()
+        let testZippedFrameworkPath = temporaryDirectory.appending(component: "uUI.xcframework.zip")
+        try FileHandler.shared.copy(from: fixturePath(path: try RelativePath(validating: "uUI.xcframework.zip")), to: testZippedFrameworkPath)
+                
         // When
         let result = try subject.changeExtension(path: testZippedFrameworkPath, to: "txt")
 

--- a/Tests/TuistSupportTests/Utils/FileHandlerTests.swift
+++ b/Tests/TuistSupportTests/Utils/FileHandlerTests.swift
@@ -89,8 +89,11 @@ final class FileHandlerTests: TuistUnitTestCase {
         // Given
         let temporaryDirectory = try temporaryPath()
         let testZippedFrameworkPath = temporaryDirectory.appending(component: "uUI.xcframework.zip")
-        try FileHandler.shared.copy(from: fixturePath(path: try RelativePath(validating: "uUI.xcframework.zip")), to: testZippedFrameworkPath)
-                
+        try FileHandler.shared.copy(
+            from: fixturePath(path: try RelativePath(validating: "uUI.xcframework.zip")),
+            to: testZippedFrameworkPath
+        )
+
         // When
         let result = try subject.changeExtension(path: testZippedFrameworkPath, to: "txt")
 


### PR DESCRIPTION
### Short description 📝

After fixing a regression introduced after rolling out multi-part uploads (Tuist Cloud), `main` started failing when running unit tests. All the failures have in common that `Tests/Fixtures` is missing, so my guess is that a test is deleting the directory and causes all the tests depending on fixtures to fail.

I've taken the opportunity to ensure we use `logger.notice` consistently throughout the codebase, and remove an empty line that we were printing from one of the mappers and caused an empty line every time you ran a command.

### How to test the changes locally 🧐

All tests should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
