### PR TITLE
Add `PackageSettings.spmLinkingStyle` to allow users to opt into SPM's linking logic 

### DIFF
--- a/Sources/ProjectDescription/PackageSettings.swift
+++ b/Sources/ProjectDescription/PackageSettings.swift
@@ -26,6 +26,17 @@ import Foundation
 /// )
 /// ```
 public struct PackageSettings: Codable, Equatable {
+    /**
+     When packages are linked statically, which is the default of Tuist's integration using XcodeProj primitives,
+     issues might arise due to missing extensions. This is a [known issue](https://github.com/apple/swift/issues/48561)
+     that the SPM circumvents using the `-r` flag with the linker, or the `GENERATE_MASTER_OBJECT_FILE` build setting with the
+     packages' targets.
+
+     Opting-into that behaviour can have a negative impact on the final binary size, and therefore we keep it as disable but giving
+     developers an option to opt into it easily. When this value is set to true, it applies it to all the packages of the project that are static.
+     */
+    public var enableMasterObjectFileGenerationInStaticTargets: Bool
+
     /// The custom `Product` type to be used for SPM targets.
     public var productTypes: [String: Product]
 
@@ -54,18 +65,22 @@ public struct PackageSettings: Codable, Equatable {
     ///     - baseSettings: Additional settings to be added to targets generated from SwiftPackageManager.
     ///     - targetSettings: Additional settings to be added to targets generated from SwiftPackageManager.
     ///     - projectOptions: Custom project configurations to be used for projects generated from SwiftPackageManager.
+    ///     - enableMasterObjectFileGenerationInStaticTargets: Sets the `GENERATE_MASTER_OBJECT_FILE` build setting in static
+    /// targets.
     public init(
         productTypes: [String: Product] = [:],
         productDestinations: [String: Destinations] = [:],
         baseSettings: Settings = .settings(),
         targetSettings: [String: SettingsDictionary] = [:],
-        projectOptions: [String: Project.Options] = [:]
+        projectOptions: [String: Project.Options] = [:],
+        enableMasterObjectFileGenerationInStaticTargets: Bool = false
     ) {
         self.productTypes = productTypes
         self.productDestinations = productDestinations
         self.baseSettings = baseSettings
         self.targetSettings = targetSettings
         self.projectOptions = projectOptions
+        self.enableMasterObjectFileGenerationInStaticTargets = enableMasterObjectFileGenerationInStaticTargets
         dumpIfNeeded(self)
     }
 }

--- a/Sources/ProjectDescription/PackageSettings.swift
+++ b/Sources/ProjectDescription/PackageSettings.swift
@@ -27,15 +27,19 @@ import Foundation
 /// ```
 public struct PackageSettings: Codable, Equatable {
     /**
-     When packages are linked statically, which is the default of Tuist's integration using XcodeProj primitives,
-     issues might arise due to missing extensions. This is a [known issue](https://github.com/apple/swift/issues/48561)
-     that the SPM circumvents using the `-r` flag with the linker, or the `GENERATE_MASTER_OBJECT_FILE` build setting with the
-     packages' targets.
+     SPM tries to make linking work by making build-time decisions like how to link packages on behalf of users.
+     While this is desirable at a small scale (it's convenient), we believe it's not a good idea at a large scale because it might
+     cause issues like duplicated symbols or increased binary size.
 
-     Opting-into that behaviour can have a negative impact on the final binary size, and therefore we keep it as disable but giving
-     developers an option to opt into it easily. When this value is set to true, it applies it to all the packages of the project that are static.
+     We believe that how things are linked is something that Xcode project maintainers should think about, with Tuist helping
+     with any complexities associated with it, but we acknowledge the interest of some of our users to align with SPM's convenient
+     behaviour, and therefore we include this flag for users to opt-into that behaviour.
+
+     Here are some things that we do as part of that.
+
+     - We set the `GENERATE_MASTER_OBJECT_FILE` build setting in static targets by default (https://github.com/apple/swift/issues/48561)
      */
-    public var enableMasterObjectFileGenerationInStaticTargets: Bool
+    public var spmLinkingStyle: Bool
 
     /// The custom `Product` type to be used for SPM targets.
     public var productTypes: [String: Product]
@@ -65,7 +69,7 @@ public struct PackageSettings: Codable, Equatable {
     ///     - baseSettings: Additional settings to be added to targets generated from SwiftPackageManager.
     ///     - targetSettings: Additional settings to be added to targets generated from SwiftPackageManager.
     ///     - projectOptions: Custom project configurations to be used for projects generated from SwiftPackageManager.
-    ///     - enableMasterObjectFileGenerationInStaticTargets: Sets the `GENERATE_MASTER_OBJECT_FILE` build setting in static
+    ///     - spmLinkingStyle: When `true`, it mimics SPM's linking style.
     /// targets.
     public init(
         productTypes: [String: Product] = [:],
@@ -73,14 +77,14 @@ public struct PackageSettings: Codable, Equatable {
         baseSettings: Settings = .settings(),
         targetSettings: [String: SettingsDictionary] = [:],
         projectOptions: [String: Project.Options] = [:],
-        enableMasterObjectFileGenerationInStaticTargets: Bool = false
+        spmLinkingStyle: Bool = false
     ) {
         self.productTypes = productTypes
         self.productDestinations = productDestinations
         self.baseSettings = baseSettings
         self.targetSettings = targetSettings
         self.projectOptions = projectOptions
-        self.enableMasterObjectFileGenerationInStaticTargets = enableMasterObjectFileGenerationInStaticTargets
+        self.spmLinkingStyle = spmLinkingStyle
         dumpIfNeeded(self)
     }
 }

--- a/Sources/TuistGraph/Models/Dependencies/PackageSettings.swift
+++ b/Sources/TuistGraph/Models/Dependencies/PackageSettings.swift
@@ -21,6 +21,10 @@ public struct PackageSettings: Equatable, Codable {
     /// Swift tools version of the parsed `Package.swift`
     public let swiftToolsVersion: Version
 
+    /// When true, it sets the GENERATE_MASTER_OBJECT_FILE build setting in the static targets.
+    /// Context: https://github.com/apple/swift/issues/48561#issuecomment-1108262925
+    public let enableMasterObjectFileGenerationInStaticTargets: Bool
+
     /// Initializes a new `PackageSettings` instance.
     /// - Parameters:
     ///    - productTypes: The custom `Product` types to be used for SPM targets.
@@ -33,7 +37,8 @@ public struct PackageSettings: Equatable, Codable {
         baseSettings: Settings,
         targetSettings: [String: SettingsDictionary],
         projectOptions: [String: TuistGraph.Project.Options] = [:],
-        swiftToolsVersion: Version
+        swiftToolsVersion: Version,
+        enableMasterObjectFileGenerationInStaticTargets: Bool
     ) {
         self.productTypes = productTypes
         self.productDestinations = productDestinations
@@ -41,5 +46,6 @@ public struct PackageSettings: Equatable, Codable {
         self.targetSettings = targetSettings
         self.projectOptions = projectOptions
         self.swiftToolsVersion = swiftToolsVersion
+        self.enableMasterObjectFileGenerationInStaticTargets = enableMasterObjectFileGenerationInStaticTargets
     }
 }

--- a/Sources/TuistGraph/Models/Dependencies/PackageSettings.swift
+++ b/Sources/TuistGraph/Models/Dependencies/PackageSettings.swift
@@ -21,9 +21,8 @@ public struct PackageSettings: Equatable, Codable {
     /// Swift tools version of the parsed `Package.swift`
     public let swiftToolsVersion: Version
 
-    /// When true, it sets the GENERATE_MASTER_OBJECT_FILE build setting in the static targets.
-    /// Context: https://github.com/apple/swift/issues/48561#issuecomment-1108262925
-    public let enableMasterObjectFileGenerationInStaticTargets: Bool
+    /// When true, it tries to mimic SPM's linking style
+    public let spmLinkingStyle: Bool
 
     /// Initializes a new `PackageSettings` instance.
     /// - Parameters:
@@ -38,7 +37,7 @@ public struct PackageSettings: Equatable, Codable {
         targetSettings: [String: SettingsDictionary],
         projectOptions: [String: TuistGraph.Project.Options] = [:],
         swiftToolsVersion: Version,
-        enableMasterObjectFileGenerationInStaticTargets: Bool
+        spmLinkingStyle: Bool
     ) {
         self.productTypes = productTypes
         self.productDestinations = productDestinations
@@ -46,6 +45,6 @@ public struct PackageSettings: Equatable, Codable {
         self.targetSettings = targetSettings
         self.projectOptions = projectOptions
         self.swiftToolsVersion = swiftToolsVersion
-        self.enableMasterObjectFileGenerationInStaticTargets = enableMasterObjectFileGenerationInStaticTargets
+        self.spmLinkingStyle = spmLinkingStyle
     }
 }

--- a/Sources/TuistGraphTesting/Models/PackageSettings+TestData.swift
+++ b/Sources/TuistGraphTesting/Models/PackageSettings+TestData.swift
@@ -10,7 +10,8 @@ extension PackageSettings {
         baseSettings: Settings = .test(),
         targetSettings: [String: SettingsDictionary] = [:],
         projectOptions: [String: TuistGraph.Project.Options] = [:],
-        swiftToolsVersion: Version = Version("5.4.9")
+        swiftToolsVersion: Version = Version("5.4.9"),
+        enableMasterObjectFileGenerationInStaticTargets: Bool = false
     ) -> PackageSettings {
         PackageSettings(
             productTypes: productTypes,
@@ -18,7 +19,8 @@ extension PackageSettings {
             baseSettings: baseSettings,
             targetSettings: targetSettings,
             projectOptions: projectOptions,
-            swiftToolsVersion: swiftToolsVersion
+            swiftToolsVersion: swiftToolsVersion,
+            enableMasterObjectFileGenerationInStaticTargets: enableMasterObjectFileGenerationInStaticTargets
         )
     }
 }

--- a/Sources/TuistGraphTesting/Models/PackageSettings+TestData.swift
+++ b/Sources/TuistGraphTesting/Models/PackageSettings+TestData.swift
@@ -11,7 +11,7 @@ extension PackageSettings {
         targetSettings: [String: SettingsDictionary] = [:],
         projectOptions: [String: TuistGraph.Project.Options] = [:],
         swiftToolsVersion: Version = Version("5.4.9"),
-        enableMasterObjectFileGenerationInStaticTargets: Bool = false
+        spmLinkingStyle: Bool = false
     ) -> PackageSettings {
         PackageSettings(
             productTypes: productTypes,
@@ -20,7 +20,7 @@ extension PackageSettings {
             targetSettings: targetSettings,
             projectOptions: projectOptions,
             swiftToolsVersion: swiftToolsVersion,
-            enableMasterObjectFileGenerationInStaticTargets: enableMasterObjectFileGenerationInStaticTargets
+            spmLinkingStyle: spmLinkingStyle
         )
     }
 }

--- a/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
+++ b/Sources/TuistLoader/Loaders/RecursiveManifestLoader.swift
@@ -134,8 +134,7 @@ public class RecursiveManifestLoader: RecursiveManifestLoading {
                     packageInfo: packageInfo,
                     path: $0,
                     packageType: .local,
-                    packageSettings: packageSettings,
-                    packageToProject: [:]
+                    packageSettings: packageSettings
                 )
             }
             var newDependenciesPaths = Set<AbsolutePath>()

--- a/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
+++ b/Sources/TuistLoader/Loaders/SwiftPackageManagerGraphLoader.swift
@@ -151,8 +151,7 @@ public final class SwiftPackageManagerGraphLoader: SwiftPackageManagerGraphLoadi
                 packageInfo: packageInfo.info,
                 path: packageInfo.folder,
                 packageType: .external(artifactPaths: packageToTargetsToArtifactPaths[packageInfo.name] ?? [:]),
-                packageSettings: packageSettings,
-                packageToProject: packageToProject
+                packageSettings: packageSettings
             )
             result[.path(packageInfo.folder.pathString)] = manifest
         }

--- a/Sources/TuistLoader/Models+ManifestMappers/PackageSettings+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/PackageSettings+ManifestMapper.swift
@@ -29,7 +29,7 @@ extension TuistGraph.PackageSettings {
             targetSettings: targetSettings,
             projectOptions: projectOptions,
             swiftToolsVersion: swiftToolsVersion,
-            enableMasterObjectFileGenerationInStaticTargets: manifest.enableMasterObjectFileGenerationInStaticTargets
+            spmLinkingStyle: manifest.spmLinkingStyle
         )
     }
 }

