### PR TITLE
Delete the version from Constants.swift

### DIFF
--- a/Sources/TuistSupport/Constants.swift
+++ b/Sources/TuistSupport/Constants.swift
@@ -8,7 +8,6 @@ public enum Constants {
     public static let githubAPIURL = "https://api.github.com"
     public static let githubSlug = "tuist/tuist"
     public static let communityURL = "https://github.com/tuist/tuist/discussions/categories/general"
-    public static let version = "4.3.4"
     public static let bundleName: String = "tuist.zip"
     public static let trueValues: [String] = ["1", "true", "TRUE", "yes", "YES"]
     public static let tuistDirectoryName: String = "Tuist"


### PR DESCRIPTION
### Short description 📝
The release process owns the source of truth, so we no longer need the version hardcoded here. I'm removing it to prevent confusion.