### PR TITLE
Improve the error message when parsing malformed property list files.

### DIFF
--- a/Tests/TuistSupportTests/Utils/FileHandlerTests.swift
+++ b/Tests/TuistSupportTests/Utils/FileHandlerTests.swift
@@ -18,6 +18,8 @@ final class FileHandlerErrorTests: XCTestCase {
 }
 
 final class FileHandlerTests: TuistUnitTestCase {
+    struct TestDecodable: Decodable {}
+
     private var subject: FileHandler!
     private let fileManager = FileManager.default
 
@@ -102,6 +104,25 @@ final class FileHandlerTests: TuistUnitTestCase {
         XCTAssertEqual(result.basenameWithoutExt, testZippedFrameworkPath.basenameWithoutExt)
         XCTAssertEqual(result.basename, "\(testZippedFrameworkPath.basenameWithoutExt).txt")
         _ = try subject.changeExtension(path: result, to: "zip")
+    }
+
+    func test_readPlistFile_throwsAnError_when_invalidPlist() throws {
+        // Given
+        let temporaryDirectory = try temporaryPath()
+        let plistPath = temporaryDirectory.appending(component: "file.plist")
+        try FileHandler.shared.touch(plistPath)
+
+        // When/Then
+        var _error: Error? = nil
+        do {
+            let _: TestDecodable = try subject.readPlistFile<TestDecodable>(plistPath)
+        } catch {
+            _error = error
+        }
+        XCTAssertEqual(
+            _error as? FileHandlerError,
+            FileHandlerError.propertyListDecodeError(plistPath, description: "The given data was not a valid property list.")
+        )
     }
 
     // MARK: - Private


### PR DESCRIPTION
### Short description 📝
The logic that we use to parse property list files doesn't handle errors gracefully when the file is malformated leading to users not knowing how to debug it. This PR improves error handling by throwing a different error that contains the description from the error thrown by the standard APIs.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
