### PR TITLE
Add Tuist/.build to .gitignore in default template

### DIFF
--- a/Templates/default/Gitignore.stencil
+++ b/Templates/default/Gitignore.stencil
@@ -68,3 +68,4 @@ Derived/
 
 ### Tuist managed dependencies ###
 Tuist/Dependencies
+Tuist/.build

--- a/Templates/default/Gitignore.stencil
+++ b/Templates/default/Gitignore.stencil
@@ -67,5 +67,4 @@ graph.dot
 Derived/
 
 ### Tuist managed dependencies ###
-Tuist/Dependencies
 Tuist/.build


### PR DESCRIPTION
### Short description 📝

I'm new to Tuist and setup a project with `tuist init`. After installing and caching dependencies in `Tuist/Dependencies` I saw the contents of `Tuist/.build` in my git repo. Apparently it also includes other git repos (I guess resolved packages). I asked in the Tuist Slack, if it's okay to add this folder to the `.gitignore`. @danieleformichelli asked me to make a PR so this is that.

Be aware that I'm not familiar enough with Tuist to comment on whether ignoring the folder can issues in any scenario and whether it's a reasonable thing in the default template or not.

### How to test the changes locally 🧐

Run `tuist init` and check the `.gitignore`.

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
