### PR TITLE
Add missing region parameter in the RunActionOptions of Scheme creation

### DIFF
--- a/Sources/ProjectDescription/RunActionOptions.swift
+++ b/Sources/ProjectDescription/RunActionOptions.swift
@@ -70,12 +70,14 @@ public struct RunActionOptions: Equatable, Codable {
 
     public static func options(
         language: SchemeLanguage? = nil,
+        region: String? = nil,
         storeKitConfigurationPath: Path? = nil,
         simulatedLocation: SimulatedLocation? = nil,
         enableGPUFrameCaptureMode: GPUFrameCaptureMode = GPUFrameCaptureMode.default
     ) -> Self {
         self.init(
             language: language,
+            region: region,
             storeKitConfigurationPath: storeKitConfigurationPath,
             simulatedLocation: simulatedLocation,
             enableGPUFrameCaptureMode: enableGPUFrameCaptureMode


### PR DESCRIPTION
### Short description 📝

Could not use **region** parameter in creating schemes with **RunActionOptions**

### How to test the changes locally 🧐
tuist edit
Try to create a scheme with public static method

```swift
public static func options(
        language: SchemeLanguage? = nil,
        region: String? = nil, // <---- was missing
        storeKitConfigurationPath: Path? = nil,
        simulatedLocation: SimulatedLocation? = nil,
        enableGPUFrameCaptureMode: GPUFrameCaptureMode = GPUFrameCaptureMode.default
    )
`

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
