### PR TITLE
Get PRODUCT_NAME value from settings if consistent and present

### DIFF
--- a/Sources/TuistCore/Graph/ModelExtensions/Target+Core.swift
+++ b/Sources/TuistCore/Graph/ModelExtensions/Target+Core.swift
@@ -17,29 +17,6 @@ public enum TargetError: FatalError, Equatable {
     }
 }
 
-enum TargetProductNameWithExtensionError: Equatable, FatalError {
-    case inconsistentProductNameAcrossConfigurations(target: String, productNames: Set<String>)
-    case productNameWithVariables(target: String, productName: String)
-
-    var type: ErrorType {
-        switch self {
-        case .inconsistentProductNameAcrossConfigurations:
-            return .abort
-        case .productNameWithVariables:
-            return .abort
-        }
-    }
-
-    var description: String {
-        switch self {
-        case let .inconsistentProductNameAcrossConfigurations(target, productNames):
-            return "The target '\(target)' has inconsistent PRODUCT_NAMEs across configurations (\(productNames.joined(separator: ", "))) that might cause Tuist to behave unpredictably. Ensure the same name is used across all the configurations."
-        case let .productNameWithVariables(target, productName):
-            return "The target '\(target)' has a PRODUCT_NAME that contains variables, '\(productName)', which might cause Tuist to behave unpredictably. Make sure the name contains no variables or let Xcode set the default."
-        }
-    }
-}
-
 extension Target {
     /// Returns the product name including the extension
     /// if the PRODUCT_NAME build setting of the target is set and contains a static value that's consistent

--- a/Tests/TuistGraphTests/Models/TargetTests.swift
+++ b/Tests/TuistGraphTests/Models/TargetTests.swift
@@ -56,6 +56,54 @@ final class TargetTests: TuistUnitTestCase {
         )
     }
 
+    func test_productNameWithExtension_when_buildSettingsProductNameStaticAndConsistentValue() {
+        // Given
+        let target = Target.test(
+            name: "Test",
+            product: .framework,
+            settings: .test(
+                base: ["PRODUCT_NAME": "Tuist"],
+                debug: .test(settings: ["PRODUCT_NAME": "Tuist"]),
+                release: .test(settings: ["PRODUCT_NAME": "Tuist"])
+            )
+        )
+
+        // When
+        XCTAssertEqual(target.productNameWithExtension, "Tuist.framework")
+    }
+
+    func test_productNameWithExtension_when_buildSettingsProductNameDynamicAndConsistentValue() {
+        // Given
+        let target = Target.test(
+            name: "Test",
+            product: .framework,
+            settings: .test(
+                base: ["PRODUCT_NAME": "$OTHER_VARIABLE"],
+                debug: .test(settings: ["PRODUCT_NAME": "$OTHER_VARIABLE"]),
+                release: .test(settings: ["PRODUCT_NAME": "$OTHER_VARIABLE"])
+            )
+        )
+
+        // When
+        XCTAssertEqual(target.productNameWithExtension, "Test.framework")
+    }
+
+    func test_productNameWithExtension_when_buildSettingsProductNameStaticAndInconsistentValue() {
+        // Given
+        let target = Target.test(
+            name: "Test",
+            product: .framework,
+            settings: .test(
+                base: ["PRODUCT_NAME": "Tuist"],
+                debug: .test(settings: ["PRODUCT_NAME": "TuistDebug"]),
+                release: .test(settings: ["PRODUCT_NAME": "TuistRelease"])
+            )
+        )
+
+        // When
+        XCTAssertEqual(target.productNameWithExtension, "Test.framework")
+    }
+
     func test_productNameWithExtension_when_staticLibrary() {
         let target = Target.test(name: "Test", product: .staticLibrary)
         XCTAssertEqual(target.productNameWithExtension, "libTest.a")


### PR DESCRIPTION
### Short description 📝
The `Target.productNameWithExtension` doesn't consider any value set in the target's build settings. This PR extends the implementation to read the value from there if it's:
1. Static
2. Consistent throughout the configurations

When not, we default to Xcode's default value.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
