### PR TITLE
Create embbed script phase for each framework

### DIFF
--- a/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/LinkGeneratorTests.swift
@@ -60,7 +60,8 @@ final class LinkGeneratorTests: XCTestCase {
     func test_generateEmbedPhase() throws {
         // Given
         var dependencies: Set<GraphDependencyReference> = []
-        dependencies.insert(GraphDependencyReference.testFramework())
+        dependencies.insert(GraphDependencyReference.testFramework(path: "/frameworks/first.framework"))
+        dependencies.insert(GraphDependencyReference.testFramework(path: "/frameworks/second.framework"))
         dependencies.insert(GraphDependencyReference.product(
             target: "Test",
             productName: "Test.framework"
@@ -95,10 +96,16 @@ final class LinkGeneratorTests: XCTestCase {
 
         // Then
         let scriptBuildPhase: PBXShellScriptBuildPhase? = pbxTarget.buildPhases.first as? PBXShellScriptBuildPhase
-        XCTAssertEqual(scriptBuildPhase?.name, "Embed Precompiled Frameworks")
+        XCTAssertEqual(scriptBuildPhase?.name, "Embed Precompiled Framework first.framework")
         XCTAssertEqual(scriptBuildPhase?.shellScript, "script")
         XCTAssertEqual(scriptBuildPhase?.inputPaths, ["$(SRCROOT)/frameworks/A.framework"])
         XCTAssertEqual(scriptBuildPhase?.outputPaths, ["output/A.framework"])
+
+        let secondBuildPhase: PBXShellScriptBuildPhase? = pbxTarget.buildPhases.dropFirst().first as? PBXShellScriptBuildPhase
+        XCTAssertEqual(secondBuildPhase?.name, "Embed Precompiled Framework second.framework")
+        XCTAssertEqual(secondBuildPhase?.shellScript, "script")
+        XCTAssertEqual(secondBuildPhase?.inputPaths, ["$(SRCROOT)/frameworks/A.framework"])
+        XCTAssertEqual(secondBuildPhase?.outputPaths, ["output/A.framework"])
 
         let embedBuildPhase = try XCTUnwrap(pbxTarget.embedFrameworksBuildPhases().first)
         XCTAssertEqual(embedBuildPhase.name, "Embed Frameworks")


### PR DESCRIPTION
### Short description 📝

Currently, when embedding precompiled  frameworks, `tuist`, performs all embedding in one Script Phase.
i.e.
```sh
... Embedding script
install_framework "$SRCROOT/../Frameworks/WizardLoggerSpells.framework"
install_framework "$SRCROOT/../Frameworks/WizardLoggerCharms.framework"
install_framework "$SRCROOT/../Frameworks/WizardLoggerPotions.framework"
install_framework "$SRCROOT/../Frameworks/WizardLoggerEnchantments.framework"
install_framework "$SRCROOT/../Frameworks/WizardLoggerMysteries.framework"
install_framework "$SRCROOT/../Frameworks/WizardLoggerArcana.framework"
```
The more frameworks, we have, the longer this script will run.
This script will run on one core, so it won't be parallelized.

<p align="center">
  <img width="473" alt="image" src="https://github.com/tuist/tuist/assets/119268/a15e25e7-399f-4f03-9865-1626611e37eb">
  <br>
  <em>Two targets have a lot of frameworks in them to embed</em>
</p>

> Describe here the purpose of your PR.

The thing is, that since the inputs and outputs of the script are well-defined, we can use the Xcode's ability to run scripts in parallel. This will work only if `FUSE_BUILD_SCRIPT_PHASES` enabled, but it won't hurt, if this option is disabled



<table>
  <tr>
    <td><img src="https://github.com/tuist/tuist/assets/119268/6aecf149-e237-4992-b390-bcf8415e86c0" alt="alt-text" width="width"></td>
    <td><img src="https://github.com/tuist/tuist/assets/119268/aa82d7f2-1803-4233-a745-63f72d65cb4f" alt="alt-text" width="width"></td>
  </tr>
  <tr>
    <td align="center">With <i>FUSE_BUILD_SCRIPT_PHASES</i> = NO</td>
    <td align="center">With <i>FUSE_BUILD_SCRIPT_PHASES</i> = YES</td>
  </tr>
</table>

This PR changes the behavior of how Tuist processes precompiled frameworks. Now, each framework will be processed in its own script phase. This, with `FUSE_BUILD_SCRIPT_PHASES` setting enabled, will greatly increase CPU utilization during the build, which will lead to decreased building times.

More information about parallelization can be found here: 
https://developer.apple.com/videos/play/wwdc2022/110364/

### How to test the changes locally 🧐
Generate a project using tuist with some precompiled frameworks.
Project still should be built and run the same as before. The only difference is that proejct now will have multiple embed script phase, each one for the framework.
Turn on `FUSE_BUILD_SCRIPT_PHASES` setting in Xcode, and check that now those script phases are running in parallel.

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
