### PR TITLE
Support xcodebuild arguments in build and test commands

### DIFF
--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
@@ -71,9 +71,9 @@ open class TuistAcceptanceTestCase: XCTestCase {
     }
 
     public func run(_ command: (some AsyncParsableCommand).Type, _ arguments: [String] = []) async throws {
-        let arguments = arguments + [
+        let arguments = [
             "--path", fixturePath.pathString,
-        ]
+        ] + arguments
 
         var parsedCommand = try command.parse(arguments)
         try await parsedCommand.run()

--- a/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
+++ b/Sources/TuistAcceptanceTesting/TuistAcceptanceTestCase.swift
@@ -97,10 +97,10 @@ open class TuistAcceptanceTestCase: XCTestCase {
     }
 
     public func run(_ command: EditCommand.Type, _ arguments: [String] = []) async throws {
-        let arguments = arguments + [
+        let arguments = [
             "--path", fixturePath.pathString,
             "--permanent",
-        ]
+        ] + arguments
 
         let parsedCommand = try command.parse(arguments)
         try await parsedCommand.run()
@@ -121,20 +121,20 @@ open class TuistAcceptanceTestCase: XCTestCase {
     }
 
     public func run(_ command: TestCommand.Type, _ arguments: [String] = []) async throws {
-        let arguments = arguments + [
+        let arguments = [
             "--derived-data-path", derivedDataPath.pathString,
             "--path", fixturePath.pathString,
-        ]
+        ] + arguments
 
         let parsedCommand = try command.parse(arguments)
         try await parsedCommand.run()
     }
 
     public func run(_ command: BuildCommand.Type, _ arguments: [String] = []) async throws {
-        let arguments = arguments + [
+        let arguments = [
             "--derived-data-path", derivedDataPath.pathString,
             "--path", fixturePath.pathString,
-        ]
+        ] + arguments
 
         let parsedCommand = try command.parse(arguments)
         try await parsedCommand.run()
@@ -145,10 +145,10 @@ open class TuistAcceptanceTestCase: XCTestCase {
     }
 
     public func run(_ command: GenerateCommand.Type, _ arguments: [String] = []) async throws {
-        let arguments = arguments + [
+        let arguments = [
             "--no-open",
             "--path", fixturePath.pathString,
-        ]
+        ] + arguments
 
         let parsedCommand = try command.parse(arguments)
         try await parsedCommand.run()

--- a/Sources/TuistAutomation/Utilities/TargetBuilder.swift
+++ b/Sources/TuistAutomation/Utilities/TargetBuilder.swift
@@ -18,6 +18,7 @@ public protocol TargetBuilding {
     ///   - device: An optional device specifier to use when building the scheme.
     ///   - osVersion: An optional OS number to use when building the scheme.
     ///   - graphTraverser: The Graph traverser.
+    ///   - passthroughXcodeBuildArguments: The passthrough xcodebuild arguments to pass to xcodebuild
     func buildTarget(
         _ target: GraphTarget,
         platform: TuistGraph.Platform,
@@ -30,7 +31,8 @@ public protocol TargetBuilding {
         device: String?,
         osVersion: Version?,
         rosetta: Bool,
-        graphTraverser: GraphTraversing
+        graphTraverser: GraphTraversing,
+        passthroughXcodeBuildArguments: [String]
     ) async throws
 }
 
@@ -87,7 +89,8 @@ public final class TargetBuilder: TargetBuilding {
         device: String?,
         osVersion: Version?,
         rosetta: Bool,
-        graphTraverser: GraphTraversing
+        graphTraverser: GraphTraversing,
+        passthroughXcodeBuildArguments: [String]
     ) async throws {
         logger.log(level: .notice, "Building scheme \(scheme.name)", metadata: .section)
 
@@ -116,7 +119,8 @@ public final class TargetBuilder: TargetBuilding {
                 rosetta: rosetta,
                 derivedDataPath: derivedDataPath,
                 clean: clean,
-                arguments: buildArguments
+                arguments: buildArguments,
+                passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
             )
             .printFormattedOutput()
 

--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -163,8 +163,6 @@ public final class XcodeBuildController: XcodeBuildControlling {
                 command.append(contentsOf: ["-skip-test-configuration", configuration])
             }
         }
-        
-        
 
         return try run(command: command)
     }

--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -95,7 +95,8 @@ public final class XcodeBuildController: XcodeBuildControlling {
         retryCount: Int,
         testTargets: [TestIdentifier],
         skipTestTargets: [TestIdentifier],
-        testPlanConfiguration: TestPlanConfiguration?
+        testPlanConfiguration: TestPlanConfiguration?,
+        passthroughXcodeBuildArguments: [String]
     ) throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         var command = ["/usr/bin/xcrun", "xcodebuild"]
 
@@ -114,6 +115,9 @@ public final class XcodeBuildController: XcodeBuildControlling {
         // Arguments
         command.append(contentsOf: arguments.flatMap(\.arguments))
 
+        // Passthrough arguments
+        command.append(contentsOf: passthroughXcodeBuildArguments)
+        
         // Retry On Failure
         if retryCount > 0 {
             command.append(contentsOf: XcodeBuildArgument.retryCount(retryCount).arguments)
@@ -159,6 +163,8 @@ public final class XcodeBuildController: XcodeBuildControlling {
                 command.append(contentsOf: ["-skip-test-configuration", configuration])
             }
         }
+        
+        
 
         return try run(command: command)
     }

--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -38,7 +38,8 @@ public final class XcodeBuildController: XcodeBuildControlling {
         rosetta: Bool,
         derivedDataPath: AbsolutePath?,
         clean: Bool = false,
-        arguments: [XcodeBuildArgument]
+        arguments: [XcodeBuildArgument],
+        passthroughXcodeBuildArguments: [String]
     ) throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         var command = ["/usr/bin/xcrun", "xcodebuild"]
 
@@ -56,6 +57,9 @@ public final class XcodeBuildController: XcodeBuildControlling {
 
         // Arguments
         command.append(contentsOf: arguments.flatMap(\.arguments))
+
+        // Passthrough arguments
+        command.append(contentsOf: passthroughXcodeBuildArguments)
 
         // Destination
         switch destination {

--- a/Sources/TuistAutomationTesting/Utilities/MockTargetBuilder.swift
+++ b/Sources/TuistAutomationTesting/Utilities/MockTargetBuilder.swift
@@ -18,7 +18,8 @@ public final class MockTargetBuilder: TargetBuilding {
         String?,
         Version?,
         Bool,
-        GraphTraversing
+        GraphTraversing,
+        [String]
     ) throws -> Void)?
 
     public func buildTarget(
@@ -33,7 +34,8 @@ public final class MockTargetBuilder: TargetBuilding {
         device: String?,
         osVersion: Version?,
         rosetta: Bool,
-        graphTraverser: GraphTraversing
+        graphTraverser: GraphTraversing,
+        passthroughXcodeBuildArguments: [String]
     ) throws {
         try buildTargetStub?(
             target,
@@ -46,7 +48,8 @@ public final class MockTargetBuilder: TargetBuilding {
             device,
             osVersion,
             rosetta,
-            graphTraverser
+            graphTraverser,
+            passthroughXcodeBuildArguments
         )
     }
 }

--- a/Sources/TuistCore/Automation/XcodeBuildControlling.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildControlling.swift
@@ -40,6 +40,7 @@ public protocol XcodeBuildControlling {
     ///   - testTargets: A list of test identifiers indicating which tests to run
     ///   - skipTestTargets: A list of test identifiers indicating which tests to skip
     ///   - testPlanConfiguration: A configuration object indicating which test plan to use and its configurations
+    ///   - passthroughXcodeBuildArguments: Passthrough xcodebuild arguments.
     func test(
         _ target: XcodeBuildTarget,
         scheme: String,
@@ -52,7 +53,8 @@ public protocol XcodeBuildControlling {
         retryCount: Int,
         testTargets: [TestIdentifier],
         skipTestTargets: [TestIdentifier],
-        testPlanConfiguration: TestPlanConfiguration?
+        testPlanConfiguration: TestPlanConfiguration?,
+        passthroughXcodeBuildArguments: [String]
     ) throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error>
 
     /// Returns an observable that archives the given project using xcodebuild.

--- a/Sources/TuistCore/Automation/XcodeBuildControlling.swift
+++ b/Sources/TuistCore/Automation/XcodeBuildControlling.swift
@@ -16,6 +16,7 @@ public protocol XcodeBuildControlling {
     ///   to determine the destination.
     ///   - clean: True if xcodebuild should clean the project before building.
     ///   - arguments: Extra xcodebuild arguments.
+    ///   - passthroughXcodeBuildArguments: Passthrough xcodebuild arguments.
     func build(
         _ target: XcodeBuildTarget,
         scheme: String,
@@ -23,7 +24,8 @@ public protocol XcodeBuildControlling {
         rosetta: Bool,
         derivedDataPath: AbsolutePath?,
         clean: Bool,
-        arguments: [XcodeBuildArgument]
+        arguments: [XcodeBuildArgument],
+        passthroughXcodeBuildArguments: [String]
     ) throws -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error>
 
     /// Returns an observable to test the given project using xcodebuild.

--- a/Sources/TuistCoreTesting/Automation/MockXcodeBuildController.swift
+++ b/Sources/TuistCoreTesting/Automation/MockXcodeBuildController.swift
@@ -12,7 +12,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         Bool,
         AbsolutePath?,
         Bool,
-        [XcodeBuildArgument]
+        [XcodeBuildArgument],
+        [String]
     ) -> [SystemEvent<XcodeBuildOutput>])?
 
     func build(
@@ -22,7 +23,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         rosetta: Bool,
         derivedDataPath: AbsolutePath?,
         clean: Bool,
-        arguments: [XcodeBuildArgument]
+        arguments: [XcodeBuildArgument],
+        passthroughXcodeBuildArguments: [String]
     ) -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         if let buildStub {
             return buildStub(
@@ -32,7 +34,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
                 rosetta,
                 derivedDataPath,
                 clean,
-                arguments
+                arguments,
+                passthroughXcodeBuildArguments
             ).asAsyncThrowingStream()
         } else {
             return AsyncThrowingStream {

--- a/Sources/TuistCoreTesting/Automation/MockXcodeBuildController.swift
+++ b/Sources/TuistCoreTesting/Automation/MockXcodeBuildController.swift
@@ -59,7 +59,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
             Int,
             [TestIdentifier],
             [TestIdentifier],
-            TestPlanConfiguration?
+            TestPlanConfiguration?,
+            [String]
         )
             -> [SystemEvent<XcodeBuildOutput>]
     )?
@@ -76,7 +77,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         retryCount: Int,
         testTargets: [TestIdentifier],
         skipTestTargets: [TestIdentifier],
-        testPlanConfiguration: TestPlanConfiguration?
+        testPlanConfiguration: TestPlanConfiguration?,
+        passthroughXcodeBuildArguments: [String]
     ) -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         if let testStub {
             let results = testStub(
@@ -91,7 +93,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
                 retryCount,
                 testTargets,
                 skipTestTargets,
-                testPlanConfiguration
+                testPlanConfiguration,
+                passthroughXcodeBuildArguments
             )
             if let testErrorStub {
                 return AsyncThrowingStream {

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -36,7 +36,7 @@ public struct BuildOptions: ParsableArguments {
     public var generate: Bool = false
 
     @Flag(
-        help: "[Deprecated] When passed, it cleans the project before building it"
+        help: "When passed, it cleans the project before building it"
     )
     public var clean: Bool = false
 
@@ -49,31 +49,31 @@ public struct BuildOptions: ParsableArguments {
 
     @Option(
         name: .shortAndLong,
-        help: "[Deprecated] Build on a specific device."
+        help: "Build on a specific device."
     )
     public var device: String?
 
     @Option(
         name: .long,
-        help: "[Deprecated] Build for a specific platform."
+        help: "Build for a specific platform."
     )
     public var platform: String?
 
     @Option(
         name: .shortAndLong,
-        help: "[Deprecated] Build with a specific version of the OS."
+        help: "Build with a specific version of the OS."
     )
     public var os: String?
 
     @Flag(
         name: .long,
-        help: "[Deprecated] When passed, append arch=x86_64 to the 'destination' to run simulator in a Rosetta mode."
+        help: "When passed, append arch=x86_64 to the 'destination' to run simulator in a Rosetta mode."
     )
     public var rosetta: Bool = false
 
     @Option(
         name: [.long, .customShort("C")],
-        help: "[Deprecated] The configuration to be used when building the scheme."
+        help: "The configuration to be used when building the scheme."
     )
     public var configuration: String?
 
@@ -130,24 +130,6 @@ public struct BuildCommand: AsyncParsableCommand {
         }
 
         // Suggest the user to use passthrough arguments if already supported by xcodebuild
-        if buildOptions.platform != nil || buildOptions.os != nil || buildOptions.device != nil || buildOptions.rosetta {
-            logger
-                .warning(
-                    "--platform, --os, --device, and --rosetta are deprecated please use -destination DESTINATION after the terminator (--) instead to passthrough parameters to xcodebuild"
-                )
-        }
-        if let configuration = buildOptions.configuration {
-            logger
-                .warning(
-                    "--configuration is deprecated please use -configuration \(configuration) after the terminator (--) instead to passthrough parameters to xcodebuild"
-                )
-        }
-        if buildOptions.clean {
-            logger
-                .warning(
-                    "--clean is deprecated please use clean after the terminator (--) instead to passthrough parameters to xcodebuild"
-                )
-        }
         if let derivedDataPath = buildOptions.derivedDataPath {
             logger
                 .warning(

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -115,16 +115,18 @@ public struct BuildCommand: AsyncParsableCommand {
     @OptionGroup()
     var buildOptions: BuildOptions
 
+    private var notAllowedPassthroughXcodeBuildArguments = [
+        "-scheme",
+        "-workspace",
+        "-project",
+    ]
+    
     public func run() async throws {
         // Check if passthrough arguments are already handled by tuist
-        if buildOptions.passthroughXcodeBuildArguments.contains("-scheme") {
-            throw BuildCommandError.passthroughArgumentAlreadyHandled("-scheme")
-        }
-        if buildOptions.passthroughXcodeBuildArguments.contains("-workspace") {
-            throw BuildCommandError.passthroughArgumentAlreadyHandled("-workspace")
-        }
-        if buildOptions.passthroughXcodeBuildArguments.contains("-project") {
-            throw BuildCommandError.passthroughArgumentAlreadyHandled("-project")
+        try notAllowedPassthroughXcodeBuildArguments.forEach {
+            if buildOptions.passthroughXcodeBuildArguments.contains($0) {
+                throw BuildCommandError.passthroughArgumentAlreadyHandled($0)
+            }
         }
 
         // Suggest the user to use passthrough arguments if already supported by xcodebuild

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -10,7 +10,7 @@ enum XcodeBuildPassthroughArgumentError: FatalError, Equatable {
     var description: String {
         switch self {
         case let .alreadyHandled(argument):
-            "The argument \(argument) added after the terminator (--) cannot be passthrough to xcodebuild because it is handled by tuist"
+            "The argument \(argument) added after the terminator (--) cannot be passed through to xcodebuild because it is handled by Tuist."
         }
     }
 
@@ -96,7 +96,7 @@ public struct BuildOptions: ParsableArguments {
 
     @Argument(
         parsing: .postTerminator,
-        help: "xcodebuild arguments that will be passthrough"
+        help: "Arguments that will be passed through to xcodebuild"
     )
     var passthroughXcodeBuildArguments: [String] = []
 }

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -4,19 +4,19 @@ import TSCBasic
 import TSCUtility
 import TuistSupport
 
-enum BuildCommandError: FatalError, Equatable {
-    case passthroughArgumentAlreadyHandled(String)
+enum XcodeBuildPassthroughArgumentError: FatalError, Equatable {
+    case alreadyHandled(String)
 
     var description: String {
         switch self {
-        case let .passthroughArgumentAlreadyHandled(argument):
+        case let .alreadyHandled(argument):
             "The argument \(argument) added after the terminator (--) cannot be passthrough to xcodebuild because it is handled by tuist"
         }
     }
 
     var type: ErrorType {
         switch self {
-        case .passthroughArgumentAlreadyHandled:
+        case .alreadyHandled:
             .abort
         }
     }
@@ -125,7 +125,7 @@ public struct BuildCommand: AsyncParsableCommand {
         // Check if passthrough arguments are already handled by tuist
         try notAllowedPassthroughXcodeBuildArguments.forEach {
             if buildOptions.passthroughXcodeBuildArguments.contains($0) {
-                throw BuildCommandError.passthroughArgumentAlreadyHandled($0)
+                throw XcodeBuildPassthroughArgumentError.alreadyHandled($0)
             }
         }
 

--- a/Sources/TuistKit/Commands/BuildCommand.swift
+++ b/Sources/TuistKit/Commands/BuildCommand.swift
@@ -93,7 +93,7 @@ public struct BuildOptions: ParsableArguments {
         help: "When passed, it generates the project and skips building. This is useful for debugging purposes."
     )
     public var generateOnly: Bool = false
-    
+
     @Argument(
         parsing: .postTerminator,
         help: "xcodebuild arguments that will be passthrough"
@@ -120,7 +120,7 @@ public struct BuildCommand: AsyncParsableCommand {
         "-workspace",
         "-project",
     ]
-    
+
     public func run() async throws {
         // Check if passthrough arguments are already handled by tuist
         try notAllowedPassthroughXcodeBuildArguments.forEach {
@@ -131,16 +131,28 @@ public struct BuildCommand: AsyncParsableCommand {
 
         // Suggest the user to use passthrough arguments if already supported by xcodebuild
         if buildOptions.platform != nil || buildOptions.os != nil || buildOptions.device != nil || buildOptions.rosetta {
-            logger.warning("--platform, --os, --device, and --rosetta are deprecated please use -destination DESTINATION after the terminator (--) instead to passthrough parameters to xcodebuild")
+            logger
+                .warning(
+                    "--platform, --os, --device, and --rosetta are deprecated please use -destination DESTINATION after the terminator (--) instead to passthrough parameters to xcodebuild"
+                )
         }
         if let configuration = buildOptions.configuration {
-            logger.warning("--configuration is deprecated please use -configuration \(configuration) after the terminator (--) instead to passthrough parameters to xcodebuild")
+            logger
+                .warning(
+                    "--configuration is deprecated please use -configuration \(configuration) after the terminator (--) instead to passthrough parameters to xcodebuild"
+                )
         }
         if buildOptions.clean {
-            logger.warning("--clean is deprecated please use clean after the terminator (--) instead to passthrough parameters to xcodebuild")
+            logger
+                .warning(
+                    "--clean is deprecated please use clean after the terminator (--) instead to passthrough parameters to xcodebuild"
+                )
         }
         if let derivedDataPath = buildOptions.derivedDataPath {
-            logger.warning("--derivedDataPath is deprecated please use -derivedDataPath \(derivedDataPath) after the terminator (--) instead to passthrough parameters to xcodebuild")
+            logger
+                .warning(
+                    "--derivedDataPath is deprecated please use -derivedDataPath \(derivedDataPath) after the terminator (--) instead to passthrough parameters to xcodebuild"
+                )
         }
 
         let absolutePath = if let path = buildOptions.path {

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -25,7 +25,7 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
 
     @Flag(
         name: .shortAndLong,
-        help: "[Deprecated] When passed, it cleans the project before testing it."
+        help: "When passed, it cleans the project before testing it."
     )
     var clean: Bool = false
 
@@ -37,31 +37,31 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
 
     @Option(
         name: .shortAndLong,
-        help: "[Deprecated] Test on a specific device."
+        help: "Test on a specific device."
     )
     var device: String?
 
     @Option(
         name: .long,
-        help: "[Deprecated] Test on a specific platform."
+        help: "Test on a specific platform."
     )
     var platform: String?
 
     @Option(
         name: .shortAndLong,
-        help: "[Deprecated] Test with a specific version of the OS."
+        help: "Test with a specific version of the OS."
     )
     var os: String?
 
     @Flag(
         name: .long,
-        help: "[Deprecated] When passed, append arch=x86_64 to the 'destination' to run simulator in a Rosetta mode."
+        help: "When passed, append arch=x86_64 to the 'destination' to run simulator in a Rosetta mode."
     )
     var rosetta: Bool = false
 
     @Option(
         name: [.long, .customShort("C")],
-        help: "[Deprecated] The configuration to be used when testing the scheme."
+        help: "The configuration to be used when testing the scheme."
     )
     var configuration: String?
 
@@ -73,7 +73,7 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
 
     @Option(
         name: [.long, .customShort("T")],
-        help: "[Deprecated] Path where test result bundle will be saved."
+        help: "Path where test result bundle will be saved."
     )
     var resultBundlePath: String?
 
@@ -163,34 +163,10 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
         }
 
         // Suggest the user to use passthrough arguments if already supported by xcodebuild
-        if platform != nil || os != nil || device != nil || rosetta {
-            logger
-                .warning(
-                    "--platform, --os, --device, and --rosetta are deprecated please use -destination DESTINATION after the terminator (--) instead to passthrough parameters to xcodebuild"
-                )
-        }
-        if let configuration {
-            logger
-                .warning(
-                    "--configuration is deprecated please use -configuration \(configuration) after the terminator (--) instead to passthrough parameters to xcodebuild"
-                )
-        }
-        if clean {
-            logger
-                .warning(
-                    "--clean is deprecated please use clean after the terminator (--) instead to passthrough parameters to xcodebuild"
-                )
-        }
         if let derivedDataPath {
             logger
                 .warning(
                     "--derivedDataPath is deprecated please use -derivedDataPath \(derivedDataPath) after the terminator (--) instead to passthrough parameters to xcodebuild"
-                )
-        }
-        if let resultBundlePath {
-            logger
-                .warning(
-                    "--resultBundlePath is deprecated please use -resultBundlePath \(resultBundlePath) after the terminator (--) instead to passthrough parameters to xcodebuild"
                 )
         }
         if retryCount > 0 {

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -5,24 +5,6 @@ import TSCBasic
 import TuistCore
 import TuistSupport
 
-enum TestCommandError: FatalError, Equatable {
-    case passthroughArgumentAlreadyHandled(String)
-
-    var description: String {
-        switch self {
-        case let .passthroughArgumentAlreadyHandled(argument):
-            "The argument \(argument) added after the terminator (--) cannot be passthrough to xcodebuild because it is handled by tuist"
-        }
-    }
-
-    var type: ErrorType {
-        switch self {
-        case .passthroughArgumentAlreadyHandled:
-            .abort
-        }
-    }
-}
-
 /// Command that tests a target from the project in the current directory.
 public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
     public init() {}
@@ -176,7 +158,7 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
         // Check if passthrough arguments are already handled by tuist
         try notAllowedPassthroughXcodeBuildArguments.forEach {
             if passthroughXcodeBuildArguments.contains($0) {
-                throw TestCommandError.passthroughArgumentAlreadyHandled($0)
+                throw XcodeBuildPassthroughArgumentError.alreadyHandled($0)
             }
         }
         

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -135,14 +135,14 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
         help: "xcodebuild arguments that will be passthrough"
     )
     var passthroughXcodeBuildArguments: [String] = []
-    
+
     public func validate() throws {
         try TestService().validateParameters(
             testTargets: testTargets,
             skipTestTargets: skipTestTargets
         )
     }
-    
+
     private var notAllowedPassthroughXcodeBuildArguments = [
         "-scheme",
         "-workspace",
@@ -151,7 +151,7 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
         "-skip-test-configuration",
         "-only-test-configuration",
         "-only-testing",
-        "-skip-testing"
+        "-skip-testing",
     ]
 
     public func run() async throws {
@@ -161,27 +161,45 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
                 throw XcodeBuildPassthroughArgumentError.alreadyHandled($0)
             }
         }
-        
+
         // Suggest the user to use passthrough arguments if already supported by xcodebuild
         if platform != nil || os != nil || device != nil || rosetta {
-            logger.warning("--platform, --os, --device, and --rosetta are deprecated please use -destination DESTINATION after the terminator (--) instead to passthrough parameters to xcodebuild")
+            logger
+                .warning(
+                    "--platform, --os, --device, and --rosetta are deprecated please use -destination DESTINATION after the terminator (--) instead to passthrough parameters to xcodebuild"
+                )
         }
         if let configuration {
-            logger.warning("--configuration is deprecated please use -configuration \(configuration) after the terminator (--) instead to passthrough parameters to xcodebuild")
+            logger
+                .warning(
+                    "--configuration is deprecated please use -configuration \(configuration) after the terminator (--) instead to passthrough parameters to xcodebuild"
+                )
         }
         if clean {
-            logger.warning("--clean is deprecated please use clean after the terminator (--) instead to passthrough parameters to xcodebuild")
+            logger
+                .warning(
+                    "--clean is deprecated please use clean after the terminator (--) instead to passthrough parameters to xcodebuild"
+                )
         }
         if let derivedDataPath {
-            logger.warning("--derivedDataPath is deprecated please use -derivedDataPath \(derivedDataPath) after the terminator (--) instead to passthrough parameters to xcodebuild")
+            logger
+                .warning(
+                    "--derivedDataPath is deprecated please use -derivedDataPath \(derivedDataPath) after the terminator (--) instead to passthrough parameters to xcodebuild"
+                )
         }
         if let resultBundlePath {
-            logger.warning("--resultBundlePath is deprecated please use -resultBundlePath \(resultBundlePath) after the terminator (--) instead to passthrough parameters to xcodebuild")
+            logger
+                .warning(
+                    "--resultBundlePath is deprecated please use -resultBundlePath \(resultBundlePath) after the terminator (--) instead to passthrough parameters to xcodebuild"
+                )
         }
         if retryCount > 0 {
-            logger.warning("--retryCount is deprecated please use -retry-tests-on-failure -test-iterations \(retryCount + 1) after the terminator (--) instead to passthrough parameters to xcodebuild")
+            logger
+                .warning(
+                    "--retryCount is deprecated please use -retry-tests-on-failure -test-iterations \(retryCount + 1) after the terminator (--) instead to passthrough parameters to xcodebuild"
+                )
         }
-        
+
         let absolutePath = if let path {
             try AbsolutePath(validating: path, relativeTo: FileHandler.shared.currentPath)
         } else {
@@ -216,7 +234,7 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
                 )
             },
             validateTestTargetsParameters: false,
-            generateOnly: generateOnly, 
+            generateOnly: generateOnly,
             passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
         )
     }

--- a/Sources/TuistKit/Services/BuildService.swift
+++ b/Sources/TuistKit/Services/BuildService.swift
@@ -65,7 +65,8 @@ public final class BuildService {
         osVersion: String?,
         rosetta: Bool,
         generateOnly: Bool,
-        generator: ((Config) throws -> Generating)? = nil
+        generator: ((Config) throws -> Generating)? = nil,
+        passthroughXcodeBuildArguments: [String]
     ) async throws {
         let graph: Graph
         let config = try configLoader.loadConfig(path: path)
@@ -128,7 +129,8 @@ public final class BuildService {
                 device: device,
                 osVersion: osVersion?.version(),
                 rosetta: rosetta,
-                graphTraverser: graphTraverser
+                graphTraverser: graphTraverser,
+                passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
             )
         } else {
             var cleaned = false
@@ -159,7 +161,8 @@ public final class BuildService {
                     device: device,
                     osVersion: osVersion?.version(),
                     rosetta: rosetta,
-                    graphTraverser: graphTraverser
+                    graphTraverser: graphTraverser,
+                    passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
                 )
                 cleaned = true
             }

--- a/Sources/TuistKit/Services/RunService.swift
+++ b/Sources/TuistKit/Services/RunService.swift
@@ -119,7 +119,7 @@ final class RunService {
             device: device,
             osVersion: version?.version(),
             rosetta: rosetta,
-            graphTraverser: graphTraverser, 
+            graphTraverser: graphTraverser,
             passthroughXcodeBuildArguments: []
         )
 

--- a/Sources/TuistKit/Services/RunService.swift
+++ b/Sources/TuistKit/Services/RunService.swift
@@ -119,7 +119,8 @@ final class RunService {
             device: device,
             osVersion: version?.version(),
             rosetta: rosetta,
-            graphTraverser: graphTraverser
+            graphTraverser: graphTraverser, 
+            passthroughXcodeBuildArguments: []
         )
 
         let minVersion: Version?

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -261,7 +261,7 @@ public final class TestService { // swiftlint:disable:this type_body_length
                     retryCount: retryCount,
                     testTargets: testTargets,
                     skipTestTargets: skipTestTargets,
-                    testPlanConfiguration: testPlanConfiguration, 
+                    testPlanConfiguration: testPlanConfiguration,
                     passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
                 )
             }

--- a/Sources/TuistKit/Services/TestService.swift
+++ b/Sources/TuistKit/Services/TestService.swift
@@ -170,7 +170,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
         testPlanConfiguration: TestPlanConfiguration?,
         validateTestTargetsParameters: Bool = true,
         generator: Generating? = nil,
-        generateOnly: Bool
+        generateOnly: Bool,
+        passthroughXcodeBuildArguments: [String]
     ) async throws {
         if validateTestTargetsParameters {
             try validateParameters(
@@ -260,7 +261,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
                     retryCount: retryCount,
                     testTargets: testTargets,
                     skipTestTargets: skipTestTargets,
-                    testPlanConfiguration: testPlanConfiguration
+                    testPlanConfiguration: testPlanConfiguration, 
+                    passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
                 )
             }
         } else {
@@ -289,7 +291,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
                     retryCount: retryCount,
                     testTargets: testTargets,
                     skipTestTargets: skipTestTargets,
-                    testPlanConfiguration: testPlanConfiguration
+                    testPlanConfiguration: testPlanConfiguration,
+                    passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
                 )
             }
         }
@@ -314,7 +317,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
         retryCount: Int,
         testTargets: [TestIdentifier],
         skipTestTargets: [TestIdentifier],
-        testPlanConfiguration: TestPlanConfiguration?
+        testPlanConfiguration: TestPlanConfiguration?,
+        passthroughXcodeBuildArguments: [String]
     ) async throws {
         logger.log(level: .notice, "Testing scheme \(scheme.name)", metadata: .section)
         if let testPlan = testPlanConfiguration?.testPlan, let testPlans = scheme.testAction?.testPlans,
@@ -371,7 +375,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
             retryCount: retryCount,
             testTargets: testTargets,
             skipTestTargets: skipTestTargets,
-            testPlanConfiguration: testPlanConfiguration
+            testPlanConfiguration: testPlanConfiguration,
+            passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
         )
         .printFormattedOutput()
     }

--- a/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
@@ -139,6 +139,20 @@ extension XCTestCase {
         }
         XCTFail("No error was thrown", file: file, line: line)
     }
+    
+    public func XCTAssertThrows(
+        _ closure: @autoclosure () async throws -> some Any,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await closure()
+        } catch {
+            XCTAssertTrue(true)
+            return
+        }
+        XCTFail("No error was thrown", file: file, line: line)
+    }
 
     public func XCTAssertCodableEqualToJson<C: Codable>(
         _ subject: C,

--- a/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
@@ -139,7 +139,7 @@ extension XCTestCase {
         }
         XCTFail("No error was thrown", file: file, line: line)
     }
-    
+
     public func XCTAssertThrows(
         _ closure: @autoclosure () async throws -> some Any,
         file: StaticString = #file,

--- a/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
@@ -151,7 +151,6 @@ extension XCTestCase {
         } catch {
             // Succeeded
         }
-        
     }
 
     public func XCTAssertCodableEqualToJson<C: Codable>(

--- a/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
+++ b/Sources/TuistSupportTesting/Extensions/XCTestCase+Extras.swift
@@ -147,11 +147,11 @@ extension XCTestCase {
     ) async {
         do {
             _ = try await closure()
+            XCTFail("No error was thrown", file: file, line: line)
         } catch {
-            XCTAssertTrue(true)
-            return
+            // Succeeded
         }
-        XCTFail("No error was thrown", file: file, line: line)
+        
     }
 
     public func XCTAssertCodableEqualToJson<C: Codable>(

--- a/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
+++ b/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
@@ -37,7 +37,14 @@ final class BuildAcceptanceTestInvalidArguments: TuistAcceptanceTestCase {
         )
         await XCTAssertThrowsSpecific(
             try await run(BuildCommand.self, "MyApp", "--", "-parallelizeTargets", "YES", "-enableAddressSanitizer"),
-            SystemError.terminated(command: "xcodebuild", code: 64, standardError: Data("xcodebuild: error: The flag -addressSanitizerEnabled must be supplied with an argument YES or NO\n".utf8))
+            SystemError.terminated(
+                command: "xcodebuild",
+                code: 64,
+                standardError: Data(
+                    "xcodebuild: error: The flag -addressSanitizerEnabled must be supplied with an argument YES or NO\n"
+                        .utf8
+                )
+            )
         )
         // SystemError is too verbose to inline it
         // xcodebuild: error: option '-configuration' may only be provided once

--- a/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
+++ b/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
@@ -35,18 +35,11 @@ final class BuildAcceptanceTestInvalidArguments: TuistAcceptanceTestCase {
             try await run(BuildCommand.self, "MyApp", "--", "-workspace", "MyApp"),
             XcodeBuildPassthroughArgumentError.alreadyHandled("-workspace")
         )
-        await XCTAssertThrowsSpecific(
-            try await run(BuildCommand.self, "MyApp", "--", "-parallelizeTargets", "YES", "-enableAddressSanitizer"),
-            SystemError.terminated(
-                command: "xcodebuild",
-                code: 64,
-                standardError: Data(
-                    "xcodebuild: error: The flag -addressSanitizerEnabled must be supplied with an argument YES or NO\n"
-                        .utf8
-                )
-            )
+        // SystemError is verbose and would lead to flakyness
+        // xcodebuild: error: The flag -addressSanitizerEnabled must be supplied with an argument YES or NO
+        await XCTAssertThrows(
+            try await run(BuildCommand.self, "MyApp", "--", "-parallelizeTargets", "YES", "-enableAddressSanitizer")
         )
-        // SystemError is too verbose to inline it
         // xcodebuild: error: option '-configuration' may only be provided once
         // Usage: xcodebuild [-project <projectname>] ...
         await XCTAssertThrows(

--- a/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
+++ b/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
@@ -25,15 +25,15 @@ final class BuildAcceptanceTestInvalidArguments: TuistAcceptanceTestCase {
         try await run(GenerateCommand.self)
         await XCTAssertThrowsSpecific(
             try await run(BuildCommand.self, "MyApp", "--", "-scheme", "MyApp"),
-            BuildCommandError.passthroughArgumentAlreadyHandled("-scheme")
+            XcodeBuildPassthroughArgumentError.alreadyHandled("-scheme")
         )
         await XCTAssertThrowsSpecific(
             try await run(BuildCommand.self, "MyApp", "--", "-project", "MyApp"),
-            BuildCommandError.passthroughArgumentAlreadyHandled("-project")
+            XcodeBuildPassthroughArgumentError.alreadyHandled("-project")
         )
         await XCTAssertThrowsSpecific(
             try await run(BuildCommand.self, "MyApp", "--", "-workspace", "MyApp"),
-            BuildCommandError.passthroughArgumentAlreadyHandled("-workspace")
+            XcodeBuildPassthroughArgumentError.alreadyHandled("-workspace")
         )
         await XCTAssertThrowsSpecific(
             try await run(BuildCommand.self, "MyApp", "--", "-parallelizeTargets", "YES", "-enableAddressSanitizer"),

--- a/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
+++ b/Tests/TuistAutomationAcceptanceTests/BuildAcceptanceTests.swift
@@ -39,6 +39,12 @@ final class BuildAcceptanceTestInvalidArguments: TuistAcceptanceTestCase {
             try await run(BuildCommand.self, "MyApp", "--", "-parallelizeTargets", "YES", "-enableAddressSanitizer"),
             SystemError.terminated(command: "xcodebuild", code: 64, standardError: Data("xcodebuild: error: The flag -addressSanitizerEnabled must be supplied with an argument YES or NO\n".utf8))
         )
+        // SystemError is too verbose to inline it
+        // xcodebuild: error: option '-configuration' may only be provided once
+        // Usage: xcodebuild [-project <projectname>] ...
+        await XCTAssertThrows(
+            try await run(BuildCommand.self, "MyApp", "--configuration", "Debug", "--", "-configuration", "Debug")
+        )
     }
 }
 

--- a/Tests/TuistAutomationAcceptanceTests/TestAcceptanceTests.swift
+++ b/Tests/TuistAutomationAcceptanceTests/TestAcceptanceTests.swift
@@ -25,35 +25,35 @@ final class TestAcceptanceTests: TuistAcceptanceTestCase {
         try setUpFixture(.appWithFrameworkAndTests)
         await XCTAssertThrowsSpecific(
             try await run(TestCommand.self, "App", "--", "-scheme", "App"),
-            TestCommandError.passthroughArgumentAlreadyHandled("-scheme")
+            XcodeBuildPassthroughArgumentError.alreadyHandled("-scheme")
         )
         await XCTAssertThrowsSpecific(
             try await run(TestCommand.self, "App", "--", "-project", "App"),
-            TestCommandError.passthroughArgumentAlreadyHandled("-project")
+            XcodeBuildPassthroughArgumentError.alreadyHandled("-project")
         )
         await XCTAssertThrowsSpecific(
             try await run(TestCommand.self, "App", "--", "-workspace", "App"),
-            TestCommandError.passthroughArgumentAlreadyHandled("-workspace")
+            XcodeBuildPassthroughArgumentError.alreadyHandled("-workspace")
         )
         await XCTAssertThrowsSpecific(
             try await run(TestCommand.self, "App", "--", "-testPlan", "TestPlan"),
-            TestCommandError.passthroughArgumentAlreadyHandled("-testPlan")
+            XcodeBuildPassthroughArgumentError.alreadyHandled("-testPlan")
         )
         await XCTAssertThrowsSpecific(
             try await run(TestCommand.self, "App", "--", "-skip-test-configuration", "TestPlan"),
-            TestCommandError.passthroughArgumentAlreadyHandled("-skip-test-configuration")
+            XcodeBuildPassthroughArgumentError.alreadyHandled("-skip-test-configuration")
         )
         await XCTAssertThrowsSpecific(
             try await run(TestCommand.self, "App", "--", "-only-test-configuration", "TestPlan"),
-            TestCommandError.passthroughArgumentAlreadyHandled("-only-test-configuration")
+            XcodeBuildPassthroughArgumentError.alreadyHandled("-only-test-configuration")
         )
         await XCTAssertThrowsSpecific(
             try await run(TestCommand.self, "App", "--", "-only-testing", "AppTests"),
-            TestCommandError.passthroughArgumentAlreadyHandled("-only-testing")
+            XcodeBuildPassthroughArgumentError.alreadyHandled("-only-testing")
         )
         await XCTAssertThrowsSpecific(
             try await run(TestCommand.self, "App", "--", "-skip-testing", "AppTests"),
-            TestCommandError.passthroughArgumentAlreadyHandled("-skip-testing")
+            XcodeBuildPassthroughArgumentError.alreadyHandled("-skip-testing")
         )
         await XCTAssertThrowsSpecific(
             try await run(TestCommand.self, "App", "--", "-parallelizeTargets", "YES", "-enableAddressSanitizer"),

--- a/Tests/TuistAutomationAcceptanceTests/TestAcceptanceTests.swift
+++ b/Tests/TuistAutomationAcceptanceTests/TestAcceptanceTests.swift
@@ -14,13 +14,13 @@ final class TestAcceptanceTests: TuistAcceptanceTestCase {
         try await run(TestCommand.self, "--test-targets", "FrameworkTests/FrameworkTests")
         try await run(TestCommand.self, "App", "--", "-testLanguage", "en")
     }
-    
+
     func test_with_app_with_test_plan() async throws {
         try setUpFixture(.appWithTestPlan)
         try await run(TestCommand.self)
         try await run(TestCommand.self, "App", "--test-plan", "All")
     }
-    
+
     func test_with_invalid_arguments() async throws {
         try setUpFixture(.appWithFrameworkAndTests)
         await XCTAssertThrowsSpecific(
@@ -57,13 +57,20 @@ final class TestAcceptanceTests: TuistAcceptanceTestCase {
         )
         await XCTAssertThrowsSpecific(
             try await run(TestCommand.self, "App", "--", "-parallelizeTargets", "YES", "-enableAddressSanitizer"),
-            SystemError.terminated(command: "xcodebuild", code: 64, standardError: Data("xcodebuild: error: The flag -addressSanitizerEnabled must be supplied with an argument YES or NO\n".utf8))
+            SystemError.terminated(
+                command: "xcodebuild",
+                code: 64,
+                standardError: Data(
+                    "xcodebuild: error: The flag -addressSanitizerEnabled must be supplied with an argument YES or NO\n"
+                        .utf8
+                )
+            )
         )
         // SystemError is too verbose to inline it
         // xcodebuild: error: option '-configuration' may only be provided once
         // Usage: xcodebuild [-project <projectname>] ...
         await XCTAssertThrows(
-            try await run(TestCommand.self, "App", "--configuration", "Debug", "--", "-configuration",  "Debug")
+            try await run(TestCommand.self, "App", "--configuration", "Debug", "--", "-configuration", "Debug")
         )
     }
 }

--- a/Tests/TuistAutomationAcceptanceTests/TestAcceptanceTests.swift
+++ b/Tests/TuistAutomationAcceptanceTests/TestAcceptanceTests.swift
@@ -55,18 +55,11 @@ final class TestAcceptanceTests: TuistAcceptanceTestCase {
             try await run(TestCommand.self, "App", "--", "-skip-testing", "AppTests"),
             XcodeBuildPassthroughArgumentError.alreadyHandled("-skip-testing")
         )
-        await XCTAssertThrowsSpecific(
-            try await run(TestCommand.self, "App", "--", "-parallelizeTargets", "YES", "-enableAddressSanitizer"),
-            SystemError.terminated(
-                command: "xcodebuild",
-                code: 64,
-                standardError: Data(
-                    "xcodebuild: error: The flag -addressSanitizerEnabled must be supplied with an argument YES or NO\n"
-                        .utf8
-                )
-            )
+        // SystemError is verbose and would lead to flakyness
+        // xcodebuild: error: The flag -addressSanitizerEnabled must be supplied with an argument YES or NO
+        await XCTAssertThrows(
+            try await run(TestCommand.self, "App", "--", "-parallelizeTargets", "YES", "-enableAddressSanitizer")
         )
-        // SystemError is too verbose to inline it
         // xcodebuild: error: option '-configuration' may only be provided once
         // Usage: xcodebuild [-project <projectname>] ...
         await XCTAssertThrows(

--- a/Tests/TuistKitTests/Services/BuildServiceTests.swift
+++ b/Tests/TuistKitTests/Services/BuildServiceTests.swift
@@ -98,7 +98,7 @@ final class BuildServiceTests: TuistUnitTestCase {
             return buildArguments
         }
         targetBuilder
-            .buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _device, _osVersion, _, _ in
+            .buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _device, _osVersion, _, _, _ in
                 XCTAssertEqual(_workspacePath, workspacePath)
                 XCTAssertEqual(_scheme, scheme)
                 XCTAssertTrue(_clean)
@@ -145,7 +145,7 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_skipSigning, skipSigning)
             return buildArguments
         }
-        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _, _, _, _ in
+        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _, _, _, _, _ in
             XCTAssertEqual(_workspacePath, workspacePath)
             XCTAssertEqual(_scheme, scheme)
             XCTAssertTrue(_clean)
@@ -192,7 +192,7 @@ final class BuildServiceTests: TuistUnitTestCase {
             return buildArguments
         }
         targetBuilder
-            .buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _device, _osVersion, _, _ in
+            .buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _device, _osVersion, _, _, _ in
                 XCTAssertEqual(_workspacePath, workspacePath)
                 XCTAssertNil(_device)
                 XCTAssertNil(_osVersion)
@@ -248,7 +248,7 @@ final class BuildServiceTests: TuistUnitTestCase {
             XCTAssertEqual(_skipSigning, skipSigning)
             return buildArguments
         }
-        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _, _, _, _ in
+        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _, _, _, _, _ in
             XCTAssertEqual(_workspacePath, workspacePath)
             if _scheme.name == "A" {
                 XCTAssertEqual(_scheme, schemeA)
@@ -312,7 +312,8 @@ extension BuildService {
         platform: String? = nil,
         osVersion: String? = nil,
         rosetta: Bool = false,
-        generateOnly: Bool = false
+        generateOnly: Bool = false,
+        passthroughXcodeBuildArguments: [String] = []
     ) async throws {
         try await run(
             schemeName: schemeName,
@@ -326,7 +327,8 @@ extension BuildService {
             platform: platform,
             osVersion: osVersion,
             rosetta: rosetta,
-            generateOnly: generateOnly
+            generateOnly: generateOnly, 
+            passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
         )
     }
 }

--- a/Tests/TuistKitTests/Services/BuildServiceTests.swift
+++ b/Tests/TuistKitTests/Services/BuildServiceTests.swift
@@ -327,7 +327,7 @@ extension BuildService {
             platform: platform,
             osVersion: osVersion,
             rosetta: rosetta,
-            generateOnly: generateOnly, 
+            generateOnly: generateOnly,
             passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
         )
     }

--- a/Tests/TuistKitTests/Services/RunServiceTests.swift
+++ b/Tests/TuistKitTests/Services/RunServiceTests.swift
@@ -113,7 +113,7 @@ final class RunServiceTests: TuistUnitTestCase {
         let clean = true
         let configuration = "Test"
         targetBuilder
-            .buildTargetStub = { _, _workspacePath, _scheme, _clean, _configuration, _, _, _, _, _, _ in
+            .buildTargetStub = { _, _workspacePath, _scheme, _clean, _configuration, _, _, _, _, _, _, _ in
                 // Then
                 XCTAssertEqual(_workspacePath, workspacePath)
                 XCTAssertEqual(_scheme.name, schemeName)
@@ -185,7 +185,7 @@ final class RunServiceTests: TuistUnitTestCase {
         buildGraphInspector.workspacePathStub = { _ in workspacePath }
         buildGraphInspector.runnableSchemesStub = { _ in [.test()] }
         buildGraphInspector.runnableTargetStub = { _, _ in .test() }
-        targetBuilder.buildTargetStub = { _, _, _, _, _, _, _, _, _, _, _ in expectation.fulfill() }
+        targetBuilder.buildTargetStub = { _, _, _, _, _, _, _, _, _, _, _, _ in expectation.fulfill() }
         targetRunner.assertCanRunTargetStub = { _ in throw TestError() }
 
         // Then

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -203,7 +203,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedRosetta: Bool?
-        xcodebuildController.testStub = { _, _, _, _, rosetta, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, rosetta, _, _, _, _, _, _, _, _ in
             testedRosetta = rosetta
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -238,7 +238,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -270,7 +270,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -313,7 +313,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -345,7 +345,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -374,7 +374,7 @@ final class TestServiceTests: TuistUnitTestCase {
         }
         var testedSchemes: [String] = []
         xcodebuildController.testErrorStub = NSError.test()
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return []
         }
@@ -409,7 +409,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -429,7 +429,7 @@ final class TestServiceTests: TuistUnitTestCase {
         let expectedResourceBundlePath = try AbsolutePath(validating: "/test")
         var resourceBundlePath: AbsolutePath?
 
-        xcodebuildController.testStub = { _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _, _ in
             resourceBundlePath = gotResourceBundlePath
             return []
         }
@@ -460,7 +460,7 @@ final class TestServiceTests: TuistUnitTestCase {
         let expectedResourceBundlePath = try AbsolutePath(validating: "/test")
         var resourceBundlePath: AbsolutePath?
 
-        xcodebuildController.testStub = { _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _, _ in
             resourceBundlePath = gotResourceBundlePath
             return []
         }
@@ -505,7 +505,7 @@ final class TestServiceTests: TuistUnitTestCase {
         }
 
         var passedRetryCount = 0
-        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, retryCount, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, retryCount, _, _, _, _ in
             passedRetryCount = retryCount
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -538,7 +538,7 @@ final class TestServiceTests: TuistUnitTestCase {
         }
 
         var passedRetryCount = -1
-        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, retryCount, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, retryCount, _, _, _, _ in
             passedRetryCount = retryCount
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -581,7 +581,7 @@ final class TestServiceTests: TuistUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
             return [.standardOutput(.init(raw: "success"))]
         }
@@ -621,7 +621,7 @@ final class TestServiceTests: TuistUnitTestCase {
         generator.generateWithGraphStub = { path in
             (path, Graph.test())
         }
-        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, _, _, _, _, _ in
             [.standardOutput(.init(raw: "success"))]
         }
 
@@ -662,7 +662,8 @@ extension TestService {
         testTargets: [TestIdentifier] = [],
         skipTestTargets: [TestIdentifier] = [],
         testPlanConfiguration: TestPlanConfiguration? = nil,
-        generateOnly: Bool = false
+        generateOnly: Bool = false,
+        passthroughXcodeBuildArguments: [String] = []
     ) async throws {
         try await run(
             schemeName: schemeName,
@@ -680,7 +681,8 @@ extension TestService {
             testTargets: testTargets,
             skipTestTargets: skipTestTargets,
             testPlanConfiguration: testPlanConfiguration,
-            generateOnly: generateOnly
+            generateOnly: generateOnly, 
+            passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
         )
     }
 }

--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -681,7 +681,7 @@ extension TestService {
             testTargets: testTargets,
             skipTestTargets: skipTestTargets,
             testPlanConfiguration: testPlanConfiguration,
-            generateOnly: generateOnly, 
+            generateOnly: generateOnly,
             passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
         )
     }

--- a/docs/docs/guide/automation/build.md
+++ b/docs/docs/guide/automation/build.md
@@ -21,20 +21,16 @@ Understanding the build process is crucial to optimize the build times. Unfortun
 
 ## Building schemes
 
-To build schemes of a project, you can use the `tuist build` command. This command will generate the project if needed, and then build it using the `xcodebuild` command-line tool.
+To build schemes of a project, you can use the `tuist build` command. This command will generate the project if needed, and then build it using the `xcodebuild` command-line tool. We support the use of the `--` terminator to forward all subsequent arguments directly to `xcodebuild. Arguments such as `-workspace` or `-project` cannot be used because tuist takes care of them.
 
 ::: code-group
 ```bash [Build a scheme]
 tuist build MyScheme
 ```
 ```bash [Build a specific configuration]
-tuist build MyScheme --configuration Debug
+tuist build MyScheme -- -configuration Debug
 ```
 ```bash [Build all schemes without binary cache]
 tuist build --no-binary-cache
 ```
 :::
-
-> [!NOTE] XCODEBUILD ARGUMENT FORWARDING
-> We don't support forwarding arbitrary arguments to `xcodebuild` yet. If you need to pass arguments to `xcodebuild`, you can use the `--verbose` flag to see the command that Tuist is running, and then run it manually with the arguments you need.
-

--- a/docs/docs/guide/automation/test.md
+++ b/docs/docs/guide/automation/test.md
@@ -21,21 +21,17 @@ Test flakiness is a tremendous source of frustration for developers and loss of 
 
 ## Running scheme tests
 
-To run the tests of a project, you can use the `tuist test` command. This command will generate the project if needed, and then run the tests using the `xcodebuild` command-line tool.
+To run the tests of a project, you can use the `tuist test` command. This command will generate the project if needed, and then run the tests using the `xcodebuild` command-line tool. We support the use of the `--` terminator to forward all subsequent arguments directly to `xcodebuild. Arguments such as `-workspace` or `-project` cannot be used because tuist takes care of them.
 
 ::: code-group
 ```bash [Running scheme tests]
 tuist test MyScheme
 ```
 ```bash [Running all tests without binary cache]
-tuist test --no-binary-cache
+tuist test -- --no-binary-cache
 ```
 
 ```bash [Running all tests without selective testing]
 tuist test --no-selective-testing
 ```
 :::
-
-> [!NOTE] XCODEBUILD ARGUMENT FORWARDING
-> We don't support forwarding arbitrary arguments to `xcodebuild` yet. If you need to pass arguments to `xcodebuild`, you can use the `--verbose` flag to see the command that Tuist is running, and then run it manually with the arguments you need.
-

--- a/docs/docs/guide/automation/test.md
+++ b/docs/docs/guide/automation/test.md
@@ -21,14 +21,14 @@ Test flakiness is a tremendous source of frustration for developers and loss of 
 
 ## Running scheme tests
 
-To run the tests of a project, you can use the `tuist test` command. This command will generate the project if needed, and then run the tests using the `xcodebuild` command-line tool. We support the use of the `--` terminator to forward all subsequent arguments directly to `xcodebuild. Arguments such as `-workspace` or `-project` cannot be used because tuist takes care of them.
+To run the tests of a project, you can use the `tuist test` command. This command will generate the project if needed, and then run the tests using the `xcodebuild` command-line tool. We support the use of the `--` terminator to forward all subsequent arguments directly to `xcodebuild`. Arguments such as `-workspace` or `-project` cannot be used because tuist takes care of them.
 
 ::: code-group
 ```bash [Running scheme tests]
 tuist test MyScheme
 ```
 ```bash [Running all tests without binary cache]
-tuist test -- --no-binary-cache
+tuist test --no-binary-cache
 ```
 
 ```bash [Running all tests without selective testing]


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6292

### Short description 📝

As described in the issue, supporting standard xcodebuild arguments in `tuist build` and `tuist test` doesn't scale. For every _first-class_ xcodebuild parameter we want to provide good ergonomics for, we also add some overhead if some arguments are shortened or reworded for clarity, while everybody is familiar with `xcodebuild` arguments already.

Also, consider the amount of boilerplate and validation we do in `XcodeBuildArgument` for parsing the argument into a type and the other way around when passing the arguments to `xcodebuild`. The typed xcodebuild arguments are not justified as they're not used in different command pipeline parts.

### How to test the changes locally 🧐

For `tuist build`, the arguments `clean`, `device`, `platform`, `os`, `rosetta`, `configuration`, and `derivedDataPath` are now deprecated and you will get a warning asking you to use the default `xcodebuild` arguments after the terminator `--`. The same will happen when using `tuist test` with a couple of extra deprecated arguments: `retryCount` and `resultBundlePath`.

```bash
tuist build --path PATH --configuration Debug # warning
```

Running `tuist build` or `tuist test` with arguments already supported by `xcodebuild` (after the terminator `--`) should work as expected:

```bash
tuist build --path PATH -- -configuration Debug
```

Please note that tuist already sets some `xcodebuild` parameters for you. If you try to use the arguments `-scheme`, `-workspace`, or `-project` after the terminator `--` it will throw an error. For `tuist test` the disallowed arguments also includes `-testPlan`, `-skip-test-configuration`, `-only-test-configuration`, `-only-testing`, and `-skip-testing`.

```bash
tuist build -- -project MyApp # error
```

### Contributor checklist ✅

- [X] The code has been linted using run `mise run lint:fix`
- [X] The change is tested via unit testing or acceptance testing, or both
- [X] The title of the PR is formulated in a way that is usable as a changelog entry
- [X] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