--- a/Sources/TuistLoader/Models+ManifestMappers/PackageSettings+ManifestMapper.swift
+++ b/Sources/TuistLoader/Models+ManifestMappers/PackageSettings+ManifestMapper.swift
@@ -28,7 +28,8 @@ extension TuistGraph.PackageSettings {
             baseSettings: baseSettings,
             targetSettings: targetSettings,
             projectOptions: projectOptions,
-            swiftToolsVersion: swiftToolsVersion
+            swiftToolsVersion: swiftToolsVersion,
+            enableMasterObjectFileGenerationInStaticTargets: manifest.enableMasterObjectFileGenerationInStaticTargets
         )
     }
 }

--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -427,7 +427,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
             logger.debug("Target \(target.name) ignored by product type")
             return nil
         }
-
+        
         let targetPath = try target.basePath(packageFolder: packageFolder)
 
         let moduleMap: ModuleMap?
@@ -588,7 +588,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
             }
         }
 
-        let settings = try Settings.from(
+        var settings = try Settings.from(
             target: target,
             packageFolder: packageFolder,
             packageName: packageInfo.name,
@@ -598,6 +598,10 @@ public final class PackageInfoMapper: PackageInfoMapping {
             baseSettings: baseSettings,
             targetSettings: targetSettings
         )
+        
+        if product == .staticLibrary || product == .staticFramework, settings?.base["GENERATE_MASTER_OBJECT_FILE"] == nil {
+            settings?.base["GENERATE_MASTER_OBJECT_FILE"] = ["YES"]
+        }
 
         return .target(
             name: PackageInfoMapper.sanitize(targetName: target.name),

--- a/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
@@ -72,7 +72,7 @@ final class PackageSettingsLoaderTests: TuistUnitTestCase {
             ),
             targetSettings: [:],
             swiftToolsVersion: TSCUtility.Version("5.4.9"),
-            enableMasterObjectFileGenerationInStaticTargets: true
+            spmLinkingStyle: false
         )
         XCTAssertEqual(manifestLoader.registerPluginsCount, 1)
         XCTAssertEqual(got, expected)

--- a/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/PackageSettingsLoaderTests.swift
@@ -71,7 +71,8 @@ final class PackageSettingsLoaderTests: TuistUnitTestCase {
                 defaultSettings: .recommended
             ),
             targetSettings: [:],
-            swiftToolsVersion: TSCUtility.Version("5.4.9")
+            swiftToolsVersion: TSCUtility.Version("5.4.9"),
+            enableMasterObjectFileGenerationInStaticTargets: true
         )
         XCTAssertEqual(manifestLoader.registerPluginsCount, 1)
         XCTAssertEqual(got, expected)

--- a/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
@@ -305,8 +305,7 @@ final class RecursiveManifestLoaderTests: TuistUnitTestCase {
             packageInfo: .value(packageA),
             path: .any,
             packageType: .any,
-            packageSettings: .any,
-            packageToProject: .any
+            packageSettings: .any
         )
         .willReturn(
             .test(name: "PackageA")

--- a/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
+++ b/Tests/TuistLoaderTests/SwiftPackageManager/PackageInfoMapperTests.swift
@@ -3284,6 +3284,39 @@ final class PackageInfoMapperTests: TuistUnitTestCase {
             )
         )
     }
