### PR TITLE
Fix failing acceptance tests due to empty run id

### DIFF
--- a/Sources/TuistKit/Commands/GenerateCommand.swift
+++ b/Sources/TuistKit/Commands/GenerateCommand.swift
@@ -11,7 +11,7 @@ public struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
     public static var analyticsDelegate: TrackableParametersDelegate?
     public static var generatorFactory: GeneratorFactorying = GeneratorFactory()
     public static var cacheStorageFactory: CacheStorageFactorying = EmptyCacheStorageFactory()
-    public var runId = ""
+    public var runId = UUID().uuidString
 
     public static var configuration: CommandConfiguration {
         CommandConfiguration(

--- a/Sources/TuistKit/Commands/GraphCommand.swift
+++ b/Sources/TuistKit/Commands/GraphCommand.swift
@@ -13,7 +13,7 @@ public struct GraphCommand: AsyncParsableCommand, HasTrackableParameters {
     public init() {}
 
     public static var analyticsDelegate: TrackableParametersDelegate?
-    public var runId = ""
+    public var runId = UUID().uuidString
 
     public static var configuration: CommandConfiguration {
         CommandConfiguration(

--- a/Sources/TuistKit/Commands/InitCommand.swift
+++ b/Sources/TuistKit/Commands/InitCommand.swift
@@ -21,7 +21,7 @@ public struct InitCommand: ParsableCommand, HasTrackableParameters {
     }
 
     public static var analyticsDelegate: TrackableParametersDelegate?
-    public var runId = ""
+    public var runId = UUID().uuidString
 
     @Option(
         help: "The platform (ios, tvos, visionos, watchos or macos) the product will be for (Default: ios)",

--- a/Sources/TuistKit/Commands/TestCommand.swift
+++ b/Sources/TuistKit/Commands/TestCommand.swift
@@ -14,7 +14,7 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
     public static var analyticsDelegate: TrackableParametersDelegate?
     public static var generatorFactory: GeneratorFactorying = GeneratorFactory()
     public static var cacheStorageFactory: CacheStorageFactorying = EmptyCacheStorageFactory()
-    public var runId = ""
+    public var runId = UUID().uuidString
 
     public static var configuration: CommandConfiguration {
         CommandConfiguration(

--- a/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
+++ b/Sources/TuistKit/Commands/TrackableCommand/TrackableCommand.swift
@@ -41,12 +41,14 @@ public class TrackableCommand: TrackableParametersDelegate {
     }
 
     public func run() async throws {
-        let runId = UUID().uuidString
+        let runId: String
         let timer = clock.startTimer()
         if var command = command as? HasTrackableParameters & ParsableCommand {
             type(of: command).analyticsDelegate = self
-            command.runId = runId
+            runId = command.runId
             self.command = command
+        } else {
+            runId = UUID().uuidString
         }
         do {
             if var asyncCommand = command as? AsyncParsableCommand {


### PR DESCRIPTION
### Short description 📝

Some acceptance tests can fail because we don't set the `runId` since we skip going through the `TuistCommand` that sets it.

To get around this, we get the run id from the command instead of setting in the `TuistCommand`.

### How to test the changes locally 🧐

Tests should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
