### PR TITLE
Add support for the new `package` access modifier

### DIFF
--- a/Sources/TuistCoreTesting/Graph/DependenciesGraph+TestData.swift
+++ b/Sources/TuistCoreTesting/Graph/DependenciesGraph+TestData.swift
@@ -93,7 +93,7 @@ extension TuistCore.DependenciesGraph {
                     ),
                     .sdk(name: "WatchKit", type: .framework, status: .required, condition: .when([.watchos])),
                 ],
-                settings: Self.spmSettings(with: [
+                settings: Self.spmSettings(packageName: "Tuist", with: [
                     "HEADER_SEARCH_PATHS": [
                         "$(SRCROOT)/customPath/cSearchPath",
                         "$(SRCROOT)/customPath/cxxSearchPath",
@@ -122,7 +122,7 @@ extension TuistCore.DependenciesGraph {
                         path: Self.packageFolder(spmFolder: spmFolder, packageName: "another-dependency")
                     ),
                 ],
-                settings: Self.spmSettings()
+                settings: Self.spmSettings(packageName: "TuistKit")
             ),
         ]
 
@@ -190,7 +190,7 @@ extension TuistCore.DependenciesGraph {
                         name: "ALibraryUtils"
                     ),
                 ],
-                settings: Self.spmSettings()
+                settings: Self.spmSettings(packageName: "ALibrary")
             ),
             .target(
                 name: "ALibraryUtils",
@@ -203,7 +203,7 @@ extension TuistCore.DependenciesGraph {
                 sources: [
                     "\(packageFolder.pathString)/Sources/ALibraryUtils/**",
                 ],
-                settings: Self.spmSettings()
+                settings: Self.spmSettings(packageName: "ALibraryUtils")
             ),
         ]
 
@@ -258,7 +258,7 @@ extension TuistCore.DependenciesGraph {
                 sources: [
                     "\(packageFolder.pathString)/Sources/AnotherLibrary/**",
                 ],
-                settings: Self.spmSettings()
+                settings: Self.spmSettings(packageName: "AnotherLibrary")
             ),
         ]
 
@@ -321,7 +321,7 @@ extension TuistCore.DependenciesGraph {
                         condition: .when([.ios, .macos, .tvos, .watchos])
                     ),
                 ],
-                settings: Self.spmSettings()
+                settings: Self.spmSettings(packageName: "Alamofire")
             ),
         ]
 
@@ -406,7 +406,7 @@ extension TuistCore.DependenciesGraph {
                     .sdk(name: "z", type: .library, status: .required),
                     .sdk(name: "StoreKit", type: .framework, status: .required),
                 ],
-                settings: Self.spmSettings()
+                settings: Self.spmSettings(packageName: "GoogleAppMeasurementTarget")
             ),
             .target(
                 name: "GoogleAppMeasurementWithoutAdIdSupportTarget",
@@ -448,7 +448,7 @@ extension TuistCore.DependenciesGraph {
                     .sdk(name: "z", type: .library, status: .required),
                     .sdk(name: "StoreKit", type: .framework, status: .required),
                 ],
-                settings: Self.spmSettings()
+                settings: Self.spmSettings(packageName: "GoogleAppMeasurementWithoutAdIdSupportTarget")
             ),
         ]
 
