### PR TITLE
Updated init template with `.mise.toml` and `Package.swift` files

### DIFF
--- a/Sources/TuistKit/Services/InitService.swift
+++ b/Sources/TuistKit/Services/InitService.swift
@@ -117,6 +117,7 @@ class InitService {
                 let parsedAttributes = try parseAttributes(
                     name: name,
                     platform: platform,
+                    tuistVersion: Constants.version,
                     requiredTemplateOptions: requiredTemplateOptions,
                     optionalTemplateOptions: optionalTemplateOptions,
                     template: template
@@ -137,6 +138,7 @@ class InitService {
             let parsedAttributes = try parseAttributes(
                 name: name,
                 platform: platform,
+                tuistVersion: Constants.version,
                 requiredTemplateOptions: requiredTemplateOptions,
                 optionalTemplateOptions: optionalTemplateOptions,
                 template: template
@@ -177,6 +179,7 @@ class InitService {
     private func parseAttributes(
         name: String,
         platform: Platform,
+        tuistVersion: String,
         requiredTemplateOptions: [String: String],
         optionalTemplateOptions: [String: String?],
         template: Template
@@ -184,11 +187,11 @@ class InitService {
         let defaultAttributes: [String: TuistGraph.Template.Attribute.Value] = [
             "name": .string(name),
             "platform": .string(platform.caseValue),
+            "tuist_version": .string(tuistVersion)
         ]
         return try template.attributes.reduce(into: defaultAttributes) { attributesDictionary, attribute in
-            if attribute.name == "name" || attribute.name == "platform" {
-                return
-            }
+            if defaultAttributes.keys.contains(attribute.name) { return }
+            
             switch attribute {
             case let .required(name):
                 guard let option = requiredTemplateOptions[name]

--- a/Sources/TuistKit/Services/InitService.swift
+++ b/Sources/TuistKit/Services/InitService.swift
@@ -252,7 +252,7 @@ class InitService {
             return .iOS
         }
     }
-    
+
     private func fetchTuistVersion() throws -> String {
         return try System.shared.capture([CommandLine.arguments[0], "version"])
     }

--- a/Sources/TuistKit/Services/InitService.swift
+++ b/Sources/TuistKit/Services/InitService.swift
@@ -44,17 +44,20 @@ class InitService {
     private let templatesDirectoryLocator: TemplatesDirectoryLocating
     private let templateGenerator: TemplateGenerating
     private let templateGitLoader: TemplateGitLoading
+    private let tuistVersionLoader: TuistVersionLoading
 
     init(
         templateLoader: TemplateLoading = TemplateLoader(),
         templatesDirectoryLocator: TemplatesDirectoryLocating = TemplatesDirectoryLocator(),
         templateGenerator: TemplateGenerating = TemplateGenerator(),
-        templateGitLoader: TemplateGitLoading = TemplateGitLoader()
+        templateGitLoader: TemplateGitLoading = TemplateGitLoader(),
+        tuistVersionLoader: TuistVersionLoading = TuistVersionLoader()
     ) {
         self.templateLoader = templateLoader
         self.templatesDirectoryLocator = templatesDirectoryLocator
         self.templateGenerator = templateGenerator
         self.templateGitLoader = templateGitLoader
+        self.tuistVersionLoader = tuistVersionLoader
     }
 
     func loadTemplateOptions(
@@ -110,7 +113,7 @@ class InitService {
         let path = try self.path(path)
         let name = try self.name(name, path: path)
         let templateName = templateName ?? "default"
-        let tuistVersion = try fetchTuistVersion()
+        let tuistVersion = try tuistVersionLoader.getVersion()
         try verifyDirectoryIsEmpty(path: path)
 
         if templateName.isGitURL {
@@ -251,9 +254,5 @@ class InitService {
         } else {
             return .iOS
         }
-    }
-
-    private func fetchTuistVersion() throws -> String {
-        return try System.shared.capture([CommandLine.arguments[0], "version"])
     }
 }

--- a/Sources/TuistKit/Services/InitService.swift
+++ b/Sources/TuistKit/Services/InitService.swift
@@ -187,11 +187,11 @@ class InitService {
         let defaultAttributes: [String: TuistGraph.Template.Attribute.Value] = [
             "name": .string(name),
             "platform": .string(platform.caseValue),
-            "tuist_version": .string(tuistVersion)
+            "tuist_version": .string(tuistVersion),
         ]
         return try template.attributes.reduce(into: defaultAttributes) { attributesDictionary, attribute in
             if defaultAttributes.keys.contains(attribute.name) { return }
-            
+
             switch attribute {
             case let .required(name):
                 guard let option = requiredTemplateOptions[name]

--- a/Sources/TuistKit/Services/InitService.swift
+++ b/Sources/TuistKit/Services/InitService.swift
@@ -110,6 +110,7 @@ class InitService {
         let path = try self.path(path)
         let name = try self.name(name, path: path)
         let templateName = templateName ?? "default"
+        let tuistVersion = try fetchTuistVersion()
         try verifyDirectoryIsEmpty(path: path)
 
         if templateName.isGitURL {
@@ -117,7 +118,7 @@ class InitService {
                 let parsedAttributes = try parseAttributes(
                     name: name,
                     platform: platform,
-                    tuistVersion: Constants.version,
+                    tuistVersion: tuistVersion,
                     requiredTemplateOptions: requiredTemplateOptions,
                     optionalTemplateOptions: optionalTemplateOptions,
                     template: template
@@ -138,7 +139,7 @@ class InitService {
             let parsedAttributes = try parseAttributes(
                 name: name,
                 platform: platform,
-                tuistVersion: Constants.version,
+                tuistVersion: tuistVersion,
                 requiredTemplateOptions: requiredTemplateOptions,
                 optionalTemplateOptions: optionalTemplateOptions,
                 template: template
@@ -250,5 +251,9 @@ class InitService {
         } else {
             return .iOS
         }
+    }
+    
+    private func fetchTuistVersion() throws -> String {
+        return try System.shared.capture([CommandLine.arguments[0], "version"])
     }
 }

--- a/Sources/TuistKit/Utils/TuistVersionLoader.swift
+++ b/Sources/TuistKit/Utils/TuistVersionLoader.swift
@@ -1,0 +1,18 @@
+import Foundation
+import TuistSupport
+
+protocol TuistVersionLoading {
+    func getVersion() throws -> String
+}
+
+final class TuistVersionLoader: TuistVersionLoading {
+    private let system: Systeming
+
+    init(system: Systeming = System.shared) {
+        self.system = system
+    }
+
+    func getVersion() throws -> String {
+        try system.capture(["tuist", "version"])
+    }
+}

--- a/Templates/default/Package.stencil
+++ b/Templates/default/Package.stencil
@@ -1,3 +1,4 @@
+// swift-tools-version: 5.9
 import ProjectDescription
 
 let project = Project(

--- a/Templates/default/Package.stencil
+++ b/Templates/default/Package.stencil
@@ -1,0 +1,8 @@
+import ProjectDescription
+
+let project = Project(
+    name: "{{ name }}", 
+    packages: [
+        // Add your dependencies here
+    ]
+)

--- a/Templates/default/Package.stencil
+++ b/Templates/default/Package.stencil
@@ -1,9 +1,21 @@
 // swift-tools-version: 5.9
-import ProjectDescription
+import PackageDescription
 
-let project = Project(
-    name: "{{ name }}", 
-    packages: [
-        // Add your dependencies here
+#if TUIST
+    import ProjectDescription
+
+    let packageSettings = PackageSettings(
+        // Customize the product types for specific package product
+        // Default is .staticFramework
+        // productTypes: ["Alamofire": .framework,] 
+        productTypes: [:]
+    )
+#endif
+
+let package = Package(
+    name: "{{ name }}",
+    dependencies: [
+        // Add your own dependencies here:
+        // .package(url: "https://github.com/Alamofire/Alamofire", from: "5.0.0"),
     ]
 )

--- a/Templates/default/Package.stencil
+++ b/Templates/default/Package.stencil
@@ -17,5 +17,6 @@ let package = Package(
     dependencies: [
         // Add your own dependencies here:
         // .package(url: "https://github.com/Alamofire/Alamofire", from: "5.0.0"),
+        // You can read more about dependencies here: https://docs.tuist.io/documentation/tuist/dependencies
     ]
 )

--- a/Templates/default/default.swift
+++ b/Templates/default/default.swift
@@ -41,6 +41,10 @@ let template = Template(
             templatePath: "Gitignore.stencil"
         ),
         .file(
+            path: ".mise.toml",
+            templatePath: "mise.stencil"
+        ),
+        .file(
             path: appPath + "/Resources/LaunchScreen.storyboard",
             templatePath: "LaunchScreen+\(platformAttribute).stencil"
         ),

--- a/Templates/default/default.swift
+++ b/Templates/default/default.swift
@@ -17,7 +17,7 @@ let template = Template(
             templatePath: "AppProject.stencil"
         ),
         .file(
-            path: projectPath + "/Package.swift",
+            path: projectPath + "/Tuist/Package.swift",
             templatePath: "Package.stencil"
         ),
         .file(

--- a/Templates/default/default.swift
+++ b/Templates/default/default.swift
@@ -17,6 +17,10 @@ let template = Template(
             templatePath: "AppProject.stencil"
         ),
         .file(
+            path: projectPath + "/Package.swift",
+            templatePath: "Package.stencil"
+        ),
+        .file(
             path: appPath + "/Sources/\(nameAttribute)App.swift",
             templatePath: "app.stencil"
         ),

--- a/Templates/default/mise.stencil
+++ b/Templates/default/mise.stencil
@@ -1,0 +1,2 @@
+[tools]
+tuist = "{{ tuist_version }}"

--- a/Tests/TuistAcceptanceTests/InitAcceptanceTests.swift
+++ b/Tests/TuistAcceptanceTests/InitAcceptanceTests.swift
@@ -8,6 +8,7 @@ import XCTest
 final class InitAcceptanceTestmacOSApp: TuistAcceptanceTestCase {
     func test_init_macos_app() async throws {
         try run(InitCommand.self, "--platform", "macos", "--name", "Test")
+        try await run(InstallCommand.self)
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self)
     }
@@ -16,6 +17,7 @@ final class InitAcceptanceTestmacOSApp: TuistAcceptanceTestCase {
 final class InitAcceptanceTestiOSApp: TuistAcceptanceTestCase {
     func test_init_ios_app() async throws {
         try run(InitCommand.self, "--platform", "ios", "--name", "My-App")
+        try await run(InstallCommand.self)
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self)
     }

--- a/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
+++ b/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
@@ -7,6 +7,7 @@ import XCTest
 final class BuildAcceptanceTestWithTemplates: TuistAcceptanceTestCase {
     func test_with_templates() async throws {
         try run(InitCommand.self, "--platform", "ios", "--name", "MyApp")
+        try await run(InstallCommand.self)
         try await run(GenerateCommand.self)
         try await run(BuildCommand.self)
         try await run(BuildCommand.self, "MyApp")

--- a/Tests/TuistKitTests/Mocks/MockTuistVersionLoader.swift
+++ b/Tests/TuistKitTests/Mocks/MockTuistVersionLoader.swift
@@ -1,0 +1,8 @@
+//
+//  MockTuistVersionLoader.swift
+//  TuistKit
+//
+//  Created by dimash on 20.03.2024.
+//
+
+import Foundation

--- a/Tests/TuistKitTests/Mocks/MockTuistVersionLoader.swift
+++ b/Tests/TuistKitTests/Mocks/MockTuistVersionLoader.swift
@@ -1,9 +1,10 @@
 import Foundation
+@testable import TuistKit
 
 public final class MockTuistVersionLoader: TuistVersionLoading {
     var getVersionStub: String = "4.0.1"
     private(set) var getVersionCalls = 0
-    func getVersion() throws -> String {
+    public func getVersion() throws -> String {
         getVersionStub
     }
 }

--- a/Tests/TuistKitTests/Mocks/MockTuistVersionLoader.swift
+++ b/Tests/TuistKitTests/Mocks/MockTuistVersionLoader.swift
@@ -1,8 +1,9 @@
-//
-//  MockTuistVersionLoader.swift
-//  TuistKit
-//
-//  Created by dimash on 20.03.2024.
-//
-
 import Foundation
+
+public final class MockTuistVersionLoader: TuistVersionLoading {
+    var getVersionStub: String = "4.0.1"
+    private(set) var getVersionCalls = 0
+    func getVersion() throws -> String {
+        getVersionStub
+    }
+}

--- a/Tests/TuistKitTests/Services/InitServiceTests.swift
+++ b/Tests/TuistKitTests/Services/InitServiceTests.swift
@@ -85,6 +85,7 @@ final class InitServiceTests: TuistUnitTestCase {
         let expectedAttributes: [String: TuistGraph.Template.Attribute.Value] = [
             "name": .string("Name"),
             "platform": .string("iOS"),
+            "tuist_version": .string(Constants.version),
         ]
         var generatorAttributes: [String: TuistGraph.Template.Attribute.Value] = [:]
         templateGenerator.generateStub = { _, _, attributes in

--- a/Tests/TuistKitTests/Services/InitServiceTests.swift
+++ b/Tests/TuistKitTests/Services/InitServiceTests.swift
@@ -16,6 +16,7 @@ final class InitServiceTests: TuistUnitTestCase {
     var templateGenerator: MockTemplateGenerator!
     var templateLoader: MockTemplateLoader!
     var templateGitLoader: MockTemplateGitLoader!
+    var tuistVersionLoader: MockTuistVersionLoader!
 
     override func setUp() {
         super.setUp()
@@ -23,11 +24,13 @@ final class InitServiceTests: TuistUnitTestCase {
         templateGenerator = MockTemplateGenerator()
         templateLoader = MockTemplateLoader()
         templateGitLoader = MockTemplateGitLoader()
+        tuistVersionLoader = MockTuistVersionLoader()
         subject = InitService(
             templateLoader: templateLoader,
             templatesDirectoryLocator: templatesDirectoryLocator,
             templateGenerator: templateGenerator,
-            templateGitLoader: templateGitLoader
+            templateGitLoader: templateGitLoader,
+            tuistVersionLoader: tuistVersionLoader
         )
     }
 
@@ -60,10 +63,14 @@ final class InitServiceTests: TuistUnitTestCase {
         templatesDirectoryLocator.templateDirectoriesStub = { _ in
             [defaultTemplatePath]
         }
+
+        let tuistVersion = "4.0.3"
+        tuistVersionLoader.getVersionStub = tuistVersion
+
         let expectedAttributes: [String: TuistGraph.Template.Attribute.Value] = [
             "name": .string("Name"),
             "platform": .string("macOS"),
-            "tuist_version": .string(Constants.version),
+            "tuist_version": .string(tuistVersion),
         ]
         var generatorAttributes: [String: TuistGraph.Template.Attribute.Value] = [:]
         templateGenerator.generateStub = { _, _, attributes in
@@ -83,10 +90,14 @@ final class InitServiceTests: TuistUnitTestCase {
         templatesDirectoryLocator.templateDirectoriesStub = { _ in
             [defaultTemplatePath]
         }
+
+        let tuistVersion = "4.0.3"
+        tuistVersionLoader.getVersionStub = tuistVersion
+
         let expectedAttributes: [String: TuistGraph.Template.Attribute.Value] = [
             "name": .string("Name"),
             "platform": .string("iOS"),
-            "tuist_version": .string(Constants.version),
+            "tuist_version": .string(tuistVersion),
         ]
         var generatorAttributes: [String: TuistGraph.Template.Attribute.Value] = [:]
         templateGenerator.generateStub = { _, _, attributes in
@@ -112,10 +123,14 @@ final class InitServiceTests: TuistUnitTestCase {
                 items: []
             )
         }
+
+        let tuistVersion = "4.0.3"
+        tuistVersionLoader.getVersionStub = tuistVersion
+
         let expectedAttributes: [String: TuistGraph.Template.Attribute.Value] = [
             "name": .string("Name"),
             "platform": .string("macOS"),
-            "tuist_version": .string(Constants.version),
+            "tuist_version": .string(tuistVersion),
             "required": .string("requiredValue"),
             "optional": .string("optionalValue"),
         ]
@@ -151,6 +166,9 @@ final class InitServiceTests: TuistUnitTestCase {
             ])
         }
 
+        let tuistVersion = "4.0.3"
+        tuistVersionLoader.getVersionStub = tuistVersion
+
         let defaultTemplatePath = try temporaryPath().appending(component: "default")
         templatesDirectoryLocator.templateDirectoriesStub = { _ in
             [defaultTemplatePath]
@@ -159,7 +177,7 @@ final class InitServiceTests: TuistUnitTestCase {
         let expectedAttributes: [String: TuistGraph.Template.Attribute.Value] = [
             "name": .string("Name"),
             "platform": .string("iOS"),
-            "tuist_version": .string(Constants.version),
+            "tuist_version": .string(tuistVersion),
             "optional": context,
         ]
 
@@ -185,6 +203,9 @@ final class InitServiceTests: TuistUnitTestCase {
             ])
         }
 
+        let tuistVersion = "4.0.3"
+        tuistVersionLoader.getVersionStub = tuistVersion
+
         let defaultTemplatePath = try temporaryPath().appending(component: "default")
         templatesDirectoryLocator.templateDirectoriesStub = { _ in
             [defaultTemplatePath]
@@ -193,7 +214,7 @@ final class InitServiceTests: TuistUnitTestCase {
         let expectedAttributes: [String: TuistGraph.Template.Attribute.Value] = [
             "name": .string("Name"),
             "platform": .string("iOS"),
-            "tuist_version": .string(Constants.version),
+            "tuist_version": .string(tuistVersion),
             "optional": defaultIntegerValue,
         ]
 

--- a/Tests/TuistKitTests/Services/InitServiceTests.swift
+++ b/Tests/TuistKitTests/Services/InitServiceTests.swift
@@ -63,6 +63,7 @@ final class InitServiceTests: TuistUnitTestCase {
         let expectedAttributes: [String: TuistGraph.Template.Attribute.Value] = [
             "name": .string("Name"),
             "platform": .string("macOS"),
+            "tuist_version": .string(Constants.version),
         ]
         var generatorAttributes: [String: TuistGraph.Template.Attribute.Value] = [:]
         templateGenerator.generateStub = { _, _, attributes in
@@ -114,6 +115,7 @@ final class InitServiceTests: TuistUnitTestCase {
         let expectedAttributes: [String: TuistGraph.Template.Attribute.Value] = [
             "name": .string("Name"),
             "platform": .string("macOS"),
+            "tuist_version": .string(Constants.version),
             "required": .string("requiredValue"),
             "optional": .string("optionalValue"),
         ]
@@ -157,6 +159,7 @@ final class InitServiceTests: TuistUnitTestCase {
         let expectedAttributes: [String: TuistGraph.Template.Attribute.Value] = [
             "name": .string("Name"),
             "platform": .string("iOS"),
+            "tuist_version": .string(Constants.version),
             "optional": context,
         ]
 
@@ -190,6 +193,7 @@ final class InitServiceTests: TuistUnitTestCase {
         let expectedAttributes: [String: TuistGraph.Template.Attribute.Value] = [
             "name": .string("Name"),
             "platform": .string("iOS"),
+            "tuist_version": .string(Constants.version),
             "optional": defaultIntegerValue,
         ]
 

--- a/Tests/TuistKitTests/Utils/TuistVersionLoaderTests.swift
+++ b/Tests/TuistKitTests/Utils/TuistVersionLoaderTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+@testable import TuistKit
+@testable import TuistSupportTesting
+
+final class TuistVersionLoaderTests: TuistUnitTestCase {
+    private var mockSystem: MockSystem!
+
+    private var sut: TuistVersionLoader!
+
+    override func setUp() {
+        super.setUp()
+        mockSystem = MockSystem()
+        sut = TuistVersionLoader(system: mockSystem)
+    }
+
+    func test_getVersion_passesRightArguments() throws {
+        // given
+        let version = "4.0.1"
+        mockSystem.stubs = ["tuist version": (stderror: nil, stdout: version, exitstatus: 0)]
+
+        // when
+        let result = try sut.getVersion()
+
+        // then
+        XCTAssertTrue(mockSystem.called(["tuist", "version"]))
+        XCTAssertEqual(result, "4.0.1")
+    }
+
+    override func tearDown() {
+        mockSystem = nil
+        sut = nil
+        super.tearDown()
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5897

### Short description 📝

Add `.mise.toml` and `Tuist/Package.swift` generation in init command default template.

### How to test the changes locally 🧐
Create empty folder and run `tuist init`. This will generate iOS platform app with your folder name. These changes additionally create `.mise.toml` file with tuist version you are using and `Tuist/Package.swift` to add your external dependencies.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
