### PR TITLE
Fix integration of swift-testing

### DIFF
--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -457,9 +457,14 @@ public class GraphTraverser: GraphTraversing {
     }
 
     public func allSwiftMacroTargets(path: AbsolutePath, name: String) -> Set<GraphTarget> {
-        let dependencies = allTargetDependencies(path: path, name: name)
+        var dependencies = allTargetDependencies(path: path, name: name)
             .filter { [.staticFramework, .framework, .dynamicLibrary, .staticLibrary].contains($0.target.product) }
             .filter { self.directSwiftMacroExecutables(path: $0.path, name: $0.target.name).count != 0 }
+
+        if let target = target(path: path, name: name), !directSwiftMacroExecutables(path: path, name: name).isEmpty {
+            dependencies.insert(target)
+        }
+
         return Set(dependencies)
     }
 

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -71,6 +71,22 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
             )
         }
 
+        /**
+         Targets that depend on a Swift Macro have the following dependency graph:
+
+         Target -> MyMacro (Static framework) -> MyMacro (Executable)
+
+         The executable is compiled transitively through the static library, and we place it inside the framework to make it available to the target depending on the framework
+         to point it with the `-load-plugin-executable $(BUILD_DIR)/$(CONFIGURATION)/ExecutableName\#ExecutableName` build setting.
+         */
+        let directSwiftMacroExecutables = graphTraverser.directSwiftMacroExecutables(path: path, name: target.name).sorted()
+        try generateCopySwiftMacroExecutableScriptBuildPhase(
+            directSwiftMacroExecutables: directSwiftMacroExecutables,
+            target: target,
+            pbxTarget: pbxTarget,
+            pbxproj: pbxproj
+        )
+
         if target.supportsSources {
             try generateSourcesBuildPhase(
                 files: target.sources,
@@ -405,6 +421,60 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
             pbxBuildFiles.forEach { pbxproj.add(object: $0) }
             copyFilesPhase.files = pbxBuildFiles
         }
+    }
+
+    private func generateCopySwiftMacroExecutableScriptBuildPhase(
+        directSwiftMacroExecutables: [GraphDependencyReference],
+        target: Target,
+        pbxTarget: PBXTarget,
+        pbxproj: PBXProj
+    ) throws {
+        if directSwiftMacroExecutables.isEmpty { return }
+
+        let copySwiftMacrosBuildPhase = PBXShellScriptBuildPhase(name: "Copy Swift Macro executable into $BUILT_PRODUCT_DIR")
+
+        let executableNames = directSwiftMacroExecutables.compactMap {
+            switch $0 {
+            case let .product(_, productName, _):
+                return productName
+            default:
+                return nil
+            }
+        }
+
+        let copyLines = executableNames.map {
+            """
+            if [[ -f "$BUILD_DIR/$CONFIGURATION/\($0)" && ! -f "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\($0)" ]]; then
+                mkdir -p "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/"
+                cp "$BUILD_DIR/$CONFIGURATION/\($0)" "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\($0)"
+            fi
+            """
+        }
+        copySwiftMacrosBuildPhase.shellScript = """
+        #  This build phase serves two purposes:
+        #  - Force Xcode build system to compile the macOS executable transitively when compiling for non-macOS destinations
+        #  - Place the artifacts in the "Debug" directory where the built artifacts for the active destination live. We default to "Debug" because otherwise the Xcode editor fails to resolve the macro references.
+        \(copyLines.joined(separator: "\n"))
+        """
+
+        copySwiftMacrosBuildPhase.inputPaths = executableNames.map { "$BUILD_DIR/$CONFIGURATION/\($0)" }
+
+        copySwiftMacrosBuildPhase.outputPaths = target.supportedPlatforms
+            .filter { $0 != .macOS }
+            .flatMap { platform in
+                var sdks: [String] = []
+                sdks.append(platform.xcodeDeviceSDK)
+                if let simulatorSDK = platform.xcodeSimulatorSDK { sdks.append(simulatorSDK) }
+                return sdks
+            }
+            .flatMap { sdk in
+                executableNames.map { executable in
+                    "$BUILD_DIR/Debug-\(sdk)/\(executable)"
+                }
+            }
+
+        pbxproj.add(object: copySwiftMacrosBuildPhase)
+        pbxTarget.buildPhases.append(copySwiftMacrosBuildPhase)
     }
 
     private func generateResourcesBuildFile(

--- a/Sources/TuistGenerator/Generator/LinkGenerator.swift
+++ b/Sources/TuistGenerator/Generator/LinkGenerator.swift
@@ -116,23 +116,6 @@ final class LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_
             fileElements: fileElements
         )
 
