### PR TITLE
Fix regression in ModuleMapMapper due to outdated Graph properties

### DIFF
--- a/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -85,6 +85,14 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
                         targetB1.name: targetB1,
                         targetB2.name: targetB2,
                     ],
+                ],
+                dependencies: [
+                    .target(name: targetA.name, path: projectAPath): [
+                        .target(name: targetB1.name, path: projectBPath),
+                    ],
+                    .target(name: targetB1.name, path: projectBPath): [
+                        .target(name: targetB2.name, path: projectBPath),
+                    ],
                 ]
             )
         )
@@ -164,6 +172,14 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
                         mappedTargetB1.name: mappedTargetB1,
                         mappedTargetB2.name: mappedTargetB2,
                     ],
+                ],
+                dependencies: [
+                    .target(name: targetA.name, path: projectAPath): [
+                        .target(name: targetB1.name, path: projectBPath),
+                    ],
+                    .target(name: targetB1.name, path: projectBPath): [
+                        .target(name: targetB2.name, path: projectBPath),
+                    ],
                 ]
             ),
             gotGraph
@@ -221,6 +237,11 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
                     ],
                     projectBPath: [
                         targetB.name: targetB,
+                    ],
+                ],
+                dependencies: [
+                    .target(name: targetA.name, path: projectAPath): [
+                        .target(name: targetB.name, path: projectBPath),
                     ],
                 ]
             )
@@ -287,6 +308,11 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
                     ],
                     projectBPath: [
                         mappedTargetB.name: mappedTargetB,
+                    ],
+                ],
+                dependencies: [
+                    .target(name: projectA.name, path: projectAPath): [
+                        .target(name: projectB.name, path: projectBPath),
                     ],
                 ]
             ),


### PR DESCRIPTION
### Short description 📝

The latest release contains a regression due to: https://github.com/tuist/tuist/pull/6218

The regression happened because:
- `ModuleMapMapper` is no longer called that early in the process before other mappers update the graph
- We made some bad design decisions in the past and `targets` and `dependencies` are available in two ways. In mappers, we don't always update both properties (in this case `Graph.dependencies` and `Target.dependencies`) which makes the other one outdated. That's exactly what happened here.

The solution for now is to access target dependencies through `GraphTraverser` but long-term, we should get rid of these duplicated properties altogether, so bugs like this are no longer possible.

### How to test the changes locally 🧐

Run `tuist generate` when using binaries.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