@@ -527,7 +527,7 @@ extension TuistCore.DependenciesGraph {
                 sources: [
                     "\(packageFolder.pathString)/Sources/GULAppDelegateSwizzler/**",
                 ],
-                settings: Self.spmSettings()
+                settings: Self.spmSettings(packageName: "GULAppDelegateSwizzler")
             ),
             .target(
                 name: "GULMethodSwizzler",
@@ -540,7 +540,7 @@ extension TuistCore.DependenciesGraph {
                 sources: [
                     "\(packageFolder.pathString)/Sources/GULMethodSwizzler/**",
                 ],
-                settings: Self.spmSettings()
+                settings: Self.spmSettings(packageName: "GULMethodSwizzler")
             ),
 
             .target(
@@ -554,7 +554,7 @@ extension TuistCore.DependenciesGraph {
                 sources: [
                     "\(packageFolder.pathString)/Sources/GULNSData/**",
                 ],
-                settings: Self.spmSettings()
+                settings: Self.spmSettings(packageName: "GULNSData")
             ),
             .target(
                 name: "GULNetwork",
@@ -567,7 +567,7 @@ extension TuistCore.DependenciesGraph {
                 sources: [
                     "\(packageFolder.pathString)/Sources/GULNetwork/**",
                 ],
-                settings: Self.spmSettings()
+                settings: Self.spmSettings(packageName: "GULNetwork")
             ),
         ]
 
@@ -622,7 +622,7 @@ extension TuistCore.DependenciesGraph {
                 sources: [
                     "\(packageFolder.pathString)/Sources/nanopb/**",
                 ],
-                settings: Self.spmSettings()
+                settings: Self.spmSettings(packageName: "nanopb")
             ),
         ]
 
@@ -661,6 +661,7 @@ extension DependenciesGraph {
     }
 
     static func spmSettings(
+        packageName: String,
         baseSettings: Settings = .settings(),
         with customSettings: SettingsDictionary = [:],
         moduleMap: String? = nil
@@ -675,6 +676,7 @@ extension DependenciesGraph {
             "FRAMEWORK_SEARCH_PATHS": ["$(inherited)", "$(PLATFORM_DIR)/Developer/Library/Frameworks"],
             "GCC_NO_COMMON_BLOCKS": "NO",
             "USE_HEADERMAP": "NO",
+            "OTHER_SWIFT_FLAGS": ["-package-name", packageName],
         ]
         var settingsDictionary = customSettings.merging(defaultSpmSettings, uniquingKeysWith: { custom, _ in custom })
 

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -418,7 +418,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
             uniquingKeysWith: { userDefined, _ in userDefined }
         )
 
-        let targetSettings = targetSettings.merging(
+        var targetSettings = targetSettings.merging(
             // Force enable testing search paths
             Dictionary(
                 uniqueKeysWithValues: [
@@ -441,6 +441,19 @@ public final class PackageInfoMapper: PackageInfoMapping {
                 userDefined.merging(defaultDictionary, uniquingKeysWith: { userDefined, _ in userDefined })
             }
         )
+        // Setting the -package-name Swift compiler flag
+        targetSettings = targetSettings.mapValues { settings in
+            var settings = settings
+            settings["OTHER_SWIFT_FLAGS"] = switch settings["OTHER_SWIFT_FLAGS"] {
+            case let .array(items):
+                .array(items + ["-package-name", name])
+            case let .string(value):
+                "\(value) -package-name \(name)"
+            case .none:
+                .array(["-package-name", name])
+            }
+            return settings
+        }
 
         let targets: [ProjectDescription.Target] = try packageInfo.targets
             .compactMap { target -> ProjectDescription.Target? in

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -442,18 +442,9 @@ public final class PackageInfoMapper: PackageInfoMapping {
             }
         )
         // Setting the -package-name Swift compiler flag
-        targetSettings = targetSettings.mapValues { settings in
-            var settings = settings
-            settings["OTHER_SWIFT_FLAGS"] = switch settings["OTHER_SWIFT_FLAGS"] {
-            case let .array(items):
-                .array(items + ["-package-name", name])
-            case let .string(value):
-                "\(value) -package-name \(name)"
-            case .none:
-                .array(["-package-name", name])
-            }
-            return settings
-        }
+        var baseSettings = baseSettings.with(base: [
+            "OTHER_SWIFT_FLAGS": ["$(inherited)", "-package-name", name],
+        ])
 
         let targets: [ProjectDescription.Target] = try packageInfo.targets
             .compactMap { target -> ProjectDescription.Target? in

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -442,7 +442,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
             }
         )
         // Setting the -package-name Swift compiler flag
-        var baseSettings = baseSettings.with(base: [
+        let baseSettings = baseSettings.with(base: [
             "OTHER_SWIFT_FLAGS": ["$(inherited)", "-package-name", name],
         ])
 

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -3278,6 +3278,7 @@ extension ProjectDescription.Target {
 
     fileprivate static func test(
         _ name: String,
+        packageName: String = "Package",
         basePath: AbsolutePath = "/",
         destinations: ProjectDescription.Destinations = [.iPhone, .iPad, .appleVisionWithiPadDesign, .macWithiPadDesign],
         product: ProjectDescription.Product = .staticFramework,
@@ -3318,7 +3319,12 @@ extension ProjectDescription.Target {
             resources: resources.isEmpty ? nil : .resources(resources),
             headers: headers,
             dependencies: dependencies,
-            settings: DependenciesGraph.spmSettings(baseSettings: baseSettings, with: customSettings, moduleMap: moduleMap)
+            settings: DependenciesGraph.spmSettings(
+                packageName: packageName,
+                baseSettings: baseSettings,
+                with: customSettings,
+                moduleMap: moduleMap
+            )
         )
     }
 }


### PR DESCRIPTION
### Short description 📝
Apple [introduced](https://github.com/apple/swift-evolution/blob/main/proposals/0386-package-access-modifier.md) a new access modifier in packages for package targets to indicate that only targets from the same package can access a given API. In practice, it requires to compile the target with the Swift compiler flag `-package-name {PackageName}`

### How to test the changes locally 🧐
If you generate a project that has external dependencies, you should see the `OTHER_SWIFT_FLAGS` setting set to `-package-name {PackageName}`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
