### PR TITLE
Fix integration of SPM packages with slashes in their targets names

### DIFF
--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -62,7 +62,7 @@ class TargetLinter: TargetLinting {
         bundleIdentifier = bundleIdentifier.replacingOccurrences(of: "\\$\\(.+\\)", with: "", options: .regularExpression)
 
         var allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
-        allowed.formUnion(CharacterSet(charactersIn: "-."))
+        allowed.formUnion(CharacterSet(charactersIn: "-./"))
 
         if !bundleIdentifier.unicodeScalars.allSatisfy({ allowed.contains($0) }) {
             let reason =

--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -36,7 +36,8 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
         var additionalTargets: [Target] = []
         var sideEffects: [SideEffectDescriptor] = []
 
-        let bundleName = "\(project.name)_\(target.name.replacingOccurrences(of: "-", with: "_"))"
+        let sanitizedTargetName = target.name.sanitizedModuleName
+        let bundleName = "\(project.name)_\(sanitizedTargetName)"
         var modifiedTarget = target
 
         if !target.supportsResources {

--- a/Sources/TuistGraph/Models/Target.swift
+++ b/Sources/TuistGraph/Models/Target.swift
@@ -83,7 +83,7 @@ public struct Target: Equatable, Hashable, Comparable, Codable {
         self.product = product
         self.destinations = destinations
         self.bundleId = bundleId
-        self.productName = productName ?? name.replacingOccurrences(of: "-", with: "_")
+        self.productName = productName ?? name.sanitizedModuleName
         self.deploymentTargets = deploymentTargets
         self.infoPlist = infoPlist
         self.entitlements = entitlements

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -375,6 +375,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
 
     fileprivate class func sanitize(targetName: String) -> String {
         targetName.replacingOccurrences(of: ".", with: "_")
+            .replacingOccurrences(of: "/", with: "_")
     }
 
     // swiftlint:disable:next function_body_length
@@ -596,7 +597,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
                 .sanitize(targetName: target.name)
                 .replacingOccurrences(of: "-", with: "_"),
             bundleId: target.name
-                .replacingOccurrences(of: "_", with: "."),
+                .replacingOccurrences(of: "_", with: ".").replacingOccurrences(of: "/", with: "."),
             deploymentTargets: deploymentTargets,
             infoPlist: .default,
             sources: sources,

--- a/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
@@ -59,7 +59,7 @@ public final class SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerMod
         let sanitizedModuleName = moduleName.sanitizedModuleName
         let umbrellaHeaderPath = publicHeadersPath.appending(component: sanitizedModuleName + ".h")
         let nestedUmbrellaHeaderPath = publicHeadersPath
-            .appending(components: sanitizedModuleName, moduleName + ".h")
+            .appending(components: sanitizedModuleName, sanitizedModuleName + ".h")
         let customModuleMapPath = try Self.customModuleMapPath(publicHeadersPath: publicHeadersPath)
         let generatedModuleMapPath: AbsolutePath
 
@@ -69,12 +69,12 @@ public final class SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerMod
                 .parentDirectory
                 .appending(
                     components: Constants.DerivedDirectory.dependenciesDerivedDirectory,
-                    moduleName,
-                    "\(moduleName).modulemap"
+                    sanitizedModuleName,
+                    "\(sanitizedModuleName).modulemap"
                 )
         } else {
             generatedModuleMapPath = packageDirectory.appending(
-                components: Constants.DerivedDirectory.name, "\(moduleName).modulemap"
+                components: Constants.DerivedDirectory.name, "\(sanitizedModuleName).modulemap"
             )
         }
 

--- a/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/SwiftPackageManagerModuleMapGenerator.swift
@@ -56,7 +56,7 @@ public final class SwiftPackageManagerModuleMapGenerator: SwiftPackageManagerMod
         moduleName: String,
         publicHeadersPath: AbsolutePath
     ) throws -> ModuleMap {
-        let sanitizedModuleName = moduleName.replacingOccurrences(of: "-", with: "_")
+        let sanitizedModuleName = moduleName.sanitizedModuleName
         let umbrellaHeaderPath = publicHeadersPath.appending(component: sanitizedModuleName + ".h")
         let nestedUmbrellaHeaderPath = publicHeadersPath
             .appending(components: sanitizedModuleName, moduleName + ".h")

--- a/Sources/TuistSupport/Extensions/String+Extras.swift
+++ b/Sources/TuistSupport/Extensions/String+Extras.swift
@@ -232,6 +232,12 @@ extension String {
             return self
         }
     }
+
+    /// Formats the current string to a Uniform Type Identifier
+    public var sanitizedModuleName: String {
+        replacingOccurrences(of: "-", with: "_")
+            .replacingOccurrences(of: "/", with: "_")
+    }
 }
 
 extension Array where Element: CustomStringConvertible {

--- a/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -428,7 +428,7 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
         // Given
         let projectName = "sdk-with-dash"
         let targetName = "target-with-dash"
-        let expectedBundleName = "\(projectName)_\(targetName.replacingOccurrences(of: "-", with: "_"))"
+        let expectedBundleName = "sdk-with-dash_target_with_dash"
         let sources: [SourceFile] = ["/ViewController.m", "/ViewController2.swift"]
         let resources: [ResourceFileElement] = [.file(path: "/AbsolutePath/Project/Resources/image.png")]
         let target = Target.test(name: targetName, product: .staticLibrary, sources: sources, resources: .init(resources))

--- a/fixtures/ios_app_with_spm_dependencies/App/Sources/ContentView.swift
+++ b/fixtures/ios_app_with_spm_dependencies/App/Sources/ContentView.swift
@@ -1,4 +1,5 @@
 import Buy
+import KSCrash_Installations
 import Pay
 import SwiftUI
 
@@ -7,6 +8,8 @@ struct ContentView: View {
         // Use Mobile Buy SDK
         _ = Card.CreditCard(firstName: "", lastName: "", number: "", expiryMonth: "", expiryYear: "")
         _ = PayAddress()
+        // Use KSCrash
+        _ = KSCrashInstallationStandard()
     }
 
     var body: some View {

--- a/fixtures/ios_app_with_spm_dependencies/Project.swift
+++ b/fixtures/ios_app_with_spm_dependencies/Project.swift
@@ -15,6 +15,8 @@ let project = Project(
             dependencies: [
                 .external(name: "Buy"),
                 .external(name: "Pay"),
+                .external(name: "KSCrash"),
+                .sdk(name: "c++", type: .library, status: .required),
             ]
         ),
         .target(

--- a/fixtures/ios_app_with_spm_dependencies/Tuist/Package.resolved
+++ b/fixtures/ios_app_with_spm_dependencies/Tuist/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "6ed714a381b77d6163cdedad8446d73742573b78187635c59175fa22d0a3df2c",
+  "originHash" : "fc3374625da9a1a42edd765287e0715853d94414eda5959e9d420d041ec3b010",
   "pins" : [
+    {
+      "identity" : "kscrash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kstenerud/KSCrash",
+      "state" : {
+        "revision" : "0ad825211ec38404e03b6f677a2312deb728528a",
+        "version" : "1.17.1"
+      }
+    },
     {
       "identity" : "mobile-buy-sdk-ios",
       "kind" : "remoteSourceControl",

--- a/fixtures/ios_app_with_spm_dependencies/Tuist/Package.swift
+++ b/fixtures/ios_app_with_spm_dependencies/Tuist/Package.swift
@@ -6,5 +6,7 @@ let package = Package(
     dependencies: [
         // Has space symbols in package name
         .package(url: "https://github.com/Shopify/mobile-buy-sdk-ios", exact: "12.0.0"),
+        // Has targets with slash symbols in their names
+        .package(url: "https://github.com/kstenerud/KSCrash", exact: "1.17.1"),
     ]
 )


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6145

### Short description 📝

Although targets names and bundle identifiers have to be [Uniform Type Identifiers](https://developer.apple.com/documentation/uniformtypeidentifiers/defining_file_and_data_types_for_your_app), SPM is able to process some non-compliant targets such as those that contain a slash "/" in their name just by replacing it with an underscore "_".
This PS brings the same to enable Tuist to work with dependencies like [KSCrash](https://github.com/kstenerud/KSCrash/tree/1.17.1).

### How to test the changes locally 🧐

KSCrash was added as an SPM dependency in the `app_with_spm_dependencies` fixture.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
