### PR TITLE
Fix extra logs from Xcode commands

### DIFF
--- a/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -310,7 +310,7 @@ public final class XcodeBuildController: XcodeBuildControlling {
         
         logger.debug("Running xcodebuild command: \(command.joined(separator: " "))")
         
-        try System.shared.runAndPrint(command,
+        try System.shared.run(command,
                                       verbose: false,
                                       environment: System.shared.env,
                                       redirection: .stream(stdout: { bytes in

--- a/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
+++ b/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
@@ -85,7 +85,7 @@ public class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting {
 
         arguments.append(contentsOf: ["-workspace", workspacePath.pathString, "-list"])
 
-        try System.shared.runAndPrint(
+        try System.shared.run(
             arguments,
             verbose: false,
             environment: System.shared.env,

--- a/Sources/TuistSupport/System/System.swift
+++ b/Sources/TuistSupport/System/System.swift
@@ -131,7 +131,7 @@ public final class System: Systeming {
     }
 
     public func runAndPrint(_ arguments: [String], verbose: Bool, environment: [String: String]) throws {
-        try run(arguments, verbose: false, environment: environment, redirection: streamToStandardOutputs)
+        try run(arguments, verbose: verbose, environment: environment, redirection: streamToStandardOutputs)
     }
 
     private var streamToStandardOutputs: TSCBasic.Process.OutputRedirection {

--- a/Sources/TuistSupport/System/System.swift
+++ b/Sources/TuistSupport/System/System.swift
@@ -129,7 +129,7 @@ public final class System: Systeming {
     public func runAndPrint(_ arguments: [String]) throws {
         try run(arguments, verbose: false, environment: env, redirection: streamToStandardOutputs)
     }
-    
+
     public func runAndPrint(_ arguments: [String], verbose: Bool, environment: [String: String]) throws {
         try run(arguments, verbose: false, environment: environment, redirection: streamToStandardOutputs)
     }

--- a/Sources/TuistSupport/System/Systeming.swift
+++ b/Sources/TuistSupport/System/Systeming.swift
@@ -45,7 +45,7 @@ public protocol Systeming {
     /// - Throws: An error if the command fails.
     func runAndPrint(_ arguments: [String], verbose: Bool, environment: [String: String]) throws
 
-    /// Runs a command in the shell printing its output.
+    /// Runs a command in the shell and redirects output based on the passed in parameter.
     ///
     /// - Parameters:
     ///   - arguments: Command.

--- a/Sources/TuistSupport/System/Systeming.swift
+++ b/Sources/TuistSupport/System/Systeming.swift
@@ -53,7 +53,7 @@ public protocol Systeming {
     ///   - environment: Environment that should be used when running the task.
     ///   - redirection: Output Redirection behavior for the underlying `Process`
     /// - Throws: An error if the command fails.
-    func runAndPrint(
+    func run(
         _ arguments: [String],
         verbose: Bool,
         environment: [String: String],

--- a/Sources/TuistSupportTesting/Utils/MockSystem.swift
+++ b/Sources/TuistSupportTesting/Utils/MockSystem.swift
@@ -60,7 +60,7 @@ public final class MockSystem: Systeming {
         _ = try capture(arguments, verbose: false, environment: env)
     }
 
-    public func runAndPrint(
+    public func run(
         _ arguments: [String],
         verbose _: Bool,
         environment _: [String: String],

--- a/Tests/TuistSupportIntegrationTests/System/SystemIntegrationTests.swift
+++ b/Tests/TuistSupportIntegrationTests/System/SystemIntegrationTests.swift
@@ -30,7 +30,7 @@ final class SystemIntegrationTests: TuistTestCase {
 
     func test_run_output_is_redirected() throws {
         var output = ""
-        try subject.runAndPrint(
+        try subject.run(
             ["echo", "hola"],
             verbose: false,
             environment: System.shared.env,


### PR DESCRIPTION
Fixes issue introduced with the Combine removal that would emit logs to `stdOut` and `stdError` *along* with redirection.  

### Short description 📝

This changes the the `runAndPrint(..., redirection:)`  method to only be `run(..., redirection:)` and removes the default behavior which logs process output to `stdOut` and `stdErr`.  The other `runAndPrint`  commands now call `run(...)` and pass in a redirect that logs to std*.  This allows more granular control around printing and output redirection.

### How to test the changes locally 🧐

Run `tuist build` and observe it's not emitting raw Xcode logs.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
