### PR TITLE
Fixes #6321: Handle formatting multiline text

### DIFF
--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -298,18 +298,32 @@ public final class XcodeBuildController: XcodeBuildControlling {
                     if self?.environment.isVerbose == true {
                         return SystemEvent.standardError(XcodeBuildOutput(raw: line))
                     } else {
-                        return SystemEvent.standardError(XcodeBuildOutput(raw: self?.formatter.format(line) ?? ""))
+                        return SystemEvent.standardError(XcodeBuildOutput(raw: self?.format(line) ?? ""))
                     }
                 case let .standardOutput(outputData):
                     guard let line = String(data: outputData, encoding: .utf8) else { return nil }
                     if self?.environment.isVerbose == true {
                         return SystemEvent.standardOutput(XcodeBuildOutput(raw: line))
                     } else {
-                        return SystemEvent.standardOutput(XcodeBuildOutput(raw: self?.formatter.format(line) ?? ""))
+                        return SystemEvent.standardOutput(XcodeBuildOutput(raw: self?.format(line) ?? ""))
                     }
                 }
             }
             .eraseToAnyPublisher()
             .stream
+    }
+}
+
+// MARK: - Helpers
+
+fileprivate extension XcodeBuildController {
+    func format(_ multiLineText: String) -> String {
+        multiLineText.split(separator: "\n").map {
+            let line = String($0)
+            let formattedLine = formatter.format(line)
+
+            return formattedLine ?? ""
+        }
+        .joined(separator: "\n")
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6321

### Short description 📝

> When multiline data received from xcodebuild logs was formatted, I noticed a bug where only the first captured group in the multiline text was being logged, while others were being ignored. To address this, splitting up the text before passing it to the XCBeautify formatter seemed appropriate to me.

### How to test the changes locally 🧐

> To verify the fix:
1. Check out the branch and build Tuist.
2. Download the sample project attached to the issue.
3. Run the tests for the target using the new build.
4. Confirm that logs for all the tests are present.

### Contributor checklist ✅

- [ ] The code has been linted using run `mise run lint:fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [ ] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
