### PR TITLE
Refactor tuist build to enable Tuist Cloud caching

### DIFF
--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -4,106 +4,114 @@ import TSCBasic
 import TSCUtility
 import TuistSupport
 
-/// Command that builds a target from the project in the current directory.
-public struct BuildCommand: AsyncParsableCommand {
+public struct BuildOptions: ParsableArguments {
     public init() {}
-    public static var configuration: CommandConfiguration {
-        CommandConfiguration(
-            commandName: "build",
-            abstract: "Builds a project"
-        )
-    }
-
+    
     @Argument(
         help: "The scheme to be built. By default it builds all the buildable schemes of the project in the current directory."
     )
-    var scheme: String?
+    public var scheme: String?
 
     @Flag(
         help: "Force the generation of the project before building."
     )
-    var generate: Bool = false
+    public var generate: Bool = false
 
     @Flag(
         help: "When passed, it cleans the project before building it"
     )
-    var clean: Bool = false
+    public var clean: Bool = false
 
     @Option(
         name: .shortAndLong,
         help: "The path to the directory that contains the project to be built.",
         completion: .directory
     )
-    var path: String?
+    public var path: String?
 
     @Option(
         name: .shortAndLong,
         help: "Build on a specific device."
     )
-    var device: String?
+    public var device: String?
 
     @Option(
         name: .long,
         help: "Build for a specific platform."
     )
-    var platform: String?
+    public var platform: String?
 
     @Option(
         name: .shortAndLong,
         help: "Build with a specific version of the OS."
     )
-    var os: String?
+    public var os: String?
 
     @Flag(
         name: .long,
         help: "When passed, append arch=x86_64 to the 'destination' to run simulator in a Rosetta mode."
     )
-    var rosetta: Bool = false
+    public var rosetta: Bool = false
 
     @Option(
         name: [.long, .customShort("C")],
         help: "The configuration to be used when building the scheme."
     )
-    var configuration: String?
+    public var configuration: String?
 
     @Option(
         help: "The directory where build products will be copied to when the project is built.",
         completion: .directory
     )
-    var buildOutputPath: String?
+    public var buildOutputPath: String?
 
     @Option(
         help: "Overrides the folder that should be used for derived data when building the project."
     )
-    var derivedDataPath: String?
+    public var derivedDataPath: String?
 
     @Flag(
         name: .long,
         help: "When passed, it generates the project and skips building. This is useful for debugging purposes."
     )
-    var generateOnly: Bool = false
+    public var generateOnly: Bool = false
+}
+
+/// Command that builds a target from the project in the current directory.
+public struct BuildCommand: AsyncParsableCommand {
+    public init() {}
+    
+    public static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            commandName: "build",
+            abstract: "Builds a project"
+        )
+    }
+    
+    @OptionGroup()
+    var buildOptions: BuildOptions
 
     public func run() async throws {
         let absolutePath: AbsolutePath
-        if let path {
+        if let path = buildOptions.path {
             absolutePath = try AbsolutePath(validating: path, relativeTo: FileHandler.shared.currentPath)
         } else {
             absolutePath = FileHandler.shared.currentPath
         }
 
         try await BuildService().run(
-            schemeName: scheme,
-            generate: generate,
-            clean: clean,
-            configuration: configuration,
-            buildOutputPath: buildOutputPath.map { try AbsolutePath(validating: $0, relativeTo: FileHandler.shared.currentPath) },
-            derivedDataPath: derivedDataPath,
+            schemeName: buildOptions.scheme,
+            generate: buildOptions.generate,
+            clean: buildOptions.clean,
+            configuration: buildOptions.configuration,
+            buildOutputPath: buildOptions.buildOutputPath.map { try AbsolutePath(validating: $0, relativeTo: FileHandler.shared.currentPath) },
+            derivedDataPath: buildOptions.derivedDataPath,
             path: absolutePath,
-            device: device,
-            platform: platform,
-            osVersion: os,
-            rosetta: rosetta,
-            generateOnly: generateOnly
+            device: buildOptions.device,
+            platform: buildOptions.platform,
+            osVersion: buildOptions.os,
+            rosetta: buildOptions.rosetta,
+            generateOnly: buildOptions.generateOnly
         )
     }
 }

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -6,7 +6,7 @@ import TuistSupport
 
 public struct BuildOptions: ParsableArguments {
     public init() {}
-    
+
     @Argument(
         help: "The scheme to be built. By default it builds all the buildable schemes of the project in the current directory."
     )
@@ -80,14 +80,14 @@ public struct BuildOptions: ParsableArguments {
 /// Command that builds a target from the project in the current directory.
 public struct BuildCommand: AsyncParsableCommand {
     public init() {}
-    
+
     public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "build",
             abstract: "Builds a project"
         )
     }
-    
+
     @OptionGroup()
     var buildOptions: BuildOptions
 
@@ -104,7 +104,10 @@ public struct BuildCommand: AsyncParsableCommand {
             generate: buildOptions.generate,
             clean: buildOptions.clean,
             configuration: buildOptions.configuration,
-            buildOutputPath: buildOptions.buildOutputPath.map { try AbsolutePath(validating: $0, relativeTo: FileHandler.shared.currentPath) },
+            buildOutputPath: buildOptions.buildOutputPath.map { try AbsolutePath(
+                validating: $0,
+                relativeTo: FileHandler.shared.currentPath
+            ) },
             derivedDataPath: buildOptions.derivedDataPath,
             path: absolutePath,
             device: buildOptions.device,

--- a/Sources/TuistKit/Generator/GeneratorFactory.swift
+++ b/Sources/TuistKit/Generator/GeneratorFactory.swift
@@ -8,7 +8,7 @@ import TuistSupport
 
 /// The protocol describes the interface of a factory that instantiates
 /// generators for different commands
-protocol GeneratorFactorying {
+public protocol GeneratorFactorying {
     /// Returns the generator to generate a project to run tests on.
     /// - Parameter config: The project configuration
     /// - Parameter testsCacheDirectory: The cache directory used for tests.
@@ -38,7 +38,7 @@ public class GeneratorFactory: GeneratorFactorying {
         self.contentHasher = contentHasher
     }
 
-    func test(
+    public func test(
         config: Config,
         testsCacheDirectory: AbsolutePath,
         testPlan: String?,

--- a/Sources/TuistKit/Services/BuildService.swift
+++ b/Sources/TuistKit/Services/BuildService.swift
@@ -33,13 +33,13 @@ enum BuildServiceError: FatalError {
     }
 }
 
-final class BuildService {
+public final class BuildService {
     private let generatorFactory: GeneratorFactorying
     private let buildGraphInspector: BuildGraphInspecting
     private let targetBuilder: TargetBuilding
     private let configLoader: ConfigLoading
 
-    init(
+    public init(
         generatorFactory: GeneratorFactorying = GeneratorFactory(),
         buildGraphInspector: BuildGraphInspecting = BuildGraphInspector(),
         targetBuilder: TargetBuilding = TargetBuilder(),
@@ -52,7 +52,7 @@ final class BuildService {
     }
 
     // swiftlint:disable:next function_body_length
-    func run(
+    public func run(
         schemeName: String?,
         generate: Bool,
         clean: Bool,
@@ -64,11 +64,12 @@ final class BuildService {
         platform: String?,
         osVersion: String?,
         rosetta: Bool,
-        generateOnly: Bool
+        generateOnly: Bool,
+        generator: ((Config) throws -> Generating)? = nil
     ) async throws {
         let graph: Graph
         let config = try configLoader.loadConfig(path: path)
-        let generator = generatorFactory.default(config: config)
+        let generator = try generator?(config) ?? generatorFactory.default(config: config)
         if try (generate || buildGraphInspector.workspacePath(directory: path) == nil) {
             graph = try await generator.generateWithGraph(path: path).1
         } else {


### PR DESCRIPTION
### Short description 📝

Refactoring to make it possible to define our own BuildCommand with a custom generator for Tuist Cloud.

### How to test the changes locally 🧐

CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
