### PR TITLE
Fix docs deployment

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -119,7 +119,7 @@ workflows:
       - name: Deploy to Cloudflare Pages
         script: |
           mise install node@latest
-          mise x npm:wrangler@latest -- wrangler pages deploy --branch main --commit-hash $CM_COMMIT --branch $CM_BRANCH --project-name tuist-docs .build/documentation
+          mise x npm:wrangler@latest -- wrangler pages deploy --commit-hash $CM_COMMIT --branch $CM_BRANCH --project-name tuist-docs .build/documentation
     triggering:
       events:
         - push


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6076

### Short description 📝

The docs were not being deployed because of `branch` being specified twice and `wrangler` interpreted that as a `main,main` branch – which is not our production branch, so it would only deploy the docs as a preview.

### How to test the changes locally 🧐

I tested this by faking the deploy as the `main` branch (and removing the redundant `branch` param)

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
