### PR TITLE
Fix resources filename mismatch when a dependency has a +

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -160,7 +160,7 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
     }
 
     private func synthesizedFilePath(target: Target, project: Project, fileExtension: String) -> AbsolutePath {
-        let filename = "TuistBundle+\(target.name.camelized.uppercasingFirst).\(fileExtension)"
+        let filename = "TuistBundle+\(target.name.uppercasingFirst).\(fileExtension)"
         return project.derivedDirectoryPath(for: target).appending(components: Constants.DerivedDirectory.sources, filename)
     }
 

--- a/fixtures/multiplatform_app_with_sdk/Project.swift
+++ b/fixtures/multiplatform_app_with_sdk/Project.swift
@@ -39,6 +39,7 @@ let project = Project(
                 .external(name: "FirebaseAnalytics"),
                 .external(name: "FirebasePerformance", condition: .when([.ios])),
                 .external(name: "FirebaseRemoteConfig"),
+                .external(name: "FirebaseInAppMessaging-Beta"),
                 .sdk(name: "MobileCoreServices", type: .framework, status: .required, condition: .when([.ios])),
             ]
         ),

--- a/fixtures/multiplatform_app_with_sdk/Tuist/Package.resolved
+++ b/fixtures/multiplatform_app_with_sdk/Tuist/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "fcf5ced6dae2d43fced2581e673cc3b59bdb8ffa",
-        "version" : "10.23.0"
+        "revision" : "888f0b6026e2441a69e3ee2ad5293c7a92031e62",
+        "version" : "10.23.1"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "6ec4ca62b00a665fa09b594fab897753a8c635fa",
-        "version" : "10.23.0"
+        "revision" : "c7a5917ebe48d69f421aadf154ef3969c8b7f12d",
+        "version" : "10.23.1"
       }
     },
     {

--- a/fixtures/multiplatform_app_with_sdk/Tuist/Package.swift
+++ b/fixtures/multiplatform_app_with_sdk/Tuist/Package.swift
@@ -4,6 +4,6 @@ import PackageDescription
 let package = Package(
     name: "PackageName",
     dependencies: [
-        .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.23.0"),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "10.23.1"),
     ]
 )


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6099

### Short description 📝

The `ResourcesProjectMapper` would have a mismatch between referencing the bundle accessor file and the actual filename when the dependency had a +. To fix this, we no longer run `camelized` for the generated filename (I don't see why we'd need to do that).

### How to test the changes locally 🧐

Integrating `FirebaseAppMessaging-Beta` via `Tuist/Package.swift` should work.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
