### PR TITLE
Add note about the directory requirement

### DIFF
--- a/docs/docs/guide/introduction/adopting-tuist/swift-package.md
+++ b/docs/docs/guide/introduction/adopting-tuist/swift-package.md
@@ -13,6 +13,9 @@ Tuist supports using `Package.swift` as a DSL for your projects–It converts yo
 > [!WARNING]
 > The aim of this feature is to provide an easy way for developers to assess the impact of adopting Tuist and [Tuist Cloud](/cloud/what-is-cloud) in their Swift Packages. Therefore, we don't plan to support the full range of Swift Package Manager features nor to bring every Tuist's unique features like [project description helpers](/guide/project/code-sharing) to the packages world.
 
+> [!NOTE]
+> For `tuist generate` to work with a Swift Package, either a `.git` or a `Tuist` directory need to be present in your project.
+
 ## Using Tuist with a Swift Package
 
 We are going to use Tuist with the [Swift Composable Architecture](https://github.com/pointfreeco/swift-composable-architecture) repository, which contains a Swift Package. The first thing that we need to do is to clone the repository:

--- a/docs/docs/guide/introduction/adopting-tuist/swift-package.md
+++ b/docs/docs/guide/introduction/adopting-tuist/swift-package.md
@@ -13,8 +13,8 @@ Tuist supports using `Package.swift` as a DSL for your projects–It converts yo
 > [!WARNING]
 > The aim of this feature is to provide an easy way for developers to assess the impact of adopting Tuist and [Tuist Cloud](/cloud/what-is-cloud) in their Swift Packages. Therefore, we don't plan to support the full range of Swift Package Manager features nor to bring every Tuist's unique features like [project description helpers](/guide/project/code-sharing) to the packages world.
 
-> [!NOTE]
-> For `tuist generate` to work with a Swift Package, either a `.git` or a `Tuist` directory need to be present in your project.
+> [!NOTE] ROOT DIRECTORY
+> Tuist commands expect a certain [directory structure](/guide/project/directory-structure.html#standard-tuist-projects) whose root is identified by a `Tuist` or a `.git` directory.
 
 ## Using Tuist with a Swift Package
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6423

### Short description 📝

`tuist generate` does not work in a `Package.swift` project unless a `.git` or a `Tuist` directory is present as highlighted [here](https://github.com/tuist/tuist/issues/6423#issuecomment-2181078491). I'm adding a note to the docs, although long-term, it would be good to consider an alternative approaches.

While we _could_ assume we're in a project's root if we find a `Package.swift`, this would mean that if your project has multiple of them and you run `tuist generate` deeper in the directory structure, the behavior may be different based on where you run the command.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
