### PR TITLE
Fix integration of SPM packages with spaces in their name

### DIFF
--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceFixtures.swift
@@ -39,6 +39,7 @@ public enum TuistAcceptanceFixtures {
     case iosAppWithOnDemandResources
     case iosAppWithPluginsAndTemplates
     case iosAppWithPrivacyManifest
+    case iosAppWithSpmDependencies
     case iosAppWithRemoteBinarySwiftPackage
     case iosAppWithRemoteSwiftPackage
     case iosAppWithStaticFrameworks
@@ -142,6 +143,8 @@ public enum TuistAcceptanceFixtures {
             return "ios_app_with_multi_configs"
         case .iosAppWithOnDemandResources:
             return "ios_app_with_on_demand_resources"
+        case .iosAppWithSpmDependencies:
+            return "ios_app_with_spm_dependencies"
         case .iosAppWithPluginsAndTemplates:
             return "ios_app_with_plugins_and_templates"
         case .iosAppWithPrivacyManifest:

--- a/Sources/TuistCoreTesting/Graph/DependenciesGraph+TestData.swift
+++ b/Sources/TuistCoreTesting/Graph/DependenciesGraph+TestData.swift
@@ -676,7 +676,7 @@ extension DependenciesGraph {
             "FRAMEWORK_SEARCH_PATHS": ["$(inherited)", "$(PLATFORM_DIR)/Developer/Library/Frameworks"],
             "GCC_NO_COMMON_BLOCKS": "NO",
             "USE_HEADERMAP": "NO",
-            "OTHER_SWIFT_FLAGS": ["-package-name", packageName],
+            "OTHER_SWIFT_FLAGS": ["-package-name", packageName.quotedIfContainsSpaces],
         ]
         var settingsDictionary = customSettings.merging(defaultSpmSettings, uniquingKeysWith: { custom, _ in custom })
 

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -292,16 +292,10 @@ public final class PackageInfoMapper: PackageInfoMapping {
             }
         )
 
-        let sanitizedPackageName = if packageInfo.name.contains(" ") {
-            "\"\(packageInfo.name)\""
-        } else {
-            packageInfo.name
-        }
-
         let baseSettings = packageSettings.baseSettings.with(
             base: packageSettings.baseSettings.base.combine(
                 with: [
-                    "OTHER_SWIFT_FLAGS": ["$(inherited)", "-package-name", sanitizedPackageName],
+                    "OTHER_SWIFT_FLAGS": ["$(inherited)", "-package-name", packageInfo.name.quotedIfContainsSpaces],
                 ]
             )
         )

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -292,10 +292,16 @@ public final class PackageInfoMapper: PackageInfoMapping {
             }
         )
 
+        let sanitizedPackageName = if packageInfo.name.contains(" ") {
+            "\"\(packageInfo.name)\""
+        } else {
+            packageInfo.name
+        }
+
         let baseSettings = packageSettings.baseSettings.with(
             base: packageSettings.baseSettings.base.combine(
                 with: [
-                    "OTHER_SWIFT_FLAGS": ["$(inherited)", "-package-name", packageInfo.name],
+                    "OTHER_SWIFT_FLAGS": ["$(inherited)", "-package-name", sanitizedPackageName],
                 ]
             )
         )

--- a/Sources/TuistSupport/Extensions/String+Extras.swift
+++ b/Sources/TuistSupport/Extensions/String+Extras.swift
@@ -223,6 +223,15 @@ extension String {
             return true
         }
     }
+
+    /// Encloses the current string inside quotes if it contains spaces
+    public var quotedIfContainsSpaces: String {
+        if contains(" ") {
+            return "\"\(self)\""
+        } else {
+            return self
+        }
+    }
 }
 
 extension Array where Element: CustomStringConvertible {

--- a/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
+++ b/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
@@ -152,3 +152,12 @@ final class BuildAcceptanceTestMultiplatformAppWithMacrosAndEmbeddedWatchOSApp: 
         try await run(BuildCommand.self, "App", "--platform", "ios")
     }
 }
+
+final class BuildAcceptanceTestIosAppWithSPMDependencies: TuistAcceptanceTestCase {
+    func test() async throws {
+        try setUpFixture(.iosAppWithSpmDependencies)
+        try await run(InstallCommand.self)
+        try await run(GenerateCommand.self)
+        try await run(BuildCommand.self, "App", "--platform", "ios")
+    }
+}

--- a/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
+++ b/Tests/TuistDependenciesAcceptanceTests/DependenciesAcceptanceTests.swift
@@ -31,3 +31,13 @@ final class DependenciesAcceptanceTestAppWithSPMDependenciesWithoutInstall: Tuis
         XCTFail("Generate should have failed.")
     }
 }
+
+final class DependenciesAcceptanceTestIosAppWithSPMDependencies: TuistAcceptanceTestCase {
+    func test_ios_app_spm_dependencies() async throws {
+        try setUpFixture(.iosAppWithSpmDependencies)
+        try await run(InstallCommand.self)
+        try await run(GenerateCommand.self)
+        try await run(BuildCommand.self, "App")
+        try await run(TestCommand.self, "App")
+    }
+}

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -3223,6 +3223,46 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             expectedTargets
         )
     }
