### PR TITLE
Fix dependency declaration with `XcodeGraphTesting` defined in `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,7 @@ var targets: [Target] = [
         dependencies: [
             "TuistCore",
             "TuistSupportTesting",
-            "XcodeGraphTesting",
+            .product(name: "XcodeGraphTesting", package: "XcodeGraph"),
             pathDependency,
         ],
         linkerSettings: [.linkedFramework("XCTest")]
@@ -248,7 +248,7 @@ var targets: [Target] = [
             "TuistLoader",
             pathDependency,
             "TuistCore",
-            "XcodeGraphTesting",
+            .product(name: "XcodeGraphTesting", package: "XcodeGraph"),
             "ProjectDescription",
             "TuistSupportTesting",
         ],


### PR DESCRIPTION
I just noticed that the dependency is wrongly defined in `Package.swift`, which causes packages depending on Tuist packages downstream to fail the resolution.

> [!NOTE]
> One might think that we should add a CI step to prevent this from happening, but since this setup of another repo consuming the packages here is something we are reverting, I don't think is worth investing in it.