### PR TITLE
Add xcodePackage target dependency with better local package support

### DIFF
--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -47,6 +47,8 @@ public enum TargetDependency: Codable, Hashable {
         /// Dependency on a local SPM package.
         /// **Note**: If your local package has external, non-local package dependencies, they still need to be defined in your
         /// `Tuist/Package.swift` file.
+        ///
+        /// To link to external package dependencies from you local packages, refer to them via the `byName` static initializer.
         case local(Path)
         /// Dependency on an external SPM package dependency imported through `Tuist/Package.swift`.
         case external
@@ -102,7 +104,7 @@ public enum TargetDependency: Codable, Hashable {
     ///
     /// Or you can depend on a local package by:
     /// ```
-    /// .xcodePackage(product: "MyLibrary", source: .local(.relativeToRoot("MyLocalPackage")))
+    /// .xcodePackage(product: "MyLibrary", source: .local("MyLocalPackage"))
     /// ```
     ///
     /// - Parameters:

--- a/Sources/ProjectDescription/TargetDependency.swift
+++ b/Sources/ProjectDescription/TargetDependency.swift
@@ -43,6 +43,15 @@ public enum TargetDependency: Codable, Hashable {
         case macro
     }
 
+    public enum PackageSource: Hashable, Codable {
+        /// Dependency on a local SPM package.
+        /// **Note**: If your local package has external, non-local package dependencies, they still need to be defined in your
+        /// `Tuist/Package.swift` file.
+        case local(Path)
+        /// Dependency on an external SPM package dependency imported through `Tuist/Package.swift`.
+        case external
+    }
+
     /// Dependency on another target within the same project
     ///
     /// - Parameters:
@@ -76,7 +85,6 @@ public enum TargetDependency: Codable, Hashable {
     case library(path: Path, publicHeaders: Path, swiftModuleMap: Path?, condition: PlatformCondition? = nil)
 
     /// Dependency on a swift package manager product using Xcode native integration. It's recommended to use `external` instead.
-    /// For more info, check the [external dependencies documentation](https://docs.tuist.io/guides/third-party-dependencies/).
     ///
     /// - Parameters:
     ///   - product: The name of the output product. ${PRODUCT_NAME} inside Xcode.
@@ -84,6 +92,25 @@ public enum TargetDependency: Codable, Hashable {
     ///   - type: The type of package being integrated.
     ///   - condition: condition under which to use this dependency, `nil` if this should always be used
     case package(product: String, type: PackageType = .runtime, condition: PlatformCondition? = nil)
+
+    /// Dependency on a Swift Package Manager product using Tuist's recommended XcodeProj-based integration.
+    ///
+    /// You can either depend on an external SPM dependency that needs to be also defined in the `Tuist/Package.swift`:
+    /// ```
+    /// .xcodePackage(product: "Alamofire", source: .external)
+    /// ```
+    ///
+    /// Or you can depend on a local package by:
+    /// ```
+    /// .xcodePackage(product: "MyLibrary", source: .local(.relativeToRoot("MyLocalPackage")))
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - product: The name of the output product. ${PRODUCT_NAME} inside Xcode.
+    ///              e.g. RxSwift
+    ///   - source: The source of package to be integreated.
+    ///   - condition: condition under which to use this dependency, `nil` if this should always be used
+    case xcodePackage(product: String, source: PackageSource = .external, condition: PlatformCondition? = nil)
 
     /// Dependency on system library or framework
     ///
@@ -153,6 +180,8 @@ public enum TargetDependency: Codable, Hashable {
             return "xctest"
         case .external:
             return "external"
+        case .xcodePackage:
+            return "xcode-package"
         }
     }
 }

--- a/Sources/TuistKit/Utils/ManifestGraphLoader.swift
+++ b/Sources/TuistKit/Utils/ManifestGraphLoader.swift
@@ -125,7 +125,7 @@ public final class ManifestGraphLoader: ManifestGraphLoading {
             at: path,
             packageSettings: packageSettings
         )
-        let (workspaceModels, manifestProjects) = (
+        let (workspace, manifestProjects) = (
             try converter.convert(manifest: allManifests.workspace, path: allManifests.path),
             allManifests.projects
         )
@@ -139,15 +139,16 @@ public final class ManifestGraphLoader: ManifestGraphLoading {
             projects: manifestProjects,
             plugins: plugins,
             externalDependencies: dependenciesGraph.externalDependencies
+                .merging(allManifests.packageProducts, uniquingKeysWith: { $1 })
         ) +
             dependenciesGraph.externalProjects.values
 
         // Check circular dependencies
-        try graphLoaderLinter.lintWorkspace(workspace: workspaceModels, projects: projectsModels)
+        try graphLoaderLinter.lintWorkspace(workspace: workspace, projects: projectsModels)
 
         // Apply any registered model mappers
         let (updatedModels, modelMapperSideEffects) = try workspaceMapper.map(
-            workspace: .init(workspace: workspaceModels, projects: projectsModels)
+            workspace: .init(workspace: workspace, projects: projectsModels)
         )
 
         // Load graph

--- a/Sources/TuistSupportTesting/SwiftPackageManager/MockSwiftPackageManagerController.swift
+++ b/Sources/TuistSupportTesting/SwiftPackageManager/MockSwiftPackageManagerController.swift
@@ -41,6 +41,7 @@ public final class MockSwiftPackageManagerController: SwiftPackageManagerControl
             ?? .init(
                 name: "Package",
                 products: [],
+                dependencies: [],
                 targets: [],
                 platforms: [],
                 cLanguageStandard: nil,

--- a/Sources/TuistSupportTesting/SwiftPackageManager/PackageInfo+TestData.swift
+++ b/Sources/TuistSupportTesting/SwiftPackageManager/PackageInfo+TestData.swift
@@ -9,6 +9,7 @@ extension PackageInfo {
     public static func test(
         name: String = "Package",
         products: [Product] = [],
+        dependencies: [PackageDependency] = [],
         targets: [Target] = [],
         platforms: [Platform] = [],
         cLanguageStandard: String? = nil,
@@ -18,6 +19,7 @@ extension PackageInfo {
         .init(
             name: name,
             products: products,
+            dependencies: dependencies,
             targets: targets,
             platforms: platforms,
             cLanguageStandard: cLanguageStandard,
@@ -582,6 +584,7 @@ extension PackageInfo {
             products: [
                 .init(name: "Tuist", type: .library(.static), targets: ["Tuist"]),
             ],
+            dependencies: [],
             targets: [
                 .init(
                     name: "Tuist",
@@ -698,6 +701,7 @@ extension PackageInfo {
             products: [
                 .init(name: "ALibrary", type: .library(.automatic), targets: ["ALibrary", "ALibraryUtils"]),
             ],
+            dependencies: [],
             targets: [
                 .init(
                     name: "ALibrary",
@@ -745,6 +749,7 @@ extension PackageInfo {
             products: [
                 .init(name: "AnotherLibrary", type: .library(.automatic), targets: ["AnotherLibrary"]),
             ],
+            dependencies: [],
             targets: [
                 .init(
                     name: "AnotherLibrary",
@@ -902,6 +907,7 @@ extension PackageInfo {
             products: [
                 .init(name: "Alamofire", type: .library(.automatic), targets: ["Alamofire"]),
             ],
+            dependencies: [],
             targets: [
                 .init(
                     name: "Alamofire",
@@ -1270,6 +1276,7 @@ extension PackageInfo {
                     targets: ["GoogleAppMeasurementWithoutAdIdSupportTarget"]
                 ),
             ],
+            dependencies: [],
             targets: [
                 .init(
                     name: "GoogleAppMeasurementTarget",
@@ -1406,6 +1413,7 @@ extension PackageInfo {
                 .init(name: "GULNSData", type: .library(.automatic), targets: ["GULNSData"]),
                 .init(name: "GULNetwork", type: .library(.automatic), targets: ["GULNetwork"]),
             ],
+            dependencies: [],
             targets: [
                 .init(
                     name: "GULAppDelegateSwizzler",
@@ -1475,6 +1483,7 @@ extension PackageInfo {
             products: [
                 .init(name: "nanopb", type: .library(.automatic), targets: ["nanopb"]),
             ],
+            dependencies: [],
             targets: [
                 .init(
                     name: "nanopb",

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -37,6 +37,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target_1", "Target_2"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target_1", type: .binary, url: "https://binary.target.com"),
                         .test(name: "Target_2"),
@@ -77,6 +78,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target_1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target_1",
@@ -100,6 +102,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product2", type: .library(.automatic), targets: ["Target_2"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target_2"),
                     ],
@@ -149,6 +152,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target_1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target_1",
@@ -172,6 +176,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "com.example.dep-1", type: .library(.automatic), targets: ["com.example.dep-1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "com.example.dep-1"),
                     ],
@@ -221,6 +226,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product", type: .library(.automatic), targets: ["Target_1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target_1",
@@ -270,6 +276,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product_1", type: .library(.automatic), targets: ["Target_1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target_1",
@@ -300,6 +307,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         .init(name: "Product_2", type: .library(.automatic), targets: ["Target_2"]),
                         .init(name: "Product_3", type: .library(.automatic), targets: ["Target_3"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target_2"),
                         .test(name: "Target_3"),
@@ -359,6 +367,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target1"),
                     ],
@@ -397,6 +406,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target1"),
                     ],
@@ -443,6 +453,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target1"),
                     ],
@@ -491,6 +502,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         products: [
                             .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                         ],
+                        dependencies: [],
                         targets: [
                             .test(name: "Target1"),
                         ],
@@ -535,6 +547,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target_1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target_1", type: .binary, url: "https://binary.target.com"),
                     ],
@@ -563,6 +576,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target_1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target_1"),
                     ],
@@ -604,6 +618,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -659,6 +674,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "com.example.product-1", type: .library(.automatic), targets: ["com.example.target-1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "com.example.target-1"),
                     ],
@@ -706,6 +722,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target1"),
                         .test(name: "Target2"),
@@ -746,6 +763,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1", "Target2", "Target3"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target1"),
                         .test(name: "Target2", type: .test),
@@ -786,6 +804,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         .init(name: "Product2", type: .plugin, targets: ["Target2"]),
                         .init(name: "Product3", type: .test, targets: ["Target3"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target1"),
                         .test(name: "Target2"),
@@ -823,6 +842,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target1", sources: ["Subfolder", "Another/Subfolder/file.swift"]),
                     ],
@@ -886,6 +906,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -1001,6 +1022,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target1"),
                     ],
@@ -1052,6 +1074,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1"
@@ -1100,6 +1123,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -1155,6 +1179,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -1188,6 +1213,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1"
@@ -1244,6 +1270,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -1334,6 +1361,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -1350,6 +1378,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Dependency1", type: .library(.automatic), targets: ["Dependency1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Dependency1",
@@ -1366,6 +1395,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Dependency2", type: .library(.automatic), targets: ["Dependency2"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Dependency2"
@@ -1425,6 +1455,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -1490,6 +1521,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -1550,6 +1582,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target1"),
                     ],
@@ -1600,6 +1633,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target1"),
                     ],
@@ -1650,6 +1684,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -1691,6 +1726,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -1732,6 +1768,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -1777,6 +1814,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -1821,6 +1859,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -1860,6 +1899,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -1900,6 +1940,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -1940,6 +1981,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -1980,6 +2022,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -2019,6 +2062,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -2063,6 +2107,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -2104,6 +2149,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -2184,6 +2230,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -2236,6 +2283,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -2291,6 +2339,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -2335,6 +2384,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -2381,6 +2431,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -2407,6 +2458,48 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         )
     }
 
+    func testMap_whenHasDependencies() throws {
+        let basePath = try temporaryPath()
+        let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))
+        let localDependencyPath = basePath.appending(try RelativePath(validating: "LocalPackage"))
+        try fileHandler.createFolder(sourcesPath)
+        try fileHandler.createFolder(localDependencyPath)
+
+        let project = try subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageInfos: [
+                "Package": .init(
+                    name: "Package",
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    dependencies: [
+                        .local(path: localDependencyPath.pathString),
+                    ],
+                    targets: [
+                        .test(
+                            name: "Target1"
+                        ),
+                    ],
+                    platforms: [.ios],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+        XCTAssertBetterEqual(
+            project,
+            .testWithDefaultConfigs(
+                name: "Package",
+                targets: [
+                    .test("Target1", basePath: basePath),
+                ]
+            )
+        )
+    }
+
     func testMap_whenBinaryTargetDependency_mapsToXcframework() throws {
         let basePath = try temporaryPath()
         let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))
@@ -2423,6 +2516,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -2473,6 +2567,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -2513,6 +2608,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -2563,6 +2659,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -2611,6 +2708,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             products: [
                 .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
             ],
+            dependencies: [],
             targets: [
                 .test(
                     name: "Target1",
@@ -2629,6 +2727,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 .init(name: "Product2", type: .library(.automatic), targets: ["Target2", "Target3"]),
                 .init(name: "Product3", type: .library(.automatic), targets: ["Target4"]),
             ],
+            dependencies: [],
             targets: [
                 .test(name: "Target2"),
                 .test(name: "Target3"),
@@ -2674,6 +2773,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             products: [
                 .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
             ],
+            dependencies: [],
             targets: [
                 .test(
                     name: "Target1",
@@ -2692,6 +2792,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 .init(name: "Product2", type: .library(.automatic), targets: ["Target2", "Target3"]),
                 .init(name: "Product3", type: .library(.automatic), targets: ["Target4"]),
             ],
+            dependencies: [],
             targets: [
                 .test(name: "Target2"),
                 .test(name: "Target3"),
@@ -2738,6 +2839,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target1"),
                     ],
@@ -2774,6 +2876,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target1"),
                     ],
@@ -2810,6 +2913,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target1"),
                     ],
@@ -2846,6 +2950,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target1"),
                     ],
@@ -2882,6 +2987,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target1"),
                     ],
@@ -2922,6 +3028,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(name: "Target1"),
                     ],
@@ -2970,6 +3077,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product1", type: .library(.automatic), targets: allTargets),
                     ],
+                    dependencies: [],
                     targets: allTargets.map { .test(name: $0) },
                     platforms: [.ios],
                     cLanguageStandard: nil,
@@ -3034,6 +3142,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     products: [
                         .init(name: "Product", type: .library(.automatic), targets: ["Target1"]),
                     ],
+                    dependencies: [],
                     targets: [
                         .test(
                             name: "Target1",
@@ -3108,6 +3217,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             products: [
                 .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
             ],
+            dependencies: [],
             targets: [
                 .test(
                     name: "Target1",
@@ -3131,6 +3241,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             products: [
                 .init(name: "Product2", type: .library(.automatic), targets: ["Target2", "Target3"]),
             ],
+            dependencies: [],
             targets: [
                 .test(name: "Target2"),
                 .test(name: "Target3"),

--- a/Tests/TuistSupportTests/SwiftPackageManager/PackageInfoTests.swift
+++ b/Tests/TuistSupportTests/SwiftPackageManager/PackageInfoTests.swift
@@ -13,6 +13,9 @@ final class PackageInfoTests: XCTestCase {
                     PackageInfo.Product(name: "tuist", type: .executable, targets: ["tuist"]),
                     PackageInfo.Product(name: "tuist", type: .library(.dynamic), targets: ["ProjectDescription"]),
                 ],
+                dependencies: [
+                    .local(path: "MyLocalDependency"),
+                ],
                 targets: [
                     PackageInfo.Target(
                         name: "tuist",

--- a/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Add External Dependencies/Project.swift
+++ b/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Add External Dependencies/Project.swift
@@ -13,7 +13,7 @@ let project = Project(
             infoPlist: .default,
             sources: ["Targets/App/Sources/**"],
             dependencies: [
-                .external(name: "Alamofire"),
+                .xcodePackage(name: "Alamofire"),
             ]
         ),
     ]

--- a/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Add External Dependencies/dependencies-gitignore.txt
+++ b/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Add External Dependencies/dependencies-gitignore.txt
@@ -1,2 +1,0 @@
-Tuist/Dependencies/graph.json
-Tuist/Dependencies/SwiftPackageManager

--- a/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Add External Dependencies/external-dependencies.tutorial
+++ b/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Add External Dependencies/external-dependencies.tutorial
@@ -29,14 +29,9 @@
         
         @Steps {
             @Step {
-                Run `tuist install` to resolve the dependencies using the Swift Package Manager under `Tuist/Dependencies`. The generated workspace will contain projects and targets for them.
+                Run `tuist install` to resolve the dependencies using the Swift Package Manager defined in `Tuist/Package.swift`. The generated workspace will contain projects and targets for them. Don't forget to add `Tuist/.build` to your `.gitignore`. 
                 
                 @Code(name: "Console", file: "tuist-install.sh", reset: true)
-            }
-            
-            @Step {
-                Don't forget to ignore the following directories and files from your version control system.
-                @Code(name: ".gitignore", file: "dependencies-gitignore.txt", reset: true)
             }
         }
     }
@@ -51,7 +46,7 @@
             }
 
             @Step {
-                Use the `.external` target dependency option to declare the dependency.
+                Use the `.xcodePackage` target dependency option to declare the dependency.
                 @Code(name: "Project.swift", file: "Project.swift", reset: true)
             }
             

--- a/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Add External Dependencies/local-package.swift
+++ b/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Add External Dependencies/local-package.swift
@@ -1,14 +1,14 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
-    name: "LocalSwiftPackageC",
-    products: [.library(name: "LibraryC", targets: ["LibraryC"])],
+    name: "MyLocalPackage",
+    products: [.library(name: "MyLibrary", targets: ["MyLibrary"])],
     targets: [
         .target(
-            name: "LibraryC",
+            name: "MyLibrary",
             dependencies: [
                 .byName(name: "Alamofire"),
             ]

--- a/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Add External Dependencies/project-local-package.swift
+++ b/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Add External Dependencies/project-local-package.swift
@@ -13,7 +13,7 @@ let project = Project(
             infoPlist: .default,
             sources: ["Targets/App/Sources/**"],
             dependencies: [
-                .xcodePackage(product: "Alamofire"),
+                .xcodePackage(product: "MyLibrary", source: .local("MyLocalPackage")),
             ]
         ),
     ]

--- a/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Add External Dependencies/swift-package-manager-dependencies.tutorial
+++ b/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/Getting-Started/Add External Dependencies/swift-package-manager-dependencies.tutorial
@@ -1,13 +1,13 @@
 @Tutorial(time: 5) {
-    @Intro(title: "Adding external Dependencies") {
-        Learn how to integrate external Package dependencies into your Tuist project.
+    @Intro(title: "Adding Swift Package Manager dependencies") {
+        Learn how to integrate Swift Package Manager dependencies into your Tuist project.
 
         @Image(source: "Logo-Blurred.png", alt: "Blurred Tuist Logo.")
     }
 
     @Section(title: "Defining package dependencies") {
         @ContentAndMedia {
-            External dependencies are defined in a `Package.swift` manifest file in the `/Tuist` directory in the root of your project. You can also define your `Package.swift` directly in the root if you are working on an SPM package.
+            External package dependencies are defined in a `Package.swift` manifest file in the `/Tuist` directory in the root of your project. You can also define your `Package.swift` directly in the root if you are working on an SPM package.
         }
 
         @Steps {
@@ -56,6 +56,21 @@
             }
         }
     }
-        
+
+    @Section(title: "Integrating local package dependencies") {
+        dd
+
+        @Steps {
+            @Step {
+                Use the `.xcodePackage` target dependency option to declare the dependency.
+                @Code(name: "Project.swift", file: "project-local-package.swift", reset: true)
+            }
+
+            @Step {
+                External dependencies still need to be declared in the root `Tuist/Package.swift`. But you can link to them through your `Package.swift` via `.byName(name: "ExternalProduct")`
+                @Code(name: "Package.swift", file: "local-package.swift", reset: true)
+            }
+        }
+    }
 }
 

--- a/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/tuist-tutorials.tutorial
+++ b/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/Tutorials/Tuist Tutorial/tuist-tutorials.tutorial
@@ -10,6 +10,6 @@
         
         @TutorialReference(tutorial: "doc:install")
         @TutorialReference(tutorial: "doc:create-project")
-        @TutorialReference(tutorial: "doc:external-dependencies")
+        @TutorialReference(tutorial: "doc:swift-package-manager-dependencies")
     }
 }

--- a/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/dependencies.md
+++ b/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/dependencies.md
@@ -41,6 +41,7 @@ When instantiating a `Target`, you can pass the `dependencies` argument with any
 - `XCFramework`: Declares a dependency with a binary XCFramework.
 - `SDK`: Declares a dependency with a system SDK.
 - `XCTest`: Declares a dependency with XCTest.
+- `XcodePackage`: Declares a dependency on an SPM package. The package can either be local or external.
 
 Note that every dependency type accepts a `condition` option to conditionally link the dependency based on the platform. By default, it links the dependency for all platforms the target supports.
 

--- a/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/dependencies.md
+++ b/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/dependencies.md
@@ -65,7 +65,7 @@ Thanks to that, we can not only give you more control over the integration but a
 
 XcodeProj's integration is more likely to take more time to support new Swift Package features or handle more package configurations. However, the mapping logic between Swift Packages and XcodeProj targets is open-source and can be contributed to by the community. This is contrary to Xcode's default integration, which is closed-source and maintained by Apple.
 
-You can follow the <doc:external-dependencies> tutorial to learn more about how to integrate Swift Packages in your project.
+You can follow the <doc:swift-package-manager-dependencies> tutorial to learn more about how to integrate Swift Packages in your project.
 
 > Note: The **schemes** are not automatically created for Swift Package projects to keep the schemes list clean. You can create them via Xcode's UI.
 

--- a/fixtures/app_with_spm_dependencies/App/Project.swift
+++ b/fixtures/app_with_spm_dependencies/App/Project.swift
@@ -44,6 +44,7 @@ let project = Project(
                 .external(name: "AirshipPreferenceCenter"),
                 .external(name: "MarkdownUI"),
                 .external(name: "GoogleMobileAds"),
+                .xcodePackage(product: "LibraryD", source: .local(.relativeToRoot("LocalSwiftPackageD"))),
             ],
             settings: .targetSettings
         ),

--- a/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
+++ b/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
@@ -7,6 +7,7 @@ import ComposableArchitecture
 import CrashReporter
 import GoogleMobileAds
 import GoogleSignIn
+import LibraryD
 import libzstd
 import MarkdownUI
 import NYTPhotoViewer

--- a/fixtures/app_with_spm_dependencies/LocalSwiftPackageC/Package.swift
+++ b/fixtures/app_with_spm_dependencies/LocalSwiftPackageC/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version:5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "LocalSwiftPackageC",
+    products: [.library(name: "LibraryC", targets: ["LibraryC"])],
+    targets: [
+        .target(name: "LibraryC"),
+    ]
+)

--- a/fixtures/app_with_spm_dependencies/LocalSwiftPackageC/Sources/LibraryC/MyStruct.swift
+++ b/fixtures/app_with_spm_dependencies/LocalSwiftPackageC/Sources/LibraryC/MyStruct.swift
@@ -1,3 +1,7 @@
+import Alamofire
+
 public struct MyStruct {
-    public init() {}
+    public init() {
+        _ = AF.download("http://www.tuist.io")
+    }
 }

--- a/fixtures/app_with_spm_dependencies/LocalSwiftPackageC/Sources/LibraryC/MyStruct.swift
+++ b/fixtures/app_with_spm_dependencies/LocalSwiftPackageC/Sources/LibraryC/MyStruct.swift
@@ -1,0 +1,3 @@
+public struct MyStruct {
+    public init() {}
+}

--- a/fixtures/app_with_spm_dependencies/LocalSwiftPackageD/Package.swift
+++ b/fixtures/app_with_spm_dependencies/LocalSwiftPackageD/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version:5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "LocalSwiftPackageD",
+    products: [.library(name: "LibraryD", targets: ["LibraryD"])],
+    dependencies: [
+        .package(path: "../LocalSwiftPackageC"),
+    ],
+    targets: [
+        .target(
+            name: "LibraryD",
+            dependencies: ["LibraryC"]
+        ),
+    ]
+)

--- a/fixtures/app_with_spm_dependencies/LocalSwiftPackageD/Sources/LibraryD/MyStruct.swift
+++ b/fixtures/app_with_spm_dependencies/LocalSwiftPackageD/Sources/LibraryD/MyStruct.swift
@@ -1,0 +1,5 @@
+import LibraryC
+
+public struct MyLibraryDStruct {
+    let libraryC = MyStruct()
+}


### PR DESCRIPTION
### Short description 📝

This PR adds a new `TargetDependency`:
```swift
public enum PackageSource: Hashable, Codable {
  case local(Path)
  case external
}

case xcodePackage(product: String, source: PackageSource = .external, condition: PlatformCondition? = nil)
```

This new type should eventually replace the current `external` dependency. I am not deprecating that case just yet until we stabilise the new API.

The primary purpose of the new API is to make it easier to link to local packages from existing `Project.swift`.

Before, users had to link all their local packages in the `Tuist/Package.swift`. Additionally, these local packages were missing the autogenerated schemes that one would expect for local targets.

The new API allows developers to directly link to local packages. It doesn't come without tradeoffs – primarily, remote dependencies in local packages still need to be defined in `Tuist/Package.swift`. However, local packages can link to remote dependencies via `.byName` (or a pure String) as long as the dependency is resolved with the `Tuist/Package.swift`.

We believe this will bring better ergonomics of migrating to Tuist when coming from SPM-based modularization and make `Package.swift` a first-class manifest.

### How to test the changes locally 🧐

Play with `app_with_spm_dependencies` where we're using the new integration for local packages.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
