### PR TITLE
Fix generation of SPM packages when some resources are missing

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -65,7 +65,10 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
             additionalTargets.append(resourcesTarget)
         }
 
-        if target.supportsSources, target.sources.contains(where: { $0.path.extension == "swift" }) {
+        if target.supportsSources,
+           target.sources.contains(where: { $0.path.extension == "swift" }),
+           !target.sources.contains(where: { $0.path.basename == "\(target.name)Resources.swift" })
+        {
             let (filePath, data) = synthesizedSwiftFile(bundleName: bundleName, target: target, project: project)
 
             let hash = try data.map(contentHasher.hash)

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -766,6 +766,18 @@ extension ResourceFileElements {
                 return try handleProcessResource(resourceAbsolutePath: resourceAbsolutePath)
             }
         }
+            .filter {
+                switch $0 {
+                case let .glob(pattern: pattern, excluding: _, tags: _, inclusionCondition: _):
+                    // We will automatically skip including globs of non-existing directories for packages
+                    if !FileHandler.shared.exists(try AbsolutePath(validating: String(pattern.pathString)).parentDirectory) {
+                        return false
+                    }
+                    return true
+                case .folderReference:
+                    return true
+                }
+            }
 
         // Add default resources path if necessary
         // They are handled like a `.process` rule

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -766,18 +766,18 @@ extension ResourceFileElements {
                 return try handleProcessResource(resourceAbsolutePath: resourceAbsolutePath)
             }
         }
-            .filter {
-                switch $0 {
-                case let .glob(pattern: pattern, excluding: _, tags: _, inclusionCondition: _):
-                    // We will automatically skip including globs of non-existing directories for packages
-                    if !FileHandler.shared.exists(try AbsolutePath(validating: String(pattern.pathString)).parentDirectory) {
-                        return false
-                    }
-                    return true
-                case .folderReference:
-                    return true
+        .filter {
+            switch $0 {
+            case let .glob(pattern: pattern, excluding: _, tags: _, inclusionCondition: _):
+                // We will automatically skip including globs of non-existing directories for packages
+                if !FileHandler.shared.exists(try AbsolutePath(validating: String(pattern.pathString)).parentDirectory) {
+                    return false
                 }
+                return true
+            case .folderReference:
+                return true
             }
+        }
 
         // Add default resources path if necessary
         // They are handled like a `.process` rule

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -893,6 +893,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                 .init(rule: .copy, path: "Resource/Folder"),
                                 .init(rule: .process, path: "Another/Resource/Folder"),
                                 .init(rule: .process, path: "AnotherOne/Resource/Folder"),
+                                .init(rule: .process, path: "AnotherOne/Resource/Folder/NonExisting"),
                             ],
                             exclude: [
                                 "AnotherOne/Resource",
@@ -907,7 +908,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             ]
         )
 
-        XCTAssertEqual(
+        XCTAssertBetterEqual(
             project,
             .testWithDefaultConfigs(
                 name: "Package",

--- a/fixtures/app_with_spm_dependencies/App/Project.swift
+++ b/fixtures/app_with_spm_dependencies/App/Project.swift
@@ -41,6 +41,7 @@ let project = Project(
                 .external(name: "libzstd"),
                 .external(name: "NYTPhotoViewer"),
                 .external(name: "SVProgressHUD"),
+                .external(name: "AirshipPreferenceCenter"),
             ],
             settings: .targetSettings
         ),

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
@@ -91,6 +91,15 @@
       }
     },
     {
+      "identity" : "ios-library",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/urbanairship/ios-library.git",
+      "state" : {
+        "revision" : "53040c77617a2acc5d9a7b69cf5bbbf36f94ad4b",
+        "version" : "17.7.3"
+      }
+    },
+    {
       "identity" : "nimble",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble",

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .package(url: "https://github.com/Quick/Quick", exact: "7.4.0"),
         .package(url: "https://github.com/Quick/Nimble", exact: "13.2.0"),
         .package(url: "https://github.com/SVProgressHUD/SVProgressHUD", exact: "2.3.1"),
-        // Has missing resources
+        // Has missing resources and its own resource bundle accessors
         .package(url: "https://github.com/urbanairship/ios-library.git", .exact("17.7.3")),
         .package(path: "../LocalSwiftPackage"),
         .package(path: "../StringifyMacro"),

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.swift
@@ -32,6 +32,8 @@ let package = Package(
         .package(url: "https://github.com/Quick/Quick", exact: "7.4.0"),
         .package(url: "https://github.com/Quick/Nimble", exact: "13.2.0"),
         .package(url: "https://github.com/SVProgressHUD/SVProgressHUD", exact: "2.3.1"),
+        // Has missing resources
+        .package(url: "https://github.com/urbanairship/ios-library.git", .exact("17.7.3")),
         .package(path: "../LocalSwiftPackage"),
         .package(path: "../StringifyMacro"),
     ]


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6019

### Short description 📝

We skip adding globs where the base folder doesn't exist at all for external dependencies as we shouldn't be stricter than SPM.

### How to test the changes locally 🧐

You should be able to generate and build the `app_with_spm_dependencies` project

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
