### PR TITLE
Fix tuist generate for app_with_spm_dependencies fixture

### DIFF
--- a/fixtures/app_with_spm_dependencies/LocalSwiftPackage/Package.swift
+++ b/fixtures/app_with_spm_dependencies/LocalSwiftPackage/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .target(
             name: "Styles",
             dependencies: [
-                .product(name: "LibraryA", package: "LocalSwiftPackageB", condition: .when(platforms: [.macOS])),
+                .product(name: "LibraryA", package: "LocalSwiftPackageB"),
             ],
             resources: [
                 .process("Resources/Fonts"),


### PR DESCRIPTION
### Short description 📝

A small fix for `tuist generate` of `app_with_spm_dependencies` when using the released version of `tuist`. The issue was due to platform mismatch. There might be an opportunity for better error message as the error user would get is that `XXX dependency hash was not previously calculated`.

### How to test the changes locally 🧐

CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