+
+    func testMap_whenSPMLinkingStyle() throws {
+        let basePath = try temporaryPath()
+        let sourcesPath = basePath.appending(try RelativePath(validating: "Package/Sources/Target1"))
+        try fileHandler.createFolder(sourcesPath)
+
+        let project = try XCTUnwrap(subject.map(
+            package: "Package",
+            basePath: basePath,
+            packageInfos: [
+                "Package": .init(
+                    name: "Package",
+                    products: [
+                        .init(name: "Product1", type: .library(.automatic), targets: ["Target1"]),
+                    ],
+                    targets: [
+                        .test(
+                            name: "Target1"
+                        ),
+                    ],
+                    platforms: [.ios],
+                    cLanguageStandard: nil,
+                    cxxLanguageStandard: nil,
+                    swiftLanguageVersions: nil
+                ),
+            ],
+            packageSettings: .test(spmLinkingStyle: true)
+        ))
+
+        XCTAssertEqual(project.targets.count, 1)
+        let target = try XCTUnwrap(project.targets.first)
+        XCTAssertEqual(target.settings?.base["GENERATE_MASTER_OBJECT_FILE"], "YES")
+    }
 }
 
 private func defaultSpmResources(_ target: String, customPath: String? = nil) -> ProjectDescription.ResourceFileElements {
@@ -3337,10 +3370,7 @@ extension PackageInfoMapping {
             packageInfo: packageInfos[package]!,
             path: basePath.appending(component: package),
             packageType: packageType ?? .external(artifactPaths: packageToTargetsToArtifactPaths[package]!),
-            packageSettings: packageSettings,
-            packageToProject: Dictionary(uniqueKeysWithValues: packageInfos.keys.map {
-                ($0, basePath.appending(component: $0))
-            })
+            packageSettings: packageSettings
         )
     }
 }

