### PR TITLE
Update docs for optional Cloud.Option

### DIFF
--- a/Sources/ProjectDescription/Cloud.swift
+++ b/Sources/ProjectDescription/Cloud.swift
@@ -4,9 +4,8 @@ import Foundation
 public struct Cloud: Codable, Equatable {
     /// Options for cloud configuration.
     public enum Option: String, Codable, Equatable {
-        /// Marks whether cloud connection is optional.
-        /// If not present, tuist commands will fail regardless of whether an authentication token is available locally from
-        /// `tuist cloud auth` or not.
+        /// Marks whether Tuist Cloud authentication is optional.
+        /// If present, the interaction with Tuist Cloud will be skipped (instead of failing) if a user is not authenticated.
         case optional
     }
 


### PR DESCRIPTION
### Short description 📝

Makes the docs for `Cloud.Option.optional` more clear.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
