### PR TITLE
Fix the look up of the templates directory in a Homebrew installation

### DIFF
--- a/Sources/TuistScaffold/TemplatesDirectoryLocator.swift
+++ b/Sources/TuistScaffold/TemplatesDirectoryLocator.swift
@@ -55,8 +55,7 @@ public final class TemplatesDirectoryLocator: TemplatesDirectoryLocating {
                    bin/
                        tuist
                    share/
-                       tuist/
-                           Templates
+                       Templates
                 */
             bundlePath.parentDirectory.appending(try! RelativePath(validating: "share/Templates")),
             // swiftlint:disable:previous force_try

--- a/Sources/TuistScaffold/TemplatesDirectoryLocator.swift
+++ b/Sources/TuistScaffold/TemplatesDirectoryLocator.swift
@@ -58,7 +58,7 @@ public final class TemplatesDirectoryLocator: TemplatesDirectoryLocating {
                        tuist/
                            Templates
                 */
-            bundlePath.parentDirectory.appending(try! RelativePath(validating: "share/tuist")),
+            bundlePath.parentDirectory.appending(try! RelativePath(validating: "share/Templates")),
             // swiftlint:disable:previous force_try
         ]
         let candidates = paths.map { path in


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5763

### Short description 📝

The directory structure convention that we had in our logic was wrong. It should be the path `share/Templates`, relative to the root directory of the formula.

<img width="752" alt="image" src="https://github.com/tuist/tuist/assets/663605/b56f1be0-38d9-49d5-ae12-0b656dff4ec8">

### How to test the changes locally 🧐
It's a bit tricky to test locally but it requires reproducing the Homebrew directory structure.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
