### PR TITLE
Fix the initialization of projects in Homebrew-managed installations

### DIFF
--- a/Sources/TuistScaffold/TemplatesDirectoryLocator.swift
+++ b/Sources/TuistScaffold/TemplatesDirectoryLocator.swift
@@ -57,7 +57,7 @@ public final class TemplatesDirectoryLocator: TemplatesDirectoryLocating {
                    share/
                        Templates
                 */
-            bundlePath.parentDirectory.appending(try! RelativePath(validating: "share/Templates")),
+            bundlePath.parentDirectory.appending(try! RelativePath(validating: "share")),
             // swiftlint:disable:previous force_try
         ]
         let candidates = paths.map { path in


### PR DESCRIPTION
Fixes https://github.com/tuist/tuist/issues/5921

### Short description 📝
It turns out that the candidate that we were using for looking up `init` templates in a Homebrew installation was wrong. This PR fixes it.

### How to test the changes locally 🧐
You'll have to build Tuist, reproduce a Homebrew installation with the binary in it, and then run `tuist init`.

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
