### PR TITLE
Allow iOS app extensions to depend on bundles

### DIFF
--- a/Sources/TuistGenerator/Linter/GraphLinter.swift
+++ b/Sources/TuistGenerator/Linter/GraphLinter.swift
@@ -443,6 +443,7 @@ public class GraphLinter: GraphLinting {
             LintableTarget(platform: .iOS, product: .dynamicLibrary),
             LintableTarget(platform: .iOS, product: .staticFramework),
             LintableTarget(platform: .iOS, product: .framework),
+            LintableTarget(platform: .iOS, product: .bundle),
             LintableTarget(platform: .macOS, product: .macro),
         ],
         LintableTarget(platform: .iOS, product: .appClip): [

--- a/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
+++ b/Tests/TuistGeneratorAcceptanceTests/GenerateAcceptanceTests.swift
@@ -483,6 +483,11 @@ final class GenerateAcceptanceTestiOSAppWithExtensions: TuistAcceptanceTestCase 
             "App.app",
             destination: "Debug-iphonesimulator"
         )
+        try await XCTAssertProductWithDestinationContainsResource(
+            "WidgetExtension.appex",
+            destination: "Debug-iphonesimulator",
+            resource: "Bundle.bundle/dummy.jpg"
+        )
     }
 }
 

--- a/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
+++ b/Tests/TuistGeneratorTests/Linter/GraphLinterTests.swift
@@ -233,6 +233,33 @@ final class GraphLinterTests: TuistUnitTestCase {
         XCTAssertTrue(result.isEmpty)
     }
 
+    func test_lint_appExtension_canDependOnBundle() throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let appExtension = Target.empty(name: "app_extension", product: .appExtension)
+        let bundle = Target.empty(name: "bundle", product: .bundle)
+        let project = Project.empty(path: path)
+
+        let dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: appExtension.name, path: path): Set([.target(name: bundle.name, path: path)]),
+            .target(name: bundle.name, path: path): Set([]),
+        ]
+
+        let graph = Graph.test(
+            path: path,
+            projects: [path: project],
+            dependencies: dependencies
+        )
+        let config = Config.test()
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let result = subject.lint(graphTraverser: graphTraverser, config: config)
+
+        // Then
+        XCTAssertTrue(result.isEmpty)
+    }
+
     func test_lint_frameworkDependsOnBundle() throws {
         // Given
         let path: AbsolutePath = "/project"

--- a/fixtures/ios_app_with_extensions/Project.swift
+++ b/fixtures/ios_app_with_extensions/Project.swift
@@ -96,6 +96,7 @@ let project = Project(
             sources: "WidgetExtension/Sources/**",
             resources: "WidgetExtension/Resources/**",
             dependencies: [
+                .target(name: "Bundle"),
                 .target(name: "StaticFramework"),
             ]
         ),
@@ -118,6 +119,13 @@ let project = Project(
                 ],
             ]),
             sources: "AppIntentExtension/Sources/**"
+        ),
+        .target(
+            name: "Bundle",
+            destinations: .iOS,
+            product: .bundle,
+            bundleId: "io.tuist.App.Bundle",
+            resources: "Bundle/**"
         ),
     ]
 )


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6406

### Short description 📝

Previously, Tuist didn't allow iOS app extensions to depend on bundle targets. This is, however, a combination that is possible with Xcode and is natively supported in Xcodegen, for example.

After reporting the issue I received confirmation this was a bug. This PR fixes it by adding the combination to the graph linter. For testing, the PR extends the `app_with_extensions` fixture & acceptance tests by adding a dummy bundle that is then made a dependency of one of the extensions. I also added a unit test for the graph linter.

### How to test the changes locally 🧐

1. Generate the `app_with_extensions` Tuist project. The generate command should be successful
2. Open the resulting workspace and build any target that depends on the Bundle target (for example, App)
3. Open the derived data and navigate to the build products of the build, go inside the package contents
4. Bundle.bundle should be there

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
