### PR TITLE
Fix DEFINES_MODULE warning

### DIFF
--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -1013,9 +1013,17 @@ extension ProjectDescription.Settings {
 
         if let moduleMap {
             switch moduleMap {
-            case .directory, .header:
+            case .directory, .header, .custom:
                 settingsDictionary["DEFINES_MODULE"] = "NO"
-            case .none, .nestedHeader, .custom:
+                switch settingsDictionary["OTHER_CFLAGS"] ?? .array(["$(inherited)"]) {
+                case let .array(values):
+                    settingsDictionary["OTHER_CFLAGS"] = .array(values + ["-fmodule-name=\(target.name)"])
+                case let .string(value):
+                    settingsDictionary["OTHER_CFLAGS"] = .array(
+                        value.split(separator: " ").map(String.init) + ["-fmodule-name=\(target.name)"]
+                    )
+                }
+            case .none, .nestedHeader:
                 break
             }
         }

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -1192,7 +1192,6 @@ final class GraphTraverserTests: TuistUnitTestCase {
         let swiftSyntaxDynamicXCFramework = GraphDependency.testXCFramework(linking: .dynamic)
 
         let project = Project.test(targets: [target])
-        let graphTarget = GraphDependency.target(name: target.name, path: project.path)
 
         // Given: Value Graph
         let graph = Graph.test(

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -752,7 +752,7 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
         XCTAssertTrue(pbxBuildPhase is PBXResourcesBuildPhase)
 
         let resourceBuildPhase = try XCTUnwrap(nativeTarget.buildPhases.first as? PBXResourcesBuildPhase)
-        var buildFiles = try XCTUnwrap(resourceBuildPhase.files)
+        let buildFiles = try XCTUnwrap(resourceBuildPhase.files)
 
         for buildFile in buildFiles {
             // Explicitly exctracting the original path because it gets lost in translation for resource files

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -1020,6 +1020,8 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         basePath: basePath,
                         customSettings: [
                             "HEADER_SEARCH_PATHS": ["$(SRCROOT)/Sources/Target1/include"],
+                            "DEFINES_MODULE": "NO",
+                            "OTHER_CFLAGS": .array(["-fmodule-name=Target1"]),
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Target1/include/module.modulemap"
                     ),
@@ -1067,6 +1069,10 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         "Target1",
                         basePath: basePath,
                         customSources: .custom(nil),
+                        customSettings: [
+                            "DEFINES_MODULE": "NO",
+                            "OTHER_CFLAGS": .array(["-fmodule-name=Target1"]),
+                        ],
                         moduleMap: "$(SRCROOT)/Sources/Target1/module.modulemap"
                     ),
                 ]
@@ -1150,6 +1156,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             "HEADER_SEARCH_PATHS": ["$(SRCROOT)/Sources/Target1/include"],
                             "MODULEMAP_FILE": .string("$(SRCROOT)/Sources/Target1/include/Target1.modulemap"),
                             "DEFINES_MODULE": "NO",
+                            "OTHER_CFLAGS": .array(["-fmodule-name=Target1"]),
                         ]
                     ),
                 ]
@@ -1198,7 +1205,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 ),
             ]
         )
-        XCTAssertEqual(
+        XCTAssertBetterEqual(
             project,
             .testWithDefaultConfigs(
                 name: "Package",
@@ -1213,6 +1220,8 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                 "$(SRCROOT)/Sources/Dependency1/include",
                                 "$(SRCROOT)/Sources/Dependency2/include",
                             ],
+                            "DEFINES_MODULE": "NO",
+                            "OTHER_CFLAGS": .array(["-fmodule-name=Target1"]),
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Target1/include/module.modulemap"
                     ),
@@ -1225,6 +1234,8 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                 "$(SRCROOT)/Sources/Dependency1/include",
                                 "$(SRCROOT)/Sources/Dependency2/include",
                             ],
+                            "DEFINES_MODULE": "NO",
+                            "OTHER_CFLAGS": .array(["-fmodule-name=Dependency1"]),
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Dependency1/include/module.modulemap"
                     ),
@@ -1233,6 +1244,8 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         basePath: basePath,
                         customSettings: [
                             "HEADER_SEARCH_PATHS": ["$(SRCROOT)/Sources/Dependency2/include"],
+                            "DEFINES_MODULE": "NO",
+                            "OTHER_CFLAGS": .array(["-fmodule-name=Dependency2"]),
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Dependency2/include/module.modulemap"
                     ),
@@ -1321,6 +1334,8 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                 "$(SRCROOT)/../Package2/Sources/Dependency1/include",
                                 "$(SRCROOT)/../Package3/Sources/Dependency2/include",
                             ],
+                            "DEFINES_MODULE": "NO",
+                            "OTHER_CFLAGS": .array(["-fmodule-name=Target1"]),
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Target1/include/module.modulemap"
                     ),
@@ -1392,6 +1407,8 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         ],
                         customSettings: [
                             "HEADER_SEARCH_PATHS": ["$(SRCROOT)/Custom/Headers"],
+                            "DEFINES_MODULE": "NO",
+                            "OTHER_CFLAGS": .array(["-fmodule-name=Target1"]),
                         ],
                         moduleMap: "$(SRCROOT)/Custom/Headers/module.modulemap"
                     ),
@@ -1452,6 +1469,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         customSettings: [
                             "HEADER_SEARCH_PATHS": ["$(SRCROOT)/Sources/Dependency1/include"],
                             "DEFINES_MODULE": "NO",
+                            "OTHER_CFLAGS": .array(["-fmodule-name=Dependency1"]),
                         ],
                         moduleMap: "$(SRCROOT)/Sources/Dependency1/include/Dependency1.modulemap"
                     ),


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5513

### Short description 📝

We already fixed the attached issue once by setting the `DEFINES_MODULE` setting to `NO`. That was correct but the setting does two things:
- Generates a modulemap
- Adds the `"-fmodule-name=\(target.name)"` as part of C flags

While we do not need the former, as we're generating the modulemap ourselves (or the package specifies a custom modulemap), we still need the latter. Once we add `-fmodule-name`, we can finally safely disable the `DEFINES_MODULE` setting.

### How to test the changes locally 🧐

Build `app_with_spm_dependencies` fixture -> you shouldn't see a warning related to `DEFINES_MODULE`.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
