### PR TITLE
Surface current organization usage in cloud organization show

### DIFF
--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationShowService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationShowService.swift
@@ -14,15 +14,18 @@ protocol CloudOrganizationShowServicing {
 
 final class CloudOrganizationShowService: CloudOrganizationShowServicing {
     private let getOrganizationService: GetOrganizationServicing
+    private let getOrganizationUsageService: GetOrganizationUsageServicing
     private let cloudURLService: CloudURLServicing
     private let configLoader: ConfigLoading
 
     init(
         getOrganizationService: GetOrganizationServicing = GetOrganizationService(),
+        getOrganizationUsageService: GetOrganizationUsageServicing = GetOrganizationUsageService(),
         cloudURLService: CloudURLServicing = CloudURLService(),
         configLoader: ConfigLoading = ConfigLoader()
     ) {
         self.getOrganizationService = getOrganizationService
+        self.getOrganizationUsageService = getOrganizationUsageService
         self.cloudURLService = cloudURLService
         self.configLoader = configLoader
     }
@@ -42,6 +45,11 @@ final class CloudOrganizationShowService: CloudOrganizationShowServicing {
         let cloudURL = try cloudURLService.url(configCloudURL: config.cloud?.url)
 
         let organization = try await getOrganizationService.getOrganization(
+            organizationName: organizationName,
+            serverURL: cloudURL
+        )
+
+        let organizationUsage = try await getOrganizationUsageService.getOrganizationUsage(
             organizationName: organizationName,
             serverURL: cloudURL
         )
@@ -86,6 +94,9 @@ final class CloudOrganizationShowService: CloudOrganizationShowServicing {
 
         logger.info("""
         \(baseInfo.joined(separator: "\n"))
+
+        \("Usage".bold()) (current calendar month)
+        Remote cache hits: \(organizationUsage.currentMonthRemoteCacheHits)
 
         \("Organization members".bold()) (total number: \(organization.members.count))
         \(membersTable)

--- a/Sources/TuistServer/Models/CloudOrganizationUsage.swift
+++ b/Sources/TuistServer/Models/CloudOrganizationUsage.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Path
+
+/// Cloud organization usage
+public struct CloudOrganizationUsage: Codable {
+    public init(
+        currentMonthRemoteCacheHits: Int
+    ) {
+        self.currentMonthRemoteCacheHits = currentMonthRemoteCacheHits
+    }
+
+    public let currentMonthRemoteCacheHits: Int
+}
+
+extension CloudOrganizationUsage {
+    init(_ organizationUsage: Components.Schemas.OrganizationUsage) {
+        currentMonthRemoteCacheHits = Int(organizationUsage.current_month_remote_cache_hits)
+    }
+}
+
+#if DEBUG
+    extension CloudOrganizationUsage {
+        public static func test(
+            currentMonthRemoteCacheHits: Int = 100
+        ) -> Self {
+            .init(
+                currentMonthRemoteCacheHits: currentMonthRemoteCacheHits
+            )
+        }
+    }
+#endif

--- a/Sources/TuistServer/OpenAPI/Client.swift
+++ b/Sources/TuistServer/OpenAPI/Client.swift
@@ -1604,6 +1604,78 @@ public struct Client: APIProtocol {
             }
         )
     }
+    /// Shows the usage of an organization
+    ///
+    /// Returns the usage of the organization with the given identifier. (e.g. number of remote cache hits)
+    ///
+    /// - Remark: HTTP `GET /api/organizations/{organization_name}/usage`.
+    /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/usage/get(showOrganizationUsage)`.
+    public func showOrganizationUsage(_ input: Operations.showOrganizationUsage.Input) async throws
+        -> Operations.showOrganizationUsage.Output
+    {
+        try await client.send(
+            input: input,
+            forOperation: Operations.showOrganizationUsage.id,
+            serializer: { input in
+                let path = try converter.renderedRequestPath(
+                    template: "/api/organizations/{}/usage",
+                    parameters: [input.path.organization_name]
+                )
+                var request: OpenAPIRuntime.Request = .init(path: path, method: .get)
+                suppressMutabilityWarning(&request)
+                try converter.setHeaderFieldAsText(
+                    in: &request.headerFields,
+                    name: "accept",
+                    value: "application/json"
+                )
+                return request
+            },
+            deserializer: { response in
+                switch response.statusCode {
+                case 200:
+                    let headers: Operations.showOrganizationUsage.Output.Ok.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.showOrganizationUsage.Output.Ok.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas.OrganizationUsage.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .ok(.init(headers: headers, body: body))
+                case 403:
+                    let headers: Operations.showOrganizationUsage.Output.Forbidden.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.showOrganizationUsage.Output.Forbidden.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .forbidden(.init(headers: headers, body: body))
+                case 404:
+                    let headers: Operations.showOrganizationUsage.Output.NotFound.Headers = .init()
+                    try converter.validateContentTypeIfPresent(
+                        in: response.headerFields,
+                        substring: "application/json"
+                    )
+                    let body: Operations.showOrganizationUsage.Output.NotFound.Body =
+                        try converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: response.body,
+                            transforming: { value in .json(value) }
+                        )
+                    return .notFound(.init(headers: headers, body: body))
+                default: return .undocumented(statusCode: response.statusCode, .init())
+                }
+            }
+        )
+    }
     /// List projects the authenticated user has access to.
     ///
     /// - Remark: HTTP `GET /api/projects`.

--- a/Sources/TuistServer/OpenAPI/Types.swift
+++ b/Sources/TuistServer/OpenAPI/Types.swift
@@ -145,6 +145,14 @@ public protocol APIProtocol: Sendable {
     /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/members/{user_name}/delete(removeOrganizationMember)`.
     func removeOrganizationMember(_ input: Operations.removeOrganizationMember.Input) async throws
         -> Operations.removeOrganizationMember.Output
+    /// Shows the usage of an organization
+    ///
+    /// Returns the usage of the organization with the given identifier. (e.g. number of remote cache hits)
+    ///
+    /// - Remark: HTTP `GET /api/organizations/{organization_name}/usage`.
+    /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/usage/get(showOrganizationUsage)`.
+    func showOrganizationUsage(_ input: Operations.showOrganizationUsage.Input) async throws
+        -> Operations.showOrganizationUsage.Output
     /// List projects the authenticated user has access to.
     ///
     /// - Remark: HTTP `GET /api/projects`.
@@ -1070,6 +1078,23 @@ public enum Components {
                 case name
                 case role
             }
+        }
+        /// The usage of an organization.
+        ///
+        /// - Remark: Generated from `#/components/schemas/OrganizationUsage`.
+        public struct OrganizationUsage: Codable, Equatable, Hashable, Sendable {
+            /// The number of remote cache hits in the current month
+            ///
+            /// - Remark: Generated from `#/components/schemas/OrganizationUsage/current_month_remote_cache_hits`.
+            public var current_month_remote_cache_hits: Swift.Double
+            /// Creates a new `OrganizationUsage`.
+            ///
+            /// - Parameters:
+            ///   - current_month_remote_cache_hits: The number of remote cache hits in the current month
+            public init(current_month_remote_cache_hits: Swift.Double) {
+                self.current_month_remote_cache_hits = current_month_remote_cache_hits
+            }
+            public enum CodingKeys: String, CodingKey { case current_month_remote_cache_hits }
         }
         /// - Remark: Generated from `#/components/schemas/Project`.
         public struct Project: Codable, Equatable, Hashable, Sendable {
@@ -4813,6 +4838,165 @@ public enum Operations {
             ///
             /// HTTP response code: `404 notFound`.
             case notFound(Operations.removeOrganizationMember.Output.NotFound)
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+    }
+    /// Shows the usage of an organization
+    ///
+    /// Returns the usage of the organization with the given identifier. (e.g. number of remote cache hits)
+    ///
+    /// - Remark: HTTP `GET /api/organizations/{organization_name}/usage`.
+    /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/usage/get(showOrganizationUsage)`.
+    public enum showOrganizationUsage {
+        public static let id: String = "showOrganizationUsage"
+        public struct Input: Sendable, Equatable, Hashable {
+            public struct Path: Sendable, Equatable, Hashable {
+                public var organization_name: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - organization_name:
+                public init(organization_name: Swift.String) {
+                    self.organization_name = organization_name
+                }
+            }
+            public var path: Operations.showOrganizationUsage.Input.Path
+            public struct Query: Sendable, Equatable, Hashable {
+                /// Creates a new `Query`.
+                public init() {}
+            }
+            public var query: Operations.showOrganizationUsage.Input.Query
+            public struct Headers: Sendable, Equatable, Hashable {
+                /// Creates a new `Headers`.
+                public init() {}
+            }
+            public var headers: Operations.showOrganizationUsage.Input.Headers
+            public struct Cookies: Sendable, Equatable, Hashable {
+                /// Creates a new `Cookies`.
+                public init() {}
+            }
+            public var cookies: Operations.showOrganizationUsage.Input.Cookies
+            @frozen public enum Body: Sendable, Equatable, Hashable {}
+            public var body: Operations.showOrganizationUsage.Input.Body?
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - query:
+            ///   - headers:
+            ///   - cookies:
+            ///   - body:
+            public init(
+                path: Operations.showOrganizationUsage.Input.Path,
+                query: Operations.showOrganizationUsage.Input.Query = .init(),
+                headers: Operations.showOrganizationUsage.Input.Headers = .init(),
+                cookies: Operations.showOrganizationUsage.Input.Cookies = .init(),
+                body: Operations.showOrganizationUsage.Input.Body? = nil
+            ) {
+                self.path = path
+                self.query = query
+                self.headers = headers
+                self.cookies = cookies
+                self.body = body
+            }
+        }
+        @frozen public enum Output: Sendable, Equatable, Hashable {
+            public struct Ok: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.showOrganizationUsage.Output.Ok.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas.OrganizationUsage)
+                }
+                /// Received HTTP response body
+                public var body: Operations.showOrganizationUsage.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.showOrganizationUsage.Output.Ok.Headers = .init(),
+                    body: Operations.showOrganizationUsage.Output.Ok.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The organization usage
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/usage/get(showOrganizationUsage)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.showOrganizationUsage.Output.Ok)
+            public struct Forbidden: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.showOrganizationUsage.Output.Forbidden.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.showOrganizationUsage.Output.Forbidden.Body
+                /// Creates a new `Forbidden`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.showOrganizationUsage.Output.Forbidden.Headers = .init(),
+                    body: Operations.showOrganizationUsage.Output.Forbidden.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The authenticated subject is not authorized to perform this action
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/usage/get(showOrganizationUsage)/responses/403`.
+            ///
+            /// HTTP response code: `403 forbidden`.
+            case forbidden(Operations.showOrganizationUsage.Output.Forbidden)
+            public struct NotFound: Sendable, Equatable, Hashable {
+                public struct Headers: Sendable, Equatable, Hashable {
+                    /// Creates a new `Headers`.
+                    public init() {}
+                }
+                /// Received HTTP response headers
+                public var headers: Operations.showOrganizationUsage.Output.NotFound.Headers
+                @frozen public enum Body: Sendable, Equatable, Hashable {
+                    case json(Components.Schemas._Error)
+                }
+                /// Received HTTP response body
+                public var body: Operations.showOrganizationUsage.Output.NotFound.Body
+                /// Creates a new `NotFound`.
+                ///
+                /// - Parameters:
+                ///   - headers: Received HTTP response headers
+                ///   - body: Received HTTP response body
+                public init(
+                    headers: Operations.showOrganizationUsage.Output.NotFound.Headers = .init(),
+                    body: Operations.showOrganizationUsage.Output.NotFound.Body
+                ) {
+                    self.headers = headers
+                    self.body = body
+                }
+            }
+            /// The organization with the given name was not found
+            ///
+            /// - Remark: Generated from `#/paths//api/organizations/{organization_name}/usage/get(showOrganizationUsage)/responses/404`.
+            ///
+            /// HTTP response code: `404 notFound`.
+            case notFound(Operations.showOrganizationUsage.Output.NotFound)
             /// Undocumented response.
             ///
             /// A response with a code that is not documented in the OpenAPI document.

--- a/Sources/TuistServer/OpenAPI/cloud.yml
+++ b/Sources/TuistServer/OpenAPI/cloud.yml
@@ -341,6 +341,17 @@ components:
       title: OrganizationMember
       type: object
       x-struct: Elixir.TuistCloudWeb.API.Schemas.OrganizationMember
+    OrganizationUsage:
+      description: The usage of an organization.
+      properties:
+        current_month_remote_cache_hits:
+          description: The number of remote cache hits in the current month
+          type: number
+      required:
+        - current_month_remote_cache_hits
+      title: OrganizationUsage
+      type: object
+      x-struct: Elixir.TuistCloudWeb.API.Schemas.OrganizationUsage
     Project:
       properties:
         full_name:
@@ -383,7 +394,7 @@ components:
       scheme: bearer
       type: http
 info:
-  title: Tuist Cloud
+  title: Tuist
   version: 0.1.0
 openapi: 3.0.0
 paths:
@@ -1332,6 +1343,39 @@ paths:
                 $ref: '#/components/schemas/Error'
           description: The organization or the user with the given name was not found
       summary: Updates a member in an organization
+      tags: []
+  /api/organizations/{organization_name}/usage:
+    get:
+      callbacks: {}
+      description: Returns the usage of the organization with the given identifier. (e.g. number of remote cache hits)
+      operationId: showOrganizationUsage
+      parameters:
+        - description: The name of the organization to show.
+          in: path
+          name: organization_name
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationUsage'
+          description: The organization usage
+        403:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The authenticated subject is not authorized to perform this action
+        404:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: The organization with the given name was not found
+      summary: Shows the usage of an organization
       tags: []
   /api/projects:
     get:

--- a/Sources/TuistServer/Services/GetOrganizationUsage.swift
+++ b/Sources/TuistServer/Services/GetOrganizationUsage.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Mockable
+import OpenAPIURLSession
+import TuistSupport
+
+@Mockable
+public protocol GetOrganizationUsageServicing {
+    func getOrganizationUsage(
+        organizationName: String,
+        serverURL: URL
+    ) async throws -> CloudOrganizationUsage
+}
+
+enum GetOrganizationUsageServiceError: FatalError {
+    case unknownError(Int)
+    case notFound(String)
+    case forbidden(String)
+
+    var type: ErrorType {
+        switch self {
+        case .unknownError:
+            return .bug
+        case .forbidden, .notFound:
+            return .abort
+        }
+    }
+
+    var description: String {
+        switch self {
+        case let .unknownError(statusCode):
+            return "We could not get the OrganizationUsage due to an unknown cloud response of \(statusCode)."
+        case let .forbidden(message), let .notFound(message):
+            return message
+        }
+    }
+}
+
+public final class GetOrganizationUsageService: GetOrganizationUsageServicing {
+    public init() {}
+
+    public func getOrganizationUsage(
+        organizationName: String,
+        serverURL: URL
+    ) async throws -> CloudOrganizationUsage {
+        let client = Client.cloud(serverURL: serverURL)
+
+        let response = try await client.showOrganizationUsage(
+            .init(
+                path: .init(
+                    organization_name: organizationName
+                )
+            )
+        )
+        switch response {
+        case let .ok(okResponse):
+            switch okResponse.body {
+            case let .json(organizationUsage):
+                return CloudOrganizationUsage(organizationUsage)
+            }
+        case let .notFound(notFound):
+            switch notFound.body {
+            case let .json(error):
+                throw GetOrganizationUsageServiceError.notFound(error.message)
+            }
+        case let .forbidden(forbidden):
+            switch forbidden.body {
+            case let .json(error):
+                throw GetOrganizationUsageServiceError.forbidden(error.message)
+            }
+        case let .undocumented(statusCode: statusCode, _):
+            throw GetOrganizationUsageServiceError.unknownError(statusCode)
+        }
+    }
+}

--- a/Tests/TuistKitTests/Cloud/CloudOrganizationShowServiceTests.swift
+++ b/Tests/TuistKitTests/Cloud/CloudOrganizationShowServiceTests.swift
@@ -10,6 +10,7 @@ import XCTest
 
 final class CloudOrganizationShowServiceTests: TuistUnitTestCase {
     private var getOrganizationService: MockGetOrganizationServicing!
+    private var getOrganizationUsageService: MockGetOrganizationUsageServicing!
     private var subject: CloudOrganizationShowService!
     private var configLoader: MockConfigLoading!
     private var cloudURL: URL!
@@ -17,17 +18,20 @@ final class CloudOrganizationShowServiceTests: TuistUnitTestCase {
     override func setUp() {
         super.setUp()
         getOrganizationService = .init()
+        getOrganizationUsageService = .init()
         configLoader = MockConfigLoading()
         cloudURL = URL(string: "https://test.cloud.tuist.io")!
         given(configLoader).loadConfig(path: .any).willReturn(.test(cloud: .test(url: cloudURL)))
         subject = CloudOrganizationShowService(
             getOrganizationService: getOrganizationService,
+            getOrganizationUsageService: getOrganizationUsageService,
             configLoader: configLoader
         )
     }
 
     override func tearDown() {
         getOrganizationService = nil
+        getOrganizationUsageService = nil
         configLoader = nil
         cloudURL = nil
         subject = nil
@@ -64,6 +68,10 @@ final class CloudOrganizationShowServiceTests: TuistUnitTestCase {
                 )
             )
 
+        given(getOrganizationUsageService)
+            .getOrganizationUsage(organizationName: .any, serverURL: .any)
+            .willReturn(.test(currentMonthRemoteCacheHits: 210))
+
         // When
         try await subject.run(
             organizationName: "tuist",
@@ -76,6 +84,9 @@ final class CloudOrganizationShowServiceTests: TuistUnitTestCase {
         \(TerminalStyle.bold.open)Organization\(TerminalStyle.reset.open)
         Name: test-one
         Plan: Team
+
+        \(TerminalStyle.bold.open)Usage\(TerminalStyle.reset.open) (current calendar month)
+        Remote cache hits: 210
 
         \(TerminalStyle.bold.open)Organization members\(TerminalStyle.reset.open) (total number: 2)
         username  email              role
@@ -99,6 +110,9 @@ final class CloudOrganizationShowServiceTests: TuistUnitTestCase {
                     ssoOrganization: .google("tuist.io")
                 )
             )
+        given(getOrganizationUsageService)
+            .getOrganizationUsage(organizationName: .any, serverURL: .any)
+            .willReturn(.test())
 
         // When
         try await subject.run(


### PR DESCRIPTION
### Short description 📝

For better visibility into projects, we are surfacing the remote cache hits for current month in the `tuist cloud organization show` command. Example output:
```
Organization
Name: tuist
Plan: None

Usage (current calendar month)
Remote cache hits: 260

Organization members (total number: 1)
username  email           role
tuist     tuist@tuist.io  admin

There are currently no invited users.
```

### How to test the changes locally 🧐

Run `tuist cloud organization show` for an arbitrary organization and you should see its remote cache usage for the current month.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
