### PR TITLE
Remove duplicate branch_triggering definition in codemagic.yaml

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -37,14 +37,8 @@ workflows:
           mise install
       - name: Build
         script: swift build --configuration debug
-    triggering: &branch_triggering
-      events:
-        - push
-        - pull_request
-      branch_patterns:
-        - pattern: '*'
-          include: true
-      cancel_previous_builds: true
+    triggering:
+      << : *branch_triggering
   build_docs:
     name: Build Documentation
     max_build_duration: 60


### PR DESCRIPTION
### Short description 📝

The `spm_build` job added [here](https://github.com/tuist/tuist/pull/6393/files#diff-bf0ae6a913219a09775a2f777446c5ebaa55b75a6f39c47bd39ac8ce45b2693aR40-R47) includes a duplicate `branch_triggering` definition. The codemagic pipelines that don't run due to the invalid yaml configuration:
```
Found duplicate anchor 'branch_triggering'; first occurrence
  in "<byte string>", line 17, column 17:
        triggering: &branch_triggering
                    ^
second occurrence
  in "<byte string>", line 40, column 17:
        triggering: &branch_triggering
```

I have no idea how that PR succeeded in the first place 🤔 unless we merged without waiting for the results.

### How to test the changes locally 🧐

CI should pass.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint:fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
