### PR TITLE
Filter out empty auxiliary groups

### DIFF
--- a/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
@@ -145,6 +145,8 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
             graphTraverser: graphTraverser
         )
 
+        groups.removeEmptyAuxiliaryGroups()
+
         let xcodeProj = XcodeProj(workspace: workspace, pbxproj: pbxproj)
         return ProjectDescriptor(
             path: project.path,

--- a/Sources/TuistGenerator/Generator/ProjectGroups.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGroups.swift
@@ -34,6 +34,17 @@ class ProjectGroups {
     private let pbxproj: PBXProj
     private let projectGroups: [String: PBXGroup]
 
+    private var auxiliaryGroups: [PBXGroup] {
+        // List of groups Xcode doesn't have by default if empty
+        //
+        // Note: The`Products` group is always included in the pbxproj but Xcode
+        // hides it in the UI if its empty.
+        [
+            frameworks,
+            cachedFrameworks,
+        ]
+    }
+
     // MARK: - Init
 
     private init(
@@ -65,6 +76,13 @@ class ProjectGroups {
             throw ProjectGroupsError.missingGroup(name)
         }
         return group
+    }
+
+    func removeEmptyAuxiliaryGroups() {
+        for emptyGroup in auxiliaryGroups.filter(\.children.isEmpty) {
+            sortedMain.children.removeAll(where: { $0 == emptyGroup })
+            pbxproj.delete(object: emptyGroup)
+        }
     }
 
     static func generate(

--- a/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
@@ -120,6 +120,49 @@ final class ProjectGroupsTests: XCTestCase {
         ])
     }
 
+    func test_removeEmptyAuxiliaryGroups_removesEmptyGroups() throws {
+        // Given
+        let project = Project.test()
+        subject = ProjectGroups.generate(
+            project: project,
+            pbxproj: pbxproj
+        )
+
+        // When
+        subject.removeEmptyAuxiliaryGroups()
+
+        // Then
+        let paths = subject.sortedMain.children.map(\.nameOrPath)
+        XCTAssertEqual(paths, [
+            "Project",
+            "Products",
+        ])
+    }
+
+    func test_removeEmptyAuxiliaryGroups_preservesNonEmptyGroups() throws {
+        // Given
+        let project = Project.test()
+        subject = ProjectGroups.generate(
+            project: project,
+            pbxproj: pbxproj
+        )
+
+        addFile(to: subject.frameworks)
+        addFile(to: subject.cachedFrameworks)
+
+        // When
+        subject.removeEmptyAuxiliaryGroups()
+
+        // Then
+        let paths = subject.sortedMain.children.map(\.nameOrPath)
+        XCTAssertEqual(paths, [
+            "Project",
+            "Frameworks",
+            "Cache",
+            "Products",
+        ])
+    }
+
     func test_targetFrameworks() throws {
         subject = ProjectGroups.generate(
             project: project,
@@ -212,5 +255,13 @@ final class ProjectGroupsTests: XCTestCase {
         XCTAssertNil(main.indentWidth)
         XCTAssertNil(main.tabWidth)
         XCTAssertNil(main.wrapsLines)
+    }
+
+    // MARK: - Helpers
+
+    private func addFile(to group: PBXGroup) {
+        let file = PBXFileReference()
+        pbxproj.add(object: file)
+        group.children.append(file)
     }
 }


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/6141

### Short description 📝

- https://github.com/tuist/tuist/pull/6057 introduced a `Cache` group to help distinguish cached artifacts from system libraries
- This didn't account for cases where the cache or cloud features aren't in use thus causing an additional `Cache` group to appear in all generated projects
- As a short term mitation we can filter out empty "auxiliary" groups at the end of the project generation steps
- This includes groups Xcode doesn't have by default including the `Frameworks` group which it only adds if a system library dependency is added

### Notes 📝

- The `Product` group isn't treated as an auxiliary group as Xcode always has this group in the generated `pbxproj`, the UI however hides it when empty
- A longer term solution would be extend the project/target API to allow the cache mapper to add groups instead of `TuistGenerator` having awareness about the cache feature

### How to test the changes locally 🧐

- Generate the fixture `ios_app_with_tests`
- Verify the `Frameworks` and `Cache` groups are no longer present
- Generate the fixture `ios_app_with_sdk`
- Verify the `Frameworks` group is still present (as there are system library dependencies)
- Verify the `Cache` group is no longer present

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
