### PR TITLE
Fix adding newline at the end of tuist version in `.mise.toml` file

### DIFF
--- a/Sources/TuistKit/Utils/TuistVersionLoader.swift
+++ b/Sources/TuistKit/Utils/TuistVersionLoader.swift
@@ -15,6 +15,6 @@ final class TuistVersionLoader: TuistVersionLoading {
     func getVersion() throws -> String {
         try system
             .capture(["tuist", "version"])
-            .replacingOccurrences(of: "\n", with: "")
+            .spm_chomp()
     }
 }

--- a/Sources/TuistKit/Utils/TuistVersionLoader.swift
+++ b/Sources/TuistKit/Utils/TuistVersionLoader.swift
@@ -13,6 +13,8 @@ final class TuistVersionLoader: TuistVersionLoading {
     }
 
     func getVersion() throws -> String {
-        try system.capture(["tuist", "version"])
+        try system
+            .capture(["tuist", "version"])
+            .replacingOccurrences(of: "\n", with: "")
     }
 }

--- a/Tests/TuistKitTests/Utils/TuistVersionLoaderTests.swift
+++ b/Tests/TuistKitTests/Utils/TuistVersionLoaderTests.swift
@@ -26,7 +26,7 @@ final class TuistVersionLoaderTests: TuistUnitTestCase {
         XCTAssertTrue(mockSystem.called(["tuist", "version"]))
         XCTAssertEqual(result, "4.0.1")
     }
-    
+
     func test_getVersion_removesNewLines() throws {
         // given
         let version = "4.0.1\n"

--- a/Tests/TuistKitTests/Utils/TuistVersionLoaderTests.swift
+++ b/Tests/TuistKitTests/Utils/TuistVersionLoaderTests.swift
@@ -26,6 +26,19 @@ final class TuistVersionLoaderTests: TuistUnitTestCase {
         XCTAssertTrue(mockSystem.called(["tuist", "version"]))
         XCTAssertEqual(result, "4.0.1")
     }
+    
+    func test_getVersion_removesNewLines() throws {
+        // given
+        let version = "4.0.1\n"
+        mockSystem.stubs = ["tuist version": (stderror: nil, stdout: version, exitstatus: 0)]
+
+        // when
+        let result = try sut.getVersion()
+
+        // then
+        XCTAssertTrue(mockSystem.called(["tuist", "version"]))
+        XCTAssertEqual(result, "4.0.1")
+    }
 
     override func tearDown() {
         mockSystem = nil


### PR DESCRIPTION
### Short description 📝

This PR fixes configuration of `.mise.toml` file when executing `tuist init`. Before `tuist init` command used to result mise parsing error with output:

```
mise error parsing config file: ~/TestingTuist/.mise.toml
mise TOML parse error at line 2, column 16
  |
2 | tuist = "3.39.3
  |                ^
invalid basic string
```

### How to test the changes locally 🧐

Create empty folder and run `tuist init` there. 

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
