### PR TITLE
Add support for XCFrameworks with .dylib libraries

### DIFF
--- a/Sources/TuistCore/MetadataProviders/XCFrameworkMetadataProvider.swift
+++ b/Sources/TuistCore/MetadataProviders/XCFrameworkMetadataProvider.swift
@@ -141,7 +141,7 @@ public final class XCFrameworkMetadataProvider: PrecompiledMetadataProvider, XCF
             binaryPath = try AbsolutePath(validating: library.identifier, relativeTo: xcframeworkPath)
                 .appending(try RelativePath(validating: library.path.pathString))
                 .appending(component: library.path.basenameWithoutExt)
-        case "a":
+        case "a", "dylib":
             binaryPath = try AbsolutePath(validating: library.identifier, relativeTo: xcframeworkPath)
                 .appending(try RelativePath(validating: library.path.pathString))
         default:


### PR DESCRIPTION
Tuist should not error when an XCFramework contains .dylib libraries

### Short description 📝

According to the XCFramework documentation "an XCFramework can include dynamic library files" for macOS. This indeed works without fail and should be allowed. However, the documentation is wrong or outdated for iOS and iOS Simulator. These platforms also allow .dylib libs in an XCFramework.

Tuist does not allow dynamic library files even for macOS. Using an XCFramework containing .dylib files, regardless of platform, throws a "XCFrameworkMetadataProviderError.supportedArchitectureReferencesNotFound" error and prints  "couldn't find any supported architecture [...]" which, at the very least, is misleading.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
