### PR TITLE
SPM dependencies now implicitly support all platforms

### DIFF
--- a/Sources/TuistCore/Simulator/SimulatorController.swift
+++ b/Sources/TuistCore/Simulator/SimulatorController.swift
@@ -143,7 +143,6 @@ public final class SimulatorController: SimulatorControlling {
         deviceName: String?
     ) async throws -> [SimulatorDeviceAndRuntime] {
         let devicesAndRuntimes = try await devicesAndRuntimes()
-        let maxRuntimeVersion = devicesAndRuntimes.map(\.runtime.version).max()
         let availableDevices = devicesAndRuntimes
             .sorted(by: { $0.runtime.version >= $1.runtime.version })
             .filter { simulatorDeviceAndRuntime in
@@ -160,13 +159,18 @@ public final class SimulatorController: SimulatorControlling {
                     guard simulatorDeviceAndRuntime.device.name == deviceName else { return false }
                 }
 
-                if version == nil, let maxRuntimeVersion {
-                    guard simulatorDeviceAndRuntime.runtime.version == maxRuntimeVersion else { return false }
-                }
-
                 return true
             }
-        return availableDevices
+
+        let maxRuntimeVersion = availableDevices.map(\.runtime.version).max()
+
+        return availableDevices.filter { simulatorDeviceAndRuntime in
+            if version == nil, let maxRuntimeVersion {
+                return simulatorDeviceAndRuntime.runtime.version == maxRuntimeVersion
+            } else {
+                return true
+            }
+        }
     }
 
     public func findAvailableDevice(

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -541,18 +541,8 @@ extension ProjectDescription.Target {
         if target.type == .macro {
             destinations = Set<ProjectDescription.Destination>([.mac])
         } else {
-            // All packages implicitly support all platforms, we constrain this with the platforms defined in `Package.swift`
-            let packageDestinations: ProjectDescription.Destinations = Set(
-                try packageInfo.platforms.flatMap { platform -> ProjectDescription.Destinations in
-                    return try platform.destinations()
-                }
-            )
-
-            if packageDestinations.isEmpty {
-                destinations = Set(Destination.allCases)
-            } else {
-                destinations = Set(Destination.allCases).intersection(packageDestinations)
-            }
+            // All packages implicitly support all platforms
+            destinations = Set(Destination.allCases)
         }
 
         if macroDependencies.contains(where: { dependency in

--- a/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -11,6 +11,7 @@ final class DependenciesAcceptanceTestAppWithSPMDependencies: TuistAcceptanceTes
         try await run(InstallCommand.self)
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self, "App")
+        try await run(BuildCommand.self, "VisionOSApp")
         try await run(TestCommand.self, "AppKit")
     }
 }

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -387,7 +387,13 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     .test(
                         "Target1",
                         basePath: basePath,
-                        deploymentTargets: .iOS("9.0")
+                        deploymentTargets: .multiplatform(
+                            iOS: "9.0",
+                            macOS: "10.10",
+                            watchOS: "2.0",
+                            tvOS: "9.0",
+                            visionOS: "1.0"
+                        )
                     ),
                 ]
             )
@@ -410,7 +416,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     targets: [
                         .test(name: "Target1"),
                     ],
-                    platforms: [.init(platformName: "maccatalyst", version: "13.0", options: [])],
+                    platforms: [.init(platformName: "maccatalyst", version: "12.0", options: [])],
                     cLanguageStandard: nil,
                     cxxLanguageStandard: nil,
                     swiftLanguageVersions: nil
@@ -418,7 +424,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             ]
         )
 
