### PR TITLE
Fix integration of Cuckoo

### DIFF
--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -282,6 +282,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
                     "XCTVapor", // https://github.com/vapor/vapor
                     "MockableTest", // https://github.com/Kolos65/Mockable.git
                     "Testing", // https://github.com/apple/swift-testing
+                    "Cuckoo", // https://github.com/Brightify/Cuckoo
                 ].map {
                     ($0, ["ENABLE_TESTING_SEARCH_PATHS": "YES"])
                 }

--- a/fixtures/app_with_spm_dependencies/App/Project.swift
+++ b/fixtures/app_with_spm_dependencies/App/Project.swift
@@ -58,6 +58,7 @@ let project = Project(
                 .target(name: "AppKit"),
                 .external(name: "Nimble"),
                 .external(name: "Testing"),
+                .external(name: "Cuckoo"),
             ],
             settings: .targetSettings
         ),

--- a/fixtures/app_with_spm_dependencies/App/Tests/AppKit/AppKitTests.swift
+++ b/fixtures/app_with_spm_dependencies/App/Tests/AppKit/AppKitTests.swift
@@ -1,3 +1,4 @@
+import Cuckoo
 import Nimble
 import Testing
 

--- a/fixtures/app_with_spm_dependencies/Tuist/Package.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/Package.swift
@@ -41,5 +41,7 @@ let package = Package(
         .package(path: "../LocalSwiftPackage"),
         .package(path: "../StringifyMacro"),
         .package(url: "https://github.com/kishikawakatsumi/UICKeyChainStore", exact: "2.2.1"),
+        // Has XCTest API in a non-test target. Tuist will add Test Search path to support it
+        .package(url: "https://github.com/Brightify/Cuckoo.git", exact: "1.10.4"),
     ]
 )


### PR DESCRIPTION
### Short description 📝

Cuckoo is using XCTest APIs, as such it needs the XCTest framework to be available.
Adding it to the hard coded list, should solve that issue.

### How to test the changes locally 🧐

You can reproduce the problem in t[his example repo](https://github.com/danibachar/TuistCuckoo)
We have updated the fixture `app_with_spm_dependencies` to include Cuckoo and import it, such that it should compile.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
