### PR TITLE
Add documentation about `@_implementationOnly` to the dependencies page

### DIFF
--- a/docs/docs/guide/project/dependencies.md
+++ b/docs/docs/guide/project/dependencies.md
@@ -340,3 +340,11 @@ let packageSettings = PackageSettings(
 let package = Package(
 ...
 ```
+
+### Transitive static dependencies leaking through `.swiftmodule`
+
+When a dynamic framework or library depends on static ones through `import StaticSwiftModule`, the symbols are included referenced in the `.swiftmodule` of the dynamic framework or library, potentially [causing the compilation to fail](https://forums.swift.org/t/compiling-a-dynamic-framework-with-a-statically-linked-library-creates-dependencies-in-swiftmodule-file/22708/1). To prevent that, you'll have to import the static dependency using:
+
+```swift
+@_implementationOnly import StaticModule
+```

--- a/docs/docs/guide/project/dependencies.md
+++ b/docs/docs/guide/project/dependencies.md
@@ -343,7 +343,7 @@ let package = Package(
 
 ### Transitive static dependencies leaking through `.swiftmodule`
 
-When a dynamic framework or library depends on static ones through `import StaticSwiftModule`, the symbols are included referenced in the `.swiftmodule` of the dynamic framework or library, potentially [causing the compilation to fail](https://forums.swift.org/t/compiling-a-dynamic-framework-with-a-statically-linked-library-creates-dependencies-in-swiftmodule-file/22708/1). To prevent that, you'll have to import the static dependency using:
+When a dynamic framework or library depends on static ones through `import StaticSwiftModule`, the symbols are included in the `.swiftmodule` of the dynamic framework or library, potentially [causing the compilation to fail](https://forums.swift.org/t/compiling-a-dynamic-framework-with-a-statically-linked-library-creates-dependencies-in-swiftmodule-file/22708/1). To prevent that, you'll have to import the static dependency using:
 
 ```swift
 @_implementationOnly import StaticModule

--- a/docs/docs/guide/project/dependencies.md
+++ b/docs/docs/guide/project/dependencies.md
@@ -343,7 +343,7 @@ let package = Package(
 
 ### Transitive static dependencies leaking through `.swiftmodule`
 
-When a dynamic framework or library depends on static ones through `import StaticSwiftModule`, the symbols are included in the `.swiftmodule` of the dynamic framework or library, potentially [causing the compilation to fail](https://forums.swift.org/t/compiling-a-dynamic-framework-with-a-statically-linked-library-creates-dependencies-in-swiftmodule-file/22708/1). To prevent that, you'll have to import the static dependency using:
+When a dynamic framework or library depends on static ones through `import StaticSwiftModule`, the symbols are included in the `.swiftmodule` of the dynamic framework or library, potentially [causing the compilation to fail](https://forums.swift.org/t/compiling-a-dynamic-framework-with-a-statically-linked-library-creates-dependencies-in-swiftmodule-file/22708/1). To prevent that, you'll have to import the static dependency using [`@_implementationOnly`](https://github.com/apple/swift/blob/main/docs/ReferenceGuides/UnderscoredAttributes.md#_implementationonly):
 
 ```swift
 @_implementationOnly import StaticModule


### PR DESCRIPTION
While debugging an issue with Tuist caching in a scenario where an app depends transitively on a static pre-compiled module through a dynamic one, @thedavidharris pointed me to [this Swift forum](https://forums.swift.org/t/compiling-a-dynamic-framework-with-a-statically-linked-library-creates-dependencies-in-swiftmodule-file/22708/9) where they touch on the need of using `@_implementationOnly` when importing those transitive dependencies to prevent their symbols to leak through the `.swiftmodule` of the dynamic ones.
Because this is not trivial to realize, I'm adding some notes in our documentation to help users come across this scenario in the future.