### PR TITLE
Remove PackageSettings platforms property

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -321,8 +321,7 @@ var targets: [Target] = [
         // To revert once we release Tuist 4
         targetSettings: [
             "MockableTest": ["ENABLE_TESTING_SEARCH_PATHS": "YES"],
-        ],
-        platforms: [.macOS]
+        ]
     )
 
 #endif

--- a/Sources/ProjectDescription/PackageSettings.swift
+++ b/Sources/ProjectDescription/PackageSettings.swift
@@ -39,27 +39,21 @@ public struct PackageSettings: Codable, Equatable {
     /// Custom project configurations to be used for projects generated from SwiftPackageManager.
     public var projectOptions: [String: Project.Options]
 
-    /// The custom set of `platforms` that are used by your project
-    public let platforms: Set<PackagePlatform>
-
     /// Creates `PackageSettings` instance for custom Swift Package Manager configuration.
     /// - Parameter productTypes: The custom `Product` types to be used for SPM targets.
     /// - Parameter baseSettings: Additional settings to be added to targets generated from SwiftPackageManager.
     /// - Parameter targetSettings: Additional settings to be added to targets generated from SwiftPackageManager.
     /// - Parameter projectOptions: Custom project configurations to be used for projects generated from SwiftPackageManager.
-    /// - Parameter platforms: The custom set of `platforms` that are used by your project
     public init(
         productTypes: [String: Product] = [:],
         baseSettings: Settings = .settings(),
         targetSettings: [String: SettingsDictionary] = [:],
-        projectOptions: [String: Project.Options] = [:],
-        platforms: Set<PackagePlatform> = Set(PackagePlatform.allCases)
+        projectOptions: [String: Project.Options] = [:]
     ) {
         self.productTypes = productTypes
         self.baseSettings = baseSettings
         self.targetSettings = targetSettings
         self.projectOptions = projectOptions
-        self.platforms = platforms
         dumpIfNeeded(self)
     }
 }

--- a/Sources/TuistGraph/Models/Dependencies/PackageSettings.swift
+++ b/Sources/TuistGraph/Models/Dependencies/PackageSettings.swift
@@ -18,9 +18,6 @@ public struct PackageSettings: Equatable {
     /// Swift tools version of the parsed `Package.swift`
     public let swiftToolsVersion: Version
 
-    /// The custom set of `platforms` that are used by your project
-    public let platforms: Set<PackagePlatform>
-
     /// Initializes a new `PackageSettings` instance.
     /// - Parameters:
     ///    - productTypes: The custom `Product` types to be used for SPM targets.
@@ -32,14 +29,12 @@ public struct PackageSettings: Equatable {
         baseSettings: Settings,
         targetSettings: [String: SettingsDictionary],
         projectOptions: [String: TuistGraph.Project.Options] = [:],
-        swiftToolsVersion: Version,
-        platforms: Set<PackagePlatform>
+        swiftToolsVersion: Version
     ) {
         self.productTypes = productTypes
         self.baseSettings = baseSettings
         self.targetSettings = targetSettings
         self.projectOptions = projectOptions
         self.swiftToolsVersion = swiftToolsVersion
-        self.platforms = platforms
     }
 }

--- a/Sources/TuistGraphTesting/Models/PackageSettings+TestData.swift
+++ b/Sources/TuistGraphTesting/Models/PackageSettings+TestData.swift
@@ -9,16 +9,14 @@ extension PackageSettings {
         baseSettings: Settings = .test(),
         targetSettings: [String: SettingsDictionary] = [:],
         projectOptions: [String: TuistGraph.Project.Options] = [:],
-        swiftToolsVersion: Version = Version("5.4.9"),
-        platforms: Set<PackagePlatform> = [.iOS]
+        swiftToolsVersion: Version = Version("5.4.9")
     ) -> PackageSettings {
         PackageSettings(
             productTypes: productTypes,
             baseSettings: baseSettings,
             targetSettings: targetSettings,
             projectOptions: projectOptions,
-            swiftToolsVersion: swiftToolsVersion,
-            platforms: platforms
+            swiftToolsVersion: swiftToolsVersion
         )
     }
 }

