### PR TITLE
Add missing catch for unsupported platform error

### DIFF
--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -483,28 +483,27 @@ public final class PackageInfoMapper: PackageInfoMapping {
 
         if target.type.supportsDependencies {
             let linkerDependencies: [ProjectDescription.TargetDependency] = target.settings.compactMap { setting in
-                let condition = ProjectDescription.PlatformCondition.from(setting.condition)
+                do {
+                    let condition = try ProjectDescription.PlatformCondition.from(setting.condition)
 
-                // The condition returned only unsupported platforms
-                if condition == nil, setting.condition != nil {
-                    return nil
-                }
-
-                switch (setting.tool, setting.name) {
-                case (.linker, .linkedFramework):
-                    return .sdk(name: setting.value[0], type: .framework, status: .required, condition: condition)
-                case (.linker, .linkedLibrary):
-                    return .sdk(name: setting.value[0], type: .library, status: .required, condition: condition)
-                case (.c, _), (.cxx, _), (_, .enableUpcomingFeature), (.swift, _), (.linker, .headerSearchPath), (
-                    .linker,
-                    .define
-                ),
-                (.linker, .unsafeFlags), (_, .enableExperimentalFeature):
+                    switch (setting.tool, setting.name) {
+                    case (.linker, .linkedFramework):
+                        return .sdk(name: setting.value[0], type: .framework, status: .required, condition: condition)
+                    case (.linker, .linkedLibrary):
+                        return .sdk(name: setting.value[0], type: .library, status: .required, condition: condition)
+                    case (.c, _), (.cxx, _), (_, .enableUpcomingFeature), (.swift, _), (.linker, .headerSearchPath), (
+                        .linker,
+                        .define
+                    ),
+                    (.linker, .unsafeFlags), (_, .enableExperimentalFeature):
+                        return nil
+                    }
+                } catch {
                     return nil
                 }
             }
 
-            dependencies = try linkerDependencies + target.dependencies.map {
+            dependencies = try linkerDependencies + target.dependencies.compactMap {
                 switch $0 {
                 case let .byName(name: name, condition: condition), let .product(
                     name: name,
@@ -516,7 +515,12 @@ public final class PackageInfoMapper: PackageInfoMapping {
                     name: name,
                     condition: condition
                 ):
-                    let platformCondition = try ProjectDescription.PlatformCondition.from(condition)
+                    let platformCondition: ProjectDescription.PlatformCondition?
+                    do {
+                        platformCondition = try ProjectDescription.PlatformCondition.from(condition)
+                    } catch {
+                        return nil
+                    }
                     if let target = packageInfo.targets.first(where: { $0.name == name }) {
                         if target.type == .binary, case let .external(artifactPaths: artifactPaths) = packageType {
                             guard let artifactPath = artifactPaths[target.name] else {
@@ -1217,10 +1221,12 @@ extension PackageInfoMapper {
 }
 
 extension ProjectDescription.PlatformCondition {
+    struct OnlyConditionsWithUnsupportedPlatforms: Error {}
+
     /// Map from a package condition to ProjectDescription.PlatformCondition
     /// - Parameter condition: condition representing platforms that a given dependency applies to
     /// - Returns: set of PlatformFilters to be used with `GraphDependencyRefrence`
-    fileprivate static func from(_ condition: PackageInfo.PackageConditionDescription?) -> Self? {
+    fileprivate static func from(_ condition: PackageInfo.PackageConditionDescription?) throws -> Self? {
         guard let condition else { return nil }
         let filters: [ProjectDescription.PlatformFilter] = condition.platformNames.compactMap { name in
             switch name {
@@ -1239,6 +1245,11 @@ extension ProjectDescription.PlatformCondition {
             default:
                 return nil
             }
+        }
+
+        // If empty, we know there are no supported platforms and this dependency should not be included in the graph
+        if filters.isEmpty {
+            throw OnlyConditionsWithUnsupportedPlatforms()
         }
 
         return .when(Set(filters))


### PR DESCRIPTION
### Short description 📝

This is a follow-up to: https://github.com/tuist/tuist/pull/6047

I haven't noticed I'd need to add the condition check in a bunch of other places. Instead of removing the `try-catch` pattern, I'm providing a better fix by adding a missing `try-catch` which was the actual issue.

### How to test the changes locally 🧐

Generate and build `app_with_spm_dependencies`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
