### PR TITLE
Remove upload of result bundles to CI

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -72,8 +72,6 @@ workflows:
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build
-    artifacts:
-      - /tmp/tuist/**
     scripts:
       - name: Set environment variables
         script: | 
@@ -85,7 +83,7 @@ workflows:
       - name: Install Tuist dependencies
         script: mise x -- tuist install
       - name: Run tests
-        script: mise x -- tuist test TuistUnitTests --result-bundle-path /tmp/tuist/test-result-bundle
+        script: mise x -- tuist test TuistUnitTests
     triggering:
       << : *branch_triggering
   cache:
@@ -98,8 +96,6 @@ workflows:
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build
-    artifacts:
-      - /tmp/tuist/**
     scripts:
       - name: Set environment variables
         script: | 
@@ -161,8 +157,6 @@ workflows:
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build
-    artifacts:
-      - /tmp/tuist/**
     scripts:
       - name: Set environment variables
         script: | 
@@ -178,7 +172,7 @@ workflows:
       - name: Install Tuist dependencies
         script: mise x -- tuist install
       - name: Run tests
-        script: mise x -- tuist test TuistAutomationAcceptanceTests --result-bundle-path /tmp/tuist/automation-acceptance-test-result-bundle
+        script: mise x -- tuist test TuistAutomationAcceptanceTests
     triggering:
       << : *branch_triggering
   
@@ -192,8 +186,6 @@ workflows:
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build
-    artifacts:
-      - /tmp/tuist/**
     scripts:
       - name: Set environment variables
         script: | 
@@ -209,7 +201,7 @@ workflows:
       - name: Install Tuist dependencies
         script: mise x -- tuist install
       - name: Run tests
-        script: mise x -- tuist test --result-bundle-path /tmp/tuist/dependencies-acceptance-test-result-bundle TuistDependenciesAcceptanceTests
+        script: mise x -- tuist test
     triggering:
       << : *branch_triggering
 
@@ -223,8 +215,6 @@ workflows:
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build
-    artifacts:
-      - /tmp/tuist/**
     scripts:
       - name: Set environment variables
         script: | 
@@ -240,7 +230,7 @@ workflows:
       - name: Install Tuist dependencies
         script: mise x -- tuist install
       - name: Run tests
-        script: mise x -- tuist test TuistGeneratorAcceptanceTests --result-bundle-path /tmp/tuist/generator-acceptance-test-result-bundle
+        script: mise x -- tuist test TuistGeneratorAcceptanceTests
     triggering:
       << : *branch_triggering
 
@@ -254,8 +244,6 @@ workflows:
     cache:
       cache_paths:
         - $CM_BUILD_DIR/.build
-    artifacts:
-      - /tmp/tuist/**
     scripts:
       - name: Set environment variables
         script: | 
@@ -271,6 +259,6 @@ workflows:
       - name: Install Tuist dependencies
         script: mise x -- tuist install
       - name: Run tests
-        script: mise x -- tuist test tuistAcceptanceTests --result-bundle-path /tmp/tuist/tuist-acceptance-test-result-bundle
+        script: mise x -- tuist test tuistAcceptanceTests
     triggering:
       << : *branch_triggering


### PR DESCRIPTION
### Short description 📝

The [Tuist dashboard](https://cloud.tuist.io/tuist/tuist) is now available to everyone. Since we now upload the result bundles from the CI to the Tuist server, we no longer have to do the dance in the CI pipeline.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
