### PR TITLE
Fix README's broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ tuist generate # Generates Xcode project & workspace
 tuist build # Builds your project
 ```
 
-Check out [the project "Get Started" guide](https://docs.tuist.io/guide/introduction/adopting-tuist/new-project) to learn more about Tuist and all its features.
+Check out [the project "Adopting Tuist" guide](https://docs.tuist.io/guide/introduction/adopting-tuist/new-project) to learn more about Tuist and all its features.
 
 ## 📝 Documentation
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ tuist generate # Generates Xcode project & workspace
 tuist build # Builds your project
 ```
 
-Check out [the project "Get Started" guide](https://docs.tuist.io/guide/introduction/adopting-tuist/new-project.html) to learn more about Tuist and all its features.
+Check out [the project "Get Started" guide](https://docs.tuist.io/guide/introduction/adopting-tuist/new-project) to learn more about Tuist and all its features.
 
 ## 📝 Documentation
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ tuist generate # Generates Xcode project & workspace
 tuist build # Builds your project
 ```
 
-Check out [the project "Get Started" guide](https://docs.tuist.io/documentation/tuist) to learn more about Tuist and all its features.
+Check out [the project "Get Started" guide](https://docs.tuist.io/guide/introduction/adopting-tuist/new-project.html) to learn more about Tuist and all its features.
 
 ## 📝 Documentation
 
 Do you want to know more about what Tuist can offer you? Or perhaps want to contribute to the project and you need a starting point?
 
-You can check out [the project documentation](https://docs.tuist.io/documentation/tuist/).
+You can check out [the project documentation](https://docs.tuist.io).
 
 ### 🔬 Sample projects
 


### PR DESCRIPTION
### Short description 📝

While checking the documentation I noticed some README links are throwing a 404 error. 

Documentation was [revamped](https://github.com/tuist/tuist/pull/6159) recently and there is a note at the bottom about path redirection, which I'm not sure if README links are part of.

### Contributor checklist ✅

- [X] The code has been linted using run `mise run lint:fix`
- [X] The change is tested via unit testing or acceptance testing, or both
- [X] The title of the PR is formulated in a way that is usable as a changelog entry
- [X] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
