### PR TITLE
Making `tuist run` interactive by selecting simulators

### DIFF
--- a/Sources/TuistAutomation/Utilities/TargetRunner.swift
+++ b/Sources/TuistAutomation/Utilities/TargetRunner.swift
@@ -153,8 +153,12 @@ public final class TargetRunner: TargetRunning {
         let settings = try await xcodeBuildController
             .showBuildSettings(.workspace(workspacePath), scheme: schemeName, configuration: configuration, derivedDataPath: nil)
         let bundleId = settings[target.target.name]?.productBundleIdentifier ?? target.target.bundleId
-        let simulator = try await simulatorController
-            .findAvailableDevice(platform: platform, version: version, minVersion: minVersion, deviceName: deviceName)
+        let simulator = try await simulatorController.askForAvailableDevice(
+            platform: platform,
+            version: version,
+            minVersion: minVersion,
+            deviceName: deviceName
+        )
 
         logger.debug("Running app \(appPath.pathString) with arguments [\(arguments.joined(separator: ", "))]")
         logger.notice("Running app \(bundleId) on \(simulator.device.name)", metadata: .section)

--- a/Sources/TuistCore/Simulator/SimulatorController.swift
+++ b/Sources/TuistCore/Simulator/SimulatorController.swift
@@ -18,6 +18,20 @@ public protocol SimulatorControlling {
         deviceName: String?
     ) async throws -> SimulatorDeviceAndRuntime
 
+    /// Ask the user to select one of the available devices defined by given parameters
+    /// if there is more than one, otherwise return the only one available
+    /// - Parameters:
+    ///    - platform: Given platform
+    ///    - version: Specific version, ignored if nil
+    ///    - minVersion: Minimum version of the OS
+    ///    - deviceName: Specific device name (eg. iPhone X)
+    func askForAvailableDevice(
+        platform: Platform,
+        version: Version?,
+        minVersion: Version?,
+        deviceName: String?
+    ) async throws -> SimulatorDeviceAndRuntime
+
     func findAvailableDevices(
         platform: Platform,
         version: Version?,
@@ -81,8 +95,11 @@ public enum SimulatorControllerError: Equatable, FatalError {
 
 public final class SimulatorController: SimulatorControlling {
     private let jsonDecoder = JSONDecoder()
+    private let userInputReader: UserInputReading
 
-    public init() {}
+    public init(userInputReader: UserInputReading = UserInputReader()) {
+        self.userInputReader = userInputReader
+    }
 
     /// Returns the list of simulator devices that are available in the system.
     func devices() async throws -> [SimulatorDevice] {
@@ -189,6 +206,37 @@ public final class SimulatorController: SimulatorControlling {
         else { throw SimulatorControllerError.deviceNotFound(platform, version, deviceName, try await devicesAndRuntimes())
         }
         return device
+    }
+
+    public func askForAvailableDevice(
+        platform: Platform,
+        version: Version?,
+        minVersion: Version?,
+        deviceName: String?
+    ) async throws -> SimulatorDeviceAndRuntime {
+        let availableDevices = try await findAvailableDevices(
+            platform: platform,
+            version: version,
+            minVersion: minVersion,
+            deviceName: deviceName
+        )
+        if availableDevices.isEmpty {
+            throw SimulatorControllerError.deviceNotFound(
+                platform,
+                version,
+                deviceName,
+                try await devicesAndRuntimes()
+            )
+        }
+        if availableDevices.count == 1, let onlyOption = availableDevices.first {
+            return onlyOption
+        }
+        var prompt = "Select the simulator device where you want to run the app:\n"
+        for (index, availableDevice) in availableDevices.enumerated() {
+            prompt += "\t\(index): \(availableDevice.device.name) (\(availableDevice.device.udid))\n"
+        }
+        let choice = userInputReader.readInt(asking: prompt, maxValueAllowed: availableDevices.count)
+        return availableDevices[choice]
     }
 
     public func installApp(at path: AbsolutePath, device: SimulatorDevice) throws {

--- a/Sources/TuistCoreTesting/Simulator/MockSimulatorController.swift
+++ b/Sources/TuistCoreTesting/Simulator/MockSimulatorController.swift
@@ -19,6 +19,16 @@ public final class MockSimulatorController: SimulatorControlling {
         findAvailableDevicesStub?(platform, version, minVersion, deviceName) ?? [SimulatorDeviceAndRuntime.test()]
     }
 
+    public var askForAvailableDeviceStub: ((Platform, Version?, Version?, String?) -> SimulatorDeviceAndRuntime)?
+    public func askForAvailableDevice(
+        platform: TuistGraph.Platform,
+        version: TSCUtility.Version?,
+        minVersion: TSCUtility.Version?,
+        deviceName: String?
+    ) async throws -> TuistCore.SimulatorDeviceAndRuntime {
+        askForAvailableDeviceStub?(platform, version, minVersion, deviceName) ?? SimulatorDeviceAndRuntime.test()
+    }
+
     public var findAvailableDeviceStub: ((Platform, Version?, Version?, String?) -> SimulatorDeviceAndRuntime)?
     public func findAvailableDevice(
         platform: Platform,

--- a/Sources/TuistSupport/UserInputReader.swift
+++ b/Sources/TuistSupport/UserInputReader.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+public protocol UserInputReading {
+    /// Reads an integer from the user
+    /// - Parameters:
+    ///   - prompt: The prompt to be shown to the user providing context and the allowed options
+    ///   - maxValueAllowed: The max value allowed given the list of options provided in the prompt
+    func readInt(asking prompt: String, maxValueAllowed: Int) -> Int
+}
+
+public struct UserInputReader: UserInputReading {
+    private var reader: (Bool) -> String?
+
+    public init(reader: @escaping (Bool) -> String? = readLine) {
+        self.reader = reader
+    }
+
+    public func readInt(asking prompt: String, maxValueAllowed: Int) -> Int {
+        while true {
+            logger.notice("\(prompt)")
+            if let input = reader(true), !input.isEmpty, let intValue = Int(input), intValue < maxValueAllowed {
+                return intValue
+            } else {
+                logger.notice("Invalid input. Please enter a valid integer.")
+            }
+        }
+    }
+}

--- a/Tests/TuistSupportTests/Utils/UserInputReaderTests.swift
+++ b/Tests/TuistSupportTests/Utils/UserInputReaderTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import TuistSupport
+
+class UserInputReaderTests: XCTestCase {
+    func test_read_int_valid_input() {
+        // Given
+        var fakeReadLine = StringReader(input: "0")
+        let reader: UserInputReader = .init { _ in
+            fakeReadLine.readLine()
+        }
+
+        // When
+        let result = reader.readInt(asking: "prompt", maxValueAllowed: 1)
+
+        // Then
+        XCTAssertEqual(result, Int(fakeReadLine.input))
+    }
+
+    func test_read_int_after_incorrect_inputs() {
+        // Given
+        var fakeReadLine = StringReader(input: "a21")
+        let reader: UserInputReader = .init { _ in
+            fakeReadLine.readLine()
+        }
+
+        // When
+        let result = reader.readInt(asking: "prompt", maxValueAllowed: 2)
+
+        // Then
+        XCTAssertEqual(result, Int(String(fakeReadLine.input.last!)))
+    }
+}
+
+// Custom string reader to simulate user input
+private struct StringReader {
+    let input: String
+    var index: String.Index
+
+    init(input: String) {
+        self.input = input
+        index = input.startIndex
+    }
+
+    mutating func readLine() -> String? {
+        guard index < input.endIndex else { return nil }
+        defer { index = input.index(after: index) }
+        return String(input[index...])
+    }
+}

--- a/docs/docs/guide/automation/run.md
+++ b/docs/docs/guide/automation/run.md
@@ -22,4 +22,4 @@ tuist run MyApp --device "iPhone 15" --os "17.4.1"
 :::
 
 > [!NOTE] EXISTING SIMULATORS
-> If Tuist can't find a destination that matches the specified device and OS, it will use the first available simulator.
+> If Tuist can't find a destination that matches the specified device and OS or none is provided, it will ask in which available simulator to run, in case of many available, or pick the only one available otherwise.


### PR DESCRIPTION
### Short description 📝

In a recent conversation with @pepicrft, we discussed the potential benefits of making tuist run interactive. This PR initiates that process by listing the active available simulators and prompting the user to pick one if no destination is provided and multiple simulators are available, instead of defaulting to the first available simulator.

### How to test the changes locally 🧐

1. Follow these [steps](https://docs.tuist.io/contributors/get-started.html#run-tuist) using an appropriate iOS fixture, such as ios_app_large.
2. Pass the `run {scheme}` argument (e.g., `App1` if you used the mentioned fixture) to the scheme.
3. Press CMD+R. If multiple simulators are booted, the bottom debug area will prompt you to select a destination.

https://github.com/tuist/tuist/assets/1938501/ecde3a7b-5764-4aa7-b38a-84b588ddd3d1

### Contributor checklist ✅

- [X] The code has been linted using run `mise run lint:fix`
- [X] The change is tested via unit testing or acceptance testing, or both
- [X] The title of the PR is formulated in a way that is usable as a changelog entry
- [X] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
