### PR TITLE
Add support for `.pch` headers

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -221,8 +221,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj",
       "state" : {
-        "revision" : "e29e0db843062f5157f77d5b68f237eb5aa43f12",
-        "version" : "8.18.0"
+        "revision" : "75e787fb3eb5a8397c3d06d5a71e667ac2d20ac1",
+        "version" : "8.19.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -424,7 +424,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftDocOrg/GraphViz", exact: "0.2.0"),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit", exact: "2.10.1"),
         .package(url: "https://github.com/SwiftGen/SwiftGen", exact: "6.6.2"),
-        .package(url: "https://github.com/tuist/XcodeProj", exact: "8.18.0"),
+        .package(url: "https://github.com/tuist/XcodeProj", exact: "8.19.0"),
         .package(url: "https://github.com/cpisciotta/xcbeautify", from: "1.4.0"),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", from: "1.0.2"),
         .package(url: "https://github.com/Kolos65/Mockable.git", from: "0.0.2"),


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5878

### Short description 📝
This PR updates XcodeProj to 8.19.0, which includes `.pch` files as supported header files.

### How to test the changes locally 🧐
You can add a `.pch` file as a header of a project.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
