### PR TITLE
Add test coverage for iPadDesign destinations

### DIFF
--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -258,6 +258,7 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         let releaseConfig = configurationList?.configuration(name: "Release")
 
         let expectedSettings: SettingsDictionary = [
+            "SDKROOT": "iphoneos",
             "TARGETED_DEVICE_FAMILY": "1,2",
             "IPHONEOS_DEPLOYMENT_TARGET": "12.0",
             "SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD": "YES",
@@ -266,6 +267,10 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
 
         assert(config: debugConfig, contains: expectedSettings)
         assert(config: releaseConfig, contains: expectedSettings)
+
+        // SUPPORTED_PLATFORMS is only set when multiple platforms are defined by the target
+        XCTAssertNil(debugConfig?.buildSettings["SUPPORTED_PLATFORMS"])
+        XCTAssertNil(releaseConfig?.buildSettings["SUPPORTED_PLATFORMS"])
     }
 
     func test_generateTargetWithDeploymentTarget_whenIOS_withoutMacAndVisionForIPhoneSupport() throws {


### PR DESCRIPTION

### Short description 📝

I noticed that tests did not fail with #6033 and they should have.  This just adds extra logic to a test case to ensure that if a target only has iphone/ipad and _____withIpadDesign destinations it will act as a single platform iOS target.

### How to test the changes locally 🧐

Run tests, they should not fail.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
