### PR TITLE
Fix integration of latest Firebase

### DIFF
--- a/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
@@ -103,6 +103,9 @@ public final class SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerMod
             // User defined modulemap exists, use it
             return .custom(customModuleMapPath, umbrellaHeaderPath: nil)
         } else if FileHandler.shared.exists(publicHeadersPath) {
+            if FileHandler.shared.glob(publicHeadersPath, glob: "**/*.h").isEmpty {
+                return .none
+            }
             // Consider the public headers folder as umbrella directory
             let generatedModuleMapContent =
                 """

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -1480,6 +1480,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
         let dependencyHeadersPath = basePath.appending(try RelativePath(validating: "Package/Sources/Dependency1/include"))
         let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))
         try fileHandler.createFolder(dependencyHeadersPath)
+        try fileHandler.touch(dependencyHeadersPath.appending(component: "Header.h"))
         try fileHandler.createFolder(sourcesPath)
         let project = try subject.map(
             package: "Package",

--- a/fixtures/multiplatform_app_with_sdk/Project.swift
+++ b/fixtures/multiplatform_app_with_sdk/Project.swift
@@ -38,6 +38,7 @@ let project = Project(
                 .sdk(name: "ARKit", type: .framework, status: .required, condition: .when([.ios])),
                 .external(name: "FirebaseAnalytics"),
                 .external(name: "FirebasePerformance", condition: .when([.ios])),
+                .external(name: "FirebaseRemoteConfig"),
                 .sdk(name: "MobileCoreServices", type: .framework, status: .required, condition: .when([.ios])),
             ]
         ),

--- a/fixtures/multiplatform_app_with_sdk/Tuist/Package.resolved
+++ b/fixtures/multiplatform_app_with_sdk/Tuist/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/abseil-cpp-binary.git",
       "state" : {
-        "revision" : "bfc0b6f81adc06ce5121eb23f628473638d67c5c",
-        "version" : "1.2022062300.0"
+        "revision" : "7ce7be095bc3ed3c98b009532fe2d7698c132614",
+        "version" : "1.2024011601.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "fe09d61a539e11fdbe24f269bba10144b6145fe2",
-        "version" : "10.22.0"
+        "revision" : "fcf5ced6dae2d43fced2581e673cc3b59bdb8ffa",
+        "version" : "10.23.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "bf3bb24f6b60a7acedaef504e9ce97154203217a",
-        "version" : "10.22.0"
+        "revision" : "6ec4ca62b00a665fa09b594fab897753a8c635fa",
+        "version" : "10.23.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "a673bc2937fbe886dd1f99c401b01b6d977a9c98",
-        "version" : "1.49.1"
+        "revision" : "67043f6389d0e28b38fa02d1c6952afeb04d807f",
+        "version" : "1.62.1"
       }
     },
     {

--- a/fixtures/multiplatform_app_with_sdk/Tuist/Package.swift
+++ b/fixtures/multiplatform_app_with_sdk/Tuist/Package.swift
@@ -4,6 +4,6 @@ import PackageDescription
 let package = Package(
     name: "PackageName",
     dependencies: [
-        .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.15.0"),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.23.0"),
     ]
 )


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6097

### Short description 📝

The latest Firebase library does not compile due to the following:
- `publicHeadersSearchPath` is set on `FirebaseRemoteConfigInterop` – but it has no headers, it's a Swift only target with classes with the `@objc` annotation
  - We were still generating a modulemap, thinking the target had an umbrella headers directory
- `FirebaseRemoteConfigInternal` is an objc target that depends on `FirebaseRemoteConfigInterop` – it would try to use the generated modulemap but no headers would be found.

To solve this, we don't generate a modulemap when a `publicHeadersDir` exists but it has no headers. We also should skip setting the `DEFINES_MODULE=NO` in those cases, so the objc target can consume the bridging header automatically generated by Xcode.

### How to test the changes locally 🧐

Build `multiplatform_app_with_sdk` which now includes the latest Firebase version.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
