### PR TITLE
Make a clear distinction between installing and activating a tool with Mise

### DIFF
--- a/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/installation.md
+++ b/docs/Sources/tuist/tuist.docc/Articles/Tuist/Users/installation.md
@@ -22,9 +22,14 @@ Once installed, you can install Tuist through any of the following commands:
 mise install tuist            # Install the current version specified in .tool-versions/.mise.toml
 mise install tuist@x.y.z      # Install a specific version number
 mise install tuist@3          # Install a fuzzy version number
+```
+
+Note that unlike tools like Homebrew, which install and activate a single version of the tool globally, **Mise requires the activation of a version** either globally or scoped to a project. This is done by running `mise use`:
+
+```bash
 mise use tuist@x.y.z          # Use tuist-x.y.z in the current project
-mise use -g tuist@x.y.z       # Use tuist-x.y.z as the global default
 mise use tuist@latest         # Use the latest tuist in the current directory
+mise use -g tuist@x.y.z       # Use tuist-x.y.z as the global default
 mise use -g tuist@system      # Use the system's tuist as the global default
 ```
 


### PR DESCRIPTION
Related: https://github.com/jdx/mise/issues/1773

### Short description 📝
Based on [this conversation](https://github.com/jdx/mise/issues/1773), it seems that people assume that Mise will automatically activate versions of Tuist after running `mise install`. This PR changes the documentation to introduce the reader to the concept of activating versions, which is different from the Homebrew approach that they might be used to.