### PR TITLE
Add cached artifacts into a new group called `/Cache`

### DIFF
--- a/Sources/TuistGenerator/Generator/ProjectFileElements.swift
+++ b/Sources/TuistGenerator/Generator/ProjectFileElements.swift
@@ -289,7 +289,7 @@ class ProjectFileElements {
                 from: sourceRootPath,
                 fileAbsolutePath: path,
                 name: path.basename,
-                toGroup: groups.frameworks,
+                toGroup: groups.cachedFrameworks,
                 pbxproj: pbxproj
             )
             compiled[path] = fileElement

--- a/Sources/TuistGenerator/Generator/ProjectGroups.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGroups.swift
@@ -29,6 +29,7 @@ class ProjectGroups {
     @SortedPBXGroup var sortedMain: PBXGroup
     let products: PBXGroup
     let frameworks: PBXGroup
+    let cachedFrameworks: PBXGroup
 
     private let pbxproj: PBXProj
     private let projectGroups: [String: PBXGroup]
@@ -40,12 +41,14 @@ class ProjectGroups {
         projectGroups: [(name: String, group: PBXGroup)],
         products: PBXGroup,
         frameworks: PBXGroup,
+        cachedFrameworks: PBXGroup,
         pbxproj: PBXProj
     ) {
         sortedMain = main
         self.projectGroups = Dictionary(uniqueKeysWithValues: projectGroups)
         self.products = products
         self.frameworks = frameworks
+        self.cachedFrameworks = cachedFrameworks
         self.pbxproj = pbxproj
     }
 
@@ -98,6 +101,11 @@ class ProjectGroups {
         pbxproj.add(object: frameworksGroup)
         mainGroup.children.append(frameworksGroup)
 
+        /// Cached frameworks
+        let cacheGroup = PBXGroup(children: [], sourceTree: .group, name: "Cache")
+        pbxproj.add(object: cacheGroup)
+        mainGroup.children.append(cacheGroup)
+
         /// Products
         let productsGroup = PBXGroup(children: [], sourceTree: .group, name: "Products")
         pbxproj.add(object: productsGroup)
@@ -108,6 +116,7 @@ class ProjectGroups {
             projectGroups: projectGroups,
             products: productsGroup,
             frameworks: frameworksGroup,
+            cachedFrameworks: cacheGroup,
             pbxproj: pbxproj
         )
     }

--- a/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectFileElementsTests.swift
@@ -842,7 +842,7 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         )
 
         // Then
