### PR TITLE
Fix warnings for excluded resources

### DIFF
--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -1019,25 +1019,6 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
                                 ],
                                 tags: []
                             ),
-                            .glob(
-                                pattern: .path(
-                                    basePath
-                                        .appending(
-                                            try RelativePath(validating: "Package/Sources/Target1/AnotherOne/Resource/Folder/**")
-                                        )
-                                        .pathString
-                                ),
-                                excluding: [
-                                    .path(
-                                        basePath
-                                            .appending(
-                                                try RelativePath(validating: "Package/Sources/Target1/AnotherOne/Resource/**")
-                                            )
-                                            .pathString
-                                    ),
-                                ],
-                                tags: []
-                            ),
                         ]
                     ),
                 ]


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/5928

### Short description 📝

In some cases, PackageInfoMapper processes resource file elements which are listed in the corresponding package target `exclude` list/glob. For example, it happens when a target is missing `sources`. In this case, PackageInfoMapper finds all resource-oriented files in the `path` even if these files should be excluded.
This is a PR to exclude such files from the generated manifest info.

### How to test the changes locally 🧐

> Include a set of steps for the reviewer to test the changes locally (see [the documentation](https://docs.tuist.io/contributors/testing-strategy) for reference).

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
