### PR TITLE
Add Linting to require conditions for multiplatform dependencies with mismatched platforms.

### DIFF
--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -91,6 +91,7 @@ public class GraphLinter: GraphLinting {
         var issues: [LintingIssue] = []
   
         issues.append(contentsOf: lintDependencyRelationships(graphTraverser: graphTraverser))
+        issues.append(contentsOf: lintLinkableDependencies(graphTraverser: graphTraverser))
         issues.append(contentsOf: staticProductsLinter.lint(graphTraverser: graphTraverser, config: config))
         issues.append(contentsOf: lintPrecompiledFrameworkDependencies(graphTraverser: graphTraverser))
         issues.append(contentsOf: lintPackageDependencies(graphTraverser: graphTraverser))
@@ -98,7 +99,46 @@ public class GraphLinter: GraphLinting {
 
         return issues
     }
+    
+    private func lintLinkableDependencies(graphTraverser: GraphTraversing) -> [LintingIssue] {
+        let linkableProducts: Set<Product> = [
+            .framework,
+            .staticFramework,
+            .staticLibrary,
+            .dynamicLibrary,
+        ]
         
+        let dependencyIssues = graphTraverser.dependencies.flatMap { fromDependency, _ -> [LintingIssue] in
+            guard case let GraphDependency.target(fromTargetName, fromTargetPath) = fromDependency,
+                  let fromTarget = graphTraverser.target(path: fromTargetPath, name: fromTargetName) else { return [] }
+            
+            let fromPlatforms = fromTarget.target.supportedPlatforms
+            
+            let dependencies: [LintingIssue] = graphTraverser.directTargetDependencies(path: fromTargetPath, name: fromTargetName).flatMap { dependentTarget in
+                guard linkableProducts.contains(dependentTarget.target.product) else { return [LintingIssue]() }
+                
+                var requiredPlatforms = fromPlatforms
+                
+                if let condition = dependentTarget.condition {
+                    requiredPlatforms.formIntersection(Set(condition.platformFilters.compactMap(\.platform)))
+                }
+                
+                let unaccountedPlatforms = requiredPlatforms.subtracting(dependentTarget.target.supportedPlatforms)
+                
+                if !unaccountedPlatforms.isEmpty {
+                    let missingPlatforms = unaccountedPlatforms.map(\.rawValue).joined(separator: ", ")
+                    return [LintingIssue(reason: "Target \(fromTargetName) with depends on \(dependentTarget.target.name) and but does not support the required platforms \(missingPlatforms). This dependency requires a condition.", severity: .error)]
+                } else {
+                    return [LintingIssue]()
+                }
+            }
+
+            return dependencies
+        }
+        
+        return dependencyIssues
+    }
+    
     private func lintDependencyRelationships(graphTraverser: GraphTraversing) -> [LintingIssue] {
         let dependencyIssues = graphTraverser.dependencies.flatMap { fromDependency, toDependencies -> [LintingIssue] in
             toDependencies.flatMap { toDependency -> [LintingIssue] in

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -89,6 +89,17 @@ public class GraphLinter: GraphLinting {
 
     private func lintDependencies(graphTraverser: GraphTraversing, config: Config) -> [LintingIssue] {
         var issues: [LintingIssue] = []
+  
+        issues.append(contentsOf: lintDependencyRelationships(graphTraverser: graphTraverser))
+        issues.append(contentsOf: staticProductsLinter.lint(graphTraverser: graphTraverser, config: config))
+        issues.append(contentsOf: lintPrecompiledFrameworkDependencies(graphTraverser: graphTraverser))
+        issues.append(contentsOf: lintPackageDependencies(graphTraverser: graphTraverser))
+        issues.append(contentsOf: lintAppClip(graphTraverser: graphTraverser))
+
+        return issues
+    }
+        
+    private func lintDependencyRelationships(graphTraverser: GraphTraversing) -> [LintingIssue] {
         let dependencyIssues = graphTraverser.dependencies.flatMap { fromDependency, toDependencies -> [LintingIssue] in
             toDependencies.flatMap { toDependency -> [LintingIssue] in
                 guard case let GraphDependency.target(fromTargetName, fromTargetPath) = fromDependency else { return [] }
@@ -98,15 +109,10 @@ public class GraphLinter: GraphLinting {
                 return lintDependency(from: fromTarget, to: toTarget)
             }
         }
-
-        issues.append(contentsOf: dependencyIssues)
-        issues.append(contentsOf: staticProductsLinter.lint(graphTraverser: graphTraverser, config: config))
-        issues.append(contentsOf: lintPrecompiledFrameworkDependencies(graphTraverser: graphTraverser))
-        issues.append(contentsOf: lintPackageDependencies(graphTraverser: graphTraverser))
-        issues.append(contentsOf: lintAppClip(graphTraverser: graphTraverser))
-
-        return issues
+        return dependencyIssues
     }
+    
+    
 
     private func lintDependency(from: GraphTarget, to: GraphTarget) -> [LintingIssue] {
         let fromPlatforms = from.target.supportedPlatforms

--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -89,7 +89,7 @@ public class GraphLinter: GraphLinting {
 
     private func lintDependencies(graphTraverser: GraphTraversing, config: Config) -> [LintingIssue] {
         var issues: [LintingIssue] = []
-  
+
         issues.append(contentsOf: lintDependencyRelationships(graphTraverser: graphTraverser))
         issues.append(contentsOf: lintLinkableDependencies(graphTraverser: graphTraverser))
         issues.append(contentsOf: staticProductsLinter.lint(graphTraverser: graphTraverser, config: config))
@@ -99,7 +99,7 @@ public class GraphLinter: GraphLinting {
 
         return issues
     }
-    
+
     private func lintLinkableDependencies(graphTraverser: GraphTraversing) -> [LintingIssue] {
         let linkableProducts: Set<Product> = [
             .framework,
@@ -107,38 +107,42 @@ public class GraphLinter: GraphLinting {
             .staticLibrary,
             .dynamicLibrary,
         ]
-        
+
         let dependencyIssues = graphTraverser.dependencies.flatMap { fromDependency, _ -> [LintingIssue] in
             guard case let GraphDependency.target(fromTargetName, fromTargetPath) = fromDependency,
                   let fromTarget = graphTraverser.target(path: fromTargetPath, name: fromTargetName) else { return [] }
-            
+
             let fromPlatforms = fromTarget.target.supportedPlatforms
-            
-            let dependencies: [LintingIssue] = graphTraverser.directTargetDependencies(path: fromTargetPath, name: fromTargetName).flatMap { dependentTarget in
-                guard linkableProducts.contains(dependentTarget.target.product) else { return [LintingIssue]() }
-                
-                var requiredPlatforms = fromPlatforms
-                
-                if let condition = dependentTarget.condition {
-                    requiredPlatforms.formIntersection(Set(condition.platformFilters.compactMap(\.platform)))
+
+            let dependencies: [LintingIssue] = graphTraverser.directTargetDependencies(path: fromTargetPath, name: fromTargetName)
+                .flatMap { dependentTarget in
+                    guard linkableProducts.contains(dependentTarget.target.product) else { return [LintingIssue]() }
+
+                    var requiredPlatforms = fromPlatforms
+
+                    if let condition = dependentTarget.condition {
+                        requiredPlatforms.formIntersection(Set(condition.platformFilters.compactMap(\.platform)))
+                    }
+
+                    let unaccountedPlatforms = requiredPlatforms.subtracting(dependentTarget.target.supportedPlatforms)
+
+                    if !unaccountedPlatforms.isEmpty {
+                        let missingPlatforms = unaccountedPlatforms.map(\.rawValue).joined(separator: ", ")
+                        return [LintingIssue(
+                            reason: "Target \(fromTargetName) with depends on \(dependentTarget.target.name) and but does not support the required platforms \(missingPlatforms). This dependency requires a condition.",
+                            severity: .error
+                        )]
+                    } else {
+                        return [LintingIssue]()
+                    }
                 }
-                
-                let unaccountedPlatforms = requiredPlatforms.subtracting(dependentTarget.target.supportedPlatforms)
-                
-                if !unaccountedPlatforms.isEmpty {
-                    let missingPlatforms = unaccountedPlatforms.map(\.rawValue).joined(separator: ", ")
-                    return [LintingIssue(reason: "Target \(fromTargetName) with depends on \(dependentTarget.target.name) and but does not support the required platforms \(missingPlatforms). This dependency requires a condition.", severity: .error)]
-                } else {
-                    return [LintingIssue]()
-                }
-            }
 
             return dependencies
         }
-        
+
         return dependencyIssues
     }
-    
+
     private func lintDependencyRelationships(graphTraverser: GraphTraversing) -> [LintingIssue] {
         let dependencyIssues = graphTraverser.dependencies.flatMap { fromDependency, toDependencies -> [LintingIssue] in
             toDependencies.flatMap { toDependency -> [LintingIssue] in
@@ -151,8 +155,6 @@ public class GraphLinter: GraphLinting {
         }
         return dependencyIssues
     }
-    
-    
 
     private func lintDependency(from: GraphTarget, to: GraphTarget) -> [LintingIssue] {
         let fromPlatforms = from.target.supportedPlatforms

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -1906,7 +1906,10 @@ final class GraphLinterTests: TuistUnitTestCase {
                 .target(name: macOnlyTarget.name, path: path): [],
             ],
             dependencyConditions: [
-                GraphEdge(from: .target(name: iOSAndMacTarget.name, path: path), to: .target(name: macOnlyTarget.name, path: path)): try .test([.macos])
+                GraphEdge(
+                    from: .target(name: iOSAndMacTarget.name, path: path),
+                    to: .target(name: macOnlyTarget.name, path: path)
+                ): try .test([.macos]),
             ]
         )
         let config = Config.test()
@@ -1956,15 +1959,20 @@ final class GraphLinterTests: TuistUnitTestCase {
         // Then
         XCTAssertFalse(results.isEmpty)
     }
-    
+
     func test_lint_multiDestinationTarget_dependsOnTargetWithFewerSupportedPlatforms() throws {
         // Given
         let path = try temporaryPath()
         let iOSAndMacTarget = Target.test(name: "IOSAndMacTarget", destinations: [.iPhone, .mac], product: .framework)
         let iOSOnlyTarget = Target.test(name: "iOSOnlyTarget", destinations: [.iPhone], product: .framework)
-        
+
         let iOSApp = Target.test(name: "iOSApp", destinations: [.iPhone], product: .app)
-        let watchApp = Target.test(name: "WatchApp", destinations: [.appleWatch], product: .watch2App, bundleId: "io.tuist.iOSApp.WatchApp")
+        let watchApp = Target.test(
+            name: "WatchApp",
+            destinations: [.appleWatch],
+            product: .watch2App,
+            bundleId: "io.tuist.iOSApp.WatchApp"
+        )
 
         let project = Project.test(
             path: path,
@@ -1972,7 +1980,7 @@ final class GraphLinterTests: TuistUnitTestCase {
                 iOSAndMacTarget,
                 iOSOnlyTarget,
                 iOSApp,
-                watchApp
+                watchApp,
             ]
         )
         let graph = Graph.test(
@@ -1982,7 +1990,7 @@ final class GraphLinterTests: TuistUnitTestCase {
                     iOSAndMacTarget.name: iOSAndMacTarget,
                     iOSOnlyTarget.name: iOSOnlyTarget,
                     iOSApp.name: iOSApp,
-                    watchApp.name: watchApp
+                    watchApp.name: watchApp,
                 ],
             ],
             dependencies: [
@@ -2003,6 +2011,12 @@ final class GraphLinterTests: TuistUnitTestCase {
         let results = subject.lint(graphTraverser: graphTraverser, config: config)
 
         // Then
-        XCTAssertEqual(results, [LintingIssue(reason: "Target IOSAndMacTarget with depends on iOSOnlyTarget and but does not support the required platforms macos. This dependency requires a condition.", severity: .error)])
+        XCTAssertEqual(
+            results,
+            [LintingIssue(
+                reason: "Target IOSAndMacTarget with depends on iOSOnlyTarget and but does not support the required platforms macos. This dependency requires a condition.",
+                severity: .error
+            )]
+        )
     }
 }


### PR DESCRIPTION
- Extract dependency relationship linting to dedicated method
- Add linting to ensure conditions are included for targets that dont supported all the required platforms of a target.

Fixes #5978.

### Short description 📝

Adding linting to call out when a platform condition is required.  It's more complicated than just checking the set of platforms of each target because some target relationships (iOS app depending on WatchOS App) are valid.  Here we constrain the linting logic to just linkable targets but we could include 

### How to test the changes locally 🧐

Tests were added to replicate the issue and are passing with the addition of the linting rules.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
