### PR TITLE
fix: Previews crash when accessing resources from cached XCFrameworks

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -191,14 +191,12 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
                     Bundle.main.bundleURL,
                 ]
 
-                #if DEBUG
                 // This is a fix to make Previews work with bundled resources.
                 // Logic here is taken from SPM's generated `resource_bundle_accessors.swift` file,
                 // which is located under the derived data directory after building the project.
                 if let override = ProcessInfo.processInfo.environment["PACKAGE_RESOURCE_BUNDLE_PATH"] {
                     candidates.append(URL(fileURLWithPath: override))
                 }
-                #endif
 
                 for candidate in candidates {
                     let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")


### PR DESCRIPTION
This is continuation of https://github.com/tuist/tuist/pull/6008.

### Short description 📝

SPM has the `#if DEBUG` guard within which `ProcessInfo` is used. It works because SPM doesn't precompile anything, so compiling the bundle accessor happens with debug configuration. 

However, if you run `tuist cache` for all dependencies and then `tuist generate SomeFramework`, it will cause a crash when running Previews as `tuist cache` builds for release mode and resulting code will bypass this check. It still works with the previous implementation if running `tuist generate SomeFramework DependencyWithResources`, but that defeats the point of caching and makes using Previews less predictable.

While I wanted to stay as close to the original SPM implementation as possible, I don't think there is any harm in checking for this environment variable in release configuration either. It will simply be not set.

### How to test the changes locally 🧐

1. `cd fixtures/app_with_previews`
2. `tuist install`
3. `tuist cache`
4. `tuist generate PreviewsFramework`
5. Open `TestView.swift` and tap on the button in Previews and it will crash

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
