### PR TITLE
Print only JSON string for dump and when --json flag is present

### DIFF
--- a/Sources/TuistKit/Commands/DumpCommand.swift
+++ b/Sources/TuistKit/Commands/DumpCommand.swift
@@ -4,8 +4,10 @@ import Path
 import TuistLoader
 import TuistSupport
 
-struct DumpCommand: AsyncParsableCommand {
-    static var configuration: CommandConfiguration {
+public struct DumpCommand: AsyncParsableCommand {
+    public init() {}
+
+    public static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "dump",
             abstract: "Outputs the manifest as a JSON"
@@ -25,7 +27,7 @@ struct DumpCommand: AsyncParsableCommand {
     @Argument(help: "The manifest to be dumped", envKey: .dumpManifest)
     var manifest: DumpableManifest = .project
 
-    func run() async throws {
+    public func run() async throws {
         try await DumpService().run(path: path, manifest: manifest)
     }
 }

--- a/Sources/TuistKit/Commands/MachineReadableCommand.swift
+++ b/Sources/TuistKit/Commands/MachineReadableCommand.swift
@@ -1,3 +1,0 @@
-import Foundation
-
-public protocol MachineReadableCommand {}

--- a/Sources/TuistKit/Commands/MachineReadableCommand.swift
+++ b/Sources/TuistKit/Commands/MachineReadableCommand.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+public protocol MachineReadableCommand {}

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationListService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationListService.swift
@@ -45,7 +45,7 @@ final class CloudOrganizationListService: CloudOrganizationListServicing {
 
         if json {
             let json = organizations.toJSON()
-            logger.info(.init(stringLiteral: json.toString(prettyPrint: true)))
+            logger.info(.init(stringLiteral: json.toString(prettyPrint: true)), metadata: .json)
             return
         }
 

--- a/Sources/TuistKit/Services/Cloud/CloudOrganizationShowService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudOrganizationShowService.swift
@@ -56,7 +56,7 @@ final class CloudOrganizationShowService: CloudOrganizationShowServicing {
 
         if json {
             let json = try organization.toJSON()
-            logger.info(.init(stringLiteral: json.toString(prettyPrint: true)))
+            logger.info(.init(stringLiteral: json.toString(prettyPrint: true)), metadata: .json)
             return
         }
 

--- a/Sources/TuistKit/Services/Cloud/CloudProjectListService.swift
+++ b/Sources/TuistKit/Services/Cloud/CloudProjectListService.swift
@@ -45,7 +45,7 @@ final class CloudProjectListService: CloudProjectListServicing {
 
         if json {
             let json = try projects.toJSON()
-            logger.info(.init(stringLiteral: json.toString(prettyPrint: true)))
+            logger.info(.init(stringLiteral: json.toString(prettyPrint: true)), metadata: .json)
             return
         }
 

--- a/Sources/TuistKit/Services/DumpService.swift
+++ b/Sources/TuistKit/Services/DumpService.swift
@@ -45,7 +45,7 @@ final class DumpService {
         }
 
         let json: JSON = try encoded.toJSON()
-        logger.notice("\(json.toString(prettyPrint: true))")
+        logger.notice("\(json.toString(prettyPrint: true))", metadata: .json)
     }
 }
 

--- a/Sources/TuistKit/Services/ListService.swift
+++ b/Sources/TuistKit/Services/ListService.swift
@@ -42,8 +42,7 @@ class ListService {
             return PrintableTemplate(name: path.basename, description: template.description)
         }
 
-        let output = try string(for: templates, in: format)
-        logger.notice("\(output)")
+        try output(for: templates, in: format)
     }
 
     // MARK: - Helpers
@@ -56,21 +55,21 @@ class ListService {
         }
     }
 
-    private func string(
+    private func output(
         for templates: [PrintableTemplate],
         in format: ListService.OutputFormat
-    ) throws -> String {
+    ) throws {
         switch format {
         case .table:
             let textTable = TextTable<PrintableTemplate> { [
                 TextTable.Column(title: "Name", value: $0.name),
                 TextTable.Column(title: "Description", value: $0.description),
             ] }
-            return textTable.render(templates)
+            logger.notice("\(textTable.render(templates))")
 
         case .json:
             let json = try templates.toJSON()
-            return json.toString(prettyPrint: true)
+            logger.notice("\(json.toString(prettyPrint: true))", metadata: .json)
         }
     }
 

--- a/Sources/TuistServer/Client/CloudClientOutputWarningsMiddleware.swift
+++ b/Sources/TuistServer/Client/CloudClientOutputWarningsMiddleware.swift
@@ -55,7 +55,7 @@ struct CloudClientOutputWarningsMiddleware: ClientMiddleware {
             throw CloudClientOutputWarningsMiddlewareError.invalidSchema
         }
 
-        json.forEach { warningController.append(warning: $0) }
+        json.forEach { logger.warning(Logger.Message(stringLiteral: $0)) }
 
         return response
     }

--- a/Sources/TuistServer/Client/CloudClientOutputWarningsMiddleware.swift
+++ b/Sources/TuistServer/Client/CloudClientOutputWarningsMiddleware.swift
@@ -55,7 +55,7 @@ struct CloudClientOutputWarningsMiddleware: ClientMiddleware {
             throw CloudClientOutputWarningsMiddlewareError.invalidSchema
         }
 
-        json.forEach { logger.warning(Logger.Message(stringLiteral: $0)) }
+        json.forEach { logger.warning("\($0)") }
 
         return response
     }

--- a/Sources/TuistSupport/Logging/JSONLogHandler.swift
+++ b/Sources/TuistSupport/Logging/JSONLogHandler.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Logging
+
+public struct JSONLogHandler: LogHandler {
+    public var logLevel: Logger.Level
+
+    public let label: String
+
+    public init(label: String) {
+        self.init(label: label, logLevel: .info)
+    }
+
+    public init(label: String, logLevel: Logger.Level) {
+        self.label = label
+        self.logLevel = logLevel
+    }
+
+    public func log(
+        level: Logger.Level,
+        message: Logger.Message,
+        metadata: Logger.Metadata?,
+        file _: String, function _: String, line _: UInt
+    ) {
+        let string: String
+
+        switch metadata?[Logger.Metadata.tuist] {
+        case Logger.Metadata.jsonKey?:
+            string = message.description
+        default:
+            switch level {
+            case .critical:
+                if Environment.shared.shouldOutputBeColoured {
+                    string = message.description.bold()
+                } else {
+                    string = message.description
+                }
+            case .error:
+                if Environment.shared.shouldOutputBeColoured {
+                    string = message.description.red()
+                } else {
+                    string = message.description
+                }
+            default:
+                return
+            }
+        }
+
+        output(for: level).print(string)
+    }
+
+    func output(for level: Logger.Level) -> FileHandle {
+        level < .error ? .standardOutput : .standardError
+    }
+
+    public var metadata = Logger.Metadata()
+
+    public subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+        get { metadata[key] }
+        set { metadata[key] = newValue }
+    }
+}

--- a/Sources/TuistSupport/Logging/Logger.Metadata+Tuist.swift
+++ b/Sources/TuistSupport/Logging/Logger.Metadata+Tuist.swift
@@ -20,4 +20,9 @@ extension Logger.Metadata {
     public static var pretty: Logger.Metadata {
         [tuist: .string(prettyKey)]
     }
+
+    public static let jsonKey: String = "json"
+    public static var json: Logger.Metadata {
+        [tuist: .string(jsonKey)]
+    }
 }

--- a/Sources/TuistSupport/Logging/Logger.swift
+++ b/Sources/TuistSupport/Logging/Logger.swift
@@ -4,10 +4,16 @@ import class Foundation.ProcessInfo
 let logger = Logger(label: "io.tuist.support")
 
 public struct LoggingConfig {
+    public init(loggerType: LoggerType, verbose: Bool) {
+        self.loggerType = loggerType
+        self.verbose = verbose
+    }
+
     public enum LoggerType {
         case console
         case detailed
         case osLog
+        case json
     }
 
     public var loggerType: LoggerType
@@ -45,6 +51,8 @@ public enum LogOutput {
             handler = DetailedLogHandler.self
         case .console:
             handler = StandardLogHandler.self
+        case .json:
+            handler = JSONLogHandler.self
         }
 
         if config.verbose {
@@ -76,5 +84,11 @@ extension StandardLogHandler: VerboseLogHandler {
 extension OSLogHandler: VerboseLogHandler {
     public static func verbose(label: String) -> LogHandler {
         OSLogHandler(label: label, logLevel: .debug)
+    }
+}
+
+extension JSONLogHandler: VerboseLogHandler {
+    public static func verbose(label: String) -> LogHandler {
+        JSONLogHandler(label: label, logLevel: .debug)
     }
 }

--- a/Sources/tuist/TuistApp.swift
+++ b/Sources/tuist/TuistApp.swift
@@ -14,9 +14,10 @@ private enum TuistServer {
         }
 
         let machineReadableCommands = [DumpCommand.self]
-        if (CommandLine.arguments.count > 1 && machineReadableCommands.map(\._commandName).contains(CommandLine.arguments[1])) ||
-            CommandLine.arguments.contains("--json")
-        {
+        // swiftformat:disable all
+        let isCommandMachineRedable = CommandLine.arguments.count > 1 && machineReadableCommands.map { $0._commandName }.contains(CommandLine.arguments[1])
+        // swiftformat:enable all
+        if isCommandMachineRedable || CommandLine.arguments.contains("--json") {
             TuistSupport.LogOutput.bootstrap(config: LoggingConfig(loggerType: .json, verbose: false))
         } else {
             TuistSupport.LogOutput.bootstrap()

--- a/Sources/tuist/TuistApp.swift
+++ b/Sources/tuist/TuistApp.swift
@@ -15,9 +15,9 @@ private enum TuistServer {
 
         let machineReadableCommands = [DumpCommand.self]
         // swiftformat:disable all
-        let isCommandMachineRedable = CommandLine.arguments.count > 1 && machineReadableCommands.map { $0._commandName }.contains(CommandLine.arguments[1])
+        let isCommandMachineReadable = CommandLine.arguments.count > 1 && machineReadableCommands.map { $0._commandName }.contains(CommandLine.arguments[1])
         // swiftformat:enable all
-        if isCommandMachineRedable || CommandLine.arguments.contains("--json") {
+        if isCommandMachineReadable || CommandLine.arguments.contains("--json") {
             TuistSupport.LogOutput.bootstrap(config: LoggingConfig(loggerType: .json, verbose: false))
         } else {
             TuistSupport.LogOutput.bootstrap()

--- a/Sources/tuist/TuistApp.swift
+++ b/Sources/tuist/TuistApp.swift
@@ -13,8 +13,9 @@ private enum TuistServer {
             try? ProcessEnv.setVar(Constants.EnvironmentVariables.verbose, value: "true")
         }
 
-        if (CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "dump") || CommandLine.arguments
-            .contains("--json")
+        let machineReadableCommands = [DumpCommand.self]
+        if (CommandLine.arguments.count > 1 && machineReadableCommands.map(\._commandName).contains(CommandLine.arguments[1])) ||
+            CommandLine.arguments.contains("--json")
         {
             TuistSupport.LogOutput.bootstrap(config: LoggingConfig(loggerType: .json, verbose: false))
         } else {

--- a/Sources/tuist/TuistApp.swift
+++ b/Sources/tuist/TuistApp.swift
@@ -13,7 +13,13 @@ private enum TuistServer {
             try? ProcessEnv.setVar(Constants.EnvironmentVariables.verbose, value: "true")
         }
 
-        TuistSupport.LogOutput.bootstrap()
+        if (CommandLine.arguments.count > 1 && CommandLine.arguments[1] == "dump") || CommandLine.arguments
+            .contains("--json")
+        {
+            TuistSupport.LogOutput.bootstrap(config: LoggingConfig(loggerType: .json, verbose: false))
+        } else {
+            TuistSupport.LogOutput.bootstrap()
+        }
 
         try TuistSupport.Environment.shared.bootstrap()
 

--- a/Tests/TuistServerTests/Client/CloudClientOutputWarningsMiddlewareTests.swift
+++ b/Tests/TuistServerTests/Client/CloudClientOutputWarningsMiddlewareTests.swift
@@ -50,7 +50,9 @@ final class CloudClientOutputWarningsMiddlewareTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(gotResponse, response)
-        XCTAssertEqual(warningController.warnings, warnings)
+        for warning in warnings {
+            XCTAssertStandardOutput(pattern: warning)
+        }
     }
 
     func test_doesntOutputAnyWarning_whenTheHeaderIsAbsent() async throws {
@@ -66,6 +68,6 @@ final class CloudClientOutputWarningsMiddlewareTests: TuistUnitTestCase {
 
         // Then
         XCTAssertEqual(gotResponse, response)
-        XCTAssertEqual(warningController.warnings, [])
+        XCTAssertEqual(TestingLogHandler.collected[.warning, <=], "")
     }
 }


### PR DESCRIPTION
Resolves https://github.com/tuist/tuist/issues/6438

### Short description 📝

When a JSON output is requested (either by implicitly for `tuist dump` command or for other command when the `--json` flag is passed), we should only output:
- the JSON itself
- any error message

I decided to implement a `JSONLogHandler` that respects the above conditions. To know if an output is a JSON, I added a new `.json` metadata key. In `TuistApp`, we (slightly naively) parse the `CommandLine.arguments` to bootstrap the right `Logger`.

### How to test the changes locally 🧐

Add the following line somewhere in the `DumpService`:
```swift
logger.warning("This warning should not be visible")
```

And then run `tuist dump` – you should only see the JSON, not the warning. Whereas in the latest `tuist` version, you'd also see the warning itself. The same goes for the report detail log.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
