### PR TITLE
Change documentation's edit link

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -212,7 +212,7 @@ export default defineConfig({
       { text: "Changelog", link: "https://github.com/tuist/tuist/releases" },
     ],
     editLink: {
-      pattern: "https://github.com/tuist/docs/edit/main/docs/:path",
+      pattern: "https://github.com/tuist/tuist/edit/main/docs/docs/:path",
     },
     sidebar: {
       "/contributors": [


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/YYY

### Short description 📝

Changed  documentation's "Edit this page" link that was point to a different repository.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
