### PR TITLE
Skip traversal for targets with a dependency on macros in linter.

### DIFF
--- a/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
@@ -1289,6 +1289,60 @@ class StaticProductsGraphLinterTests: XCTestCase {
         XCTAssertEqual(results, [])
     }
 
+    func test_lint_whenMacrosLinkedTwice() throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let app = Target.test(name: "App")
+
+        let dynamicFrameworkA = Target.test(name: "FrameworkA", product: .framework)
+        let dynamicFrameworkB = Target.test(name: "FrameworkB", product: .framework)
+
+        let macroStaticFramework = Target.test(name: "MacroStaticFramework", product: .staticFramework)
+        let macroExecutable = Target.test(name: "Macro", product: .macro)
+        let swiftSyntax = Target.test(name: "SwiftSyntax", product: .staticLibrary)
+
+        let project = Project
+            .test(targets: [app, dynamicFrameworkA, dynamicFrameworkB, macroExecutable])
+
+        let appDependency = GraphDependency.target(name: app.name, path: path)
+        let dynamicFrameworkADependency = GraphDependency.target(name: dynamicFrameworkA.name, path: path)
+        let dynamicFrameworkBDependency = GraphDependency.target(name: dynamicFrameworkB.name, path: path)
+        let macroStaticFrameworkDependency = GraphDependency.target(name: macroStaticFramework.name, path: path)
+        let macroExecutableDependency = GraphDependency.target(name: macroExecutable.name, path: path)
+        let swiftSyntaxDependency = GraphDependency.target(name: swiftSyntax.name, path: path)
+
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            appDependency: Set([dynamicFrameworkADependency, dynamicFrameworkBDependency]),
+            dynamicFrameworkADependency: Set([macroStaticFrameworkDependency]),
+            dynamicFrameworkBDependency: Set([macroStaticFrameworkDependency]),
+            macroStaticFrameworkDependency: Set([macroExecutableDependency]),
+            macroExecutableDependency: Set([swiftSyntaxDependency]),
+        ]
+
+        let graph = Graph.test(
+            path: path,
+            projects: [path: project],
+            targets: [path: [
+                app.name: app,
+                dynamicFrameworkA.name: dynamicFrameworkA,
+                dynamicFrameworkB.name: dynamicFrameworkB,
+                macroStaticFramework.name: macroStaticFramework,
+                macroExecutable.name: macroExecutable,
+                swiftSyntax.name: swiftSyntax,
+            ]],
+            dependencies: dependencies
+        )
+
+        let config = Config.test()
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let results = subject.lint(graphTraverser: graphTraverser, config: config)
+
+        // Then
+        XCTAssertEqual(results, [])
+    }
+
     // MARK: - Helpers
 
     private func warning(product node: String, type: String = "Target", linkedBy: [GraphDependency]) -> LintingIssue {


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6209

### Short description 📝

Users reported getting "static side effects" warnings that seem to be false positives in their projects. They happen when the project has Swift Macros; our logic doesn't account for that. We need to adjust the logic that checks for side effects to skip the traversal when it comes across a macro executable.

### How to test the changes locally 🧐

Create a project with an app that depends on 2 dynamic frameworks
Add a Swift Macros to each of those 2 dynamic frameworks
Generate the project

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
