### PR TITLE
Add docs for Prometheus metrics

### DIFF
--- a/docs/docs/cloud/on-premise.md
+++ b/docs/docs/cloud/on-premise.md
@@ -316,7 +316,7 @@ volumes:
 
 ## Metrics
 
-You can ingest metrics gathered by the Tuist server using [Prometheus](https://prometheus.io/) and a visualization tool such as [Grafana](https://grafana.com/) to create a custom dashboard tailored to your needs. The Prometheus metrics are served via the `/metrics` endpoint.
+You can ingest metrics gathered by the Tuist server using [Prometheus](https://prometheus.io/) and a visualization tool such as [Grafana](https://grafana.com/) to create a custom dashboard tailored to your needs. The Prometheus metrics are served via the `/metrics` endpoint. The Prometheus' [scrape_interval](https://prometheus.io/docs/introduction/first_steps/#configuring-prometheus) should be set as less than 10_000 seconds (we recommend keeping the default of 15 seconds).
 
 ### Runs metrics
 


### PR DESCRIPTION
### Short description 📝

We're adding documentation for the new prometheus metrics that are available to on-premise Tuist customers. This will change in the future and should be available to everyone, but we'll need to first figure out proper authentication and scope metrics to an organization which is not necessary for on-premise customers.

This also allows on-premise customers who can't install Timescale to still have metrics.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x]  The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