--- a/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -163,24 +163,6 @@ public final class SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoadi
             packageToTargetsToArtifactPaths: packageToTargetsToArtifactPaths
         )
 
-        let destinations: ProjectDescription
-            .Destinations = Set(packageSettings.platforms.flatMap { platform -> ProjectDescription.Destinations in
-                switch platform {
-                case .iOS:
-                    [.iPhone, .iPad, .appleVisionWithiPadDesign, .macWithiPadDesign]
-                case .macCatalyst:
-                    [.macCatalyst]
-                case .macOS:
-                    [.mac]
-                case .tvOS:
-                    [.appleTv]
-                case .watchOS:
-                    [.appleWatch]
-                case .visionOS:
-                    [.appleVision]
-                }
-            })
-
         let externalProjects: [Path: ProjectDescription.Project] = try packageInfos.reduce(into: [:]) { result, packageInfo in
             let manifest = try packageInfoMapper.map(
                 packageInfo: packageInfo.info,
@@ -192,7 +174,6 @@ public final class SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoadi
                 targetSettings: packageSettings.targetSettings,
                 projectOptions: packageSettings.projectOptions[packageInfo.name],
                 minDeploymentTargets: preprocessInfo.platformToMinDeploymentTarget,
-                destinations: destinations,
                 targetToProducts: preprocessInfo.targetToProducts,
                 targetToResolvedDependencies: preprocessInfo.targetToResolvedDependencies,
                 macroDependencies: preprocessInfo.macroDependencies,

--- a/Sources/TuistLoader/Models+ManifestMappers/PackageSettings+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/PackageSettings+ManifestMapper.swift
@@ -20,15 +20,13 @@ extension TuistGraph.PackageSettings {
         let projectOptions: [String: TuistGraph.Project.Options] = manifest
             .projectOptions
             .mapValues { .from(manifest: $0) }
-        let platforms = try Set(manifest.platforms.map { try TuistGraph.PackagePlatform.from(manifest: $0) })
 
         return .init(
             productTypes: productTypes,
             baseSettings: baseSettings,
             targetSettings: targetSettings,
             projectOptions: projectOptions,
-            swiftToolsVersion: swiftToolsVersion,
-            platforms: platforms
+            swiftToolsVersion: swiftToolsVersion
         )
     }
 }

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -538,7 +538,13 @@ extension ProjectDescription.Target {
             destinations = Set<ProjectDescription.Destination>([.mac])
         } else {
             // All packages implicitly support all platforms, we constrain this with the platforms defined in `Package.swift`
-            destinations = Set(Destination.allCases)
+            let packageDestinations: ProjectDescription.Destinations = Set(
+                try packageInfo.platforms.flatMap { platform -> ProjectDescription.Destinations in
+                    return try platform.destinations()
+                }
+            )
+
+            destinations = Set(Destination.allCases).intersection(packageDestinations)
         }
 
         if macroDependencies.contains(where: { dependency in
@@ -1071,7 +1077,7 @@ extension ProjectDescription.Settings {
 }
 
 extension ProjectDescription.PackagePlatform {
-    fileprivate func destinations() throws -> ProjectDescription.Destinations {
+    fileprivate func destinations() -> ProjectDescription.Destinations {
         switch self {
         case .iOS:
             return [.iPhone, .iPad, .macWithiPadDesign, .appleVisionWithiPadDesign]

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -135,7 +135,6 @@ public protocol PackageInfoMapping {
         targetSettings: [String: TuistGraph.SettingsDictionary],
         projectOptions: TuistGraph.Project.Options?,
         minDeploymentTargets: ProjectDescription.DeploymentTargets,
-        destinations: ProjectDescription.Destinations,
         targetToProducts: [String: Set<PackageInfo.Product>],
         targetToResolvedDependencies: [String: [PackageInfoMapper.ResolvedDependency]],
         macroDependencies: Set<PackageInfoMapper.ResolvedDependency>,
@@ -398,7 +397,6 @@ public final class PackageInfoMapper: PackageInfoMapping {
         targetSettings: [String: TuistGraph.SettingsDictionary],
         projectOptions: TuistGraph.Project.Options?,
         minDeploymentTargets: ProjectDescription.DeploymentTargets,
-        destinations: ProjectDescription.Destinations,
         targetToProducts: [String: Set<PackageInfo.Product>],
         targetToResolvedDependencies: [String: [PackageInfoMapper.ResolvedDependency]],
         macroDependencies: Set<PackageInfoMapper.ResolvedDependency>,
@@ -459,7 +457,6 @@ public final class PackageInfoMapper: PackageInfoMapping {
                     productTypes: productTypes,
                     baseSettings: baseSettings,
                     targetSettings: targetSettings,
-                    packageDestinations: destinations,
                     minDeploymentTargets: minDeploymentTargets,
                     targetToResolvedDependencies: targetToResolvedDependencies,
                     targetToModuleMap: targetToModuleMap,
@@ -511,7 +508,6 @@ extension ProjectDescription.Target {
         productTypes: [String: TuistGraph.Product],
         baseSettings: TuistGraph.Settings,
         targetSettings: [String: TuistGraph.SettingsDictionary],
-        packageDestinations: ProjectDescription.Destinations,
         minDeploymentTargets: ProjectDescription.DeploymentTargets,
         targetToResolvedDependencies: [String: [PackageInfoMapper.ResolvedDependency]],
         targetToModuleMap: [String: ModuleMap],
@@ -542,7 +538,7 @@ extension ProjectDescription.Target {
             destinations = Set<ProjectDescription.Destination>([.mac])
         } else {
             // All packages implicitly support all platforms, we constrain this with the platforms defined in `Package.swift`
-            destinations = packageDestinations.intersection(Set(Destination.allCases))
+            destinations = Set(Destination.allCases)
         }
 
         if macroDependencies.contains(where: { dependency in

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -544,7 +544,11 @@ extension ProjectDescription.Target {
                 }
             )
 
-            destinations = Set(Destination.allCases).intersection(packageDestinations)
+            if packageDestinations.isEmpty {
+                destinations = Set(Destination.allCases)
+            } else {
+                destinations = Set(Destination.allCases).intersection(packageDestinations)
+            }
         }
 
         if macroDependencies.contains(where: { dependency in

--- a/Tests/TuistKitIntegrationTests/Commands/DumpServiceIntegrationTests.swift
+++ b/Tests/TuistKitIntegrationTests/Commands/DumpServiceIntegrationTests.swift
@@ -256,7 +256,7 @@ final class DumpServiceTests: TuistTestCase {
         import ProjectDescription
 
         let packageSettings = PackageSettings(
-            platforms: [.iOS, .watchOS]
+            targetSettings: ["TargetA": ["OTHER_LDFLAGS": "-ObjC"]]
         )
 
         #endif

--- a/Tests/TuistLoaderIntegrationTests/Loaders/ManifestLoaderTests.swift
+++ b/Tests/TuistLoaderIntegrationTests/Loaders/ManifestLoaderTests.swift
@@ -158,7 +158,7 @@ final class ManifestLoaderTests: TuistTestCase {
         import ProjectDescription
 
         let packageSettings = PackageSettings(
-            platforms: [.iOS, .watchOS]
+            targetSettings: ["TargetA": ["OTHER_LDFLAGS": "-ObjC"]]
         )
 
         #endif
@@ -188,7 +188,13 @@ final class ManifestLoaderTests: TuistTestCase {
         // Then
         XCTAssertEqual(
             got,
-            .init(platforms: [.iOS, .watchOS])
+            .init(
+                targetSettings: [
+                    "TargetA": [
+                        "OTHER_LDFLAGS": "-ObjC",
+                    ],
+                ]
+            )
         )
     }
 

--- a/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
@@ -50,12 +50,6 @@ final class PackageSettingsLoaderTests: TuistUnitTestCase {
             TSCUtility.Version("5.4.9")
         }
 
-        manifestLoader.loadPackageSettingsStub = { _ in
-            PackageSettings(
-                platforms: [.iOS, .macOS]
-            )
-        }
-
         // When
         let got = try subject.loadPackageSettings(at: temporaryPath, with: plugins)
 
@@ -72,8 +66,7 @@ final class PackageSettingsLoaderTests: TuistUnitTestCase {
                 defaultSettings: .recommended
             ),
             targetSettings: [:],
-            swiftToolsVersion: TSCUtility.Version("5.4.9"),
-            platforms: [.iOS, .macOS]
+            swiftToolsVersion: TSCUtility.Version("5.4.9")
         )
         XCTAssertEqual(manifestLoader.registerPluginsCount, 1)
         XCTAssertEqual(got, expected)

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -40,7 +40,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         .test(name: "Target_1", type: .binary, url: "https://binary.target.com"),
                         .test(name: "Target_2"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -103,7 +103,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -115,7 +115,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target_2"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -162,7 +162,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -174,7 +174,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "com.example.dep-1"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -221,7 +221,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         .test(name: "Dependency_1"),
                         .test(name: "Dependency_2"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -277,7 +277,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -291,7 +291,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         .test(name: "Target_2"),
                         .test(name: "Target_3"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -334,7 +334,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target1"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -371,7 +371,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target1"),
                     ],
-                    platforms: [],
+                    platforms: [PackageInfo.Platform(platformName: "iOS", version: "9.0", options: [])],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -415,8 +415,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
                 ),
-            ],
-            platforms: [.macCatalyst]
+            ]
         )
 
         XCTAssertEqual(
@@ -452,7 +451,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         targets: [
                             .test(name: "Target1"),
                         ],
-                        platforms: [],
+                        platforms: [.ios],
                         cLanguageStandard: nil,
                         cxxLanguageStandard: nil,
                         swiftLanguageVersions: nil
@@ -495,7 +494,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target_1", type: .binary, url: "https://binary.target.com"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -522,7 +521,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target_1"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -569,7 +568,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -616,7 +615,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "com.example.target-1"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -663,7 +662,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         .test(name: "Target1"),
                         .test(name: "Target2"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -703,7 +702,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         .test(name: "Target2", type: .test),
                         .test(name: "Target3", type: .binary),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -742,7 +741,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         .test(name: "Target2"),
                         .test(name: "Target3"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -776,7 +775,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target1", sources: ["Subfolder", "Another/Subfolder/file.swift"]),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -848,7 +847,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -951,7 +950,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target1"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -1003,7 +1002,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             name: "Target1"
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -1051,13 +1050,12 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             type: .system
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
                 ),
-            ],
-            platforms: [.iOS]
+            ]
         )
 
         XCTAssertBetterEqual(
@@ -1106,7 +1104,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             type: .system
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -1137,7 +1135,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             name: "Target1"
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -1198,7 +1196,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         ),
                         .test(name: "Dependency2"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -1283,7 +1281,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             dependencies: [.product(name: "Dependency1", package: "Package2", moduleAliases: nil, condition: nil)]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -1298,7 +1296,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             dependencies: [.product(name: "Dependency2", package: "Package3", moduleAliases: nil, condition: nil)]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -1312,7 +1310,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             name: "Dependency2"
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -1376,7 +1374,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             publicHeadersPath: "Headers"
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -1438,7 +1436,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         ),
                         .test(name: "Dependency1"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -1496,13 +1494,12 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target1"),
                     ],
-                    platforms: [],
+                    platforms: [.ios, .tvos],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
                 ),
-            ],
-            platforms: [.iOS, .tvOS]
+            ]
         )
 
         // Then
@@ -1548,13 +1545,12 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target1"),
                     ],
-                    platforms: [],
+                    platforms: [.tvos],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
                 ),
-            ],
-            platforms: [.tvOS]
+            ]
         )
         XCTAssertEqual(
             project,
@@ -1593,8 +1589,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
                 ),
-            ],
-            platforms: [.iOS]
+            ]
         )
 
         let other = ProjectDescription.Project.testWithDefaultConfigs(
@@ -1635,7 +1630,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             settings: [.init(tool: .c, name: .headerSearchPath, condition: nil, value: ["value"])]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -1675,7 +1670,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             settings: [.init(tool: .cxx, name: .headerSearchPath, condition: nil, value: ["value"])]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -1719,7 +1714,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -1762,7 +1757,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -1804,7 +1799,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -1843,7 +1838,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -1882,7 +1877,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -1921,7 +1916,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -1959,7 +1954,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -1997,7 +1992,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -2041,7 +2036,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -2081,7 +2076,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -2158,7 +2153,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -2216,7 +2211,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -2259,7 +2254,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -2302,7 +2297,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                             ]
                         ),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -2346,7 +2341,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         ),
                         .test(name: "Dependency1"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -2387,7 +2382,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         ),
                         .test(name: "Dependency1", type: .binary),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -2436,7 +2431,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         ),
                         .test(name: "Dependency1"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -2477,7 +2472,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         ),
                         .test(name: "Dependency1", type: .binary, url: "someURL"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -2526,7 +2521,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         ),
                         .test(name: "Dependency1", type: .binary, path: "Dependency1/Dependency1.xcframework"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -2570,7 +2565,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 ),
                 .test(name: "Dependency1"),
             ],
