### PR TITLE
Allow setting visionOS deployment target for appleVisionWithiPadDesign

### DIFF
--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -212,7 +212,7 @@ class TargetLinter: TargetLinting {
             let osVersionRegex = "\\b[0-9]+\\.[0-9]+(?:\\.[0-9]+)?\\b"
             if !version.matches(pattern: osVersionRegex) { return [versionFormatIssue] }
 
-            let destinations = target.destinations
+            let destinations = target.destinations.sorted(by: { $0.rawValue < $1.rawValue })
             let inconsistentPlatformIssue = LintingIssue(
                 reason: "Found an inconsistency between target destinations `\(destinations)` and deployment target `\(platform.caseValue)`",
                 severity: .error

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -223,7 +223,10 @@ class TargetLinter: TargetLinting {
             case .macOS: if !target.supports(.macOS) { return [inconsistentPlatformIssue] }
             case .watchOS: if !target.supports(.watchOS) { return [inconsistentPlatformIssue] }
             case .tvOS: if !target.supports(.tvOS) { return [inconsistentPlatformIssue] }
-            case .visionOS: if !target.supports(.visionOS) { return [inconsistentPlatformIssue] }
+            case .visionOS:
+                if !target.supports(.visionOS), !target.destinations.contains(.appleVisionWithiPadDesign) {
+                    return [inconsistentPlatformIssue]
+                }
             }
             return []
         }

--- a/Sources/TuistGraph/Models/Destination.swift
+++ b/Sources/TuistGraph/Models/Destination.swift
@@ -31,7 +31,7 @@ public enum Destination: String, Codable, Equatable, CaseIterable {
 
     public var platform: Platform {
         switch self {
-        case .iPad, .iPhone, .macCatalyst, .macWithiPadDesign:
+        case .iPad, .iPhone, .macCatalyst, .macWithiPadDesign, .appleVisionWithiPadDesign:
             return .iOS
         case .mac:
             return .macOS
@@ -39,7 +39,7 @@ public enum Destination: String, Codable, Equatable, CaseIterable {
             return .tvOS
         case .appleWatch:
             return .watchOS
-        case .appleVision, .appleVisionWithiPadDesign:
+        case .appleVision:
             return .visionOS
         }
     }

--- a/Sources/TuistGraph/Models/Destination.swift
+++ b/Sources/TuistGraph/Models/Destination.swift
@@ -31,7 +31,7 @@ public enum Destination: String, Codable, Equatable, CaseIterable {
 
     public var platform: Platform {
         switch self {
-        case .iPad, .iPhone, .macCatalyst, .macWithiPadDesign, .appleVisionWithiPadDesign:
+        case .iPad, .iPhone, .macCatalyst, .macWithiPadDesign:
             return .iOS
         case .mac:
             return .macOS
@@ -39,7 +39,7 @@ public enum Destination: String, Codable, Equatable, CaseIterable {
             return .tvOS
         case .appleWatch:
             return .watchOS
-        case .appleVision:
+        case .appleVision, .appleVisionWithiPadDesign:
             return .visionOS
         }
     }

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -515,6 +515,43 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         assert(config: releaseConfig, contains: expectedSettings)
     }
 
+    func test_generateTargetWithDeploymentTarget_whenVisionWithiPadDesign() throws {
+        // Given
+        let project = Project.test()
+        let target = Target.test(
+            destinations: [.iPhone, .iPad, .appleVisionWithiPadDesign],
+            deploymentTargets: .init(iOS: "16.0", visionOS: "1.0")
+        )
+        let graph = Graph.test(path: project.path)
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        try subject.generateTargetConfig(
+            target,
+            project: project,
+            pbxTarget: pbxTarget,
+            pbxproj: pbxproj,
+            projectSettings: .default,
+            fileElements: ProjectFileElements(),
+            graphTraverser: graphTraverser,
+            sourceRootPath: try AbsolutePath(validating: "/project")
+        )
+
+        // Then
+        let configurationList = pbxTarget.buildConfigurationList
+        let debugConfig = configurationList?.configuration(name: "Debug")
+        let releaseConfig = configurationList?.configuration(name: "Release")
+
+        let expectedSettings: SettingsDictionary = [
+            "TARGETED_DEVICE_FAMILY": "1,2",
+            "XROS_DEPLOYMENT_TARGET": "1.0",
+            "IPHONEOS_DEPLOYMENT_TARGET": "16.0",
+        ]
+
+        assert(config: debugConfig, contains: expectedSettings)
+        assert(config: releaseConfig, contains: expectedSettings)
+    }
+
     func test_generateTargetWithMultiplePlatforms() throws {
         // Given
         let project = Project.test()

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -546,6 +546,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
             "TARGETED_DEVICE_FAMILY": "1,2",
             "XROS_DEPLOYMENT_TARGET": "1.0",
             "IPHONEOS_DEPLOYMENT_TARGET": "16.0",
+            "SDKROOT": "iphoneos",
         ]
 
         assert(config: debugConfig, contains: expectedSettings)

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -274,7 +274,7 @@ final class TargetLinterTests: TuistUnitTestCase {
         }
     }
 
-    func test_lint_when_visionos_deployment_target_is_invalid_for_iPad_design() {
+    func test_lint_when_visionos_iPad_designed_deployment_target_is_valid() {
         let targets = [
             Target(
                 name: "visionOS",

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -274,6 +274,42 @@ final class TargetLinterTests: TuistUnitTestCase {
         }
     }
 
+    func test_lint_when_visionos_deployment_target_is_invalid_for_iPad_design() {
+        let targets = [
+            Target(
+                name: "visionOS",
+                destinations: [.appleVision],
+                product: .app,
+                productName: "visionOS",
+                bundleId: "io.tuist.visionOS",
+                deploymentTargets: .visionOS("1.0"),
+                filesGroup: .group(name: "Project")
+            ),
+            Target(
+                name: "iPadVision",
+                destinations: [.iPhone, .iPad, .appleVisionWithiPadDesign],
+                product: .app,
+                productName: "visionOS",
+                bundleId: "io.tuist.visionOS",
+                deploymentTargets: .init(iOS: "16.0", visionOS: "1.0"),
+                filesGroup: .group(name: "Project")
+            ),
+        ]
+
+        for target in targets {
+            let got = subject.lint(target: target)
+
+            // Then
+            XCTDoesNotContainLintingIssue(
+                got,
+                LintingIssue(
+                    reason: "Found an inconsistency between target destinations `[TuistGraph.Destination.appleVisionWithiPadDesign, TuistGraph.Destination.iPad, TuistGraph.Destination.iPhone]` and deployment target `visionOS`",
+                    severity: .error
+                )
+            )
+        }
+    }
+
     func test_lint_when_deployment_target_version_is_invalid() {
         let validVersions = ["tuist", "tuist9.0.1", "1.0tuist", "10_0", "1_1_3"]
         for version in validVersions {


### PR DESCRIPTION
### Short description 📝

I reported this issue on Slack and discussed with @waltflanagan, when setting `appleVisionWithiPadDesign` - you should be able to set a `visionOS`-specific deployment target.

Otherwise, Xcode defaults to the latest one, which could be 1.1 (even if you want 1.0, for example).

### How to test the changes locally 🧐

- Create a project that has iPhone, iPad and appleVisionWithiPadDesign Destinations. 
- Set a multiplatform deployment target for iOS & visionOS.
- Before this fix, this yields this error:

![image](https://github.com/tuist/tuist/assets/605076/77fcc846-cb51-47b3-80dc-af95b9384259)

I've added tests to cover these areas.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
