### PR TITLE
Prune targets with no destinations after platform narrowing

### DIFF
--- a/Sources/TuistDependencies/Mappers/PruneOrphanExternalTargetsGraphMapper.swift
+++ b/Sources/TuistDependencies/Mappers/PruneOrphanExternalTargetsGraphMapper.swift
@@ -21,7 +21,7 @@ public struct PruneOrphanExternalTargetsGraphMapper: GraphMapping {
             let targets = Dictionary(uniqueKeysWithValues: targets.compactMap { targetName, target -> (String, Target)? in
                 let project = graph.projects[projectPath]!
                 let graphTarget = GraphTarget(path: projectPath, target: target, project: project)
-                if orphanExternalTargets.contains(graphTarget) {
+                if orphanExternalTargets.contains(graphTarget) || target.destinations.isEmpty {
                     return nil
                 } else {
                     return (targetName, target)

--- a/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
+++ b/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
@@ -54,8 +54,8 @@ public final class GraphMapperFactory: GraphMapperFactorying {
     ) -> [GraphMapping] {
         var mappers: [GraphMapping] = []
         mappers.append(UpdateWorkspaceProjectsGraphMapper())
-        mappers.append(PruneOrphanExternalTargetsGraphMapper())
         mappers.append(ExternalProjectsPlatformNarrowerGraphMapper())
+        mappers.append(PruneOrphanExternalTargetsGraphMapper())
         if config.generationOptions.enforceExplicitDependencies {
             mappers.append(ExplicitDependencyGraphMapper())
         }

--- a/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -11,6 +11,7 @@ final class DependenciesAcceptanceTestAppWithSPMDependencies: TuistAcceptanceTes
         try await run(InstallCommand.self)
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self, "App")
+        try await run(TestCommand.self, "AppKit")
     }
 }
 

--- a/Tests/TuistDependenciesTests/Mappers/PruneOrphanExternalTargetsGraphMapperTests.swift
+++ b/Tests/TuistDependenciesTests/Mappers/PruneOrphanExternalTargetsGraphMapperTests.swift
@@ -27,16 +27,21 @@ final class PruneOrphanExternalTargetsGraphMapperTests: TuistUnitTestCase {
         let appDependency = GraphDependency.target(name: app.name, path: project.path)
         let directPackageProduct = Target.test(name: "DirectPackage", destinations: [.iPhone], product: .app)
         let transitivePackageProduct = Target.test(name: "TransitivePackage", destinations: [.iPhone], product: .app)
+        let transitivePackageProductWithNoDestinations = Target.test(name: "TransitivePackageWithNoDestination", destinations: [], product: .app)
         let packageDevProduct = Target.test(name: "DevPackage", destinations: [.iPhone], product: .app)
         let packageProject = Project.test(
             path: try! AbsolutePath(validating: "/Package"),
             name: "Package",
-            targets: [directPackageProduct, transitivePackageProduct, packageDevProduct],
+            targets: [directPackageProduct, transitivePackageProduct, transitivePackageProductWithNoDestinations, packageDevProduct],
             isExternal: true
         )
         let directPackageProductDependency = GraphDependency.target(name: directPackageProduct.name, path: packageProject.path)
         let transitivePackageProductDependency = GraphDependency.target(
             name: transitivePackageProduct.name,
+            path: packageProject.path
+        )
+        let transitivePackageProductWithNoDestinationsDependency = GraphDependency.target(
+            name: transitivePackageProductWithNoDestinations.name,
             path: packageProject.path
         )
 
@@ -48,11 +53,12 @@ final class PruneOrphanExternalTargetsGraphMapperTests: TuistUnitTestCase {
             ], packageProject.path: [
                 directPackageProduct.name: directPackageProduct,
                 transitivePackageProduct.name: transitivePackageProduct,
+                transitivePackageProductWithNoDestinations.name: transitivePackageProductWithNoDestinations,
                 packageDevProduct.name: packageDevProduct,
             ]],
             dependencies: [
                 appDependency: Set([directPackageProductDependency]),
-                directPackageProductDependency: Set([transitivePackageProductDependency]),
+                directPackageProductDependency: Set([transitivePackageProductDependency, transitivePackageProductWithNoDestinationsDependency]),
             ]
         )
 
@@ -64,5 +70,6 @@ final class PruneOrphanExternalTargetsGraphMapperTests: TuistUnitTestCase {
         XCTAssertNotNil(gotGraph.targets[packageProject.path]?[directPackageProduct.name])
         XCTAssertNotNil(gotGraph.targets[packageProject.path]?[transitivePackageProduct.name])
         XCTAssertNil(gotGraph.targets[packageProject.path]?[packageDevProduct.name])
+        XCTAssertNil(gotGraph.targets[packageProject.path]?[transitivePackageProductWithNoDestinations.name])
     }
 }

--- a/Tests/TuistDependenciesTests/Mappers/PruneOrphanExternalTargetsGraphMapperTests.swift
+++ b/Tests/TuistDependenciesTests/Mappers/PruneOrphanExternalTargetsGraphMapperTests.swift
@@ -27,12 +27,21 @@ final class PruneOrphanExternalTargetsGraphMapperTests: TuistUnitTestCase {
         let appDependency = GraphDependency.target(name: app.name, path: project.path)
         let directPackageProduct = Target.test(name: "DirectPackage", destinations: [.iPhone], product: .app)
         let transitivePackageProduct = Target.test(name: "TransitivePackage", destinations: [.iPhone], product: .app)
-        let transitivePackageProductWithNoDestinations = Target.test(name: "TransitivePackageWithNoDestination", destinations: [], product: .app)
+        let transitivePackageProductWithNoDestinations = Target.test(
+            name: "TransitivePackageWithNoDestination",
+            destinations: [],
+            product: .app
+        )
         let packageDevProduct = Target.test(name: "DevPackage", destinations: [.iPhone], product: .app)
         let packageProject = Project.test(
             path: try! AbsolutePath(validating: "/Package"),
             name: "Package",
-            targets: [directPackageProduct, transitivePackageProduct, transitivePackageProductWithNoDestinations, packageDevProduct],
+            targets: [
+                directPackageProduct,
+                transitivePackageProduct,
+                transitivePackageProductWithNoDestinations,
+                packageDevProduct,
+            ],
             isExternal: true
         )
         let directPackageProductDependency = GraphDependency.target(name: directPackageProduct.name, path: packageProject.path)
@@ -58,7 +67,10 @@ final class PruneOrphanExternalTargetsGraphMapperTests: TuistUnitTestCase {
             ]],
             dependencies: [
                 appDependency: Set([directPackageProductDependency]),
-                directPackageProductDependency: Set([transitivePackageProductDependency, transitivePackageProductWithNoDestinationsDependency]),
+                directPackageProductDependency: Set([
+                    transitivePackageProductDependency,
+                    transitivePackageProductWithNoDestinationsDependency,
+                ]),
             ]
         )
 

