### PR TITLE
Align settings transformers method signatures

### DIFF
--- a/Sources/ProjectDescription/SettingsTransformers.swift
+++ b/Sources/ProjectDescription/SettingsTransformers.swift
@@ -110,12 +110,22 @@ extension SettingsDictionary {
 
     /// Sets `"OTHER_SWIFT_FLAGS"` to `flags`
     public func otherSwiftFlags(_ flags: String...) -> SettingsDictionary {
-        merging(["OTHER_SWIFT_FLAGS": SettingValue(flags.joined(separator: " "))])
+        otherSwiftFlags(flags)
+    }
+
+    /// Sets `"OTHER_SWIFT_FLAGS"` to `flags`
+    public func otherSwiftFlags(_ flags: [String]) -> SettingsDictionary {
+        merging(["OTHER_SWIFT_FLAGS": .array(flags)])
     }
 
     /// Sets `"SWIFT_ACTIVE_COMPILATION_CONDITIONS"` to `conditions`
     public func swiftActiveCompilationConditions(_ conditions: String...) -> SettingsDictionary {
-        merging(["SWIFT_ACTIVE_COMPILATION_CONDITIONS": SettingValue(conditions.joined(separator: " "))])
+        swiftActiveCompilationConditions(conditions)
+    }
+
+    /// Sets `"SWIFT_ACTIVE_COMPILATION_CONDITIONS"` to `conditions`
+    public func swiftActiveCompilationConditions(_ conditions: [String]) -> SettingsDictionary {
+        merging(["SWIFT_ACTIVE_COMPILATION_CONDITIONS": .array(conditions)])
     }
 
     // MARK: - Swift Compiler - Code Generation

--- a/Sources/ProjectDescription/SettingsTransformers.swift
+++ b/Sources/ProjectDescription/SettingsTransformers.swift
@@ -109,6 +109,7 @@ extension SettingsDictionary {
     // MARK: - Swift Compiler - Custom Flags
 
     /// Sets `"OTHER_SWIFT_FLAGS"` to `flags`
+    @available(*, deprecated, message: "Please use the version with array support")
     public func otherSwiftFlags(_ flags: String...) -> SettingsDictionary {
         otherSwiftFlags(flags)
     }
@@ -119,6 +120,7 @@ extension SettingsDictionary {
     }
 
     /// Sets `"SWIFT_ACTIVE_COMPILATION_CONDITIONS"` to `conditions`
+    @available(*, deprecated, message: "Please use the version with array support")
     public func swiftActiveCompilationConditions(_ conditions: String...) -> SettingsDictionary {
         swiftActiveCompilationConditions(conditions)
     }

--- a/Tests/ProjectDescriptionTests/SettingsTests.swift
+++ b/Tests/ProjectDescriptionTests/SettingsTests.swift
@@ -115,10 +115,10 @@ final class SettingsTests: XCTestCase {
             "VERSION_INFO_PREFIX": "A_Prefix",
             "VERSION_INFO_SUFFIX": "A_Suffix",
             "SWIFT_VERSION": "5.2.1",
-            "OTHER_SWIFT_FLAGS": "first second third",
+            "OTHER_SWIFT_FLAGS": ["first", "second", "third"],
             "ENABLE_BITCODE": "YES",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
-            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "FIRST SECOND THIRD",
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": ["FIRST", "SECOND", "THIRD"],
             "SWIFT_OBJC_BRIDGING_HEADER": "/my/bridging/header/path.h",
             "OTHER_CFLAGS": ["$(inherited)", "-my-c-flag"],
             "OTHER_LDFLAGS": ["$(inherited)", "-my-linker-flag"],
@@ -138,15 +138,44 @@ final class SettingsTests: XCTestCase {
         ])
     }
 
-    func test_settingsDictionary_swiftActiveCompilationConditions() {
+    func test_settingsDictionary_otherSwiftFlags() {
         /// Given/When
-        let settings = SettingsDictionary()
-            .swiftActiveCompilationConditions("FIRST", "SECOND", "THIRD")
+        let settingsVariadic = SettingsDictionary()
+            .otherSwiftFlags("FIRST", "SECOND", "THIRD")
+
+        let settingsArray = SettingsDictionary()
+            .otherSwiftFlags(["FIRST", "SECOND", "THIRD"])
 
         /// Then
-        XCTAssertEqual(settings, [
-            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "FIRST SECOND THIRD",
+        XCTAssertEqual(settingsVariadic, [
+            "OTHER_SWIFT_FLAGS": ["FIRST", "SECOND", "THIRD"],
         ])
+
+        XCTAssertEqual(settingsArray, [
+            "OTHER_SWIFT_FLAGS": ["FIRST", "SECOND", "THIRD"],
+        ])
+
+        XCTAssertEqual(settingsVariadic, settingsArray)
+    }
+
+    func test_settingsDictionary_swiftActiveCompilationConditions() {
+        /// Given/When
+        let settingsVariadic = SettingsDictionary()
+            .swiftActiveCompilationConditions("FIRST", "SECOND", "THIRD")
+
+        let settingsArray = SettingsDictionary()
+            .swiftActiveCompilationConditions(["FIRST", "SECOND", "THIRD"])
+
+        /// Then
+        XCTAssertEqual(settingsVariadic, [
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": ["FIRST", "SECOND", "THIRD"],
+        ])
+
+        XCTAssertEqual(settingsArray, [
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": ["FIRST", "SECOND", "THIRD"],
+        ])
+
+        XCTAssertEqual(settingsVariadic, settingsArray)
     }
 
     func test_settingsDictionary_SwiftCompilationMode() {


### PR DESCRIPTION
### Short description 📝

While working with some of the SettingsTransformers I saw some mismatch between the method signature of `otherSwiftFlags`, `swiftActiveCompilationConditions` and `otherCFlags`, `otherLinkerFlags` even though all of these settings are defined as `String List` in the Xcode Project manifest. 

Therefore I thought it would makes sense to align these APIs. I kept the variadic parameter version of the transformers to not cause any breaking changes. Underlying they will now all point to a version 

### How to test the changes locally 🧐

All of these changes should be covered by unit tests.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
