### PR TITLE
Support "Code Sign on Copy" in Copy Files Actions

### DIFF
--- a/Sources/ProjectDescription/CopyFileElement.swift
+++ b/Sources/ProjectDescription/CopyFileElement.swift
@@ -1,8 +1,9 @@
 import Foundation
 
-/// A file element from a glob pattern or a folder reference which is conditionally applied to specific platforms with an optional "Code Sign On Copy" flag.
+/// A file element from a glob pattern or a folder reference which is conditionally applied to specific platforms with an optional
+/// "Code Sign On Copy" flag.
 public enum CopyFileElement: Codable, Equatable {
-    /// A file path (or glob pattern) to include with an optional PlatformCondition to control which platforms it applies. 
+    /// A file path (or glob pattern) to include with an optional PlatformCondition to control which platforms it applies.
     /// "Code Sign on Copy" can be optionally enabled for the glob.
     case glob(pattern: Path, condition: PlatformCondition? = nil, codeSignOnCopy: Bool = false)
 

--- a/Sources/ProjectDescription/CopyFileElement.swift
+++ b/Sources/ProjectDescription/CopyFileElement.swift
@@ -3,11 +3,11 @@ import Foundation
 /// A file element from a glob pattern or a folder reference which is conditionally applied to specific platforms.
 public enum CopyFileElement: Codable, Equatable {
     /// A file path (or glob pattern) to include with an optional PlatformCondition to control which platforms it applies to.
-    case glob(pattern: Path, condition: PlatformCondition? = nil)
+    case glob(pattern: Path, condition: PlatformCondition? = nil, codeSign: Bool = false)
 
     /// A directory path to include as a folder reference with an optional PlatformCondition to control which platforms it applies
     /// to.
-    case folderReference(path: Path, condition: PlatformCondition? = nil)
+    case folderReference(path: Path, condition: PlatformCondition? = nil, codeSign: Bool = false)
 
     private enum TypeName: String, Codable {
         case glob

--- a/Sources/ProjectDescription/CopyFileElement.swift
+++ b/Sources/ProjectDescription/CopyFileElement.swift
@@ -1,13 +1,14 @@
 import Foundation
 
-/// A file element from a glob pattern or a folder reference which is conditionally applied to specific platforms.
+/// A file element from a glob pattern or a folder reference which is conditionally applied to specific platforms with an optional "Code Sign On Copy" flag.
 public enum CopyFileElement: Codable, Equatable {
-    /// A file path (or glob pattern) to include with an optional PlatformCondition to control which platforms it applies to.
-    case glob(pattern: Path, condition: PlatformCondition? = nil, codeSign: Bool = false)
+    /// A file path (or glob pattern) to include with an optional PlatformCondition to control which platforms it applies. 
+    /// "Code Sign on Copy" can be optionally enabled for the glob.
+    case glob(pattern: Path, condition: PlatformCondition? = nil, codeSignOnCopy: Bool = false)
 
     /// A directory path to include as a folder reference with an optional PlatformCondition to control which platforms it applies
-    /// to.
-    case folderReference(path: Path, condition: PlatformCondition? = nil, codeSign: Bool = false)
+    /// to. "Code Sign on Copy" can be optionally enabled for the folder reference.
+    case folderReference(path: Path, condition: PlatformCondition? = nil, codeSignOnCopy: Bool = false)
 
     private enum TypeName: String, Codable {
         case glob

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -409,9 +409,21 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
                 guard let fileReference = fileElements.file(path: filePath) else {
                     throw BuildPhaseGenerationError.missingFileReference(filePath)
                 }
+                
+                var settings: [String: Any]?
+
+                /// Source file ATTRIBUTES
+                /// example: `settings = {ATTRIBUTES = (Codesign, )`}
+                if file.codeSign {
+                    var settingsCopy = settings ?? [:]
+                    var attributes = settingsCopy["ATTRIBUTES"] as? [String] ?? []
+                    attributes.append("CodeSignOnCopy")
+                    settingsCopy["ATTRIBUTES"] = attributes
+                    settings = settingsCopy
+                }
 
                 if buildFilesCache.contains(filePath) == false {
-                    let pbxBuildFile = PBXBuildFile(file: fileReference)
+                    let pbxBuildFile = PBXBuildFile(file: fileReference, settings: settings)
                     pbxBuildFile.applyPlatformFilters(file.condition?.platformFilters)
                     pbxBuildFiles.append(pbxBuildFile)
                     buildFilesCache.insert(filePath)

--- a/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
+++ b/Sources/TuistGenerator/Generator/BuildPhaseGenerator.swift
@@ -409,12 +409,12 @@ final class BuildPhaseGenerator: BuildPhaseGenerating {
                 guard let fileReference = fileElements.file(path: filePath) else {
                     throw BuildPhaseGenerationError.missingFileReference(filePath)
                 }
-                
+
                 var settings: [String: Any]?
 
-                /// Source file ATTRIBUTES
+                /// File ATTRIBUTES
                 /// example: `settings = {ATTRIBUTES = (Codesign, )`}
-                if file.codeSign {
+                if file.codeSignOnCopy {
                     var settingsCopy = settings ?? [:]
                     var attributes = settingsCopy["ATTRIBUTES"] as? [String] ?? []
                     attributes.append("CodeSignOnCopy")

--- a/Sources/TuistGraph/Models/CopyFileElement.swift
+++ b/Sources/TuistGraph/Models/CopyFileElement.swift
@@ -2,14 +2,14 @@ import Foundation
 import TSCBasic
 
 public enum CopyFileElement: Equatable, Hashable, Codable {
-    case file(path: AbsolutePath, condition: PlatformCondition? = nil)
-    case folderReference(path: AbsolutePath, condition: PlatformCondition? = nil)
+    case file(path: AbsolutePath, condition: PlatformCondition? = nil, codeSign: Bool = false)
+    case folderReference(path: AbsolutePath, condition: PlatformCondition? = nil, codeSign: Bool = false)
 
     public var path: AbsolutePath {
         switch self {
-        case let .file(path, _):
+        case let .file(path, _, _):
             return path
-        case let .folderReference(path, _):
+        case let .folderReference(path, _, _):
             return path
         }
     }
@@ -25,8 +25,15 @@ public enum CopyFileElement: Equatable, Hashable, Codable {
 
     public var condition: PlatformCondition? {
         switch self {
-        case let .file(_, condition), let .folderReference(_, condition):
+        case let .file(_, condition, _), let .folderReference(_, condition, _):
             return condition
+        }
+    }
+    
+    public var codeSign: Bool {
+        switch self {
+        case let .file(_, _, codesign), let .folderReference(_, _, codesign):
+            return codesign
         }
     }
 }

--- a/Sources/TuistGraph/Models/CopyFileElement.swift
+++ b/Sources/TuistGraph/Models/CopyFileElement.swift
@@ -2,8 +2,8 @@ import Foundation
 import TSCBasic
 
 public enum CopyFileElement: Equatable, Hashable, Codable {
-    case file(path: AbsolutePath, condition: PlatformCondition? = nil, codeSign: Bool = false)
-    case folderReference(path: AbsolutePath, condition: PlatformCondition? = nil, codeSign: Bool = false)
+    case file(path: AbsolutePath, condition: PlatformCondition? = nil, codeSignOnCopy: Bool = false)
+    case folderReference(path: AbsolutePath, condition: PlatformCondition? = nil, codeSignOnCopy: Bool = false)
 
     public var path: AbsolutePath {
         switch self {
@@ -29,11 +29,11 @@ public enum CopyFileElement: Equatable, Hashable, Codable {
             return condition
         }
     }
-    
-    public var codeSign: Bool {
+
+    public var codeSignOnCopy: Bool {
         switch self {
-        case let .file(_, _, codesign), let .folderReference(_, _, codesign):
-            return codesign
+        case let .file(_, _, codeSignOnCopy), let .folderReference(_, _, codeSignOnCopy):
+            return codeSignOnCopy
         }
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/CopyFileElement+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/CopyFileElement+ManifestMapper.swift
@@ -51,12 +51,12 @@ extension TuistGraph.CopyFileElement {
         }
 
         switch manifest {
-        case let .glob(pattern: pattern, condition: condition):
+        case let .glob(pattern: pattern, condition: condition, codeSign: codeSign):
             let resolvedPath = try generatorPaths.resolve(path: pattern)
-            return try globFiles(resolvedPath).map { .file(path: $0, condition: condition?.asGraphCondition) }
-        case let .folderReference(path: folderReferencePath, condition: condition):
+            return try globFiles(resolvedPath).map { .file(path: $0, condition: condition?.asGraphCondition, codeSign: codeSign) }
+        case let .folderReference(path: folderReferencePath, condition: condition, codeSign: codeSign):
             let resolvedPath = try generatorPaths.resolve(path: folderReferencePath)
-            return folderReferences(resolvedPath).map { .folderReference(path: $0, condition: condition?.asGraphCondition) }
+            return folderReferences(resolvedPath).map { .folderReference(path: $0, condition: condition?.asGraphCondition, codeSign: codeSign) }
         }
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/CopyFileElement+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/CopyFileElement+ManifestMapper.swift
@@ -51,12 +51,20 @@ extension TuistGraph.CopyFileElement {
         }
 
         switch manifest {
-        case let .glob(pattern: pattern, condition: condition, codeSign: codeSign):
+        case let .glob(pattern: pattern, condition: condition, codeSignOnCopy: codeSign):
             let resolvedPath = try generatorPaths.resolve(path: pattern)
-            return try globFiles(resolvedPath).map { .file(path: $0, condition: condition?.asGraphCondition, codeSign: codeSign) }
-        case let .folderReference(path: folderReferencePath, condition: condition, codeSign: codeSign):
+            return try globFiles(resolvedPath).map { .file(
+                path: $0,
+                condition: condition?.asGraphCondition,
+                codeSignOnCopy: codeSign)
+            }
+        case let .folderReference(path: folderReferencePath, condition: condition, codeSignOnCopy: codeSign):
             let resolvedPath = try generatorPaths.resolve(path: folderReferencePath)
-            return folderReferences(resolvedPath).map { .folderReference(path: $0, condition: condition?.asGraphCondition, codeSign: codeSign) }
+            return folderReferences(resolvedPath).map { .folderReference(
+                path: $0,
+                condition: condition?.asGraphCondition,
+                codeSignOnCopy: codeSign
+            ) }
         }
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/CopyFileElement+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/CopyFileElement+ManifestMapper.swift
@@ -56,7 +56,8 @@ extension TuistGraph.CopyFileElement {
             return try globFiles(resolvedPath).map { .file(
                 path: $0,
                 condition: condition?.asGraphCondition,
-                codeSignOnCopy: codeSign)
+                codeSignOnCopy: codeSign
+            )
             }
         case let .folderReference(path: folderReferencePath, condition: condition, codeSignOnCopy: codeSign):
             let resolvedPath = try generatorPaths.resolve(path: folderReferencePath)

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -903,7 +903,7 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
             "font3.ttf",
             "font4.ttf",
             "font5.ttf",
-            "font6.ttf"
+            "font6.ttf",
         ])
 
         XCTAssertEqual(firstBuildPhase.files?.map(\.platformFilters), [
@@ -912,18 +912,18 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
             ["macos"],
             nil,
             ["macos"],
-            nil
+            nil,
         ])
-        
+
         XCTAssertEqual(firstBuildPhase.files?.map(\.settings) as? [[String: [String]]?], [
             nil,
             nil,
             nil,
             ["ATTRIBUTES": ["Codesign"]],
             ["ATTRIBUTES": ["Codesign"]],
-            nil
+            nil,
         ])
-        
+
         let secondBuildPhase = try XCTUnwrap(nativeTarget.buildPhases.last as? PBXCopyFilesBuildPhase)
         XCTAssertEqual(secondBuildPhase.name, "Copy Templates")
         XCTAssertEqual(secondBuildPhase.dstSubfolderSpec, .sharedSupport)

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -866,9 +866,9 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
             .file(path: "/path/fonts/font1.ttf"),
             .file(path: "/path/fonts/font2.ttf"),
             .file(path: "/path/fonts/font3.ttf", condition: .when([.macos])),
-            .file(path: "/path/fonts/font4.ttf", codeSign: true),
-            .file(path: "/path/fonts/font5.ttf", condition: .when([.macos]), codeSign: true),
-            .file(path: "/path/fonts/font6.ttf", codeSign: false),
+            .file(path: "/path/fonts/font4.ttf", codeSignOnCopy: true),
+            .file(path: "/path/fonts/font5.ttf", condition: .when([.macos]), codeSignOnCopy: true),
+            .file(path: "/path/fonts/font6.ttf", codeSignOnCopy: false),
         ]
 
         let templates: [CopyFileElement] = [
@@ -919,8 +919,8 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
             nil,
             nil,
             nil,
-            ["ATTRIBUTES": ["Codesign"]],
-            ["ATTRIBUTES": ["Codesign"]],
+            ["ATTRIBUTES": ["CodeSignOnCopy"]],
+            ["ATTRIBUTES": ["CodeSignOnCopy"]],
             nil,
         ])
 

--- a/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
+++ b/Tests/TuistGeneratorTests/Generator/BuildPhaseGeneratorTests.swift
@@ -866,6 +866,9 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
             .file(path: "/path/fonts/font1.ttf"),
             .file(path: "/path/fonts/font2.ttf"),
             .file(path: "/path/fonts/font3.ttf", condition: .when([.macos])),
+            .file(path: "/path/fonts/font4.ttf", codeSign: true),
+            .file(path: "/path/fonts/font5.ttf", condition: .when([.macos]), codeSign: true),
+            .file(path: "/path/fonts/font6.ttf", codeSign: false),
         ]
 
         let templates: [CopyFileElement] = [
@@ -898,14 +901,29 @@ final class BuildPhaseGeneratorTests: TuistUnitTestCase {
             "font1.ttf",
             "font2.ttf",
             "font3.ttf",
+            "font4.ttf",
+            "font5.ttf",
+            "font6.ttf"
         ])
 
         XCTAssertEqual(firstBuildPhase.files?.map(\.platformFilters), [
             nil,
             nil,
             ["macos"],
+            nil,
+            ["macos"],
+            nil
         ])
-
+        
+        XCTAssertEqual(firstBuildPhase.files?.map(\.settings) as? [[String: [String]]?], [
+            nil,
+            nil,
+            nil,
+            ["ATTRIBUTES": ["Codesign"]],
+            ["ATTRIBUTES": ["Codesign"]],
+            nil
+        ])
+        
         let secondBuildPhase = try XCTUnwrap(nativeTarget.buildPhases.last as? PBXCopyFilesBuildPhase)
         XCTAssertEqual(secondBuildPhase.name, "Copy Templates")
         XCTAssertEqual(secondBuildPhase.dstSubfolderSpec, .sharedSupport)


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6301

### Short description 📝
Adds support for code sign on copy to CopyFileElement. This allows developers to mark certain copied files for code signing just like they can in Xcode.

### How to test the changes locally 🧐
1. Pull the PR onto your local machine
2. Download the test project
3. Build the test project using the branch
4. Observe "Code sign on copy" checked in the generated Xcode Project

[TuistProj.zip](https://github.com/tuist/tuist/files/15381797/TuistProj.zip)

### Contributor checklist ✅
- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅
- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry