### PR TITLE
Add capability to specify variable entitlements

### DIFF
--- a/Sources/ProjectDescription/Entitlements.swift
+++ b/Sources/ProjectDescription/Entitlements.swift
@@ -9,7 +9,26 @@ public enum Entitlements: Codable, Equatable {
     /// A dictionary with the entitlements content. Tuist generates the .entitlements file at the generation time.
     case dictionary([String: Plist.Value])
 
-    /// A user defined xcconfig variable map to .entitlements file
+    /**
+      A user defined xcconfig variable map to .entitlements file.
+
+      This should be used when the project has different entitlements files per config (aka: debug,release,staging,etc)
+
+       ````
+      .target(
+          ...
+          entitlements: .variable("$(ENTITLEMENT_FILE_VARIABLE)"),
+      )
+       ````
+
+      Or as literal string
+      ````
+     .target(
+         ...
+         entitlements: $(ENTITLEMENT_FILE_VARIABLE),
+     )
+      ````
+      */
     case variable(String)
 
     // MARK: - Error

--- a/Sources/ProjectDescription/Entitlements.swift
+++ b/Sources/ProjectDescription/Entitlements.swift
@@ -10,7 +10,7 @@ public enum Entitlements: Codable, Equatable {
     case dictionary([String: Plist.Value])
 
     /// A user defined xcconfig variable map to .entitlements file
-    case xcconfig(String? = nil)
+    case variable(String)
 
     // MARK: - Error
 
@@ -35,7 +35,7 @@ public enum Entitlements: Codable, Equatable {
 extension Entitlements: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
         if value.hasPrefix("$(") {
-            self = .xcconfig(value)
+            self = .variable(value)
         } else {
             self = .file(path: .path(value))
         }

--- a/Sources/ProjectDescription/Entitlements.swift
+++ b/Sources/ProjectDescription/Entitlements.swift
@@ -9,6 +9,9 @@ public enum Entitlements: Codable, Equatable {
     /// A dictionary with the entitlements content. Tuist generates the .entitlements file at the generation time.
     case dictionary([String: Plist.Value])
 
+    /// A user defined xcconfig variable map to .entitlements file
+    case xcconfig(String? = nil)
+
     // MARK: - Error
 
     public enum CodingError: Error {
@@ -31,6 +34,10 @@ public enum Entitlements: Codable, Equatable {
 
 extension Entitlements: ExpressibleByStringInterpolation {
     public init(stringLiteral value: String) {
-        self = .file(path: .path(value))
+        if value.hasPrefix("$(") {
+            self = .xcconfig(value)
+        } else {
+            self = .file(path: .path(value))
+        }
     }
 }

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -260,7 +260,7 @@ final class ConfigGenerator: ConfigGenerating {
                     settings["CODE_SIGN_ENTITLEMENTS"] = .string("$(SRCROOT)/\(relativePath)")
                 }
             }
-            if case let .xcconfig(configName) = entitlements {
+            if case let .variable(configName) = entitlements {
                 settings["CODE_SIGN_ENTITLEMENTS"] = .string(configName)
             }
         }

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -251,12 +251,17 @@ final class ConfigGenerator: ConfigGenerating {
         }
 
         // Entitlements
-        if let entitlements = target.entitlements, let path = entitlements.path {
-            let relativePath = path.relative(to: sourceRootPath).pathString
-            if project.xcodeProjPath.parentDirectory == sourceRootPath {
-                settings["CODE_SIGN_ENTITLEMENTS"] = .string(relativePath)
-            } else {
-                settings["CODE_SIGN_ENTITLEMENTS"] = .string("$(SRCROOT)/\(relativePath)")
+        if let entitlements = target.entitlements {
+            if let path = entitlements.path {
+                let relativePath = path.relative(to: sourceRootPath).pathString
+                if project.xcodeProjPath.parentDirectory == sourceRootPath {
+                    settings["CODE_SIGN_ENTITLEMENTS"] = .string(relativePath)
+                } else {
+                    settings["CODE_SIGN_ENTITLEMENTS"] = .string("$(SRCROOT)/\(relativePath)")
+                }
+            }
+            if case let .xcconfig(configName) = entitlements {
+                settings["CODE_SIGN_ENTITLEMENTS"] = .string(configName)
             }
         }
 

--- a/Sources/TuistGenerator/Generator/ConfigGenerator.swift
+++ b/Sources/TuistGenerator/Generator/ConfigGenerator.swift
@@ -259,8 +259,7 @@ final class ConfigGenerator: ConfigGenerating {
                 } else {
                     settings["CODE_SIGN_ENTITLEMENTS"] = .string("$(SRCROOT)/\(relativePath)")
                 }
-            }
-            if case let .variable(configName) = entitlements {
+            } else if case let .variable(configName) = entitlements {
                 settings["CODE_SIGN_ENTITLEMENTS"] = .string(configName)
             }
         }

--- a/Sources/TuistGraph/Models/Plist.swift
+++ b/Sources/TuistGraph/Models/Plist.swift
@@ -141,7 +141,7 @@ public enum Entitlements: Equatable, Codable {
     case dictionary([String: Plist.Value])
 
     // A user defined xcconfig variable map to .entitlements file
-    case xcconfig(String)
+    case variable(String)
 
     // MARK: - Public
 
@@ -159,6 +159,10 @@ public enum Entitlements: Equatable, Codable {
 
 extension Entitlements: ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
-        self = .file(path: try! AbsolutePath(validating: value)) // swiftlint:disable:this force_try
+        if value.hasPrefix("$(") {
+            self = .variable(value)
+        } else {
+            self = .file(path: try! AbsolutePath(validating: value)) // swiftlint:disable:this force_try
+        }
     }
 }

--- a/Sources/TuistGraph/Models/Plist.swift
+++ b/Sources/TuistGraph/Models/Plist.swift
@@ -140,6 +140,9 @@ public enum Entitlements: Equatable, Codable {
     // User defined dictionary of keys/values for an .entitlements file.
     case dictionary([String: Plist.Value])
 
+    // A user defined xcconfig variable map to .entitlements file
+    case xcconfig(String)
+
     // MARK: - Public
 
     public var path: AbsolutePath? {

--- a/Sources/TuistLoader/Models+ManifestMappers/Entitlements+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Entitlements+ManifestMapper.swift
@@ -19,8 +19,8 @@ extension TuistGraph.Entitlements {
             return .dictionary(
                 dictionary.mapValues { TuistGraph.Plist.Value.from(manifest: $0) }
             )
-        case let .xcconfig(setting):
-            return .xcconfig(setting ?? "$(CODE_SIGN_ENTITLEMENTS)")
+        case let .variable(setting):
+            return .variable(setting)
         case .none:
             return .none
         }

--- a/Sources/TuistLoader/Models+ManifestMappers/Entitlements+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/Entitlements+ManifestMapper.swift
@@ -19,6 +19,8 @@ extension TuistGraph.Entitlements {
             return .dictionary(
                 dictionary.mapValues { TuistGraph.Plist.Value.from(manifest: $0) }
             )
+        case let .xcconfig(setting):
+            return .xcconfig(setting ?? "$(CODE_SIGN_ENTITLEMENTS)")
         case .none:
             return .none
         }

--- a/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/ConfigGeneratorTests.swift
@@ -839,6 +839,46 @@ final class ConfigGeneratorTests: TuistUnitTestCase {
         XCTAssertEqual(targetSettingsResult, nil)
     }
 
+    func test_generateTargetConfig_entitlementAreCorrectlyMappedToXCConfig_when_targetIsAppClipAndXCConfigIsProvided() throws {
+        let projectSettings = Settings.default
+        let appClip = Target.test(
+            name: "app",
+            platform: .iOS,
+            product: .appClip,
+            entitlements: .xcconfig("$(MY_CUSTOM_VARIABLE)")
+        )
+
+        let project = Project.test(targets: [appClip])
+
+        let graph = Graph.test(path: project.path, projects: [project.path: project], targets: [
+            project.path: [
+                appClip.name: appClip,
+            ],
+        ])
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        try subject.generateTargetConfig(
+            appClip,
+            project: project,
+            pbxTarget: pbxTarget,
+            pbxproj: pbxproj,
+            projectSettings: projectSettings,
+            fileElements: ProjectFileElements(),
+            graphTraverser: graphTraverser,
+            sourceRootPath: try AbsolutePath(validating: "/project")
+        )
+
+        // Then
+        let targetSettingsResult = try pbxTarget
+            .buildConfigurationList?
+            .buildConfigurations
+            .first { $0.name == "Debug" }?
+            .buildSettings
+            .toSettings()["CODE_SIGN_ENTITLEMENTS"]
+        XCTAssertEqual(targetSettingsResult, "$(MY_CUSTOM_VARIABLE)")
+    }
+
     // MARK: - Helpers
 
     private func generateProjectConfig(config _: BuildConfiguration) throws {


### PR DESCRIPTION
Currently, Xcode don't have a good support for variables inside an entitlement value, causing an issue in projects with multiple environments and appclip

Resolves https://github.com/tuist/tuist/issues/5940

For some reason, Xcode are not solving variables defined in xcconfig on the entitlements file and for appclips the linter are forcing us to provide one file:

```
An AppClip '[REDACTED]' requires its Parent Application Identifiers Entitlement to be set
Fatal linting issues found
Consider creating an issue using the following link: https://github.com/tuist/tuist/issues/new/choose
```

![Screenshot 2024-05-16 at 09 51 33](https://github.com/tuist/tuist/assets/7849484/1736f870-e214-4fca-b588-9e165597d37c)

So this PR provides a capability to provide this file using a xcconfig settings, changing the `CODE_SIGN_ENTITLEMENTS` variable in a dynamic way.

### Short description 📝

> Add capability to set CODE_SIGN_ENTITLEMENTS on XCConfig to be able to sign appclip properly in a project with multiple environments

### How to test the changes locally 🧐

> Create a target with multiple configs one should have a different bundle_id
> add a appclip to this target
> Add a xcconfig settings on project
> Create one entitlements file per config
> Set `.xcconfig()` or a string literal "$(<config-name>)" on appclip entitlement

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
