### PR TITLE
Fix generation of Quick's SPM QuickObjcRuntime target

### DIFF
--- a/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
+++ b/Sources/TuistLoader/SwiftPackageManager/PackageInfoMapper.swift
@@ -282,6 +282,7 @@ public final class PackageInfoMapper: PackageInfoMapping {
                     "Nimble", // https://github.com/Quick/Nimble
                     "NimbleObjectiveC", // https://github.com/Quick/Nimble
                     "Quick", // https://github.com/Quick/Quick
+                    "QuickObjCRuntime", // https://github.com/Quick/Quick
                     "RxTest", // https://github.com/ReactiveX/RxSwift
                     "RxTest-Dynamic", // https://github.com/ReactiveX/RxSwift
                     "SnapshotTesting", // https://github.com/pointfreeco/swift-snapshot-testing


### PR DESCRIPTION
Added Quick's QuickObjcRuntime target to the list of testing targets to automatically add 'ENABLE_TESTING_SEARCH_PATHS=YES'

Resolves [#6444 - Quick's QuickObjcRuntime target is not included in the list of targets that need testing search paths](https://github.com/tuist/tuist/issues/6444)

### Short description 📝

> Adding another target for Tuist to automatically set `ENABLE_TESTING_SEARCH_PATHS = "YES"` for, as it was missing.

### How to test the changes locally 🧐

> Try to run some tests with Quick where `QuickObjCRuntime` is being built as part of the scheme.

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
