### PR TITLE
Upload test run result bundle objects

### DIFF
--- a/Sources/TuistKit/Utils/TuistAnalyticsCloudBackend.swift
+++ b/Sources/TuistKit/Utils/TuistAnalyticsCloudBackend.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TSCBasic
 import TuistAnalytics
 import TuistAsyncQueue
 import TuistCore
@@ -56,8 +57,8 @@ public class TuistAnalyticsCloudBackend: TuistAnalyticsBackend {
             .appending(component: "\(Constants.resultBundleName).xcresult")
 
         if fileHandler.exists(resultBundle) {
-            try await analyticsArtifactUploadService.uploadAnalyticsArtifact(
-                artifactPath: resultBundle,
+            try await analyticsArtifactUploadService.uploadResultBundle(
+                resultBundle,
                 commandEventId: cloudCommandEvent.id,
                 serverURL: config.url
             )

--- a/Sources/TuistServer/Models/CloudCommandEvent.swift
+++ b/Sources/TuistServer/Models/CloudCommandEvent.swift
@@ -15,6 +15,23 @@ public struct CloudCommandEvent: Codable {
         self.name = name
         self.url = url
     }
+
+    public struct Artifact: Equatable {
+        let type: ArtifactType
+        let name: String?
+
+        init(
+            type: ArtifactType,
+            name: String? = nil
+        ) {
+            self.type = type
+            self.name = name
+        }
+
+        enum ArtifactType {
+            case resultBundle, invocationRecord, resultBundleObject
+        }
+    }
 }
 
 extension CloudCommandEvent {
@@ -22,6 +39,25 @@ extension CloudCommandEvent {
         id = Int(commandEvent.id)
         name = commandEvent.name
         url = URL(string: commandEvent.url)!
+    }
+}
+
+extension Components.Schemas.CommandEventArtifact {
+    init(_ artifact: CloudCommandEvent.Artifact) {
+        self = .init(name: artifact.name, _type: .init(artifact.type))
+    }
+}
+
+extension Components.Schemas.CommandEventArtifact._typePayload {
+    init(_ type: CloudCommandEvent.Artifact.ArtifactType) {
+        switch type {
+        case .resultBundle:
+            self = .result_bundle
+        case .invocationRecord:
+            self = .invocation_record
+        case .resultBundleObject:
+            self = .result_bundle_object
+        }
     }
 }
 

--- a/Sources/TuistServer/Models/InvocationRecord.swift
+++ b/Sources/TuistServer/Models/InvocationRecord.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+struct InvocationRecord: Codable {
+    let actions: XCObjectArray<ActionRecord>
+}
+
+struct ActionRecord: Codable {
+    let schemeCommandName: XCObjectItem<String>
+    let actionResult: ActionResult
+}
+
+struct ActionResult: Codable {
+    let testsRef: Reference?
+
+    struct Reference: Codable {
+        let id: XCObjectItem<String>
+    }
+}
+
+struct XCObjectArray<T: Codable>: Codable {
+    // swiftlint:disable:next identifier_name
+    let _values: [T]
+}
+
+struct XCObjectItem<T: Codable>: Codable {
+    // swiftlint:disable:next identifier_name
+    let _value: T
+}

--- a/Sources/TuistServer/OpenAPI/Types.swift
+++ b/Sources/TuistServer/OpenAPI/Types.swift
@@ -700,6 +700,10 @@ public enum Components {
         ///
         /// - Remark: Generated from `#/components/schemas/CommandEventArtifact`.
         public struct CommandEventArtifact: Codable, Equatable, Hashable, Sendable {
+            /// The name of the file. It's used only for certain types such as result_bundle_object
+            ///
+            /// - Remark: Generated from `#/components/schemas/CommandEventArtifact/name`.
+            public var name: Swift.String?
             /// The command event artifact type.
             ///
             /// - Remark: Generated from `#/components/schemas/CommandEventArtifact/type`.
@@ -708,11 +712,15 @@ public enum Components {
                 _AutoLosslessStringConvertible, CaseIterable
             {
                 case result_bundle
+                case invocation_record
+                case result_bundle_object
                 /// Parsed a raw value that was not defined in the OpenAPI document.
                 case undocumented(String)
                 public init?(rawValue: String) {
                     switch rawValue {
                     case "result_bundle": self = .result_bundle
+                    case "invocation_record": self = .invocation_record
+                    case "result_bundle_object": self = .result_bundle_object
                     default: self = .undocumented(rawValue)
                     }
                 }
@@ -720,9 +728,13 @@ public enum Components {
                     switch self {
                     case let .undocumented(string): return string
                     case .result_bundle: return "result_bundle"
+                    case .invocation_record: return "invocation_record"
+                    case .result_bundle_object: return "result_bundle_object"
                     }
                 }
-                public static var allCases: [_typePayload] { [.result_bundle] }
+                public static var allCases: [_typePayload] {
+                    [.result_bundle, .invocation_record, .result_bundle_object]
+                }
             }
             /// The command event artifact type.
             ///
@@ -731,11 +743,19 @@ public enum Components {
             /// Creates a new `CommandEventArtifact`.
             ///
             /// - Parameters:
+            ///   - name: The name of the file. It's used only for certain types such as result_bundle_object
             ///   - _type: The command event artifact type.
-            public init(_type: Components.Schemas.CommandEventArtifact._typePayload) {
+            public init(
+                name: Swift.String? = nil,
+                _type: Components.Schemas.CommandEventArtifact._typePayload
+            ) {
+                self.name = name
                 self._type = _type
             }
-            public enum CodingKeys: String, CodingKey { case _type = "type" }
+            public enum CodingKeys: String, CodingKey {
+                case name
+                case _type = "type"
+            }
         }
         /// - Remark: Generated from `#/components/schemas/Error`.
         public struct _Error: Codable, Equatable, Hashable, Sendable {

--- a/Sources/TuistServer/OpenAPI/cloud.yml
+++ b/Sources/TuistServer/OpenAPI/cloud.yml
@@ -192,10 +192,15 @@ components:
     CommandEventArtifact:
       description: It represents an artifact that's associated with a command event (e.g. result bundles)
       properties:
+        name:
+          description: The name of the file. It's used only for certain types such as result_bundle_object
+          type: string
         type:
           description: The command event artifact type.
           enum:
             - result_bundle
+            - invocation_record
+            - result_bundle_object
           type: string
       required:
         - type

--- a/Sources/TuistServer/Services/MultipartUploadCompleteAnalyticsService.swift
+++ b/Sources/TuistServer/Services/MultipartUploadCompleteAnalyticsService.swift
@@ -6,6 +6,7 @@ import TuistSupport
 @Mockable
 public protocol MultipartUploadCompleteAnalyticsServicing {
     func uploadAnalyticsArtifact(
+        _ artifact: CloudCommandEvent.Artifact,
         commandEventId: Int,
         uploadId: String,
         parts: [(etag: String, partNumber: Int)],
@@ -41,6 +42,7 @@ public final class MultipartUploadCompleteAnalyticsService: MultipartUploadCompl
     public init() {}
 
     public func uploadAnalyticsArtifact(
+        _ artifact: CloudCommandEvent.Artifact,
         commandEventId: Int,
         uploadId: String,
         parts: [(etag: String, partNumber: Int)],
@@ -52,7 +54,7 @@ public final class MultipartUploadCompleteAnalyticsService: MultipartUploadCompl
                 path: .init(run_id: commandEventId),
                 body: .json(
                     .init(
-                        command_event_artifact: .init(_type: .result_bundle),
+                        command_event_artifact: .init(artifact),
                         multipart_upload_parts: .init(
                             parts: parts
                                 .map { .init(etag: $0.etag, part_number: $0.partNumber) },

--- a/Sources/TuistServer/Services/MultipartUploadGenerateURLAnalyticsService.swift
+++ b/Sources/TuistServer/Services/MultipartUploadGenerateURLAnalyticsService.swift
@@ -5,6 +5,7 @@ import TuistSupport
 @Mockable
 public protocol MultipartUploadGenerateURLAnalyticsServicing {
     func uploadAnalytics(
+        _ artifact: CloudCommandEvent.Artifact,
         commandEventId: Int,
         partNumber: Int,
         uploadId: String,
@@ -40,6 +41,7 @@ public final class MultipartUploadGenerateURLAnalyticsService: MultipartUploadGe
     public init() {}
 
     public func uploadAnalytics(
+        _ artifact: CloudCommandEvent.Artifact,
         commandEventId: Int,
         partNumber: Int,
         uploadId: String,
@@ -51,9 +53,7 @@ public final class MultipartUploadGenerateURLAnalyticsService: MultipartUploadGe
                 path: .init(run_id: commandEventId),
                 body: .json(
                     .init(
-                        command_event_artifact: .init(
-                            _type: .result_bundle
-                        ),
+                        command_event_artifact: .init(artifact),
                         multipart_upload_part: .init(
                             part_number: partNumber,
                             upload_id: uploadId

--- a/Sources/TuistServer/Services/MultipartUploadStartAnalyticsService.swift
+++ b/Sources/TuistServer/Services/MultipartUploadStartAnalyticsService.swift
@@ -5,6 +5,7 @@ import TuistSupport
 @Mockable
 public protocol MultipartUploadStartAnalyticsServicing {
     func uploadAnalyticsArtifact(
+        _ artifact: CloudCommandEvent.Artifact,
         commandEventId: Int,
         serverURL: URL
     ) async throws -> String
@@ -39,6 +40,7 @@ public final class MultipartUploadStartAnalyticsService: MultipartUploadStartAna
     public init() {}
 
     public func uploadAnalyticsArtifact(
+        _ artifact: CloudCommandEvent.Artifact,
         commandEventId: Int,
         serverURL: URL
     ) async throws -> String {
@@ -46,7 +48,7 @@ public final class MultipartUploadStartAnalyticsService: MultipartUploadStartAna
         let response = try await client.startAnalyticsArtifactMultipartUpload(
             .init(
                 path: .init(run_id: commandEventId),
-                body: .json(.init(_type: .result_bundle))
+                body: .json(.init(artifact))
             )
         )
         switch response {

--- a/Sources/TuistServer/Utilities/XCResultToolController.swift
+++ b/Sources/TuistServer/Utilities/XCResultToolController.swift
@@ -1,0 +1,31 @@
+import Mockable
+import TSCBasic
+import TuistSupport
+
+@Mockable
+protocol XCResultToolControlling {
+    func resultBundleObject(_ path: AbsolutePath) throws -> String
+    func resultBundleObject(_ path: AbsolutePath, id: String) throws -> String
+}
+
+final class XCResultToolController: XCResultToolControlling {
+    private let system: Systeming
+
+    init(
+        system: Systeming = System.shared
+    ) {
+        self.system = system
+    }
+
+    func resultBundleObject(_ path: AbsolutePath) throws -> String {
+        try system.capture(
+            ["/usr/bin/xcrun", "xcresulttool", "get", "--path", path.pathString, "--format", "json"]
+        )
+    }
+
+    func resultBundleObject(_ path: AbsolutePath, id: String) throws -> String {
+        try system.capture(
+            ["/usr/bin/xcrun", "xcresulttool", "get", "--path", path.pathString, "--id", id, "--format", "json"]
+        )
+    }
+}

--- a/Tests/TuistKitTests/Utils/TuistAnalyticsCloudBackendTests.swift
+++ b/Tests/TuistKitTests/Utils/TuistAnalyticsCloudBackendTests.swift
@@ -133,8 +133,8 @@ final class TuistAnalyticsCloudBackendTests: TuistUnitTestCase {
         try fileHandler.createFolder(resultBundle)
 
         given(analyticsArtifactUploadService)
-            .uploadAnalyticsArtifact(
-                artifactPath: .value(resultBundle),
+            .uploadResultBundle(
+                .value(resultBundle),
                 commandEventId: .value(10),
                 serverURL: .value(config.url)
             )

--- a/Tests/TuistKitTests/Utils/TuistAnalyticsDispatcherTests.swift
+++ b/Tests/TuistKitTests/Utils/TuistAnalyticsDispatcherTests.swift
@@ -63,8 +63,8 @@ final class TuistAnalyticsDispatcherTests: TuistUnitTestCase {
             .willReturn(.test(id: 10))
 
         given(analyticsArtifactUploadService)
-            .uploadAnalyticsArtifact(
-                artifactPath: .any,
+            .uploadResultBundle(
+                .any,
                 commandEventId: .value(10),
                 serverURL: .value(cloudURL)
             )

--- a/Tests/TuistServerTests/TestData/InvocationRecord+TestData.swift
+++ b/Tests/TuistServerTests/TestData/InvocationRecord+TestData.swift
@@ -1,0 +1,635 @@
+import Foundation
+
+extension AnalyticsArtifactUploadServiceTests {
+    var invocationRecordMockString: String {
+        #"""
+        {
+          "_type" : {
+            "_name" : "ActionsInvocationRecord"
+          },
+          "actions" : {
+            "_type" : {
+              "_name" : "Array"
+            },
+            "_values" : [
+              {
+                "_type" : {
+                  "_name" : "ActionRecord"
+                },
+                "actionResult" : {
+                  "_type" : {
+                    "_name" : "ActionResult"
+                  },
+                  "coverage" : {
+                    "_type" : {
+                      "_name" : "CodeCoverageInfo"
+                    }
+                  },
+                  "diagnosticsRef" : {
+                    "_type" : {
+                      "_name" : "Reference"
+                    },
+                    "id" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "0~OswFMxdHsqFpfWmB3LFdBaMZLu-tXkrmvBsNwQ0BKaT9taUvjiIfOuMGRBR-MawOmNo0LnXLkdHQm5N67mVz1w=="
+                    }
+                  },
+                  "issues" : {
+                    "_type" : {
+                      "_name" : "ResultIssueSummaries"
+                    },
+                    "testFailureSummaries" : {
+                      "_type" : {
+                        "_name" : "Array"
+                      },
+                      "_values" : [
+                        {
+                          "_type" : {
+                            "_name" : "TestFailureIssueSummary",
+                            "_supertype" : {
+                              "_name" : "IssueSummary"
+                            }
+                          },
+                          "documentLocationInCreatingWorkspace" : {
+                            "_type" : {
+                              "_name" : "DocumentLocation"
+                            },
+                            "concreteTypeName" : {
+                              "_type" : {
+                                "_name" : "String"
+                              },
+                              "_value" : "DVTTextDocumentLocation"
+                            },
+                            "url" : {
+                              "_type" : {
+                                "_name" : "String"
+                              },
+                              "_value" : "file:\/\/\/Users\/builder\/clone\/Tests\/TuistDependenciesAcceptanceTests\/DependenciesAcceptanceTests.swift#EndingLineNumber=40&StartingLineNumber=40"
+                            }
+                          },
+                          "issueType" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "Uncategorized"
+                          },
+                          "message" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "failed: caught error: \"The 'xcodebuild' command exited with error code 65 and message:\n2024-05-20 12:44:17.788570+0000 xcodebuild[14114:50965] [devicemanager] DeviceManager sending check-in request: F988FF5A-CDAC-42C9-9C3F-BE87134AD171\n2024-05-20 12:44:17.790440+0000 xcodebuild[14114:50965] [devicemanager] DeviceManager check-in (F988FF5A-CDAC-42C9-9C3F-BE87134AD171) completed successfully\n2024-05-20 12:44:17.793515+0000 xcodebuild[14114:50961] [All] MobileDevice.framework version: 1643.100.58\n2024-05-20 12:44:17.798111+0000 xcodebuild[14114:50961] [All] RemotePairing.framework version: 117.100.41\n2024-05-20 12:44:17.798690+0000 xcodebuild[14114:50961] [library] USBMuxListenerCreateFiltered:898 Created 0x600003581f40\n2024-05-20 12:44:17.798774+0000 xcodebuild[14114:50961] [All] Subscribed for device notifications from usbmuxd.\n2024-05-20 12:44:18.054503+0000 xcodebuild[14114:50949] [general] initializing workspace at path \/var\/folders\/w2\/rrf5p87d1bbfyphxc7jdnyvh0000gn\/T\/TemporaryDirectory.AMHRiB\/ios_app_with_spm_dependencies\/App.xcworkspace\n2024-05-20 12:44:18.055591+0000 xcodebuild[14114:50949] [general] setting up workspace \/var\/folders\/w2\/rrf5p87d1bbfyphxc7jdnyvh0000gn\/T\/TemporaryDirectory.AMHRiB\/ios_app_with_spm_dependencies\/App.xcworkspace\n2024-05-20 12:44:18.071588+0000 xcodebuild[14114:50949] [general] using plugin library at \/Applications\/Xcode-15.3.app\/Contents\/SharedFrameworks\/SwiftPM.framework\/SharedSupport\/PluginAPI\n2024-05-20 12:44:18.071680+0000 xcodebuild[14114:50949] [general] synchronizing contents of workspace at path \/var\/folders\/w2\/rrf5p87d1bbfyphxc7jdnyvh0000gn\/T\/TemporaryDirectory.AMHRiB\/ios_app_with_spm_dependencies\/App.xcworkspace\n2024-05-20 12:44:18.071698+0000 xcodebuild[14114:50949] [general] marking workspace as having finished initial package resolution\n--- xcodebuild: WARNING: Using the first of multiple matching destinations:\n{ platform:iOS Simulator, id:2B6F50E6-2782-405A-94DF-E659C9398717, OS:17.4, name:iPad Pro (12.9-inch) (6th generation) }\n{ platform:iOS Simulator, id:2B6F50E6-2782-405A-94DF-E659C9398717, OS:17.4, name:iPad Pro (12.9-inch) (6th generation) }\n2024-05-20 12:44:18.106264+0000 xcodebuild[14114:50949] [building] creating scheme operation preamble operations for build command Build\nTesting failed:\n\tCompiling for iOS 14.0, but module 'App' has a minimum deployment target of iOS 16.0: \/Users\/builder\/Library\/Developer\/Xcode\/DerivedData\/App-fzcodvpjdyxljhcxfidulaohhxre\/Build\/Products\/Debug-iphonesimulator\/App.swiftmodule\/arm64-apple-ios-simulator.swiftmodule\n\tTesting cancelled because the build failed.\n\n** TEST FAILED **\n\n\nThe following build commands failed:\n\tSwiftEmitModule normal arm64 Emitting\\ module\\ for\\ AppTests (in target 'AppTests' from project 'App')\n(1 failure)\n\""
+                          },
+                          "testCaseName" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "DependenciesAcceptanceTestIosAppWithSPMDependencies.test_ios_app_spm_dependencies()"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "logRef" : {
+                    "_type" : {
+                      "_name" : "Reference"
+                    },
+                    "id" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "0~P3EqtGf1QBDVW81JX_KQylSrGzn-HJAEOm1bhpBdwiiWhpaRIfCbhxtixsVOOLHp6jGB-YAVUqA1rmIc7dBy4g=="
+                    },
+                    "targetType" : {
+                      "_type" : {
+                        "_name" : "TypeDefinition"
+                      },
+                      "name" : {
+                        "_type" : {
+                          "_name" : "String"
+                        },
+                        "_value" : "ActivityLogSection"
+                      }
+                    }
+                  },
+                  "metrics" : {
+                    "_type" : {
+                      "_name" : "ResultMetrics"
+                    },
+                    "testsCount" : {
+                      "_type" : {
+                        "_name" : "Int"
+                      },
+                      "_value" : "3"
+                    },
+                    "testsFailedCount" : {
+                      "_type" : {
+                        "_name" : "Int"
+                      },
+                      "_value" : "1"
+                    }
+                  },
+                  "resultName" : {
+                    "_type" : {
+                      "_name" : "String"
+                    },
+                    "_value" : "action"
+                  },
+                  "status" : {
+                    "_type" : {
+                      "_name" : "String"
+                    },
+                    "_value" : "failed"
+                  },
+                  "testsRef" : {
+                    "_type" : {
+                      "_name" : "Reference"
+                    },
+                    "id" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "0~8YCjlb3k7BnCmnR4_ZFg18UnVp4hOkZw8KiWEX8RunY_pe9wBaIbW90Jo1HePHl7st5Le_nRyAP4_dSvsdxYpw=="
+                    },
+                    "targetType" : {
+                      "_type" : {
+                        "_name" : "TypeDefinition"
+                      },
+                      "name" : {
+                        "_type" : {
+                          "_name" : "String"
+                        },
+                        "_value" : "ActionTestPlanRunSummaries"
+                      }
+                    }
+                  }
+                },
+                "buildResult" : {
+                  "_type" : {
+                    "_name" : "ActionResult"
+                  },
+                  "coverage" : {
+                    "_type" : {
+                      "_name" : "CodeCoverageInfo"
+                    }
+                  },
+                  "issues" : {
+                    "_type" : {
+                      "_name" : "ResultIssueSummaries"
+                    }
+                  },
+                  "logRef" : {
+                    "_type" : {
+                      "_name" : "Reference"
+                    },
+                    "id" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "0~JlTezqV63xbUrp0gsF4KV89HvbbNAfQ_g5JOvwR1ecy70PjnlqcfDdyHgggMuhSwJYY9MSoVtKYHzmxj3ZaRcw=="
+                    },
+                    "targetType" : {
+                      "_type" : {
+                        "_name" : "TypeDefinition"
+                      },
+                      "name" : {
+                        "_type" : {
+                          "_name" : "String"
+                        },
+                        "_value" : "ActivityLogSection"
+                      }
+                    }
+                  },
+                  "metrics" : {
+                    "_type" : {
+                      "_name" : "ResultMetrics"
+                    }
+                  },
+                  "resultName" : {
+                    "_type" : {
+                      "_name" : "String"
+                    },
+                    "_value" : "build"
+                  },
+                  "status" : {
+                    "_type" : {
+                      "_name" : "String"
+                    },
+                    "_value" : "succeeded"
+                  }
+                },
+                "endedTime" : {
+                  "_type" : {
+                    "_name" : "Date"
+                  },
+                  "_value" : "2024-05-20T12:44:51.162+0000"
+                },
+                "runDestination" : {
+                  "_type" : {
+                    "_name" : "ActionRunDestinationRecord"
+                  },
+                  "displayName" : {
+                    "_type" : {
+                      "_name" : "String"
+                    },
+                    "_value" : "My Mac"
+                  },
+                  "localComputerRecord" : {
+                    "_type" : {
+                      "_name" : "ActionDeviceRecord"
+                    },
+                    "busSpeedInMHz" : {
+                      "_type" : {
+                        "_name" : "Int"
+                      },
+                      "_value" : "0"
+                    },
+                    "cpuCount" : {
+                      "_type" : {
+                        "_name" : "Int"
+                      },
+                      "_value" : "1"
+                    },
+                    "cpuKind" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "Apple M1 (Virtual)"
+                    },
+                    "cpuSpeedInMHz" : {
+                      "_type" : {
+                        "_name" : "Int"
+                      },
+                      "_value" : "0"
+                    },
+                    "identifier" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "0000FE00-343A79319AA17942"
+                    },
+                    "isConcreteDevice" : {
+                      "_type" : {
+                        "_name" : "Bool"
+                      },
+                      "_value" : "true"
+                    },
+                    "logicalCPUCoresPerPackage" : {
+                      "_type" : {
+                        "_name" : "Int"
+                      },
+                      "_value" : "4"
+                    },
+                    "modelCode" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "VirtualMac2,1"
+                    },
+                    "modelName" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "Apple Virtual Machine 1"
+                    },
+                    "modelUTI" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "com.apple.virtual-machine"
+                    },
+                    "name" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "My Mac"
+                    },
+                    "nativeArchitecture" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "arm64e"
+                    },
+                    "operatingSystemVersion" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "14.3.1"
+                    },
+                    "operatingSystemVersionWithBuildNumber" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "14.3.1 (23D60)"
+                    },
+                    "physicalCPUCoresPerPackage" : {
+                      "_type" : {
+                        "_name" : "Int"
+                      },
+                      "_value" : "4"
+                    },
+                    "platformRecord" : {
+                      "_type" : {
+                        "_name" : "ActionPlatformRecord"
+                      },
+                      "identifier" : {
+                        "_type" : {
+                          "_name" : "String"
+                        },
+                        "_value" : "com.apple.platform.macosx"
+                      },
+                      "userDescription" : {
+                        "_type" : {
+                          "_name" : "String"
+                        },
+                        "_value" : "macOS"
+                      }
+                    },
+                    "ramSizeInMegabytes" : {
+                      "_type" : {
+                        "_name" : "Int"
+                      },
+                      "_value" : "8192"
+                    }
+                  },
+                  "targetArchitecture" : {
+                    "_type" : {
+                      "_name" : "String"
+                    },
+                    "_value" : "arm64"
+                  },
+                  "targetDeviceRecord" : {
+                    "_type" : {
+                      "_name" : "ActionDeviceRecord"
+                    },
+                    "busSpeedInMHz" : {
+                      "_type" : {
+                        "_name" : "Int"
+                      },
+                      "_value" : "0"
+                    },
+                    "cpuCount" : {
+                      "_type" : {
+                        "_name" : "Int"
+                      },
+                      "_value" : "1"
+                    },
+                    "cpuKind" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "Apple M1 (Virtual)"
+                    },
+                    "cpuSpeedInMHz" : {
+                      "_type" : {
+                        "_name" : "Int"
+                      },
+                      "_value" : "0"
+                    },
+                    "identifier" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "0000FE00-343A79319AA17942"
+                    },
+                    "isConcreteDevice" : {
+                      "_type" : {
+                        "_name" : "Bool"
+                      },
+                      "_value" : "true"
+                    },
+                    "logicalCPUCoresPerPackage" : {
+                      "_type" : {
+                        "_name" : "Int"
+                      },
+                      "_value" : "4"
+                    },
+                    "modelCode" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "VirtualMac2,1"
+                    },
+                    "modelName" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "Apple Virtual Machine 1"
+                    },
+                    "modelUTI" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "com.apple.virtual-machine"
+                    },
+                    "name" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "My Mac"
+                    },
+                    "nativeArchitecture" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "arm64e"
+                    },
+                    "operatingSystemVersion" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "14.3.1"
+                    },
+                    "operatingSystemVersionWithBuildNumber" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "14.3.1 (23D60)"
+                    },
+                    "physicalCPUCoresPerPackage" : {
+                      "_type" : {
+                        "_name" : "Int"
+                      },
+                      "_value" : "4"
+                    },
+                    "platformRecord" : {
+                      "_type" : {
+                        "_name" : "ActionPlatformRecord"
+                      },
+                      "identifier" : {
+                        "_type" : {
+                          "_name" : "String"
+                        },
+                        "_value" : "com.apple.platform.macosx"
+                      },
+                      "userDescription" : {
+                        "_type" : {
+                          "_name" : "String"
+                        },
+                        "_value" : "macOS"
+                      }
+                    },
+                    "ramSizeInMegabytes" : {
+                      "_type" : {
+                        "_name" : "Int"
+                      },
+                      "_value" : "8192"
+                    }
+                  },
+                  "targetSDKRecord" : {
+                    "_type" : {
+                      "_name" : "ActionSDKRecord"
+                    },
+                    "identifier" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "macosx14.4"
+                    },
+                    "name" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "macOS 14.4"
+                    },
+                    "operatingSystemVersion" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "14.4"
+                    }
+                  }
+                },
+                "schemeCommandName" : {
+                  "_type" : {
+                    "_name" : "String"
+                  },
+                  "_value" : "Test"
+                },
+                "schemeTaskName" : {
+                  "_type" : {
+                    "_name" : "String"
+                  },
+                  "_value" : "BuildAndAction"
+                },
+                "startedTime" : {
+                  "_type" : {
+                    "_name" : "Date"
+                  },
+                  "_value" : "2024-05-20T12:34:11.228+0000"
+                },
+                "testPlanName" : {
+                  "_type" : {
+                    "_name" : "String"
+                  },
+                  "_value" : "TuistDependenciesAcceptanceTests"
+                },
+                "title" : {
+                  "_type" : {
+                    "_name" : "String"
+                  },
+                  "_value" : "Testing workspace Tuist with scheme TuistDependenciesAcceptanceTests"
+                }
+              }
+            ]
+          },
+          "issues" : {
+            "_type" : {
+              "_name" : "ResultIssueSummaries"
+            },
+            "testFailureSummaries" : {
+              "_type" : {
+                "_name" : "Array"
+              },
+              "_values" : [
+                {
+                  "_type" : {
+                    "_name" : "TestFailureIssueSummary",
+                    "_supertype" : {
+                      "_name" : "IssueSummary"
+                    }
+                  },
+                  "documentLocationInCreatingWorkspace" : {
+                    "_type" : {
+                      "_name" : "DocumentLocation"
+                    },
+                    "concreteTypeName" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "DVTTextDocumentLocation"
+                    },
+                    "url" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "file:\/\/\/Users\/builder\/clone\/Tests\/TuistDependenciesAcceptanceTests\/DependenciesAcceptanceTests.swift#EndingLineNumber=40&StartingLineNumber=40"
+                    }
+                  },
+                  "issueType" : {
+                    "_type" : {
+                      "_name" : "String"
+                    },
+                    "_value" : "Uncategorized"
+                  },
+                  "message" : {
+                    "_type" : {
+                      "_name" : "String"
+                    },
+                    "_value" : "failed: caught error: \"The 'xcodebuild' command exited with error code 65 and message:\n2024-05-20 12:44:17.788570+0000 xcodebuild[14114:50965] [devicemanager] DeviceManager sending check-in request: F988FF5A-CDAC-42C9-9C3F-BE87134AD171\n2024-05-20 12:44:17.790440+0000 xcodebuild[14114:50965] [devicemanager] DeviceManager check-in (F988FF5A-CDAC-42C9-9C3F-BE87134AD171) completed successfully\n2024-05-20 12:44:17.793515+0000 xcodebuild[14114:50961] [All] MobileDevice.framework version: 1643.100.58\n2024-05-20 12:44:17.798111+0000 xcodebuild[14114:50961] [All] RemotePairing.framework version: 117.100.41\n2024-05-20 12:44:17.798690+0000 xcodebuild[14114:50961] [library] USBMuxListenerCreateFiltered:898 Created 0x600003581f40\n2024-05-20 12:44:17.798774+0000 xcodebuild[14114:50961] [All] Subscribed for device notifications from usbmuxd.\n2024-05-20 12:44:18.054503+0000 xcodebuild[14114:50949] [general] initializing workspace at path \/var\/folders\/w2\/rrf5p87d1bbfyphxc7jdnyvh0000gn\/T\/TemporaryDirectory.AMHRiB\/ios_app_with_spm_dependencies\/App.xcworkspace\n2024-05-20 12:44:18.055591+0000 xcodebuild[14114:50949] [general] setting up workspace \/var\/folders\/w2\/rrf5p87d1bbfyphxc7jdnyvh0000gn\/T\/TemporaryDirectory.AMHRiB\/ios_app_with_spm_dependencies\/App.xcworkspace\n2024-05-20 12:44:18.071588+0000 xcodebuild[14114:50949] [general] using plugin library at \/Applications\/Xcode-15.3.app\/Contents\/SharedFrameworks\/SwiftPM.framework\/SharedSupport\/PluginAPI\n2024-05-20 12:44:18.071680+0000 xcodebuild[14114:50949] [general] synchronizing contents of workspace at path \/var\/folders\/w2\/rrf5p87d1bbfyphxc7jdnyvh0000gn\/T\/TemporaryDirectory.AMHRiB\/ios_app_with_spm_dependencies\/App.xcworkspace\n2024-05-20 12:44:18.071698+0000 xcodebuild[14114:50949] [general] marking workspace as having finished initial package resolution\n--- xcodebuild: WARNING: Using the first of multiple matching destinations:\n{ platform:iOS Simulator, id:2B6F50E6-2782-405A-94DF-E659C9398717, OS:17.4, name:iPad Pro (12.9-inch) (6th generation) }\n{ platform:iOS Simulator, id:2B6F50E6-2782-405A-94DF-E659C9398717, OS:17.4, name:iPad Pro (12.9-inch) (6th generation) }\n2024-05-20 12:44:18.106264+0000 xcodebuild[14114:50949] [building] creating scheme operation preamble operations for build command Build\nTesting failed:\n\tCompiling for iOS 14.0, but module 'App' has a minimum deployment target of iOS 16.0: \/Users\/builder\/Library\/Developer\/Xcode\/DerivedData\/App-fzcodvpjdyxljhcxfidulaohhxre\/Build\/Products\/Debug-iphonesimulator\/App.swiftmodule\/arm64-apple-ios-simulator.swiftmodule\n\tTesting cancelled because the build failed.\n\n** TEST FAILED **\n\n\nThe following build commands failed:\n\tSwiftEmitModule normal arm64 Emitting\\ module\\ for\\ AppTests (in target 'AppTests' from project 'App')\n(1 failure)\n\""
+                  },
+                  "testCaseName" : {
+                    "_type" : {
+                      "_name" : "String"
+                    },
+                    "_value" : "DependenciesAcceptanceTestIosAppWithSPMDependencies.test_ios_app_spm_dependencies()"
+                  }
+                }
+              ]
+            }
+          },
+          "metadataRef" : {
+            "_type" : {
+              "_name" : "Reference"
+            },
+            "id" : {
+              "_type" : {
+                "_name" : "String"
+              },
+              "_value" : "0~VbN52oFuHDTG0EcAOQetUdZLbKa9zYQrCBFDkKY7h3D2Xi29FsjOinUPBURI9WNvHK3-dvcDm8cZNYvXbsYCHw=="
+            },
+            "targetType" : {
+              "_type" : {
+                "_name" : "TypeDefinition"
+              },
+              "name" : {
+                "_type" : {
+                  "_name" : "String"
+                },
+                "_value" : "ActionsInvocationMetadata"
+              }
+            }
+          },
+          "metrics" : {
+            "_type" : {
+              "_name" : "ResultMetrics"
+            },
+            "testsCount" : {
+              "_type" : {
+                "_name" : "Int"
+              },
+              "_value" : "3"
+            },
+            "testsFailedCount" : {
+              "_type" : {
+                "_name" : "Int"
+              },
+              "_value" : "1"
+            }
+          }
+        }
+
+        """#
+    }
+}


### PR DESCRIPTION
### Short description 📝

Uploads invocation record along with all test result bundle objects to the Tuist server.

### How to test the changes locally 🧐

Run `tuist test` in `ios_app_with_frameworks` and the run detail should surface the test results. Note that the server PR must be merged first before this will work.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
