### PR TITLE
Remove Deprecated ‘platforms’ Parameter from PackageSettings Documentation

### DIFF
--- a/Sources/ProjectDescription/PackageSettings.swift
+++ b/Sources/ProjectDescription/PackageSettings.swift
@@ -14,8 +14,7 @@ import Foundation
 ///     let packageSettings = PackageSettings(
 ///         productTypes: [
 ///             "Alamofire": .framework, // default is .staticFramework
-///         ],
-///         platforms: [.iOS]
+///         ]
 ///     )
 /// #endif
 ///


### PR DESCRIPTION

### Short description 📝

> Remove deprecated `platforms` param from the `PackageSettings` usage documentation comment.

### How to test the changes locally 🧐

> No code changes

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