-            platforms: [],
+            platforms: [.ios],
             cLanguageStandard: nil,
             cxxLanguageStandard: nil,
             swiftLanguageVersions: nil
@@ -2585,7 +2580,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 .test(name: "Target3"),
                 .test(name: "Target4"),
             ],
-            platforms: [],
+            platforms: [.ios],
             cLanguageStandard: nil,
             cxxLanguageStandard: nil,
             swiftLanguageVersions: nil
@@ -2638,7 +2633,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 ),
                 .test(name: "Dependency1"),
             ],
-            platforms: [],
+            platforms: [.ios],
             cLanguageStandard: nil,
             cxxLanguageStandard: nil,
             swiftLanguageVersions: nil
@@ -2653,7 +2648,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 .test(name: "Target3"),
                 .test(name: "Target4"),
             ],
-            platforms: [],
+            platforms: [.ios],
             cLanguageStandard: nil,
             cxxLanguageStandard: nil,
             swiftLanguageVersions: nil
@@ -2703,7 +2698,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target1"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: "c99",
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -2738,7 +2733,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target1"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: "gnu++14",
                     swiftLanguageVersions: nil
@@ -2773,7 +2768,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target1"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: ["4.0.0"]
@@ -2808,7 +2803,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target1"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: ["4.0.0", "5.0.0", "4.2.0"]
@@ -2843,7 +2838,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target1"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: ["4.0.0", "5.0.0", "4.2.0"]
@@ -2879,7 +2874,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target1"),
                     ],
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -2922,7 +2917,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         .init(name: "Product1", type: .library(.automatic), targets: allTargets),
                     ],
                     targets: allTargets.map { .test(name: $0) },
