### PR TITLE
Fix custom configurations from target when `enforceExplicitDependencies` option  is enabled

### DIFF
--- a/Sources/TuistGenerator/Mappers/ExplicitDependencyGraphMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ExplicitDependencyGraphMapper.swift
@@ -77,7 +77,7 @@ public struct ExplicitDependencyGraphMapper: GraphMapping {
         target.settings = Settings(
             base: target.settings?.base ?? [:],
             baseDebug: additionalSettings,
-            configurations: [:]
+            configurations: target.settings?.configurations ?? [:]
         )
 
         let copyBuiltProductsScript: String

--- a/Tests/TuistGeneratorTests/ProjectMappers/ExplicitDependencyGraphMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ExplicitDependencyGraphMapperTests.swift
@@ -33,7 +33,13 @@ final class ExplicitDependencyGraphMapperTests: TuistUnitTestCase {
         let dynamicLibraryB: Target = .test(
             name: "DynamicLibraryB",
             product: .dynamicLibrary,
-            productName: "DynamicLibraryB"
+            productName: "DynamicLibraryB",
+            settings: .test(
+                configurations: [
+                    .debug: .test(),
+                    .release: .test()
+                ]
+            )
         )
         let externalFrameworkC: Target = .test(
             name: "ExternalFrameworkC",
@@ -172,6 +178,10 @@ final class ExplicitDependencyGraphMapperTests: TuistUnitTestCase {
                     baseDebug: [
                         "BUILT_PRODUCTS_DIR": "$(CONFIGURATION_BUILD_DIR)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME)",
                         "TARGET_BUILD_DIR": "$(CONFIGURATION_BUILD_DIR)$(TARGET_BUILD_SUBPATH)/$(PRODUCT_NAME)",
+                    ],
+                    configurations: [
+                        .debug: .test(),
+                        .release: .test()
                     ]
                 ),
                 scripts: [

--- a/Tests/TuistGeneratorTests/ProjectMappers/ExplicitDependencyGraphMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ExplicitDependencyGraphMapperTests.swift
@@ -37,7 +37,7 @@ final class ExplicitDependencyGraphMapperTests: TuistUnitTestCase {
             settings: .test(
                 configurations: [
                     .debug: .test(),
-                    .release: .test()
+                    .release: .test(),
                 ]
             )
         )
@@ -181,7 +181,7 @@ final class ExplicitDependencyGraphMapperTests: TuistUnitTestCase {
                     ],
                     configurations: [
                         .debug: .test(),
-                        .release: .test()
+                        .release: .test(),
                     ]
                 ),
                 scripts: [


### PR DESCRIPTION
Resolves [https://github.com/tuist/tuist/issues/6017](https://github.com/tuist/tuist/issues/6017)

### Short description 📝

Add target configurations when the `enforceExplicitDependencies` option is **enabled**

### How to test the changes locally 🧐

- Executing unit-tests of `ExplicitDependencyGraphMapperTests` 

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
