### PR TITLE
Fix integration of local packages with Objective C targets

### DIFF
--- a/Sources/TuistGenerator/Mappers/DeleteDerivedDirectoryProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/DeleteDerivedDirectoryProjectMapper.swift
@@ -6,9 +6,14 @@ import TuistSupport
 /// A project mapper that returns side effects to delete the derived directory.
 public final class DeleteDerivedDirectoryProjectMapper: ProjectMapping {
     private let derivedDirectoryName: String
-
-    public init(derivedDirectoryName: String = Constants.DerivedDirectory.name) {
+    private let fileHandler: FileHandling
+    
+    public init(
+        derivedDirectoryName: String = Constants.DerivedDirectory.name,
+        fileHandler: FileHandling = FileHandler.shared
+    ) {
         self.derivedDirectoryName = derivedDirectoryName
+        self.fileHandler = fileHandler
     }
 
     // MARK: - ProjectMapping
@@ -17,10 +22,17 @@ public final class DeleteDerivedDirectoryProjectMapper: ProjectMapping {
         logger.debug("Transforming project \(project.name): Deleting /Derived directory")
 
         let derivedDirectoryPath = project.path.appending(component: derivedDirectoryName)
-        let directoryDescriptor = DirectoryDescriptor(path: derivedDirectoryPath, state: .absent)
+        
+        let sideEffects: [SideEffectDescriptor] = try fileHandler.contentsOfDirectory(derivedDirectoryPath)
+            .filter { $0.extension != "modulemap" }
+            .map {
+                if fileHandler.isFolder($0) {
+                    return .directory(DirectoryDescriptor(path: $0, state: .absent))
+                } else {
+                    return .file(FileDescriptor(path: $0, state: .absent))
+                }
+            }
 
-        return (project, [
-            .directory(directoryDescriptor),
-        ])
+        return (project, sideEffects)
     }
 }

--- a/Sources/TuistGenerator/Mappers/DeleteDerivedDirectoryProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/DeleteDerivedDirectoryProjectMapper.swift
@@ -7,7 +7,7 @@ import TuistSupport
 public final class DeleteDerivedDirectoryProjectMapper: ProjectMapping {
     private let derivedDirectoryName: String
     private let fileHandler: FileHandling
-    
+
     public init(
         derivedDirectoryName: String = Constants.DerivedDirectory.name,
         fileHandler: FileHandling = FileHandler.shared
@@ -22,7 +22,11 @@ public final class DeleteDerivedDirectoryProjectMapper: ProjectMapping {
         logger.debug("Transforming project \(project.name): Deleting /Derived directory")
 
         let derivedDirectoryPath = project.path.appending(component: derivedDirectoryName)
-        
+
+        if !fileHandler.exists(derivedDirectoryPath) {
+            return (project, [])
+        }
+
         let sideEffects: [SideEffectDescriptor] = try fileHandler.contentsOfDirectory(derivedDirectoryPath)
             .filter { $0.extension != "modulemap" }
             .map {

--- a/Tests/TuistGeneratorTests/ProjectMappers/DeleteDerivedDirectoryProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/DeleteDerivedDirectoryProjectMapperTests.swift
@@ -24,14 +24,19 @@ public final class DeleteDerivedDirectoryProjectMapperTests: TuistUnitTestCase {
 
     func test_map_returns_sideEffectsToDeleteDerivedDirectories() throws {
         // Given
-        let projectA = Project.test(path: "/projectA")
+        let projectPath = try temporaryPath()
+        let derivedDirectory = projectPath.appending(component: Constants.DerivedDirectory.name)
+        let projectA = Project.test(path: projectPath)
+        try fileHandler.createFolder(derivedDirectory)
+        try fileHandler.createFolder(derivedDirectory.appending(component: "InfoPlists"))
+        try fileHandler.touch(derivedDirectory.appending(component: "TargetA.modulemap"))
 
         // When
         let (_, sideEffects) = try subject.map(project: projectA)
 
         // Then
         XCTAssertEqual(sideEffects, [
-            .directory(.init(path: projectA.path.appending(component: Constants.DerivedDirectory.name), state: .absent)),
+            .directory(.init(path: derivedDirectory.appending(component: "InfoPlists"), state: .absent)),
         ])
     }
 }

--- a/fixtures/app_with_spm_dependencies/LocalSwiftPackageB/Package.swift
+++ b/fixtures/app_with_spm_dependencies/LocalSwiftPackageB/Package.swift
@@ -8,10 +8,10 @@ let package = Package(
     defaultLocalization: "en",
     products: [.library(name: "LibraryA", targets: ["LibraryA"])],
     targets: [
-        .target(name: "LibraryA"),
+        .target(name: "LibraryA", dependencies: ["LibraryAProxy"]),
         .target(
             name: "LibraryAProxy"
-        )
+        ),
     ],
     cxxLanguageStandard: .cxx17
 )

--- a/fixtures/app_with_spm_dependencies/LocalSwiftPackageB/Package.swift
+++ b/fixtures/app_with_spm_dependencies/LocalSwiftPackageB/Package.swift
@@ -9,5 +9,9 @@ let package = Package(
     products: [.library(name: "LibraryA", targets: ["LibraryA"])],
     targets: [
         .target(name: "LibraryA"),
-    ]
+        .target(
+            name: "LibraryAProxy"
+        )
+    ],
+    cxxLanguageStandard: .cxx17
 )

--- a/fixtures/app_with_spm_dependencies/LocalSwiftPackageB/Sources/LibraryA/MyStruct.swift
+++ b/fixtures/app_with_spm_dependencies/LocalSwiftPackageB/Sources/LibraryA/MyStruct.swift
@@ -1,1 +1,3 @@
+import LibraryAProxy
+
 public struct MyStruct {}

--- a/fixtures/app_with_spm_dependencies/LocalSwiftPackageB/Sources/LibraryAProxy/Test.mm
+++ b/fixtures/app_with_spm_dependencies/LocalSwiftPackageB/Sources/LibraryAProxy/Test.mm
@@ -1,0 +1,5 @@
+#import "Test.h"
+
+@implementation Test { }
+
+@end

--- a/fixtures/app_with_spm_dependencies/LocalSwiftPackageB/Sources/LibraryAProxy/include/Test.h
+++ b/fixtures/app_with_spm_dependencies/LocalSwiftPackageB/Sources/LibraryAProxy/include/Test.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface Test : NSObject
+
+@end


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5955

### Short description 📝

A project with a local Swift package that contains objc code would fail to build. This is because we'd:
- [Generate a module map](https://github.com/tuist/tuist/blob/main/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift) into the `Derived` directory (a different directory is used for remote packages)
- And then we would always [delete it](https://github.com/tuist/tuist/blob/main/Sources/TuistGenerator/Mappers/DeleteDerivedDirectoryProjectMapper.swift). Since the `DeleteDerivedDirectoryProjectMapper` is always run after the SPM graph is loaded, the modulemap would never be preserved

For now, I make sure the mapper does _not_ delete the `modulemap`. This is not an optimal solution but one that works for now. As we make `Package.swift` first-class citizens, we will also move away from preloading the whole SPM graph and running operations on it before the rest of the graph – instead, the SPM `Package.swift` manifests will be treated the same way as any other manifest.

### How to test the changes locally 🧐

`app_with_spm_dependencies` should build (I also tried the example in the attached issue)

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