+
+    func testMap_whenTargetNameContainsSpaces() throws {
+        let packageName = "Package With Space"
+        let basePath = try temporaryPath()
+        let sourcesPath = basePath.appending(try RelativePath(validating: "\(packageName)/Sources/Target1"))
+        try fileHandler.createFolder(sourcesPath)
+
+        let project = try subject.map(
+            package: packageName,
+            basePath: basePath,
+            packageInfos: [
+                packageName: .init(
+                    name: packageName,
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(name: "Target1"),
+                    ],
+                    platforms: [.ios],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ]
+        )
+        XCTAssertBetterEqual(
+            project,
+            .testWithDefaultConfigs(
+                name: packageName,
+                targets: [
+                    .test(
+                        "Target1",
+                        packageName: packageName,
+                        basePath: basePath
+                    ),
+                ]
+            )
+        )
+    }
 }
 
 private func defaultSpmResources(_ target: String, customPath: String? = nil) -> ProjectDescription.ResourceFileElements {
@@ -3394,7 +3434,7 @@ extension ProjectDescription.Target {
             // swiftlint:disable:next force_try
             sources =
                 .sourceFilesList(globs: [
-                    basePath.appending(try! RelativePath(validating: "Package/Sources/\(name)/**"))
+                    basePath.appending(try! RelativePath(validating: "\(packageName)/Sources/\(name)/**"))
                         .pathString,
                 ])
         }

--- a/fixtures/ios_app_with_spm_dependencies/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/fixtures/ios_app_with_spm_dependencies/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_spm_dependencies/App/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/fixtures/ios_app_with_spm_dependencies/App/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_spm_dependencies/App/Resources/Assets.xcassets/Contents.json
+++ b/fixtures/ios_app_with_spm_dependencies/App/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_spm_dependencies/App/Resources/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/fixtures/ios_app_with_spm_dependencies/App/Resources/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fixtures/ios_app_with_spm_dependencies/App/Sources/AppApp.swift
+++ b/fixtures/ios_app_with_spm_dependencies/App/Sources/AppApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct AppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/fixtures/ios_app_with_spm_dependencies/App/Sources/ContentView.swift
+++ b/fixtures/ios_app_with_spm_dependencies/App/Sources/ContentView.swift
@@ -1,0 +1,24 @@
+import Buy
+import Pay
+import SwiftUI
+
+struct ContentView: View {
+    init() {
+        // Use Mobile Buy SDK
+        _ = Card.CreditCard(firstName: "", lastName: "", number: "", expiryMonth: "", expiryYear: "")
+        _ = PayAddress()
+    }
+
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/fixtures/ios_app_with_spm_dependencies/AppTests/AppTests.swift
+++ b/fixtures/ios_app_with_spm_dependencies/AppTests/AppTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import App
+
+final class AppTests: XCTestCase {
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+}

--- a/fixtures/ios_app_with_spm_dependencies/Project.swift
+++ b/fixtures/ios_app_with_spm_dependencies/Project.swift
@@ -1,0 +1,31 @@
+import ProjectDescription
+
+let project = Project(
+    name: "App",
+    targets: [
+        .target(
+            name: "App",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "io.tuist.app",
+            deploymentTargets: .iOS("14.0"),
+            infoPlist: .default,
+            sources: "App/Sources/**",
+            resources: "App/Resources/**",
+            dependencies: [
+                .external(name: "Buy"),
+                .external(name: "Pay"),
+            ]
+        ),
+        .target(
+            name: "AppTests",
+            destinations: .iOS,
+            product: .unitTests,
+            bundleId: "io.tuist.app.tests",
+            deploymentTargets: .iOS("14.0"),
+            infoPlist: .default,
+            sources: "AppTests/**",
+            dependencies: [.target(name: "App")]
+        ),
+    ]
+)

--- a/fixtures/ios_app_with_spm_dependencies/README.md
+++ b/fixtures/ios_app_with_spm_dependencies/README.md
@@ -1,0 +1,3 @@
+# iOS app with SPM dependencies
+
+An iOS application project with various SPM dependencies.

--- a/fixtures/ios_app_with_spm_dependencies/Tuist/Package.resolved
+++ b/fixtures/ios_app_with_spm_dependencies/Tuist/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "6ed714a381b77d6163cdedad8446d73742573b78187635c59175fa22d0a3df2c",
+  "pins" : [
+    {
+      "identity" : "mobile-buy-sdk-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Shopify/mobile-buy-sdk-ios",
+      "state" : {
+        "revision" : "6bd23c2f6243f73ef6ec135723d4909bc068409e",
+        "version" : "12.0.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/fixtures/ios_app_with_spm_dependencies/Tuist/Package.swift
+++ b/fixtures/ios_app_with_spm_dependencies/Tuist/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version: 5.10
+import PackageDescription
+
+let package = Package(
+    name: "PackageName",
+    dependencies: [
+        // Has space symbols in package name
+        .package(url: "https://github.com/Shopify/mobile-buy-sdk-ios", exact: "12.0.0"),
+    ]
+)


### PR DESCRIPTION
### Short description 📝

> Describe here the purpose of your PR.

If a package contains space symbols in its name, PackageInfoMapper produces invalid Swift flags, making compiler recognize words as separate flags:
`OTHER_SWIFT_FLAGS = "$(inherited) -package-name Mobile Buy SDK";`
This PR fixes this by enclosing such names inside quotes:
`OTHER_SWIFT_FLAGS = "$(inherited) -package-name \"Mobile Buy SDK\"";`

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

This PR adds a new fixture `ios_app_with_spm_dependencies` with an application target that depends on [Mobile Buy SDK](https://github.com/Shopify/mobile-buy-sdk-ios)

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
