### PR TITLE
Force addition of macro flags regardless of inherited presence

### DIFF
--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -185,6 +185,16 @@ final class ConfigGenerator: ConfigGenerating {
             settingsHelper.extend(buildSettings: &settings, with: target.settings?.baseDebug ?? [:])
         }
         settingsHelper.extend(buildSettings: &settings, with: configuration?.settings ?? [:])
+        settingsHelper
+            .extend(
+                buildSettings: &settings,
+                with: swiftMacrosDerivedSettings(
+                    target: target,
+                    graphTraverser: graphTraverser,
+                    projectPath: project.path
+                ),
+                inherit: true
+            )
 
         let variantBuildConfiguration = XCBuildConfiguration(
             name: buildConfiguration.xcodeValue,
@@ -223,10 +233,6 @@ final class ConfigGenerator: ConfigGenerating {
         settings.merge(deploymentTargetDerivedSettings(target: target)) { $1 }
         settings
             .merge(watchTargetDerivedSettings(target: target, graphTraverser: graphTraverser, projectPath: project.path)) { $1 }
-        settings
-            .merge(swiftMacrosDerivedSettings(target: target, graphTraverser: graphTraverser, projectPath: project.path)) {
-                $1
-            }
     }
 
     private func generalTargetDerivedSettings(

--- a/fixtures/app_with_spm_dependencies/Tuist/ProjectDescriptionHelpers/Settings+Templates.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/ProjectDescriptionHelpers/Settings+Templates.swift
@@ -10,6 +10,7 @@ extension ProjectDescription.Settings {
 
     public static var targetSettings: Self {
         .settings(
+            base: [:].otherSwiftFlags("-enable-actor-data-race-checks"),
             configurations: BuildEnvironment.allCases.map(\.targetConfiguration)
         )
     }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5944

### Short description 📝

We should add macro flags to `OTHER_SWIFT_FLAGS` regardless of whether a user adds `$(inherited)` or not as without those flags, the project wouldn't build. We should always avoid generating an invalid project if we know that will be the case.

### How to test the changes locally 🧐

Generation and build of `app_with_spm_dependencies` should succeed (I added a swift flag without the `$(inherited)` value)

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
