### PR TITLE
Showcase objc import of a package dependency

### DIFF
--- a/fixtures/app_with_spm_dependencies/Features/FeatureOne/Project.swift
+++ b/fixtures/app_with_spm_dependencies/Features/FeatureOne/Project.swift
@@ -10,9 +10,11 @@ let project = Project(
             destinations: .iOS,
             product: .framework,
             bundleId: "io.tuist.featureOne",
-            sources: ["Sources/**"],
+            sources: ["Sources/*.{swift,m}"],
+            headers: .headers(public: "Sources/*.h"),
             dependencies: [
                 .external(name: "Alamofire"),
+                .external(name: "UICKeyChainStore"),
             ],
             settings: .targetSettings
         ),

--- a/fixtures/app_with_spm_dependencies/Features/FeatureOne/Sources/ObjectiveFeature.h
+++ b/fixtures/app_with_spm_dependencies/Features/FeatureOne/Sources/ObjectiveFeature.h
@@ -1,0 +1,16 @@
+//
+//  ObjectiveFeature.h
+//  FeatureOne
+//
+//  Created by Shai Mishali on 23/03/2024.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ObjectiveFeature : NSObject
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/fixtures/app_with_spm_dependencies/Features/FeatureOne/Sources/ObjectiveFeature.m
+++ b/fixtures/app_with_spm_dependencies/Features/FeatureOne/Sources/ObjectiveFeature.m
@@ -1,0 +1,13 @@
+//
+//  ObjectiveFeature.m
+//  FeatureOne
+//
+//  Created by Shai Mishali on 23/03/2024.
+//
+
+#import "ObjectiveFeature.h"
+@import UICKeyChainStore;
+
+@implementation ObjectiveFeature
+
+@end

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.resolved
@@ -379,6 +379,15 @@
       }
     },
     {
+      "identity" : "uickeychainstore",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kishikawakatsumi/UICKeyChainStore",
+      "state" : {
+        "revision" : "8220ac38124613fb709508426f75fbac6921e261",
+        "version" : "2.2.1"
+      }
+    },
+    {
       "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.swift
@@ -41,5 +41,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-testing", .upToNextMajor(from: "0.5.1")),
         .package(path: "../LocalSwiftPackage"),
         .package(path: "../StringifyMacro"),
+        .package(url: "https://github.com/kishikawakatsumi/UICKeyChainStore", exact: "2.2.1"),
     ]
 )


### PR DESCRIPTION
### Short description 📝

Updates the `app_with_spm_dependencies` to test the scenario of importing an SPM dependency managed by Tuist in Objective C cc @freak4pc 

This was raised in https://github.com/tuist/tuist/issues/6106 

### How to test the changes locally 🧐

Tests should pass

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
