### PR TITLE
Fix compiling libraries with umbrella headers that have a dash

### DIFF
--- a/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
@@ -51,9 +51,10 @@ public final class SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerMod
         moduleName: String,
         publicHeadersPath: AbsolutePath
     ) throws -> ModuleMap {
-        let umbrellaHeaderPath = publicHeadersPath.appending(component: moduleName + ".h")
-        let nestedUmbrellaHeaderPath = publicHeadersPath.appending(component: moduleName).appending(component: moduleName + ".h")
         let sanitizedModuleName = moduleName.replacingOccurrences(of: "-", with: "_")
+        let umbrellaHeaderPath = publicHeadersPath.appending(component: sanitizedModuleName + ".h")
+        let nestedUmbrellaHeaderPath = publicHeadersPath
+            .appending(components: sanitizedModuleName, moduleName + ".h")
         let customModuleMapPath = try Self.customModuleMapPath(publicHeadersPath: publicHeadersPath)
         let generatedModuleMapPath: AbsolutePath
 

--- a/fixtures/app_with_spm_dependencies/App/Project.swift
+++ b/fixtures/app_with_spm_dependencies/App/Project.swift
@@ -42,6 +42,7 @@ let project = Project(
                 .external(name: "NYTPhotoViewer"),
                 .external(name: "SVProgressHUD"),
                 .external(name: "AirshipPreferenceCenter"),
+                .external(name: "MarkdownUI"),
             ],
             settings: .targetSettings
         ),

--- a/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
+++ b/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
@@ -7,6 +7,7 @@ import ComposableArchitecture
 import CrashReporter
 import GoogleSignIn
 import libzstd
+import MarkdownUI
 import NYTPhotoViewer
 import Realm
 import RealmSwift
@@ -52,6 +53,9 @@ public enum AppKit {
 
         // Use SVProgressHUD
         SVProgressHUD.show()
+
+        // Use MarkdownUI
+        _ = BulletedList(of: [""])
     }
 }
 

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
@@ -100,6 +100,15 @@
       }
     },
     {
+      "identity" : "networkimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/NetworkImage",
+      "state" : {
+        "revision" : "7aff8d1b31148d32c5933d75557d42f6323ee3d1",
+        "version" : "6.0.0"
+      }
+    },
+    {
       "identity" : "nimble",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble",
@@ -250,6 +259,15 @@
       "state" : {
         "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
         "version" : "1.5.4"
+      }
+    },
+    {
+      "identity" : "swift-markdown-ui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
+      "state" : {
+        "revision" : "ae799d015a5374708f7b4c85f3294c05f2a564e2",
+        "version" : "2.3.0"
       }
     },
     {

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.swift
@@ -34,6 +34,8 @@ let package = Package(
         .package(url: "https://github.com/SVProgressHUD/SVProgressHUD", exact: "2.3.1"),
         // Has missing resources and its own resource bundle accessors
         .package(url: "https://github.com/urbanairship/ios-library.git", .exact("17.7.3")),
+        // Has an umbrella header where moduleName must be sanitized
+        .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.2.0"),
         .package(path: "../LocalSwiftPackage"),
         .package(path: "../StringifyMacro"),
     ]


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6037

### Short description 📝

The [swift-markdown-ui](https://github.com/gonzalezreal/swift-markdown-ui) library has two headers in the public headers path:
- `cfmark-gfm.h`
- and `cfmark_gfm.h`

When comparing with the generated module map by SPM, it turns out we should only use the header that has the sanitized version (dashes replaced with underscores)

### How to test the changes locally 🧐

The `app_with_spm_dependencies` fixture that now has the `swift-markdown-ui` as a dependency should build.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
