### PR TITLE
Fix `tuist clean` not cleaning anything if no categories are provided

### DIFF
--- a/Sources/TuistKit/Commands/CleanCommand.swift
+++ b/Sources/TuistKit/Commands/CleanCommand.swift
@@ -16,7 +16,7 @@ public struct CleanCommand: ParsableCommand {
         help: "The cache and artifact categories to be cleaned. If no category is specified, everything is cleaned.",
         envKey: .cleanCleanCategories
     )
-    var cleanCategories: [TuistCleanCategory] = TuistCleanCategory.allCases.map { $0 }
+    var cleanCategories: [TuistCleanCategory]
 
     @Option(
         name: .shortAndLong,
@@ -28,7 +28,7 @@ public struct CleanCommand: ParsableCommand {
 
     public func run() throws {
         try CleanService().run(
-            categories: cleanCategories,
+            categories: cleanCategories.isEmpty ? TuistCleanCategory.allCases : cleanCategories,
             path: path
         )
     }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6418. Regression introduced in https://github.com/tuist/tuist/pull/6359.

### Short description 📝

The current way of declaring the default value does not work and `cleanCategories` is left empty. Why this happens I did not have time to dig into right now, but most likely some feature of [swift-argument-parser](https://github.com/apple/swift-argument-parser).

### How to test the changes locally 🧐

See the issue for repro steps. I have manually tested this with `tuist clean`, `tuist clean dependencies`, and `TUIST_CLEAN_CLEAN_CATEGORIES=dependencies tuist clean`. Perhaps it might be worth it to add unit tests for this as well?

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [ ] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [ ] The code architecture and patterns are consistent with the rest of the codebase
- [ ] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