--- a/docs/docs/guide/project/dependencies.md
+++ b/docs/docs/guide/project/dependencies.md
@@ -267,8 +267,8 @@ func productType() -> Product {
 
 Note that Tuist [does not default to convenience through implicit configuration due to its costs](/guide/introduction/cost-of-convenience). What this means is that we rely on you setting the linking type and any additional build settings that are sometimes required, like the [`-ObjC` linker flag](https://github.com/pointfreeco/swift-composable-architecture/discussions/1657#discussioncomment-4119184), to ensure the resulting binaries are correct. Therefore, the stance that we take is providing you with the resources, usually in the shape of documentation, to make the right decisions.
 
-> [!TIP] EXAMPLE: COMPOSABLE ARCHITECTURE
-> A Swift Package that many projects integrate is [Composable Architecture](https://github.com/pointfreeco/swift-composable-architecture). As described [here](https://github.com/pointfreeco/swift-composable-architecture/discussions/1657#discussioncomment-4119184) and the [troubleshooting section](#troubleshooting), you'll need to set the `OTHER_LDFLAGS` build setting to `$(inherited) -ObjC` when linking the packages statically, which is Tuist's default linking type. Alternatively, you can override the product type for the package to be dynamic.
+> [!TIP] OPTING INTO SPM's LINKING BEHAVIOUR
+> From version `4.16.1`, Tuist supports opting into Swift Package Manager's linking behaviour trough `PackageSettings(spmLinkingStype: true)`. When set, we'll try to mimic SPM's default behaviour (convenience over explicitness and control) applying some build settings automatically. **Note** that this might have undesired side effects, like increasing the binary size, and should be used with caution.
 
 ### Scenarios
 

--- a/docs/docs/guide/project/dependencies.md
+++ b/docs/docs/guide/project/dependencies.md
@@ -268,7 +268,7 @@ func productType() -> Product {
 Note that Tuist [does not default to convenience through implicit configuration due to its costs](/guide/introduction/cost-of-convenience). What this means is that we rely on you setting the linking type and any additional build settings that are sometimes required, like the [`-ObjC` linker flag](https://github.com/pointfreeco/swift-composable-architecture/discussions/1657#discussioncomment-4119184), to ensure the resulting binaries are correct. Therefore, the stance that we take is providing you with the resources, usually in the shape of documentation, to make the right decisions.
 
 > [!TIP] OPTING INTO SPM's LINKING BEHAVIOUR
-> From version `4.16.1`, Tuist supports opting into Swift Package Manager's linking behaviour trough `PackageSettings(spmLinkingStype: true)`. When set, we'll try to mimic SPM's default behaviour (convenience over explicitness and control) applying some build settings automatically. **Note** that this might have undesired side effects, like increasing the binary size, and should be used with caution.
+> From version `4.16.2`, Tuist supports opting into Swift Package Manager's linking behaviour trough `PackageSettings(spmLinkingStype: true)`. When set, we'll try to mimic SPM's default behaviour (convenience over explicitness and control) applying some build settings automatically. **Note** that this might have undesired side effects, like increasing the binary size, and should be used with caution.
 
 ### Scenarios
 


### PR DESCRIPTION
Related https://github.com/tuist/tuist/issues/6320

### Short description 📝

@kapitoshka438 [uncovered](https://github.com/tuist/tuist/issues/6320#issuecomment-2148595905) that the reason why some packages succeed when integrated by SPM is because they pass the `-r` option to the linker, which in Xcode build settings terms translates to `GENERATE_MASTER_OBJECT_FILE=YES`, which makes compilations succeed by [performing a single-object prelink](https://developer.apple.com/documentation/xcode/build-settings-reference#Perform-Single-Object-Prelink). Although convenient at a small scale, letting the build system make these decisions on your behalf might be undesirable because it might increase the binary size of the app.

This PR brings some of that convenience by adding a new `PackageSetting(spmLinkingStyle: true)`. Note that we can bring more SPM's behavior and put them behind that flag that users can opt-in. I didn't set the default value to `true` because that might pose a breaking change to existing users. The default value is something that we can iterate on in the future.

### How to test the changes locally 🧐

You can generate a project with a fixture that contains SPM packages linked statically. You should see the build setting set.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
