### PR TITLE
Fix sporadic errors when Tuist tries to preserve the SPM lockfile across project generations

### DIFF
--- a/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
+++ b/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
@@ -58,12 +58,11 @@ public class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting {
             .appending(try RelativePath(validating: "\(workspaceName)/xcshareddata/swiftpm"))
         let workspacePackageResolvedPath = workspacePackageResolvedFolderPath.appending(component: "Package.resolved")
 
-        if fileHandler.exists(rootPackageResolvedPath) {
-            try fileHandler.createFolder(workspacePackageResolvedFolderPath)
-            if fileHandler.exists(workspacePackageResolvedPath) {
-                try fileHandler.delete(workspacePackageResolvedPath)
+        if fileHandler.exists(rootPackageResolvedPath), !fileHandler.exists(workspacePackageResolvedPath) {
+            if !fileHandler.exists(workspacePackageResolvedPath.parentDirectory) {
+                try fileHandler.createFolder(workspacePackageResolvedPath.parentDirectory)
             }
-            try fileHandler.copy(from: rootPackageResolvedPath, to: workspacePackageResolvedPath)
+            try fileHandler.linkFile(atPath: rootPackageResolvedPath, toPath: workspacePackageResolvedPath)
         }
 
         let workspacePath = path.appending(component: workspaceName)
@@ -98,12 +97,9 @@ public class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting {
             })
         )
 
-        if fileHandler.exists(rootPackageResolvedPath) {
-            try fileHandler.delete(rootPackageResolvedPath)
-        }
-        
-        if fileHandler.exists(workspacePackageResolvedPath) {
+        if !fileHandler.exists(rootPackageResolvedPath), fileHandler.exists(workspacePackageResolvedPath) {
             try fileHandler.copy(from: workspacePackageResolvedPath, to: rootPackageResolvedPath)
+            try fileHandler.linkFile(atPath: rootPackageResolvedPath, toPath: workspacePackageResolvedPath)
         }
     }
 }

--- a/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
+++ b/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
@@ -101,7 +101,9 @@ public class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting {
         if fileHandler.exists(rootPackageResolvedPath) {
             try fileHandler.delete(rootPackageResolvedPath)
         }
-
-        try fileHandler.linkFile(atPath: workspacePackageResolvedPath, toPath: rootPackageResolvedPath)
+        
+        if fileHandler.exists(workspacePackageResolvedPath) {
+            try fileHandler.copy(from: workspacePackageResolvedPath, to: rootPackageResolvedPath)
+        }
     }
 }

--- a/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
+++ b/Sources/TuistGenerator/Utils/SwiftPackageManagerInteractor.swift
@@ -99,7 +99,9 @@ public class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting {
 
         if !fileHandler.exists(rootPackageResolvedPath), fileHandler.exists(workspacePackageResolvedPath) {
             try fileHandler.copy(from: workspacePackageResolvedPath, to: rootPackageResolvedPath)
-            try fileHandler.linkFile(atPath: rootPackageResolvedPath, toPath: workspacePackageResolvedPath)
+            if !fileHandler.exists(workspacePackageResolvedPath) {
+                try fileHandler.linkFile(atPath: rootPackageResolvedPath, toPath: workspacePackageResolvedPath)
+            }
         }
     }
 }

--- a/Tests/TuistGeneratorIntegrationTests/Generator/SwiftPackageManagerInteractorTests.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Generator/SwiftPackageManagerInteractorTests.swift
@@ -106,6 +106,56 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         XCTAssertTrue(FileHandler.shared.exists(temporaryPath.appending(component: ".package.resolved")))
     }
 
