### PR TITLE
Prevent cached frameworks from crashing in Previews after deleting derived data

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -197,9 +197,9 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
                 if let override = ProcessInfo.processInfo.environment["PACKAGE_RESOURCE_BUNDLE_PATH"] {
                     candidates.append(URL(fileURLWithPath: override))
 
-                    // Deleting derived data and not building the frameworks containing resources may result in a state
+                    // Deleting derived data and not rebuilding the frameworks containing resources may result in a state
                     // where the bundles are only available in the framework's directory that is actively being previewed.
-                    // Since we don't know which framework is being actively previewed, we need to look in the subpaths also.
+                    // Since we don't know which framework this is, we also need to look in all the framework subpaths.
                     if let subpaths = try? FileManager.default.contentsOfDirectory(atPath: override) {
                         for subpath in subpaths {
                             if subpath.hasSuffix(".framework") {

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -196,7 +196,7 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
                 // which is located under the derived data directory after building the project.
                 if let override = ProcessInfo.processInfo.environment["PACKAGE_RESOURCE_BUNDLE_PATH"] {
                     candidates.append(URL(fileURLWithPath: override))
-                    
+
                     // Deleting derived data and not building the frameworks containing resources may result in a state
                     // where the bundles are only available in the framework's directory that is actively being previewed.
                     // Since we don't know which framework is being actively previewed, we need to look in the subpaths also.

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -196,6 +196,13 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
                 // which is located under the derived data directory after building the project.
                 if let override = ProcessInfo.processInfo.environment["PACKAGE_RESOURCE_BUNDLE_PATH"] {
                     candidates.append(URL(fileURLWithPath: override))
+                    
+                    // Deleting derived data and not building the frameworks containing resources may result in a state
+                    // where the bundles are only available in the framework's directory that is actively being previewed.
+                    // Since we don't know which framework is being actively previewed, we need to look in the subpaths also.
+                    if let subpaths = try? FileManager.default.contentsOfDirectory(atPath: override) {
+                        candidates.append(contentsOf: subpaths.map { URL(fileURLWithPath: override + "/" + $0) })
+                    }
                 }
 
                 for candidate in candidates {

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -201,7 +201,11 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
                     // where the bundles are only available in the framework's directory that is actively being previewed.
                     // Since we don't know which framework is being actively previewed, we need to look in the subpaths also.
                     if let subpaths = try? FileManager.default.contentsOfDirectory(atPath: override) {
-                        candidates.append(contentsOf: subpaths.map { URL(fileURLWithPath: override + "/" + $0) })
+                        for subpath in subpaths {
+                            if subpath.hasSuffix(".framework") {
+                                candidates.append(URL(fileURLWithPath: override + "/" + subpath))
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
This fixes another crash in Previews when using frameworks with resources after deleting derived data.

### Short description 📝

This crash happens when the framework has never been built from sources by Previews. In this scenario the resource bundles are only contained within the framework that is being previewed. The solution proposal here does shallow enumeration of the contents of `PACKAGE_RESOURCE_BUNDLE_PATH` and adds all `.framework` directories to candidates as we don't know which framework is the one being previewed.

The worst case here is that we look into a few unnecessary directories when running Previews.

Hopefully this is the final fix for these obscure crashes. 😅 

### How to test the changes locally 🧐

1. `rm -rf ~/Library/Developer/Xcode/DerivedData`
2. `cd fixtures/app_with_previews`
3. `tuist install`
4. `tuist cache`
5. `tuist generate PreviewsFramework`
6. Open `TestView.swift` in Previews and tap the button and it will crash as it cannot find the bundle for `ResourcesFramework`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
