### PR TITLE
Add ProjectAutomation-auto package product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -334,6 +334,10 @@ let package = Package(
             targets: ["ProjectAutomation"]
         ),
         .library(
+            name: "ProjectAutomation-auto",
+            targets: ["ProjectAutomation"]
+        ),
+        .library(
             name: "TuistKit",
             targets: ["TuistKit"]
         ),


### PR DESCRIPTION
### Short description 📝

The `ProjectAutomation` package product declared in the `Package.swift` within this repository sets the [Product.Library.LibraryType](https://developer.apple.com/documentation/packagedescription/product/library/librarytype) to `.dynamic` in contrast to not specifying it as in the `tuist/ProjectAutomation` repository. Setting the type to `.dynamic` forces consumers of the `ProjectAutomation` product to ship the built `libProjectAutomation.dylib` in addition to their binary (e.g. tuist plugins or separate command line tools). 

To allow consumers to link ProjectAutomation into their binary, this PR adds a new `ProjectAutomation-auto` package product, similarly to the [SwiftToolsSupport-auto](https://github.com/apple/swift-tools-support-core/blob/b170d46b94d6c1cd91db97d2e3a1e0bdb5b79a24/Package.swift#L36-L42).

Prior discussion on Slack: https://tuist-community.slack.com/archives/CTB0DBVD2/p1717681311979379

### How to test the changes locally 🧐

1. Create a Swift Package depending on the new `ProjectAutomation-auto` product
2. Archive the executable product of that package
3. Assert that `ProjectAutomation` is linked into the binary and not built as a separate `libProjectAutomation.dylib`

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [ ] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
