### PR TITLE
Fix Tests

### DIFF
--- a/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -498,7 +498,6 @@ final class TestServiceTests: TuistUnitTestCase {
 
         xcodebuildController.testStub = { _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _, _ in
             resultBundlePath = gotResourceBundlePath
-            return []
         }
         generator.generateWithGraphStub = { path in
             (path, Graph.test())


### PR DESCRIPTION
The method signature on the mock controller changed while another PR was in flight causing this to pass on the branch but fail on `main`.
