### PR TITLE
Fix --platform case sensitivity with test and build commands

### DIFF
--- a/Sources/TuistGraph/Models/Platform.swift
+++ b/Sources/TuistGraph/Models/Platform.swift
@@ -1,4 +1,14 @@
 import Foundation
+import TuistSupport
+
+struct UnsupportedPlatformError: FatalError, CustomStringConvertible, Equatable {
+    let type: TuistSupport.ErrorType = .abort
+
+    let input: String
+    var description: String {
+        "Specified platform \(input) does not map to any of these supported platforms: \(Platform.allCases.map(\.caseValue).joined(separator: ", ")) "
+    }
+}
 
 public enum Platform: String, CaseIterable, Codable, Comparable {
     case iOS = "ios"
@@ -15,6 +25,17 @@ public enum Platform: String, CaseIterable, Codable, Comparable {
         case .watchOS: return "watchOS"
         case .visionOS: return "visionOS"
         }
+    }
+
+    init?(commandLineValue: String) {
+        self.init(rawValue: commandLineValue.lowercased())
+    }
+
+    public static func from(commandLineValue: String) throws -> Platform {
+        guard let platform = Platform(rawValue: commandLineValue.lowercased()) else {
+            throw UnsupportedPlatformError(input: commandLineValue)
+        }
+        return platform
     }
 
     public static func < (lhs: Platform, rhs: Platform) -> Bool {

--- a/Sources/TuistKit/Services/BuildService.swift
+++ b/Sources/TuistKit/Services/BuildService.swift
@@ -110,8 +110,8 @@ public final class BuildService {
 
             let buildPlatform: TuistGraph.Platform
 
-            if let platform, let inputPlatform = TuistGraph.Platform(rawValue: platform) {
-                buildPlatform = inputPlatform
+            if let platform {
+                buildPlatform = try TuistGraph.Platform.from(commandLineValue: platform)
             } else {
                 buildPlatform = try graphTarget.target.servicePlatform
             }
@@ -141,8 +141,8 @@ public final class BuildService {
 
                 let buildPlatform: TuistGraph.Platform
 
-                if let platform, let inputPlatform = TuistGraph.Platform(rawValue: platform) {
-                    buildPlatform = inputPlatform
+                if let platform {
+                    buildPlatform = try TuistGraph.Platform.from(commandLineValue: platform)
                 } else {
                     buildPlatform = try graphTarget.target.servicePlatform
                 }

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -338,8 +338,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
 
         let buildPlatform: TuistGraph.Platform
 
-        if let platform, let inputPlatform = TuistGraph.Platform(rawValue: platform) {
-            buildPlatform = inputPlatform
+        if let platform {
+            buildPlatform = try TuistGraph.Platform.from(commandLineValue: platform)
         } else {
             buildPlatform = try buildableTarget.target.servicePlatform
         }

--- a/Tests/TuistGraphTests/Models/PlatformTests.swift
+++ b/Tests/TuistGraphTests/Models/PlatformTests.swift
@@ -19,6 +19,38 @@ final class PlatformTests: XCTestCase {
         XCTAssertCodable(subject)
     }
 
+    func test_caseInsensitiveCommandInput() {
+        XCTAssertEqual(Platform.macOS, Platform(commandLineValue: "macos"))
+        XCTAssertEqual(Platform.macOS, Platform(commandLineValue: "macOS"))
+        XCTAssertEqual(Platform.macOS, Platform(commandLineValue: "MACOS"))
+        XCTAssertEqual(Platform.iOS, Platform(commandLineValue: "ios"))
+        XCTAssertEqual(Platform.iOS, Platform(commandLineValue: "iOS"))
+        XCTAssertEqual(Platform.iOS, Platform(commandLineValue: "IOS"))
+        XCTAssertEqual(Platform.tvOS, Platform(commandLineValue: "tvos"))
+        XCTAssertEqual(Platform.tvOS, Platform(commandLineValue: "tvOS"))
+        XCTAssertEqual(Platform.watchOS, Platform(commandLineValue: "watchos"))
+        XCTAssertEqual(Platform.watchOS, Platform(commandLineValue: "watchOS"))
+        XCTAssertEqual(Platform.visionOS, Platform(commandLineValue: "visionos"))
+        XCTAssertEqual(Platform.visionOS, Platform(commandLineValue: "visionOS"))
+    }
+
+    func test_caseInvalidPlatform_throws() {
+        do {
+            let _ = try Platform.from(commandLineValue: "not_a_platform")
+            XCTFail("Expected erro to be thrown")
+        } catch let error as UnsupportedPlatformError {
+            XCTAssertEqual(error, UnsupportedPlatformError(input: "not_a_platform"))
+        } catch {
+            XCTFail("Unexpected error thrown")
+        }
+    }
+
+    func test_caseValidPlatform_doesNotThrow() throws {
+        XCTAssertEqual(Platform.iOS, try Platform.from(commandLineValue: "iOS"))
+        XCTAssertEqual(Platform.macOS, try Platform.from(commandLineValue: "macOS"))
+        XCTAssertEqual(Platform.macOS, try Platform.from(commandLineValue: "macos"))
+    }
+
     func test_xcodeSdkRoot_returns_the_right_value() {
         XCTAssertEqual(Platform.macOS.xcodeSdkRoot, "macosx")
         XCTAssertEqual(Platform.iOS.xcodeSdkRoot, "iphoneos")


### PR DESCRIPTION
Changed based on user feedback that `--platform iOS` doesn't work.  It should.  So lets lowercase our input and provide better messaging if we get an invalid value.

### How to test the changes locally 🧐

Run `tuist build` with various values for `--platform`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
