### PR TITLE
Provide better error message for a missing Tuist server token

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -70,6 +70,7 @@ var targets: [Target] = [
             "XcodeGraph",
             "Mockable",
             "TuistServer",
+            .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
         ],
         swiftSettings: [
             .define("MOCKING", .when(configuration: .debug)),

--- a/Sources/TuistKit/Commands/TuistCommand.swift
+++ b/Sources/TuistKit/Commands/TuistCommand.swift
@@ -1,8 +1,10 @@
 @_exported import ArgumentParser
 import Foundation
+import OpenAPIRuntime
 import Path
 import TuistAnalytics
 import TuistLoader
+import TuistServer
 import TuistSupport
 
 public struct TuistCommand: AsyncParsableCommand {
@@ -86,6 +88,11 @@ public struct TuistCommand: AsyncParsableCommand {
         } catch let error as FatalError {
             WarningController.shared.flush()
             errorHandler.fatal(error: error)
+            _exit(exitCode(for: error).rawValue)
+        } catch let error as ClientError where error.underlyingError is CloudClientAuthenticationError {
+            WarningController.shared.flush()
+            // swiftlint:disable:next force_cast
+            logger.error("\((error.underlyingError as! CloudClientAuthenticationError).description)")
             _exit(exitCode(for: error).rawValue)
         } catch {
             WarningController.shared.flush()

--- a/Sources/TuistServer/Client/CloudClientAuthenticationMiddleware.swift
+++ b/Sources/TuistServer/Client/CloudClientAuthenticationMiddleware.swift
@@ -2,20 +2,20 @@ import Foundation
 import OpenAPIRuntime
 import TuistSupport
 
-enum CloudClientAuthenticationError: FatalError {
+public enum CloudClientAuthenticationError: FatalError {
     case notAuthenticated
 
-    var type: ErrorType {
+    public var type: ErrorType {
         switch self {
         case .notAuthenticated:
             return .abort
         }
     }
 
-    var description: String {
+    public var description: String {
         switch self {
         case .notAuthenticated:
-            return "No cloud authentication token found. Authenticate by running `tuist cloud auth`."
+            return "No Tuist authentication token found. Authenticate by running `tuist cloud auth`."
         }
     }
 }

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -256,6 +256,7 @@ public enum Module: String, CaseIterable {
                 .external(name: "ArgumentParser"),
                 .external(name: "GraphViz"),
                 .external(name: "AnyCodable"),
+                .external(name: "OpenAPIRuntime"),
             ]
         case .core:
             [


### PR DESCRIPTION
### Short description 📝

If you currently run any Tuist operation that sends a request to the server without the CLI being authenticated, you will get an error similar to:
```
We received an error that we couldn't handle:
    - Localized description: Client error - operationID: listProjects, operationInput: Input(path: TuistServer.Operations.listProjects.Input.Path(), query: TuistServer.Operations.listProjects.Input.Query(), headers: TuistServer.Operations.listProjects.Input.Headers(), cookies: TuistServer.Operations.listProjects.Input.Cookies(), body: nil), request: path: /api/projects, query: <nil>, method: HTTPMethod(value: OpenAPIRuntime.HTTPMethod.(unknown context at $102bf7910).OpenAPIHTTPMethod.GET), header fields: [accept: application/json], body (prefix): <nil>, baseURL: https://cloud.tuist.io, response: <nil>, underlying error: The operation couldn’t be completed. (TuistServer.CloudClientAuthenticationError error 0.)
    - Error: Client error - operationID: listProjects, operationInput: Input(path: TuistServer.Operations.listProjects.Input.Path(), query: TuistServer.Operations.listProjects.Input.Query(), headers: TuistServer.Operations.listProjects.Input.Headers(), cookies: TuistServer.Operations.listProjects.Input.Cookies(), body: nil), request: path: /api/projects, query: <nil>, method: HTTPMethod(value: OpenAPIRuntime.HTTPMethod.(unknown context at $102bf7910).OpenAPIHTTPMethod.GET), header fields: [accept: application/json], body (prefix): <nil>, baseURL: https://cloud.tuist.io, response: <nil>, underlying error: The operation couldn’t be completed. (TuistServer.CloudClientAuthenticationError error 0.)

If you think it's a legit issue, please file an issue including the reproducible steps: https://github.com/tuist/tuist/issues/new/choose
Consider creating an issue using the following link: https://github.com/tuist/tuist/issues/new/choose
```

The error originally comes from the [CloudClientAuthenticationMiddleware](https://github.com/tuist/tuist/blob/main/Sources/TuistServer/Client/CloudClientAuthenticationMiddleware.swift#L34) but the swift-openapi library wraps the error that does conform to our `FatalError` into its own `ClientError` – which is an error we no longer expect downstream.

To get around this, we can handle the `ClientError` in the `TuistCommand` and pluck out the `underlyingError` when it conforms to `FatalError`.

I did think about handling this closer to the client, but I couldn't figure out a good way where we wouldn't have to do the same error dance whenever we call the `client`.

### How to test the changes locally 🧐

- Run `tuist cloud logout`
- Run an operation that involves a server, such as `tuist cloud project list`

Instead of the confusing error from above, you should see the following error:
```
No Tuist authentication token found. Authenticate by running `tuist cloud auth`.
```

### Contributor checklist ✅

- [x] The code has been linted using run `mise run lint-fix`
- [x] The change is tested via unit testing or acceptance testing, or both -> it's a bit hard to test the changes with unit tests, so I'm skipping this
- [x] The title of the PR is formulated in a way that is usable as a changelog entry
- [x] In case the PR introduces changes that affect users, the documentation has been updated

### Reviewer checklist ✅

- [x] The code architecture and patterns are consistent with the rest of the codebase
- [x] Reviewer has checked that, if needed, the PR includes the label `changelog:added`, `changelog:fixed`, or `changelog:changed`, and the title is usable as a changelog entry
