### PR TITLE
Fix setting custom package baseSettings

### DIFF
--- a/Sources/TuistCoreTesting/Graph/DependenciesGraph+TestData.swift
+++ b/Sources/TuistCoreTesting/Graph/DependenciesGraph+TestData.swift
@@ -721,10 +721,31 @@ extension DependenciesGraph {
         }
 
         return .settings(
-            base: baseSettings.base.merging(settingsDictionary, uniquingKeysWith: { $1 }),
+            base: baseSettings.base.combine(with: settingsDictionary),
             configurations: baseSettings.configurations,
             defaultSettings: baseSettings.defaultSettings
         )
+    }
+}
+
+extension SettingsDictionary {
+    /// Combines two `SettingsDictionary`. Instead of overriding values for a duplicate key, it combines them.
+    func combine(with settings: SettingsDictionary) -> SettingsDictionary {
+        merging(settings, uniquingKeysWith: { oldValue, newValue in
+            let newValues: [String]
+            switch newValue {
+            case let .string(value):
+                newValues = [value]
+            case let .array(values):
+                newValues = values
+            }
+            switch oldValue {
+            case let .array(values):
+                return .array(values + newValues)
+            case let .string(value):
+                return .array(value.split(separator: " ").map(String.init) + newValues)
+            }
+        })
     }
 }
 

--- a/Sources/TuistGraph/Models/Settings.swift
+++ b/Sources/TuistGraph/Models/Settings.swift
@@ -52,6 +52,25 @@ extension SettingsDictionary {
             }
         }
     }
+
+    /// Combines two `SettingsDictionary`. Instead of overriding values for a duplicate key, it combines them.
+    public func combine(with settings: SettingsDictionary) -> SettingsDictionary {
+        merging(settings, uniquingKeysWith: { oldValue, newValue in
+            let newValues: [String]
+            switch newValue {
+            case let .string(value):
+                newValues = [value]
+            case let .array(values):
+                newValues = values
+            }
+            switch oldValue {
+            case let .array(values):
+                return .array(values + newValues)
+            case let .string(value):
+                return .array(value.split(separator: " ").map(String.init) + newValues)
+            }
+        })
+    }
 }
 
 public struct Configuration: Equatable, Codable {

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -289,10 +289,14 @@ public final class PackageInfoMapper: PackageInfoMapping {
                 userDefined.merging(defaultDictionary, uniquingKeysWith: { userDefined, _ in userDefined })
             }
         )
-        // Setting the -package-name Swift compiler flag
-        let baseSettings = packageSettings.baseSettings.with(base: [
-            "OTHER_SWIFT_FLAGS": ["$(inherited)", "-package-name", packageInfo.name],
-        ])
+
+        let baseSettings = packageSettings.baseSettings.with(
+            base: packageSettings.baseSettings.base.combine(
+                with: [
+                    "OTHER_SWIFT_FLAGS": ["$(inherited)", "-package-name", packageInfo.name],
+                ]
+            )
+        )
 
         var targetToProducts: [String: Set<PackageInfo.Product>] = [:]
         for product in packageInfo.products {

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -370,7 +370,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             ]
         )
 
-        XCTAssertEqual(
+        XCTAssertBetterEqual(
             project,
             .testWithDefaultConfigs(
                 name: "Package",
@@ -2121,6 +2121,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             ],
             packageSettings: .test(
                 baseSettings: .init(
+                    base: [
+                        "EXCLUDED_ARCHS[sdk=iphonesimulator*]": .string("x86_64"),
+                    ],
                     configurations: [
                         .init(name: "Debug", variant: .debug): .init(
                             settings: ["CUSTOM_SETTING_1": .string("CUSTOM_VALUE_1")],
@@ -2134,7 +2137,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 )
             )
         )
-        XCTAssertEqual(
+        XCTAssertBetterEqual(
             project,
             .testWithDefaultConfigs(
                 name: "Package",
@@ -2143,6 +2146,9 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                         "Target1",
                         basePath: basePath,
                         baseSettings: .settings(
+                            base: [
+                                "EXCLUDED_ARCHS[sdk=iphonesimulator*]": .string("x86_64"),
+                            ],
                             configurations: [
                                 .debug(
                                     name: "Debug",

--- a/fixtures/app_with_spm_dependencies/Tuist/ProjectDescriptionHelpers/Settings+Templates.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/ProjectDescriptionHelpers/Settings+Templates.swift
@@ -10,7 +10,9 @@ extension ProjectDescription.Settings {
 
     public static var targetSettings: Self {
         .settings(
-            base: [:].otherSwiftFlags("-enable-actor-data-race-checks"),
+            base: [
+                "SOME_BASE_FLAG": .string("VALUE"),
+            ].otherSwiftFlags("-enable-actor-data-race-checks"),
             configurations: BuildEnvironment.allCases.map(\.targetConfiguration)
         )
     }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6065

### Short description 📝

Fixes regression introduced in: https://github.com/tuist/tuist/pull/5983

The bug was introduced on [this line](https://github.com/tuist/tuist/pull/5983/files#diff-1c339ffd386decd8199e092df9f0e1d8376a7990683e563c7c97bc0548c229deR445-R447) since `.with(base: ...)` does not combine two `base` settings but replaces the original one with the new one. Instead, we should combine the user-provided `baseSettings` with our custom one.

### How to test the changes locally 🧐

`tuist generate` in `app_with_spm_dependencies`. The dependency targets should have the `SOME_BASE_FLAG` value in their settings.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
