### PR TITLE
Fix Swift Macros when embedded apps

### DIFF
--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
@@ -53,6 +53,7 @@ public enum TuistAcceptanceFixtures {
     case macosAppWithExtensions
     case manifestWithLogs
     case multiplatformAppWithExtension
+    case multiplatformAppWithMacrosAndEmbeddedWatchOSApp
     case multiplatformAppWithSdk
     case multiplatformµFeatureUnitTestsWithExplicitDependencies
     case plugin
@@ -171,6 +172,8 @@ public enum TuistAcceptanceFixtures {
             return "manifest_with_logs"
         case .multiplatformAppWithExtension:
             return "multiplatform_app_with_extension"
+        case .multiplatformAppWithMacrosAndEmbeddedWatchOSApp:
+            return "multiplatform_app_with_macros_and_embedded_watchos_app"
         case .multiplatformAppWithSdk:
             return "multiplatform_app_with_sdk"
         case .multiplatformµFeatureUnitTestsWithExplicitDependencies:

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -425,7 +425,7 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
 
     private func generateCopySwiftMacroExecutableScriptBuildPhase(
         directSwiftMacroExecutables: [GraphDependencyReference],
-        target: Target,
+        target _: Target,
         pbxTarget: PBXTarget,
         pbxproj: PBXProj
     ) throws {
@@ -459,19 +459,9 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
 
         copySwiftMacrosBuildPhase.inputPaths = executableNames.map { "$BUILD_DIR/$CONFIGURATION/\($0)" }
 
-        copySwiftMacrosBuildPhase.outputPaths = target.supportedPlatforms
-            .filter { $0 != .macOS }
-            .flatMap { platform in
-                var sdks: [String] = []
-                sdks.append(platform.xcodeDeviceSDK)
-                if let simulatorSDK = platform.xcodeSimulatorSDK { sdks.append(simulatorSDK) }
-                return sdks
-            }
-            .flatMap { sdk in
-                executableNames.map { executable in
-                    "$BUILD_DIR/Debug-\(sdk)/\(executable)"
-                }
-            }
+        copySwiftMacrosBuildPhase.outputPaths = executableNames.map { executable in
+            "$BUILD_DIR/Debug-$EFFECTIVE_PLATFORM_NAME/\(executable)"
+        }
 
         pbxproj.add(object: copySwiftMacrosBuildPhase)
         pbxTarget.buildPhases.append(copySwiftMacrosBuildPhase)

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -82,7 +82,6 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
         let directSwiftMacroExecutables = graphTraverser.directSwiftMacroExecutables(path: path, name: target.name).sorted()
         try generateCopySwiftMacroExecutableScriptBuildPhase(
             directSwiftMacroExecutables: directSwiftMacroExecutables,
-            target: target,
             pbxTarget: pbxTarget,
             pbxproj: pbxproj
         )
@@ -425,7 +424,6 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
 
     private func generateCopySwiftMacroExecutableScriptBuildPhase(
         directSwiftMacroExecutables: [GraphDependencyReference],
-        target _: Target,
         pbxTarget: PBXTarget,
         pbxproj: PBXProj
     ) throws {

--- a/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
+++ b/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
@@ -143,3 +143,12 @@ final class BuildAcceptanceTestAppWithSPMDependencies: TuistAcceptanceTestCase {
         try await run(BuildCommand.self, "App", "--platform", "ios")
     }
 }
+
+final class BuildAcceptanceTestMultiplatformAppWithMacrosAndEmbeddedWatchOSApp: TuistAcceptanceTestCase {
+    func test() async throws {
+        try setUpFixture(.multiplatformAppWithMacrosAndEmbeddedWatchOSApp)
+        try await run(InstallCommand.self)
+        try await run(GenerateCommand.self)
+        try await run(BuildCommand.self, "App", "--platform", "ios")
+    }
+}

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -1616,13 +1616,9 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
             "if [[ -f \"$BUILD_DIR/$CONFIGURATION/macro\" && ! -f \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/macro\" ]]; then\n    mkdir -p \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/\"\n    cp \"$BUILD_DIR/$CONFIGURATION/macro\" \"$BUILD_DIR/Debug$EFFECTIVE_PLATFORM_NAME/macro\"\nfi"
         XCTAssertTrue(buildPhase?.shellScript?.contains(expectedScript) == true)
         XCTAssertTrue(buildPhase?.inputPaths.contains("$BUILD_DIR/$CONFIGURATION/\(macroExecutable.productName)") == true)
-        XCTAssertTrue(
-            buildPhase?.outputPaths
-                .contains("$BUILD_DIR/Debug-iphonesimulator/\(macroExecutable.productName)") == true
-        )
-        XCTAssertTrue(
-            buildPhase?.outputPaths
-                .contains("$BUILD_DIR/Debug-iphoneos/\(macroExecutable.productName)") == true
+        XCTAssertEqual(
+            buildPhase?.outputPaths,
+            ["$BUILD_DIR/Debug-$EFFECTIVE_PLATFORM_NAME/\(macroExecutable.productName)"]
         )
     }
 

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/App/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/App/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/App/Resources/Assets.xcassets/Contents.json
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/App/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/App/Sources/ContentView.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/App/Sources/ContentView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundColor(.accentColor)
+            Text("Hello, world!")
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/App/Sources/TestApp.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/App/Sources/TestApp.swift
@@ -1,0 +1,15 @@
+import ModuleA
+import SwiftUI
+
+@main
+struct TestApp: App {
+    init() {
+        ModuleA.test()
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Sources/ModuleA.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Modules/ModuleA/Sources/ModuleA.swift
@@ -1,0 +1,12 @@
+import CasePaths
+
+@CasePathable
+enum AppAction {
+    case home
+}
+
+public enum ModuleA {
+    public static func test() {
+        print("Module A")
+    }
+}

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Project.swift
@@ -1,0 +1,62 @@
+import ProjectDescription
+
+let project = Project(
+    name: "AppWithWatchApp",
+    targets: [
+        .target(
+            name: "App",
+            destinations: [.iPhone, .appleVision],
+            product: .app,
+            bundleId: "io.tuist.App",
+            infoPlist: .default,
+            sources: [
+                "App/Sources/**",
+            ],
+            resources: [
+                "App/Resources/**",
+            ],
+            dependencies: [
+                .target(name: "WatchApp", condition: .when([.ios])),
+                .target(name: "ModuleA"),
+            ]
+        ),
+        .target(
+            name: "WatchApp",
+            destinations: [.appleWatch],
+            product: .app,
+            bundleId: "io.tuist.App.watchkitapp",
+            infoPlist: nil,
+            sources: "WatchApp/Sources/**",
+            resources: "WatchApp/Resources/**",
+            dependencies: [
+                .target(name: "ModuleA"),
+            ],
+            settings: .settings(
+                base: [
+                    "GENERATE_INFOPLIST_FILE": true,
+                    "CURRENT_PROJECT_VERSION": "1.0",
+                    "MARKETING_VERSION": "1.0",
+                    "INFOPLIST_KEY_UISupportedInterfaceOrientations": [
+                        "UIInterfaceOrientationPortrait",
+                        "UIInterfaceOrientationPortraitUpsideDown",
+                    ],
+                    "INFOPLIST_KEY_WKCompanionAppBundleIdentifier": "io.tuist.App",
+                    "INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp": false,
+                ]
+            )
+        ),
+        .target(
+            name: "ModuleA",
+            destinations: [.iPhone, .appleVision, .appleWatch],
+            product: .framework,
+            productName: "ModuleA",
+            bundleId: "io.tuist.modulea",
+            sources: [
+                "Modules/ModuleA/Sources/**",
+            ],
+            dependencies: [
+                .external(name: "CasePaths"),
+            ]
+        ),
+    ]
+)

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.resolved
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.resolved
@@ -1,0 +1,32 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "e593aba2c6222daad7c4f2732a431eed2c09bb07",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax",
+      "state" : {
+        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
+        "version" : "510.0.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "b13b1d1a8e787a5ffc71ac19dcaf52183ab27ba2",
+        "version" : "1.1.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/Tuist/Package.swift
@@ -1,0 +1,9 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "Dependencies",
+    dependencies: [
+        .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.3.0"),
+    ]
+)

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/WatchApp/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/WatchApp/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/WatchApp/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/WatchApp/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "watchos",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/WatchApp/Resources/Assets.xcassets/Contents.json
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/WatchApp/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/WatchApp/Sources/ContentView.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/WatchApp/Sources/ContentView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundColor(.accentColor)
+            Text("Hello, world!")
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/WatchApp/Sources/WatchApp.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/WatchApp/Sources/WatchApp.swift
@@ -1,0 +1,21 @@
+import CasePaths
+import ModuleA
+import SwiftUI
+
+@CasePathable
+enum WatchAppAction {
+    case home
+}
+
+@main
+struct WatchApp: App {
+    init() {
+        ModuleA.test()
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/WatchApp/Sources/WatchConfig.swift
+++ b/fixtures/multiplatform_app_with_macros_and_embedded_watchos_app/WatchApp/Sources/WatchConfig.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public enum WatchConfig {
+    public static let title: String = "Hello, watchOS"
+}


### PR DESCRIPTION
Fixes https://github.com/tuist/tuist/issues/5988
Fixes https://github.com/tuist/tuist/issues/5766

### Short description 📝
As diagnosed [here](https://github.com/tuist/tuist/issues/5766) by @alexanderwe, the issue happens when the graph contains multiple destinations, for example, iPhone and Watch simulators, which leads to the same Swift Macro command run multiple times and causes the compilation to fail. This PR solves it by adjusting the `output` files to have a single one that uses the `$EFFECTIVE_PLATFORM_NAME` environment variable to disambiguate this scenario.

### How to test the changes locally 🧐
You can run `tuist install` and `tuist generate` against the fixture `multiplatform_app_with_macros_and_embedded_watchos_app`. The generated project should compile successfully.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
