### PR TITLE
Add missing `region` parameter in static helper `RunActionOptions`.`options`

### DIFF
--- a/Sources/ProjectDescription/RunActionOptions.swift
+++ b/Sources/ProjectDescription/RunActionOptions.swift
@@ -55,6 +55,8 @@ public struct RunActionOptions: Equatable, Codable {
     /// - Parameters:
     ///     - language: language (e.g. "pl").
     ///
+    ///     - region: region (e.g. "US").
+    ///
     ///     - storeKitConfigurationPath: The path of the
     ///     [StoreKit configuration
     /// file](https://developer.apple.com/documentation/xcode/setting_up_storekit_testing_in_xcode#3625700).

--- a/Sources/ProjectDescription/RunActionOptions.swift
+++ b/Sources/ProjectDescription/RunActionOptions.swift
@@ -53,7 +53,7 @@ public struct RunActionOptions: Equatable, Codable {
     /// Creates an `RunActionOptions` instance
     ///
     /// - Parameters:
-    ///     - language: language (e.g. "pl").
+    ///     - language: language (e.g. "en").
     ///
     ///     - region: region (e.g. "US").
     ///

--- a/Sources/ProjectDescription/RunActionOptions.swift
+++ b/Sources/ProjectDescription/RunActionOptions.swift
@@ -70,12 +70,14 @@ public struct RunActionOptions: Equatable, Codable {
 
     public static func options(
         language: SchemeLanguage? = nil,
+        region: String? = nil,
         storeKitConfigurationPath: Path? = nil,
         simulatedLocation: SimulatedLocation? = nil,
         enableGPUFrameCaptureMode: GPUFrameCaptureMode = GPUFrameCaptureMode.default
     ) -> Self {
         self.init(
             language: language,
+            region: region,
             storeKitConfigurationPath: storeKitConfigurationPath,
             simulatedLocation: simulatedLocation,
             enableGPUFrameCaptureMode: enableGPUFrameCaptureMode

--- a/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
+++ b/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
@@ -171,12 +171,14 @@ extension RunAction {
     public static func test(
         configuration: ConfigurationName = .debug,
         executable: TargetReference? = nil,
-        arguments: Arguments? = nil
+        arguments: Arguments? = nil,
+        options: RunActionOptions = nil
     ) -> RunAction {
         RunAction(
             configuration: configuration,
             executable: executable,
-            arguments: arguments
+            arguments: arguments,
+            options: options
         )
     }
 }

--- a/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
+++ b/Sources/TuistLoaderTesting/Loaders/TestData/ProjectDescription+TestData.swift
@@ -172,7 +172,7 @@ extension RunAction {
         configuration: ConfigurationName = .debug,
         executable: TargetReference? = nil,
         arguments: Arguments? = nil,
-        options: RunActionOptions = nil
+        options: RunActionOptions = .options()
     ) -> RunAction {
         RunAction(
             configuration: configuration,

--- a/Tests/ProjectDescriptionTests/SchemeTests.swift
+++ b/Tests/ProjectDescriptionTests/SchemeTests.swift
@@ -38,6 +38,13 @@ final class SchemeTests: XCTestCase {
                 arguments: Arguments(
                     environmentVariables: ["run": "b"],
                     launchArguments: [LaunchArgument(name: "run", isEnabled: true)]
+                ),
+                options: RunActionOptions(
+                    language: .init(identifier: "en"),
+                    region: "US",
+                    storeKitConfigurationPath: nil,
+                    simulatedLocation: nil,
+                    enableGPUFrameCaptureMode: .autoEnabled
                 )
             )
         )
@@ -80,6 +87,13 @@ final class SchemeTests: XCTestCase {
                 arguments: Arguments(
                     environmentVariables: ["run": "b"],
                     launchArguments: [LaunchArgument(name: "run", isEnabled: true)]
+                ),
+                options: RunActionOptions(
+                    language: .init(identifier: "en"),
+                    region: "US",
+                    storeKitConfigurationPath: nil,
+                    simulatedLocation: nil,
+                    enableGPUFrameCaptureMode: .autoEnabled
                 )
             )
         )
@@ -87,6 +101,8 @@ final class SchemeTests: XCTestCase {
         // Then
         XCTAssertEqual(subject.runAction?.configuration.rawValue, "Release")
         XCTAssertEqual(subject.testAction?.configuration.rawValue, "Debug")
+        XCTAssertEqual(subject.runAction?.options.language, "en")
+        XCTAssertEqual(subject.runAction?.options.region, "US")
     }
 
     // MARK: - Helpers

--- a/Tests/ProjectDescriptionTests/SchemeTests.swift
+++ b/Tests/ProjectDescriptionTests/SchemeTests.swift
@@ -40,7 +40,7 @@ final class SchemeTests: XCTestCase {
                     launchArguments: [LaunchArgument(name: "run", isEnabled: true)]
                 ),
                 options: RunActionOptions(
-                    language: .init(identifier: "en"),
+                    language: "en",
                     region: "US",
                     storeKitConfigurationPath: nil,
                     simulatedLocation: nil,
@@ -89,7 +89,7 @@ final class SchemeTests: XCTestCase {
                     launchArguments: [LaunchArgument(name: "run", isEnabled: true)]
                 ),
                 options: RunActionOptions(
-                    language: .init(identifier: "en"),
+                    language: "en",
                     region: "US",
                     storeKitConfigurationPath: nil,
                     simulatedLocation: nil,


### PR DESCRIPTION
### Short description 📝

Could not use **region** parameter in creating schemes with **RunActionOptions**

### How to test the changes locally 🧐
> Try to create a scheme with RunAction having the region parameter

```swift
public static func options(
        language: SchemeLanguage? = nil,
        region: String? = nil, // <---- was missing
        storeKitConfigurationPath: Path? = nil,
        simulatedLocation: SimulatedLocation? = nil,
        enableGPUFrameCaptureMode: GPUFrameCaptureMode = GPUFrameCaptureMode.default
    )
```

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
