### PR TITLE
Adds FilesLinter that makes sure all required files are available

### DIFF
--- a/Sources/TuistCore/Graph/ModelExtensions/Target+Core.swift
+++ b/Sources/TuistCore/Graph/ModelExtensions/Target+Core.swift
@@ -93,13 +93,19 @@ extension Target {
 
             let paths: [AbsolutePath]
 
-            do {
-                paths = try FileHandler.shared
-                    .throwingGlob(base, glob: sourcePath.basename)
-                    .filter { !$0.isInOpaqueDirectory }
-            } catch let GlobError.nonExistentDirectory(invalidGlob) {
-                paths = []
-                invalidGlobs.append(invalidGlob)
+            if source.path.pathString.isGlobComponent {
+                do {
+                    paths = try FileHandler.shared
+                        .throwingGlob(base, glob: sourcePath.basename)
+                        .filter {
+                            return !$0.isInOpaqueDirectory
+                        }
+                } catch let GlobError.nonExistentDirectory(invalidGlob) {
+                    paths = []
+                    invalidGlobs.append(invalidGlob)
+                }
+            } else {
+                paths = [source.path]
             }
 
             Set(paths)

--- a/Sources/TuistGraph/Models/SourceFileGlob.swift
+++ b/Sources/TuistGraph/Models/SourceFileGlob.swift
@@ -1,9 +1,13 @@
 import Foundation
+import TSCBasic
 
 /// A type that represents a list of source files defined by a glob.
 public struct SourceFileGlob: Equatable {
     /// Glob pattern to unfold all the source files.
     public let glob: String
+
+    /// Reference to the AbsolutePath
+    public let path: AbsolutePath
 
     /// Glob pattern used for filtering out files.
     public let excluding: [String]
@@ -25,13 +29,14 @@ public struct SourceFileGlob: Equatable {
     ///   - codeGen: Source file code generation attribute.
     ///   - compilationCondition: Condition for file compilation.
     public init(
-        glob: String,
+        glob: AbsolutePath,
         excluding: [String] = [],
         compilerFlags: String? = nil,
         codeGen: FileCodeGen? = nil,
         compilationCondition: PlatformCondition? = nil
     ) {
-        self.glob = glob
+        self.glob = glob.pathString
+        path = glob
         self.excluding = excluding
         self.compilerFlags = compilerFlags
         self.codeGen = codeGen

--- a/Sources/TuistGraph/Models/Target.swift
+++ b/Sources/TuistGraph/Models/Target.swift
@@ -12,7 +12,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable {
         "playground", "rcproject", "mlpackage",
     ]
     public static let validFolderExtensions: [String] = [
-        "framework", "bundle", "app", "xcassets", "appiconset", "scnassets",
+        "framework", "bundle", "app", "xcassets", "appiconset", "scnassets", "strings",
     ]
 
     // MARK: - Attributes

--- a/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/ResourceFileElement+ManifestMapper.swift
@@ -24,38 +24,21 @@ extension TuistGraph.ResourceFileElement {
                 excluded.formUnion(globs)
             }
 
+            if !path.pathString.isGlobComponent {
+                return [path]
+            }
+
             let files = try FileHandler.shared
                 .throwingGlob(.root, glob: String(path.pathString.dropFirst()))
                 .filter { !$0.isInOpaqueDirectory }
                 .filter(includeFiles)
                 .filter { !excluded.contains($0) }
 
-            if files.isEmpty {
-                if FileHandler.shared.isFolder(path) {
-                    logger.warning("'\(path.pathString)' is a directory, try using: '\(path.pathString)/**' to list its files")
-                } else {
-                    // FIXME: This should be done in a linter.
-                    logger.warning("No files found at: \(path.pathString)")
-                }
+            if files.isEmpty && FileHandler.shared.isFolder(path) {
+                logger.warning("'\(path.pathString)' is a directory, try using: '\(path.pathString)/**' to list its files")
             }
 
             return files
-        }
-
-        func folderReferences(_ path: AbsolutePath) -> [AbsolutePath] {
-            guard FileHandler.shared.exists(path) else {
-                // FIXME: This should be done in a linter.
-                logger.warning("\(path.pathString) does not exist")
-                return []
-            }
-
-            guard FileHandler.shared.isFolder(path) else {
-                // FIXME: This should be done in a linter.
-                logger.warning("\(path.pathString) is not a directory - folder reference paths need to point to directories")
-                return []
-            }
-
-            return [path]
         }
 
         switch manifest {
@@ -69,7 +52,7 @@ extension TuistGraph.ResourceFileElement {
             ) }
         case let .folderReference(folderReferencePath, tags, condition):
             let resolvedPath = try generatorPaths.resolve(path: folderReferencePath)
-            return folderReferences(resolvedPath).map { ResourceFileElement.folderReference(
+            return [resolvedPath].map { ResourceFileElement.folderReference(
                 path: $0,
                 tags: tags,
                 inclusionCondition: condition?.asGraphCondition

--- a/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
@@ -207,7 +207,7 @@ extension TuistGraph.Target {
 
         // Sources
         let allSources = try TuistGraph.Target.sources(targetName: targetName, sources: manifest.sources?.globs.map { glob in
-            let globPath = try generatorPaths.resolve(path: glob.glob).pathString
+            let globPath = try generatorPaths.resolve(path: glob.glob)
             let excluding: [String] = try glob.excluding.compactMap { try generatorPaths.resolve(path: $0).pathString }
             let mappedCodeGen = glob.codeGen.map(TuistGraph.FileCodeGen.from)
             return TuistGraph.SourceFileGlob(

--- a/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
+++ b/Sources/TuistSupport/Extensions/AbsolutePath+Extras.swift
@@ -151,7 +151,7 @@ extension AbsolutePath: ExpressibleByStringLiteral {
 }
 
 extension String {
-    var isGlobComponent: Bool {
+    public var isGlobComponent: Bool {
         let globCharacters = CharacterSet(charactersIn: "*{}")
         return rangeOfCharacter(from: globCharacters) != nil
     }


### PR DESCRIPTION
### Short description 📝

Adds FilesLinter that makes sure that all non-glob files would would present warnings

Resolves https://github.com/tuist/tuist/issues/5552

### How to test the changes locally 🧐

The command should be useable through out the entire project, however to test this following the steps below would be the best approach:

- Go to `fixtures` that's missing resources, or sources.
- Running `tuist generate --no-open` should flush a lot of warnings which is to be expected

#### Output
```
...
The following warnings need attention:
 · No files found at: /ios_app_with_framework_and_missing_resources/App/Resources/**/*.png
 · No files found at:/ios_app_with_framework_and_missing_resources/App/Resources/*.xcassets
 · No files found at:/ios_app_with_framework_and_missing_resources/StaticFramework/Resources/images/t.txt
 · The target StaticFramework doesn't contain source files.
 · No files found at: /ios_app_with_framework_and_missing_resources/StaticFramework/Resources/images/**/*.png
 ...
```

- Running `tuist generate --no-open`  should flush non-glob warnings as shown below

#### Output
```
[33m · No resources found at: Resources/images/t.txt
 · No files found at: Sources/App+internals.swift
 · The target StaticFramework doesn't contain source files.[0m
```

### Contributor checklist ✅

- [X] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [X] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