-                    platforms: [],
+                    platforms: [.ios],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -2992,13 +2987,12 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         .test(name: "Dependency1"),
                         .test(name: "Dependency2"),
                     ],
-                    platforms: [],
+                    platforms: [.ios, .tvos],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
                 ),
-            ],
-            platforms: [.iOS, .tvOS]
+            ]
         )
 
         let expected: ProjectDescription.Project = .testWithDefaultConfigs(
@@ -3074,7 +3068,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     ]
                 ),
             ],
-            platforms: [],
+            platforms: [.ios, .tvos],
             cLanguageStandard: nil,
             cxxLanguageStandard: nil,
             swiftLanguageVersions: nil
@@ -3087,7 +3081,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 .test(name: "Target2"),
                 .test(name: "Target3"),
             ],
-            platforms: [],
+            platforms: [.ios, .tvos],
             cLanguageStandard: nil,
             cxxLanguageStandard: nil,
             swiftLanguageVersions: nil
@@ -3095,8 +3089,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         let project = try subject.map(
             package: "Package",
             basePath: basePath,
-            packageInfos: ["Package": package1, "Package2": package2],
-            platforms: [.iOS, .tvOS]
+            packageInfos: ["Package": package1, "Package2": package2]
         )
 
         let expected: ProjectDescription.Project = .testWithDefaultConfigs(
@@ -3133,7 +3126,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         let projectTargets = project!.targets.sorted(by: \.name)
         let expectedTargets = expected.targets.sorted(by: \.name)
 
-        XCTAssertEqual(
+        XCTAssertBetterEqual(
             projectTargets,
             expectedTargets
         )
@@ -3162,7 +3155,6 @@ extension PackageInfoMapping {
         package: String,
         basePath: AbsolutePath = "/",
         packageInfos: [String: PackageInfo] = [:],
-        platforms: Set<TuistGraph.PackagePlatform> = [.iOS],
         baseSettings: TuistGraph.Settings = .default,
         targetSettings: [String: TuistGraph.SettingsDictionary] = [:],
         swiftToolsVersion: TSCUtility.Version? = nil,
@@ -3191,23 +3183,6 @@ extension PackageInfoMapping {
             packageToFolder: packageToFolder,
             packageToTargetsToArtifactPaths: packageToTargetsToArtifactPaths
         )
-
-        let destinations: ProjectDescription.Destinations = Set(platforms.flatMap { platform -> ProjectDescription.Destinations in
-            switch platform {
-            case .iOS:
-                [.iPhone, .iPad, .appleVisionWithiPadDesign, .macWithiPadDesign]
-            case .macCatalyst:
-                [.macCatalyst]
-            case .macOS:
-                [.mac]
-            case .tvOS:
-                [.appleTv]
-            case .watchOS:
-                [.appleWatch]
-            case .visionOS:
-                [.appleVision]
-            }
-        })
 
         return try map(
             packageInfo: packageInfos[package]!,

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -3219,7 +3219,6 @@ extension PackageInfoMapping {
             targetSettings: targetSettings,
             projectOptions: projectOptions,
             minDeploymentTargets: preprocessInfo.platformToMinDeploymentTarget,
-            destinations: destinations,
             targetToProducts: preprocessInfo.targetToProducts,
             targetToResolvedDependencies: preprocessInfo.targetToResolvedDependencies,
             macroDependencies: preprocessInfo.macroDependencies,

--- a/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Add External Dependencies/Package.swift
+++ b/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Add External Dependencies/Package.swift
@@ -8,8 +8,7 @@ import PackageDescription
     let packageSettings = PackageSettings(
         productTypes: [
             "Alamofire": .framework, // default is .staticFramework
-        ],
-        platforms: [.iOS]
+        ]
     )
 #endif
 

--- a/fixtures/app_with_plugins/Package.swift
+++ b/fixtures/app_with_plugins/Package.swift
@@ -10,10 +10,7 @@ import PackageDescription
     let localPlugin = LocalHelper(name: "local")
     let remotePlugin = RemoteHelper(name: "remote")
 
-    let packageSettings = PackageSettings(
-        platforms: [.iOS, .macOS]
-    )
-
+    let packageSettings = PackageSettings()
 #endif
 
 let package = Package(

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.swift
@@ -9,8 +9,7 @@ import PackageDescription
         baseSettings: .targetSettings,
         projectOptions: [
             "LocalSwiftPackage": .options(disableSynthesizedResourceAccessors: false),
-        ],
-        platforms: [.iOS, .watchOS]
+        ]
     )
 
 #endif

--- a/fixtures/multiplatform_app_with_sdk/Package.swift
+++ b/fixtures/multiplatform_app_with_sdk/Package.swift
@@ -1,14 +1,6 @@
 // swift-tools-version: 5.9
 import PackageDescription
 
-#if TUIST
-    import ProjectDescription
-
-    let packageSettings = PackageSettings(
-        platforms: [.macOS, .iOS]
-    )
-#endif
-
 let package = Package(
     name: "PackageName",
     dependencies: [


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5910

### Short description 📝

As discussed in the attached issue, the `platforms` property of `PackageSettings` never should have made it to the 4.x cut. It currently doesn't do anything as the stripping of platforms is automatic in one of our mappers.

While technically a breaking change, we believe this won't cause much convenience for developers to fix and will bring clarity as this property can currently cause a lot of confusion.

### How to test the changes locally 🧐

CI passing should be fine here.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
