### PR TITLE
Upgrade to xcbeautify 1.6.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -212,8 +212,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/cpisciotta/xcbeautify",
       "state" : {
-        "revision" : "9895885c427f758a9edfc1c016863418de8e9e8d",
-        "version" : "1.5.0"
+        "revision" : "82bc54c25c78284555759277d4d92fef5627f95e",
+        "version" : "1.6.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -425,7 +425,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit", exact: "2.10.1"),
         .package(url: "https://github.com/SwiftGen/SwiftGen", exact: "6.6.2"),
         .package(url: "https://github.com/tuist/XcodeProj", exact: "8.19.0"),
-        .package(url: "https://github.com/cpisciotta/xcbeautify", from: "1.5.0"),
+        .package(url: "https://github.com/cpisciotta/xcbeautify", from: "1.6.0"),
         .package(url: "https://github.com/krzysztofzablocki/Difference.git", from: "1.0.2"),
         .package(url: "https://github.com/Kolos65/Mockable.git", from: "0.0.2"),
     ],


### PR DESCRIPTION
### Short description 📝

Reference: https://github.com/cpisciotta/xcbeautify/releases/tag/1.6.0

Tuist users should see notable accuracy and time improvements to their logs with this change. Namely, `SwiftCompile` commands are properly captured now.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
