### PR TITLE
Document how to control the log level in the Tuist on-premise instance

### DIFF
--- a/docs/docs/cloud/on-premise.md
+++ b/docs/docs/cloud/on-premise.md
@@ -73,6 +73,7 @@ As an on-premise user, you'll receive a license key that you'll need to expose a
 | `TUIST_SECRET_KEY_PASSWORD` | Pepper to generate hashed passwords | No | `$TUIST_SECRET_KEY_BASE` | |
 | `TUIST_SECRET_KEY_TOKENS` | Secret key to generate random tokens | No | `$TUIST_SECRET_KEY_BASE` | |        
 | `TUIST_USE_IPV6` | When `1` it configures the app to use IPv6 addresses | No | `0` | `1`|
+| `TUIST_LOG_LEVEL` | The log level to use for the app | No | `info` | [Log levels](https://hexdocs.pm/logger/1.12.3/Logger.html#module-levels) |
 
 ### Authentication environment configuration
 


### PR DESCRIPTION
I'm documenting how to control the log-level of the Tuist server in on-premise instances.