### PR TITLE
Add missing `SwiftToolsSupport` dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -97,6 +97,7 @@ var targets: [Target] = [
         dependencies: [
             pathDependency,
             loggingDependency,
+            swiftToolsSupportDependency,
             "KeychainAccess",
             "ZIPFoundation",
             "ProjectDescription",


### PR DESCRIPTION
We recently made the project depend on `twist/XcodeGraph.` I introduced a regression in the `Package.swift`  where the dependency between `TuistSupport` and `SwiftToolsSupport` is missing. This PR adds it back.