### PR TITLE
Change TSCBasic import to Path for CacheAnalyticsStore

### DIFF
--- a/Sources/TuistServer/Cache/CacheAnalytics.swift
+++ b/Sources/TuistServer/Cache/CacheAnalytics.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Mockable
-import TSCBasic
+import Path
 import TuistSupport
 import XcodeGraph
 


### PR DESCRIPTION
### Short description 📝

We should be using `Path` library instead of `TSCBasic`.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
