### PR TITLE
Fix some typos in From Tuist v3 to v4

### DIFF
--- a/docs/docs/guide/introduction/from-v3-to-v4.md
+++ b/docs/docs/guide/introduction/from-v3-to-v4.md
@@ -41,7 +41,7 @@ We renamed the `tuist fetch` command to `tuist install` to align with the indust
 
 ### [Adopt `Package.swift` as the DSL for dependencies](https://github.com/tuist/tuist/pull/5862)
 
-Before Tuist 4, you could define dependencies in a `Dependencies.swift` file. This proprietary format broke the support in tools like [Dependabot](https://github.com/dependabot) or [Renovatebot](https://github.com/renovatebot/renovate) to automatically update dependencies. Moreover, it introduced unnecessary indirections ofr users. Therefore, we decided to embrace `Package.swift` as the only way to define dependencies in Tuist. If you were using the `Dependencies.swift` file, you'll have to move the content from your `Tuist/Dependencies.swift` to a `Package.swift` at the root, and use the `#if TUIST` directive to configure the integration. You can read more about how to integrate Swift Package dependencies [here](/guide/project/dependencies.html#swift-packages)
+Before Tuist 4, you could define dependencies in a `Dependencies.swift` file. This proprietary format broke the support in tools like [Dependabot](https://github.com/dependabot) or [Renovatebot](https://github.com/renovatebot/renovate) to automatically update dependencies. Moreover, it introduced unnecessary indirections for users. Therefore, we decided to embrace `Package.swift` as the only way to define dependencies in Tuist. If you were using the `Dependencies.swift` file, you'll have to move the content from your `Tuist/Dependencies.swift` to a `Package.swift` at the root, and use the `#if TUIST` directive to configure the integration. You can read more about how to integrate Swift Package dependencies [here](/guide/project/dependencies.html#swift-packages)
 
 ### Renamed `tuist cache warm` to `tuist cache`
 
@@ -74,7 +74,7 @@ tuist generate Foo
 ### [Dropped signing capabilities](https://github.com/tuist/tuist/pull/5716)
 
 Signing is already solved by community tooling like [Fastlane](https://fastlane.tools/) and Xcode itself, which do a much better job at that. We felt that signing was an stretch goal for Tuist, and that it was better to focus on the core features of the project. If you were using Tuist signing capabilities, which consisted of encrypting the certificates and profiles in the repository and installing them in the right places at generation time, you might want to replicate that logic in your own scripts that run before project generation. In particular:
-  - A script that decrypts the certificates and profiles using a key either stored in the file-system or in a environment variable, and installs certificates in the keychain, and the provisioning profiles in the directory `~/Library/MobileDevice/Provisioning\ Profiles`.
+  - A script that decrypts the certificates and profiles using a key either stored in the file-system or in an environment variable, and installs certificates in the keychain, and the provisioning profiles in the directory `~/Library/MobileDevice/Provisioning\ Profiles`.
   - A script that can take an existing profiles and certificates and encrypt them.
 
 > [!TIP] SIGNING REQUIREMENTS


### PR DESCRIPTION
### Short description 📝

Fixes some minor typos that I discovered while reading through the migration guide.

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