+    func test_generate_linksRootPackageResolved_before_resolving() async throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+        let target = anyTarget(dependencies: [
+            .package(product: "Example", type: .runtime),
+        ])
+        let package = Package.remote(url: "http://some.remote/repo.git", requirement: .exact("branch"))
+        let project = Project.test(
+            path: temporaryPath,
+            name: "Test",
+            settings: .default,
+            targets: [target],
+            packages: [
+                package,
+            ]
+        )
+        let graph = Graph.test(
+            path: project.path,
+            packages: [project.path: ["Test": package]],
+            dependencies: [GraphDependency.packageProduct(path: project.path, product: "Test", type: .runtime): Set()]
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        let workspace = Workspace.test(
+            name: project.name,
+            projects: [project.path]
+        )
+        let rootPackageResolvedPath = temporaryPath.appending(component: ".package.resolved")
+        try FileHandler.shared.write("package", path: rootPackageResolvedPath, atomically: false)
+
+        let workspacePath = temporaryPath.appending(component: workspace.name + ".xcworkspace")
+        system.succeedCommand(["xcodebuild", "-resolvePackageDependencies", "-workspace", workspacePath.pathString, "-list"])
+
+        // When
+        try await subject.install(graphTraverser: graphTraverser, workspaceName: workspacePath.basename)
+
+        // Then
+        let workspacePackageResolvedPath = temporaryPath
+            .appending(try RelativePath(validating: "\(workspace.name).xcworkspace/xcshareddata/swiftpm/Package.resolved"))
+        XCTAssertEqual(
+            try FileHandler.shared.readTextFile(workspacePackageResolvedPath),
+            "package"
+        )
+        try FileHandler.shared.write("changedPackage", path: rootPackageResolvedPath, atomically: false)
+        XCTAssertEqual(
+            try FileHandler.shared.readTextFile(workspacePackageResolvedPath),
+            "changedPackage"
+        )
+    }
+
     func test_generate_doesNotAddPackageDependencyManager() async throws {
         // Given
         let temporaryPath = try temporaryPath()

--- a/Tests/TuistGeneratorIntegrationTests/Generator/SwiftPackageManagerInteractorTests.swift
+++ b/Tests/TuistGeneratorIntegrationTests/Generator/SwiftPackageManagerInteractorTests.swift
@@ -106,56 +106,6 @@ final class SwiftPackageManagerInteractorTests: TuistUnitTestCase {
         XCTAssertTrue(FileHandler.shared.exists(temporaryPath.appending(component: ".package.resolved")))
     }
 
-    func test_generate_linksRootPackageResolved_before_resolving() async throws {
-        // Given
-        let temporaryPath = try temporaryPath()
-        let target = anyTarget(dependencies: [
-            .package(product: "Example", type: .runtime),
-        ])
-        let package = Package.remote(url: "http://some.remote/repo.git", requirement: .exact("branch"))
-        let project = Project.test(
-            path: temporaryPath,
-            name: "Test",
-            settings: .default,
-            targets: [target],
-            packages: [
-                package,
-            ]
-        )
-        let graph = Graph.test(
-            path: project.path,
-            packages: [project.path: ["Test": package]],
-            dependencies: [GraphDependency.packageProduct(path: project.path, product: "Test", type: .runtime): Set()]
-        )
-        let graphTraverser = GraphTraverser(graph: graph)
-
-        let workspace = Workspace.test(
-            name: project.name,
-            projects: [project.path]
-        )
-        let rootPackageResolvedPath = temporaryPath.appending(component: ".package.resolved")
-        try FileHandler.shared.write("package", path: rootPackageResolvedPath, atomically: false)
-
-        let workspacePath = temporaryPath.appending(component: workspace.name + ".xcworkspace")
-        system.succeedCommand(["xcodebuild", "-resolvePackageDependencies", "-workspace", workspacePath.pathString, "-list"])
-
-        // When
-        try await subject.install(graphTraverser: graphTraverser, workspaceName: workspacePath.basename)
-
-        // Then
-        let workspacePackageResolvedPath = temporaryPath
-            .appending(try RelativePath(validating: "\(workspace.name).xcworkspace/xcshareddata/swiftpm/Package.resolved"))
-        XCTAssertEqual(
-            try FileHandler.shared.readTextFile(workspacePackageResolvedPath),
-            "package"
-        )
-        try FileHandler.shared.write("changedPackage", path: rootPackageResolvedPath, atomically: false)
-        XCTAssertEqual(
-            try FileHandler.shared.readTextFile(workspacePackageResolvedPath),
-            "changedPackage"
-        )
-    }
-
     func test_generate_doesNotAddPackageDependencyManager() async throws {
         // Given
         let temporaryPath = try temporaryPath()


### PR DESCRIPTION
Resolves: https://github.com/tuist/tuist/issues/6213

### Short description 📝

I came across [this issue](https://github.com/tuist/tuist/issues/6213) and decided to fix it. The logic made assumptions about the existence of some files, so this PR gets rid of them.

### How to test the changes locally 🧐
You should be able to run `tuist generate --no-binary-cache` pointing to a project that contains packages natively integrated and see a `.package.resolved` at the root that's symlinked from within the Xcode project.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
