### PR TITLE
Fix µFeature documentation dependency logic

### DIFF
--- a/docs/docs/guide/scale/ufeatures-architecture.md
+++ b/docs/docs/guide/scale/ufeatures-architecture.md
@@ -49,11 +49,14 @@ We recommend following a naming convention for targets, something that you can e
 | `Feature` | `FeatureInterface` | Source code and resources |
 | `FeatureInterface` | - | Public interface and models |
 | `FeatureTests` | `Feature`, `FeatureTesting` | Unit and integration tests |
-| `FeatureTesting` | `Feature` | Testing data and mocks |
+| `FeatureTesting` | `FeatureInterface` | Testing data and mocks |
 | `FeatureExample` | `FeatureTesting`, `Feature` | Example app |
 
+> [!TIP] UI Previews
+> `Feature` can use `FeatureTesting` as a Development Asset to allow for UI previews
+
 > [!IMPORTANT] COMPILER DIRECTIVES INSTEAD OF TESTING TARGETS
-> Alternatively, you can use compiler directives to include test data and mocks in the mani feature target when compiling for `Debug`. You simplify the graph, but you'll end up compiling code that you won't need for running the app.
+> Alternatively, you can use compiler directives to include test data and mocks in the `Feature` or `FeatureInterface` targets when compiling for `Debug`. You simplify the graph, but you'll end up compiling code that you won't need for running the app.
 
 ## Why a µFeature
 


### PR DESCRIPTION
### Short description 📝

The target "FeatureTesting" should depend on protocols and models from "FeatureInterface" not on concrete implementations from the "Feature" target.
Also rephrased the "COMPILER DIRECTIVES INSTEAD OF TESTING TARGETS" content, removing a typo (mani feature)


### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
