### PR TITLE
Add On Demand Resources Support

### DIFF
--- a/Sources/ProjectDescription/OnDemandResourcesTags.swift
+++ b/Sources/ProjectDescription/OnDemandResourcesTags.swift
@@ -1,0 +1,12 @@
+/// On-demand resources tags associated with Initial Install and Prefetched Order categories
+public struct OnDemandResourcesTags: Codable, Equatable {
+    /// Initial install tags associated with on demand resources
+    public let initialInstall: [String]?
+    /// Prefetched tag order associated with on demand resources
+    public let prefetchOrder: [String]?
+
+    public init(initialInstall: [String]?, prefetchOrder: [String]?) {
+        self.initialInstall = initialInstall
+        self.prefetchOrder = prefetchOrder
+    }
+}

--- a/Sources/ProjectDescription/OnDemandResourcesTags.swift
+++ b/Sources/ProjectDescription/OnDemandResourcesTags.swift
@@ -5,8 +5,11 @@ public struct OnDemandResourcesTags: Codable, Equatable {
     /// Prefetched tag order associated with on demand resources
     public let prefetchOrder: [String]?
 
-    public init(initialInstall: [String]?, prefetchOrder: [String]?) {
-        self.initialInstall = initialInstall
-        self.prefetchOrder = prefetchOrder
+    /// Returns OnDemandResourcesTags.
+    /// - Parameter initialInstall: An array of strings that lists the tags assosiated with the Initial install tags category.
+    /// - Parameter prefetchOrder: An array of strings that lists the tags associated with the Prefetch tag order category.
+    /// - Returns: OnDemandResourcesTags.
+    public static func tags(initialInstall: [String]?, prefetchOrder: [String]?) -> Self {
+        OnDemandResourcesTags(initialInstall: initialInstall, prefetchOrder: prefetchOrder)
     }
 }

--- a/Sources/ProjectDescription/Target.swift
+++ b/Sources/ProjectDescription/Target.swift
@@ -70,6 +70,9 @@ public struct Target: Codable, Equatable {
     /// Specifies whether if the target can be merged as part of another binary or not
     public var mergeable: Bool
 
+    /// The target's tags associated with on demand resources
+    public var onDemandResourcesTags: OnDemandResourcesTags?
+
     public static func target(
         name: String,
         destinations: Destinations,
@@ -92,7 +95,8 @@ public struct Target: Codable, Equatable {
         additionalFiles: [FileElement] = [],
         buildRules: [BuildRule] = [],
         mergedBinaryType: MergedBinaryType = .disabled,
-        mergeable: Bool = false
+        mergeable: Bool = false,
+        onDemandResourcesTags: OnDemandResourcesTags? = nil
     ) -> Self {
         self.init(
             name: name,
@@ -116,7 +120,8 @@ public struct Target: Codable, Equatable {
             additionalFiles: additionalFiles,
             buildRules: buildRules,
             mergedBinaryType: mergedBinaryType,
-            mergeable: mergeable
+            mergeable: mergeable,
+            onDemandResourcesTags: onDemandResourcesTags
         )
     }
 }

--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
@@ -36,6 +36,7 @@ public enum TuistAcceptanceFixtures {
     case iosAppWithLocalBinarySwiftPackage
     case iosAppWithLocalSwiftPackage
     case iosAppWithMultiConfigs
+    case iosAppWithOnDemandResources
     case iosAppWithPluginsAndTemplates
     case iosAppWithPrivacyManifest
     case iosAppWithRemoteBinarySwiftPackage
@@ -139,6 +140,8 @@ public enum TuistAcceptanceFixtures {
             return "ios_app_with_local_swift_package"
         case .iosAppWithMultiConfigs:
             return "ios_app_with_multi_configs"
+        case .iosAppWithOnDemandResources:
+            return "ios_app_with_on_demand_resources"
         case .iosAppWithPluginsAndTemplates:
             return "ios_app_with_plugins_and_templates"
         case .iosAppWithPrivacyManifest:

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -361,6 +361,22 @@ final class ConfigGenerator: ConfigGenerating {
             }
         }
 
+        if let initialInstallTags = target.onDemandResourcesTags?.initialInstall, !initialInstallTags.isEmpty {
+            settings["ON_DEMAND_RESOURCES_INITIAL_INSTALL_TAGS"] = .string(
+                initialInstallTags.sorted().map {
+                    $0.replacingOccurrences(of: " ", with: "\\ ")
+                }.joined(separator: " ")
+            )
+        }
+
+        if let prefetchOrder = target.onDemandResourcesTags?.prefetchOrder, !prefetchOrder.isEmpty {
+            settings["ON_DEMAND_RESOURCES_PREFETCH_ORDER"] = .string(
+                prefetchOrder.map {
+                    $0.replacingOccurrences(of: " ", with: "\\ ")
+                }.joined(separator: " ")
+            )
+        }
+
         return settings
     }
 

--- a/Sources/TuistGenerator/Generator/KnownAssetTagsFetcher.swift
+++ b/Sources/TuistGenerator/Generator/KnownAssetTagsFetcher.swift
@@ -14,12 +14,12 @@ private struct ContentJson: Decodable {
     let properties: ContentProperties
 }
 
-protocol KnownAssetTagsGenerating: AnyObject {
-    func generate(project: Project) throws -> [String]
+protocol KnownAssetTagsFetching: AnyObject {
+    func fetch(project: Project) throws -> [String]
 }
 
-final class KnownAssetTagsGenerator: KnownAssetTagsGenerating {
-    func generate(project: Project) throws -> [String] {
+final class KnownAssetTagsFetcher: KnownAssetTagsFetching {
+    func fetch(project: Project) throws -> [String] {
         var tags = project.targets.map { $0.resources.resources.map(\.tags).flatMap { $0 } }.flatMap { $0 }
 
         let initialInstallTags = project.targets.compactMap {

--- a/Sources/TuistGenerator/Generator/KnownAssetTagsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/KnownAssetTagsGenerator.swift
@@ -36,8 +36,9 @@ final class KnownAssetTagsGenerator: KnownAssetTagsGenerating {
         var assetContentsPaths: Set<Path> = []
         let decoder = JSONDecoder()
         for target in project.targets {
-            for resource in target.resources.resources {
-                guard let children = try? resource.path.path.recursiveChildren() else { continue }
+            let assetCatalogs = target.resources.resources.filter { $0.path.extension == "xcassets" }
+            for assetCatalog in assetCatalogs {
+                guard let children = try? assetCatalog.path.path.recursiveChildren() else { continue }
                 let contents = children.filter { $0.lastComponent == "Contents.json" }
                 for content in contents {
                     assetContentsPaths.insert(content)

--- a/Sources/TuistGenerator/Generator/KnownAssetTagsGenerator.swift
+++ b/Sources/TuistGenerator/Generator/KnownAssetTagsGenerator.swift
@@ -1,0 +1,61 @@
+import Foundation
+import PathKit
+import TuistGraph
+
+private struct ContentJson: Decodable {
+    struct ContentProperties: Decodable {
+        enum CodingKeys: String, CodingKey {
+            case onDemandResourceTags = "on-demand-resource-tags"
+        }
+
+        let onDemandResourceTags: [String]
+    }
+
+    let properties: ContentProperties
+}
+
+protocol KnownAssetTagsGenerating: AnyObject {
+    func generate(project: Project) throws -> [String]
+}
+
+final class KnownAssetTagsGenerator: KnownAssetTagsGenerating {
+    func generate(project: Project) throws -> [String] {
+        var tags = project.targets.map { $0.resources.resources.map(\.tags).flatMap { $0 } }.flatMap { $0 }
+
+        let initialInstallTags = project.targets.compactMap {
+            $0.onDemandResourcesTags?.initialInstall?.compactMap { $0 }
+        }.flatMap { $0 }
+
+        let prefetchOrderTags = project.targets.compactMap {
+            $0.onDemandResourcesTags?.prefetchOrder?.compactMap { $0 }
+        }.flatMap { $0 }
+
+        tags.append(contentsOf: initialInstallTags)
+        tags.append(contentsOf: prefetchOrderTags)
+
+        var assetContentsPaths: Set<Path> = []
+        let decoder = JSONDecoder()
+        for target in project.targets {
+            for resource in target.resources.resources {
+                guard let children = try? resource.path.path.recursiveChildren() else { continue }
+                let contents = children.filter { $0.lastComponent == "Contents.json" }
+                for content in contents {
+                    assetContentsPaths.insert(content)
+                }
+            }
+        }
+
+        var assetsTags: [String] = []
+        for path in assetContentsPaths {
+            guard let data = try? Data(contentsOf: path.url) else { continue }
+            guard let attributes = try? decoder.decode(ContentJson.self, from: data) else { continue }
+            assetsTags.append(contentsOf: attributes.properties.onDemandResourceTags)
+        }
+
+        tags.append(contentsOf: assetsTags)
+
+        let uniqueTags = Set(tags).sorted()
+
+        return uniqueTags
+    }
+}

--- a/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
@@ -295,12 +295,9 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
     private func generateAttributes(project: Project) -> [String: Any] {
         var attributes: [String: Any] = [:]
 
-        /// ODR tags
-        let tags = project.targets.map { $0.resources.resources.map(\.tags).flatMap { $0 } }.flatMap { $0 }
-        let uniqueTags = Set(tags).sorted()
-
-        if !uniqueTags.isEmpty {
-            attributes["KnownAssetTags"] = uniqueTags
+        // On Demand Resources tags
+        if let knownAssetTags = try? KnownAssetTagsGenerator().generate(project: project), !knownAssetTags.isEmpty {
+            attributes["KnownAssetTags"] = knownAssetTags
         }
 
         // BuildIndependentTargetsInParallel

--- a/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
@@ -54,6 +54,9 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
     /// Generator for the project schemes.
     let schemeDescriptorsGenerator: SchemeDescriptorsGenerating
 
+    /// Generator for the project known asset tags associated with on-demand resources.
+    let knownAssetTagsGenerator: KnownAssetTagsGenerating
+
     // MARK: - Init
 
     /// Initializes the project generator with its attributes.
@@ -62,14 +65,17 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
     ///   - targetGenerator: Generator for the project targets.
     ///   - configGenerator: Generator for the project configuration.
     ///   - schemeDescriptorsGenerator: Generator for the project schemes.
+    ///   - knownAssetTagsGenerator: Generator for the project known asset tags associated with on-demand resources.
     init(
         targetGenerator: TargetGenerating = TargetGenerator(),
         configGenerator: ConfigGenerating = ConfigGenerator(),
-        schemeDescriptorsGenerator: SchemeDescriptorsGenerating = SchemeDescriptorsGenerator()
+        schemeDescriptorsGenerator: SchemeDescriptorsGenerating = SchemeDescriptorsGenerator(),
+        knownAssetTagsGenerator: KnownAssetTagsGenerating = KnownAssetTagsGenerator()
     ) {
         self.targetGenerator = targetGenerator
         self.configGenerator = configGenerator
         self.schemeDescriptorsGenerator = schemeDescriptorsGenerator
+        self.knownAssetTagsGenerator = knownAssetTagsGenerator
     }
 
     // MARK: - ProjectGenerating
@@ -296,7 +302,7 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
         var attributes: [String: Any] = [:]
 
         // On Demand Resources tags
-        if let knownAssetTags = try? KnownAssetTagsGenerator().generate(project: project), !knownAssetTags.isEmpty {
+        if let knownAssetTags = try? knownAssetTagsGenerator.generate(project: project), !knownAssetTags.isEmpty {
             attributes["KnownAssetTags"] = knownAssetTags
         }
 

--- a/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ProjectDescriptorGenerator.swift
@@ -54,8 +54,8 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
     /// Generator for the project schemes.
     let schemeDescriptorsGenerator: SchemeDescriptorsGenerating
 
-    /// Generator for the project known asset tags associated with on-demand resources.
-    let knownAssetTagsGenerator: KnownAssetTagsGenerating
+    /// Fetcher for the project known asset tags associated with on-demand resources.
+    let knownAssetTagsFetcher: KnownAssetTagsFetching
 
     // MARK: - Init
 
@@ -65,17 +65,17 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
     ///   - targetGenerator: Generator for the project targets.
     ///   - configGenerator: Generator for the project configuration.
     ///   - schemeDescriptorsGenerator: Generator for the project schemes.
-    ///   - knownAssetTagsGenerator: Generator for the project known asset tags associated with on-demand resources.
+    ///   - knownAssetTagsFetcher: Fetcher for the project known asset tags associated with on-demand resources.
     init(
         targetGenerator: TargetGenerating = TargetGenerator(),
         configGenerator: ConfigGenerating = ConfigGenerator(),
         schemeDescriptorsGenerator: SchemeDescriptorsGenerating = SchemeDescriptorsGenerator(),
-        knownAssetTagsGenerator: KnownAssetTagsGenerating = KnownAssetTagsGenerator()
+        knownAssetTagsFetcher: KnownAssetTagsFetching = KnownAssetTagsFetcher()
     ) {
         self.targetGenerator = targetGenerator
         self.configGenerator = configGenerator
         self.schemeDescriptorsGenerator = schemeDescriptorsGenerator
-        self.knownAssetTagsGenerator = knownAssetTagsGenerator
+        self.knownAssetTagsFetcher = knownAssetTagsFetcher
     }
 
     // MARK: - ProjectGenerating
@@ -302,7 +302,7 @@ final class ProjectDescriptorGenerator: ProjectDescriptorGenerating {
         var attributes: [String: Any] = [:]
 
         // On Demand Resources tags
-        if let knownAssetTags = try? knownAssetTagsGenerator.generate(project: project), !knownAssetTags.isEmpty {
+        if let knownAssetTags = try? knownAssetTagsFetcher.fetch(project: project), !knownAssetTags.isEmpty {
             attributes["KnownAssetTags"] = knownAssetTags
         }
 

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -40,6 +40,7 @@ class TargetLinter: TargetLinting {
         issues.append(contentsOf: validateCoreDataModelsExist(target: target))
         issues.append(contentsOf: validateCoreDataModelVersionsExist(target: target))
         issues.append(contentsOf: lintMergeableLibrariesOnlyAppliesToDynamicTargets(target: target))
+        issues.append(contentsOf: lintOnDemandResourcesTags(target: target))
         for script in target.scripts {
             issues.append(contentsOf: targetScriptLinter.lint(script))
         }
@@ -291,6 +292,20 @@ class TargetLinter: TargetLinting {
             )]
         }
         return []
+    }
+
+    private func lintOnDemandResourcesTags(target: Target) -> [LintingIssue] {
+        guard let odrTags = target.onDemandResourcesTags else { return [] }
+        guard let initialInstall = odrTags.initialInstall, let prefetchOrder = odrTags.prefetchOrder else {
+            return []
+        }
+        let intersection = Set(initialInstall).intersection(Set(prefetchOrder))
+        return intersection.map { tag in
+            LintingIssue(
+                reason: "Prefetched Order Tag \"\(tag)\" is already assigned to Initial Install Tags category for the target \(target.name) and will be ignored by Xcode",
+                severity: .warning
+            )
+        }
     }
 }
 

--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -295,10 +295,9 @@ class TargetLinter: TargetLinting {
     }
 
     private func lintOnDemandResourcesTags(target: Target) -> [LintingIssue] {
-        guard let odrTags = target.onDemandResourcesTags else { return [] }
-        guard let initialInstall = odrTags.initialInstall, let prefetchOrder = odrTags.prefetchOrder else {
-            return []
-        }
+        guard let onDemandResourcesTags = target.onDemandResourcesTags else { return [] }
+        guard let initialInstall = onDemandResourcesTags.initialInstall else { return [] }
+        guard let prefetchOrder = onDemandResourcesTags.prefetchOrder else { return [] }
         let intersection = Set(initialInstall).intersection(Set(prefetchOrder))
         return intersection.map { tag in
             LintingIssue(

--- a/Sources/TuistGraph/Models/OnDemandResourcesTags.swift
+++ b/Sources/TuistGraph/Models/OnDemandResourcesTags.swift
@@ -1,0 +1,9 @@
+public struct OnDemandResourcesTags: Codable, Equatable {
+    public let initialInstall: [String]?
+    public let prefetchOrder: [String]?
+
+    public init(initialInstall: [String]?, prefetchOrder: [String]?) {
+        self.initialInstall = initialInstall
+        self.prefetchOrder = prefetchOrder
+    }
+}

--- a/Sources/TuistGraph/Models/Target.swift
+++ b/Sources/TuistGraph/Models/Target.swift
@@ -46,6 +46,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable {
     public var prune: Bool
     public let mergedBinaryType: MergedBinaryType
     public let mergeable: Bool
+    public let onDemandResourcesTags: OnDemandResourcesTags?
 
     // MARK: - Init
 
@@ -75,7 +76,8 @@ public struct Target: Equatable, Hashable, Comparable, Codable {
         buildRules: [BuildRule] = [],
         prune: Bool = false,
         mergedBinaryType: MergedBinaryType = .disabled,
-        mergeable: Bool = false
+        mergeable: Bool = false,
+        onDemandResourcesTags: OnDemandResourcesTags? = nil
     ) {
         self.name = name
         self.product = product
@@ -103,6 +105,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable {
         self.prune = prune
         self.mergedBinaryType = mergedBinaryType
         self.mergeable = mergeable
+        self.onDemandResourcesTags = onDemandResourcesTags
     }
 
     /// Target can be included in the link phase of other targets

--- a/Sources/TuistGraphTesting/Models/Target+TestData.swift
+++ b/Sources/TuistGraphTesting/Models/Target+TestData.swift
@@ -139,7 +139,8 @@ extension Target {
         environmentVariables: [String: EnvironmentVariable] = [:],
         filesGroup: ProjectGroup = .group(name: "Project"),
         dependencies: [TargetDependency] = [],
-        rawScriptBuildPhases: [RawScriptBuildPhase] = []
+        rawScriptBuildPhases: [RawScriptBuildPhase] = [],
+        onDemandResourcesTags: OnDemandResourcesTags? = nil
     ) -> Target {
         Target(
             name: name,
@@ -160,7 +161,8 @@ extension Target {
             environmentVariables: environmentVariables,
             filesGroup: filesGroup,
             dependencies: dependencies,
-            rawScriptBuildPhases: rawScriptBuildPhases
+            rawScriptBuildPhases: rawScriptBuildPhases,
+            onDemandResourcesTags: onDemandResourcesTags
         )
     }
 

--- a/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Target+ManifestMapper.swift
@@ -101,6 +101,10 @@ extension TuistGraph.Target {
             TuistGraph.BuildRule.from(manifest: $0)
         }
 
+        let onDemandResourcesTags = manifest.onDemandResourcesTags.map {
+            TuistGraph.OnDemandResourcesTags(initialInstall: $0.initialInstall, prefetchOrder: $0.prefetchOrder)
+        }
+
         return TuistGraph.Target(
             name: name,
             destinations: destinations,
@@ -125,7 +129,8 @@ extension TuistGraph.Target {
             additionalFiles: additionalFiles,
             buildRules: buildRules,
             mergedBinaryType: mergedBinaryType,
-            mergeable: manifest.mergeable
+            mergeable: manifest.mergeable,
+            onDemandResourcesTags: onDemandResourcesTags
         )
     }
 

--- a/Tests/TuistAcceptanceTests/EditAcceptanceTests.swift
+++ b/Tests/TuistAcceptanceTests/EditAcceptanceTests.swift
@@ -48,6 +48,14 @@ final class EditAcceptanceTestSPMPackage: TuistAcceptanceTestCase {
     }
 }
 
+final class EditAcceptanceTestAppWithOnDemandResources: TuistAcceptanceTestCase {
+    func test_app_with_on_demand_resources() async throws {
+        try setUpFixture(.iosAppWithOnDemandResources)
+        try await run(EditCommand.self)
+        try build(scheme: "Manifests")
+    }
+}
+
 extension TuistAcceptanceTestCase {
     fileprivate func build(scheme: String) throws {
         try System.shared.runAndPrint(

--- a/Tests/TuistAcceptanceTests/EditAcceptanceTests.swift
+++ b/Tests/TuistAcceptanceTests/EditAcceptanceTests.swift
@@ -48,14 +48,6 @@ final class EditAcceptanceTestSPMPackage: TuistAcceptanceTestCase {
     }
 }
 
-final class EditAcceptanceTestAppWithOnDemandResources: TuistAcceptanceTestCase {
-    func test_app_with_on_demand_resources() async throws {
-        try setUpFixture(.iosAppWithOnDemandResources)
-        try await run(EditCommand.self)
-        try build(scheme: "Manifests")
-    }
-}
-
 extension TuistAcceptanceTestCase {
     fileprivate func build(scheme: String) throws {
         try System.shared.runAndPrint(

--- a/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -138,6 +138,36 @@ final class GenerateAcceptanceTestiOSAppWithFrameworkAndResources: TuistAcceptan
     }
 }
 
+final class GenerateAcceptanceTestiOSAppWithOnDemandResources: TuistAcceptanceTestCase {
+    func test_ios_app_with_on_demand_resources() async throws {
+        try setUpFixture(.iosAppWithOnDemandResources)
+        try await run(GenerateCommand.self)
+        try await run(BuildCommand.self)
+        let pbxprojPath = xcodeprojPath.appending(component: "project.pbxproj")
+        let data = try Data(contentsOf: pbxprojPath.url)
+        let pbxProj = try PBXProj(data: data)
+        let attributes = try XCTUnwrap(pbxProj.projects.first?.attributes)
+        let knownAssetTags = try XCTUnwrap(attributes["KnownAssetTags"] as? [String])
+        let givenTags = [
+            "ar-resource-group",
+            "cube-texture",
+            "data",
+            "data file",
+            "datafile",
+            "datafolder",
+            "image",
+            "image-stack",
+            "json",
+            "nestedimage",
+            "newfolder",
+            "sprite",
+            "tag with space",
+            "texture",
+        ]
+        XCTAssertEqual(knownAssetTags, givenTags)
+    }
+}
+
 final class GenerateAcceptanceTestiOSAppWithPrivacyManifest: TuistAcceptanceTestCase {
     func test_ios_app_with_privacy_manifest() async throws {
         try setUpFixture(.iosAppWithPrivacyManifest)

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -454,4 +454,23 @@ final class TargetLinterTests: TuistUnitTestCase {
             severity: .warning
         ))
     }
+
+    func test_lint_when_target_has_invalid_on_demand_resources_tags() throws {
+        // Given
+        let target = Target.empty(
+            onDemandResourcesTags: .init(
+                initialInstall: ["tag1", "tag2"],
+                prefetchOrder: ["tag2", "tag3"]
+            )
+        )
+
+        // When
+        let got = subject.lint(target: target)
+
+        // Then
+        XCTContainsLintingIssue(got, .init(
+            reason: "Prefetched Order Tag \"tag2\" is already assigned to Initial Install Tags category for the target \(target.name) and will be ignored by Xcode",
+            severity: .warning
+        ))
+    }
 }

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -157,6 +157,13 @@ An iOS application with local Swift package.
 
 An workspace that contains an application and frameworks that leverage multiple configurations (Debug, Beta and Release) each of which also has an associated xcconfig file within `ConfigurationFiles`.
 
+## ios_app_with_on_demand_resources
+
+An iOS applicaiton with on-demand resources. It contains file resources and asset catalogs associated with tags which in turn are distributed between three categories:
+- Initial install tags
+- Prefetch tag order
+- Dowloaded only on demand
+
 ## ios_app_with_remote_swift_package
 
 An iOS application with remote Swift package.

--- a/fixtures/ios_app_with_on_demand_resources/.gitignore
+++ b/fixtures/ios_app_with_on_demand_resources/.gitignore
@@ -1,0 +1,70 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+### Projects ###
+*.xcodeproj
+*.xcworkspace
+
+### Tuist derived files ###
+graph.dot
+Derived/
+
+### Tuist managed dependencies ###
+Tuist/.build

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/AR Resources.arresourcegroup/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/AR Resources.arresourcegroup/Contents.json
@@ -1,0 +1,14 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "on-demand-resource-tags" : [
+      "ar-resource-group"
+    ]
+  },
+  "resources" : [
+
+  ]
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Cube Texture.cubetextureset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Cube Texture.cubetextureset/Contents.json
@@ -1,0 +1,43 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "on-demand-resource-tags" : [
+      "cube-texture"
+    ]
+  },
+  "textures" : [
+    {
+      "cube-face" : "x-",
+      "filename" : "Universal -X.mipmapset",
+      "idiom" : "universal"
+    },
+    {
+      "cube-face" : "y-",
+      "filename" : "Universal -Y.mipmapset",
+      "idiom" : "universal"
+    },
+    {
+      "cube-face" : "z-",
+      "filename" : "Universal -Z.mipmapset",
+      "idiom" : "universal"
+    },
+    {
+      "cube-face" : "x+",
+      "filename" : "Universal +X.mipmapset",
+      "idiom" : "universal"
+    },
+    {
+      "cube-face" : "y+",
+      "filename" : "Universal +Y.mipmapset",
+      "idiom" : "universal"
+    },
+    {
+      "cube-face" : "z+",
+      "filename" : "Universal +Z.mipmapset",
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Cube Texture.cubetextureset/Universal +X.mipmapset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Cube Texture.cubetextureset/Universal +X.mipmapset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "levels" : [
+    {
+      "mipmap-level" : "base"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Cube Texture.cubetextureset/Universal +Y.mipmapset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Cube Texture.cubetextureset/Universal +Y.mipmapset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "levels" : [
+    {
+      "mipmap-level" : "base"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Cube Texture.cubetextureset/Universal +Z.mipmapset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Cube Texture.cubetextureset/Universal +Z.mipmapset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "levels" : [
+    {
+      "mipmap-level" : "base"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Cube Texture.cubetextureset/Universal -X.mipmapset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Cube Texture.cubetextureset/Universal -X.mipmapset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "levels" : [
+    {
+      "mipmap-level" : "base"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Cube Texture.cubetextureset/Universal -Y.mipmapset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Cube Texture.cubetextureset/Universal -Y.mipmapset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "levels" : [
+    {
+      "mipmap-level" : "base"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Cube Texture.cubetextureset/Universal -Z.mipmapset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Cube Texture.cubetextureset/Universal -Z.mipmapset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "levels" : [
+    {
+      "mipmap-level" : "base"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Data.dataset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Data.dataset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "data" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "on-demand-resource-tags" : [
+      "data"
+    ]
+  }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Image.imageset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Image.imageset/Contents.json
@@ -1,0 +1,25 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "on-demand-resource-tags" : [
+      "image"
+    ]
+  }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/NewFolder/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/NewFolder/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "on-demand-resource-tags" : [
+      "newfolder"
+    ]
+  }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/NewFolder/nestedimage.imageset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/NewFolder/nestedimage.imageset/Contents.json
@@ -1,0 +1,25 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "on-demand-resource-tags" : [
+      "nestedimage"
+    ]
+  }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Sprites.spriteatlas/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Sprites.spriteatlas/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "on-demand-resource-tags" : [
+      "sprite"
+    ]
+  }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Sprites.spriteatlas/Sprite.imageset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Sprites.spriteatlas/Sprite.imageset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Stack.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Stack.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Stack.imagestack/Back.imagestacklayer/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Stack.imagestack/Back.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Stack.imagestack/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Stack.imagestack/Contents.json
@@ -1,0 +1,22 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "layers" : [
+    {
+      "filename" : "Front.imagestacklayer"
+    },
+    {
+      "filename" : "Middle.imagestacklayer"
+    },
+    {
+      "filename" : "Back.imagestacklayer"
+    }
+  ],
+  "properties" : {
+    "on-demand-resource-tags" : [
+      "image-stack"
+    ]
+  }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Stack.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Stack.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Stack.imagestack/Front.imagestacklayer/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Stack.imagestack/Front.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Stack.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Stack.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Stack.imagestack/Middle.imagestacklayer/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Stack.imagestack/Middle.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Texture.textureset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Texture.textureset/Contents.json
@@ -1,0 +1,18 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "on-demand-resource-tags" : [
+      "tag with space",
+      "texture"
+    ]
+  },
+  "textures" : [
+    {
+      "filename" : "Universal.mipmapset",
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Texture.textureset/Universal.mipmapset/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Assets.xcassets/Texture.textureset/Universal.mipmapset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "levels" : [
+    {
+      "mipmap-level" : "base"
+    }
+  ]
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/LaunchScreen.storyboard
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Resources/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Sources/AppWithOnDemandResourcesApp.swift
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Sources/AppWithOnDemandResourcesApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct AppWithOnDemandResourcesApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Sources/ContentView.swift
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Sources/ContentView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+public struct ContentView: View {
+    public init() {}
+
+    public var body: some View {
+        Text("Hello, World!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Tests/AppWithOnDemandResourcesTests.swift
+++ b/fixtures/ios_app_with_on_demand_resources/AppWithOnDemandResources/Tests/AppWithOnDemandResourcesTests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import XCTest
+
+final class AppWithOnDemandResourcesTests: XCTestCase {
+    func test_twoPlusTwo_isFour() {
+        XCTAssertEqual(2 + 2, 4)
+    }
+}

--- a/fixtures/ios_app_with_on_demand_resources/Project.swift
+++ b/fixtures/ios_app_with_on_demand_resources/Project.swift
@@ -1,0 +1,39 @@
+import ProjectDescription
+
+let project = Project(
+    name: "AppWithOnDemandResources",
+    targets: [
+        .target(
+            name: "AppWithOnDemandResources",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "io.tuist.AppWithOnDemandResources",
+            infoPlist: .extendingDefault(
+                with: [
+                    "UILaunchStoryboardName": "LaunchScreen.storyboard",
+                ]
+            ),
+            sources: ["AppWithOnDemandResources/Sources/**"],
+            resources: [
+                "AppWithOnDemandResources/Resources/**",
+                .folderReference(path: "AppWithOnDemandResources/OnDemandResources", tags: ["datafolder"]),
+                .glob(pattern: "AppWithOnDemandResources/on-demand-data.txt", tags: ["datafile"]),
+            ],
+            dependencies: [],
+            onDemandResourcesTags: .init(
+                initialInstall: ["json", "data file"],
+                prefetchOrder: ["image-stack", "image", "tag with space"]
+            )
+        ),
+        .target(
+            name: "AppWithOnDemandResourcesTests",
+            destinations: .iOS,
+            product: .unitTests,
+            bundleId: "io.tuist.AppWithOnDemandResourcesTests",
+            infoPlist: .default,
+            sources: ["AppWithOnDemandResources/Tests/**"],
+            resources: [],
+            dependencies: [.target(name: "AppWithOnDemandResources")]
+        ),
+    ]
+)

--- a/fixtures/ios_app_with_on_demand_resources/Project.swift
+++ b/fixtures/ios_app_with_on_demand_resources/Project.swift
@@ -20,7 +20,7 @@ let project = Project(
                 .glob(pattern: "AppWithOnDemandResources/on-demand-data.txt", tags: ["datafile"]),
             ],
             dependencies: [],
-            onDemandResourcesTags: .init(
+            onDemandResourcesTags: .tags(
                 initialInstall: ["json", "data file"],
                 prefetchOrder: ["image-stack", "image", "tag with space"]
             )

--- a/fixtures/ios_app_with_on_demand_resources/Tuist/Config.swift
+++ b/fixtures/ios_app_with_on_demand_resources/Tuist/Config.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let config = Config()


### PR DESCRIPTION
### Short description 📝

_On-demand_ resources are app contents that are hosted on the App Store and are separate from the related app bundle that you download.
The resources can be of any type supported by bundles except for executable code. Supported on-demand resource types are described in [Apple Developer Documentation](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/On_Demand_Resources_Guide/index.html#//apple_ref/doc/uid/TP40015083-CH2-SW1).
Developers identify on-demand resources during development by assigning them one or more tags. A tag is a string identifier they create.

It's important for us to understand how are tags defined in generated `pbxproj`.

Tags assigned to resource files or folders are defined in targets `PBXBuildFile` section:
```
/* Begin PBXBuildFile section */
  ...
  6CD9B9A8A7B99902ADF2733A /* on-demand-data.txt in Resources */ = {isa = PBXBuildFile; fileRef = C76E1D013C995B4365F328A4 /* on-demand-data.txt */; settings = {ASSET_TAGS = (datafile, ); }; };
  ...
/* End PBXBuildFile section */
```
Tags assigned to assets in Asset Catalogs are not presented in pbxproj and defined in their `Contents.json`:
```
{
  ...
  "properties" : {
    "on-demand-resource-tags" : [
      "image"
    ]
  }
}
```
All tags assigned to any type of on-demand resources are listed in `PBXProject` section in alphabet order:
```
/* Begin PBXProject section */
		F6B39DFD5CF1C50192B21AD0 /* Project object */ = {
			isa = PBXProject;
			attributes = {
				BuildIndependentTargetsInParallel = YES;
				KnownAssetTags = (
					"ar-resource-group",
					"cube-texture",
					data,
				);
  ...
/* End PBXProject section */
```
On targets level, each tag is assigned to one of the categories below:
- Initial install tags (alphabet order)
- Prefetch tag order (order-sensitive)
- Dowloaded only on demand (alphabet order)

Initial install tags and Prefetched order tags are defined in the targets `XCBuildConfiguration` section:
```
814E5CB981F34CFCEFE45501 /* Release */ = {
			isa = XCBuildConfiguration;
			buildSettings = {
				...
				ON_DEMAND_RESOURCES_INITIAL_INSTALL_TAGS = "data\\ file json";
				ON_DEMAND_RESOURCES_PREFETCH_ORDER = "image-stack image tag\\ with\\ space";
				...
```
The last category is default, not described in pbxproj and represents all tags from `KnownAssetTags` excluding tags from the first two categories.

This pull request add support for on-demand resources.

- During project generation, we parse tags in all `Contents.json` in Asset Catalogs to generate KnownAssetTags (defining tags for file resources was already implemented).
- `Target` init has got additional parameters to define Initial Install Tags and Prefetch Order Tags

### How to test the changes locally 🧐

This PR adds new fixture: `ios_app_with_on_demand_resources`, with acceptance, generation, edit and lint tests.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
