### PR TITLE
Fix caching ProjectDescriptionHelpers across macOS versions

### DIFF
--- a/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasher.swift
+++ b/Sources/TuistLoader/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasher.swift
@@ -16,10 +16,18 @@ public protocol ProjectDescriptionHelpersHashing: AnyObject {
 
 public final class ProjectDescriptionHelpersHasher: ProjectDescriptionHelpersHashing {
     /// Tuist version.
-    let tuistVersion: String
+    private let tuistVersion: String
+    private let machineEnvironment: MachineEnvironmentRetrieving
+    private let swiftVersionProvider: SwiftVersionProviding
 
-    public init(tuistVersion: String = Constants.version) {
+    public init(
+        tuistVersion: String = Constants.version,
+        machineEnvironment: MachineEnvironmentRetrieving = MachineEnvironment.shared,
+        swiftVersionProvider: SwiftVersionProviding = SwiftVersionProvider.shared
+    ) {
         self.tuistVersion = tuistVersion
+        self.machineEnvironment = machineEnvironment
+        self.swiftVersionProvider = swiftVersionProvider
     }
 
     // MARK: - ProjectDescriptionHelpersHashing
@@ -31,14 +39,15 @@ public final class ProjectDescriptionHelpersHasher: ProjectDescriptionHelpersHas
             .compactMap { $0.sha256() }
             .compactMap { $0.compactMap { byte in String(format: "%02x", byte) }.joined() }
         let tuistEnvVariables = Environment.shared.manifestLoadingVariables.map { "\($0.key)=\($0.value)" }.sorted()
-        let swiftVersion = try SwiftVersionProvider.shared.swiftVersion()
+        let swiftVersion = try swiftVersionProvider.swiftVersion()
+        let macosVersion = machineEnvironment.macOSVersion
         #if DEBUG
             let debug = true
         #else
             let debug = false
         #endif
 
-        let identifiers = [swiftVersion, tuistVersion] + fileHashes + tuistEnvVariables + ["\(debug)"]
+        let identifiers = [macosVersion, swiftVersion, tuistVersion] + fileHashes + tuistEnvVariables + ["\(debug)"]
 
         return identifiers.joined(separator: "-").md5
     }

--- a/Sources/TuistSupport/MachineEnvironment.swift
+++ b/Sources/TuistSupport/MachineEnvironment.swift
@@ -1,6 +1,8 @@
 import CryptoKit
 import Foundation
+import Mockable
 
+@Mockable
 public protocol MachineEnvironmentRetrieving: Sendable {
     var clientId: String { get }
     var macOSVersion: String { get }

--- a/Tests/TuistLoaderTests/Loaders/ManifestLoaderFactoryTests.swift
+++ b/Tests/TuistLoaderTests/Loaders/ManifestLoaderFactoryTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Mockable
 import Path
 import TuistSupport
 import XCTest
@@ -7,6 +8,12 @@ import XCTest
 @testable import TuistSupportTesting
 
 final class ManifestLoaderFactoryTests: TuistUnitTestCase {
+    override func setUp() {
+        super.setUp()
+
+        system.succeedCommand(["/usr/bin/xcrun", "swift", "-version"], output: "Swift Version 5.2.1")
+    }
+
     func test_create_default_cached_manifest_loader() {
         // Given
         let sut = ManifestLoaderFactory()

--- a/Tests/TuistLoaderTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasherTests.swift
+++ b/Tests/TuistLoaderTests/ProjectDescriptionHelpers/ProjectDescriptionHelpersHasherTests.swift
@@ -8,15 +8,24 @@ import XCTest
 @testable import TuistLoader
 @testable import TuistSupportTesting
 
-class ProjectDescriptionHelpersHasherTests: TuistUnitTestCase {
-    var subject: ProjectDescriptionHelpersHasher!
+final class ProjectDescriptionHelpersHasherTests: TuistUnitTestCase {
+    private var subject: ProjectDescriptionHelpersHasher!
+    private var machineEnvironment: MockMachineEnvironmentRetrieving!
 
     override func setUp() {
         super.setUp()
         given(swiftVersionProvider)
             .swiftVersion()
             .willReturn("5.2")
-        subject = ProjectDescriptionHelpersHasher(tuistVersion: "3.2.1")
+        machineEnvironment = .init()
+        given(machineEnvironment)
+            .macOSVersion
+            .willReturn("15.2.4")
+        subject = ProjectDescriptionHelpersHasher(
+            tuistVersion: "3.2.1",
+            machineEnvironment: machineEnvironment,
+            swiftVersionProvider: swiftVersionProvider
+        )
     }
 
     override func tearDown() {
@@ -34,7 +43,7 @@ class ProjectDescriptionHelpersHasherTests: TuistUnitTestCase {
         // Then
         for _ in 0 ..< 20 {
             let got = try subject.hash(helpersDirectory: temporaryDir)
-            XCTAssertEqual(got, "0a46768e766bdd05bdf901098d323b8a")
+            XCTAssertEqual(got, "5032b92c268cb7283c91ee37ec935c73")
         }
     }
 


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6403

### Short description 📝

Since we don't build the `ProjectDescriptionHelpers` module for distribution, we need to add the current macOS version to the final hash as we can't reuse the module across macOS SDKs.

### How to test the changes locally 🧐

It's difficult to reproduce this end-to-end unless you are about to upgrade 😐 But the unit tests should be good enough here. We can always get back to this if users still run into the issue.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
