### PR TITLE
Fix wrong linking settings for transitive static pre-compiled binaries with intermediate dynamic pre-compiled binaries in the branch 

### DIFF
--- a/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -1084,9 +1084,16 @@ public class GraphTraverser: GraphTraversing {
     }
 
     func canDependencyLinkStaticProducts(dependency: GraphDependency) -> Bool {
-        guard case let GraphDependency.target(name, path) = dependency,
-              let target = target(path: path, name: name) else { return false }
-        return target.target.canLinkStaticProducts()
+        switch dependency {
+        case let .target(name, path):
+            guard let target = target(path: path, name: name) else { return false }
+            return target.target.canLinkStaticProducts()
+        case let .xcframework(xcframework): return xcframework.linking == .dynamic
+        case let .framework(_, _, _, _, linking, _, _): return linking == .dynamic
+        case let .library(_, _, linking, _, _): return linking == .dynamic
+        default:
+            return false
+        }
     }
 
     func unitTestHost(path: AbsolutePath, name: String) -> GraphTarget? {

--- a/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/TuistCoreTests/Graph/GraphTraverserTests.swift
@@ -1943,7 +1943,6 @@ final class GraphTraverserTests: TuistUnitTestCase {
         // Then
         XCTAssertEqual(got, [
             GraphDependencyReference(dependencyPrecompiledDynamicBinaryA),
-            GraphDependencyReference(dependencyPrecompiledStaticBinaryB),
         ])
 
         // When


### PR DESCRIPTION
### Short description 📝
When using Tuist's caching functionality, some users reported symbol issues when running their apps after replacing all the targets with binaries. It turns out that we had a bug in the logic that caused the linking of transitive static pre-compiled binaries when there are intermediate dynamic pre-compiled binaries in the branch.

For example, given the graph  App > Precompiled dynamic binary > Precompiled static binary, we were linking the static binary at the app level when we should not because it's already been linked into the dynamic library.

This PR fixes it by adjusting one of the internal functions of the graph traverse that did not take into account the linking of the pre-compiled `GraphDependency`.

### How to test the changes locally 🧐
It's a bit tricky because you need a project with the above graph.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
