### PR TITLE
Fix missing -package-name when a target has custom swiftSettings

### DIFF
--- a/Sources/TuistCoreTesting/Graph/DependenciesGraph+TestData.swift
+++ b/Sources/TuistCoreTesting/Graph/DependenciesGraph+TestData.swift
@@ -678,7 +678,7 @@ extension DependenciesGraph {
             "USE_HEADERMAP": "NO",
             "OTHER_SWIFT_FLAGS": ["-package-name", packageName.quotedIfContainsSpaces],
         ]
-        var settingsDictionary = customSettings.merging(defaultSpmSettings, uniquingKeysWith: { custom, _ in custom })
+        var settingsDictionary = defaultSpmSettings.combine(with: customSettings)
 
         if let moduleMap {
             settingsDictionary["MODULEMAP_FILE"] = .string(moduleMap)

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -1013,7 +1013,18 @@ extension ProjectDescription.Settings {
             }
 
         return .settings(
-            base: .from(settingsDictionary: baseSettings.base).merging(mappedSettingsDictionary, uniquingKeysWith: { $1 }),
+            base: .from(settingsDictionary: baseSettings.base)
+                .merging(
+                    mappedSettingsDictionary,
+                    uniquingKeysWith: {
+                        switch ($0, $1) {
+                        case let (.array(leftArray), .array(rightArray)):
+                            return SettingValue.array(leftArray + rightArray)
+                        default:
+                            return $1
+                        }
+                    }
+                ),
             configurations: configurations
                 .sorted { $0.name.rawValue < $1.name.rawValue },
             defaultSettings: .from(defaultSettings: baseSettings.defaultSettings)

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -1983,12 +1983,16 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 ),
             ]
         )
-        XCTAssertEqual(
+        XCTAssertBetterEqual(
             project,
             .testWithDefaultConfigs(
                 name: "Package",
                 targets: [
-                    .test("Target1", basePath: basePath, customSettings: ["OTHER_SWIFT_FLAGS": ["key1", "key2", "key3"]]),
+                    .test(
+                        "Target1",
+                        basePath: basePath,
+                        customSettings: ["OTHER_SWIFT_FLAGS": ["$(inherited)", "key1", "key2", "key3"]]
+                    ),
                 ]
             )
         )
@@ -2022,7 +2026,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 ),
             ]
         )
-        XCTAssertEqual(
+        XCTAssertBetterEqual(
             project,
             .testWithDefaultConfigs(
                 name: "Package",
@@ -2030,7 +2034,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     .test(
                         "Target1",
                         basePath: basePath,
-                        customSettings: ["OTHER_SWIFT_FLAGS": ["-enable-upcoming-feature \"Foo\""]]
+                        customSettings: ["OTHER_SWIFT_FLAGS": ["$(inherited)", "-enable-upcoming-feature \"Foo\""]]
                     ),
                 ]
             )
@@ -2065,7 +2069,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                 ),
             ]
         )
