### PR TITLE
Do not automatically add -ObjC flag when integrating Objective-C dependencies

### DIFF
--- a/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ModuleMapMapper.swift
@@ -10,7 +10,6 @@ import TuistSupport
 public final class ModuleMapMapper: GraphMapping { // swiftlint:disable:this type_body_length
     private static let modulemapFileSetting = "MODULEMAP_FILE"
     private static let otherCFlagsSetting = "OTHER_CFLAGS"
-    private static let otherLinkerFlagsSetting = "OTHER_LDFLAGS"
     private static let otherSwiftFlagsSetting = "OTHER_SWIFT_FLAGS"
     private static let headerSearchPaths = "HEADER_SEARCH_PATHS"
 
@@ -80,14 +79,6 @@ public final class ModuleMapMapper: GraphMapping { // swiftlint:disable:this typ
                     targetToDependenciesMetadata: targetToDependenciesMetadata
                 ) {
                     mappedSettingsDictionary[Self.headerSearchPaths] = updatedHeaderSearchPaths
-                }
-
-                if let updatedOtherLinkerFlags = Self.updatedOtherLinkerFlags(
-                    targetID: targetID,
-                    oldOtherLinkerFlags: mappedSettingsDictionary[Self.otherLinkerFlagsSetting],
-                    targetToDependenciesMetadata: targetToDependenciesMetadata
-                ) {
-                    mappedSettingsDictionary[Self.otherLinkerFlagsSetting] = updatedOtherLinkerFlags
                 }
 
                 let targetSettings = target.settings ?? Settings(
@@ -276,29 +267,5 @@ public final class ModuleMapMapper: GraphMapping { // swiftlint:disable:this typ
         }
 
         return .array(mappedOtherCFlags)
-    }
-
-    private static func updatedOtherLinkerFlags(
-        targetID: TargetID,
-        oldOtherLinkerFlags: SettingsDictionary.Value?,
-        targetToDependenciesMetadata: [TargetID: Set<DependencyMetadata>]
-    ) -> SettingsDictionary.Value? {
-        guard let dependenciesModuleMaps = targetToDependenciesMetadata[targetID]?.compactMap(\.moduleMapPath),
-              !dependenciesModuleMaps.isEmpty
-        else { return nil }
-
-        var mappedOtherLinkerFlags: [String]
-        switch oldOtherLinkerFlags ?? .array(["$(inherited)"]) {
-        case let .array(values):
-            mappedOtherLinkerFlags = values
-        case let .string(value):
-            mappedOtherLinkerFlags = value.split(separator: " ").map(String.init)
-        }
-
-        if !mappedOtherLinkerFlags.contains("-ObjC") {
-            mappedOtherLinkerFlags.append("-ObjC")
-        }
-
-        return .array(mappedOtherLinkerFlags)
     }
 }

--- a/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -114,7 +114,6 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
                     "-fmodule-map-file=$(SRCROOT)/../B/B2/B2.module",
                 ]),
                 "HEADER_SEARCH_PATHS": .array(["$(inherited)", "$(SRCROOT)/../B/B1/include", "$(SRCROOT)/../B/B2/include"]),
-                "OTHER_LDFLAGS": .array(["$(inherited)", "-ObjC"]),
             ]),
             dependencies: [
                 .project(target: "B1", path: projectBPath),
@@ -134,7 +133,6 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
                 "OTHER_CFLAGS": .array(["$(inherited)", "-fmodule-map-file=$(SRCROOT)/B2/B2.module"]),
                 "OTHER_SWIFT_FLAGS": .array(["$(inherited)", "-Xcc", "-fmodule-map-file=$(SRCROOT)/B2/B2.module"]),
                 "HEADER_SEARCH_PATHS": .array(["$(SRCROOT)/B1/include", "$(SRCROOT)/B2/include"]),
-                "OTHER_LDFLAGS": .array(["$(inherited)", "-ObjC"]),
             ]),
             dependencies: [
                 .target(name: "B2"),
@@ -262,7 +260,6 @@ final class ModuleMapMapperTests: TuistUnitTestCase {
                         "-fmodule-map-file=$(SRCROOT)/../B/B/B.module",
                     ]),
                     "HEADER_SEARCH_PATHS": .array(["$(inherited)", "$(SRCROOT)/../B/B/include"]),
