### PR TITLE
Skip flagging the install error if there's no instance of external dependency in the graph

### DIFF
--- a/Sources/ProjectDescription/Project.swift
+++ b/Sources/ProjectDescription/Project.swift
@@ -106,4 +106,17 @@ public struct Project: Codable, Equatable {
         self.resourceSynthesizers = resourceSynthesizers
         dumpIfNeeded(self)
     }
+
+    /// The project contains targets that depend on external dependencies
+    public var containsExternalDependencies: Bool {
+        targets.contains(where: { target in
+            target.dependencies.contains(where: {
+                if case .external = $0 {
+                    return true
+                } else {
+                    return false
+                }
+            })
+        })
+    }
 }

--- a/Sources/TuistKit/Generator/Generator.swift
+++ b/Sources/TuistKit/Generator/Generator.swift
@@ -81,7 +81,6 @@ public class Generator: Generating {
 
     func load(path: AbsolutePath) async throws -> (Graph, [SideEffectDescriptor]) {
         logger.notice("Loading and constructing the graph", metadata: .section)
-        logger.notice("It might take a while if the cache is empty")
 
         let (graph, sideEffectDescriptors, issues) = try await manifestGraphLoader.load(path: path)
 

--- a/Sources/TuistKit/Generator/Generator.swift
+++ b/Sources/TuistKit/Generator/Generator.swift
@@ -81,6 +81,7 @@ public class Generator: Generating {
 
     func load(path: AbsolutePath) async throws -> (Graph, [SideEffectDescriptor]) {
         logger.notice("Loading and constructing the graph", metadata: .section)
+        logger.notice("It might take a while if the cache is empty")
 
         let (graph, sideEffectDescriptors, issues) = try await manifestGraphLoader.load(path: path)
 

--- a/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -113,8 +113,6 @@ public final class ManifestGraphLoader: ManifestGraphLoading {
         if let packagePath = manifestFilesLocator.locatePackageManifest(at: path),
            isSPMProjectOnly || hasExternalDependencies
         {
-            logger.notice("It might take a while if the cache is empty")
-
             let loadedPackageSettings = try packageSettingsLoader.loadPackageSettings(
                 at: packagePath.parentDirectory,
                 with: plugins

--- a/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -111,7 +111,8 @@ public final class ManifestGraphLoader: ManifestGraphLoading {
 
         // Load SPM graph only if is SPM Project only or the workspace is using external dependencies
         if let packagePath = manifestFilesLocator.locatePackageManifest(at: path),
-           isSPMProjectOnly || hasExternalDependencies {
+           isSPMProjectOnly || hasExternalDependencies
+        {
             let loadedPackageSettings = try packageSettingsLoader.loadPackageSettings(
                 at: packagePath.parentDirectory,
                 with: plugins

--- a/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -101,7 +101,7 @@ public final class ManifestGraphLoader: ManifestGraphLoading {
 
         // Load Workspace
         var allManifests = try recursiveManifestLoader.loadWorkspace(at: path)
-
+        let isSPMProjectOnly = allManifests.projects.isEmpty
         let hasExternalDependencies = allManifests.projects.values.contains { $0.containsExternalDependencies }
 
         // Load DependenciesGraph
@@ -109,8 +109,9 @@ public final class ManifestGraphLoader: ManifestGraphLoading {
         let dependenciesGraph: TuistGraph.DependenciesGraph
         let packageSettings: TuistGraph.PackageSettings?
 
-        // Load SPM graph only if Workspace is using external dependencies
-        if let packagePath = manifestFilesLocator.locatePackageManifest(at: path), hasExternalDependencies {
+        // Load SPM graph only if is SPM Project only or the workspace is using external dependencies
+        if let packagePath = manifestFilesLocator.locatePackageManifest(at: path),
+           isSPMProjectOnly || hasExternalDependencies {
             let loadedPackageSettings = try packageSettingsLoader.loadPackageSettings(
                 at: packagePath.parentDirectory,
                 with: plugins

--- a/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -106,10 +106,6 @@ public final class ManifestGraphLoader: ManifestGraphLoading {
 
         // Load DependenciesGraph
 
-        if hasExternalDependencies {
-            logger.notice("It might take a while if the cache is empty")
-        }
-
         let dependenciesGraph: TuistGraph.DependenciesGraph
         let packageSettings: TuistGraph.PackageSettings?
 
@@ -117,6 +113,8 @@ public final class ManifestGraphLoader: ManifestGraphLoading {
         if let packagePath = manifestFilesLocator.locatePackageManifest(at: path),
            isSPMProjectOnly || hasExternalDependencies
         {
+            logger.notice("It might take a while if the cache is empty")
+
             let loadedPackageSettings = try packageSettingsLoader.loadPackageSettings(
                 at: packagePath.parentDirectory,
                 with: plugins

--- a/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -106,6 +106,10 @@ public final class ManifestGraphLoader: ManifestGraphLoading {
 
         // Load DependenciesGraph
 
+        if hasExternalDependencies {
+            logger.notice("It might take a while if the cache is empty")
+        }
+
         let dependenciesGraph: TuistGraph.DependenciesGraph
         let packageSettings: TuistGraph.PackageSettings?
 

--- a/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
@@ -95,7 +95,7 @@ public class RecursiveManifestLoader: RecursiveManifestLoading {
         }.flatMap {
             fileHandler.glob($0, glob: "")
         }.filter {
-            fileHandler.isFolder($0) && $0.basename != Constants.tuistDirectoryName && $0.pathString.contains(".build/checkouts")
+            fileHandler.isFolder($0) && $0.basename != Constants.tuistDirectoryName
         }.filter {
             let manifests = manifestLoader.manifests(at: $0)
             return manifests.contains(.package) && !manifests.contains(.project) && !manifests.contains(.workspace)

--- a/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
@@ -98,7 +98,8 @@ public class RecursiveManifestLoader: RecursiveManifestLoading {
             fileHandler.isFolder($0) && $0.basename != Constants.tuistDirectoryName
         }.filter {
             let manifests = manifestLoader.manifests(at: $0)
-            return manifests.contains(.package) && !manifests.contains(.project) && !manifests.contains(.workspace) && !$0.pathString.contains(".build/checkouts")
+            return manifests.contains(.package) && !manifests.contains(.project) && !manifests.contains(.workspace) && !$0
+                .pathString.contains(".build/checkouts")
         }
 
         let packageProjects = try loadPackageProjects(paths: packagePaths, packageSettings: packageSettings)

--- a/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
@@ -89,7 +89,7 @@ public class RecursiveManifestLoader: RecursiveManifestLoading {
         throws -> LoadedWorkspace
     {
         let generatorPaths = GeneratorPaths(manifestDirectory: loadedWorkspace.path)
-        let projectSearchPaths = (loadedWorkspace.workspace.projects)
+        let projectSearchPaths = loadedWorkspace.workspace.projects.isEmpty ? ["."] : loadedWorkspace.workspace.projects
         let packagePaths = try projectSearchPaths.map {
             try generatorPaths.resolve(path: $0)
         }.flatMap {

--- a/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
@@ -98,7 +98,7 @@ public class RecursiveManifestLoader: RecursiveManifestLoading {
             fileHandler.isFolder($0) && $0.basename != Constants.tuistDirectoryName
         }.filter {
             let manifests = manifestLoader.manifests(at: $0)
-            return manifests.contains(.package) && !manifests.contains(.project) && !manifests.contains(.workspace)
+            return manifests.contains(.package) && !manifests.contains(.project) && !manifests.contains(.workspace) && !$0.pathString.contains(".build/checkouts")
         }
 
         let packageProjects = try loadPackageProjects(paths: packagePaths, packageSettings: packageSettings)

--- a/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
@@ -6,14 +6,13 @@ import TuistSupport
 
 /// A component that can load a manifest and all its (transitive) manifest dependencies
 public protocol RecursiveManifestLoading {
-    
     /// Load manifest at path
     /// - Parameter path: Path of the manifest
     /// - Returns: Loaded manifest
     func loadWorkspace(
         at path: AbsolutePath
     ) throws -> LoadedWorkspace
-    
+
     /// Load package projects and merge in the loaded manifest
     /// - Parameters:
     ///   - loadedWorkspace: manifest to merge in
@@ -87,7 +86,8 @@ public class RecursiveManifestLoader: RecursiveManifestLoading {
     }
 
     public func loadAndMergePackageProjects(in loadedWorkspace: LoadedWorkspace, packageSettings: TuistGraph.PackageSettings)
-    throws -> LoadedWorkspace {
+        throws -> LoadedWorkspace
+    {
         let generatorPaths = GeneratorPaths(manifestDirectory: loadedWorkspace.path)
         let projectSearchPaths = (loadedWorkspace.workspace.projects)
         let packagePaths = try projectSearchPaths.map {

--- a/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -87,9 +87,16 @@ public final class SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoadi
 
         let workspaceState = try JSONDecoder()
             .decode(SwiftPackageManagerWorkspaceState.self, from: try fileHandler.readFile(workspacePath))
+        
         let packageInfos: [
             // swiftlint:disable:next large_tuple
-            (id: String, name: String, folder: AbsolutePath, targetToArtifactPaths: [String: AbsolutePath], info: PackageInfo)
+            (
+                id: String,
+                name: String,
+                folder: AbsolutePath,
+                targetToArtifactPaths: [String: AbsolutePath],
+                info: PackageInfo
+            )
         ]
         packageInfos = try workspaceState.object.dependencies.map(context: .concurrent) { dependency in
             let name = dependency.packageRef.name

--- a/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -87,7 +87,7 @@ public final class SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoadi
 
         let workspaceState = try JSONDecoder()
             .decode(SwiftPackageManagerWorkspaceState.self, from: try fileHandler.readFile(workspacePath))
-        
+
         let packageInfos: [
             // swiftlint:disable:next large_tuple
             (

--- a/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
@@ -52,10 +52,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         try stub(manifest: projectA, at: try RelativePath(validating: "Some/Path/A"))
 
         // When
-        let manifests = try subject.loadWorkspace(
-            at: path.appending(try RelativePath(validating: "Some/Path/A")),
-            packageSettings: nil
-        )
+        let manifests = try subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path/A")))
 
         // Then
         XCTAssertEqual(withRelativePaths(manifests.projects), [
@@ -91,10 +88,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         try stub(manifest: projectC, at: try RelativePath(validating: "Some/Path/C"))
 
         // When
-        let manifests = try subject.loadWorkspace(
-            at: path.appending(try RelativePath(validating: "Some/Path/A")),
-            packageSettings: nil
-        )
+        let manifests = try subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path/A")))
 
         // Then
         XCTAssertEqual(withRelativePaths(manifests.projects), [
@@ -146,10 +140,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         try stub(manifest: projectE, at: try RelativePath(validating: "Some/Path/E"))
 
         // When
-        let manifests = try subject.loadWorkspace(
-            at: path.appending(try RelativePath(validating: "Some/Path/A")),
-            packageSettings: nil
-        )
+        let manifests = try subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path/A")))
 
         // Then
         XCTAssertEqual(withRelativePaths(manifests.projects), [
@@ -175,10 +166,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
 
         // When / Then
         XCTAssertThrowsSpecific(
-            try subject.loadWorkspace(
-                at: path.appending(try RelativePath(validating: "Some/Path/A")),
-                packageSettings: nil
-            ),
+            try subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path/A"))),
             ManifestLoaderError.manifestNotFound(.project, path.appending(try RelativePath(validating: "Some/Path/B")))
         )
     }
@@ -218,10 +206,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         try stub(manifest: workspace, at: try RelativePath(validating: "Some/Path"))
 
         // When
-        let manifests = try subject.loadWorkspace(
-            at: path.appending(try RelativePath(validating: "Some/Path")),
-            packageSettings: nil
-        )
+        let manifests = try subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path")))
 
         // Then
         XCTAssertEqual(manifests.path, path.appending(try RelativePath(validating: "Some/Path")))
@@ -267,10 +252,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         try stub(manifest: workspace, at: try RelativePath(validating: "Some/Path"))
 
         // When
-        let manifests = try subject.loadWorkspace(
-            at: path.appending(try RelativePath(validating: "Some/Path")),
-            packageSettings: nil
-        )
+        let manifests = try subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path")))
 
         // Then
         XCTAssertEqual(manifests.path, path.appending(try RelativePath(validating: "Some/Path")))
@@ -305,10 +287,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         try stub(manifest: workspace, at: try RelativePath(validating: "Some/Path"))
 
         // When
-        let manifests = try subject.loadWorkspace(
-            at: path.appending(try RelativePath(validating: "Some/Path")),
-            packageSettings: nil
-        )
+        let manifests = try subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path")))
 
         // Then
         XCTAssertEqual(manifests.path, path.appending(try RelativePath(validating: "Some/Path")))
@@ -334,10 +313,8 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
         )
 
         // When
-        let manifests = try subject.loadWorkspace(
-            at: path.appending(try RelativePath(validating: "Some/Path/A")),
-            packageSettings: .test()
-        )
+        var manifests = try subject.loadWorkspace(at: path.appending(try RelativePath(validating: "Some/Path/A")))
+        manifests = try subject.loadAndMergePackageProjects(in: manifests, packageSettings: .test())
 
         // Then
         XCTAssertEqual(withRelativePaths(manifests.projects), [


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6053

### Short description 📝

Skip flagging the install error if there's no instance of external dependency in the graph

### How to test the changes locally 🧐

Have a project with dependencies integrated by Xcode, but also  Package.json defined for external dependencis.
Project should be able to be generated without tuist install for fetching dependencies

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing
- [ ] The change is tested via integration testing
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
