### PR TITLE
Fix typo in `appleVisionWithiPadDesign` comment

### DIFF
--- a/Sources/ProjectDescription/Destination.swift
+++ b/Sources/ProjectDescription/Destination.swift
@@ -39,7 +39,7 @@ public enum Destination: String, Codable, Equatable, CaseIterable {
     case appleTv
     /// visionOS support
     case appleVision
-    /// visionOS support useing iPad design
+    /// visionOS support using iPad design
     case appleVisionWithiPadDesign
 
     /// SDK Platform of a destination


### PR DESCRIPTION
### Short description 📝

This PR fixes a small typo discovered in the documentation for the `Destination` enum - specifically the comment attributed to `appleVisionWithiPadDesign`.

### How to test the changes locally 🧐

Not applicable given the limited scope of the changes.

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