-        /**
-         Targets that depend on a Swift Macro have the following dependency graph:
-
-         Target -> MyMacro (Static framework) -> MyMacro (Executable)
-
-         The executable is compiled transitively through the static library, and we place it inside the framework to make it available to the target depending on the framework
-         to point it with the `-load-plugin-executable $(BUILD_DIR)/$(CONFIGURATION)/ExecutableName\#ExecutableName` build setting.
-         */
-        let directSwiftMacroExecutables = graphTraverser.directSwiftMacroExecutables(path: path, name: target.name).sorted()
-        try generateCopySwiftMacroExecutableScriptBuildPhase(
-            directSwiftMacroExecutables: directSwiftMacroExecutables,
-            target: target,
-            pbxTarget: pbxTarget,
-            pbxproj: pbxproj,
-            fileElements: fileElements
-        )
-
         try generatePackages(
             target: target,
             pbxTarget: pbxTarget,
@@ -511,61 +494,6 @@ final class LinkGenerator: LinkGenerating { // swiftlint:disable:this type_body_
             target: target,
             fileElements: fileElements
         )
-    }
-
-    func generateCopySwiftMacroExecutableScriptBuildPhase(
-        directSwiftMacroExecutables: [GraphDependencyReference],
-        target: Target,
-        pbxTarget: PBXTarget,
-        pbxproj: PBXProj,
-        fileElements _: ProjectFileElements
-    ) throws {
-        if directSwiftMacroExecutables.isEmpty { return }
-
-        let copySwiftMacrosBuildPhase = PBXShellScriptBuildPhase(name: "Copy Swift Macro executable into $BUILT_PRODUCT_DIR")
-
-        let executableNames = directSwiftMacroExecutables.compactMap {
-            switch $0 {
-            case let .product(_, productName, _):
-                return productName
-            default:
-                return nil
-            }
-        }
-
-        let copyLines = executableNames.map {
-            """
-            if [[ -f "$BUILD_DIR/$CONFIGURATION/\($0)" && ! -f "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\($0)" ]]; then
-                mkdir -p "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/"
-                cp "$BUILD_DIR/$CONFIGURATION/\($0)" "$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\($0)"
-            fi
-            """
-        }
-        copySwiftMacrosBuildPhase.shellScript = """
-        #  This build phase serves two purposes:
-        #  - Force Xcode build system to compile the macOS executable transitively when compiling for non-macOS destinations
-        #  - Place the artifacts in the "Debug" directory where the built artifacts for the active destination live. We default to "Debug" because otherwise the Xcode editor fails to resolve the macro references.
-        \(copyLines.joined(separator: "\n"))
-        """
-
-        copySwiftMacrosBuildPhase.inputPaths = executableNames.map { "$BUILD_DIR/$CONFIGURATION/\($0)" }
-
-        copySwiftMacrosBuildPhase.outputPaths = target.supportedPlatforms
-            .filter { $0 != .macOS }
-            .flatMap { platform in
-                var sdks: [String] = []
-                sdks.append(platform.xcodeDeviceSDK)
-                if let simulatorSDK = platform.xcodeSimulatorSDK { sdks.append(simulatorSDK) }
-                return sdks
-            }
-            .flatMap { sdk in
-                executableNames.map { executable in
-                    "$BUILD_DIR/Debug-\(sdk)/\(executable)"
-                }
-            }
-
-        pbxproj.add(object: copySwiftMacrosBuildPhase)
-        pbxTarget.buildPhases.append(copySwiftMacrosBuildPhase)
     }
 
     private func generateDependenciesBuildPhase(

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -280,7 +280,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
                     "ViewInspector", // https://github.com/nalexn/ViewInspector
                     "XCTVapor", // https://github.com/vapor/vapor
                     "MockableTest", // https://github.com/Kolos65/Mockable.git
-                    "Testing",
+                    "Testing", // https://github.com/apple/swift-testing
                 ].map {
                     ($0, ["ENABLE_TESTING_SEARCH_PATHS": "YES"])
                 }

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -280,6 +280,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
                     "ViewInspector", // https://github.com/nalexn/ViewInspector
                     "XCTVapor", // https://github.com/vapor/vapor
                     "MockableTest", // https://github.com/Kolos65/Mockable.git
+                    "Testing",
                 ].map {
                     ($0, ["ENABLE_TESTING_SEARCH_PATHS": "YES"])
                 }

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -4720,9 +4720,14 @@ final class GraphTraverserTests: TuistUnitTestCase {
 
         // When
         let got = subject.allSwiftMacroTargets(path: project.path, name: app.name)
+        let gotDirectMacroFramework = subject.allSwiftMacroTargets(path: project.path, name: directMacroFramework.name)
 
         // Then
         XCTAssertEqual(got.sorted(), [
+            GraphTarget(path: project.path, target: directMacroFramework, project: project),
+            GraphTarget(path: project.path, target: transitiveMacroLibrary, project: project),
+        ])
+        XCTAssertEqual(gotDirectMacroFramework.sorted(), [
             GraphTarget(path: project.path, target: directMacroFramework, project: project),
             GraphTarget(path: project.path, target: transitiveMacroLibrary, project: project),
         ])

--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -973,65 +973,6 @@ final class LinkGeneratorTests: XCTestCase {
         ])
     }
 
