### PR TITLE
Fix target linter warnings for target products that allow dots and hyphens

### DIFF
--- a/Sources/TuistGenerator/Linter/TargetLinter.swift
+++ b/Sources/TuistGenerator/Linter/TargetLinter.swift
@@ -76,14 +76,14 @@ class TargetLinter: TargetLinting {
     private func lintProductName(target: Target) -> [LintingIssue] {
         var allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
 
-        let allowsDot = target.product == .app || target.product == .commandLineTool
-        if allowsDot {
-            allowed.formUnion(CharacterSet(charactersIn: "."))
+        let allowsExtraCharacters = target.product != .framework && target.product != .staticFramework
+        if allowsExtraCharacters {
+            allowed.formUnion(CharacterSet(charactersIn: ".-"))
         }
 
         if target.productName.unicodeScalars.allSatisfy(allowed.contains) == false {
             let reason =
-                "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9)\(allowsDot ? ", period (.)" : ""), and underscore (_) characters."
+                "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9)\(allowsExtraCharacters ? ", period (.), hyphen (-)" : ""), and underscore (_) characters."
 
             return [LintingIssue(reason: reason, severity: .warning)]
         }

--- a/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/TargetLinterTests.swift
@@ -27,12 +27,12 @@ final class TargetLinterTests: TuistUnitTestCase {
             let got = self.subject.lint(target: target)
             let reason: String
             switch target.product {
-            case .app, .commandLineTool:
-                reason =
-                    "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), period (.), and underscore (_) characters."
-            default:
+            case .framework, .staticFramework:
                 reason =
                     "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), and underscore (_) characters."
+            default:
+                reason =
+                    "Invalid product name '\(target.productName)'. This string must contain only alphanumeric (A-Z,a-z,0-9), period (.), hyphen (-), and underscore (_) characters."
             }
 
             self.XCTContainsLintingIssue(got, LintingIssue(reason: reason, severity: .warning))
@@ -44,11 +44,14 @@ final class TargetLinterTests: TuistUnitTestCase {
         }
 
         XCTAssertValidProductNameApp(Target.test(product: .app, productName: "MyApp.iOS"))
+        XCTAssertValidProductNameApp(Target.test(product: .app, productName: "MyApp-iOS"))
+        XCTAssertValidProductNameApp(Target.test(product: .bundle, productName: "MyBundle.macOS"))
+        XCTAssertValidProductNameApp(Target.test(product: .bundle, productName: "MyBundle-macOS"))
         XCTAssertValidProductNameApp(Target.test(productName: "MyFramework_iOS"))
         XCTAssertValidProductNameApp(Target.test(productName: "MyFramework"))
 
         XCTAssertInvalidProductNameApp(Target.test(product: .framework, productName: "MyFramework.iOS"))
-        XCTAssertInvalidProductNameApp(Target.test(productName: "MyFramework-iOS"))
+        XCTAssertInvalidProductNameApp(Target.test(product: .framework, productName: "MyFramework-iOS"))
         XCTAssertInvalidProductNameApp(Target.test(productName: "ⅫFramework"))
         XCTAssertInvalidProductNameApp(Target.test(productName: "ؼFramework"))
     }


### PR DESCRIPTION
Resolves #6289
### Short description 📝

This PR fixes the target linter to allow dot (".") and hyphen ("-") in some types of target products.

### How to test the changes locally 🧐

Generate the `app_with_spm_dependencies` fixture. Target linter warnings for BrazeUI dependency bundles should not appear anymore.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
