### PR TITLE
Redirect to the home page

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -142,14 +142,6 @@ const guideSidebar = [
       },
     ],
   },
-  {
-    text: "Extensions",
-    items: [
-      { text: "Tasks", link: "/guide/extensions/tasks" },
-      { text: "Templates" },
-      { text: "Resource synthesizers" },
-    ],
-  },
 ];
 
 // https://vitepress.dev/reference/site-config

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -199,7 +199,7 @@ export default defineConfig({
 /documentation/tuist/code-reviews /contributors/code-reviews 301
 /documentation/tuist/reporting-bugs /contributors/issue-reporting 301
 /documentation/tuist/championing-projects /contributors/get-started 301
-/documentation/tuist/* /reference/project-description/:splat 301
+/documentation/tuist/* / 301
     `;
     fs.writeFile(redirectsPath, redirects);
   },


### PR DESCRIPTION
### Short description 📝
The new documentation site has some redirects set to instruct Cloudflare to redirect from the old URL slugs to the new ones. From the list, the catch-all line was redirecting to an invalid path. This PR fixes it.
