### PR TITLE
Remove trailing backslash from Cloud url if present

### DIFF
--- a/Sources/TuistLoader/Models+ManifestMappers/Cloud+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Cloud+ManifestMapper.swift
@@ -28,7 +28,7 @@ enum CloudManifestMapperError: FatalError {
 extension TuistGraph.Cloud {
     static func from(manifest: ProjectDescription.Cloud) throws -> TuistGraph.Cloud {
         var cloudURL: URL!
-        if let manifestCloudURL = URL(string: manifest.url) {
+        if let manifestCloudURL = URL(string: manifest.url.dropSuffix("/")) {
             cloudURL = manifestCloudURL
         } else {
             throw CloudManifestMapperError.invalidCloudURL(manifest.url)

--- a/Tests/TuistLoaderTests/Models+ManifestMappers/Cloud+ManifestMapperTests.swift
+++ b/Tests/TuistLoaderTests/Models+ManifestMappers/Cloud+ManifestMapperTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import TuistGraph
+import XCTest
+
+@testable import TuistLoader
+@testable import TuistSupportTesting
+
+final class CloudManifestMapperTests: TuistUnitTestCase {
+    func test_removes_trailing_back_slash_if_present_in_url() throws {
+        // When
+        let got = try TuistGraph.Cloud.from(
+            manifest: .cloud(
+                projectId: "tuist/tuist",
+                url: "https://cloud.tuist.io/"
+            )
+        )
+
+        // Then
+        XCTAssertEqual(
+            got,
+            .test(
+                url: URL(string: "https://cloud.tuist.io")!,
+                projectId: "tuist/tuist"
+            )
+        )
+    }
+}


### PR DESCRIPTION
### Short description 📝

If users specify a backslash in the `Cloud` URL, we'd send requests with double backslash.

### How to test the changes locally 🧐

Run `tuist cloud` command with a config that has a trailing backslash and observe routes don't have a duplicate backslash.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