-        XCTAssertEqual(
+        XCTAssertBetterEqual(
             project,
             .testWithDefaultConfigs(
                 name: "Package",
@@ -426,8 +432,14 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     .test(
                         "Target1",
                         basePath: basePath,
-                        destinations: [.macCatalyst],
-                        deploymentTargets: .iOS("13.0")
+                        destinations: Set(Destination.allCases),
+                        deploymentTargets: .multiplatform(
+                            iOS: "12.0",
+                            macOS: "10.13",
+                            watchOS: "4.0",
+                            tvOS: "12.0",
+                            visionOS: "1.0"
+                        )
                     ),
                 ]
             )
@@ -1509,10 +1521,8 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 .test(
                     "Target1",
                     basePath: basePath,
-                    destinations: [.iPad, .iPhone, .macWithiPadDesign, .appleVisionWithiPadDesign, .appleTv],
                     customProductName: "Target1",
                     customBundleID: "Target1",
-                    deploymentTargets: .multiplatform(iOS: "12.0", tvOS: "12.0"),
                     customSources: .custom(.sourceFilesList(globs: [
                         basePath.appending(try RelativePath(validating: "Package/Sources/Target1/**"))
                             .pathString,
@@ -1528,45 +1538,6 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         let projectTargets = project?.targets.sorted(by: \.name)
         let expectedTargets = expected.targets.sorted(by: \.name)
         XCTAssertBetterEqual(projectTargets, expectedTargets)
-    }
-
-    func testMap_whenIOSNotAvailable_takesOthers() throws {
-        let basePath = try temporaryPath()
-        let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))
-        try fileHandler.createFolder(sourcesPath)
-        let project = try subject.map(
-            package: "Package",
-            basePath: basePath,
-            packageInfos: [
-                "Package": .init(
-                    products: [
-                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
-                    ],
-                    targets: [
-                        .test(name: "Target1"),
-                    ],
-                    platforms: [.tvos],
-                    cLanguageStandard: nil,
-                    cxxLanguageStandard: nil,
-                    swiftLanguageVersions: nil
-                ),
-            ]
-        )
-        XCTAssertEqual(
-            project,
-            .testWithDefaultConfigs(
-                name: "Package",
-                targets: [
-                    .test(
-                        "Target1",
-
-                        basePath: basePath,
-                        destinations: [.appleTv],
-                        deploymentTargets: .tvOS("12.0")
-                    ),
-                ]
-            )
-        )
     }
 
     func testMap_whenPackageDefinesPlatform_configuresDeploymentTarget() throws {
@@ -1598,7 +1569,13 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 .test(
                     "Target1",
                     basePath: basePath,
-                    deploymentTargets: .iOS("13.0")
+                    deploymentTargets: .multiplatform(
+                        iOS: "13.0",
+                        macOS: "10.13",
+                        watchOS: "4.0",
+                        tvOS: "12.0",
+                        visionOS: "1.0"
+                    )
                 ),
             ]
         )
@@ -1606,7 +1583,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         dump(project?.targets.first?.destinations)
         dump(other.targets.first?.destinations)
 
-        XCTAssertEqual(
+        XCTAssertBetterEqual(
             project,
             other
         )
@@ -3001,10 +2978,8 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 .test(
                     "Target1",
                     basePath: basePath,
-                    destinations: [.iPhone, .iPad, .macWithiPadDesign, .appleVisionWithiPadDesign, .appleTv],
                     customProductName: "Target1",
                     customBundleID: "Target1",
-                    deploymentTargets: .multiplatform(iOS: "12.0", tvOS: "12.0"),
                     customSources: .custom(.sourceFilesList(globs: [
                         basePath.appending(try RelativePath(validating: "Package/Sources/Target1/**")).pathString,
                     ])),
@@ -3016,10 +2991,8 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 .test(
                     "Dependency1",
                     basePath: basePath,
-                    destinations: [.iPhone, .iPad, .macWithiPadDesign, .appleVisionWithiPadDesign, .appleTv],
                     customProductName: "Dependency1",
                     customBundleID: "Dependency1",
-                    deploymentTargets: .multiplatform(iOS: "12.0", tvOS: "12.0"),
                     customSources: .custom(.sourceFilesList(globs: [
                         basePath.appending(try RelativePath(validating: "Package/Sources/Dependency1/**")).pathString,
                     ]))
@@ -3027,10 +3000,8 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 .test(
                     "Dependency2",
                     basePath: basePath,
-                    destinations: [.iPhone, .iPad, .macWithiPadDesign, .appleVisionWithiPadDesign, .appleTv],
                     customProductName: "Dependency2",
                     customBundleID: "Dependency2",
-                    deploymentTargets: .multiplatform(iOS: "12.0", tvOS: "12.0"),
                     customSources: .custom(.sourceFilesList(globs: [
                         basePath.appending(try RelativePath(validating: "Package/Sources/Dependency2/**")).pathString,
                     ]))
@@ -3042,7 +3013,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
 
         let projectTargets = project!.targets.sorted(by: \.name)
         let expectedTargets = expected.targets.sorted(by: \.name)
-        XCTAssertEqual(projectTargets, expectedTargets)
+        XCTAssertBetterEqual(projectTargets, expectedTargets)
     }
 
     func testMap_whenTargetDependenciesOnProductHaveConditions() throws {
@@ -3098,10 +3069,8 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 .test(
                     "Target1",
                     basePath: basePath,
-                    destinations: [.iPhone, .iPad, .macWithiPadDesign, .appleVisionWithiPadDesign, .appleTv],
                     customProductName: "Target1",
                     customBundleID: "Target1",
-                    deploymentTargets: .multiplatform(iOS: "12.0", tvOS: "12.0"),
                     customSources: .custom(.sourceFilesList(globs: [
                         basePath.appending(try RelativePath(validating: "Package/Sources/Target1/**")).pathString,
                     ])),
@@ -3280,11 +3249,17 @@ extension ProjectDescription.Target {
         _ name: String,
         packageName: String = "Package",
         basePath: AbsolutePath = "/",
-        destinations: ProjectDescription.Destinations = [.iPhone, .iPad, .appleVisionWithiPadDesign, .macWithiPadDesign],
+        destinations: ProjectDescription.Destinations = Set(Destination.allCases),
         product: ProjectDescription.Product = .staticFramework,
         customProductName: String? = nil,
         customBundleID: String? = nil,
-        deploymentTargets: ProjectDescription.DeploymentTargets = .multiplatform(iOS: "12.0"),
+        deploymentTargets: ProjectDescription.DeploymentTargets = .multiplatform(
+            iOS: "12.0",
+            macOS: "10.13",
+            watchOS: "4.0",
+            tvOS: "12.0",
+            visionOS: "1.0"
+        ),
         customSources: SourceFilesListType = .default,
         resources: [ProjectDescription.ResourceFileElement] = [],
         headers: ProjectDescription.Headers? = nil,

--- a/fixtures/app_with_spm_dependencies/App/Project.swift
+++ b/fixtures/app_with_spm_dependencies/App/Project.swift
@@ -57,6 +57,16 @@ let project = Project(
             settings: .targetSettings
         ),
         .target(
+            name: "VisionOSApp",
+            destinations: [.appleVision],
+            product: .app,
+            bundleId: "io.tuist.app.applevision",
+            sources: ["Sources/VisionOS/App/**"],
+            dependencies: [
+                .external(name: "Alamofire"),
+            ]
+        ),
+        .target(
             name: "WatchApp",
             destinations: [.appleWatch],
             product: .watch2App,

--- a/fixtures/app_with_spm_dependencies/App/Sources/VisionOS/App/VisionOSApp.swift
+++ b/fixtures/app_with_spm_dependencies/App/Sources/VisionOS/App/VisionOSApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct VisionOSTestApp: App {
+    var body: some Scene {
+        WindowGroup {
+            Text("Hello, world!")
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5975

### Short description 📝

Packages implicitly support all platforms. That's also true even if the `platforms` parameter is defined. For example, a package with `platforms: [.iOS("13.0")]` still implicitly supports all platforms. The only thing the parameter does is updates the deployment target of the package products.

We assumed that when devs defined `platforms`, the platform support would be explicit – that's not true. In the attached issue, `swift-parsing` would not build for `visionOS` because it doesn't define in the platforms param: https://github.com/pointfreeco/swift-parsing/blob/main/Package.swift#L7-L12. But integrating the dependency via vanilla Xcode integration, you could actually use it for visionOS. Because as described all packages implicitly support all platforms no matter what.

### How to test the changes locally 🧐

Build the new `VisionOSApp` target in the `app_with_spm_dependencies` fixture.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
