### PR TITLE
Fix missing Products group in generated Projects

### DIFF
--- a/Sources/TuistGenerator/Generator/ProjectGroups.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGroups.swift
@@ -114,6 +114,14 @@ class ProjectGroups {
             projectGroups.append((item, projectGroup))
         }
 
+        /// Products
+        /// If the products group is the last non-empty group, it will not appear.
+        /// This appears to be an Xcode bug that is still there as of Xcode 15.3
+        /// https://developer.apple.com/forums/thread/77406
+        let productsGroup = PBXGroup(children: [], sourceTree: .group, name: "Products")
+        pbxproj.add(object: productsGroup)
+        mainGroup.children.append(productsGroup)
+        
         /// SDSKs & Pre-compiled frameworks
         let frameworksGroup = PBXGroup(children: [], sourceTree: .group, name: "Frameworks")
         pbxproj.add(object: frameworksGroup)
@@ -123,11 +131,6 @@ class ProjectGroups {
         let cacheGroup = PBXGroup(children: [], sourceTree: .group, name: "Cache")
         pbxproj.add(object: cacheGroup)
         mainGroup.children.append(cacheGroup)
-
-        /// Products
-        let productsGroup = PBXGroup(children: [], sourceTree: .group, name: "Products")
-        pbxproj.add(object: productsGroup)
-        mainGroup.children.append(productsGroup)
 
         return ProjectGroups(
             main: mainGroup,

--- a/Sources/TuistGenerator/Generator/ProjectGroups.swift
+++ b/Sources/TuistGenerator/Generator/ProjectGroups.swift
@@ -121,7 +121,7 @@ class ProjectGroups {
         let productsGroup = PBXGroup(children: [], sourceTree: .group, name: "Products")
         pbxproj.add(object: productsGroup)
         mainGroup.children.append(productsGroup)
-        
+
         /// SDSKs & Pre-compiled frameworks
         let frameworksGroup = PBXGroup(children: [], sourceTree: .group, name: "Frameworks")
         pbxproj.add(object: frameworksGroup)

--- a/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ProjectGroupsTests.swift
@@ -114,9 +114,9 @@ final class ProjectGroupsTests: XCTestCase {
             "B",
             "C",
             "A",
+            "Products",
             "Frameworks",
             "Cache",
-            "Products",
         ])
     }
 
@@ -157,9 +157,9 @@ final class ProjectGroupsTests: XCTestCase {
         let paths = subject.sortedMain.children.map(\.nameOrPath)
         XCTAssertEqual(paths, [
             "Project",
+            "Products",
             "Frameworks",
             "Cache",
-            "Products",
         ])
     }
 


### PR DESCRIPTION
Strangely, if the Products group is the last non-empty group in a project, it does not appear.  This seems to be an Xcode bug still present in Xcode 15.3
https://developer.apple.com/forums/thread/77406


### Short description 📝

Before: 
<img width="221" alt="image" src="https://github.com/tuist/tuist/assets/398293/4d60ff1e-01df-4e96-a14d-25e7a7be8b94">

After:
<img width="240" alt="image" src="https://github.com/tuist/tuist/assets/398293/515f33b1-9235-4fde-8c42-817bf91a9211">


### How to test the changes locally 🧐

Running tuist with this fix on a project that has at least one system framework dependency should exhibit the difference.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