-                    "OTHER_LDFLAGS": .array(["$(inherited)", "-ObjC"]),
                 ],
                 configurations: [:],
                 defaultSettings: .recommended

--- a/docs/docs/guide/project/dependencies.md
+++ b/docs/docs/guide/project/dependencies.md
@@ -194,3 +194,11 @@ pod install
 
 > [!WARNING] 
 > CocoaPods dependencies are not compatible with workflows like `build` or `test` that run `xcodebuild` right after generating the project. They are also incompatible with binary caching and selective testing since the fingerprinting logic doesn't account for the Pods dependencies.
+
+## Objective-C Dependencies
+
+When integrating Objective-C dependencies, the inclusion of certain flags on the consuming target may be necessary to avoid runtime crashes as detailed in [Apple Technical Q&A QA1490](https://developer.apple.com/library/archive/qa/qa1490/_index.html).
+
+Since the build system and Tuist have no way of inferring whether the flag is necessary or not, and since the flag comes with potentially undesirable side effects, Tuist will not automatically apply any of these flags, and because Swift Package Manager considers `-ObjC` to be included via an `.unsafeFlag` most packages cannot include it as part of their default linking settings when required.
+
+Consumers of Objective-C dependencies (or internal Objective-C targets) should apply  `-ObjC` or `-force_load` flags when required by setting `OTHER_LDFLAGS` on consuming targets.

--- a/fixtures/app_with_spm_dependencies/App/Project.swift
+++ b/fixtures/app_with_spm_dependencies/App/Project.swift
@@ -84,8 +84,8 @@ let project = Project(
                 with: [
                     "WKCompanionAppBundleIdentifier": "io.tuist.app",
                 ]
-            ),
-            sources: ["Sources/Watch/App/**"],
+            ), sources: ["Sources/Watch/App/**"],
+
             dependencies: [
                 .target(name: "WatchExtension"),
             ]

--- a/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
+++ b/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
@@ -32,7 +32,7 @@ public enum AppKit {
         _ = YAMLEncoder()
 
         // Use GoogleSignIn
-        _ = GIDSignIn.sharedInstance.hasPreviousSignIn()
+        _ = GIDSignIn.sharedInstance.configuration
 
         // Use Sentry
         SentrySDK.startSession()

--- a/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
+++ b/fixtures/app_with_spm_dependencies/App/Sources/AppKit/AppKit.swift
@@ -32,7 +32,7 @@ public enum AppKit {
         _ = YAMLEncoder()
 
         // Use GoogleSignIn
-        _ = GIDSignIn.sharedInstance.configuration
+        _ = GIDSignIn.sharedInstance.hasPreviousSignIn()
 
         // Use Sentry
         SentrySDK.startSession()

--- a/fixtures/app_with_spm_dependencies/README.md
+++ b/fixtures/app_with_spm_dependencies/README.md
@@ -1,0 +1,5 @@
+# Application with Swift Package Manager Dependencies
+
+This example contains an example that uses Swift Package Manager dependencies.
+
+It also contains a static Objective-C dependency that relies on the `-ObjC` linker flag to be added to the consuming application.

--- a/fixtures/app_with_spm_dependencies/Tuist/ProjectDescriptionHelpers/Settings+Templates.swift
+++ b/fixtures/app_with_spm_dependencies/Tuist/ProjectDescriptionHelpers/Settings+Templates.swift
@@ -12,6 +12,7 @@ extension ProjectDescription.Settings {
         .settings(
             base: [
                 "SOME_BASE_FLAG": .string("VALUE"),
+                "OTHER_LDFLAGS": .string("-ObjC"),
             ].otherSwiftFlags("-enable-actor-data-race-checks"),
             configurations: BuildEnvironment.allCases.map(\.targetConfiguration)
         )


### PR DESCRIPTION
This reverts commit 92970222bfa7a0e5fab9a56a86623907d375c4f5.

Resolves https://github.com/tuist/tuist/issues/6243

### Short description 📝

This reverts a change that automatically places `-ObjC` compiler flags with no opt-out behavior. This can cause issues in projects and make them unbuildable or bloat their binary size unnecessarily.

### How to test the changes locally 🧐

Test with `app_with_spm_dependencies` fixture and see that the `-ObjC` flag is not automatically added

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