-        XCTAssertEqual(
+        XCTAssertBetterEqual(
             project,
             .testWithDefaultConfigs(
                 name: "Package",
@@ -2073,7 +2077,7 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                     .test(
                         "Target1",
                         basePath: basePath,
-                        customSettings: ["OTHER_SWIFT_FLAGS": ["-enable-experimental-feature \"Foo\""]]
+                        customSettings: ["OTHER_SWIFT_FLAGS": ["$(inherited)", "-enable-experimental-feature \"Foo\""]]
                     ),
                 ]
             )

--- a/fixtures/ios_app_with_spm_dependencies/App/Sources/ContentView.swift
+++ b/fixtures/ios_app_with_spm_dependencies/App/Sources/ContentView.swift
@@ -1,4 +1,5 @@
 import Buy
+import JWTKit
 import KSCrash_Installations
 import Pay
 import SwiftUI
@@ -10,6 +11,8 @@ struct ContentView: View {
         _ = PayAddress()
         // Use KSCrash
         _ = KSCrashInstallationStandard()
+        // Use JWTKit
+        _ = JWTKit.ES256PrivateKey()
     }
 
     var body: some View {

--- a/fixtures/ios_app_with_spm_dependencies/Project.swift
+++ b/fixtures/ios_app_with_spm_dependencies/Project.swift
@@ -8,7 +8,7 @@ let project = Project(
             destinations: .iOS,
             product: .app,
             bundleId: "io.tuist.app",
-            deploymentTargets: .iOS("14.0"),
+            deploymentTargets: .iOS("16.0"),
             infoPlist: .default,
             sources: "App/Sources/**",
             resources: "App/Resources/**",
@@ -16,6 +16,7 @@ let project = Project(
                 .external(name: "Buy"),
                 .external(name: "Pay"),
                 .external(name: "KSCrash"),
+                .external(name: "JWTKit"),
                 .sdk(name: "c++", type: .library, status: .required),
             ]
         ),

--- a/fixtures/ios_app_with_spm_dependencies/Project.swift
+++ b/fixtures/ios_app_with_spm_dependencies/Project.swift
@@ -25,7 +25,7 @@ let project = Project(
             destinations: .iOS,
             product: .unitTests,
             bundleId: "io.tuist.app.tests",
-            deploymentTargets: .iOS("14.0"),
+            deploymentTargets: .iOS("16.0"),
             infoPlist: .default,
             sources: "AppTests/**",
             dependencies: [.target(name: "App")]

--- a/fixtures/ios_app_with_spm_dependencies/Tuist/Package.resolved
+++ b/fixtures/ios_app_with_spm_dependencies/Tuist/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "fc3374625da9a1a42edd765287e0715853d94414eda5959e9d420d041ec3b010",
+  "originHash" : "1daeb9a853c51e17c138cf3bca0322cfb85340fe1fbf28fe3baeb52cd037df48",
   "pins" : [
+    {
+      "identity" : "bigint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/attaswift/BigInt.git",
+      "state" : {
+        "revision" : "0ed110f7555c34ff468e72e1686e59721f2b0da6",
+        "version" : "5.3.0"
+      }
+    },
+    {
+      "identity" : "jwt-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/jwt-kit.git",
+      "state" : {
+        "revision" : "6f512cb5a531e684f2e5238924be81db0b3303b4",
+        "version" : "5.0.0-beta.3"
+      }
+    },
     {
       "identity" : "kscrash",
       "kind" : "remoteSourceControl",
@@ -17,6 +35,33 @@
       "state" : {
         "revision" : "6bd23c2f6243f73ef6ec135723d4909bc068409e",
         "version" : "12.0.0"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "c7e239b5c1492ffc3ebd7fbcc7a92548ce4e78f0",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "83640c8097acaec17c9835a083e89678cb0f2b66",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "bc1c29221f6dfeb0ebbfbc98eb95cd3d4967868e",
+        "version" : "3.4.0"
       }
     }
   ],

--- a/fixtures/ios_app_with_spm_dependencies/Tuist/Package.swift
+++ b/fixtures/ios_app_with_spm_dependencies/Tuist/Package.swift
@@ -8,5 +8,7 @@ let package = Package(
         .package(url: "https://github.com/Shopify/mobile-buy-sdk-ios", exact: "12.0.0"),
         // Has targets with slash symbols in their names
         .package(url: "https://github.com/kstenerud/KSCrash", exact: "1.17.1"),
+        // Has custom `swiftSettings` and uses the package access level
+        .package(url: "https://github.com/vapor/jwt-kit.git", .upToNextMajor(from: "5.0.0-beta.2.1")),
     ]
 )


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6203

### Short description 📝

When a package has custom `swiftSettings`, we would not merge the default and custom settings correctly in the `PackageInfoMapper`. This lead to `-package-name` not being present in `OTHER_SWIFT_FLAGS` which causes build failures for packages that depend on the package access level.

### How to test the changes locally 🧐

`ios_app_with_spm_dependencies` should now successfully build with `JWTKit` dependency.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