--- a/fixtures/app_with_spm_dependencies/App/Project.swift
+++ b/fixtures/app_with_spm_dependencies/App/Project.swift
@@ -44,6 +44,19 @@ let project = Project(
             settings: .targetSettings
         ),
         .target(
+            name: "AppKitTests",
+            destinations: .iOS,
+            product: .unitTests,
+            bundleId: "io.tuist.app.kit",
+            infoPlist: .default,
+            sources: "Tests/AppKit/**",
+            dependencies: [
+                .target(name: "AppKit"),
+                .external(name: "Nimble"),
+            ],
+            settings: .targetSettings
+        ),
+        .target(
             name: "WatchApp",
             destinations: [.appleWatch],
             product: .watch2App,

--- a/fixtures/app_with_spm_dependencies/App/Tests/AppKit/AppKitTests.swift
+++ b/fixtures/app_with_spm_dependencies/App/Tests/AppKit/AppKitTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+import Nimble
+
+final class AppKitTests: XCTestCase {
+    func testExample() {
+        expect(1).to(equal(1))
+    }
+}

--- a/fixtures/app_with_spm_dependencies/App/Tests/AppKit/AppKitTests.swift
+++ b/fixtures/app_with_spm_dependencies/App/Tests/AppKit/AppKitTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import Nimble
+import XCTest
 
 final class AppKitTests: XCTestCase {
     func testExample() {

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
@@ -46,6 +46,24 @@
       }
     },
     {
+      "identity" : "cwlcatchexception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
+      "state" : {
+        "revision" : "3b123999de19bf04905bc1dfdb76f817b0f2cc00",
+        "version" : "2.1.2"
+      }
+    },
+    {
+      "identity" : "cwlpreconditiontesting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+      "state" : {
+        "revision" : "dc9af4781f2afdd1e68e90f80b8603be73ea7abc",
+        "version" : "2.2.0"
+      }
+    },
+    {
       "identity" : "googlesignin-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleSignIn-iOS",
@@ -73,6 +91,15 @@
       }
     },
     {
+      "identity" : "nimble",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Nimble",
+      "state" : {
+        "revision" : "c1f3dd66222d5e7a1a20afc237f7e7bc432c564f",
+        "version" : "13.2.0"
+      }
+    },
+    {
       "identity" : "nytphotoviewer",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/NYTPhotoViewer",
@@ -88,6 +115,15 @@
       "state" : {
         "revision" : "1aed8f7dc79ce8e674c61e430ef51ca3db18cea9",
         "version" : "1.11.1"
+      }
+    },
+    {
+      "identity" : "quick",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Quick",
+      "state" : {
+        "revision" : "a9e6c24033a25e158384d523a556c0b96c44a839",
+        "version" : "7.4.0"
       }
     },
     {

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.swift
@@ -29,6 +29,8 @@ let package = Package(
         .package(url: "https://github.com/microsoft/appcenter-sdk-apple", .upToNextMajor(from: "5.0.4")),
         // Has SWIFTPM_MODULE_BUNDLE
         .package(url: "https://github.com/tuist/NYTPhotoViewer", branch: "develop"),
+        .package(url: "https://github.com/Quick/Quick", exact: "7.4.0"),
+        .package(url: "https://github.com/Quick/Nimble", exact: "13.2.0"),
         .package(path: "../LocalSwiftPackage"),
         .package(path: "../StringifyMacro"),
     ]


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5971

### Short description 📝

The `Nimble` library currently doesn't build for iOS-only targets. That's because we correctly narrow the platforms but that leaves [CwlPosixPreconditionTesting](https://github.com/Quick/Nimble/blob/main/Package.swift#L35-L36) with _no_ destinations (as it's for `tvOS` and `watchOS` only).

The fix is to consider a target as an orphan if it has no destinations.

### How to test the changes locally 🧐

Try `app_with_spm_dependencies` fixture that now also includes `Nimble`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
