### PR TITLE
Add status to CommandEvent

### DIFF
--- a/Sources/TuistAnalytics/Models/CommandEvent.swift
+++ b/Sources/TuistAnalytics/Models/CommandEvent.swift
@@ -15,6 +15,11 @@ public struct CommandEvent: Codable, Equatable, AsyncQueueEvent {
     public let macOSVersion: String
     public let machineHardwareName: String
     public let isCI: Bool
+    public let status: Status
+
+    public enum Status: Codable, Equatable {
+        case success, failure(String)
+    }
 
     public let id = UUID()
     public let date = Date()
@@ -32,6 +37,7 @@ public struct CommandEvent: Codable, Equatable, AsyncQueueEvent {
         case macOSVersion = "macos_version"
         case machineHardwareName
         case isCI
+        case status
     }
 
     public init(
@@ -45,7 +51,8 @@ public struct CommandEvent: Codable, Equatable, AsyncQueueEvent {
         swiftVersion: String,
         macOSVersion: String,
         machineHardwareName: String,
-        isCI: Bool
+        isCI: Bool,
+        status: Status
     ) {
         self.name = name
         self.subcommand = subcommand
@@ -58,5 +65,6 @@ public struct CommandEvent: Codable, Equatable, AsyncQueueEvent {
         self.macOSVersion = macOSVersion
         self.machineHardwareName = machineHardwareName
         self.isCI = isCI
+        self.status = status
     }
 }

--- a/Sources/TuistKit/Commands/TrackableCommand/CommandEventFactory.swift
+++ b/Sources/TuistKit/Commands/TrackableCommand/CommandEventFactory.swift
@@ -27,7 +27,8 @@ public final class CommandEventFactory {
             swiftVersion: machineEnvironment.swiftVersion,
             macOSVersion: machineEnvironment.macOSVersion,
             machineHardwareName: machineEnvironment.hardwareName,
-            isCI: machineEnvironment.isCI
+            isCI: machineEnvironment.isCI,
+            status: info.status
         )
         return commandEvent
     }

--- a/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
+++ b/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
@@ -1,6 +1,7 @@
 import AnyCodable
 import ArgumentParser
 import Foundation
+import TuistAnalytics
 import TuistAsyncQueue
 import TuistSupport
 
@@ -11,6 +12,7 @@ public struct TrackableCommandInfo {
     let parameters: [String: AnyCodable]
     let commandArguments: [String]
     let durationInMs: Int
+    let status: CommandEvent.Status
 }
 
 /// A `TrackableCommand` wraps a `ParsableCommand` and reports its execution to an analytics provider
@@ -41,11 +43,20 @@ public class TrackableCommand: TrackableParametersDelegate {
         if let command = command as? HasTrackableParameters {
             type(of: command).analyticsDelegate = self
         }
-        if var asyncCommand = command as? AsyncParsableCommand {
-            try await asyncCommand.run()
-        } else {
-            try command.run()
+        do {
+            if var asyncCommand = command as? AsyncParsableCommand {
+                try await asyncCommand.run()
+            } else {
+                try command.run()
+            }
+            try dispatchCommandEvent(timer: timer, status: .success)
+        } catch {
+            try dispatchCommandEvent(timer: timer, status: .failure("\(error)"))
+            throw error
         }
+    }
+
+    private func dispatchCommandEvent(timer: any ClockTimer, status: CommandEvent.Status) throws {
         let durationInSeconds = timer.stop()
         let durationInMs = Int(durationInSeconds * 1000)
         let configuration = type(of: command).configuration
@@ -55,7 +66,8 @@ public class TrackableCommand: TrackableParametersDelegate {
             subcommand: subcommand,
             parameters: trackedParameters,
             commandArguments: commandArguments,
-            durationInMs: durationInMs
+            durationInMs: durationInMs,
+            status: status
         )
         let commandEvent = commandEventFactory.make(from: info)
         try asyncQueue.dispatch(event: commandEvent)

--- a/Tests/TuistKitTests/CommandTracking/CommandEventFactoryTests.swift
+++ b/Tests/TuistKitTests/CommandTracking/CommandEventFactoryTests.swift
@@ -32,7 +32,8 @@ final class CommandEventFactoryTests: TuistUnitTestCase {
             subcommand: "warm",
             parameters: ["foo": "bar"],
             commandArguments: ["cache", "warm"],
-            durationInMs: 5000
+            durationInMs: 5000,
+            status: .failure("Failed!")
         )
         let expectedEvent = CommandEvent(
             name: "cache",
@@ -45,7 +46,8 @@ final class CommandEventFactoryTests: TuistUnitTestCase {
             swiftVersion: "5.1",
             macOSVersion: "10.15.0",
             machineHardwareName: "arm64",
-            isCI: false
+            isCI: false,
+            status: .failure("Failed!")
         )
 
         // When

--- a/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
+++ b/Tests/TuistKitTests/CommandTracking/TrackableCommandTests.swift
@@ -25,9 +25,12 @@ final class TrackableCommandTests: TuistTestCase {
         super.tearDown()
     }
 
-    private func makeSubject(flag: Bool = true) {
+    private func makeSubject(
+        flag: Bool = true,
+        shouldFail: Bool = false
+    ) {
         subject = TrackableCommand(
-            command: TestCommand(flag: flag),
+            command: TestCommand(flag: flag, shouldFail: shouldFail),
             commandArguments: ["cache", "warm"],
             clock: WallClock(),
             asyncQueue: mockAsyncQueue
@@ -64,18 +67,51 @@ final class TrackableCommandTests: TuistTestCase {
         XCTAssertEqual(event.name, "test")
         XCTAssertEqual(event.params, expectedParams)
     }
+
+    func test_whenCommandFails_dispatchesEventWithExpectedInfo() async throws {
+        // Given
+        makeSubject(flag: false, shouldFail: true)
+        let expectedParams: [String: AnyCodable] = ["flag": false]
+        // When
+        await XCTAssertThrowsSpecific(try await subject.run(), TestCommand.TestError.commandFailed)
+
+        // Then
+        XCTAssertEqual(mockAsyncQueue.invokedDispatchCount, 1)
+        let event = try XCTUnwrap(mockAsyncQueue.invokedDispatchParameters?.event as? CommandEvent)
+        XCTAssertEqual(event.name, "test")
+        XCTAssertEqual(event.status, .failure("Command failed"))
+    }
 }
 
 private struct TestCommand: ParsableCommand, HasTrackableParameters {
+    enum TestError: FatalError, Equatable {
+        case commandFailed
+
+        var type: TuistSupport.ErrorType {
+            switch self {
+            case .commandFailed:
+                return .abort
+            }
+        }
+
+        var description: String {
+            "Command failed"
+        }
+    }
+
     static var configuration: CommandConfiguration {
         CommandConfiguration(commandName: "test")
     }
 
     var flag: Bool = false
+    var shouldFail: Bool = false
 
     static var analyticsDelegate: TrackableParametersDelegate?
 
     func run() throws {
+        if shouldFail {
+            throw TestError.commandFailed
+        }
         TestCommand.analyticsDelegate?.addParameters(["flag": AnyCodable(flag)])
     }
 }


### PR DESCRIPTION
### Short description 📝

This addition will allow us to track the status of the command along with the error message if a command fails.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x]  The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