-        XCTAssertEqual(groups.frameworks.flattenedChildren, [
+        XCTAssertEqual(groups.cachedFrameworks.flattenedChildren, [
             "Test.framework",
         ])
 
@@ -851,6 +851,72 @@ final class ProjectFileElementsTests: TuistUnitTestCase {
         XCTAssertEqual(frameworkElement?.sourceTree, .absolute)
         XCTAssertEqual(frameworkElement?.path, frameworkPath.pathString)
         XCTAssertEqual(frameworkElement?.name, frameworkPath.basename)
+    }
+
+    func test_generateDependencies_when_cacheCompiledArtifacts_and_sdk() throws {
+        // Given
+        let pbxproj = PBXProj()
+        let sourceRootPath = try AbsolutePath(validating: "/a/project/")
+        let project = Project.test(
+            path: sourceRootPath,
+            sourceRootPath: sourceRootPath,
+            xcodeProjPath: sourceRootPath.appending(component: "Project.xcodeproj")
+        )
+        let groups = ProjectGroups.generate(project: project, pbxproj: pbxproj)
+
+        let frameworkPath = try cacheDirectoriesProvider.cacheDirectory().appending(component: "Test.framework")
+        let binaryPath = frameworkPath.appending(component: "Test")
+
+        let frameworkDependency = GraphDependencyReference.framework(
+            path: frameworkPath,
+            binaryPath: binaryPath,
+            dsymPath: nil,
+            bcsymbolmapPaths: [],
+            linking: .static,
+            architectures: [.arm64],
+            product: .framework,
+            status: .required
+        )
+
+        let sdkPath = try temporaryPath().appending(component: "ARKit.framework")
+        let sdkStatus: SDKStatus = .required
+        let sdkSource: SDKSource = .developer
+        let sdkDependency = GraphDependencyReference.sdk(
+            path: sdkPath,
+            status: sdkStatus,
+            source: sdkSource
+        )
+
+        // When
+        try subject.generate(
+            dependencyReferences: [frameworkDependency, sdkDependency],
+            groups: groups,
+            pbxproj: pbxproj,
+            sourceRootPath: sourceRootPath,
+            filesGroup: .group(name: "Project")
+        )
+
+        // Then
+        XCTAssertEqual(groups.cachedFrameworks.flattenedChildren, [
+            "Test.framework",
+        ])
+
+        let frameworkElement = subject.compiled[frameworkPath]
+        XCTAssertNotNil(frameworkElement)
+        XCTAssertEqual(frameworkElement?.sourceTree, .absolute)
+        XCTAssertEqual(frameworkElement?.path, frameworkPath.pathString)
+        XCTAssertEqual(frameworkElement?.name, frameworkPath.basename)
+
+        // Then
+        XCTAssertEqual(groups.frameworks.flattenedChildren, [
+            "ARKit.framework",
+        ])
+
+        let sdkElement = subject.compiled[sdkPath]
+        XCTAssertNotNil(sdkElement)
+        XCTAssertEqual(sdkElement?.sourceTree, .developerDir)
+        XCTAssertEqual(sdkElement?.path, sdkPath.relative(to: "/").pathString)
+        XCTAssertEqual(sdkElement?.name, sdkPath.basename)
     }
 
     func test_generateDependencies_remoteSwiftPackage_doNotGenerateElements() throws {

--- a/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
@@ -64,7 +64,7 @@ final class ProjectGroupsTests: XCTestCase {
         let main = subject.sortedMain
         XCTAssertNil(main.path)
         XCTAssertEqual(main.sourceTree, .group)
-        XCTAssertEqual(main.children.count, 4)
+        XCTAssertEqual(main.children.count, 5)
 
         XCTAssertNotNil(main.group(named: "Project"))
         XCTAssertNil(main.group(named: "Project")?.path)
@@ -78,6 +78,11 @@ final class ProjectGroupsTests: XCTestCase {
         XCTAssertEqual(subject.frameworks.name, "Frameworks")
         XCTAssertNil(subject.frameworks.path)
         XCTAssertEqual(subject.frameworks.sourceTree, .group)
+
+        XCTAssertTrue(main.children.contains(subject.cachedFrameworks))
+        XCTAssertEqual(subject.cachedFrameworks.name, "Cache")
+        XCTAssertNil(subject.cachedFrameworks.path)
+        XCTAssertEqual(subject.cachedFrameworks.sourceTree, .group)
 
         XCTAssertTrue(main.children.contains(subject.products))
         XCTAssertEqual(subject.products.name, "Products")
@@ -110,6 +115,7 @@ final class ProjectGroupsTests: XCTestCase {
             "C",
             "A",
             "Frameworks",
+            "Cache",
             "Products",
         ])
     }


### PR DESCRIPTION
### Short description 📝

The following PR addresses #5899 where we add the precompiled cached artifacts into a new group called `/Cache` since this adheres to Xcode's convention.

Resolves https://github.com/tuist/tuist/issues/5899

### How to test the changes locally 🧐

I faced issues testing this locally since the command cached isn't within the project anymore, however I have verified that the tests work and a new group is generated called `/Cache`

- Go into `app_with_spm_dependencies`
- Run `tuist install`
- Run `tuist cache --external-only` or `tuist cache`
- Run `tuist generate`
- Verify that the project App has a group called `/Cache` which should contain all the precompiled *cached* artifacts
 
### Contributor checklist ✅

- [X] The code has been linted using run `mise run lint:fix`
- [X] The change is tested via unit testing or acceptance testing, or both
- [X] The title of the PR is formulated in a way that is usable as a changelog entry

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
