### PR TITLE
Add (void) to generated Obj-C Bundle accessor

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -213,7 +213,7 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
         #import <Foundation/Foundation.h>
         #import "TuistBundle+\(targetName).h"
 
-        NSBundle* \(targetName)_SWIFTPM_MODULE_BUNDLE() {
+        NSBundle* \(targetName)_SWIFTPM_MODULE_BUNDLE(void) {
             NSURL *bundleURL = [[[NSBundle mainBundle] bundleURL] URLByAppendingPathComponent:@"\(bundleName).bundle"];
 
             NSBundle *bundle = [NSBundle bundleWithURL:bundleURL];


### PR DESCRIPTION
### Short description 📝

When trying to cache our apps using Tuist Cloud, we bumped into the following failure:
<img width="1355" alt="image" src="https://github.com/tuist/tuist/assets/605076/4a0211f4-3524-4390-8191-2b51a53187f3">

Bumping into [this SO thread](https://stackoverflow.com/questions/75943541/a-function-declaration-without-a-prototype-is-deprecated-in-all-versions-of-c), it's possible it's because we have custom configuration that have Strict Prototypes (`CLANG_WARN_STRICT_PROTOTYPES`) set to YES, but the real fix is just passing `(void)` instead of just `()`, since this seems to be "the right thing": 

> Functions of the form void func () rather than void func (void) have been flagged as obsolescent by the C standard since the year 1990. So you should (for now) never write functions with an empty parenthesis in C. Unlike C++ where the two forms are equivalent.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
