### PR TITLE
Do not generate resource accessors for internal targets with resources and Objective-C source files

### DIFF
--- a/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
+++ b/Sources/TuistGenerator/Mappers/ResourcesProjectMapper.swift
@@ -81,7 +81,8 @@ public class ResourcesProjectMapper: ProjectMapping { // swiftlint:disable:this 
             sideEffects.append(sideEffect)
         }
 
-        if target.supportsSources,
+        if project.isExternal,
+           target.supportsSources,
            target.sources.containsObjcFiles,
            target.resources.containsBundleAccessedResources
         {

--- a/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
+++ b/Tests/TuistGeneratorTests/ProjectMappers/ResourcesProjectMapperTests.swift
@@ -416,11 +416,12 @@ final class ResourcesProjectMapperTests: TuistUnitTestCase {
 
         // Then
         let gotTarget = try XCTUnwrap(gotProject.targets.values.sorted().last)
-        verifyObjcBundleAccessor(
-            for: target,
-            gotTarget: gotTarget,
-            gotSideEffects: gotSideEffects
+        XCTAssertEqual(
+            gotTarget.settings?.base["GCC_PREFIX_HEADER"],
+            nil
         )
+        XCTAssertEqual(gotTarget.sources.count, 1)
+        XCTAssertEqual(gotSideEffects.count, 0)
     }
 
     func test_map_when_project_name_has_dashes_in_it_bundle_name_include_dash_for_project_name_and_underscore_for_target_name(


### PR DESCRIPTION
### Short description 📝

As reported by Etsy, their `GCC_PREFIX_HEADER` is unexpectedly overridden by tuist. This regression was introduced [here](https://github.com/tuist/tuist/pull/6146/files#r1548592042). At the time, we thought overriding `GCC_PREFIX_HEADER` should be fine but this assumption turned out not to be true.

For the time being, we will again no longer generate objc resource accessors. We can start generating them again once we figure out how not to use `GCC_PREFIX_HEADER` as described [here](https://github.com/tuist/tuist/pull/5945#discussion_r1493303071).

### How to test the changes locally 🧐

An internal target with objc files and resources shouldn't have tuist-generated resource accessors.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
