### PR TITLE
Fix tuist clean when no category is provided

### DIFF
--- a/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
+++ b/Sources/TuistKit/Commands/EnvKey/EnvKey.swift
@@ -232,10 +232,7 @@ extension EnvKey {
         return T(argument: envValueString)
     }
 
-    func envValue<T: ExpressibleByArgument>() -> [T] {
-        guard let envValueString else {
-            return []
-        }
-        return envValueString.split(separator: ",").compactMap { T(argument: String($0)) }
+    func envValue<T: ExpressibleByArgument>() -> [T]? {
+        return envValueString?.split(separator: ",").compactMap { T(argument: String($0)) }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6418

### Short description 📝

As noted [here](https://github.com/tuist/tuist/pull/6419#issuecomment-2177821008), the issue was caused by the support for configuring commands via environment variables.

### How to test the changes locally 🧐

`tuist cloud clean` should clean all categories.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