-    func test_generateLinks_generatesAShellScriptBuildPhase_when_targetIsAMacroFramework() throws {
-        // Given
-        let app = Target.test(name: "app", platform: .iOS, product: .app)
-        let macroFramework = Target.test(name: "framework", platform: .iOS, product: .staticFramework)
-        let macroExecutable = Target.test(name: "macro", platform: .macOS, product: .macro)
-        let project = Project.test(targets: [app, macroFramework, macroExecutable])
-
-        let graph = Graph.test(path: project.path, projects: [project.path: project], targets: [
-            project.path: [
-                app.name: app,
-                macroFramework.name: macroFramework,
-                macroExecutable.name: macroExecutable,
-            ],
-        ], dependencies: [
-            .target(name: app.name, path: project.path): Set([.target(name: macroFramework.name, path: project.path)]),
-            .target(name: macroFramework.name, path: project.path): Set([.target(
-                name: macroExecutable.name,
-                path: project.path
-            )]),
-            .target(name: macroExecutable.name, path: project.path): Set([]),
-        ])
-        let graphTraverser = GraphTraverser(graph: graph)
-        let xcodeProjElements = createXcodeprojElements()
-        let fileElements = createProjectFileElements(for: [app, macroFramework, macroExecutable])
-
-        // When
-        try subject.generateLinks(
-            target: macroFramework,
-            pbxTarget: xcodeProjElements.pbxTarget,
-            pbxproj: xcodeProjElements.pbxproj,
-            fileElements: fileElements,
-            path: project.path,
-            sourceRootPath: project.path,
-            graphTraverser: graphTraverser
-        )
-
-        // Then
-        let buildPhase = xcodeProjElements
-            .pbxTarget
-            .buildPhases
-            .compactMap { $0 as? PBXShellScriptBuildPhase }
-            .first(where: { $0.name() == "Copy Swift Macro executable into $BUILT_PRODUCT_DIR" })
-
-        XCTAssertNotNil(buildPhase)
-
-        let expectedScript =
-            "if [[ -f \"$BUILD_DIR/$CONFIGURATION/macro\" && ! -f \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/macro\" ]]; then\n    mkdir -p \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\"\n    cp \"$BUILD_DIR/$CONFIGURATION/macro\" \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/macro\"\nfi"
-        XCTAssertTrue(buildPhase?.shellScript?.contains(expectedScript) == true)
-        XCTAssertTrue(buildPhase?.inputPaths.contains("$BUILD_DIR/$CONFIGURATION/\(macroExecutable.productName)") == true)
-        XCTAssertTrue(
-            buildPhase?.outputPaths
-                .contains("$BUILD_DIR/Debug-iphonesimulator/\(macroExecutable.productName)") == true
-        )
-        XCTAssertTrue(
-            buildPhase?.outputPaths
-                .contains("$BUILD_DIR/Debug-iphoneos/\(macroExecutable.productName)") == true
-        )
-    }
-
     // MARK: - Helpers
 
     struct XcodeprojElements {

--- a/fixtures/app_with_spm_dependencies/App/Project.swift
+++ b/fixtures/app_with_spm_dependencies/App/Project.swift
@@ -57,6 +57,7 @@ let project = Project(
             dependencies: [
                 .target(name: "AppKit"),
                 .external(name: "Nimble"),
+                .external(name: "Testing"),
             ],
             settings: .targetSettings
         ),

--- a/fixtures/app_with_spm_dependencies/App/Tests/AppKit/AppKitTests.swift
+++ b/fixtures/app_with_spm_dependencies/App/Tests/AppKit/AppKitTests.swift
@@ -1,8 +1,8 @@
 import Nimble
-import XCTest
+import Testing
 
-final class AppKitTests: XCTestCase {
-    func testExample() {
+struct AppKitTestingTests {
+    @Test func example() {
         expect(1).to(equal(1))
     }
 }

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
@@ -334,6 +334,15 @@
       }
     },
     {
+      "identity" : "swift-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-testing",
+      "state" : {
+        "revision" : "3ed2f90058afe4437369aee4880890e7fa65d1ec",
+        "version" : "0.5.1"
+      }
+    },
+    {
       "identity" : "swiftlint",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/SwiftLint",

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.swift
@@ -38,6 +38,7 @@ let package = Package(
         // Has an umbrella header where moduleName must be sanitized
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.2.0"),
         .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads", from: "11.1.0"),
+        .package(url: "https://github.com/apple/swift-testing", .upToNextMajor(from: "0.5.1")),
         .package(path: "../LocalSwiftPackage"),
         .package(path: "../StringifyMacro"),
     ]


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5795

### Short description 📝

This PR fixes the integration of `swift-testing`. There were two issues:
- in the hardcoded mapping for test targets, we were missing the `Testing` framework. Long-term, we should still find an automatic way to derive whether we should add the `ENABLE_TESTING_SEARCH_PATHS` or not.
- `allSwiftMacroTargets` method in the `GraphTraverser` wouldn't actually return a direct macro dependency.
- The copy macro build phase must be before the compile sources phase for targets that directly depend on a macro

### How to test the changes locally 🧐

You should be able to test `AppKit` in the `app_with_spm_dependencies` fixture.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
