### PR TITLE
Fix reading metadata of swift-package-manager-google-mobile-ads

### DIFF
--- a/Sources/TuistCore/MetadataProviders/PrecompiledMetadataProvider.swift
+++ b/Sources/TuistCore/MetadataProviders/PrecompiledMetadataProvider.swift
@@ -217,7 +217,7 @@ public class PrecompiledMetadataProvider: PrecompiledMetadataProviding {
 
         guard String(data: magic, encoding: .ascii) == archiveFormatMagic else { return }
 
-        binary.seek(to: archiveHeaderSizeOffset)
+        binary.seek(to: currentOffset + archiveHeaderSizeOffset)
         guard let sizeString = binary.readString(ofLength: 10) else { return }
 
         let size = strtoul(sizeString, nil, 10)

--- a/fixtures/app_with_spm_dependencies/App/Project.swift
+++ b/fixtures/app_with_spm_dependencies/App/Project.swift
@@ -43,6 +43,7 @@ let project = Project(
                 .external(name: "SVProgressHUD"),
                 .external(name: "AirshipPreferenceCenter"),
                 .external(name: "MarkdownUI"),
+                .external(name: "GoogleMobileAds"),
             ],
             settings: .targetSettings
         ),

--- a/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
+++ b/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
@@ -5,6 +5,7 @@ import AppCenterCrashes
 import CocoaLumberjackSwift
 import ComposableArchitecture
 import CrashReporter
+import GoogleMobileAds
 import GoogleSignIn
 import libzstd
 import MarkdownUI

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
@@ -271,6 +271,24 @@
       }
     },
     {
+      "identity" : "swift-package-manager-google-mobile-ads",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads",
+      "state" : {
+        "revision" : "ef8d21fc890eed1727195632d63a9333b9949253",
+        "version" : "11.1.0"
+      }
+    },
+    {
+      "identity" : "swift-package-manager-google-user-messaging-platform",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git",
+      "state" : {
+        "revision" : "668673ea23b3e71b9f2540d8fb9464c4dc32ecc0",
+        "version" : "2.2.0"
+      }
+    },
+    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.swift
@@ -36,6 +36,7 @@ let package = Package(
         .package(url: "https://github.com/urbanairship/ios-library.git", .exact("17.7.3")),
         // Has an umbrella header where moduleName must be sanitized
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.2.0"),
+        .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads", from: "11.1.0"),
         .package(path: "../LocalSwiftPackage"),
         .package(path: "../StringifyMacro"),
     ]


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6029

### Short description 📝

We were getting an out-of-bounds crash when reading the metadata of the `GoogleMobileAds` framework because we read the wrong size.

The binary file starts with:
```
����              ���       !<arch>
#1/20           1707775923  51519 24403 100644  372788    `
```

Where the size of the archive header is the last number, `372788`. However, we read the value of `1707775923`. 

When looking at similar frameworks that we already test in the codebase, the `libMyStaticLibrary.a` was the most similar:
```
!<arch>
#1/20           1574409870  28142 37387 100644  1148      
```

However, notice that the file starts with `!<arch>`. Whereas `GoogleMobileAds` doesn't. Turns out that when we parse the `!<arch>`, we were not adding the `currentOffset` when seeking to the archive header size.

Adding the `currentOffset` fixes the out-of-bounds read crash

### How to test the changes locally 🧐

You should be able to generate and build the `app_with_spm_dependencies` fixture that now includes the `swift-package-manager-google-mobile-ads` dependency

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
